### PR TITLE
Adrenaline Sacs doesn't prevent changelings from being stunned as long as it's in effect

### DIFF
--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -1,7 +1,7 @@
 /obj/effect/proc_holder/changeling/adrenaline
 	name = "Adrenaline Sacs"
 	desc = "We evolve additional sacs of adrenaline throughout our body."
-	helptext = "Removes all stuns instantly and adds a short-term reduction in further stuns. Can be used while unconscious. Continued use poisons the body."
+	helptext = "Removes all stuns instantly. Can be used while unconscious. Continued use poisons the body." //yogs - changed text to suit the below change
 	chemical_cost = 30
 	dna_cost = 2
 	req_human = 1

--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -14,7 +14,7 @@
 	user.SetUnconscious(0)
 	user.SetStun(0)
 	user.SetKnockdown(0)
-	user.reagents.add_reagent("changelingadrenaline", 10)
+	//user.reagents.add_reagent("changelingadrenaline", 10) //yogs - lings no longer get prolonged anti-stun reagents
 	user.reagents.add_reagent("changelinghaste", 2) //For a really quick burst of speed
 	user.adjustStaminaLoss(-75)
 	return TRUE


### PR DESCRIPTION
### Intent of your Pull Request

Changes it so it now removes whatever stuns they might have at the time, but don't prevent them from being further stunned. Also lessens they amount of toxins they take from using the ability, since those two are intertwined.

People want lings to be more stealthy and less combatty, so here you go. Can still be used to get out of combat, but not to buff you during combat 🤷‍♂️ 

#### Changelog

:cl:  
tweak: Adrenaline Sacs now un-stuns you, but doesnt prevent you from being stunned
/:cl:
