### PR TITLE
Adds prebase chem closet items

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -96,3 +96,8 @@
 	new /obj/item/storage/box/pillbottles(src)
 	new /obj/item/storage/box/medsprays(src)
 	new /obj/item/storage/box/medsprays(src)
+	//yogs start - adds reagent bottles
+	new /obj/item/reagent_containers/glass/bottle/facid(src)
+	new /obj/item/reagent_containers/glass/bottle/capsaicin(src)
+	new /obj/item/reagent_containers/glass/bottle/mutagen(src)
+	//yogs end


### PR DESCRIPTION
These three were in them before we rebased, that's why.

:cl:  
rscadd: Chemical closets have been restocked.
/:cl:
