### PR TITLE
moves holoparasites to nuke ops

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -391,7 +391,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndie_kit/guardian
 	cost = 18
 	surplus = 0
-	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
+	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops) //yogs - turned from exclude to include.
 	player_minimum = 25
 	restricted = TRUE
 


### PR DESCRIPTION
### Intent of your Pull Request

removing holoparasites from traitor and IAA, adding them to nuke and clown ops. closes #1093 

#### Changelog

:cl:  
tweak: holoparasites have been removed from traitor uplinks and added to nuke op uplinks
/:cl:
