### PR TITLE
Various changes to Yogstation map

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -37055,7 +37055,6 @@
 /area/science/test_area)
 "bOK" = (
 /obj/structure/barricade/wooden,
-/obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bON" = (
@@ -37459,22 +37458,10 @@
 	name = "Maint Bar Access";
 	req_access_txt = "12"
 	},
-/obj/structure/barricade/wooden{
-	name = "wooden barricade (CLOSED)"
-	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bPW" = (
 /obj/effect/decal/cleanable/oil,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"bPX" = (
-/obj/structure/closet/emcloset,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"bPY" = (
-/obj/structure/girder,
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -37774,6 +37761,10 @@
 /area/maintenance/port/aft)
 "bRf" = (
 /obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 4;
+	name = "4maintenance loot spawner"
+	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
 	},
@@ -51808,6 +51799,16 @@
 	},
 /turf/open/floor/plasteel/vault/telecomms/mainframe,
 /area/tcommsat/server)
+"pew" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "pfK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/incinerator_output{
 	dir = 1
@@ -75677,7 +75678,7 @@ bxy
 aaf
 aaf
 bCq
-bPY
+bSp
 cOw
 bCq
 bCq
@@ -75934,7 +75935,7 @@ bxy
 aaH
 aaH
 bCq
-bPX
+bHE
 bRg
 bRg
 bCq
@@ -76191,9 +76192,9 @@ bGi
 aaf
 aaf
 bLv
-bQa
 bHE
 bHE
+ciT
 bCq
 bHE
 bLv
@@ -77733,7 +77734,7 @@ bLu
 bHE
 bHE
 bHE
-bHE
+bRh
 bLv
 aaf
 bLv
@@ -79535,7 +79536,7 @@ aaa
 aaf
 aaf
 bCq
-bTE
+pew
 bAx
 bCq
 bWC

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -13912,7 +13912,6 @@
 	icon_state = "warningline";
 	dir = 6
 	},
-/obj/vehicle/ridden/secway,
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 4;
 	areastring = "/area/ai_monitored/security/armory";

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -29189,14 +29189,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"buE" = (
-/obj/structure/table,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "buF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -37066,10 +37058,6 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"bOL" = (
-/obj/structure/closet/crate,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "bON" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -49818,6 +49806,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"hxY" = (
+/obj/machinery/computer/bounty{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "hyH" = (
 /obj/machinery/light{
 	dir = 4
@@ -75923,8 +75917,8 @@ boN
 bqo
 brO
 btt
-buE
 bvZ
+hxY
 bxu
 bxx
 bwT
@@ -76181,7 +76175,7 @@ bbR
 bbR
 btu
 bbR
-bOL
+bbR
 bxy
 byF
 bwW

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -3984,11 +3984,12 @@
 /turf/open/space,
 /area/solar/port/fore)
 "ajr" = (
-/obj/machinery/computer/gulag_teleporter_computer,
+/obj/structure/table,
+/obj/item/restraints/handcuffs,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "ajs" = (
-/obj/machinery/gulag_teleporter,
+/obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "ajt" = (
@@ -4290,6 +4291,10 @@
 /obj/structure/chair{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel,
 /area/security/processing)
 "akb" = (
@@ -4308,13 +4313,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
-/area/security/processing)
-"akd" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "ake" = (
@@ -78435,7 +78433,7 @@ aaa
 aaa
 aiU
 ajr
-aka
+alq
 akH
 alq
 amb
@@ -78692,7 +78690,7 @@ aaa
 aaa
 aiU
 aju
-akd
+aka
 akK
 als
 ame


### PR DESCRIPTION
- Removed secways because they are overpowered shits.
- Added the bounty console to replace stocks in cargo
- Made the new old bar more accessible and added some more lootspawns
- Removed the labor camp teleporter because it's overpowered


:cl:
rscadd: The station has been supplied with a bounty console.  
rscdel: Due to budget cuts, secways and the labor camp teleporter are no longer provided to the security team.  
tweak: There has been some work on the old bar in maintenance which is now more accessible.  
/:cl:
