### PR TITLE
Move Mining Satchel of Holding to Mining Designs

### DIFF
--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -43,13 +43,3 @@
 	build_path = /obj/item/gps
 	category = list("Bluespace Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO
-
-/datum/design/miningsatchel_holding
-	name = "Mining Satchel of Holding"
-	desc = "A mining satchel that can hold an infinite amount of ores."
-	id = "minerbag_holding"
-	build_type = PROTOLATHE
-	materials = list(MAT_GOLD = 250, MAT_URANIUM = 500) //quite cheap, for more convenience
-	build_path = /obj/item/storage/bag/ore/holding
-	category = list("Bluespace Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_CARGO

--- a/code/modules/research/designs/mining_designs.dm
+++ b/code/modules/research/designs/mining_designs.dm
@@ -139,5 +139,5 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_GOLD = 250, MAT_URANIUM = 500) //quite cheap, for more convenience
 	build_path = /obj/item/storage/bag/ore/holding
-	category = list("Bluespace Designs")
+	category = list("Bluespace Designs", "Mining Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO

--- a/code/modules/research/designs/mining_designs.dm
+++ b/code/modules/research/designs/mining_designs.dm
@@ -131,3 +131,13 @@
 	build_path = /obj/item/borg/upgrade/modkit/aoe/turfs
 	category = list("Mining Designs", "Cyborg Upgrade Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO
+	
+/datum/design/miningsatchel_holding
+	name = "Mining Satchel of Holding"
+	desc = "A mining satchel that can hold an infinite amount of ores."
+	id = "minerbag_holding"
+	build_type = PROTOLATHE
+	materials = list(MAT_GOLD = 250, MAT_URANIUM = 500) //quite cheap, for more convenience
+	build_path = /obj/item/storage/bag/ore/holding
+	category = list("Bluespace Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_CARGO


### PR DESCRIPTION
### Intent of your Pull Request

Mining Satchel of Holding seems like it ought to be better categorized in the mining designs, rather than bluespace.

#### Changelog

:cl:  
tweak: Moved mining satchel of holding to mining designs from bluespace
/:cl:
