### PR TITLE
Remove co-ords from latejoin AI

### DIFF
--- a/code/modules/jobs/job_types/silicon.dm
+++ b/code/modules/jobs/job_types/silicon.dm
@@ -63,7 +63,7 @@ AI
 	. = ..()
 	var/area/A = get_area(AI)
 	var/turf/T = get_turf(AI)
-	SSticker.OnRoundstart(CALLBACK(GLOBAL_PROC, .proc/minor_announce, "[AI] has been downloaded to an empty bluespace-networked AI core at [COORD(T)], [A.name]."))
+	SSticker.OnRoundstart(CALLBACK(GLOBAL_PROC, .proc/minor_announce, "[AI] has been downloaded to an empty bluespace-networked AI core in [A.name].")) //YOGS - removed the co-ordinates
 
 /datum/job/ai/config_check()
 	return CONFIG_GET(flag/allow_ai)

--- a/code/modules/jobs/job_types/silicon.dm
+++ b/code/modules/jobs/job_types/silicon.dm
@@ -62,7 +62,6 @@ AI
 /datum/job/ai/announce(mob/living/silicon/ai/AI)
 	. = ..()
 	var/area/A = get_area(AI)
-	var/turf/T = get_turf(AI)
 	SSticker.OnRoundstart(CALLBACK(GLOBAL_PROC, .proc/minor_announce, "[AI] has been downloaded to an empty bluespace-networked AI core in [A.name].")) //YOGS - removed the co-ordinates
 
 /datum/job/ai/config_check()


### PR DESCRIPTION
Announcing the co-ordinates in an IC announcement just seems... off?