### PR TITLE
blob core attacks now flash in big bold red

### DIFF
--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2860,6 +2860,7 @@
 #include "yogstation\code\modules\admin\verbs\spawnfloorcluwne.dm"
 #include "yogstation\code\modules\antagonists\_common\antag_datum.dm"
 #include "yogstation\code\modules\antagonists\abductor\equipment\abduction_outfits.dm"
+#include "yogstation\code\modules\antagonists\blob\blob\blobs\core.dm"
 #include "yogstation\code\modules\antagonists\changeling\changeling_power.dm"
 #include "yogstation\code\modules\antagonists\changeling\powers\absorb.dm"
 #include "yogstation\code\modules\antagonists\changeling\powers\fakedeath.dm"

--- a/yogstation/code/modules/antagonists/blob/blob/blobs/core.dm
+++ b/yogstation/code/modules/antagonists/blob/blob/blobs/core.dm
@@ -1,0 +1,5 @@
+/obj/structure/blob/core/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, overmind_reagent_trigger = 1)
+	. = ..()
+	if(obj_integrity > 0)
+		if(overmind) //we should have an overmind, but...
+			to_chat(overmind, "<span class='userdanger'>Your core is under attack!</span>")


### PR DESCRIPTION
### Intent of your Pull Request

![image](https://user-images.githubusercontent.com/20558591/50241071-ced53d00-03c6-11e9-95c6-7fab6edc3d40.png)
https://forums.yogstation.net/index.php?threads/petition-to-notify-blobs-when-their-core-is-under-attack.17876/#post-155532

#### Changelog

:cl:  
tweak: the blob now gets a big bold red message telling them their core is under attack :)
/:cl:
