### PR TITLE
Refactored DAMN DANIEL to use a component.

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -70,7 +70,6 @@
 #define COMSIG_ATOM_RAD_WAVE_PASSING "atom_rad_wave_pass"		//from base of datum/radiation_wave/check_obstructions(): (datum/radiation_wave, width)
 #define COMSIG_ATOM_CANREACH "atom_can_reach"					//from internal loop in atom/movable/proc/CanReach(): (list/next)
 	#define COMPONENT_BLOCK_REACH 1
-#define COMSIG_ATOM_POINTED_AT "atom_pointed_at"				//yogs: from base of atom/pointed_at(): (mob/user)
 /////////////////
 #define COMSIG_ATOM_ATTACK_GHOST "atom_attack_ghost"			//from base of atom/attack_ghost(): (mob/dead/observer/ghost)
 #define COMSIG_ATOM_ATTACK_HAND "atom_attack_hand"				//from base of atom/attack_hand(): (mob/user)

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -70,6 +70,7 @@
 #define COMSIG_ATOM_RAD_WAVE_PASSING "atom_rad_wave_pass"		//from base of datum/radiation_wave/check_obstructions(): (datum/radiation_wave, width)
 #define COMSIG_ATOM_CANREACH "atom_can_reach"					//from internal loop in atom/movable/proc/CanReach(): (list/next)
 	#define COMPONENT_BLOCK_REACH 1
+#define COMSIG_ATOM_POINTED_AT "atom_pointed_at"				//yogs: from base of atom/pointed_at(): (mob/user)
 /////////////////
 #define COMSIG_ATOM_ATTACK_GHOST "atom_attack_ghost"			//from base of atom/attack_ghost(): (mob/dead/observer/ghost)
 #define COMSIG_ATOM_ATTACK_HAND "atom_attack_hand"				//from base of atom/attack_hand(): (mob/user)

--- a/code/__DEFINES/~yogs_defines/components.dm
+++ b/code/__DEFINES/~yogs_defines/components.dm
@@ -1,0 +1,1 @@
+#define COMSIG_ATOM_POINTED_AT "atom_pointed_at"				//yogs: from base of atom/pointed_at(): (mob/user)

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2655,6 +2655,7 @@
 #include "yogstation\code\datums\mind.dm"
 #include "yogstation\code\datums\shuttles.dm"
 #include "yogstation\code\datums\world_topic.dm"
+#include "yogstation\code\datums\components\daniel.dm"
 #include "yogstation\code\datums\components\uplink.dm"
 #include "yogstation\code\datums\diseases\advance\symptoms\confusion.dm"
 #include "yogstation\code\datums\diseases\advance\symptoms\heal.dm"

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -98,6 +98,7 @@
 #include "code\__DEFINES\wires.dm"
 #include "code\__DEFINES\~yogs_defines\access.dm"
 #include "code\__DEFINES\~yogs_defines\admin.dm"
+#include "code\__DEFINES\~yogs_defines\components.dm"
 #include "code\__DEFINES\~yogs_defines\jobs.dm"
 #include "code\__DEFINES\~yogs_defines\keybindings.dm"
 #include "code\__DEFINES\~yogs_defines\preferences.dm"

--- a/yogstation/code/datums/components/daniel.dm
+++ b/yogstation/code/datums/components/daniel.dm
@@ -1,0 +1,9 @@
+/datum/component/daniel/Initialize()
+    if(!isobj(parent))
+        return COMPONENT_INCOMPATIBLE
+
+    RegisterSignal(parent, COMSIG_ATOM_POINTED_AT, .proc/damn)
+
+/datum/component/daniel/proc/damn(mob/user)
+    spawn(10)
+        user.say("DAMN DANIEL!")

--- a/yogstation/code/modules/clothing/shoes/colour.dm
+++ b/yogstation/code/modules/clothing/shoes/colour.dm
@@ -1,3 +1,6 @@
+/obj/item/clothing/shoes/sneakers/white/Initialize()
+	. = ..()
+	LoadComponent(/datum/component/daniel)
+
 /obj/item/clothing/shoes/sneakers/white/pointed_at(var/mob/user)
-	spawn(10)
-		user.say("DAMN DANIEL!")
+	. = ..()

--- a/yogstation/code/modules/clothing/shoes/colour.dm
+++ b/yogstation/code/modules/clothing/shoes/colour.dm
@@ -1,6 +1,4 @@
 /obj/item/clothing/shoes/sneakers/white/Initialize()
 	. = ..()
 	LoadComponent(/datum/component/daniel)
-
-/obj/item/clothing/shoes/sneakers/white/pointed_at(var/mob/user)
-	. = ..()
+	

--- a/yogstation/code/modules/mob/mob.dm
+++ b/yogstation/code/modules/mob/mob.dm
@@ -1,2 +1,2 @@
 /atom/proc/pointed_at(var/mob/user)
-	return
+	SEND_SIGNAL(src, COMSIG_ATOM_POINTED_AT, user)


### PR DESCRIPTION
This PR adds a component signal for when an atom is pointed to, and refactors the previous 'DAMN DANIEL' functionality to to use that component.

In the future, if we have any need of making people scream 'DAMN DANIEL' when they point to something else, it's as easy as one line.

#### Changelog

:cl:  
rscadd: Added component signal for when something is pointed to.
/:cl:
