### PR TITLE
Nerf timestop 2.0

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/chilling.dm
+++ b/code/modules/research/xenobiology/crossbreeding/chilling.dm
@@ -187,7 +187,7 @@ Chilling extracts:
 
 /obj/item/slimecross/chilling/sepia/do_effect(mob/user)
 	user.visible_message("<span class='warning'>[src] shatters, freezing time itself!</span>")
-	new /obj/effect/timestop(get_turf(user), 2, 300, allies)
+	new /obj/effect/timestop(get_turf(user), 2, 15, allies)
 	..()
 
 /obj/item/slimecross/chilling/cerulean


### PR DESCRIPTION
Nerfing time-stop down to half of stun time, as it stunned for 30 seconds, down to 15 seconds
Fixes Issue#4266
