### PR TITLE
romerol re-balance(?)

### DIFF
--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -12,6 +12,10 @@
 	surplus = 10
 	exclude_modes = list(/datum/game_mode/nuclear)
 
+/datum/uplink_item/stealthy_weapons/romerol_kit
+	include_objectives = list(/datum/objective/hijack)
+	exclude_modes = list()
+
 /datum/uplink_item/device_tools/arm
 	name = "Additional Arm"
 	desc = "An additional arm, automatically added to your body upon purchase, allows you to use more items at once"

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -13,16 +13,12 @@
 	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_weapons/romerol_kit
-	include_objectives = list(/datum/objective/hijack)
+	include_objectives = list(/datum/objective/hijack, /datum/objective/martyr)
 
-/datum/uplink_item/stealthy_weapons/romerol_nuke
-	name = "Romerol"
-	desc = "A highly experimental bioterror agent which creates dormant nodules to be etched into the grey matter of the brain. On death, these nodules take control of the dead body, causing limited revivification, along with slurred speech, aggression, and the ability to infect others with this agent."
-	item = /obj/item/storage/box/syndie_kit/romerol
-	cost = 25
-	cant_discount = TRUE
+/datum/uplink_item/stealthy_weapons/romerol_kit/nuke
 	surplus = 0
 	include_modes = list(/datum/game_mode/nuclear)
+	include_objectives = null
 
 /datum/uplink_item/device_tools/arm
 	name = "Additional Arm"

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -14,7 +14,15 @@
 
 /datum/uplink_item/stealthy_weapons/romerol_kit
 	include_objectives = list(/datum/objective/hijack)
-	exclude_modes = list()
+
+/datum/uplink_item/stealthy_weapons/romerol_nuke
+	name = "Romerol"
+	desc = "A highly experimental bioterror agent which creates dormant nodules to be etched into the grey matter of the brain. On death, these nodules take control of the dead body, causing limited revivification, along with slurred speech, aggression, and the ability to infect others with this agent."
+	item = /obj/item/storage/box/syndie_kit/romerol
+	cost = 25
+	cant_discount = TRUE
+	surplus = 0
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/device_tools/arm
 	name = "Additional Arm"


### PR DESCRIPTION
### Intent of your Pull Request

Makes it so romerol can only be bought during normal play if it's by a hijacker, but it can now be bought by nuke ops. 

It's quite uuh, murderboney, to say the least but I quite agree with Fluffe's sentiment that it shouldn't be completely removed, so I added it to nuke ops cause why not

#### Changelog

:cl:  
tweak: Romerol requires hijack, but can be bought by nuke-ops
/:cl:
