### PR TITLE
Turns incorporeal move into a component in preparation for shadowlings

### DIFF
--- a/code/__DEFINES/~yogs_defines/components.dm
+++ b/code/__DEFINES/~yogs_defines/components.dm
@@ -1,3 +1,3 @@
 #define COMSIG_ALT_CLICK_ON "alt_click_on" 						//from base of mob/AltClickOn(): (atom/A)
 #define COMSIG_ATOM_POINTED_AT "atom_pointed_at"				//from base of atom/pointed_at(): (mob/user)
-#define COMSIG_PROCESS_MOVE "process_move"						//from base of client/Move(): (turf/newloc, num/direction)
+#define COMSIG_PROCESS_MOVE "process_move"						//from base of client/Move(): (num/direction)

--- a/code/__DEFINES/~yogs_defines/components.dm
+++ b/code/__DEFINES/~yogs_defines/components.dm
@@ -1,2 +1,3 @@
-#define COMSIG_ALT_CLICK_ON "alt_click_on" 						//from base of mob/AltClickOn: (atom/A)
+#define COMSIG_ALT_CLICK_ON "alt_click_on" 						//from base of mob/AltClickOn(): (atom/A)
 #define COMSIG_ATOM_POINTED_AT "atom_pointed_at"				//from base of atom/pointed_at(): (mob/user)
+#define COMSIG_PROCESS_MOVE "process_move"						//from base of client/Move(): (turf/newloc, num/direction)

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -74,6 +74,7 @@
 	AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/revenant/blight(null))
 	AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/revenant/malfunction(null))
 	random_revenant_name()
+	LoadComponent(/datum/component/walk/jaunt) //yogs
 
 /mob/living/simple_animal/revenant/proc/random_revenant_name()
 	var/built_name = ""
@@ -109,6 +110,9 @@
 		unreveal_time = 0
 		revealed = FALSE
 		incorporeal_move = INCORPOREAL_MOVE_JAUNT
+		GET_COMPONENT(incorp, /datum/component/walk/jaunt) //yogs start
+		if(incorp)
+			incorp.enabled = TRUE //yogs end
 		invisibility = INVISIBILITY_REVENANT
 		to_chat(src, "<span class='revenboldnotice'>You are once more concealed.</span>")
 	if(unstun_time && world.time >= unstun_time)
@@ -240,6 +244,9 @@
 	revealed = TRUE
 	invisibility = 0
 	incorporeal_move = FALSE
+	GET_COMPONENT(incorp, /datum/component/walk/jaunt) //yogs start
+	if(incorp)
+		incorp.enabled = FALSE //yogs end
 	if(!unreveal_time)
 		to_chat(src, "<span class='revendanger'>You have been revealed!</span>")
 		unreveal_time = world.time + time
@@ -318,6 +325,9 @@
 	inhibited = FALSE
 	draining = FALSE
 	incorporeal_move = INCORPOREAL_MOVE_JAUNT
+	GET_COMPONENT(incorp, /datum/component/walk/jaunt) //yogs start
+	if(incorp)
+		incorp.enabled = TRUE //yogs end
 	invisibility = INVISIBILITY_REVENANT
 	alpha=255
 	stasis = FALSE

--- a/code/modules/mob/living/simple_animal/guardian/types/ranged.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/ranged.dm
@@ -27,6 +27,10 @@
 	var/list/snares = list()
 	var/toggle = FALSE
 
+/mob/living/simple_animal/hostile/guardian/ranged/Initialize() //yogs start
+	. = ..()
+	LoadComponent(/datum/component/walk) //yogs end
+
 /mob/living/simple_animal/hostile/guardian/ranged/ToggleMode()
 	if(src.loc == summoner)
 		if(toggle)
@@ -125,9 +129,15 @@
 /mob/living/simple_animal/hostile/guardian/ranged/Manifest(forced)
 	if (toggle)
 		incorporeal_move = INCORPOREAL_MOVE_BASIC
+		GET_COMPONENT(incorp, /datum/component/walk) //yogs start
+		if(incorp)
+			incorp.enabled = TRUE //yogs end
 	. = ..()
 
 /mob/living/simple_animal/hostile/guardian/ranged/Recall(forced)
 	// To stop scout mode from moving when recalled
 	incorporeal_move = FALSE
+	GET_COMPONENT(incorp, /datum/component/walk) //yogs start
+	if(incorp)
+		incorp.enabled = FALSE //yogs end
 	. = ..()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -84,6 +84,11 @@
 
 	if(!mob.Process_Spacemove(direct))
 		return FALSE
+
+	var/handled = SEND_SIGNAL(mob, COMSIG_PROCESS_MOVE, n, direct) //yogs start - movement components
+	if(handled)
+		return //yogs end
+
 	//We are now going to move
 	var/add_delay = mob.movement_delay()
 	if(old_move_delay + (add_delay*MOVEMENT_DELAY_BUFFER_DELTA) + MOVEMENT_DELAY_BUFFER > world.time)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -59,9 +59,9 @@
 		return FALSE
 
 	var/mob/living/L = mob  //Already checked for isliving earlier
-	if(L.incorporeal_move)	//Move though walls
+	/*if(L.incorporeal_move)	//Move though walls //yogs start - turned into component
 		Process_Incorpmove(direct)
-		return FALSE
+		return FALSE*/ //yogs end
 
 	if(mob.remote_control)					//we're controlling something, our movement is relayed to it
 		return mob.remote_control.relaymove(mob, direct)
@@ -85,9 +85,9 @@
 	if(!mob.Process_Spacemove(direct))
 		return FALSE
 
-	var/handled = SEND_SIGNAL(mob, COMSIG_PROCESS_MOVE, n, direct) //yogs start - movement components
+	var/handled = SEND_SIGNAL(L, COMSIG_PROCESS_MOVE, direct) //yogs start - movement components
 	if(handled)
-		return //yogs end
+		return FALSE//yogs end
 
 	//We are now going to move
 	var/add_delay = mob.movement_delay()

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2669,6 +2669,7 @@
 #include "yogstation\code\datums\components\crawl.dm"
 #include "yogstation\code\datums\components\daniel.dm"
 #include "yogstation\code\datums\components\uplink.dm"
+#include "yogstation\code\datums\components\walks.dm"
 #include "yogstation\code\datums\diseases\advance\symptoms\confusion.dm"
 #include "yogstation\code\datums\diseases\advance\symptoms\heal.dm"
 #include "yogstation\code\datums\ruins\free_miners.dm"

--- a/yogstation/code/datums/components/walks.dm
+++ b/yogstation/code/datums/components/walks.dm
@@ -1,0 +1,53 @@
+#define DEFER_MOVE 1 //Let /client/Move() handle the movement
+#define MOVE_ALLOWED 2 //Allow mob to pass through
+#define MOVE_NOT_ALLOWED 3 //Do not let the mob through
+
+/datum/component/walk
+/datum/component/walk/Initialize()
+	if(!istype(parent, /mob/living))
+		return COMPONENT_INCOMPATIBLE
+	RegisterSignal(parent, COMSIG_PROCESS_MOVE, .proc/handle_move)
+
+/datum/component/walk/proc/handle_move(direction)
+	var/mob/living/L = parent
+	var/turf/T = get_step(L, direction)
+	L.setDir(direction)
+	if(!T)
+		return
+	var/allowed = can_walk(L, T)
+	switch(allowed)
+		if(DEFER_MOVE)
+			return FALSE
+		if(MOVE_NOT_ALLOWED)
+			return TRUE
+		if(MOVE_ALLOWED)
+			L.forceMove(T)
+			return TRUE
+
+/datum/component/walk/proc/can_walk(mob/living/user, turf/destination)
+	return MOVE_ALLOWED
+
+/datum/component/walk/shadow
+/datum/component/walk/shadow/can_walk(mob/living/user, turf/destination)
+	return (destination.get_lumcount() ? DEFER_MOVE : MOVE_ALLOWED)
+
+/datum/component/walk/jaunt
+/datum/component/walk/jaunt/can_walk(mob/living/user, turf/destination)
+	for(var/obj/effect/decal/cleanable/salt/S in destination)
+		to_chat(user, "<span class='warning'>[S] bars your passage!</span>")
+		if(isrevenant(user))
+			var/mob/living/simple_animal/revenant/R = user
+			R.reveal(20)
+			R.stun(20)
+		return MOVE_NOT_ALLOWED
+	if(destination.flags_1 & NOJAUNT_1)
+		to_chat(user, "<span class='warning'>Some strange aura is blocking the way.</span>")
+		return MOVE_NOT_ALLOWED
+	if (locate(/obj/effect/blessing, destination))
+		to_chat(user, "<span class='warning'>Holy energies block your path!</span>")
+		return MOVE_NOT_ALLOWED
+	return MOVE_ALLOWED
+
+#undef DEFER_MOVE
+#undef MOVE_ALLOWED
+#nudef MOVE_NOT_ALLOWED

--- a/yogstation/code/datums/components/walks.dm
+++ b/yogstation/code/datums/components/walks.dm
@@ -50,4 +50,4 @@
 
 #undef DEFER_MOVE
 #undef MOVE_ALLOWED
-#nudef MOVE_NOT_ALLOWED
+#undef MOVE_NOT_ALLOWED


### PR DESCRIPTION
Refactors incorporeal move a bit and adds shadowwalk. I added the component to revenants and holoparasites too. The `incorporeal_move` variable is used in a few places though, should I remove it and refactor or leave as is?