### PR TITLE
Makes preferences update to remove already-selected mood-quirks, and add LOOC by default

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -5,7 +5,7 @@
 //	You do not need to raise this if you are adding new values that have sane defaults.
 //	Only raise this value when changing the meaning/format/name/layout of an existing value
 //	where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX	20
+#define SAVEFILE_VERSION_MAX	20.1 //yogs - this has been edited so that I know to change it if /tg/ does :)
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -147,7 +147,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	donor_item      = sanitize_integer(donor_item, 0, donor_start_tools.len, 0)
 	purrbation      = sanitize_integer(purrbation, 0, 1, initial(purrbation))
 	// yogs end
-	
+
 	load_keybindings(S) // yogs - Custom keybindings
 
 	return 1
@@ -194,14 +194,14 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["tip_delay"], tip_delay)
 	WRITE_FILE(S["pda_style"], pda_style)
 	WRITE_FILE(S["pda_color"], pda_color)
-	
+
 	// yogs start - Donor features
 	WRITE_FILE(S["donor_pda"], donor_pda)
 	WRITE_FILE(S["donor_hat"], donor_hat)
 	WRITE_FILE(S["donor_item"], donor_item)
 	WRITE_FILE(S["purrbation"], purrbation)
 	// yogs end
-	
+
 	save_keybindings(S) // yogs - Custom keybindings
 
 	return 1
@@ -237,7 +237,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	if(!S["features["mcolor"]"] || S["features["mcolor"]"] == "#000")
 		WRITE_FILE(S["features["mcolor"]"]	, "#FFF")
-	
+
 	if(!S["feature_ethcolor"] || S["feature_ethcolor"] == "#000")
 		WRITE_FILE(S["feature_ethcolor"]	, "#9c3030")
 
@@ -320,7 +320,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	if(!features["mcolor"] || features["mcolor"] == "#000")
 		features["mcolor"] = pick("FFFFFF","7F7F7F", "7FFF7F", "7F7FFF", "FF7F7F", "7FFFFF", "FF7FFF", "FFFF7F")
-	
+
 	if(!features["ethcolor"] || features["ethcolor"] == "#000")
 		features["ethcolor"] = GLOB.color_list_ethereal[pick(GLOB.color_list_ethereal)]
 

--- a/yogstation/code/modules/client/preferences_savefile.dm
+++ b/yogstation/code/modules/client/preferences_savefile.dm
@@ -17,6 +17,7 @@
 
 /datum/preferences/update_character(current_version, savefile/S)
 	.=..()
+	var/value = 0
 	for(var/V in all_quirks)
 		var/datum/quirk/T
 		for(var/datum/quirk/T2 in subtypesof(/datum/quirk)) //SSquirks may not have loaded yet so we have to find the quirks manually
@@ -31,3 +32,12 @@
 			if(T in neutral_quirks)
 				neutral_quirks -= V
 			all_quirks -= V
+		else
+			value += initial(T.value)
+
+	if(value < 0)
+		all_quirks = list()
+		positive_quirks = list()
+		negative_quirks = list()
+		neutral_quirks = list()
+		to_chat(parent, "<span class='userdanger'>Your quirks have been reset due to an insufficient balance because certain quirks have been disabled.</span>")

--- a/yogstation/code/modules/client/preferences_savefile.dm
+++ b/yogstation/code/modules/client/preferences_savefile.dm
@@ -5,6 +5,29 @@
 		keybindings = GLOB.keybinding_default
 
 	bindings.from_list(keybindings)
-	
+
 /datum/preferences/proc/save_keybindings(var/savefile/S)
 	WRITE_FILE(S["keybindings"], bindings.to_list())
+
+/datum/preferences/update_preferences(current_version, savefile/S)
+	.=..()
+	if(chat_toggles & CHAT_LOOC)
+		return .
+	chat_toggles ^= CHAT_LOOC
+
+/datum/preferences/update_character(current_version, savefile/S)
+	.=..()
+	for(var/V in all_quirks)
+		var/datum/quirk/T
+		for(var/datum/quirk/T2 in subtypesof(/datum/quirk)) //SSquirks may not have loaded yet so we have to find the quirks manually
+			if(T2.name != V)
+				continue
+			T = T2
+		if(initial(T.mood_quirk) && CONFIG_GET(flag/disable_human_mood))
+			if(T in positive_quirks)
+				positive_quirks -= V
+			if(T in negative_quirks)
+				negative_quirks -= V
+			if(T in neutral_quirks)
+				neutral_quirks -= V
+			all_quirks -= V

--- a/yogstation/code/modules/client/preferences_savefile.dm
+++ b/yogstation/code/modules/client/preferences_savefile.dm
@@ -36,8 +36,11 @@
 			value += initial(T.value)
 
 	if(value < 0)
+		to_chat(parent, "<span class='userdanger'>Your quirks have been reset due to an insufficient balance because certain quirks have been disabled.</span>")
+		to_chat(parent, "<span class='notice'>Your previously selected quirks:</span>")
+		for(var/V in all_quirks)
+			to_chat(parent, "<span class='notice'>[V]</span>")
 		all_quirks = list()
 		positive_quirks = list()
 		negative_quirks = list()
 		neutral_quirks = list()
-		to_chat(parent, "<span class='userdanger'>Your quirks have been reset due to an insufficient balance because certain quirks have been disabled.</span>")


### PR DESCRIPTION
### Intent of your Pull Request

Already selected mood_quirks can be played with despite the config disabling them, making depression/hypersensitive free points. 

This unselects them if they're already selected, and resets the player's quirks completely if their balance is now below 0.

Also enables LOOC for everyone, if they disable it again it won't be enabled but it's now enabled by default, like with any new players' savefiles

:cl:  
fix: you can no longer keep using mood_quirks after they get designated as such. Looking at you, Antoni :)
/:cl:
