### PR TITLE
Allows you to see powersink power consumption

### DIFF
--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -78,10 +78,6 @@
 				"[user] detaches \the [src] from the cable.", \
 				"<span class='notice'>You detach \the [src] from the cable.</span>",
 				"<span class='italics'>You hear some wires being disconnected from something.</span>")
-	// yogs start - multitool for power drained
-	if(istype(I, /obj/item/multitool))
-		to_chat(user, "The power dial reads [power_drained] J.")
-	// yogs end
 	else
 		return ..()
 

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -80,7 +80,7 @@
 				"<span class='italics'>You hear some wires being disconnected from something.</span>")
 	// yogs start - multitool for power drained
 	if(istype(I, /obj/item/multitool))
-		to_chat(user, "The power dial reads [power_drained] kW.")
+		to_chat(user, "The power dial reads [power_drained] J.")
 	// yogs end
 	else
 		return ..()

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -78,6 +78,10 @@
 				"[user] detaches \the [src] from the cable.", \
 				"<span class='notice'>You detach \the [src] from the cable.</span>",
 				"<span class='italics'>You hear some wires being disconnected from something.</span>")
+	// yogs start - multitool for power drained
+	if(istype(I, /obj/item/multitool))
+		to_chat(user, "The power dial reads [power_drained] kW.")
+	// yogs end
 	else
 		return ..()
 

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2639,6 +2639,7 @@
 #include "yogstation\code\game\objects\items\cards_ids.dm"
 #include "yogstation\code\game\objects\items\crayons.dm"
 #include "yogstation\code\game\objects\items\sharpener.dm"
+#include "yogstation\code\game\objects\items\devices\powersink.dm"
 #include "yogstation\code\game\objects\items\devices\PDA\cart.dm"
 #include "yogstation\code\game\objects\items\devices\PDA\PDA.dm"
 #include "yogstation\code\game\objects\items\devices\PDA\PDA_types.dm"

--- a/yogstation/code/game/objects/items/devices/powersink.dm
+++ b/yogstation/code/game/objects/items/devices/powersink.dm
@@ -2,3 +2,7 @@
 	. = ..()
 	if(isobserver(user))
 		to_chat(user, "The power dial reads [power_drained] J.")
+
+/obj/item/powersink/multitool_act(mob/user)
+	to_chat(user, "The power dial reads [power_drained] J.")
+	return TRUE

--- a/yogstation/code/game/objects/items/devices/powersink.dm
+++ b/yogstation/code/game/objects/items/devices/powersink.dm
@@ -1,0 +1,4 @@
+/obj/item/powersink/examine(mob/user)
+	. = ..()
+	if(isobserver(user))
+		to_chat(user, "The power dial reads [power_drained] kW.")

--- a/yogstation/code/game/objects/items/devices/powersink.dm
+++ b/yogstation/code/game/objects/items/devices/powersink.dm
@@ -1,4 +1,4 @@
 /obj/item/powersink/examine(mob/user)
 	. = ..()
 	if(isobserver(user))
-		to_chat(user, "The power dial reads [power_drained] kW.")
+		to_chat(user, "The power dial reads [power_drained] J.")


### PR DESCRIPTION
Can on the tin. Using either a multitool or examining it while you're an observer will show you the amount of power the powersink has consumed.

:cl:  
rscadd: Using a multitool on a powersink will now show you the amount of power consumed.
/:cl:
