### PR TITLE
Restricts romerol to glorious death and hijack

### DIFF
--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -20,7 +20,7 @@
 
 /datum/uplink_item/stealthy_weapons/romerol_kit
 	category = "Conspicuous Weapons"
-	include_objectives = list(/datum/objective/hijack)
+	include_objectives = list(/datum/objective/hijack, /datum/objective/martyr)
 
 /datum/uplink_item/stealthy_weapons/soap_clusterbang
 	category = "Conspicuous Weapons"

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -20,6 +20,7 @@
 
 /datum/uplink_item/stealthy_weapons/romerol_kit
 	category = "Conspicuous Weapons"
+	include_objectives = list(/datum/objective/hijack)
 
 /datum/uplink_item/stealthy_weapons/soap_clusterbang
 	category = "Conspicuous Weapons"


### PR DESCRIPTION
### Intent of your Pull Request

Based on [this](https://forums.yogstation.net/index.php?threads/lando-watson-report-by-null.18215/#post-157119), it looks like this is how it's enforced by admins, no point letting them buy it if they're not allowed to use it.
#### Changelog

:cl:  
tweak: romerol can now only be bought if you have glorious death or hijack
/:cl:
