### PR TITLE
Bugfix Adjustments to the Cargo Economy

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -537,9 +537,10 @@ SUBSYSTEM_DEF(shuttle)
 	if (istype(SSshuttle.shuttle_purchase_requirements_met))
 		shuttle_purchase_requirements_met = SSshuttle.shuttle_purchase_requirements_met
 
+	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 	centcom_message = SSshuttle.centcom_message
 	ordernum = SSshuttle.ordernum
-	points = SSshuttle.points
+	points = D.account_balance
 	emergencyNoEscape = SSshuttle.emergencyNoEscape
 	emergencyCallAmount = SSshuttle.emergencyCallAmount
 	shuttle_purchased = SSshuttle.shuttle_purchased

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -537,10 +537,12 @@ SUBSYSTEM_DEF(shuttle)
 	if (istype(SSshuttle.shuttle_purchase_requirements_met))
 		shuttle_purchase_requirements_met = SSshuttle.shuttle_purchase_requirements_met
 
-	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 	centcom_message = SSshuttle.centcom_message
 	ordernum = SSshuttle.ordernum
+	// yogs start - fix cargo balance
+	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 	points = D.account_balance
+	// yogs end
 	emergencyNoEscape = SSshuttle.emergencyNoEscape
 	emergencyCallAmount = SSshuttle.emergencyCallAmount
 	shuttle_purchased = SSshuttle.shuttle_purchased

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -562,7 +562,8 @@
 				dat += "<BR>Lift access restrictions on maintenance and external airlocks? <BR>\[ <A HREF='?src=[REF(src)];operation=enableemergency'>OK</A> | <A HREF='?src=[REF(src)];operation=viewmessage'>Cancel</A> \]"
 
 		if(STATE_PURCHASE)
-			dat += "Budget: [SSshuttle.points] Credits.<BR>"
+			var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
+			dat += "Budget: [D.account_balance] Credits.<BR>"
 			dat += "<BR>"
 			dat += "<b>Caution: Purchasing dangerous shuttles may lead to mutiny and/or death.</b><br>"
 			dat += "<BR>"

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -562,8 +562,10 @@
 				dat += "<BR>Lift access restrictions on maintenance and external airlocks? <BR>\[ <A HREF='?src=[REF(src)];operation=enableemergency'>OK</A> | <A HREF='?src=[REF(src)];operation=viewmessage'>Cancel</A> \]"
 
 		if(STATE_PURCHASE)
+			// yogs start - fix cargo balance
 			var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 			dat += "Budget: [D.account_balance] Credits.<BR>"
+			// yogs end
 			dat += "<BR>"
 			dat += "<b>Caution: Purchasing dangerous shuttles may lead to mutiny and/or death.</b><br>"
 			dat += "<BR>"

--- a/code/modules/cargo/bounty_console.dm
+++ b/code/modules/cargo/bounty_console.dm
@@ -35,9 +35,10 @@
 		setup_bounties()
 
 	var/dat = ""
+	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 	dat += "<a href='?src=[REF(src)];refresh=1'>Refresh</a>"
 	dat += "<a href='?src=[REF(src)];refresh=1;choice=Print'>Print Paper</a>"
-	dat += "<p>Credits: <b>[SSshuttle.points]</b></p>"
+	dat += "<p>Credits: <b>[D.account_balance]</b></p>"
 	dat += {"<table style="text-align:center;" border="1" cellspacing="0" width="100%">"}
 	dat += "<tr><th>Name</th><th>Description</th><th>Reward</th><th>Completion</th><th>Status</th></tr>"
 	for(var/datum/bounty/B in GLOB.bounties_list)

--- a/code/modules/cargo/bounty_console.dm
+++ b/code/modules/cargo/bounty_console.dm
@@ -35,10 +35,12 @@
 		setup_bounties()
 
 	var/dat = ""
-	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 	dat += "<a href='?src=[REF(src)];refresh=1'>Refresh</a>"
 	dat += "<a href='?src=[REF(src)];refresh=1;choice=Print'>Print Paper</a>"
+	// yogs start - fix cargo balance
+	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 	dat += "<p>Credits: <b>[D.account_balance]</b></p>"
+	// yogs end
 	dat += {"<table style="text-align:center;" border="1" cellspacing="0" width="100%">"}
 	dat += "<tr><th>Name</th><th>Description</th><th>Reward</th><th>Completion</th><th>Status</th></tr>"
 	for(var/datum/bounty/B in GLOB.bounties_list)

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -90,10 +90,10 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 
 	var/value = 0
 	var/purchases = 0
+	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 	for(var/datum/supply_order/SO in SSshuttle.shoppinglist)
 		if(!empty_turfs.len)
 			break
-		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 		if(D)
 			if(!D.adjust_money(-SO.pack.cost))
 				continue
@@ -108,7 +108,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 			message_admins("\A [SO.pack.name] ordered by [ADMIN_LOOKUPFLW(SO.orderer_ckey)] has shipped.")
 		purchases++
 
-	investigate_log("[purchases] orders in this shipment, worth [value] credits. [SSshuttle.points] credits left.", INVESTIGATE_CARGO)
+	investigate_log("[purchases] orders in this shipment, worth [value] credits. [D.account_balance] credits left.", INVESTIGATE_CARGO)
 
 /obj/docking_port/mobile/supply/proc/sell()
 	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -90,7 +90,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 
 	var/value = 0
 	var/purchases = 0
-	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
+	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR) // yogs - fix cargo balance
 	for(var/datum/supply_order/SO in SSshuttle.shoppinglist)
 		if(!empty_turfs.len)
 			break
@@ -108,7 +108,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 			message_admins("\A [SO.pack.name] ordered by [ADMIN_LOOKUPFLW(SO.orderer_ckey)] has shipped.")
 		purchases++
 
-	investigate_log("[purchases] orders in this shipment, worth [value] credits. [D.account_balance] credits left.", INVESTIGATE_CARGO)
+	investigate_log("[purchases] orders in this shipment, worth [value] credits. [D.account_balance] credits left.", INVESTIGATE_CARGO) // yogs - fix cargo balance
 
 /obj/docking_port/mobile/supply/proc/sell()
 	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)

--- a/yogstation/code/modules/stock_market/computer.dm
+++ b/yogstation/code/modules/stock_market/computer.dm
@@ -16,9 +16,10 @@
 	logged_in = "SS13 Cargo Department"
 
 /obj/machinery/computer/stockexchange/proc/balance()
+	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 	if (!logged_in)
 		return 0
-	return SSshuttle.points
+	return D.account_balance
 
 /obj/machinery/computer/stockexchange/attack_ai(mob/user)
 	return attack_hand(user)
@@ -178,7 +179,8 @@ a.updated {
 	if (!li)
 		to_chat(user, "<span class='danger'>No active account on the console!</span>")
 		return
-	var/b = SSshuttle.points
+	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
+	var/b = D.account_balance
 	var/avail = S.shareholders[logged_in]
 	if (!avail)
 		to_chat(user, "<span class='danger'>This account does not own any shares of [S.name]!</span>")
@@ -193,7 +195,7 @@ a.updated {
 		return
 	if (li != logged_in)
 		return
-	b = SSshuttle.points
+	b = D.account_balance
 	if (!isnum(b))
 		to_chat(user, "<span class='danger'>No active account on the console!</span>")
 		return

--- a/yogstation/code/modules/stock_market/stocks.dm
+++ b/yogstation/code/modules/stock_market/stocks.dm
@@ -247,10 +247,11 @@
 	borrow_brokers += B
 
 /datum/stock/proc/modifyAccount(whose, by, force=0)
-	if (SSshuttle.points)
-		if (by < 0 && SSshuttle.points + by < 0 && !force)
+	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
+	if (D.account_balance)
+		if (by < 0 && D.account_balance + by < 0 && !force)
 			return 0
-		SSshuttle.points += by
+		D.account_balance += by
 		GLOB.stockExchange.balanceLog(whose, by)
 		return 1
 	return 0


### PR DESCRIPTION
Due to the addition of the new economy system, a bunch of code related to cargo was left partially functional, with things such as the stock market or the shuttle purchase system relying on the former shuttlepoints variable rather than the new account balance of the cargo department. 

This pull request eliminates those bugs, linking the stock market back up to the cargo console, as well as the communications console. Furthermore, it eliminates a smaller bug wherein a message displayed by the bounty console would show the static shuttlepoints.

I've done some rudimentary testing, and it all seems to be working as intended.

Fixes issue #2881 