### PR TITLE
Fixes randomized bars spewing build_pileline warnings up your ass

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -370,6 +370,8 @@ SUBSYSTEM_DEF(air)
 		CHECK_TICK
 
 /datum/controller/subsystem/air/proc/setup_template_machinery(list/atmos_machines)
+	if(!initialized) // yogs - fixes randomized bars
+		return // yogs
 	for(var/A in atmos_machines)
 		var/obj/machinery/atmospherics/AM = A
 		AM.atmosinit()


### PR DESCRIPTION
What this PR does: 

- fix the warnings

What this PR doesn't do:

- re-add the maps
- update the maps so that the pipes actually line up and use pipe layers