### PR TITLE
Ups item count in janitor+lawyer vendors

### DIFF
--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2932,6 +2932,7 @@
 #include "yogstation\code\modules\uplink\uplink_item.dm"
 #include "yogstation\code\modules\vending\_vending.dm"
 #include "yogstation\code\modules\vending\clothesmate.dm"
+#include "yogstation\code\modules\vending\wardrobes.dm"
 #include "yogstation\code\modules\webhook\webhook.dm"
 #include "yogstation\interface\interface.dm"
 // END_INCLUDE

--- a/yogstation/code/modules/vending/wardrobes.dm
+++ b/yogstation/code/modules/vending/wardrobes.dm
@@ -1,0 +1,29 @@
+/obj/machinery/vending/wardrobe/jani_wardrobe
+	products = list(/obj/item/clothing/under/rank/janitor = 2,
+					/obj/item/cartridge/janitor = 2,
+					/obj/item/clothing/gloves/color/black = 2,
+					/obj/item/clothing/head/soft/purple = 2,
+					/obj/item/paint/paint_remover = 2,
+					/obj/item/melee/flyswatter = 2,
+					/obj/item/flashlight = 2,
+					/obj/item/caution = 6,
+					/obj/item/holosign_creator = 2,
+					/obj/item/lightreplacer = 2,
+					/obj/item/soap/nanotrasen = 2,
+					/obj/item/storage/bag/trash = 2,
+					/obj/item/clothing/shoes/galoshes = 2,
+					/obj/item/watertank/janitor = 2,
+					/obj/item/storage/belt/janitor = 2)
+
+/obj/machinery/vending/wardrobe/law_wardrobe
+	products = list(/obj/item/clothing/under/lawyer/female = 2,
+					/obj/item/clothing/under/lawyer/black = 2,
+					/obj/item/clothing/under/lawyer/red = 2,
+					/obj/item/clothing/under/lawyer/bluesuit = 2,
+					/obj/item/clothing/suit/toggle/lawyer = 2,
+					/obj/item/clothing/under/lawyer/purpsuit = 2,
+					/obj/item/clothing/suit/toggle/lawyer/purple = 2,
+					/obj/item/clothing/under/lawyer/blacksuit = 2,
+					/obj/item/clothing/suit/toggle/lawyer/black = 2,
+					/obj/item/clothing/shoes/laceup = 2,
+					/obj/item/clothing/accessory/lawyers_badge = 2)


### PR DESCRIPTION
Increases the amount of items in the vendors from enough for 1 person to enough for 2 people.

Fixes issue #3062 

:cl:  
tweak: Janitor and lawyer vendors have enough items for two!
/:cl:
