### PR TITLE
Fixes players joining as wardens who can't arrest people

### DIFF
--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -135,8 +135,8 @@ Detective
 	department_head = list("Head of Security")
 	department_flag = ENGSEC
 	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0 //yogs
+	spawn_positions = 0 //yogs
 	supervisors = "the head of security"
 	selection_color = "#ffeeee"
 	minimal_player_age = 7


### PR DESCRIPTION
### Intent of your Pull Request

Apparently detective is now just warden 2.0, so why even have the detective? If the detective isn't allowed to arrest the fucker emagging every single door including into his own office because he's "not an immediate threat", then what's the actual fucking point of him? He's now got fewer rights than regular fucking crewmembers 😂 

#### Changelog

:cl:  
fix: players can no longer spawn as a warden without the power to arrest people
/:cl:
