### PR TITLE
Revert "Revert "[MIRROR] Virus crates now contain randomly generated viruses instead of single-symptom advance presets""

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -294,7 +294,7 @@
 /area/ruin/space/has_grav/abandonedzoo)
 "aP" = (
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/bottle/liver_enhance_virion,
+/obj/item/reagent_containers/glass/bottle/random_virus,
 /obj/item/reagent_containers/dropper,
 /turf/open/floor/plasteel{
 	icon_state = "dark"

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -32,6 +32,7 @@
 	var/list/strain_data = list() //dna_spread special bullshit
 	var/list/infectable_biotypes = list(MOB_ORGANIC) //if the disease can spread on organics, synthetics, or undead
 	var/process_dead = FALSE //if this ticks while the host is dead
+	var/copy_type = null //if this is null, copies will use the type of the instance being copied
 
 /datum/disease/Destroy()
 	. = ..()
@@ -141,7 +142,7 @@
 									"bypasses_immunity", "permeability_mod", "severity", "required_organs", "needs_all_cures", "strain_data",
 									"infectable_biotypes", "process_dead")
 
-	var/datum/disease/D = new type()
+	var/datum/disease/D = copy_type ? new copy_type() : new type()
 	for(var/V in copy_vars)
 		var/val = vars[V]
 		if(islist(val))

--- a/code/datums/diseases/advance/presets.dm
+++ b/code/datums/diseases/advance/presets.dm
@@ -1,10 +1,16 @@
 // Cold
+/datum/disease/advance/cold
+	copy_type = /datum/disease/advance
+
 /datum/disease/advance/cold/New()
 	name = "Cold"
 	symptoms = list(new/datum/symptom/sneeze)
 	..()
 
 // Flu
+/datum/disease/advance/flu
+	copy_type = /datum/disease/advance
+
 /datum/disease/advance/flu/New()
 	name = "Flu"
 	symptoms = list(new/datum/symptom/cough)
@@ -13,6 +19,7 @@
 //Randomly generated Disease, for virus crates and events
 /datum/disease/advance/random
 	name = "Experimental Disease"
+	copy_type = /datum/disease/advance
 
 /datum/disease/advance/random/New(max_symptoms, max_level = 8)
 	if(!max_symptoms)
@@ -31,5 +38,5 @@
 			var/datum/symptom/S = new chosen_symptom
 			symptoms += S
 	Refresh()
-	
+
 	name = "Sample #[rand(1,10000)]"

--- a/code/datums/diseases/advance/presets.dm
+++ b/code/datums/diseases/advance/presets.dm
@@ -1,52 +1,35 @@
 // Cold
-
 /datum/disease/advance/cold/New()
 	name = "Cold"
 	symptoms = list(new/datum/symptom/sneeze)
 	..()
 
-
 // Flu
-
 /datum/disease/advance/flu/New()
 	name = "Flu"
 	symptoms = list(new/datum/symptom/cough)
 	..()
 
+//Randomly generated Disease, for virus crates and events
+/datum/disease/advance/random
+	name = "Experimental Disease"
 
-// Voice Changing
-
-/datum/disease/advance/voice_change/New()
-	name = "Epiglottis Mutation"
-	symptoms = list(new/datum/symptom/voice_change)
-	..()
-
-
-// Toxin Filter
-
-/datum/disease/advance/heal/New()
-	name = "Liver Enhancer"
-	symptoms = list(new/datum/symptom/heal)
-	..()
-
-
-// Hallucigen
-
-/datum/disease/advance/hallucigen/New()
-	name = "Second Sight"
-	symptoms = list(new/datum/symptom/hallucigen)
-	..()
-
-// Sensory Restoration
-
-/datum/disease/advance/mind_restoration/New()
-	name = "Intelligence Booster"
-	symptoms = list(new/datum/symptom/mind_restoration)
-	..()
-
-// Sensory Destruction
-
-/datum/disease/advance/narcolepsy/New()
-	name = "Experimental Insomnia Cure"
-	symptoms = list(new/datum/symptom/narcolepsy)
-	..()
+/datum/disease/advance/random/New(max_symptoms, max_level = 8)
+	if(!max_symptoms)
+		max_symptoms = rand(1, VIRUS_SYMPTOM_LIMIT)
+	var/list/datum/symptom/possible_symptoms = list()
+	for(var/symptom in subtypesof(/datum/symptom))
+		var/datum/symptom/S = symptom
+		if(initial(S.level) > max_level)
+			continue
+		if(initial(S.level) <= 0) //unobtainable symptoms
+			continue
+		possible_symptoms += S
+	for(var/i in 1 to max_symptoms)
+		var/datum/symptom/chosen_symptom = pick_n_take(possible_symptoms)
+		if(chosen_symptom)
+			var/datum/symptom/S = new chosen_symptom
+			symptoms += S
+	Refresh()
+	
+	name = "Sample #[rand(1,10000)]"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1123,18 +1123,19 @@
 
 /datum/supply_pack/medical/virus
 	name = "Virus Crate"
-	desc = "Contains twelve different bottles, each filled with a different chemical compound, each useful for virology. Also includes seven beakers and syringes. Balled-up jeans not included. Requires CMO access to open."
+	desc = "Contains twelve different bottles, containing several viral samples for virology research. Also includes seven beakers and syringes. Balled-up jeans not included. Requires CMO access to open."
 	cost = 2500
 	access = ACCESS_CMO
 	contains = list(/obj/item/reagent_containers/glass/bottle/flu_virion,
 					/obj/item/reagent_containers/glass/bottle/cold,
-					/obj/item/reagent_containers/glass/bottle/epiglottis_virion,
-					/obj/item/reagent_containers/glass/bottle/liver_enhance_virion,
+					/obj/item/reagent_containers/glass/bottle/random_virus,
+					/obj/item/reagent_containers/glass/bottle/random_virus,
+					/obj/item/reagent_containers/glass/bottle/random_virus,
+					/obj/item/reagent_containers/glass/bottle/random_virus,
 					/obj/item/reagent_containers/glass/bottle/fake_gbs,
 					/obj/item/reagent_containers/glass/bottle/magnitis,
 					/obj/item/reagent_containers/glass/bottle/pierrot_throat,
 					/obj/item/reagent_containers/glass/bottle/brainrot,
-					/obj/item/reagent_containers/glass/bottle/hallucigen_virion,
 					/obj/item/reagent_containers/glass/bottle/anxiety,
 					/obj/item/reagent_containers/glass/bottle/beesease,
 					/obj/item/storage/box/syringes,

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -61,7 +61,7 @@
 			else
 				D = new virus_type()
 		else
-			D = make_virus(max_severity, max_severity)
+			D = new /datum/disease/advance/random(max_severity, max_severity)
 		D.carrier = TRUE
 		H.ForceContractDisease(D, FALSE, TRUE)
 
@@ -73,23 +73,3 @@
 			message_admins("An event has triggered a random advanced virus outbreak on [ADMIN_LOOKUPFLW(H)]! It has these symptoms: [english_list(name_symptoms)]")
 			log_game("An event has triggered a random advanced virus outbreak on [key_name(H)]! It has these symptoms: [english_list(name_symptoms)]")
 		break
-
-/datum/round_event/disease_outbreak/proc/make_virus(max_symptoms, max_level)
-	if(max_symptoms > VIRUS_SYMPTOM_LIMIT)
-		max_symptoms = VIRUS_SYMPTOM_LIMIT
-	var/datum/disease/advance/A = new /datum/disease/advance()
-	var/list/datum/symptom/possible_symptoms = list()
-	for(var/symptom in subtypesof(/datum/symptom))
-		var/datum/symptom/S = symptom
-		if(initial(S.level) > max_level)
-			continue
-		if(initial(S.level) <= 0) //unobtainable symptoms
-			continue
-		possible_symptoms += S
-	for(var/i in 1 to max_symptoms)
-		var/datum/symptom/chosen_symptom = pick_n_take(possible_symptoms)
-		if(chosen_symptom)
-			var/datum/symptom/S = new chosen_symptom
-			A.symptoms += S
-	A.Refresh() //just in case someone already made and named the same disease
-	return A

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -226,25 +226,10 @@
 	desc = "A small bottle of Romerol. The REAL zombie powder."
 	list_reagents = list("romerol" = 30)
 
-/obj/item/reagent_containers/glass/bottle/flu_virion
-	name = "Flu virion culture bottle"
-	desc = "A small bottle. Contains H13N1 flu virion culture in synthblood medium."
-	spawned_disease = /datum/disease/advance/flu
-
-/obj/item/reagent_containers/glass/bottle/epiglottis_virion
-	name = "Epiglottis virion culture bottle"
-	desc = "A small bottle. Contains Epiglottis virion culture in synthblood medium."
-	spawned_disease = /datum/disease/advance/voice_change
-
-/obj/item/reagent_containers/glass/bottle/liver_enhance_virion
-	name = "Liver enhancement virion culture bottle"
-	desc = "A small bottle. Contains liver enhancement virion culture in synthblood medium."
-	spawned_disease = /datum/disease/advance/heal
-
-/obj/item/reagent_containers/glass/bottle/hallucigen_virion
-	name = "Hallucigen virion culture bottle"
-	desc = "A small bottle. Contains hallucigen virion culture in synthblood medium."
-	spawned_disease = /datum/disease/advance/hallucigen
+/obj/item/reagent_containers/glass/bottle/random_virus
+	name = "Experimental disease culture bottle"
+	desc = "A small bottle. Contains an untested viral culture in synthblood medium."
+	spawned_disease = /datum/disease/advance/random
 
 /obj/item/reagent_containers/glass/bottle/pierrot_throat
 	name = "Pierrot's Throat culture bottle"
@@ -255,6 +240,11 @@
 	name = "Rhinovirus culture bottle"
 	desc = "A small bottle. Contains XY-rhinovirus culture in synthblood medium."
 	spawned_disease = /datum/disease/advance/cold
+	
+/obj/item/reagent_containers/glass/bottle/flu_virion
+	name = "Flu virion culture bottle"
+	desc = "A small bottle. Contains H13N1 flu virion culture in synthblood medium."
+	spawned_disease = /datum/disease/advance/flu
 
 /obj/item/reagent_containers/glass/bottle/retrovirus
 	name = "Retrovirus culture bottle"


### PR DESCRIPTION
Reverts yogstation13/Yogstation-TG#1256

https://github.com/tgstation/tgstation/pull/38472

closes: #1286 