### PR TITLE
lavaland movespeed is now the same as on /tg/

### DIFF
--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2922,6 +2922,7 @@
 #include "yogstation\code\modules\mob\living\carbon\life.dm"
 #include "yogstation\code\modules\mob\living\carbon\reindex_screams.dm"
 #include "yogstation\code\modules\mob\living\carbon\human\human_defense.dm"
+#include "yogstation\code\modules\mob\living\carbon\human\human_movement.dm"
 #include "yogstation\code\modules\mob\living\carbon\human\life.dm"
 #include "yogstation\code\modules\mob\living\carbon\human\species.dm"
 #include "yogstation\code\modules\mob\living\carbon\human\species_types\halloween.dm"

--- a/yogstation/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/human_movement.dm
@@ -1,0 +1,16 @@
+/mob/living/carbon/human/onTransitZ(old_z,new_z)
+	.=..()
+	if(is_mining_level(new_z) || is_mining_level(old_z))
+		update_move_intent_slowdown()
+		update_movespeed()
+
+/mob/living/carbon/human/update_move_intent_slowdown()
+	if(!is_mining_level(z))
+		return ..()
+
+	var/mod = 0
+	if(m_intent == MOVE_INTENT_WALK)
+		mod = 4
+	else
+		mod = 1
+	add_movespeed_modifier(MOVESPEED_ID_MOB_WALK_RUN_CONFIG_SPEED, TRUE, 100, override = TRUE, multiplicative_slowdown = mod)


### PR DESCRIPTION
### Intent of your Pull Request

Well, as the title states, this makes our movespeed be the exact same as the default is, so that fighting megafauna isn't complete trash. 

#### Changelog

:cl:  
tweak: lavaland now has weaker gravity (you move faster)
/:cl:
