### PR TITLE
Undoes misleading slime speed potion change

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -838,13 +838,11 @@
 		to_chat(user, "<span class='warning'>The potion can only be used on items or vehicles!</span>")
 		return
 	if(isitem(C))
-		// yogs start - change speed potion
 		var/obj/item/I = C
-		if(I.slowdown <= 2 || I.obj_flags & IMMUTABLE_SLOW)
+		if(I.slowdown <= 0 || I.obj_flags & IMMUTABLE_SLOW)
 			to_chat(user, "<span class='warning'>The [C] can't be made any faster!</span>")
 			return ..()
-		I.slowdown--
-		// yogs end
+		I.slowdown = 0
 
 	if(istype(C, /obj/vehicle))
 		var/obj/vehicle/V = C


### PR DESCRIPTION
keeps the vehicle nerf, but undoes the hardsuit thing because the only hardsuits with more than 2 slowdown can only be found on old space ruins. Keep in mind, having a slowdown of 0 for hardsuits simply equals normal movement speed, and not an increase in movement speed.

The original PR was misleading. The description mentioned having insane-speed vehicles, but the hardsuit nerf was undocumented.

:cl: monster860
tweak: Makes it so slime speed potions are actually useful for something again
/:cl: