### PR TITLE
Alien disarms now take armour into account

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -271,8 +271,19 @@
 				visible_message("<span class='danger'>[M] disarmed [src]!</span>", \
 						"<span class='userdanger'>[M] disarmed [src]!</span>")
 			else
+				//yogs start
+				var/obj/item/bodypart/affecting = get_bodypart(ran_zone(M.zone_selected))
+				if(!affecting)
+					affecting = get_bodypart(BODY_ZONE_CHEST)
+				var/armour = run_armor_check(affecting, "melee")
+				if(prob(armour))
+					return
 				playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
-				Knockdown(100)
+				if(armour > 0)
+					Knockdown(100 - armour)
+				else
+					Knockdown(100)
+				//yogs end
 				add_logs(M, src, "tackled")
 				visible_message("<span class='danger'>[M] has tackled down [src]!</span>", \
 					"<span class='userdanger'>[M] has tackled down [src]!</span>")

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -277,6 +277,7 @@
 					affecting = get_bodypart(BODY_ZONE_CHEST)
 				var/armour = run_armor_check(affecting, "melee")
 				if(prob(armour))
+					to_chat(M, "<span class='notice'>[src]'s armour shields the blow!</span>")
 					return
 				playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
 				if(armour > 0)


### PR DESCRIPTION
### Intent of your Pull Request

Basically, as of right now aliens getting a singular disarm in means they win combat, now the armour value of the attacked person factors in to whether or not they get disarmed, and for how long they get disarmed for.

heavily inspired by this: https://github.com/vgstation-coders/vgstation13/pull/19010

#### Changelog

:cl:  
tweak: Armour now protects you from being disarmed by xenomorphs
/:cl:
