### PR TITLE
Removes pickup animation

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -774,39 +774,3 @@
 	if(anchored || throwing)
 		return FALSE
 	return TRUE
-
-
-/obj/item/proc/do_pickup_animation(atom/target)
-	set waitfor = FALSE
-	var/mutable_appearance/I = new(icon = src, loc = loc, layer = layer + 0.1)
-	I.plane = GAME_PLANE
-	I.transform *= 0.75
-	I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
-	var/turf/T = get_turf(src)
-	var/direction
-	var/to_x = 0
-	var/to_y = 0
-
-	flick_overlay(I, GLOB.clients, 6)
-	var/static/matrix/M = new
-	M.Turn(pick(-30, 30))
-
-	animate(I, transform = M, time = 1)
-	sleep(1)
-	animate(I, transform = matrix(), time = 1)
-	sleep(1)
-	if(!QDELETED(T) && !QDELETED(target))
-		direction = get_dir(T, target)
-	if(direction & NORTH)
-		to_y = 32
-	else if(direction & SOUTH)
-		to_y = -32
-	if(direction & EAST)
-		to_x = 32
-	else if(direction & WEST)
-		to_x = -32
-	if(!direction)
-		to_y = 16
-	animate(I, alpha = 175, pixel_x = to_x, pixel_y = to_y, time = 3, easing = CUBIC_EASING)
-	sleep(1)
-	animate(I, alpha = 0, time = 1)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -172,8 +172,6 @@
 
 /mob/proc/put_in_hand(obj/item/I, hand_index, forced = FALSE)
 	if(forced || can_put_in_hand(I, hand_index))
-		if(isturf(I.loc))
-			I.do_pickup_animation(src)
 		if(hand_index == null)
 			return FALSE
 		if(get_item_for_held_index(hand_index) != null)


### PR DESCRIPTION
I've only heard negative reactions to this change. This is to potentially revert the pull. Maybe I'm only hearing the loud minority but this was an easy enough change.

### Fair warning everyone. This is an incomplete PR that is causing the spin tiles. See Morrow's post to see what it's supposed to actually look like. I'll keep this up just in case we still don't want it.

#### Changelog

:cl:    
rscdel: Removed item pickup animation
/:cl:
