### PR TITLE
adds the ability to add job-replacements for traitoritems

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -93,8 +93,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	if(!spawn_item)
 		return
 	var/atom/A
-	if(jobspecials[user.mind.assigned_role])
-		spawn_item = jobspecials[user.mind.assigned_role]
+	if(jobspecials[user.mind.assigned_role]) //yogs
+		spawn_item = jobspecials[user.mind.assigned_role] //yogs
 	if(ispath(spawn_item))
 		A = new spawn_item(get_turf(user))
 	else

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -93,6 +93,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	if(!spawn_item)
 		return
 	var/atom/A
+	if(jobspecials[user.mind.assigned_role])
+		spawn_item = jobspecials[user.mind.assigned_role]
 	if(ispath(spawn_item))
 		A = new spawn_item(get_turf(user))
 	else
@@ -201,7 +203,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 10
 	surplus = 40
 	include_modes = list(/datum/game_mode/nuclear)
-	
+
 /datum/uplink_item/dangerous/carbine
 	name = "M-90gl Carbine"
 	desc = "A fully-loaded, specialized three-round burst carbine that fires 5.56mm ammunition from a 30 round magazine \
@@ -526,7 +528,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/backpack/duffelbag/syndie/ammo/smg
 	cost = 20
 	include_modes = list(/datum/game_mode/nuclear)
-	
+
 /datum/uplink_item/ammo/carbine
 	name = "5.56mm Toploader Magazine"
 	desc = "An additional 30-round 5.56mm magazine; suitable for use with the M-90gl carbine. \
@@ -534,7 +536,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/ammo_box/magazine/m556
 	cost = 4
 	include_modes = list(/datum/game_mode/nuclear)
-	
+
 /datum/uplink_item/ammo/a40mm
 	name = "40mm Grenade"
 	desc = "A 40mm HE grenade for use with the M-90gl's under-barrel grenade launcher. \

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -1,6 +1,7 @@
 /datum/uplink_item
 	var/list/include_objectives = list() //objectives to allow the buyer to buy this item
 	var/list/exclude_objectives = list() //objectives to disallow the buyer from buying this item
+	var/list/jobspecials = list()        //any job-replacements for this item.
 
 
 /datum/uplink_item/stealthy_weapons/door_charge


### PR DESCRIPTION
### Intent of your Pull Request

Essentially, it allows us to add minor differences to the traitor item depending on the job of the person buying them. Like, say we make a subtype of EMP grenades that honk when they EMP (because i'm bad at examples) we'd add a line to the uplink_item for EMP grenades, that essentially goes;

`jobspecials["Clown"] = /obj/item/grenade/emp/clown` 