### PR TITLE
Toy shop no longer breaks everything

### DIFF
--- a/yogstation/code/datums/ruins/lavaland.dm
+++ b/yogstation/code/datums/ruins/lavaland.dm
@@ -1,8 +1,8 @@
-/datum/map_template/ruin/lavaland
+/datum/map_template/ruin/lavaland/yogstation
 	prefix = "_maps/yogstation/RandomRuins/LavaRuins/"
 	cost = 0
 
-/datum/map_template/ruin/lavaland/toyshop
+/datum/map_template/ruin/lavaland/yogstation/toyshop
 	name = "Toy Shop"
 	id = "toyshop"
 	description = "A shop that has the entire collection of Nanotrasen brand action figures!."


### PR DESCRIPTION
turns out the toy shop ruin was overwriting where ALL ruins got their maps from, meaning any ruin not in the yogstation maps folder wouldn't appear when it spawned

:cl:  Theos
bugfix: lavaland ruins will spawn again
/:cl:
