### PR TITLE
moves screwdriver thinging vendor circuits to a radial

### DIFF
--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2791,6 +2791,7 @@
 #include "yogstation\code\game\objects\items\plushes.dm"
 #include "yogstation\code\game\objects\items\sharpener.dm"
 #include "yogstation\code\game\objects\items\circuitboards\computer_circuitboards.dm"
+#include "yogstation\code\game\objects\items\circuitboards\machine_circuitboards.dm"
 #include "yogstation\code\game\objects\items\devices\powersink.dm"
 #include "yogstation\code\game\objects\items\devices\PDA\cart.dm"
 #include "yogstation\code\game\objects\items\devices\PDA\PDA.dm"

--- a/yogstation/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/yogstation/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -1,0 +1,16 @@
+/obj/item/circuitboard/machine/vendor/screwdriver_act(mob/living/user, obj/item/I)
+	var/list/icons = list()
+	var/list/inverse = list()
+	for(var/V in vending_names_paths)
+		var/obj/machinery/vending/n = V
+		icons[vending_names_paths[n]] = image(icon = initial(n.icon), icon_state = initial(n.icon_state))
+		inverse[vending_names_paths[n]] = n
+		to_chat(world, "fuck")
+
+	var/type = show_radial_menu(user, src, icons, radius = 42)
+	to_chat(world, "fuck")
+
+	if(type)
+		set_type(inverse[type])
+
+	return TRUE

--- a/yogstation/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/yogstation/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -5,10 +5,8 @@
 		var/obj/machinery/vending/n = V
 		icons[vending_names_paths[n]] = image(icon = initial(n.icon), icon_state = initial(n.icon_state))
 		inverse[vending_names_paths[n]] = n
-		to_chat(world, "fuck")
 
 	var/type = show_radial_menu(user, src, icons, radius = 42)
-	to_chat(world, "fuck")
 
 	if(type)
 		set_type(inverse[type])


### PR DESCRIPTION
### Intent of your Pull Request
![image](https://user-images.githubusercontent.com/20558591/49311524-ae117a00-f4e1-11e8-8cbe-0096a5ec41db.png)

I was looking at old /tg/ PRs and someone mentioned this so here we go.

Much much much much much much much better than having to cycle through every single fucking item on that list.

#### Changelog

:cl:  
tweak: vendor-circuit-modification now uses a radial menu
/:cl:
