### PR TITLE
Makes the holotool less retarded

### DIFF
--- a/yogstation/code/game/objects/items/holotool/holotool.dm
+++ b/yogstation/code/game/objects/items/holotool/holotool.dm
@@ -87,7 +87,7 @@
 		return FALSE
 	return TRUE
 
-/obj/item/holotool/CtrlClick(mob/user)
+/obj/item/holotool/attack_hand(mob/user)
 	update_listing()
 	var/chosen = show_radial_menu(user, src, radial_modes, custom_check = CALLBACK(src, .proc/check_menu,user))
 	if(!check_menu(user))

--- a/yogstation/code/game/objects/items/holotool/holotool.dm
+++ b/yogstation/code/game/objects/items/holotool/holotool.dm
@@ -87,7 +87,7 @@
 		return FALSE
 	return TRUE
 
-/obj/item/holotool/attack_hand(mob/user)
+/obj/item/holotool/attack_self(mob/user)
 	update_listing()
 	var/chosen = show_radial_menu(user, src, radial_modes, custom_check = CALLBACK(src, .proc/check_menu,user))
 	if(!check_menu(user))


### PR DESCRIPTION
Right now, the holotool is a straight up downgrade from "a bunch of normal tools in a toolbelt":

- It's the same size as a toolbelt
- Makes a lot more noise than tools in a toolbelt
- Much bigger pain in the ass to switch tools than simply taking the right tool out of the toolbelt because you have to ctrl-click or use action button
- The radial icons are very unclear and confusing and all look the same unlike toolbelt items
- It's an objective item so having it makes you a target
- attack_hand isn't even used for anything anyways so there's no reason to make it use ctrl-click

the only real upgrade here is a 25% reduction in tool use time and the ability to use multiple tools at the same time.

:cl: monster860
tweak: The holotool's mode can be changed by using it in your hand instead of ctrl-clicking
/:cl:
