### PR TITLE
Someone was bitching in ooc a few days ago about airless tiles being misplaced instead of reporting it here

### DIFF
--- a/_maps/yogstation/map_files/YogStation/YogStation.dmm
+++ b/_maps/yogstation/map_files/YogStation/YogStation.dmm
@@ -7636,7 +7636,7 @@
 	},
 /obj/machinery/atmospherics/components/binary/pump/on/layer1{
 	icon_state = "pump_on_map-1";
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
@@ -12923,6 +12923,16 @@
 "azF" = (
 /turf/closed/wall,
 /area/hydroponics/garden)
+"azG" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Core";
+	req_access_txt = "16"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "azH" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -13155,6 +13165,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"aAe" = (
+/obj/structure/lattice,
+/turf/open/floor/plating/airless,
+/area/space)
 "aAf" = (
 /obj/structure/closet/wardrobe/pjs,
 /obj/effect/turf_decal/tile/neutral,
@@ -13596,6 +13610,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"aAX" = (
+/obj/item/target,
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/science/test_area)
 "aAY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	icon_state = "pipe11-3";
@@ -13726,6 +13748,24 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"aBm" = (
+/obj/machinery/camera{
+	active_power_usage = 0;
+	c_tag = "Bomb Test Site";
+	desc = "A specially-reinforced camera with a long lasting battery, used to monitor the bomb testing site.";
+	dir = 8;
+	invuln = 1;
+	light = null;
+	name = "Hardened Bomb-Test Camera";
+	network = list("toxins");
+	use_power = 0
+	},
+/obj/item/target/alien/anchored,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/science/test_area)
 "aBn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	icon_state = "vent_map_on-1";
@@ -17027,6 +17067,14 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"aHq" = (
+/obj/item/target,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/science/test_area)
 "aHr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -18013,6 +18061,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"aJk" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	icon_state = "pipe11-2";
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "aJl" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/machinery/light{
@@ -18023,6 +18078,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"aJm" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	icon_state = "pipe11-2";
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "aJn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -18114,6 +18176,13 @@
 "aJw" = (
 /turf/closed/wall,
 /area/hallway/primary/central)
+"aJx" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	icon_state = "pipe11-2";
+	dir = 8
+	},
+/turf/closed/wall,
+/area/engine/atmos)
 "aJy" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -18132,6 +18201,14 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"aJA" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+	icon_state = "manifold-2";
+	dir = 1
+	},
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "aJB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
@@ -18142,6 +18219,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"aJC" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	icon_state = "pipe11-2";
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/security/checkpoint/engineering)
 "aJD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	icon_state = "scrub_map_on-3";
@@ -18149,6 +18233,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"aJE" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "aJF" = (
 /obj/machinery/newscaster{
 	pixel_x = 30
@@ -18168,6 +18256,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"aJH" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	icon_state = "pipe11-2";
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "aJI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	icon_state = "scrub_map_on-3";
@@ -18181,6 +18276,13 @@
 "aJJ" = (
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"aJK" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	icon_state = "pipe11-2";
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/tcommsat/lounge)
 "aJL" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
@@ -18447,6 +18549,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
+"aKr" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	icon_state = "pipe11-2";
+	dir = 9
+	},
+/turf/closed/wall,
+/area/engine/engineering)
 "aKs" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/structure/window,
@@ -18483,6 +18592,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aKx" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector{
+	on = 1
+	},
+/turf/open/floor/plating/airless,
+/area/maintenance/disposal/incinerator)
 "aKy" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -18495,6 +18610,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"aKz" = (
+/obj/item/wrench,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "aKA" = (
 /obj/structure/table,
 /obj/item/aiModule/supplied/freeform,
@@ -18508,6 +18627,10 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"aKC" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/space)
 "aKD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -18545,6 +18668,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"aKJ" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "aKK" = (
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
 /turf/open/floor/plasteel,
@@ -18562,6 +18689,9 @@
 /obj/machinery/plantgenes,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"aKM" = (
+/turf/open/floor/plating/airless,
+/area/space)
 "aKQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	icon_state = "scrub_map_on-3";
@@ -42804,12 +42934,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"bHr" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "bHs" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -42845,20 +42969,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"bHw" = (
-/obj/item/target,
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/science/test_area)
-"bHx" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "bHy" = (
 /obj/structure/closet/crate,
 /obj/machinery/light/small{
@@ -42890,12 +43000,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"bHB" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/engine/atmos)
 "bHC" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -42910,13 +43014,6 @@
 "bHE" = (
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"bHF" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "bHG" = (
 /obj/structure/rack,
 /obj/item/circuitboard/computer/crew{
@@ -43033,12 +43130,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"bHS" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/security/checkpoint/engineering)
 "bHT" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -44283,27 +44374,6 @@
 	name = "hyper-reinforced wall"
 	},
 /area/science/test_area)
-"bLr" = (
-/obj/machinery/camera{
-	active_power_usage = 0;
-	c_tag = "Bomb Test Site";
-	desc = "A specially-reinforced camera with a long lasting battery, used to monitor the bomb testing site.";
-	dir = 8;
-	invuln = 1;
-	light = null;
-	name = "Hardened Bomb-Test Camera";
-	network = list("toxins");
-	use_power = 0
-	},
-/obj/item/target/alien/anchored,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	luminosity = 2;
-	initial_gas_mix = "o2=0.01;n2=0.01"
-	},
-/area/science/test_area)
 "bLu" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -44647,10 +44717,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
-"bNG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/science/test_area)
 "bNH" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
@@ -44813,14 +44879,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"bOJ" = (
-/obj/item/target,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/science/test_area)
 "bOK" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
@@ -47654,10 +47712,6 @@
 "cfw" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/port/aft)
-"cfx" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/solars/port/aft)
 "cfy" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/winterboots,
@@ -50277,12 +50331,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/tcommsat/entrance)
-"cub" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector{
-	on = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal/incinerator)
 "cuD" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/landmark/event_spawn,
@@ -52663,16 +52711,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cTk" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "AI Core";
-	req_access_txt = "16"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/circuit/airless,
-/area/ai_monitored/turret_protected/ai)
 "cTw" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating{
@@ -52933,10 +52971,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet,
 /area/library)
-"dyp" = (
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space)
 "dCA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -53201,10 +53235,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"eFB" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/space/nearstation)
 "eFU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -53338,10 +53368,6 @@
 	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
-"faD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/storage/tools)
 "fba" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -53481,13 +53507,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"fAq" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	icon_state = "intact";
-	dir = 9
-	},
-/turf/closed/wall,
-/area/engine/engineering)
 "fCx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -54391,9 +54410,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
-"hTj" = (
-/turf/open/floor/plating,
-/area/space/nearstation)
 "hUv" = (
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
@@ -55285,10 +55301,6 @@
 "kVU" = (
 /turf/closed/wall,
 /area/vacant_room/commissary)
-"kWc" = (
-/obj/item/wrench,
-/turf/open/floor/plating,
-/area/space/nearstation)
 "kWr" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -55520,10 +55532,6 @@
 	},
 /turf/closed/wall,
 /area/maintenance/aft)
-"luG" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "lvl" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -57436,13 +57444,6 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"rKG" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	icon_state = "intact";
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/tcommsat/lounge)
 "rKP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
@@ -58527,13 +58528,6 @@
 /obj/structure/bookcase/manuals/medical,
 /turf/open/floor/wood,
 /area/medical/medbay/central)
-"uDX" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	icon_state = "intact";
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "uFb" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -58559,9 +58553,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"uLO" = (
-/turf/open/floor/plating,
-/area/space)
 "uNF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58652,10 +58643,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
-"uWd" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/space)
 "uYe" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -59137,10 +59124,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
-"wki" = (
-/obj/structure/lattice,
-/turf/open/floor/plating,
-/area/space)
 "wkN" = (
 /turf/closed/wall,
 /area/science/nanite)
@@ -74095,7 +74078,7 @@ aAC
 aaf
 aoV
 qdN
-wki
+aAe
 aaa
 aaa
 aaa
@@ -75127,7 +75110,7 @@ bja
 bja
 aaa
 aaa
-wki
+aAe
 qdN
 aaa
 aaa
@@ -76668,7 +76651,7 @@ bkD
 vPm
 xfi
 tnb
-wki
+aAe
 aaa
 aaa
 aaa
@@ -76924,7 +76907,7 @@ bdH
 jqy
 tnb
 aaa
-wki
+aAe
 aaa
 aaa
 aaa
@@ -80046,9 +80029,9 @@ aaa
 aaf
 aaa
 aaa
-cfx
+aJE
 chO
-cfx
+aJE
 aaa
 aaf
 aaf
@@ -80303,9 +80286,9 @@ aaa
 aaf
 aaa
 aaa
-cfx
+aJE
 chN
-cfx
+aJE
 aaa
 aaa
 aaf
@@ -80559,11 +80542,11 @@ bCq
 bCq
 bCq
 bCq
-cfx
-cfx
+aJE
+aJE
 cyK
-cfx
-cfx
+aJE
+aJE
 aaa
 aaa
 aaf
@@ -81778,7 +81761,7 @@ axv
 arP
 aoV
 gXs
-faD
+aSs
 aSr
 rRn
 aJY
@@ -90541,7 +90524,7 @@ aop
 apI
 bfd
 aDp
-cTk
+azG
 nCV
 nCV
 aKi
@@ -91343,7 +91326,7 @@ bSC
 bLK
 aZW
 bwO
-bHF
+aJA
 bXK
 bYH
 bZz
@@ -92111,7 +92094,7 @@ sej
 aRc
 nTg
 bOd
-luG
+kJW
 bwB
 dnQ
 bHI
@@ -92371,7 +92354,7 @@ ydZ
 bMK
 bwE
 xHa
-bHS
+aJC
 bWQ
 bYN
 byZ
@@ -92628,7 +92611,7 @@ ohS
 bMK
 bwL
 bOd
-bHS
+aJC
 bOO
 bQe
 bza
@@ -92885,7 +92868,7 @@ szl
 szl
 baf
 aRe
-bHS
+aJC
 bXP
 bxH
 bzb
@@ -93142,7 +93125,7 @@ bOd
 gyl
 aFg
 xYi
-bHS
+aJC
 bXO
 aRG
 bRo
@@ -93396,7 +93379,7 @@ kJW
 bvq
 kJW
 kJW
-bHr
+aJk
 lKf
 lKf
 fme
@@ -93418,10 +93401,10 @@ ccw
 ccw
 ccw
 ccw
-uDX
+aJH
 xFm
 bFD
-fAq
+aKr
 ccw
 ccw
 cMm
@@ -93653,7 +93636,7 @@ bOd
 bvr
 gYP
 sOm
-bHx
+aJm
 doK
 doK
 doK
@@ -93675,7 +93658,7 @@ gXs
 aaa
 gXs
 gXs
-rKG
+aJK
 hnZ
 bFE
 bFO
@@ -93910,7 +93893,7 @@ bOd
 bvr
 gYP
 pIt
-bHx
+aJm
 doK
 gjF
 xtz
@@ -93932,7 +93915,7 @@ doK
 doK
 doK
 gXs
-rKG
+aJK
 cYm
 qAG
 bFT
@@ -94167,7 +94150,7 @@ fVQ
 bvt
 gYP
 vSD
-bHx
+aJm
 doK
 gjF
 gjF
@@ -94189,7 +94172,7 @@ jyf
 jyf
 doK
 aaa
-rKG
+aJK
 hbC
 iRo
 mfN
@@ -94424,7 +94407,7 @@ fnp
 aYx
 aEN
 bMK
-bHx
+aJm
 doK
 rNy
 nTv
@@ -94681,7 +94664,7 @@ hVc
 bvr
 gYP
 gFn
-bHx
+aJm
 doK
 qeh
 qsf
@@ -94938,7 +94921,7 @@ qMD
 bvr
 gYP
 vjX
-bHx
+aJm
 bLK
 soP
 ucV
@@ -95195,7 +95178,7 @@ ugv
 bvr
 jhU
 kgS
-bHx
+aJm
 bLK
 qwi
 dfM
@@ -95452,7 +95435,7 @@ bMK
 bvw
 bMK
 bMK
-bHB
+aJx
 uqP
 vAN
 eUy
@@ -97299,12 +97282,12 @@ gXs
 gXs
 pEf
 qdN
-uLO
+aKM
 qdN
 qdN
 aaa
 aaa
-uWd
+aKC
 aaa
 aaa
 aaa
@@ -97561,7 +97544,7 @@ aaa
 qdN
 qdN
 aaa
-uWd
+aKC
 aaa
 aaa
 aaa
@@ -97818,7 +97801,7 @@ aaa
 qdN
 qdN
 qdN
-uWd
+aKC
 aaa
 aaa
 aaa
@@ -98047,7 +98030,7 @@ aaf
 cDY
 aaa
 aaf
-cub
+aKx
 qkq
 wRR
 lvl
@@ -98074,8 +98057,8 @@ aaa
 aaa
 qdN
 aaa
-uLO
-uWd
+aKM
+aKC
 aaa
 aaa
 aaa
@@ -98587,7 +98570,7 @@ jlq
 jlq
 aaa
 qdN
-uWd
+aKC
 aaa
 aaa
 aaa
@@ -98844,7 +98827,7 @@ vtC
 jlq
 qdN
 qdN
-uWd
+aKC
 aaa
 aaa
 aaa
@@ -99101,7 +99084,7 @@ bGQ
 pEf
 qdN
 aaa
-uWd
+aKC
 aaa
 aaa
 aaa
@@ -99357,9 +99340,9 @@ wcB
 wcB
 pEf
 qdN
-uWd
-uWd
-uWd
+aKC
+aKC
+aKC
 aaa
 aaa
 aaa
@@ -99614,9 +99597,9 @@ xPs
 wcB
 pEf
 qdN
-uWd
-uWd
-uWd
+aKC
+aKC
+aKC
 aaa
 aaa
 aaa
@@ -99873,7 +99856,7 @@ pEf
 aaa
 aaa
 aaa
-uWd
+aKC
 aaa
 aaa
 aaa
@@ -100130,7 +100113,7 @@ pEf
 pEf
 pEf
 aaa
-uWd
+aKC
 aaa
 aaa
 aaa
@@ -100387,7 +100370,7 @@ bVJ
 bVJ
 pEf
 aaa
-uWd
+aKC
 aaa
 aaa
 aaa
@@ -100644,7 +100627,7 @@ uax
 bVJ
 pEf
 aaa
-uWd
+aKC
 aaa
 aaa
 aaa
@@ -100872,9 +100855,9 @@ bAw
 bAw
 bzs
 bzs
-hTj
-hTj
-kWc
+aaH
+aaH
+aKz
 cmd
 eGn
 cmd
@@ -100901,7 +100884,7 @@ sDZ
 bVJ
 pEf
 qdN
-uWd
+aKC
 aaa
 aaa
 aaa
@@ -101157,10 +101140,10 @@ bXG
 mUx
 bVJ
 pEf
-uLO
-uWd
+aKM
+aKC
 aaa
-dyp
+aKC
 aaa
 aaa
 aaa
@@ -101417,7 +101400,7 @@ pEf
 qdN
 aaa
 aaa
-dyp
+aKC
 aaa
 aaa
 aaa
@@ -101674,7 +101657,7 @@ pEf
 gXs
 aaa
 qdN
-dyp
+aKC
 aaa
 aaa
 aaa
@@ -101931,7 +101914,7 @@ pEf
 gXs
 qdN
 qdN
-dyp
+aKC
 aaa
 aaa
 aaa
@@ -102188,7 +102171,7 @@ bWC
 gXs
 aaa
 aaa
-dyp
+aKC
 aaa
 aaa
 aaa
@@ -102444,8 +102427,8 @@ aaa
 qdN
 qdN
 aaa
-dyp
-dyp
+aKC
+aKC
 aaa
 aaa
 aaa
@@ -102698,8 +102681,8 @@ bVI
 pEf
 gXs
 aaa
-uWd
-uWd
+aKC
+aKC
 aaa
 aaa
 aaa
@@ -102955,7 +102938,7 @@ bVI
 pEf
 gXs
 qdN
-uWd
+aKC
 aaa
 aaa
 aaa
@@ -103450,7 +103433,7 @@ aaa
 aaa
 aaa
 aaa
-uWd
+aKC
 qdN
 aaa
 gXs
@@ -103470,7 +103453,7 @@ pEf
 gXs
 qdN
 aaa
-uWd
+aKC
 aaa
 aaa
 aaa
@@ -103707,7 +103690,7 @@ aaa
 aaa
 aaa
 aaa
-uWd
+aKC
 qdN
 qdN
 aaa
@@ -103727,7 +103710,7 @@ pEf
 aaa
 qdN
 qdN
-uWd
+aKC
 aaa
 aaa
 aaa
@@ -103964,7 +103947,7 @@ aaa
 aaa
 aaa
 aaa
-uWd
+aKC
 aaa
 qdN
 aaa
@@ -103984,7 +103967,7 @@ pEf
 aaa
 aaa
 aaa
-uWd
+aKC
 aaa
 aaa
 aaa
@@ -104221,7 +104204,7 @@ aaa
 aaa
 aaa
 aaa
-uWd
+aKC
 qdN
 qdN
 aaa
@@ -104241,7 +104224,7 @@ aaa
 aaa
 aaa
 aaa
-uWd
+aKC
 aaa
 aaa
 aaa
@@ -104478,7 +104461,7 @@ aaa
 aaa
 aaa
 aaa
-uWd
+aKC
 aaa
 qdN
 qdN
@@ -104498,7 +104481,7 @@ aaa
 aaa
 aaa
 aaa
-uWd
+aKC
 aaa
 aaa
 aaa
@@ -104994,9 +104977,9 @@ aaa
 aaa
 aaa
 aaa
-uWd
-uWd
-uWd
+aKC
+aKC
+aKC
 gXs
 aaa
 pEf
@@ -105008,9 +104991,9 @@ pEf
 pEf
 aaa
 gXs
-uWd
-uWd
-uWd
+aKC
+aKC
+aKC
 aaa
 aaa
 aaa
@@ -105256,13 +105239,13 @@ aaa
 aaa
 aaa
 aaa
-eFB
-uWd
-eFB
+aKJ
+aKC
+aKJ
 bWC
-eFB
-uWd
-eFB
+aKJ
+aKC
+aKJ
 aaa
 aaa
 aaa
@@ -105515,9 +105498,9 @@ aaa
 aaa
 aaa
 aaa
-eFB
-uWd
-eFB
+aKJ
+aKC
+aKJ
 aaa
 aaa
 aaa
@@ -120113,13 +120096,13 @@ aaf
 aaf
 aaf
 bGf
-bHw
+aAX
 bJa
 bKg
 bLp
 bKg
 bNF
-bOJ
+aHq
 bGf
 aaf
 aaf
@@ -120630,10 +120613,10 @@ aaf
 bGf
 bGf
 bKi
-bLr
+aBm
 bME
-bNG
-bNG
+bGf
+bGf
 aaf
 aaf
 aaa

--- a/_maps/yogstation/map_files/YogStation/YogStation.dmm
+++ b/_maps/yogstation/map_files/YogStation/YogStation.dmm
@@ -12108,7 +12108,7 @@
 /area/crew_quarters/fitness)
 "axX" = (
 /mob/living/simple_animal/pet/dog/pug{
-	desc = "Much better at protecting the armory then your average warden.";
+	desc = "Much better at protecting the armory than your average warden.";
 	name = "Warden Jacob";
 	real_name = "Warden Jacob"
 	},

--- a/_maps/yogstation/map_files/YogsPubby/YogsPubby.dmm
+++ b/_maps/yogstation/map_files/YogsPubby/YogsPubby.dmm
@@ -1272,7 +1272,7 @@
 "acF" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3{
 	dir = 4;
-	icon_state = "inje_map";
+	icon_state = "inje_map-2";
 	name = "Waste Ejector"
 	},
 /turf/open/floor/plating/airless,
@@ -39342,7 +39342,7 @@
 "bvD" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3{
 	dir = 4;
-	icon_state = "inje_map";
+	icon_state = "inje_map-2";
 	name = "Waste Ejector"
 	},
 /turf/open/floor/plating/airless,
@@ -39968,12 +39968,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bwG" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3{
-	icon_state = "inje_map";
-	dir = 8
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "bwH" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -40474,6 +40475,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bxz" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"bxA" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -40481,7 +40489,6 @@
 	icon_state = "pipe11-3";
 	dir = 4
 	},
-/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	icon_state = "pipe11-1";
 	dir = 6
@@ -40489,14 +40496,6 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
-/area/maintenance/department/engine)
-"bxA" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
 /area/maintenance/department/engine)
 "bxB" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -42142,23 +42141,14 @@
 /turf/open/floor/engine,
 /area/medical/chemistry)
 "bAj" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
+	icon_state = "manifold-1";
+	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
 	},
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3{
-	icon_state = "inje_map";
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/maintenance/department/engine)
 "bAk" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
@@ -44002,15 +43992,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bDw" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
-	icon_state = "manifold-1";
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/department/engine)
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/disposal/incinerator)
 "bDx" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -48380,6 +48364,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet,
 /area/library)
+"bKx" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/disposal/incinerator)
+"bKy" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plating,
+/area/maintenance/disposal/incinerator)
 "bKz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
@@ -48527,6 +48520,21 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"bKP" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3{
+	icon_state = "inje_map-2";
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "bKQ" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
@@ -48567,6 +48575,13 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"bKV" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3{
+	icon_state = "inje_map-2";
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "bKW" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -50519,13 +50534,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"bTc" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
 "bTd" = (
 /obj/item/stack/sheet/cardboard{
 	amount = 14
@@ -52499,10 +52507,6 @@
 "cby" = (
 /turf/open/floor/engine/air,
 /area/engine/atmos)
-"cbz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/disposal/incinerator)
 "cbA" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -53073,11 +53077,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cec" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/plating/airless,
-/area/maintenance/disposal/incinerator)
 "ced" = (
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plating,
@@ -54903,10 +54902,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"cqy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/department/engine)
 "cqG" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -54952,10 +54947,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"crb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/chapel/office)
 "cre" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -55236,10 +55227,6 @@
 	},
 /obj/structure/chair/wood/normal,
 /turf/open/floor/plasteel/dark,
-/area/chapel/main/monastery)
-"csU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
 /area/chapel/main/monastery)
 "csY" = (
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -56047,10 +56034,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"cBT" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/disposal/incinerator)
 "cCl" = (
 /turf/closed/wall/r_wall,
 /area/science/lab)
@@ -73315,7 +73298,7 @@ aaa
 aaa
 aaa
 aaa
-crb
+cBM
 crg
 bew
 crv
@@ -75144,7 +75127,7 @@ bIn
 bzJ
 bzV
 bzX
-bAj
+bKP
 aaa
 aaa
 aaa
@@ -80262,7 +80245,7 @@ bOw
 bOw
 bOw
 bWV
-csU
+fIT
 bWV
 bWV
 bWV
@@ -83073,14 +83056,14 @@ bOz
 bHQ
 bIZ
 abI
-bxA
-cqy
-bTc
-cqy
+bwG
+bIZ
+bxz
+bIZ
 bva
 bVs
 bVC
-cqy
+bIZ
 aaa
 bva
 crB
@@ -83330,7 +83313,7 @@ bJb
 bPq
 bva
 bva
-bxA
+bwG
 bSo
 bSq
 bTX
@@ -85389,9 +85372,9 @@ bxl
 bva
 bNS
 bSw
-bxz
+bxA
 byV
-bDw
+bAj
 bVw
 bva
 iEQ
@@ -89801,7 +89784,7 @@ aaa
 aaa
 aaa
 aaa
-bwG
+bKV
 clw
 clw
 clw
@@ -98762,7 +98745,7 @@ bwd
 bYw
 bYw
 bYw
-cBT
+bDw
 bYw
 bYw
 bYw
@@ -99022,7 +99005,7 @@ bwk
 cbA
 ccp
 cdg
-cbz
+bKx
 aaa
 aaa
 aby
@@ -99536,7 +99519,7 @@ bCv
 cbC
 ccr
 cdi
-cec
+bKy
 ceA
 aaa
 aaa


### PR DESCRIPTION
So I made sure all the tiles in space were airless and all the tiles not in space were not airless.
Fixes some pipe+injector icons since they were invisible for mappers.
Hides the pipes in the walls by atmos (yogbox).
Changes the window in atmos monitoring to be reinforced as all the 4 others in that room were (yogbox).
Also fixes issue #4053 
desc = "Much better at protecting the armory then your average warden." to desc = "Much better at protecting the armory **than** your average warden."