### PR TITLE
Gives the distro to filter pump a name

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -56957,7 +56957,8 @@
 "siX" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 4
+	dir = 4;
+	name = "Distro to Filter"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"


### PR DESCRIPTION
Fixes issue #3023 

Renames it from the default "gas pump" name.