### PR TITLE
removes 6 second stun from the detective's revolver

### DIFF
--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -15,7 +15,7 @@
 /obj/item/projectile/bullet/c38
 	name = ".38 bullet"
 	damage = 15
-	knockdown = 60
+	//knockdown = 60 //yogs - commented out
 	stamina = 50
 
 // .357 (Syndie Revolver)


### PR DESCRIPTION
### Intent of your Pull Request

Nerfs the detective's revolver so it doesn't instantly knockdown, requiring two shots to knock someone down due to stamina damage, more in-line with disablers than tasers. Right now the detective's revolver acts like a tazer, but with damage, stamina damage and infinite range. 

#### Changelog

:cl:  
tweak: Detective's revolver has had it's knockdown removed, but the 50 stamina damage is still intact so you can down someone with 2 shots.
/:cl:
