### PR TITLE
Make Subspace Wavelength Analyzer easier to find

### DIFF
--- a/code/modules/research/designs/stock_parts_designs.dm
+++ b/code/modules/research/designs/stock_parts_designs.dm
@@ -288,7 +288,7 @@
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/subspace_analyzer
-	name = "Subspace Analyzer"
+	name = "Subspace Wavelength Analyzer"
 	desc = "A sophisticated analyzer capable of analyzing cryptic subspace wavelengths."
 	id = "s-analyzer"
 	build_type = PROTOLATHE

--- a/code/modules/research/designs/stock_parts_designs.dm
+++ b/code/modules/research/designs/stock_parts_designs.dm
@@ -288,7 +288,7 @@
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/subspace_analyzer
-	name = "Subspace Wavelength Analyzer"
+	name = "Subspace Wavelength Analyzer" //yogs - added Wavelength
 	desc = "A sophisticated analyzer capable of analyzing cryptic subspace wavelengths."
 	id = "s-analyzer"
 	build_type = PROTOLATHE


### PR DESCRIPTION
### Intent of your Pull Request

I was having a hard time finding the Subspace Wavelength Analyzer in the protolathe menu, because it was natural to search for 'wave' or 'wavelength' instead of analyzer (there are a few) and subspace (there are also a few). So this is just to make it easier to find for people when using the search. When a machine needs the wavelength analyzer, it uses the whole name 'subspace wavelength analyzer' so it doesn't match the protolathe name.

#### Changelog

:cl:  
tweak: Use full name for subspace wavelength analyzer in protolathe design menu

/:cl:
