### PR TITLE
Makes swarmer shells spawn

### DIFF
--- a/yogstation/code/modules/antagonists/swarmer/swarmer_event.dm
+++ b/yogstation/code/modules/antagonists/swarmer/swarmer_event.dm
@@ -1,0 +1,28 @@
+/datum/round_event_control/spawn_swarmer
+	name = "Spawn Swarmer Shell"
+	typepath = /datum/round_event/spawn_swarmer
+	weight = 7
+	max_occurrences = 1 //Only once okay fam
+	earliest_start = 30 MINUTES
+	min_players = 15
+
+
+/datum/round_event/spawn_swarmer
+
+/datum/round_event/spawn_swarmer/start()
+	if(find_swarmer())
+		return 0
+	if(!GLOB.the_gateway)
+		return 0
+	new /obj/effect/mob_spawn/swarmer(get_turf(GLOB.the_gateway))
+	if(prob(25)) //25% chance to announce it to the crew
+		var/swarmer_report = "<span class='big bold'>[command_name()] High-Priority Update</span>"
+		swarmer_report += "<br><br>Our long-range sensors have detected an odd signal emanating from your station's gateway. We recommend immediate investigation of your gateway, as something may have come through."
+		print_command_report(swarmer_report, announce=TRUE)
+
+/datum/round_event/spawn_swarmer/proc/find_swarmer()
+	for(var/i in GLOB.mob_living_list)
+		var/mob/living/L = i
+		if(istype(L, /mob/living/simple_animal/hostile/swarmer) && L.client) //If there is a swarmer with an active client, we've found our swarmer
+			return 1
+	return 0


### PR DESCRIPTION
🆑 fluffe9911 and with help from Macelarius
fix: Swarmer shells now spawn again!
🆑
Swarmer shells used the gateway and had no fail safe in place if a map does not have a gateway so this changes the gateway to the gravity generator like old yogs