### PR TITLE
PDA-lights now have different colours

### DIFF
--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
-#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+//#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 
 #include "map_files\generic\CentCom.dmm"
 

--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
-//#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 
 #include "map_files\generic\CentCom.dmm"
 

--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -120,6 +120,9 @@
 			return
 		storedpda.icon_state = P.icon_state
 		storedpda.desc = P.desc
+		storedpda.light_color = P.light_color //yogs start - pda flashlight colouring
+		storedpda.icon = P.icon // This is to prevent yogs PDAs from being blank when switched to normal PDAs, and the other way around.
+		storedpda.update_light() //yogs end - pda flashlight colouring
 		ejectpda()
 
 	else

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2652,6 +2652,7 @@
 #include "yogstation\code\modules\client\preferences.dm"
 #include "yogstation\code\modules\client\preferences_savefile.dm"
 #include "yogstation\code\modules\client\verbs\ooc.dm"
+#include "yogstation\code\modules\clothing\chameleon.dm"
 #include "yogstation\code\modules\clothing\clothing.dm"
 #include "yogstation\code\modules\clothing\donator.dm"
 #include "yogstation\code\modules\clothing\head\jobs.dm"

--- a/yogstation/code/game/objects/items/devices/PDA/PDA.dm
+++ b/yogstation/code/game/objects/items/devices/PDA/PDA.dm
@@ -2,3 +2,6 @@
 	var/mob/M = usr
 	if(usr.canUseTopic(src))
 		return attack_self(M)
+
+/obj/item/pda
+	light_color = "#ffffff"

--- a/yogstation/code/game/objects/items/devices/PDA/PDA_types.dm
+++ b/yogstation/code/game/objects/items/devices/PDA/PDA_types.dm
@@ -2,8 +2,94 @@
 	name = "telecomms PDA"
 	default_cartridge = /obj/item/cartridge/signal
 	icon_state = "pda_tcomms"
+	light_color = LIGHT_COLOR_ORANGE
 
 /obj/item/pda/para
 	name = "paramedic PDA"
 	default_cartridge = /obj/item/cartridge/paramedic
 	icon_state = "pda-medical"
+	light_color = LIGHT_COLOR_LIGHT_CYAN
+
+/obj/item/pda/clown
+	light_color = LIGHT_COLOR_PINK
+
+/obj/item/pda/medical
+	light_color = LIGHT_COLOR_LIGHT_CYAN
+
+/obj/item/pda/viro
+	light_color = LIGHT_COLOR_LIGHT_CYAN
+
+/obj/item/pda/engineering
+	light_color = LIGHT_COLOR_ORANGE
+
+/obj/item/pda/security
+	light_color = LIGHT_COLOR_RED
+
+/obj/item/pda/detective
+	light_color = LIGHT_COLOR_RED
+
+/obj/item/pda/warden
+	light_color = LIGHT_COLOR_RED
+
+/obj/item/pda/janitor
+	light_color = LIGHT_COLOR_LAVENDER
+
+/obj/item/pda/toxins
+	light_color = LIGHT_COLOR_PURPLE
+
+/obj/item/pda/heads/hop
+	light_color = LIGHT_COLOR_BLUE
+
+/obj/item/pda/heads/hos
+	light_color = LIGHT_COLOR_FLARE
+
+/obj/item/pda/heads/ce
+	light_color = LIGHT_COLOR_FIRE
+
+/obj/item/pda/heads/cmo
+	light_color = LIGHT_COLOR_CYAN
+
+/obj/item/pda/heads/rd
+	light_color = LIGHT_COLOR_PURPLE
+
+/obj/item/pda/captain
+	light_color = LIGHT_COLOR_BLUE
+
+/obj/item/pda/cargo
+	light_color = LIGHT_COLOR_YELLOW
+
+/obj/item/pda/quartermaster
+	light_color = LIGHT_COLOR_BROWN
+
+/obj/item/pda/shaftminer
+	light_color = LIGHT_COLOR_YELLOW
+
+/obj/item/pda/syndicate
+	light_color = LIGHT_COLOR_FIRE
+
+/obj/item/pda/chaplain
+	light_color = LIGHT_COLOR_SLIME_LAMP
+
+/obj/item/pda/lawyer
+	light_color = LIGHT_COLOR_DARK_BLUE
+
+/obj/item/pda/botanist
+	light_color = LIGHT_COLOR_BLUEGREEN
+
+/obj/item/pda/roboticist
+	light_color = LIGHT_COLOR_PURPLE
+
+/obj/item/pda/curator
+	light_color = LIGHT_COLOR_SLIME_LAMP
+
+/obj/item/pda/bar
+	light_color = LIGHT_COLOR_SLIME_LAMP
+
+/obj/item/pda/atmos
+	light_color = LIGHT_COLOR_ORANGE
+
+/obj/item/pda/chemist
+	light_color = LIGHT_COLOR_LIGHT_CYAN
+
+/obj/item/pda/geneticist
+	light_color = LIGHT_COLOR_LIGHT_CYAN

--- a/yogstation/code/modules/clothing/chameleon.dm
+++ b/yogstation/code/modules/clothing/chameleon.dm
@@ -1,0 +1,5 @@
+/datum/action/item_action/chameleon/change/update_item(obj/item/picked_item)
+	..()
+	if(ispath(picked_item, /obj/item/pda) && istype(target, /obj/item/pda))
+		target.light_color = initial(picked_item.light_color)
+		target.update_light()


### PR DESCRIPTION
### Intent of your Pull Request

Different jobs/departments now have different coloured PDA-flashlights. For stuff like engies and doctors I stuck to the departmental theme, but with civilians I kinda went with whatever. I also fixed a bug where PDA-icons would be invisible if you used a donor skin/sig-tech/paramedic and changed to another.

#### Changelog

:cl:  
rscadd: PDA-flashlights now have different colours!
/:cl:
