### PR TITLE
Prevents radstorm on lawyer maint APC tile

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -9621,7 +9621,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/lawoffice)
+/area/maintenance/fore)
 "avj" = (
 /obj/machinery/firealarm{
 	dir = 8;


### PR DESCRIPTION
Stops the APC tile in lawyer maint from being radstormed.
I've tested this:
1) APC still worked with the lawyer room.
2) Radstorm didn't happen on the APC tile.

Fixes #2792 
