### PR TITLE
Nerfs ash drake's modifiers

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -44,7 +44,7 @@
 		rawScaling = 20
 		scaling = 0.2
 	else
-		rawScaling = rand(90,140)
+		rawScaling = rand(90,130)
 		scaling = rawScaling / 100
 	maxHealth = round(maxHealth * scaling, 1)
 	health = round(health * scaling, 1)
@@ -60,15 +60,12 @@
 		name = "[prefix] [name]"
 		loot += /obj/item/weapon/ore/diamond
 		return
-	if(rawScaling > 115 && rawScaling < 130)
+	if(rawScaling > 115 && rawScaling <= 130)
 		var/prefix = "blazing"
 		name = "[prefix] [name]"
+		loot += pick(/obj/item/clothing/suit/armor/reactive/fire, /obj/item/clothing/suit/hooded/cloak/drake, /obj/item/weapon/dragons_blood)
 		return
-	if(rawScaling >= 130)
-		var/prefix = "infernal"
-		name = "[prefix] [name]"
-		loot += pick(/obj/item/clothing/suit/armor/reactive/fire, /obj/item/clothing/suit/hooded/cloak/drake, /obj/item/weapon/dragons_blood) //Blood is now the fuck you drop seeing as it's pretty crap.
-		return
+
 
 // VAR SCALING END //
 


### PR DESCRIPTION
I removed the "infernal" modifier and added it's drops to the "blazing" one to give miners a more skill orientated ash drake battle until we port /tg/ lavaland.

### Intent of your Pull Request
https://forums.yogstation.net/index.php?threads/lavaland-megafauna.15242/page-2
Megafauna have random "modifiers" that make the fight harder, the top modifier however, makes the ash drake nearly unbeatable to fight to the point you just skip that round and wait till the game rolls a easier modifier for it. This removes the hardest one and add's its loot to the second hardest one to make it slighty more fair for miners. 


:cl:  
tweak: Ash drakes will no longer have a "infernal" modifier.
/:cl:
