### PR TITLE
removes upgrade cost for reflective blobs

### DIFF
--- a/code/modules/antagonists/blob/blob/powers.dm
+++ b/code/modules/antagonists/blob/blob/powers.dm
@@ -120,8 +120,8 @@
 /mob/camera/blob/proc/create_shield(turf/T)
 	var/obj/structure/blob/shield/S = locate(/obj/structure/blob/shield) in T
 	if(S)
-		if(!can_buy(15))
-			return
+		//if(!can_buy(15))
+			//return //yog change
 		if(S.obj_integrity < S.max_integrity * 0.5)
 			to_chat(src, "<span class='warning'>This shield blob is too damaged to be modified properly!</span>")
 			return


### PR DESCRIPTION
holy fuck reflector blobs are so fucking bad
I’m probably going to find a way to make them always reflect too but this is a decent short term fix for the significantly broader issue of blobs being really shitty

:cl: ShadowDeath6
tweak: Converting shield blobs to reflectors no longer costs Blob Points. 
/:cl: