### PR TITLE
two more closets for janitor and 1 more sign per closet

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -19802,11 +19802,11 @@
 /turf/open/floor/plating,
 /area/storage/emergency/port)
 "aSo" = (
-/mob/living/carbon/monkey/punpun,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
+/mob/living/carbon/monkey/punpun,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aSp" = (
@@ -35902,10 +35902,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bDH" = (
-/obj/structure/closet/l3closet/janitor,
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
+/obj/structure/closet/jcloset,
 /turf/open/floor/plasteel,
 /area/janitor)
 "bDI" = (
@@ -35914,8 +35914,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bDJ" = (
-/obj/item/storage/box/lights/mixed,
-/obj/item/storage/box/lights/mixed,
+/obj/structure/closet/l3closet/janitor,
 /turf/open/floor/plasteel,
 /area/janitor)
 "bDK" = (
@@ -35925,10 +35924,11 @@
 /obj/machinery/camera{
 	c_tag = "Custodial Closet"
 	},
-/obj/vehicle/ridden/janicart,
+/obj/structure/closet/l3closet/janitor,
 /turf/open/floor/plasteel,
 /area/janitor)
 "bDL" = (
+/obj/vehicle/ridden/janicart,
 /turf/open/floor/plasteel,
 /area/janitor)
 "bDM" = (
@@ -36127,13 +36127,13 @@
 /obj/structure/table/glass,
 /obj/item/pen,
 /obj/item/clothing/neck/stethoscope,
-/mob/living/simple_animal/pet/cat/Runtime,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/mob/living/simple_animal/pet/cat/Runtime,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bEk" = (
@@ -36587,6 +36587,8 @@
 /area/hallway/primary/aft)
 "bFk" = (
 /obj/item/mop,
+/obj/item/storage/box/lights/mixed,
+/obj/item/storage/box/lights/mixed,
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel,
 /area/janitor)
@@ -43610,7 +43612,6 @@
 /obj/structure/filingcabinet/chestdrawer,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/mob/living/simple_animal/parrot/Poly,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -43621,6 +43622,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/mob/living/simple_animal/parrot/Poly,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "cbr" = (

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -69,7 +69,7 @@
 	new /obj/item/paint/paint_remover(src)
 	new /obj/item/melee/flyswatter(src)
 	new /obj/item/flashlight(src)
-	for(var/i in 1 to 4)
+	for(var/i in 1 to 4) // yogs - Makes there be 4 caution signs instead of 3
 		new /obj/item/caution(src)
 	new /obj/item/holosign_creator(src)
 	new /obj/item/lightreplacer(src)

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -69,7 +69,7 @@
 	new /obj/item/paint/paint_remover(src)
 	new /obj/item/melee/flyswatter(src)
 	new /obj/item/flashlight(src)
-	for(var/i in 1 to 3)
+	for(var/i in 1 to 4)
 		new /obj/item/caution(src)
 	new /obj/item/holosign_creator(src)
 	new /obj/item/lightreplacer(src)


### PR DESCRIPTION
### Intent of your Pull Request

Gives the janitors custodial closet two more closets of each type so that the extra janitor slots will have stuff. also has 4 signs per each closet so you can fully load a janicart with one locker
Fixes issue #1024

#### Changelog

:cl:  
rscadd: two more janitor closets in the custodial closet and 1 more sign in a jcloset
/:cl:
