### PR TITLE
makes basic stock parts able to be constructed by all lathes

### DIFF
--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2724,6 +2724,7 @@
 #include "yogstation\code\modules\power\validhunter.dm"
 #include "yogstation\code\modules\reagents\reagent_containers\hypospray.dm"
 #include "yogstation\code\modules\research\rdconsole.dm"
+#include "yogstation\code\modules\research\designs\stock_parts_designs.dm"
 #include "yogstation\code\modules\spells\spells.dm"
 #include "yogstation\code\modules\spells\spell_types\mime.dm"
 #include "yogstation\code\modules\uplink\uplink_item.dm"

--- a/yogstation/code/modules/research/designs/stock_parts_designs.dm
+++ b/yogstation/code/modules/research/designs/stock_parts_designs.dm
@@ -1,0 +1,15 @@
+/datum/design/basic_capacitor
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
+
+/datum/design/basic_scanning
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
+
+/datum/design/micro_mani
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
+
+/datum/design/basic_micro_laser
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
+
+/datum/design/basic_matter_bin
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
+


### PR DESCRIPTION
Makes the non-engi/sci departments able to build basic machines, but keeps the upgrading as part of engi/sci territory.

#### Changelog

:cl:  
tweak: all departments can now print the basic stock parts, but advanced stock parts belong to engi/sci only
/:cl:
