### PR TITLE
Replaced the office chair with a normal chair, fixing issue #3122

### DIFF
--- a/_maps/shuttles/labour_box.dmm
+++ b/_maps/shuttles/labour_box.dmm
@@ -16,8 +16,8 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
 "d" = (
-/obj/structure/chair/office/dark{
-	dir = 1
+/obj/structure/chair{
+	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)

--- a/_maps/shuttles/labour_box.dmm
+++ b/_maps/shuttles/labour_box.dmm
@@ -16,7 +16,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
 "d" = (
-/obj/structure/chair{
+/obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium/red,


### PR DESCRIPTION
![chairfix](https://user-images.githubusercontent.com/2159739/47203991-b81f5500-d347-11e8-9c19-1472a2bd3089.PNG)

### Intent of your Pull Request

Fixes #3122 
Fixes #2050 

Despite how hilarious it is for there to be a wheeled office chair in the cockpit of the labor shuttle, it was a bit of a gameplay problem as people would get sucked out the door if it was left open. I've fixed it, replacing it with a standard - and much less comfy - chair. Without wheels.

Edit: The lack of comfiness was concerning so I updated it to one of the new Comfy Shuttle Chairs.

This is my first map change ever, so I figured I'd start small to learn the merge tool and all that and fix an issue while I was at it. Hopefully I did everything right. I think this is the smallest PR I've ever written.

#### Changelog

:cl: Firewolf34
tweak: Replaced BoxStation labor shuttle cockpit chair with one sans-wheels
/:cl: