### PR TITLE
Dracula coat tweaks

### DIFF
--- a/yogstation/code/game/gamemodes/vampire/vampire_other.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_other.dm
@@ -14,6 +14,28 @@
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDEJUMPSUIT
 	armor = list("melee" = 30, "bullet" = 20, "laser" = 10, "energy" = 10, "bomb" = 0, "bio" = 0, "rad" = 0)
+	allowed = null
+	var/blood_restoration_delay = 200
+	var/next_blood_restoration_tick = 0
+
+/obj/item/clothing/suit/draculacoat/Initialize()
+	if(!allowed)
+		allowed = GLOB.security_vest_allowed
+	START_PROCESSING(SSobj, src)
+	return ..()
+
+/obj/item/clothing/suit/draculacoat/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	return ..()
+
+/obj/item/clothing/suit/draculacoat/process()
+	var/mob/living/carbon/human/user = src.loc
+	if(user && ishuman(user) && is_vampire(user) && (user.wear_suit == src))
+		if (world.time > next_blood_restoration_tick)
+			next_blood_restoration_tick = world.time + blood_restoration_delay
+			var/datum/antagonist/vampire/vampire = user.mind.has_antag_datum(/datum/antagonist/vampire)
+			if (vampire.total_blood >= 5 && vampire.usable_blood <= vampire.total_blood * 0.25)
+				vampire.usable_blood = min(vampire.usable_blood + 5, vampire.total_blood * 0.25) // 5 units every 20 seconds
 
 /mob/living/carbon/human/handle_fire()
 	. = ..()

--- a/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -4,7 +4,6 @@
 	var/vamp_req = FALSE
 
 /obj/effect/proc_holder/spell/cast_check(skipcharge = 0, mob/user = usr)
-	. = ..(skipcharge, user)
 	if(vamp_req)
 		if(!is_vampire(user))
 			return FALSE
@@ -14,6 +13,7 @@
 		if(V.usable_blood < blood_used)
 			to_chat(user, "<span class='warning'>You do not have enough blood to cast this!</span>")
 			return FALSE
+	. = ..(skipcharge, user)
 
 /obj/effect/proc_holder/spell/Initialize()
 	. = ..()
@@ -345,9 +345,10 @@
 		user.regenerate_organs()
 
 /obj/effect/proc_holder/spell/self/summon_coat
-	name = "Summon Dracula Coat (5)"
+	name = "Summon Dracula Coat (100)"
+	desc = "Allows you to summon a Vampire Coat providing passive usable blood restoration when your usable blood is very low."
 	gain_desc = "Now that you have reached full power, you can now pull a vampiric coat out of thin air!"
-	blood_used = 5
+	blood_used = 100
 	action_icon = 'yogstation/icons/mob/vampire.dmi'
 	action_icon_state = "coat"
 	action_background_icon_state = "bg_demon"


### PR DESCRIPTION
:cl:  
rscadd: Vampire's Dracula coat spell now costs 100 blood. The coat now provides the user with minor passive usable blood regeneration when the usable blood amount is below 25% of their total blood amount. It can now hold weapons too. 
bugfix: fixed vampire spells triggering their cooldown even when clicked with insufficient usable blood. 
/:cl:
tested