### PR TITLE
Adjust vehicles speed to match global move speed

### DIFF
--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -148,7 +148,11 @@
 
 	if(world.time < next_vehicle_move)
 		return
-	next_vehicle_move = world.time + vehicle_move_delay
+	var/static/datum/config_entry/number/run_delay/config_run_delay								//yogs start
+	if(isnull(config_run_delay))
+		config_run_delay = CONFIG_GET(number/run_delay)
+	var/combined_delay = vehicle_move_delay * config_run_delay
+	next_vehicle_move = world.time + combined_delay																//yogs end
 
 	if(keycheck(user))
 		var/turf/next = get_step(AM, direction)

--- a/code/modules/vehicles/_vehicle.dm
+++ b/code/modules/vehicles/_vehicle.dm
@@ -109,7 +109,11 @@
 	vehicle_move(direction)
 
 /obj/vehicle/proc/vehicle_move(direction)
-	if(lastmove + movedelay > world.time)
+	var/static/datum/config_entry/number/run_delay/config_run_delay								//yogs start
+	if(isnull(config_run_delay))
+		config_run_delay = CONFIG_GET(number/run_delay)
+	var/combined_delay = movedelay * config_run_delay
+	if(lastmove + combined_delay > world.time)																		//yogs end
 		return FALSE
 	lastmove = world.time
 	if(trailer)


### PR DESCRIPTION
Makes the move delay of any vehicle dependent on RUN_DELAY from config.
Secway and ATV move as fast as a running human now, skateboard moves twice as fast, janicart/scooter move at human walking speed, just as it was pre-rebase.