### PR TITLE
Makes the ninja's disposition appear in the logs

### DIFF
--- a/code/modules/antagonists/ninja/ninja.dm
+++ b/code/modules/antagonists/ninja/ninja.dm
@@ -11,9 +11,6 @@
 /datum/antagonist/ninja/New()
 	if(helping_station)
 		can_hijack = HIJACK_PREVENT
-		name = "Nanotrasen Ninja"
-	else
-		name = "Syndicate Ninja"
 	. = ..()
 
 /datum/antagonist/ninja/apply_innate_effects(mob/living/mob_override)
@@ -31,6 +28,7 @@
 	antag_memory += "I am an elite mercenary assassin of the mighty Spider Clan. A <font color='red'><B>SPACE NINJA</B></font>!<br>"
 	antag_memory += "Surprise is my weapon. Shadows are my armor. Without them, I am nothing. (//initialize your suit by clicking the initialize UI button, to use abilities like stealth)!<br>"
 	antag_memory += "Officially, [helping_station?"Nanotrasen":"The Syndicate"] are my employer.<br>"
+	name = "[helping_station?"Nanotrasen Ninja":"Syndicate Ninja"]"
 
 /datum/antagonist/ninja/proc/addObjectives(quantity = 6)
 	var/list/possible_targets = list()

--- a/code/modules/antagonists/ninja/ninja.dm
+++ b/code/modules/antagonists/ninja/ninja.dm
@@ -11,6 +11,9 @@
 /datum/antagonist/ninja/New()
 	if(helping_station)
 		can_hijack = HIJACK_PREVENT
+		name = "Nanotrasen Ninja"
+	else
+		name = "Syndicate Ninja"
 	. = ..()
 
 /datum/antagonist/ninja/apply_innate_effects(mob/living/mob_override)


### PR DESCRIPTION
### Intent of your Pull Request

Will make the type of ninja appear when doing logs

couldn't test this but should work every time a ninja is made organically

Fixes issue #2509 

Edit the changelog at the bottom for changes that are noticeable by the players. Remove it if this isn't the case.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.
Include [admin] in the title if it's something admin related.
Include [s] in the title if you don't want it to be announced on discord and the server.

#### Changelog

:cl:  
rscadd: Changes Ninja name in log to be either Nanotrasen Ninja or Syndicate Ninja 
/:cl:
