### PR TITLE
Allow cargo protolathe to craft Flight Suit

### DIFF
--- a/code/modules/research/designs/equipment_designs.dm
+++ b/code/modules/research/designs/equipment_designs.dm
@@ -7,7 +7,7 @@
 	materials = list(MAT_METAL=16000, MAT_GLASS = 8000, MAT_DIAMOND = 200, MAT_GOLD = 3000, MAT_SILVER = 3000, MAT_TITANIUM = 16000)	//This expensive enough for you?
 	construction_time = 250
 	category = list("Misc")
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO //yogs - added Cargo permissions
 
 /datum/design/flightpack
 	name = "Flight Pack"
@@ -18,7 +18,7 @@
 	materials = list(MAT_METAL=16000, MAT_GLASS = 8000, MAT_DIAMOND = 4000, MAT_GOLD = 12000, MAT_SILVER = 12000, MAT_URANIUM = 20000, MAT_PLASMA = 16000, MAT_TITANIUM = 16000)	//This expensive enough for you?
 	construction_time = 250
 	category = list("Misc")
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO //yogs - added Cargo permissions
 
 /datum/design/flightshoes
 	name = "Flight Shoes"
@@ -29,4 +29,4 @@
 	materials = list(MAT_METAL = 5000, MAT_GLASS = 5000, MAT_GOLD = 1500, MAT_SILVER = 1500, MAT_PLASMA = 2000, MAT_TITANIUM = 2000)
 	construction_time = 100
 	category = list("Misc")
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO //yogs - added Cargo permissions

--- a/code/modules/research/designs/equipment_designs.dm
+++ b/code/modules/research/designs/equipment_designs.dm
@@ -7,7 +7,7 @@
 	materials = list(MAT_METAL=16000, MAT_GLASS = 8000, MAT_DIAMOND = 200, MAT_GOLD = 3000, MAT_SILVER = 3000, MAT_TITANIUM = 16000)	//This expensive enough for you?
 	construction_time = 250
 	category = list("Misc")
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO
 
 /datum/design/flightpack
 	name = "Flight Pack"
@@ -18,7 +18,7 @@
 	materials = list(MAT_METAL=16000, MAT_GLASS = 8000, MAT_DIAMOND = 4000, MAT_GOLD = 12000, MAT_SILVER = 12000, MAT_URANIUM = 20000, MAT_PLASMA = 16000, MAT_TITANIUM = 16000)	//This expensive enough for you?
 	construction_time = 250
 	category = list("Misc")
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO
 
 /datum/design/flightshoes
 	name = "Flight Shoes"
@@ -29,4 +29,4 @@
 	materials = list(MAT_METAL = 5000, MAT_GLASS = 5000, MAT_GOLD = 1500, MAT_SILVER = 1500, MAT_PLASMA = 2000, MAT_TITANIUM = 2000)
 	construction_time = 100
 	category = list("Misc")
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO


### PR DESCRIPTION
### Intent of your Pull Request

Nearly every round, someone from mining breaks into Engineering to use the engineering protolathe to craft a flight suit. It's a powerful, albeit expensive tool, just with the added annoyance of having to get into engineering to make it. The only reason I think this might need further tweaking is to increase the material cost. If cargo gets manipulator upgrades, and their miners are competent, there could be a few of these running around. Maybe that's not a bad thing late game.

#### Changelog

:cl:  
tweak: Allow cargo protolathe to craft flight suit
/:cl:
