### PR TITLE
Some final fixes and tweaks for atmos

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -54570,12 +54570,6 @@
 	dir = 4
 	},
 /area/engine/atmos)
-"myB" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	name = "Pure Gas Connector Port"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "myI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/grimy,
@@ -96578,7 +96572,7 @@ bOd
 wdE
 xei
 bOd
-myB
+bOd
 ppr
 tqk
 fuJ

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -39806,6 +39806,10 @@
 	location = "Atmospherics"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Blast Door"
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bPn" = (
@@ -48006,11 +48010,6 @@
 	},
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
-"cCI" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
 "cCQ" = (
 /obj/machinery/light{
 	dir = 4
@@ -48229,9 +48228,9 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cDY" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -49400,14 +49399,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"cJy" = (
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "cKY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -50169,10 +50160,6 @@
 "cVb" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
-"cVt" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "cVO" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -50446,7 +50433,9 @@
 /area/security/courtroom)
 "dFl" = (
 /obj/structure/grille,
-/obj/machinery/meter,
+/obj/machinery/meter{
+	layer = 3.4
+	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
@@ -50662,6 +50651,10 @@
 	pixel_x = 30;
 	pixel_y = 0
 	},
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	dir = 4;
+	name = "Waste to Space"
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "eeX" = (
@@ -50875,6 +50868,13 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/engine/air,
 /area/engine/atmos)
+"eJk" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "eJp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	icon_state = "intact";
@@ -51001,6 +51001,7 @@
 /area/engine/atmos)
 "eUy" = (
 /obj/machinery/computer/atmos_control/tank/mix_tank{
+	dir = 4;
 	sensors = list("mix_sensor" = "Tank")
 	},
 /turf/open/floor/plasteel/dark,
@@ -51251,6 +51252,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"fuJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "fya" = (
 /obj/structure/table,
 /obj/item/stock_parts/subspace/amplifier,
@@ -51310,6 +51317,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"fEd" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Port to Engine"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "fEe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -51458,6 +51472,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
 "fRF" = (
@@ -51634,8 +51649,8 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "gfw" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -51673,6 +51688,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 0
 	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
+/obj/machinery/meter,
 /turf/open/floor/plasteel{
 	dir = 2
 	},
@@ -51737,6 +51756,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"gsd" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 2;
+	icon_state = "manifoldlayer";
+	level = 2
+	},
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "gsm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -51760,10 +51787,6 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
 	name = "atmos blast door"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	icon_state = "intact";
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -51880,6 +51903,12 @@
 /obj/machinery/pipedispenser,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
+"gEo" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 10
+	},
+/turf/closed/wall,
+/area/maintenance/disposal/incinerator)
 "gFn" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest,
@@ -52265,9 +52294,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "hEY" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/green/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "hFk" = (
@@ -52352,6 +52379,9 @@
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "hSl" = (
@@ -52921,6 +52951,7 @@
 "jil" = (
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "jiK" = (
@@ -52977,6 +53008,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
 "jor" = (
@@ -52991,7 +53023,6 @@
 	dir = 8
 	},
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
@@ -53018,13 +53049,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"jsq" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
-	name = "Mix to Engine"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "jsQ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -53044,6 +53068,7 @@
 	id = "atmos";
 	name = "atmos blast door"
 	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
 "jyf" = (
@@ -53061,12 +53086,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
-"jBn" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "jBX" = (
 /turf/closed/wall/r_wall,
 /area/medical/medbay/central)
@@ -53120,7 +53139,9 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "jGJ" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 2
+	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "jHt" = (
@@ -53158,7 +53179,7 @@
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
 "jJx" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -53186,6 +53207,7 @@
 "jOZ" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "jQk" = (
@@ -53314,10 +53336,7 @@
 	dir = 1
 	},
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	icon_state = "intact";
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "kft" = (
@@ -53337,7 +53356,6 @@
 /area/crew_quarters/bar)
 "kfB" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
@@ -53348,7 +53366,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
 /area/space/nearstation)
 "kgS" = (
@@ -53499,6 +53516,7 @@
 	icon_state = "intact";
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plasteel{
 	dir = 2
 	},
@@ -53621,10 +53639,8 @@
 "kHp" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/reagent_dispensers/watertank,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 10
-	},
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "kHr" = (
@@ -53698,7 +53714,6 @@
 	id = "atmos";
 	name = "atmos blast door"
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
 /area/space/nearstation)
 "kNF" = (
@@ -53801,6 +53816,12 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"lbo" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "lbw" = (
 /obj/structure/transit_tube/crossing,
 /obj/structure/lattice/catwalk,
@@ -53871,6 +53892,7 @@
 /area/medical/medbay/central)
 "lgk" = (
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
+	dir = 4;
 	sensors = list("o2_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -53881,6 +53903,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
 "lhH" = (
@@ -54033,7 +54056,7 @@
 /area/engine/atmos)
 "lrP" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -54060,10 +54083,10 @@
 /turf/open/floor/plating,
 /area/vacant_room/office/office_b)
 "lti" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ltm" = (
@@ -54313,6 +54336,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
 "lSu" = (
@@ -54545,6 +54569,12 @@
 /turf/open/floor/plasteel/white/corner{
 	dir = 4
 	},
+/area/engine/atmos)
+"myB" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	name = "Pure Gas Connector Port"
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "myI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
@@ -54821,6 +54851,7 @@
 /area/medical/morgue)
 "mYT" = (
 /obj/machinery/computer/atmos_control/tank/carbon_tank{
+	dir = 8;
 	sensors = list("co2_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -54961,13 +54992,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"nut" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	icon_state = "intact";
-	dir = 4
-	},
-/turf/closed/wall,
-/area/maintenance/disposal/incinerator)
 "nvh" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -55143,6 +55167,23 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"nOb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "intact";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	icon_state = "manifold";
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "nPT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	icon_state = "manifold";
@@ -55257,11 +55298,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4;
-	icon_state = "manifoldlayer";
-	level = 2
-	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "oef" = (
@@ -55298,14 +55334,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"oiv" = (
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "oiE" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -55425,6 +55453,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
+"oyj" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "oyD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -55723,10 +55756,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "poR" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ppr" = (
@@ -55781,6 +55814,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"puk" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "pvl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	icon_state = "intact";
@@ -55789,20 +55828,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"pvS" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4;
-	icon_state = "manifoldlayer";
-	level = 2
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "pxA" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
 	filter_type = "o2";
@@ -55909,8 +55934,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/computer/atmos_alert{
-	name = "Atmospheric Alert Console"
+/obj/machinery/computer/atmos_control/tank/mix_tank{
+	sensors = list("mix_sensor" = "Tank")
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -55930,6 +55955,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/lounge)
+"pKP" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "pMc" = (
 /obj/machinery/light{
 	dir = 8
@@ -56012,19 +56043,10 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"pYb" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	name = "Pure Gas Connector Port"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "pZc" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	icon_state = "intact";
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "pZo" = (
@@ -56061,7 +56083,9 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/meter,
+/obj/machinery/meter{
+	layer = 3.4
+	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "qeQ" = (
@@ -56125,13 +56149,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"qrx" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space/nearstation)
 "qrA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -56699,10 +56716,6 @@
 	},
 /turf/open/floor/carpet,
 /area/vacant_room)
-"rIR" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "rJj" = (
 /obj/structure/closet/l3closet/virology,
 /obj/effect/turf_decal/tile/green,
@@ -56816,13 +56829,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"rVU" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	icon_state = "intact";
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "rXn" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 0
@@ -57079,6 +57085,13 @@
 	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
+"srT" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "ssY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -57309,6 +57322,12 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
+"sSX" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "sTu" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/atmos{
@@ -57433,6 +57452,7 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "tds" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
@@ -57563,7 +57583,7 @@
 "tzH" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
-	name = "Pure to mix"
+	name = "Pure to Mix"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -57661,6 +57681,12 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"tMI" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/maintenance/disposal/incinerator)
 "tNb" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -57906,9 +57932,9 @@
 	icon_state = "intact";
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "intact";
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	icon_state = "manifold";
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -57995,6 +58021,7 @@
 /area/tcommsat/server)
 "uwE" = (
 /obj/machinery/computer/atmos_control/tank/nitrous_tank{
+	dir = 8;
 	sensors = list("n2o_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -58220,6 +58247,7 @@
 /area/engine/engineering)
 "uVg" = (
 /obj/machinery/computer/atmos_control/tank/air_tank{
+	dir = 4;
 	sensors = list("air_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -58458,6 +58486,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"vnN" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector{
+	dir = 8;
+	on = 1
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "voz" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -58542,8 +58577,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "vAN" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	layer = 2.4;
+	name = "Mix Outlet Pump"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
@@ -58609,14 +58646,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	icon_state = "manifold";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	icon_state = "manifold";
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "vIZ" = (
@@ -58739,6 +58770,13 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"vUP" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	icon_state = "intact";
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "vWA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58794,11 +58832,11 @@
 /area/tcommsat/server)
 "waG" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
-/obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "wbH" = (
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
+	dir = 4;
 	sensors = list("n2_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -58989,7 +59027,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "wwt" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
@@ -58997,8 +59034,16 @@
 	icon_state = "intact";
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"wxr" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "wyh" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/reagent_containers/blood,
@@ -59146,9 +59191,11 @@
 /area/engine/atmos)
 "wHf" = (
 /obj/structure/grille,
-/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
+	},
+/obj/machinery/meter{
+	layer = 3.4
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
@@ -59373,6 +59420,7 @@
 /area/maintenance/aft)
 "xlK" = (
 /obj/machinery/computer/atmos_control/tank/toxin_tank{
+	dir = 8;
 	sensors = list("tox_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -59418,7 +59466,9 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "xtz" = (
@@ -59470,6 +59520,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"xzh" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "xBl" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
@@ -59546,9 +59603,7 @@
 /area/medical/medbay/central)
 "xGO" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "xHa" = (
@@ -59602,14 +59657,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"xMm" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space/nearstation)
 "xNw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -59675,10 +59722,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/clerk)
-"xUs" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "xUt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -93202,23 +93245,23 @@ gXs
 doK
 qeh
 qsf
-oiv
+dFl
 doK
 qeh
 qsf
-cJy
+wHf
 doK
 qeh
 qsf
-cJy
+wHf
 doK
 gXs
 dOc
-ibZ
+cTB
 aaa
 aaa
 aaa
-ibZ
+cqY
 xIU
 cnW
 oTP
@@ -93454,28 +93497,28 @@ qwi
 dfM
 vkW
 bLK
-bLK
-gXs
+vUP
+oyj
 jvd
 lgx
-gXs
+oyj
 jnI
-gXs
+oyj
 lRM
-gXs
+oyj
 fRC
-gXs
+oyj
 lRM
-gXs
+oyj
 fRC
 jvd
-gXs
-dOc
-cTB
+oyj
+wxr
 aaa
+yjy
 aaa
+akE
 aaa
-cqY
 xIU
 xIU
 xIU
@@ -93711,7 +93754,7 @@ vAN
 eUy
 lBe
 rPO
-bLK
+vkr
 bLK
 bLK
 xUt
@@ -93727,11 +93770,11 @@ dfM
 wSG
 bLK
 bLK
-vkr
+bLK
 aaa
-yjy
 aaa
-akE
+wFe
+aaa
 aaa
 aaa
 aaa
@@ -93965,7 +94008,7 @@ drG
 ojH
 ekm
 nhI
-bOd
+puk
 tds
 kqT
 giW
@@ -93984,10 +94027,10 @@ lgk
 pxA
 ltJ
 lZJ
-lrP
+dfM
 aaa
 aaa
-wFe
+ibZ
 aaa
 aaa
 aaa
@@ -94211,9 +94254,9 @@ cpG
 bDC
 bId
 bvj
-xNw
+nOb
 jil
-bLK
+gsd
 kdK
 xvq
 okm
@@ -94222,7 +94265,7 @@ tEZ
 rYI
 bOd
 nhI
-bOd
+pKP
 bVv
 erT
 vDo
@@ -94234,14 +94277,14 @@ esg
 jfN
 mQn
 jfN
-jBn
-bOd
+jfN
+jfN
 hEY
 bOd
 bOd
 dYK
 voN
-lrP
+dfM
 gXs
 gXs
 eQx
@@ -94471,7 +94514,7 @@ bvj
 xNw
 oRZ
 uRX
-pvS
+dZL
 bOd
 lrr
 mGS
@@ -94479,7 +94522,7 @@ dnQ
 pzA
 uHU
 lti
-uHU
+eJk
 poR
 lSu
 eTZ
@@ -94491,14 +94534,14 @@ tJx
 jfN
 msl
 bOd
-tJx
-jfN
-msl
+bOd
+bOd
+srT
 bOd
 bOd
 oEO
 bLK
-vkr
+bLK
 bLK
 aag
 cTB
@@ -94993,8 +95036,8 @@ rfA
 xRJ
 rSM
 waG
-pYb
-hTb
+pKP
+sSX
 lmp
 wiH
 wNB
@@ -95013,7 +95056,7 @@ jJx
 wwt
 jGJ
 pZc
-rVU
+bLK
 sZC
 aaa
 aaa
@@ -95241,7 +95284,7 @@ bFJ
 bvj
 unM
 jOZ
-bLK
+gsd
 xGO
 usU
 bQt
@@ -95250,7 +95293,7 @@ qcq
 sBh
 ddL
 qDt
-qcq
+xzh
 qDt
 lzH
 xsN
@@ -95270,7 +95313,7 @@ bOd
 vke
 ooZ
 lrP
-qrx
+aag
 aaf
 aaf
 gXs
@@ -95507,7 +95550,7 @@ bOd
 npD
 kNF
 xDa
-bOd
+fEd
 xkn
 xQX
 eeK
@@ -95527,8 +95570,8 @@ eAl
 dlH
 psl
 lrP
-qrx
-aaf
+aoV
+aaa
 aoV
 aaa
 aaa
@@ -95764,10 +95807,10 @@ bOd
 nBq
 tEV
 hIH
-rIR
+eeX
 jDI
 tuw
-bLK
+fuJ
 bLK
 bLK
 jFF
@@ -95783,11 +95826,11 @@ dfM
 wSG
 bLK
 bLK
-vkr
-xMm
-gXs
+lbo
 aaa
+aoV
 aaa
+aoV
 aaa
 aaa
 aaa
@@ -96020,29 +96063,29 @@ hfC
 bOd
 bOd
 gfw
-jsq
-xUs
+bOd
+bOd
 jor
-cVt
-cVt
-cCI
+bLK
+fuJ
+aaf
 kNE
 kfJ
-cCI
+aaf
 kfB
-cCI
+aaf
 kfJ
-cCI
+aaf
 kfB
-cCI
+aaf
 kfJ
-cCI
+aaf
 kfB
 kNE
-cCI
+aaf
 cDY
-qrx
-gXs
+aaa
+aaa
 aaa
 aaa
 aoV
@@ -96281,7 +96324,7 @@ pGF
 bOd
 ppr
 tqk
-bLK
+fuJ
 aaf
 doK
 qeh
@@ -96297,8 +96340,8 @@ qsf
 wHf
 doK
 aaf
-aoV
-qrx
+cDY
+aaa
 aaf
 cub
 qkq
@@ -96535,10 +96578,10 @@ bOd
 wdE
 xei
 bOd
-bOd
+myB
 ppr
 tqk
-bLK
+fuJ
 aoV
 doK
 pdz
@@ -96554,8 +96597,8 @@ hUO
 hYf
 doK
 aaa
+tMI
 cfj
-nut
 cfj
 cfj
 ckf
@@ -96795,7 +96838,7 @@ jcS
 jcS
 ulJ
 tqk
-bLK
+fuJ
 aaf
 doK
 hUv
@@ -96811,7 +96854,7 @@ sSH
 tiX
 doK
 aaf
-cfj
+gEo
 kHp
 gvw
 mNF
@@ -97051,8 +97094,8 @@ rXn
 poo
 pZo
 qYV
-bMK
 bLK
+fuJ
 aoV
 doK
 hUv
@@ -97309,7 +97352,7 @@ bLK
 bLK
 bLK
 bLK
-bLK
+vnN
 aaf
 doK
 doK
@@ -97564,9 +97607,9 @@ bLT
 bLT
 bLT
 bLT
-bLT
 uJd
-tQD
+bLK
+bLK
 aaf
 aaf
 aaf
@@ -97821,8 +97864,8 @@ bAw
 bAw
 bzs
 bAw
-bAw
 iZI
+bAw
 tQD
 tQD
 tQD
@@ -98078,8 +98121,8 @@ bAw
 bAw
 bzs
 bAw
-bAw
 ycZ
+bLT
 bLT
 lxg
 hYy


### PR DESCRIPTION
Moved some pipes around to be more aesthetically and thematically pleasing, replaced the second atmos alert console in the office with another mix tank monitor, fixed some pumps which were named incorrectly, added a waste outlet that vents to space(with digital valve), moved the transit tube loop to the left slightly so the tanks are accessible, added an outlet pump to the mix tank, rotated the consoles correctly, changed the color of a pipe, and made sure every sensor, monitor, and inlet/outlet pump functions correctly.
![image](https://user-images.githubusercontent.com/10659549/47885398-40532f00-de0b-11e8-9659-9126d98db679.png)
![image](https://user-images.githubusercontent.com/10659549/47885401-45b07980-de0b-11e8-957a-4b2bd70783a7.png)

Just a bunch of shit, essentially. 

I tested the possible bug where pumps placed on top of perpendicular straight pipes causes cross-contamination, but was not able to reproduce it. It seems to work fine. I'll leave the pumps as they are for the time being, and we can work on a fix if it actual becomes reproducible.
![image](https://user-images.githubusercontent.com/10659549/47885306-c3c05080-de0a-11e8-98ce-cb057f1f1a64.png)

fixes #3117 
fixes #2719 

Also the tank meters are visible now.
fixes #3222 


:cl:  Partheo
tweak: Various small tweaks to the atmos department
bugfix: Gas meters are now visible on atmospherics' gas tanks.
bugfix: Various fixes to the atmos department
/:cl:
