### PR TITLE
Adds an admin log for anomaly-caused explosions

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -175,6 +175,8 @@
 
 /obj/effect/anomaly/flux/detonate()
 	if(explosive)
+		message_admins("An anomaly has detonated.") //yogs
+		log_game("An anomaly has detonated.") //yogs
 		explosion(src, 1, 4, 16, 18) //Low devastation, but hits a lot of stuff.
 	else
 		new /obj/effect/particle_effect/sparks(loc)


### PR DESCRIPTION
Just a quick fix for https://github.com/yogstation13/Yogstation-TG/issues/3010 , alerts admins directly before the explosion happens and logs it.