### PR TITLE
Viro console on Yogs map now alerts you when ores are added to the orm

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -48721,7 +48721,9 @@
 /obj/item/clothing/gloves/color/latex,
 /obj/machinery/requests_console{
 	department = "Virology";
+	receive_ore_updates = 1;
 	name = "Virology Requests Console";
+	
 	pixel_x = -32
 	},
 /obj/item/healthanalyzer,


### PR DESCRIPTION
I think I did it right

:cl:
tweak: the viro requests console on the Yogs map now gives an alert when ores are added to the orm
/:cl: