### PR TITLE
Removes diagonal movement

### DIFF
--- a/code/modules/keybindings/bindings_atom.dm
+++ b/code/modules/keybindings/bindings_atom.dm
@@ -2,17 +2,8 @@
 // Only way to do that is to tie the behavior into the focus's keyLoop().
 
 /atom/movable/keyLoop(client/user)
-	if(!user.keys_held["Ctrl"])
-		var/movement_dir = NONE
-		for(var/_key in user.keys_held)
-			movement_dir = movement_dir | SSinput.movement_keys[_key]
-		if(user.next_move_dir_add)
-			movement_dir |= user.next_move_dir_add
-		if(user.next_move_dir_sub)
-			movement_dir &= ~user.next_move_dir_sub
-		// Sanity checks in case you hold left and right and up to make sure you only go up
-		if((movement_dir & NORTH) && (movement_dir & SOUTH))
-			movement_dir &= ~(NORTH|SOUTH)
-		if((movement_dir & EAST) && (movement_dir & WEST))
-			movement_dir &= ~(EAST|WEST)
+	if(!user.keys_held["Ctrl"]) 
+		var/movement_dir = NONE 
+		for(var/_key in user.keys_held) 
+			movement_dir = SSinput.movement_keys[_key] 
 		user.Move(get_step(src, movement_dir), movement_dir)


### PR DESCRIPTION
Like it says on the tin. Removes diagonal movement by only allowing one movement direction to be set at once. Behaved exactly like old-yogs code in my tests.