### PR TITLE
Fixes some text when using medical scanners to check viruses

### DIFF
--- a/code/datums/diseases/appendicitis.dm
+++ b/code/datums/diseases/appendicitis.dm
@@ -2,6 +2,7 @@
 	form = "Condition"
 	name = "Appendicitis"
 	max_stages = 3
+	spread_text = "Non-Contagious" //Yogs
 	cure_text = "Surgery"
 	agent = "Shitty Appendix"
 	viable_mobtypes = list(/mob/living/carbon/human)

--- a/code/datums/diseases/cold.dm
+++ b/code/datums/diseases/cold.dm
@@ -1,6 +1,7 @@
 /datum/disease/cold
 	name = "The Cold"
 	max_stages = 3
+	spread_text = "On contact" //Yogs
 	cure_text = "Rest & Spaceacillin"
 	cures = list("spaceacillin")
 	agent = "XY-rhinovirus"

--- a/code/datums/diseases/heart_failure.dm
+++ b/code/datums/diseases/heart_failure.dm
@@ -3,7 +3,8 @@
 	name = "Myocardial Infarction"
 	max_stages = 5
 	stage_prob = 2
-	cure_text = "Heart replacement surgery to cure. Defibrillation (or as a last resort, uncontrolled electric shocking) may also be effective after the onset of cardiac arrest. Corazone can also mitigate cardiac arrest."
+	spread_text = "Non-Contagious" //Yogs
+	cure_text = "Heart replacement surgery to cure. Defibrillation (or as a last resort, uncontrolled electric shocking) may also be effective after the onset of cardiac arrest. Corazone can also mitigate cardiac arrest" //Yogs - Removed a "."
 	agent = "Shitty Heart"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	permeability_mod = 1

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -271,7 +271,7 @@
 
 /datum/disease/transformation/morph
 	name = "Gluttony's Blessing"
-	cure_text = "nothing"
+	cure_text = "Unknown" //Yogs - changed "nothing" to "unknown"
 	cures = list("adminordrazine")
 	agent = "Gluttony's Blessing"
 	desc = "A 'gift' from somewhere terrible."

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -296,7 +296,7 @@ SLIME SCANNER
 	for(var/thing in M.diseases)
 		var/datum/disease/D = thing
 		if(!(D.visibility_flags & HIDDEN_SCANNER))
-			to_chat(user, "<span class='alert'><b>Warning: [D.form] detected</b>\nName: [D.name].\nType: [D.spread_text].\nStage: [D.stage]/[D.max_stages].\nPossible Cure: [D.cure_text]</span>")
+			to_chat(user, "<span class='alert'><b>Warning: [D.form] detected</b>\nName: [D.name].\nType: [D.spread_text].\nStage: [D.stage]/[D.max_stages].\nPossible Cure: [D.cure_text].</span>") //Yogs - Added a "."
 
 	// Blood Level
 	if(M.has_dna())

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -862,7 +862,7 @@
 
 /datum/disease/transformation/dragon
 	name = "dragon transformation"
-	cure_text = "nothing"
+	cure_text = "Unknown" //Yogs - changed "nothing" to "unknown"
 	cures = list("adminordrazine")
 	agent = "dragon's blood"
 	desc = "What do dragons have to do with Space Station 13?"


### PR DESCRIPTION
One of the issues in #3371 .

Adds spread_text for some diseases that were just showing up as ".".
Changes possible cures from "nothing" to "Unknown".