### PR TITLE
Adds include/exclude objective system

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1350,7 +1350,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 20
 	restricted_roles = list("Chaplain")
 	surplus = 5 //Very low chance to get it in a surplus crate even without being the chaplain
-	hijack_only = TRUE //yogs
 
 /datum/uplink_item/role_restricted/pie_cannon
 	name = "Banana Cream Pie Cannon"

--- a/yogstation/code/modules/uplink/uplink.dm
+++ b/yogstation/code/modules/uplink/uplink.dm
@@ -4,8 +4,7 @@
 		for(var/O in U.include_objectives)
 			if(!(locate(O) in user.mind.objectives))
 				continue
-			else
-				canBuy = TRUE
+			canBuy = TRUE
 	else
 		canBuy = TRUE
 
@@ -13,8 +12,7 @@
 		for(var/O in U.exclude_objectives)
 			if(!(locate(O) in user.mind.objectives))
 				continue
-			else
-				canBuy = FALSE
+			canBuy = FALSE
 
 	if(!canBuy)
 		to_chat(user, "<span class='warning'>The Syndicate lacks resources to provide you with this item.</span>")

--- a/yogstation/code/modules/uplink/uplink.dm
+++ b/yogstation/code/modules/uplink/uplink.dm
@@ -1,20 +1,21 @@
 /datum/component/uplink/MakePurchase(mob/user, datum/uplink_item/U)
-	var/canBuy = FALSE
-	if(U.include_objectives.len)
-		for(var/O in U.include_objectives)
-			if(!(locate(O) in user.mind.objectives))
-				continue
-			canBuy = TRUE
-	else
-		canBuy = TRUE
+    var/canBuy = FALSE
 
-	if(U.exclude_objectives.len)
-		for(var/O in U.exclude_objectives)
-			if(!(locate(O) in user.mind.objectives))
-				continue
-			canBuy = FALSE
+    if(U.include_objectives.len)
+        for(var/O in U.include_objectives)
+            if(locate(O) in user.mind.objectives)
+                canBuy = TRUE
+                break
+    else
+        canBuy = TRUE
 
-	if(!canBuy)
-		to_chat(user, "<span class='warning'>The Syndicate lacks resources to provide you with this item.</span>")
-	else
-		..()
+    if(canBuy && U.exclude_objectives.len)
+        for(var/O in U.exclude_objectives)
+            if(locate(O) in user.mind.objectives)
+                canBuy = FALSE
+                break
+
+    if(canBuy)
+        return ..()
+
+    to_chat(user, "<span class='warning'>The Syndicate lacks resources to provide you with this item.</span>")

--- a/yogstation/code/modules/uplink/uplink.dm
+++ b/yogstation/code/modules/uplink/uplink.dm
@@ -1,6 +1,22 @@
 /datum/component/uplink/MakePurchase(mob/user, datum/uplink_item/U)
-	if(U.hijack_only)
-		if(!(locate(/datum/objective/hijack) in user.mind.objectives))
-			to_chat(usr, "<span class='warning'>The Syndicate lacks resources to provide you with this item.</span>")
-			return
-	..()
+	var/canBuy = FALSE
+	if(U.include_objectives.len)
+		for(var/O in U.include_objectives)
+			if(!(locate(O) in user.mind.objectives))
+				continue
+			else
+				canBuy = TRUE
+	else
+		canBuy = TRUE
+
+	if(U.exclude_objectives.len)
+		for(var/O in U.exclude_objectives)
+			if(!(locate(O) in user.mind.objectives))
+				continue
+			else
+				canBuy = FALSE
+
+	if(!canBuy)
+		to_chat(user, "<span class='warning'>The Syndicate lacks resources to provide you with this item.</span>")
+	else
+		..()

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -1,5 +1,6 @@
 /datum/uplink_item
-	var/hijack_only = FALSE //can this item be purchased only during hijackings?
+	var/list/include_objectives = list() //objectives to allow the buyer to buy this item
+	var/list/exclude_objectives = list() //objectives to disallow the buyer from buying this item
 
 /datum/uplink_item/stealthy_weapons/door_charge
 	name = "Explosive Airlock Charge"
@@ -10,3 +11,6 @@
 	cost = 2
 	surplus = 10
 	exclude_modes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/role_restricted/his_grace
+	include_objectives = list(/datum/objective/hijack)


### PR DESCRIPTION
Instead of having a hijack-only var, we can now include/exclude items based on the objectives of the buyer. If a user has both an objective that's necessary, and an objective that blocks it, the blocking takes precedence. 

I also moved his grace over to this system, and am planning on moving romerol, but pR aToMiZaTiOn

No changelog cause it doesn't affect anything in-game **YET!:tm:**