### PR TITLE
Allows a traitor chef to buy gondola meat using their uplink

### DIFF
--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -39,5 +39,5 @@
 	name = "Gondola meat"
 	desc = "A slice of gondola meat will turn any hard-working, brainwashed NT employee into a goody-two-shoes gondola in a matter of minutes."
 	item = /obj/item/reagent_containers/food/snacks/meat/slab/gondola
-	cost = 2
+	cost = 6
 	restricted_roles = list("Cook")

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -37,7 +37,7 @@
 
 /datum/uplink_item/role_restricted/gondola_meat
 	name = "Gondola meat"
-	desc = "A slice of gondola meat will turn any brainwashed Nanotrasen employee into a goody-two-shoes gondola."
+	desc = "A slice of gondola meat will turn any hard-working, brainwashed NT employee into a goody-two-shoes gondola in a matter of minutes."
 	item = /obj/item/reagent_containers/food/snacks/meat/slab/gondola
 	cost = 2
 	restricted_roles = list("Cook")

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -2,6 +2,7 @@
 	var/list/include_objectives = list() //objectives to allow the buyer to buy this item
 	var/list/exclude_objectives = list() //objectives to disallow the buyer from buying this item
 
+
 /datum/uplink_item/stealthy_weapons/door_charge
 	name = "Explosive Airlock Charge"
 	desc = "A small, easily concealable device. It can be applied to an open airlock panel, booby-trapping it. \
@@ -11,6 +12,7 @@
 	cost = 2
 	surplus = 10
 	exclude_modes = list(/datum/game_mode/nuclear)
+
 
 /datum/uplink_item/device_tools/arm
 	name = "Additional Arm"
@@ -24,8 +26,18 @@
 	user.change_number_of_hands(limbs+1)
 	to_chat(user, "You feel more dexterous")
 
+
 /datum/uplink_item/device_tools/emag
 	cost = 8
 
+
 /datum/uplink_item/role_restricted/his_grace
 	include_objectives = list(/datum/objective/hijack)
+
+
+/datum/uplink_item/role_restricted/gondola_meat
+	name = "Gondola meat"
+	desc = "A slice of gondola meat will turn any brainwashed Nanotrasen employee into a goody-two-shoes gondola."
+	item = /obj/item/reagent_containers/food/snacks/meat/slab/gondola
+	cost = 2
+	restricted_roles = list("Cook")


### PR DESCRIPTION
Gondola meat got recently added, eating it givs you a disease that transforms you into a gondola. If you can get your target to eat this, you can easily dispose of them. They currently cost 2 TC since they're pretty situational.

((also deletes an unneeded .gitkeep file))

:cl:  
rscadd: A traitor chef can now buy gondola meat using their uplink.
/:cl:
