### PR TITLE
[admin] Adds law history for silicons

### DIFF
--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -72,7 +72,7 @@ AI MODULES
 	log_law("[user.key]/[user.name] used [src.name] on [aikey]/([ainame]) from [AREACOORD(user)].[law2log ? " The law specified [law2log]" : ""]")
 	message_admins("[ADMIN_LOOKUPFLW(user)] used [src.name] on [ADMIN_LOOKUPFLW(law_datum.owner)] from [AREACOORD(user)].[law2log ? " The law specified [law2log]" : ""]")
 	if(law_datum.owner) //yogs
-		law_datum.owner.update_law_history()
+		law_datum.owner.update_law_history(user)
 
 //The proc that actually changes the silicon's laws.
 /obj/item/aiModule/proc/transmitInstructions(datum/ai_laws/law_datum, mob/sender, overflow = FALSE)

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -71,6 +71,8 @@ AI MODULES
 	GLOB.lawchanges.Add("[time] <B>:</B> [user.name]([user.key]) used [src.name] on [ainame]([aikey]).[law2log ? " The law specified [law2log]" : ""]")
 	log_law("[user.key]/[user.name] used [src.name] on [aikey]/([ainame]) from [AREACOORD(user)].[law2log ? " The law specified [law2log]" : ""]")
 	message_admins("[ADMIN_LOOKUPFLW(user)] used [src.name] on [ADMIN_LOOKUPFLW(law_datum.owner)] from [AREACOORD(user)].[law2log ? " The law specified [law2log]" : ""]")
+	if(law_datum.owner) //yogs
+		law_datum.owner.update_law_history()
 
 //The proc that actually changes the silicon's laws.
 /obj/item/aiModule/proc/transmitInstructions(datum/ai_laws/law_datum, mob/sender, overflow = FALSE)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -71,7 +71,8 @@ GLOBAL_LIST_INIT(admin_verbs_admin, world.AVerbsAdmin())
 	/client/proc/respawn_character,
 	/datum/admins/proc/open_borgopanel,
 	/datum/admins/proc/restart, //yogs - moved from +server
-	/client/proc/admin_pick_random_player //yogs
+	/client/proc/admin_pick_random_player, //yogs
+	/client/proc/get_law_history //yogs
 	)
 GLOBAL_PROTECT(admin_verbs_ban)
 GLOBAL_LIST_INIT(admin_verbs_ban, list(/client/proc/unban_panel, /client/proc/DB_ban_panel, /client/proc/stickybanpanel))
@@ -186,7 +187,7 @@ GLOBAL_LIST_INIT(admin_verbs_hideable, list(
 	/client/proc/admin_ghost,
 	/client/proc/toggle_view_range,
 	/client/proc/cmd_admin_subtle_message,
-	/client/proc/cmd_admin_headset_message,	
+	/client/proc/cmd_admin_headset_message,
 	/client/proc/cmd_admin_check_contents,
 	/datum/admins/proc/access_news_network,
 	/client/proc/admin_call_shuttle,

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -105,6 +105,8 @@
 	else
 		make_laws()
 
+	update_law_history() //yogs
+
 	if(target_ai.mind)
 		target_ai.mind.transfer_to(src)
 		if(mind.special_role)

--- a/code/modules/mob/living/silicon/robot/laws.dm
+++ b/code/modules/mob/living/silicon/robot/laws.dm
@@ -79,4 +79,5 @@
 			if (length(temp) > 0)
 				laws.supplied[index] = temp
 
+		update_law_history() //yogs
 	picturesync()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -132,6 +132,8 @@
 		if(!TryConnectToAI())
 			lawupdate = FALSE
 
+	update_law_history() //yogs
+
 	radio = new /obj/item/radio/borg(src)
 	if(!scrambledcodes && !builtInCamera)
 		builtInCamera = new (src)

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2739,6 +2739,7 @@
 #include "yogstation\code\modules\mob\dead\new_player\new_player.dm"
 #include "yogstation\code\modules\mob\living\carbon\human\life.dm"
 #include "yogstation\code\modules\mob\living\carbon\human\species_types\plantpeople.dm"
+#include "yogstation\code\modules\mob\living\silicon\silicon.dm"
 #include "yogstation\code\modules\mob\living\silicon\ai\ai.dm"
 #include "yogstation\code\modules\mob\living\silicon\ai\vox_sounds.dm"
 #include "yogstation\code\modules\mob\living\silicon\robot\robot.dm"

--- a/yogstation/code/modules/admin/admin_verbs.dm
+++ b/yogstation/code/modules/admin/admin_verbs.dm
@@ -65,7 +65,7 @@
 	set desc = "View list of law changes for silicons."
 	var/data = ""
 	for(var/mob/living/silicon/S in GLOB.silicon_mobs)
-		data += "<h1>[S.name]:</h1>\n"
+		data += "<h1>[key_name(S)]:</h1>\n"
 		data += "<ol>\n"
 		for(var/lawset in S.law_history)
 			data += " <li>[lawset]</li><br>\n"

--- a/yogstation/code/modules/admin/admin_verbs.dm
+++ b/yogstation/code/modules/admin/admin_verbs.dm
@@ -58,3 +58,16 @@
 	var/mob/chosen_player = pick(mobs)
 	to_chat(src, "[chosen_player] has been chosen")
 	holder.show_player_panel(chosen_player)
+
+/client/proc/get_law_history()
+	set name = "Get Law History"
+	set category = "Admin"
+	set desc = "View list of law changes for silicons."
+	var/data = ""
+	for(var/mob/living/silicon/S in GLOB.silicon_mobs)
+		data += "<h1>[S.name]:</h1>\n"
+		data += "<ol>\n"
+		for(var/lawset in S.law_history)
+			data += " <li>[lawset]</li><br>\n"
+		data += "</ol>\n"
+	src << browse(data, "window=law_history")

--- a/yogstation/code/modules/mob/living/silicon/silicon.dm
+++ b/yogstation/code/modules/mob/living/silicon/silicon.dm
@@ -2,7 +2,12 @@
 	var/list/law_history = list()
 
 /mob/living/silicon/proc/update_law_history(mob/uploader = null)
-	var/new_entry = "Uploaded by [uploader ? key_name(uploader) : "Law sync to AI"] at [worldtime2text()]<br>"
+	var/ai_law_sync = "UNKNOWN/Innate laws"
+	if(!uploader && iscyborg(src))
+		var/mob/living/silicon/robot/R = src
+		if(R.connected_ai)
+			ai_law_sync = "law sync with [key_name(R.connected_ai)]"
+	var/new_entry = "Uploaded by [uploader ? key_name(uploader) : ai_law_sync] at [worldtime2text()]<br>"
 	var/list/printable_laws = laws.get_law_list(include_zeroth = TRUE)
 	for(var/law in printable_laws)
 		new_entry += "[law]<br>"

--- a/yogstation/code/modules/mob/living/silicon/silicon.dm
+++ b/yogstation/code/modules/mob/living/silicon/silicon.dm
@@ -1,9 +1,11 @@
 /mob/living/silicon
 	var/list/law_history = list()
 
-/mob/living/silicon/proc/update_law_history()
-	var/new_entry = ""
+/mob/living/silicon/proc/update_law_history(mob/uploader = null)
+	var/new_entry = "Uploaded by [uploader ? key_name(uploader) : "Law sync to AI"] at [worldtime2text()]<br>"
 	var/list/printable_laws = laws.get_law_list(include_zeroth = TRUE)
 	for(var/law in printable_laws)
 		new_entry += "[law]<br>"
+	if(law_history.len && new_entry == law_history[law_history.len])
+		return
 	law_history += new_entry

--- a/yogstation/code/modules/mob/living/silicon/silicon.dm
+++ b/yogstation/code/modules/mob/living/silicon/silicon.dm
@@ -1,0 +1,9 @@
+/mob/living/silicon
+	var/list/law_history = list()
+
+/mob/living/silicon/proc/update_law_history()
+	var/new_entry = ""
+	var/list/printable_laws = laws.get_law_list(include_zeroth = TRUE)
+	for(var/law in printable_laws)
+		new_entry += "[law]<br>"
+	law_history += new_entry


### PR DESCRIPTION
Gives admins a new button, "Get Law History" in Admin tab, which shows you the law changes for all silicons. The first laws in the list are the ones the silicon started with. Looks like this:
![image](https://user-images.githubusercontent.com/16842348/43776278-9fee1768-9a4f-11e8-84e1-44c834e8ff68.png)

