### PR TITLE
The game now announces that the shuttle can be called at the 1:45 mark

### DIFF
--- a/yogstation/code/controllers/subsystem/yogs.dm
+++ b/yogstation/code/controllers/subsystem/yogs.dm
@@ -1,9 +1,12 @@
+#define ROUND_END_ANNOUNCEMENT_TIME 105 //the time at which the game will announce that the shuttle can be called, in minutes.
+
 SUBSYSTEM_DEF(Yogs)
 	name = "Yog Features"
 	flags = SS_BACKGROUND
 	init_order = -101 //last subsystem to initialize, and first to shut down
 
 	var/list/mentortickets //less of a ticket, and more just a log of everything someone has mhelped, and the responses
+	var/endedshift = FALSE //whether or not we've announced that the shift can be ended
 
 /datum/controller/subsystem/Yogs/Initialize()
 	mentortickets = list()
@@ -13,5 +16,7 @@ SUBSYSTEM_DEF(Yogs)
 	return ..()
 
 /datum/controller/subsystem/Yogs/fire(resumed = 0)
+	if(world.time > ROUND_END_ANNOUNCEMENT_TIME && !endedshift)
+		priority_announce(Crew, your shift has come to an end. \n You may call the shuttle whenever you find it appropriate.", "End of shift announcement", 'sound/ai/commandreport.ogg')
 	return
 

--- a/yogstation/code/controllers/subsystem/yogs.dm
+++ b/yogstation/code/controllers/subsystem/yogs.dm
@@ -17,6 +17,6 @@ SUBSYSTEM_DEF(Yogs)
 
 /datum/controller/subsystem/Yogs/fire(resumed = 0)
 	if(world.time > ROUND_END_ANNOUNCEMENT_TIME && !endedshift)
-		priority_announce(Crew, your shift has come to an end. \n You may call the shuttle whenever you find it appropriate.", "End of shift announcement", 'sound/ai/commandreport.ogg')
+		priority_announce("Crew, your shift has come to an end. \n You may call the shuttle whenever you find it appropriate.", "End of shift announcement", 'sound/ai/commandreport.ogg')
 	return
 

--- a/yogstation/code/controllers/subsystem/yogs.dm
+++ b/yogstation/code/controllers/subsystem/yogs.dm
@@ -18,5 +18,6 @@ SUBSYSTEM_DEF(Yogs)
 /datum/controller/subsystem/Yogs/fire(resumed = 0)
 	if(world.time > ROUND_END_ANNOUNCEMENT_TIME && !endedshift)
 		priority_announce("Crew, your shift has come to an end. \n You may call the shuttle whenever you find it appropriate.", "End of shift announcement", 'sound/ai/commandreport.ogg')
+		endedshift = TRUE
 	return
 

--- a/yogstation/code/controllers/subsystem/yogs.dm
+++ b/yogstation/code/controllers/subsystem/yogs.dm
@@ -16,7 +16,7 @@ SUBSYSTEM_DEF(Yogs)
 	return ..()
 
 /datum/controller/subsystem/Yogs/fire(resumed = 0)
-	if(world.time > ROUND_END_ANNOUNCEMENT_TIME && !endedshift)
+	if(world.time > (ROUND_END_ANNOUNCEMENT_TIME*600) && !endedshift)
 		priority_announce("Crew, your shift has come to an end. \n You may call the shuttle whenever you find it appropriate.", "End of shift announcement", 'sound/ai/commandreport.ogg')
 		endedshift = TRUE
 	return


### PR DESCRIPTION
### Intent of your Pull Request

see: https://forums.yogstation.net/index.php?threads/vote-allow-rounds-to-be-more-than-2-hours-long.18223/

#### Changelog

:cl:  
rscadd: the game will now tell you when you're allowed to call the shuttle for non-emergency purposes
/:cl:
