### PR TITLE
moves stationroom loading to the SSmapping subsystem

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -88,6 +88,7 @@ SUBSYSTEM_DEF(mapping)
 	var/list/space_ruins = levels_by_trait(ZTRAIT_SPACE_RUINS)
 	if (space_ruins.len)
 		seedRuins(space_ruins, CONFIG_GET(number/space_budget), /area/space, space_ruins_templates)
+	seedStation()
 	loading_ruins = FALSE
 #endif
 	repopulate_sorted_areas()

--- a/yogstation/code/controllers/subsystem/yogs.dm
+++ b/yogstation/code/controllers/subsystem/yogs.dm
@@ -4,7 +4,7 @@ SUBSYSTEM_DEF(YogFeatures)
 	init_order = -101 //last subsystem to initialize, and first to shut down
 
 /datum/controller/subsystem/YogFeatures/Initialize()
-	..()
+	return ..()
 
 /datum.controller/subsystem/YogFeatures/fire(resumed = 0)
 	return

--- a/yogstation/code/controllers/subsystem/yogs.dm
+++ b/yogstation/code/controllers/subsystem/yogs.dm
@@ -4,8 +4,6 @@ SUBSYSTEM_DEF(YogFeatures)
 	init_order = -101 //last subsystem to initialize, and first to shut down
 
 /datum/controller/subsystem/YogFeatures/Initialize()
-	SSmapping.seedStation()
-	return ..()
 
 /datum.controller/subsystem/YogFeatures/fire(resumed = 0)
 	return

--- a/yogstation/code/controllers/subsystem/yogs.dm
+++ b/yogstation/code/controllers/subsystem/yogs.dm
@@ -4,6 +4,7 @@ SUBSYSTEM_DEF(YogFeatures)
 	init_order = -101 //last subsystem to initialize, and first to shut down
 
 /datum/controller/subsystem/YogFeatures/Initialize()
+	..()
 
 /datum.controller/subsystem/YogFeatures/fire(resumed = 0)
 	return


### PR DESCRIPTION
So as of right now, it works fine in the yogs subsystem but if I want it to use areas properly then it needs to be during the ruinloading, otherwise they don't load properly. so now the SSyogs is unused, but oh well