### PR TITLE
makes stop sounds stop lobby music

### DIFF
--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -221,6 +221,7 @@ TOGGLE_CHECKBOX(/datum/verbs/menu/Settings/Sound, toggle_announcement_sound)()
 	var/client/C = usr.client
 	if(C && C.chatOutput && !C.chatOutput.broken && C.chatOutput.loaded)
 		C.chatOutput.stopMusic()
+		C.chatOutput.stopLobbyMusic()
 	SSblackbox.record_feedback("nested tally", "preferences_verb", 1, list("Stop Self Sounds")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 


### PR DESCRIPTION
don't feel like fixing observers having music
:cl:  McDonald072
bugfix: "Stop Sounds" now stops lobby music
/:cl:
