### PR TITLE
Removes par from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,8 +17,7 @@
 /_maps/shuttles/ @Nichlas0010
 
 #Partheo
-/icons/ @Partheo
-/yogstation/icons/ @Partheo
+#/yogstation/icons/ @Partheo
 
 #ThatLing
 


### PR DESCRIPTION
doesn't review things anywho, and he can always ask for it to be uncommented. Also removed the /icons/ since only /tg/ uses them, and they get merged anyways