### PR TITLE
makes romerol unbuyable for nuke ops

### DIFF
--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -48,3 +48,6 @@
 	item = /obj/item/reagent_containers/food/snacks/burger/cluwneburger
 	cost = 25
 	restricted_roles = list("Clown", "Cook")
+
+/datum/uplink_item/stealthy_weapons/romerol_kit
+	exclude_modes = list(/datum/game_mode/nuclear)


### PR DESCRIPTION
PRs to this branch: https://github.com/yogstation13/Yogstation-TG/pull/3179
see: https://github.com/yogstation13/Yogstation-TG/pull/3061