### PR TITLE
Makes the pinpointer pinpoint to the bluespace locker if necessary

### DIFF
--- a/code/datums/components/stationloving.dm
+++ b/code/datums/components/stationloving.dm
@@ -51,7 +51,7 @@
 
 /datum/component/stationloving/proc/in_bounds()
 	var/static/list/allowed_shuttles = typecacheof(list(/area/shuttle/syndicate, /area/shuttle/escape, /area/shuttle/pod_1, /area/shuttle/pod_2, /area/shuttle/pod_3, /area/shuttle/pod_4))
-	var/turf/T = get_turf(parent)
+	var/turf/T = get_turf_global(parent) // yogs - replace get_turf with get_turf_global
 	if (!T)
 		return FALSE
 	var/area/A = T.loc

--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -55,8 +55,8 @@
 	if(!target)
 		add_overlay("pinon[alert ? "alert" : ""]null")
 		return
-	var/turf/here = get_turf(src)
-	var/turf/there = get_turf(target)
+	var/turf/here = get_turf_global(src) // yogs - replace get_turf with get_turf_global
+	var/turf/there = get_turf_global(target) // yogs - replace get_turf with get_turf_global
 	if(here.z != there.z)
 		add_overlay("pinon[alert ? "alert" : ""]null")
 		return

--- a/yogstation/code/game/objects/structures/crates_lockers/closets/bluespace_locker.dm
+++ b/yogstation/code/game/objects/structures/crates_lockers/closets/bluespace_locker.dm
@@ -116,7 +116,7 @@
 /obj/structure/closet/bluespace/external/onTransitZ(old_z,new_z)
 	var/obj/structure/closet/O = get_other_locker()
 	if(O)
-		var/area/A = get_area(get_other_locker())
+		var/area/A = get_area(O)
 		if(A)
 			for(var/atom/movable/M in A)
 				M.onTransitZ(old_z,new_z)

--- a/yogstation/code/game/objects/structures/crates_lockers/closets/bluespace_locker.dm
+++ b/yogstation/code/game/objects/structures/crates_lockers/closets/bluespace_locker.dm
@@ -113,6 +113,15 @@
 		else
 			add_overlay(image(other.icon, "[other.icon_state]_open"))
 
+/obj/structure/closet/bluespace/external/onTransitZ(old_z,new_z)
+	var/obj/structure/closet/O = get_other_locker()
+	if(O)
+		var/area/A = get_area(get_other_locker())
+		if(A)
+			for(var/atom/movable/M in A)
+				M.onTransitZ(old_z,new_z)
+	return ..()
+
 /obj/structure/closet/bluespace/internal/proc/update_mirage()
 	var/area/A = get_area(src)
 	for(var/atom/movable/M in A)


### PR DESCRIPTION
:cl: monster860
fix: If you put the nuke disk inside the bluespace locker then the pinpointer will pinpoint to the bluespace locker instead of not pinpointing to anything at all
fix: you can no longer space the nuke disk using a bluespace locker.
/:cl:

fix #3561