### PR TITLE
adds directional airlocks to cloning and medbay

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -26720,6 +26720,7 @@
 	req_access_txt = "5"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
@@ -26739,6 +26740,7 @@
 	req_access_txt = "5"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
@@ -27250,13 +27252,6 @@
 /area/medical/chemistry)
 "bpu" = (
 /obj/structure/bed/roller,
-/obj/machinery/button/door{
-	desc = "A remote control switch for the medbay foyer.";
-	id = "MedbayFoyer";
-	name = "Medbay Exit Button";
-	normaldoorcontrol = 1;
-	pixel_y = 26
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
@@ -28471,6 +28466,7 @@
 	name = "Genetics";
 	req_access_txt = "5; 68"
 	},
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bsv" = (
@@ -29638,14 +29634,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bvn" = (
-/obj/machinery/button/door{
-	desc = "A remote control switch for the genetics doors.";
-	id = "GeneticsDoor";
-	name = "Genetics Exit Button";
-	normaldoorcontrol = 1;
-	pixel_x = 8;
-	pixel_y = 24
-	},
 /obj/structure/table,
 /obj/item/book/manual/wiki/medical_cloning{
 	pixel_y = 6


### PR DESCRIPTION
### Intent of your Pull Request

![image](https://user-images.githubusercontent.com/20558591/44278537-85c18080-a24e-11e8-9f62-3f999bb3ea8b.png)


#### Changelog

:cl:  
tweak: medbay front doors can now be opened from the inside, as can the cloning door
/:cl:
