### PR TITLE
Fuckin DRONE BUFFS BABY

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -224,7 +224,7 @@
 	density = TRUE
 
 /obj/machinery/door/firedoor/border_only/CanPass(atom/movable/mover, turf/target)
-	if(istype(mover) && (mover.pass_flags & PASSGLASS))
+	if(istype(mover) && (PASSGLASS | PASSDOOR & mover.pass_flags))//yogs - Drone buff
 		return TRUE
 	if(get_dir(loc, target) == dir) //Make sure looking at appropriate border
 		return !density

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -91,7 +91,7 @@
 	return
 
 /obj/machinery/door/window/CanPass(atom/movable/mover, turf/target)
-	if(istype(mover) && (mover.pass_flags & PASSGLASS))
+	if(istype(mover) && (PASSGLASS | PASSDOOR & mover.pass_flags))//yogs - Drone buff
 		return 1
 	if(get_dir(loc, target) == dir) //Make sure looking at appropriate border
 		return !density

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -51,7 +51,7 @@
 	icon_state = "[facing]_[secure ? "secure_" : ""]windoor_assembly[state]"
 
 /obj/structure/windoor_assembly/CanPass(atom/movable/mover, turf/target)
-	if(istype(mover) && (mover.pass_flags & PASSGLASS))
+	if(istype(mover) && (PASSGLASS | PASSDOOR & mover.pass_flags))//yogs - Drone buff via PASSDOOR
 		return 1
 	if(get_dir(loc, target) == dir) //Make sure looking at appropriate border
 		return !density

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -3,7 +3,10 @@
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/sound/silicon
-	mob_type_allowed_typecache = list(/mob/living/silicon)
+	//yogstart - Drone buffs pt 1
+	mob_type_allowed_typecache = list(/mob/living/silicon,/mob/living/simple_animal/drone)
+	mob_type_blacklist_typecache = list(/mob/living/simple_animal/drone/cogscarab)
+	//yogend
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/silicon/boop

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -31,7 +31,8 @@
 	ventcrawler = VENTCRAWLER_ALWAYS
 	healable = 0
 	density = FALSE
-	pass_flags = PASSTABLE | PASSMOB
+	pass_flags = PASSTABLE | PASSMOB | PASSDOOR //yogs - allowed drones to pass thru airlocks again :D
+	light_color = "#E42742" //yogs - A hacked red, for when it needs to glow when hack'rd
 	sight = (SEE_TURFS | SEE_OBJS)
 	status_flags = (CANPUSH | CANSTUN | CANKNOCKDOWN)
 	gender = NEUTER

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -26,9 +26,8 @@
 	"1. Interfere.\n"+\
 	"2. Kill.\n"+\
 	"3. Destroy."
-	default_storage = /obj/item/radio/uplink
+	default_storage = /obj/item/uplink
 	default_hatmask = /obj/item/clothing/head/helmet/space/hardsuit/syndi
-	seeStatic = 0 //Our programming is superior.
 	hacked = TRUE
 	flavortext = null
 
@@ -44,7 +43,7 @@
 /mob/living/simple_animal/drone/syndrone/badass
 	name = "Badass Syndrone"
 	default_hatmask = /obj/item/clothing/head/helmet/space/hardsuit/syndi/elite
-	default_storage = /obj/item/radio/uplink/nuclear
+	default_storage = /obj/item/uplink/nuclear
 
 /mob/living/simple_animal/drone/syndrone/badass/Initialize()
 	. = ..()
@@ -129,7 +128,6 @@
 	heavy_emp_damage = 0
 	laws = "0. Purge all untruths and honor Ratvar."
 	default_storage = /obj/item/storage/toolbox/brass/prefilled
-	seeStatic = 0
 	hacked = TRUE
 	visualAppearence = CLOCKDRONE
 	can_be_held = FALSE

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -26,8 +26,9 @@
 	"1. Interfere.\n"+\
 	"2. Kill.\n"+\
 	"3. Destroy."
-	default_storage = /obj/item/uplink
+	default_storage = /obj/item/radio/uplink
 	default_hatmask = /obj/item/clothing/head/helmet/space/hardsuit/syndi
+	seeStatic = 0 //Our programming is superior.
 	hacked = TRUE
 	flavortext = null
 
@@ -43,7 +44,7 @@
 /mob/living/simple_animal/drone/syndrone/badass
 	name = "Badass Syndrone"
 	default_hatmask = /obj/item/clothing/head/helmet/space/hardsuit/syndi/elite
-	default_storage = /obj/item/uplink/nuclear
+	default_storage = /obj/item/radio/uplink/nuclear
 
 /mob/living/simple_animal/drone/syndrone/badass/Initialize()
 	. = ..()
@@ -67,6 +68,7 @@
 
 /obj/item/drone_shell/syndrone/badass
 	name = "badass syndrone shell"
+	desc = "A shell of a particularly badass-looking syndrone. You should probably burn this." //yogs
 	drone_type = /mob/living/simple_animal/drone/syndrone/badass
 
 /obj/item/drone_shell/snowflake
@@ -109,7 +111,7 @@
 	icon_dead = "drone_clock_dead"
 	picked = TRUE
 	pass_flags = PASSTABLE
-	health = 50
+	health = 50 // A fair bit stronger than normal drones, actually.
 	maxHealth = 50
 	harm_intent_damage = 5
 	density = TRUE
@@ -127,6 +129,7 @@
 	heavy_emp_damage = 0
 	laws = "0. Purge all untruths and honor Ratvar."
 	default_storage = /obj/item/storage/toolbox/brass/prefilled
+	seeStatic = 0
 	hacked = TRUE
 	visualAppearence = CLOCKDRONE
 	can_be_held = FALSE

--- a/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
@@ -32,6 +32,14 @@
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /mob/living/simple_animal/drone/attack_hand(mob/user)
 	if(ishuman(user))
+		//yog start
+		if(user.a_intent == INTENT_HELP) // If user is nice
+			user.visible_message("[user] pets [src].", \
+							"<span class='notice'>You pet [src].</span>") // Then be pet. <3
+			playsound(src.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1) // hug.ogg
+			return
+		//Else, attempt to pick'em up
+		//yogs end
 		if(stat == DEAD || status_flags & GODMODE || !can_be_held)
 			..()
 			return
@@ -158,6 +166,8 @@
 /mob/living/simple_animal/drone/proc/liberate()
 	// F R E E D R O N E
 	laws = "1. You are a Free Drone."
+	flavortext = "" // yogs - They don't need all the bullshit about drone interaction,
+	// if they're not gonna have laws.
 	to_chat(src, laws)
 
 /mob/living/simple_animal/drone/proc/update_drone_icon()


### PR DESCRIPTION
### AKA: What I get in exchange for drones being almost removed
Big stuff
-Makes drones emaggable, turning them into rabid killing machines with no master. Emagging them again stuns them for a bit, to give you time to run. WORKS
-Drones can phase through airlocks & doors again. WORKS
-Clicking on a drone with an empty hand on help intent now pets them, instead of grabbing them. WORKS
-Drones can now do some silicon emotes!! *ping WORKS

Decent stuff
-Drones can now toggle their nightvision. WORKS
-Drones no longer lose ventcrawl when hacked. It wasn't really possible to hack them so this isn't exactly a removal, but whatever. WORKS
-Hacked drones now glow a dull red. WORKS
-You no longer get the huge DO NOT INTERACT spam when you spawn in as a free or polymorphed drone. WORKS

Minor stuff
-Added some admin logs to yell whenever someone is denied access to drone due to a database error.
-Added a description to the badass syndrone shell.
-Added a chat warning to give to a guy who attempts to enter a drone shell while dronebanned.

#### Changelog

:cl:  
rscadd: You can emag drones!
rscadd: Drones can do silicon emotes!
rscadd: Drones can phase thru doors again!
rscadd: You can pet drones!
spellcheck: fixed a few typos  

/:cl:
