### PR TITLE
Meteor probability switchup.

### DIFF
--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -4,9 +4,8 @@
 	name = "Meteor Wave: Normal"
 	typepath = /datum/round_event/meteor_wave
 	weight = 4
-	min_players = 15
+	min_players = 5
 	max_occurrences = 3
-	earliest_start = 25 MINUTES
 
 /datum/round_event/meteor_wave
 	startWhen		= 6
@@ -55,10 +54,9 @@
 /datum/round_event_control/meteor_wave/threatening
 	name = "Meteor Wave: Threatening"
 	typepath = /datum/round_event/meteor_wave/threatening
-	weight = 5
-	min_players = 20
+	weight = 2
+	min_players = 5
 	max_occurrences = 3
-	earliest_start = 35 MINUTES
 
 /datum/round_event/meteor_wave/threatening
 	wave_name = "threatening"
@@ -66,10 +64,9 @@
 /datum/round_event_control/meteor_wave/catastrophic
 	name = "Meteor Wave: Catastrophic"
 	typepath = /datum/round_event/meteor_wave/catastrophic
-	weight = 7
-	min_players = 25
+	weight = 1
+	min_players = 5
 	max_occurrences = 3
-	earliest_start = 45 MINUTES
 
 /datum/round_event/meteor_wave/catastrophic
 	wave_name = "catastrophic"

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -4,7 +4,7 @@
 	name = "Meteor Wave: Normal"
 	typepath = /datum/round_event/meteor_wave
 	weight = 4
-	min_players = 5
+	min_players = 10
 	max_occurrences = 3
 
 /datum/round_event/meteor_wave
@@ -55,7 +55,7 @@
 	name = "Meteor Wave: Threatening"
 	typepath = /datum/round_event/meteor_wave/threatening
 	weight = 2
-	min_players = 5
+	min_players = 20
 	max_occurrences = 3
 
 /datum/round_event/meteor_wave/threatening
@@ -65,7 +65,7 @@
 	name = "Meteor Wave: Catastrophic"
 	typepath = /datum/round_event/meteor_wave/catastrophic
 	weight = 1
-	min_players = 5
+	min_players = 25
 	max_occurrences = 3
 
 /datum/round_event/meteor_wave/catastrophic

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -4,8 +4,9 @@
 	name = "Meteor Wave: Normal"
 	typepath = /datum/round_event/meteor_wave
 	weight = 4
-	min_players = 10
+	min_players = 10 //yogs
 	max_occurrences = 3
+	//earliest_start = 25 MINUTES //yogs
 
 /datum/round_event/meteor_wave
 	startWhen		= 6
@@ -54,9 +55,10 @@
 /datum/round_event_control/meteor_wave/threatening
 	name = "Meteor Wave: Threatening"
 	typepath = /datum/round_event/meteor_wave/threatening
-	weight = 2
+	weight = 2 //yogs
 	min_players = 20
 	max_occurrences = 3
+	//earliest_start = 35 MINUTES //yogs
 
 /datum/round_event/meteor_wave/threatening
 	wave_name = "threatening"
@@ -64,9 +66,10 @@
 /datum/round_event_control/meteor_wave/catastrophic
 	name = "Meteor Wave: Catastrophic"
 	typepath = /datum/round_event/meteor_wave/catastrophic
-	weight = 1
+	weight = 1 //yogs
 	min_players = 25
 	max_occurrences = 3
+	//earliest_start = 45 MINUTES //yogs
 
 /datum/round_event/meteor_wave/catastrophic
 	wave_name = "catastrophic"


### PR DESCRIPTION
Reduces overall probability of meteors spawning while simultaneously lowering the requirement for number of players. This reverts meteor behavior to how they used to work before the rebase, which I frankly think is a superior way of going about spawning a nearly-always game ending meteor wave.


hugbox amirite