### PR TITLE
Moves hotkeys-help to OOC tab

### DIFF
--- a/yogstation/interface/interface.dm
+++ b/yogstation/interface/interface.dm
@@ -1,4 +1,7 @@
 /client/verb/hotkeys_help()
+	set name = "hotkeys-help"
+	set category = "OOC"
+
 	to_chat(src, "All hotkeys can be viewed and modified under Preferences -> Keybindings. Click on Default to switch to hotkeys mode")
 
 /client/verb/show_tickets()


### PR DESCRIPTION
Messed this up when mirroring it.

:cl:
bugfix: hotkeys-help is now displayed under the OOC tab.
/:cl: