### PR TITLE
Fix async logout bug

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -436,7 +436,6 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 
 			send2irc("Server", "[cheesy_message] (No admins online)")
 
-	sync_logout_with_db(connection_number) // yogs - logout logging
 	GLOB.ahelp_tickets.ClientLogout(src)
 	GLOB.directory -= ckey
 	GLOB.clients -= src
@@ -444,6 +443,7 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 		movingmob.client_mobs_in_contents -= mob
 		UNSETEMPTY(movingmob.client_mobs_in_contents)
 	Master.UpdateTickRate()
+	sync_logout_with_db(connection_number) // yogs - logout logging
 	return ..()
 
 /client/Destroy()

--- a/yogstation/code/modules/client/client_procs.dm
+++ b/yogstation/code/modules/client/client_procs.dm
@@ -6,5 +6,5 @@
 		return
 
 	var/datum/DBQuery/query_logout = SSdbcore.NewQuery("UPDATE [format_table_name("connection_log")] SET `left` = Now() WHERE id = [number]")
-	query_logout.Execute()
+	query_logout.Execute(async = FALSE)
 	qdel(query_logout)


### PR DESCRIPTION
Pretty sure this causes the "muh null in GLOB.clients", it errors when executing the query. Probably because it's async.