### PR TITLE
Makes it so payments can be processed using NTSL

### DIFF
--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2941,7 +2941,7 @@
 #include "yogstation\code\modules\donor\borg_ai_skin_datums.dm"
 #include "yogstation\code\modules\donor\borg_skins.dm"
 #include "yogstation\code\modules\donor\donor_items.dm"
-#include "yogstation\code\modules\economy\account.dm
+#include "yogstation\code\modules\economy\account.dm"
 #include "yogstation\code\modules\events\bad_wizard.dm"
 #include "yogstation\code\modules\events\bureaucratic_error.dm"
 #include "yogstation\code\modules\events\dolphin_migration.dm"

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2941,6 +2941,7 @@
 #include "yogstation\code\modules\donor\borg_ai_skin_datums.dm"
 #include "yogstation\code\modules\donor\borg_skins.dm"
 #include "yogstation\code\modules\donor\donor_items.dm"
+#include "yogstation\code\modules\economy\account.dm
 #include "yogstation\code\modules\events\bad_wizard.dm"
 #include "yogstation\code\modules\events\bureaucratic_error.dm"
 #include "yogstation\code\modules\events\dolphin_migration.dm"

--- a/yogstation/code/modules/economy/account.dm
+++ b/yogstation/code/modules/economy/account.dm
@@ -1,0 +1,6 @@
+/datum/bank_account/bank_card_talk(message)
+	if(!message || !bank_cards.len)
+		return
+	for(var/obj/A in bank_cards)
+		playsound(A, 'sound/machines/twobeep.ogg', 50, TRUE)
+		A.say(message);


### PR DESCRIPTION
When your ID card speaks due to bank account things, it now speaks via `say()` so that an intercom or a radio can pick it up and allows the payment to be processed by an NTSL script.

:cl: monster860
tweak: Paystand payments can now be processed using NTSL by placing the ID card used for the paystand next to an intercom, and then parsing the messages it generates when a payment is received.
fix: Oh yeah and the messaging actually works now.
/:cl: