### PR TITLE
Makes chocobos not slow as hell V2 Electric Boogaloo

### DIFF
--- a/yogstation/code/modules/mob/living/simple_animal/friendly/chocobo.dm
+++ b/yogstation/code/modules/mob/living/simple_animal/friendly/chocobo.dm
@@ -40,6 +40,7 @@
 	D.set_vehicle_dir_layer(NORTH, OBJ_LAYER)
 	D.set_vehicle_dir_layer(EAST, ABOVE_MOB_LAYER)
 	D.set_vehicle_dir_layer(WEST, ABOVE_MOB_LAYER)
+	D.vehicle_move_delay = 1
 
 /mob/living/simple_animal/chocobo/death(gibbed)
 	. = ..()


### PR DESCRIPTION
🆑 Fluffe9911
tweak: Chocobos should now run at the same speed as a person running.
/🆑
Its a bloody 8000 emag only thing it should ATLEAST be as fast as the much easier to get and cheaper atv like come on now

Also lings prob not even going to read this description but why the heck do you care you barely even play the game you meme