### PR TITLE
Change TG's Plant DNA Manipulator Values to Yogstation's current values

### DIFF
--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -16,29 +16,29 @@
 
 	var/datum/plant_gene/target
 	var/operation = ""
-	var/max_potency = 50 // See RefreshParts() for how these work
-	var/max_yield = 2
-	var/min_production = 12
-	var/max_endurance = 10 // IMPT: ALSO AFFECTS LIFESPAN
+	// yogs start
+	var/max_potency = 35 //See RefreshParts() for how these work
+	var/max_yield = 10
+	var/max_endurance = 40 //IMPT: ALSO AFFECTS LIFESPAN
+	// yogs stop
 	var/min_wchance = 67
 	var/min_wrate = 10
 
 /obj/machinery/plantgenes/RefreshParts() // Comments represent the max you can set per tier, respectively. seeds.dm [219] clamps these for us but we don't want to mislead the viewer.
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
 		if(M.rating > 3)
-			max_potency = 95
+			max_potency = 100 // yogs
 		else
-			max_potency = initial(max_potency) + (M.rating**3) // 53,59,77,95 	 Clamps at 100
+			max_potency = initial(max_potency) + (M.rating* 15) // yogs - TG's old version: 53,59,77,95 	 Clamps at 100, Yog's superior version: 50, 65, 80, 100
 
-		max_yield = initial(max_yield) + (M.rating*2) // 4,6,8,10 	Clamps at 10
+		max_yield = initial(max_yield) // yogs - TG's old version: 4,6,8,10 	Clamps at 10, Yog's version: 10 at all levels
 
 	for(var/obj/item/stock_parts/scanning_module/SM in component_parts)
 		if(SM.rating > 3) //If you create t5 parts I'm a step ahead mwahahaha!
 			min_production = 1
 		else
-			min_production = 12 - (SM.rating * 3) //9,6,3,1. Requires if to avoid going below clamp [1]
 
-		max_endurance = initial(max_endurance) + (SM.rating * 25) // 35,60,85,100	Clamps at 10min 100max
+		max_endurance = initial(max_endurance) + (SM.rating * 15) // yogs - TG's old version: 35,60,85,100	Clamps at 10min 100max, Yog's version: 55, 70, 85, 100
 
 	for(var/obj/item/stock_parts/micro_laser/ML in component_parts)
 		var/wratemod = ML.rating * 2.5

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -19,6 +19,7 @@
 	// yogs start
 	var/max_potency = 35 //See RefreshParts() for how these work
 	var/max_yield = 10
+	var/min_production = 1
 	var/max_endurance = 40 //IMPT: ALSO AFFECTS LIFESPAN
 	// yogs stop
 	var/min_wchance = 67
@@ -37,6 +38,7 @@
 		if(SM.rating > 3) //If you create t5 parts I'm a step ahead mwahahaha!
 			min_production = 1
 		else
+			min_production = 1 // yogs - TG's old version: 9,6,3,1. Requires if to avoid going below clamp [1], Yog's superior version: 1. No point of leaving this in, but I left it anyway.
 
 		max_endurance = initial(max_endurance) + (SM.rating * 15) // yogs - TG's old version: 35,60,85,100	Clamps at 10min 100max, Yog's version: 55, 70, 85, 100
 


### PR DESCRIPTION
TG, having a problem with powergaming, nerfed botany's DNA manipulator values per stock part upgrade to dumb values to nerf botany hard. The changes suck, and I think botany is perfectly fine on Yogstation as is, so this PR reverts the nerfs to Yogstation levels. The changes are listed numerically across the different types of manipulators from T1 to T4.

Summary from TG to Yogs:
**Maximum potency:** 53, 59, 77, 95 to 50, 65, 80, 100
**Maximum yield:** 4, 6, 8,1 0 to 10 at all levels
**Maximum production speed:** 9, 6, 3, 1 to 1 at all levels
**Maximum endurance:** 35, 60, 85, 100 to 55, 70, 85, 100


:cl: Yogurtshrimp69

tweak: Changed botany's plant DNA manipulator maximum and minimum values to Yogstation's values over TG's


/:cl:
