### PR TITLE
moves some uplink items around, renames conspicuous and dangerous wea…

### DIFF
--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -2,6 +2,40 @@
 	var/list/include_objectives = list() //objectives to allow the buyer to buy this item
 	var/list/exclude_objectives = list() //objectives to disallow the buyer from buying this item
 
+/////////////////////////////////
+////////Item re-balancing////////
+/////////////////////////////////
+
+/datum/uplink_item/dangerous
+	category = "Conspicuous Weapons"
+
+/datum/uplink_item/stealthy_weapons/throwingweapons
+	category = "Conspicuous Weapons"
+
+/datum/uplink_item/stealthy_weapons/martialarts
+	category = "Conspicuous Weapons"
+
+/datum/uplink_item/stealthy_weapons/cqc
+	category = "Conspicuous Weapons"
+
+/datum/uplink_item/stealthy_weapons/romerol_kit
+	category = "Conspicuous Weapons"
+
+/datum/uplink_item/stealthy_weapons/soap_clusterbang
+	category = "Conspicuous Weapons"
+
+/datum/uplink_item/dangerous/syndicate_minibomb
+	cost = 4
+
+/datum/uplink_item/device_tools/emag
+	cost = 8
+
+/datum/uplink_item/role_restricted/his_grace
+	include_objectives = list(/datum/objective/hijack)
+
+//////////////////////////
+/////////New Items////////
+//////////////////////////
 
 /datum/uplink_item/stealthy_weapons/door_charge
 	name = "Explosive Airlock Charge"
@@ -26,24 +60,13 @@
 	user.change_number_of_hands(limbs+1)
 	to_chat(user, "You feel more dexterous")
 
-/datum/uplink_item/dangerous/syndicate_minibomb
-	cost = 4
-
-/datum/uplink_item/device_tools/emag
-	cost = 8
-
-
-/datum/uplink_item/role_restricted/his_grace
-	include_objectives = list(/datum/objective/hijack)
-
-
 /datum/uplink_item/role_restricted/gondola_meat
 	name = "Gondola meat"
 	desc = "A slice of gondola meat will turn any hard-working, brainwashed NT employee into a goody-two-shoes gondola in a matter of minutes."
 	item = /obj/item/reagent_containers/food/snacks/meat/slab/gondola
 	cost = 6
 	restricted_roles = list("Cook")
-	
+
 /datum/uplink_item/role_restricted/cluwneburger
 	name = "Cluwne Burger"
 	desc = "A burger infused with the tears of thousands of cluwnes infects anyone who takes a bite with a cluwnification virus which will turn them into a cluwne"


### PR DESCRIPTION
…pons to conspicuous weapons

### Intent of your Pull Request

[22:49] Paul Von Nichdenburg: hey @council do me a favour and start a vote to replace the text in the rules that says stealthy items with items from the categories "stealthy weapons" and "stealthy tools"
[22:49] Paul Von Nichdenburg: thank you
[22:49] Paul Von Nichdenburg: in advance
[22:51] Yogurtshrimp69 .tk: Vote started

Moves items that wouldn't fit with the metashield to conspicuous weapons
#### Changelog

:cl:  
tweak: stealthy weapons now only consists of stealthy weapons :)
/:cl:
