### PR TITLE
Revert "Remove mineral access from miners"

### DIFF
--- a/code/modules/jobs/job_types/cargo_service.dm
+++ b/code/modules/jobs/job_types/cargo_service.dm
@@ -76,7 +76,7 @@ Shaft Miner
 	outfit = /datum/outfit/job/miner
 
 	access = list(ACCESS_MAINT_TUNNELS, ACCESS_MAILSORTING, ACCESS_CARGO, ACCESS_CARGO_BOT, ACCESS_QM, ACCESS_MINING, ACCESS_MINING_STATION, ACCESS_MINERAL_STOREROOM)
-	minimal_access = list(ACCESS_MINING, ACCESS_MINING_STATION, ACCESS_MAILSORTING) //YOGS - removed mineral access from shaft miners :(
+	minimal_access = list(ACCESS_MINING, ACCESS_MINING_STATION, ACCESS_MAILSORTING, ACCESS_MINERAL_STOREROOM)
 
 /datum/outfit/job/miner
 	name = "Shaft Miner (Lavaland)"


### PR DESCRIPTION
Reverts yogstation13/tg-rebase#416

You're reminded that to bypass this, all the miner needs is the mythical crowbar and screwdriver. Meaning this change is completely and utterly pointless in actually stopping miners doing what they want with their minerals.

Oh and that even if miners lost their access, it still isn't likely that the other station roles are going to get minerals because the R&D scientist is still going to dash to the ORM and pick up the minerals or the QM will hoard the minerals to sell. (And you're not going to be able to convince them to spare minerals if they're already dead set on using them)

(And before the obligatory "if this change accomplishes nothing why are you reverting it?", if this change accomplishes nothing, why are you merging it?)