### PR TITLE
Lowers Mutagen Cost back to 600 biomass like old yogs

### DIFF
--- a/yogstation/code/modules/research/designs/biogenerator_designs.dm
+++ b/yogstation/code/modules/research/designs/biogenerator_designs.dm
@@ -2,6 +2,6 @@
 	name = "Unstable Mutagen"
 	id = "unstable_mutagen"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 1000)
+	materials = list(MAT_BIOMASS = 600)
 	build_path = /obj/item/reagent_containers/glass/bottle/mutagen
 	category = list("initial","Botany Chemicals")


### PR DESCRIPTION
There IS really not that much reason for having it be so expensive honestly and plus this

"Uh, lowering the biomass cost of this might be a good idea; 1000 biomass is a LOT, especially when you remember that 30u of mutagen only gets you 6 shots at mutating a plant's species, each of which only has a 10% chance to succeed. In short, you're paying 1000 biomass for a <47% chance to mutate at least one plant." -ATH1909"

🆑 fluffe9911
tweak: Mutagen is now 600 biomass instead of 1000
/🆑