### PR TITLE
Changes command radio color

### DIFF
--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -278,7 +278,7 @@ em						{font-style: normal;	font-weight: bold;}
 .binarysay a:active, .binarysay a:visited {color: #88ff88;}
 .radio					{color: #008000;}
 .sciradio				{color: #993399;}
-.comradio				{color: #204090;}
+.comradio				{color: #204090;} // yogs
 .secradio				{color: #a30000;}
 .medradio				{color: #337296;}
 .engradio				{color: #fb5613;}

--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -278,7 +278,7 @@ em						{font-style: normal;	font-weight: bold;}
 .binarysay a:active, .binarysay a:visited {color: #88ff88;}
 .radio					{color: #008000;}
 .sciradio				{color: #993399;}
-.comradio				{color: #948f02;}
+.comradio				{color: #204090;}
 .secradio				{color: #a30000;}
 .medradio				{color: #337296;}
 .engradio				{color: #fb5613;}

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -43,7 +43,7 @@ em						{font-style: normal;	font-weight: bold;}
 .binarysay a:active, .binarysay a:visited {color: #88ff88;}
 .radio					{color: #008000;}
 .sciradio				{color: #993399;}
-.comradio				{color: #204090;}
+.comradio				{color: #204090;} // yogs
 .secradio				{color: #a30000;}
 .medradio				{color: #337296;}
 .engradio				{color: #fb5613;}

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -43,7 +43,7 @@ em						{font-style: normal;	font-weight: bold;}
 .binarysay a:active, .binarysay a:visited {color: #88ff88;}
 .radio					{color: #008000;}
 .sciradio				{color: #993399;}
-.comradio				{color: #948f02;}
+.comradio				{color: #204090;}
 .secradio				{color: #a30000;}
 .medradio				{color: #337296;}
 .engradio				{color: #fb5613;}


### PR DESCRIPTION
changes it from this:

![image](https://user-images.githubusercontent.com/3681297/52184249-cb630d00-27de-11e9-9aef-231c91b169bc.png)


to this:

![image](https://user-images.githubusercontent.com/3681297/52184242-bbe3c400-27de-11e9-97d4-4f54d2d707f7.png)


:cl: monster860
tweak: Command radio is now a very visible blue instead of an invisible ugly yellow.
/:cl:

because the captain/hop wears blue so it should match.