### PR TITLE
[admin] asay calls AOs OBSERVER instead of ADMIN

### DIFF
--- a/yogstation/code/modules/admin/verbs/adminsay.dm
+++ b/yogstation/code/modules/admin/verbs/adminsay.dm
@@ -14,10 +14,10 @@
 	msg = emoji_parse(msg)
 	msg = keywords_lookup(msg)
 	if(check_rights(R_ADMIN,0))
-		msg = "<span class='adminobserver'><span class='prefix'>ADMIN:</span> <EM>[key_name(usr, 1)]</EM> [ADMIN_FLW(mob)]: <span class='message'>[msg]</span></span>"
+		msg = "<span class='adminsay'><span class='prefix'>ADMIN:</span> <EM>[key_name(usr, 1)]</EM> [ADMIN_FLW(mob)]: <span class='message'>[msg]</span></span>"
 		to_chat(GLOB.admins, msg)
 	else
-		msg = "<span class='adminobserver'><span class='prefix'>ADMIN:</span> <EM>[key_name(usr, 1)]</EM> [ADMIN_FLW(mob)]: <span class='message'>[msg]</span></span>"
+		msg = "<span class='adminsay'><span class='prefix'>OBSERVER:</span> <EM>[key_name(usr, 1)]</EM> [ADMIN_FLW(mob)]: <span class='message'>[msg]</span></span>"
 		to_chat(GLOB.admins, msg)
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Asay") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!


### PR DESCRIPTION
### Intent of your Pull Request
Changes the ADMIN of asay to OBSERVER if they're an AO. Also changes it to using the adminsay span, which is necessary as of https://github.com/yogstation13/Yogstation-TG/pull/2035

#### Changelog

:cl:  
tweak: AOs now have OBSERVER instead of ADMIN in asay
/:cl:
