### PR TITLE
Revs don’t clap when the head of a head rev gets beheaded v2: actually might work version

### DIFF
--- a/code/game/objects/structures/guillotine.dm
+++ b/code/game/objects/structures/guillotine.dm
@@ -140,7 +140,7 @@
 			for(var/mob/M in viewers(src, 7))
 				var/mob/living/carbon/human/C = M
 				if (ishuman(M))
-					if(!((H.mind.has_antag_datum(/datum/antagonist/rev/head)) && ((H.mind.has_antag_datum(/datum/antagonist/rev/head)) || (H.mind.has_antag_datum(/datum/antagonist/rev))))) //if the victim is a revhead AND the witness is either a revhead or a rev, do not clap 
+					if(!((H.mind.has_antag_datum(/datum/antagonist/rev/head)) && ((M.mind.has_antag_datum(/datum/antagonist/rev/head)) || (M.mind.has_antag_datum(/datum/antagonist/rev))))) //if the victim is a revhead AND the witness is either a revhead or a rev, do not clap 
 						addtimer(CALLBACK(C, /mob/.proc/emote, "clap"), delay_offset * 0.3)
 						delay_offset++
 		else

--- a/code/game/objects/structures/guillotine.dm
+++ b/code/game/objects/structures/guillotine.dm
@@ -140,8 +140,9 @@
 			for(var/mob/M in viewers(src, 7))
 				var/mob/living/carbon/human/C = M
 				if (ishuman(M))
-					addtimer(CALLBACK(C, /mob/.proc/emote, "clap"), delay_offset * 0.3)
-					delay_offset++
+					if(!((H.mind.has_antag_datum(/datum/antagonist/rev/head)) && ((H.mind.has_antag_datum(/datum/antagonist/rev/head)) || (H.mind.has_antag_datum(/datum/antagonist/rev))))) //if the victim is a revhead AND the witness is either a revhead or a rev, do not clap 
+						addtimer(CALLBACK(C, /mob/.proc/emote, "clap"), delay_offset * 0.3)
+						delay_offset++
 		else
 			H.apply_damage(15 * blade_sharpness, BRUTE, head)
 			add_logs(user, H, "dropped the blade on", src, " non-fatally")


### PR DESCRIPTION
### The Death of our glorious martyr no longer compells us to clap!
If you’re a head rev or a rev, you will not clap automatically when the guillotine kills a head rev. NT’s finest can use this to try and see who’s a rev, but I don’t think that’ll matter too much since you can still manually do *clap to clap.

I’m debating also making it so mindshielded crew don’t clap when a head of staff is executed, but ehhhhhh I’ll do that later or not at all, lets see if this actually works first.

I also put my if statements on one line, if it causes lag or is annoying to read or whatever I can nest multiple if statements instead.

####Changelog:
:cl:  
tweak: Guillotined head revs no longer cause revs to clap.
/:cl:
