### PR TITLE
Changes to the engines and bars

### DIFF
--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_casino.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_casino.dmm
@@ -313,9 +313,10 @@
 "aR" = (
 /obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/drinks,
-/obj/machinery/door/window/eastleft{
+/obj/machinery/door/window/eastright{
+	base_state = "left";
 	dir = 8;
-	icon_state = "right";
+	icon_state = "left";
 	name = "Soda Dispenser";
 	req_access_txt = "0"
 	},

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_conveyor.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_conveyor.dmm
@@ -965,9 +965,13 @@
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/kitchen)
 "cC" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public{
-	name = "Bar"
+/obj/machinery/camera{
+	c_tag = "Bar South";
+	dir = 1
+	},
+/obj/structure/noticeboard{
+	dir = 1;
+	pixel_y = -27
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
@@ -979,6 +983,26 @@
 /obj/item/flashlight/lamp,
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/wood,
+/area/crew_quarters/bar)
+"cE" = (
+/obj/machinery/light,
+/obj/machinery/airalarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
+"cF" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Bar"
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
+"cG" = (
+/obj/structure/sign/barsign,
+/turf/closed/wall,
 /area/crew_quarters/bar)
 "cH" = (
 /obj/structure/window/reinforced{
@@ -1062,27 +1086,6 @@
 /area/crew_quarters/bar)
 "ds" = (
 /obj/machinery/light,
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
-"dt" = (
-/obj/machinery/camera{
-	c_tag = "Bar South";
-	dir = 1
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
-"du" = (
-/obj/structure/noticeboard{
-	pixel_y = -27
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
-"dv" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
 "dx" = (
@@ -1230,7 +1233,7 @@ cI
 cL
 df
 ao
-cC
+cF
 "}
 (7,1,1) = {"
 ae
@@ -1262,7 +1265,7 @@ bw
 cX
 aP
 ao
-cC
+cF
 "}
 (9,1,1) = {"
 ab
@@ -1293,8 +1296,8 @@ ao
 ao
 cY
 aP
-dt
-ab
+ao
+nw
 "}
 (11,1,1) = {"
 ab
@@ -1309,7 +1312,7 @@ cu
 ao
 cs
 aP
-du
+cC
 ab
 "}
 (12,1,1) = {"
@@ -1326,7 +1329,7 @@ ao
 cs
 aP
 ao
-ab
+cG
 "}
 (13,1,1) = {"
 ah
@@ -1341,7 +1344,7 @@ ao
 ao
 ch
 dh
-dv
+ao
 ab
 "}
 (14,1,1) = {"
@@ -1357,7 +1360,7 @@ ce
 ao
 cz
 ao
-ds
+cE
 ab
 "}
 (15,1,1) = {"

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_diner.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_diner.dmm
@@ -116,13 +116,8 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aq" = (
-/obj/structure/chair/americandiner/booth/end_left{
-	dir = 4;
-	icon_state = "ameribooth-end1";
-	tag = ""
-	},
-/obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/ameritard,
+/obj/structure/chair/americandiner/booth/end_left,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "ar" = (
@@ -192,6 +187,15 @@
 /obj/effect/turf_decal/ameritard,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"aB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
+	dir = 4
+	},
+/obj/effect/turf_decal/ameritard,
+/obj/structure/chair/americandiner/booth/end_right,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "aC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	icon_state = "vent_map_on-1";
@@ -201,12 +205,8 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aD" = (
-/obj/structure/chair/americandiner/booth/end_left{
-	dir = 4;
-	icon_state = "ameribooth-end1";
-	tag = ""
-	},
 /obj/effect/turf_decal/ameritard,
+/obj/structure/chair/americandiner/booth/end_right,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aE" = (
@@ -214,6 +214,15 @@
 	pixel_x = -31
 	},
 /obj/effect/turf_decal/ameritard,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"aF" = (
+/obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/ameritard,
+/obj/structure/chair/americandiner/booth/end_right{
+	icon_state = "ameribooth-end2";
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aG" = (
@@ -419,6 +428,21 @@
 	tag = ""
 	},
 /obj/effect/turf_decal/ameritard,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"bd" = (
+/obj/effect/turf_decal/ameritard,
+/obj/structure/chair/americandiner/booth/end_left{
+	dir = 4;
+	icon_state = "ameribooth-end1";
+	tag = ""
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"be" = (
+/obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/ameritard,
+/obj/structure/chair/americandiner/booth/end_left,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "bf" = (
@@ -819,12 +843,6 @@
 /obj/effect/turf_decal/ameritard,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"cb" = (
-/obj/structure/chair/americandiner/booth/single,
-/obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/ameritard,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "cd" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -1072,15 +1090,6 @@
 /obj/effect/turf_decal/ameritard,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"Ky" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
-	dir = 4
-	},
-/obj/structure/chair/americandiner/booth/single,
-/obj/effect/turf_decal/ameritard,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "Ns" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -1131,8 +1140,8 @@ ab
 aa
 ab
 az
-aq
-aD
+aF
+bd
 aE
 aN
 az
@@ -1146,7 +1155,7 @@ ab
 (3,1,1) = {"
 ab
 ab
-aA
+aq
 aO
 aO
 bc
@@ -1162,7 +1171,7 @@ ab
 (4,1,1) = {"
 ab
 az
-Ky
+aB
 aO
 aO
 bc
@@ -1210,10 +1219,10 @@ cp
 (7,1,1) = {"
 ab
 ap
-aA
+aq
 aO
 bc
-cb
+be
 aO
 bc
 HV
@@ -1226,13 +1235,13 @@ mc
 (8,1,1) = {"
 ab
 am
-aA
+aD
 aO
 bc
-aA
+aD
 aO
 bc
-HV
+aD
 aO
 bc
 az

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/engine_singulo.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/engine_singulo.dmm
@@ -239,23 +239,11 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aB" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "aC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	icon_state = "pipe11-1";
@@ -801,6 +789,24 @@
 /obj/structure/closet/wardrobe/engineering_yellow,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"bW" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/supermatter)
 "ca" = (
 /obj/item/tank/internals/emergency_oxygen/engi{
 	pixel_x = 5
@@ -1311,7 +1317,7 @@ aa
 (15,1,1) = {"
 du
 ad
-aB
+bW
 ad
 ad
 aJ
@@ -1674,7 +1680,7 @@ aa
 "}
 (28,1,1) = {"
 ab
-ac
+aB
 aH
 aE
 bb

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/engine_singulo.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/engine_singulo.dmm
@@ -138,8 +138,22 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ar" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -176,19 +190,19 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ax" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/button/door{
+	dir = 8;
+	id = "engsm";
+	name = "Radiation Shutters Control";
+	pixel_x = -24;
+	pixel_y = 0;
+	req_access_txt = "10"
+	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -454,7 +468,12 @@
 /area/engine/engineering)
 "bf" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 10
+	dir = 8
+	},
+/obj/item/stack/cable_coil/red,
+/obj/item/crowbar,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -511,12 +530,14 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "bm" = (
-/obj/machinery/field/generator{
-	anchored = 1;
-	state = 2
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "bn" = (
 /obj/machinery/power/emitter/anchored{
 	dir = 8;
@@ -559,18 +580,21 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "bs" = (
-/obj/machinery/field/generator{
-	anchored = 1;
-	state = 2
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/turf/open/floor/plating,
-/area/space/nearstation)
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "bt" = (
-/obj/machinery/the_singularitygen{
-	anchored = 1
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/turf/open/floor/engine,
+/area/engine/engineering)
 "bu" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -620,11 +644,11 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "bA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/turf_decal/stripes/line,
+/obj/item/wirecutters,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
-/obj/item/stack/cable_coil/red,
-/obj/item/crowbar,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "bB" = (
@@ -632,9 +656,14 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "bC" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/item/wirecutters,
-/turf/open/floor/engine,
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering Singularity West";
+	network = list("ss13","engine")
+	},
+/obj/machinery/power/grounding_rod{
+	anchored = 1
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "bD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -735,9 +764,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bM" = (
-/obj/item/wrench,
+/obj/machinery/power/grounding_rod{
+	anchored = 1
+	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/engine/engineering)
 "bN" = (
 /obj/structure/lattice,
 /obj/item/wirecutters,
@@ -776,15 +807,22 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "bT" = (
-/obj/structure/lattice,
-/obj/item/clothing/head/hardhat,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "bU" = (
-/obj/structure/lattice,
-/obj/item/screwdriver,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering Singularity East";
+	network = list("ss13","engine")
+	},
+/obj/machinery/power/grounding_rod{
+	anchored = 1
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "bV" = (
 /obj/structure/closet/wardrobe/engineering_yellow,
 /turf/open/floor/plasteel,
@@ -807,6 +845,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/supermatter)
+"bX" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"bY" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"bZ" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "ca" = (
 /obj/item/tank/internals/emergency_oxygen/engi{
 	pixel_x = 5
@@ -839,32 +901,23 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ce" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering Singularity West";
-	network = list("ss13","engine")
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "cf" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering Singularity East";
-	network = list("ss13","engine")
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "cg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/field/generator{
+	anchored = 1;
+	state = 2
 	},
-/obj/machinery/button/door{
-	dir = 8;
-	id = "engsm";
-	name = "Radiation Shutters Control";
-	pixel_x = -24;
-	pixel_y = 0;
-	req_access_txt = "10"
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "ch" = (
 /obj/effect/turf_decal/stripes/line{
@@ -898,6 +951,119 @@
 	req_access_txt = "10"
 	},
 /turf/open/floor/plasteel,
+/area/engine/engineering)
+"cj" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"ck" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/tesla_coil{
+	anchored = 1
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cl" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/tesla_coil{
+	anchored = 1
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cm" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cn" = (
+/obj/machinery/field/generator{
+	anchored = 1;
+	state = 2
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"co" = (
+/turf/open/floor/plating/airless,
+/area/space)
+"cp" = (
+/obj/machinery/the_singularitygen{
+	anchored = 1
+	},
+/turf/open/floor/plating/airless,
+/area/space)
+"cq" = (
+/obj/item/wrench,
+/turf/open/floor/plating/airless,
+/area/space)
+"cr" = (
+/obj/machinery/the_singularitygen/tesla,
+/turf/open/floor/plating/airless,
+/area/space)
+"cs" = (
+/obj/item/screwdriver,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"ct" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/tesla_coil{
+	anchored = 1
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cu" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Singularity West";
+	dir = 1;
+	network = list("ss13,engine")
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cv" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cw" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cx" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cy" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Singularity East";
+	dir = 1;
+	network = list("ss13,engine")
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "du" = (
 /obj/structure/sign/warning/radiation/rad_area,
@@ -1182,8 +1348,8 @@ bL
 du
 ad
 ad
-ce
-aa
+bC
+yi
 yi
 yi
 yi
@@ -1194,7 +1360,7 @@ yi
 bS
 yi
 yi
-yi
+cu
 ad
 ad
 bu
@@ -1210,17 +1376,17 @@ aE
 aK
 aM
 ad
-aa
-aa
-aQ
-aa
-aa
-aa
-aa
+yi
+yi
+yi
 aa
 aa
 aa
 aQ
+aa
+aa
+aQ
+aa
 aa
 aa
 yi
@@ -1238,20 +1404,20 @@ bF
 bv
 ag
 aJ
+yi
+bX
+cf
+cj
+cf
+cf
+cj
+cf
+cf
+cj
+cf
+cf
+cv
 aa
-aa
-aQ
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aQ
-aa
-aa
-aQ
 ad
 bu
 aa
@@ -1266,20 +1432,20 @@ bH
 bv
 aN
 aJ
+bM
+bY
+yi
+ck
+yi
+yi
+ck
+yi
+yi
+ck
+yi
+yi
+bY
 aa
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-bT
-aQ
-aQ
-aa
-aQ
 ad
 bu
 aQ
@@ -1295,19 +1461,19 @@ bv
 ag
 aJ
 aJ
-aQ
-bm
+bY
+cg
 aa
 aa
-bs
+cn
 aa
 aa
 aa
 aa
-bm
-aQ
-aQ
-aQ
+cg
+yi
+bY
+aa
 ad
 du
 aQ
@@ -1323,7 +1489,7 @@ ad
 aJ
 aJ
 aJ
-aQ
+bY
 aa
 aa
 aa
@@ -1333,9 +1499,9 @@ bR
 aa
 aa
 aa
+ct
+cw
 aQ
-aa
-aa
 ad
 bu
 aQ
@@ -1345,13 +1511,13 @@ aa
 (16,1,1) = {"
 ad
 ah
-ax
-cg
-bA
 ar
+ax
 bf
+bm
+bs
 aJ
-aQ
+bY
 aa
 aa
 aQ
@@ -1361,8 +1527,8 @@ aQ
 aQ
 aa
 aa
-aQ
-aa
+yi
+bY
 aa
 ad
 bu
@@ -1377,20 +1543,20 @@ by
 bz
 as
 aO
-bg
+bt
 aJ
-aQ
+bY
 aa
 aa
 aQ
-aR
-bM
-aR
+co
+cp
+co
 aQ
 aQ
-bm
-aQ
-aa
+cg
+yi
+bY
 aa
 ad
 bu
@@ -1405,20 +1571,20 @@ az
 au
 aL
 aP
-bC
-aJ
-aQ
+bA
+bT
+bZ
 aa
 aa
 aQ
-aR
-bt
-aR
+co
+cq
+co
 aQ
 aa
 aa
-aQ
-aa
+ct
+cw
 aa
 ad
 bu
@@ -1435,18 +1601,18 @@ bB
 ba
 bg
 aJ
-aQ
-bm
+bY
+cg
 bN
 aQ
-aR
-aR
-aR
+co
+cr
+co
 aQ
 aa
 aa
-aQ
-aa
+yi
+bY
 aa
 ad
 bu
@@ -1463,7 +1629,7 @@ aG
 aG
 bh
 aJ
-aQ
+bY
 aa
 aa
 aQ
@@ -1473,8 +1639,8 @@ aQ
 aQ
 aa
 aa
-aQ
-aa
+yi
+bY
 aa
 ad
 bu
@@ -1491,7 +1657,7 @@ ad
 aJ
 aJ
 aJ
-aQ
+bY
 aa
 aa
 aa
@@ -1501,8 +1667,8 @@ aQ
 aa
 aa
 aa
-aQ
-aa
+ct
+cw
 aQ
 ad
 bu
@@ -1519,19 +1685,19 @@ bv
 ag
 aJ
 aJ
-aQ
-bm
+bY
+cg
 aa
 aa
 aa
 aa
-bm
+cg
 aa
 aa
-bm
-aQ
-aQ
-aQ
+cg
+yi
+bY
+aa
 ad
 du
 aQ
@@ -1546,20 +1712,20 @@ aF
 bv
 ag
 aJ
+bM
+bY
+yi
+cl
+yi
+yi
+cl
+yi
+yi
+cl
+yi
+yi
+bY
 aa
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-aa
-aQ
 ad
 bu
 aQ
@@ -1574,20 +1740,20 @@ bF
 bv
 ag
 aJ
+yi
+ce
+cf
+cm
+cf
+cf
+cm
+cf
+cf
+cm
+cs
+cf
+cx
 aa
-aa
-aQ
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-bU
-aa
-aa
-aQ
 ad
 bu
 aa
@@ -1602,17 +1768,17 @@ aE
 aK
 be
 ad
-aa
-aa
-aQ
-aa
-aa
-aa
-aa
+yi
+yi
+yi
 aa
 aa
 aa
 aQ
+aa
+aa
+aQ
+aa
 aa
 aa
 aT
@@ -1630,8 +1796,7 @@ bL
 du
 ad
 ad
-cf
-aa
+bU
 yi
 yi
 yi
@@ -1643,6 +1808,7 @@ yi
 yi
 yi
 yi
+cy
 ad
 ad
 bu

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/engine_singulo.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/engine_singulo.dmm
@@ -327,7 +327,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aJ" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aK" = (

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/engine_sm.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/engine_sm.dmm
@@ -527,7 +527,6 @@
 /area/engine/engineering)
 "ba" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/closed/wall,


### PR DESCRIPTION
Made sure the booth seats were all the same for the bars, and that each bar had a barsign. Singulo engine - adds a single tile of normal flooring that was annoying me, makes the orange pipe lead to a connector (not the best, but at least now there's not a pipe unconnected to anything). SM engine - Fixes a pipe showing invisible on map editor.

Singulo engine - Replaces the plasma windows with reinforced windows. Makes it tesla+sing like before rebase.