### PR TITLE
Fixes weapon access on bartender ID

### DIFF
--- a/code/modules/jobs/job_types/cargo_service.dm
+++ b/code/modules/jobs/job_types/cargo_service.dm
@@ -152,7 +152,7 @@ Bartender
 	outfit = /datum/outfit/job/bartender
 
 	access = list(ACCESS_HYDROPONICS, ACCESS_BAR, ACCESS_KITCHEN, ACCESS_MORGUE, ACCESS_WEAPONS, ACCESS_MINERAL_STOREROOM)
-	minimal_access = list(ACCESS_BAR, ACCESS_MINERAL_STOREROOM)
+	minimal_access = list(ACCESS_BAR, ACCESS_MINERAL_STOREROOM, ACCESS_WEAPONS) //yogs - adds ACCESS_WEAPONS
 	paycheck = PAYCHECK_EASY
 	paycheck_department = ACCOUNT_SRV
 


### PR DESCRIPTION
I assume this was causing the issue. If so then fixes issue #4186 , if not just close this.

:cl:  
bugfix: Beepsky will no longer arrest bartenders for their weapon.
/:cl: