### PR TITLE
Prevents Lilith's Pact from converting mindshielded crew

### DIFF
--- a/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -273,6 +273,9 @@
 		if(is_vampire(target))
 			to_chat(user, "<span class='warning'>They're already a vampire!</span>")
 			continue
+		if(target.has_trait(TRAIT_MINDSHIELD))
+			to_chat(user, "<span class='warning'>[target]'s mind is too strong!</span>")
+			continue
 		user.visible_message("<span class='warning'>[user] latches onto [target]'s neck, and a pure dread eminates from them.</span>", "<span class='warning'>You latch onto [target]'s neck, preparing to transfer your unholy blood to them.</span>", "<span class='warning'>A dreadful feeling overcomes you</span>")
 		target.reagents.add_reagent("salbutamol", 10) //incase you're choking the victim
 		for(var/progress = 0, progress <= 3, progress++)


### PR DESCRIPTION
Gives a message when attempting to use this ability on players who are mindshielded.
Fixes issue #3353 I assume this is what they meant by "thrall".

:cl:  
tweak: Lilith's Pact no longer works on mindshielded personnel.
/:cl:
