### PR TITLE
Makes drones not shitty fucking slime creatures desparately & slowly writhing on the floor

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -27,7 +27,7 @@
 	maxHealth = 30
 	unsuitable_atmos_damage = 0
 	wander = 0
-	speed = 0
+	speed = -1 //YOGS - drones //Buffed to not be a fucking god damn piece of slug matter writhing on the fucking floor
 	ventcrawler = VENTCRAWLER_ALWAYS
 	healable = 0
 	density = FALSE


### PR DESCRIPTION
### Improves the speed of drones slightly (still not as fast as they were back at Yogs pre-rebase)
This makes drones about as fast as (but I think still slightly slower than) a person. For a metric, this would make drones take 11-12 seconds to make a lap around the central ring at Boxstation, as opposed to the current snailspace.

Mind you, this is still a nerf compared to the blistering speed they were pulling back before the rebase. It's just not as hard of a nerf as the current /tg/ one.

#### Changelog
:cl:  
tweak: We have removed the superglue previously sprayed all over drones during manufacture. They should move a little bit faster as a result. 
/:cl:
