### PR TITLE
Fixes vomit-worthy indentation

### DIFF
--- a/yogstation/code/game/area/Space_Station_13_areas.dm
+++ b/yogstation/code/game/area/Space_Station_13_areas.dm
@@ -1,14 +1,14 @@
 /area/medical/paramedic
-  name = "Paramedic Staging Area"
-  icon_state = "emergencystorage"
+	name = "Paramedic Staging Area"
+	icon_state = "emergencystorage"
 
 /area/medical/psych
-  name = "Psychiatrists office"
-  icon_state = "exam_room"
+	name = "Psychiatrists office"
+	icon_state = "exam_room"
 
 /area/clerk
-  name = "Clerks office"
-  icon_state = "cafeteria"
+	name = "Clerks office"
+	icon_state = "cafeteria"
 
 /area/maintenance
 	ambientsounds = list('sound/ambience/ambimaint1.ogg',
@@ -32,30 +32,30 @@
 /area/vacant_room/office/office_b
 	name = "Vacant Office - B"
 
- /area/tcommsat/lounge
+/area/tcommsat/lounge
 	name = "Telecommunications Satellite Lounge"
 	icon_state = "tcomsatlounge"
 
- /area/tcommsat/entrance
+/area/tcommsat/entrance
 	name = "Telecomms Teleporter"
 	icon_state = "tcomsatentrance"
 
- /area/tcommsat/chamber
+/area/tcommsat/chamber
 	name = "Abandoned Satellite"
 	icon_state = "tcomsatcham"
 
- /area/ai_monitored/turret_protected/tcomsat
+/area/ai_monitored/turret_protected/tcomsat
 	name = "Telecomms Satellite"
 	icon_state = "tcomsatlob"
 
- /area/ai_monitored/turret_protected/tcomfoyer
+/area/ai_monitored/turret_protected/tcomfoyer
 	name = "Telecomms Foyer"
 	icon_state = "tcomsatentrance"
 
- /area/ai_monitored/turret_protected/tcomwest
+/area/ai_monitored/turret_protected/tcomwest
 	name = "Telecommunications Satellite West Wing"
 	icon_state = "tcomsatwest"
 
- /area/ai_monitored/turret_protected/tcomeast
+/area/ai_monitored/turret_protected/tcomeast
 	name = "Telecommunications Satellite East Wing"
 	icon_state = "tcomsateast"


### PR DESCRIPTION
AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA

- there's spaces in front of some of the typepaths
- tabs and spaces in the same file
- this vomit worthy indentation causes FastDMM to crash
- [blame](https://github.com/yogstation13/Yogstation-TG/commit/69460c92b2733611b626f0032be814aa687e9bc4#diff-15281992f8f55014e9ce7088cf5f9af3)