### PR TITLE
[READY] NTSL refactor

### DIFF
--- a/tools/mapmerge2/dmm.py
+++ b/tools/mapmerge2/dmm.py
@@ -283,24 +283,12 @@ def save_tgm(dmm, output):
 
     # thanks to YotaXP for finding out about this one
     max_x, max_y, max_z = dmm.size
-# yogs start - multi-column mode
-    columns_to_write = 1
-    total_tiles = max_x * max_y * max_z
-    while total_tiles > 65536:
-        columns_to_write += 1
-        total_tiles -= 65536
-# yogs end
     for z in range(1, max_z + 1):
         output.write("\n")
-        for x in range(1, max_x + 1, columns_to_write): # yogs - make the step be columns_to_write
+        for x in range(1, max_x + 1):
             output.write(f"({x},{1},{z}) = {{\"\n")
             for y in range(1, max_y + 1):
-# yogs start - multi-column mode
-                for xo in range(0, columns_to_write):
-                    if (xo + x) <= max_x:
-                        output.write(f"{num_to_key(dmm.grid[x+xo, y, z], dmm.key_length)}")
-                output.write("\n")
-# yogs end
+                output.write(f"{num_to_key(dmm.grid[x, y, z], dmm.key_length)}\n")
             output.write("\"}\n")
 
 # ----------

--- a/tools/mapmerge2/dmm.py
+++ b/tools/mapmerge2/dmm.py
@@ -283,12 +283,24 @@ def save_tgm(dmm, output):
 
     # thanks to YotaXP for finding out about this one
     max_x, max_y, max_z = dmm.size
+# yogs start - multi-column mode
+    columns_to_write = 1
+    total_tiles = max_x * max_y * max_z
+    while total_tiles > 65536:
+        columns_to_write += 1
+        total_tiles -= 65536
+# yogs end
     for z in range(1, max_z + 1):
         output.write("\n")
-        for x in range(1, max_x + 1):
+        for x in range(1, max_x + 1, columns_to_write): # yogs - make the step be columns_to_write
             output.write(f"({x},{1},{z}) = {{\"\n")
             for y in range(1, max_y + 1):
-                output.write(f"{num_to_key(dmm.grid[x, y, z], dmm.key_length)}\n")
+# yogs start - multi-column mode
+                for xo in range(0, columns_to_write):
+                    if (xo + x) <= max_x:
+                        output.write(f"{num_to_key(dmm.grid[x+xo, y, z], dmm.key_length)}")
+                output.write("\n")
+# yogs end
             output.write("\"}\n")
 
 # ----------

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3115,6 +3115,7 @@
 #include "yogstation\code\modules\scripting\Interpreter\Evaluation.dm"
 #include "yogstation\code\modules\scripting\Interpreter\Interaction.dm"
 #include "yogstation\code\modules\scripting\Interpreter\Interpreter.dm"
+#include "yogstation\code\modules\scripting\Interpreter\Objects.dm"
 #include "yogstation\code\modules\scripting\Interpreter\Scope.dm"
 #include "yogstation\code\modules\scripting\Parser\Expressions.dm"
 #include "yogstation\code\modules\scripting\Parser\Keywords.dm"

--- a/yogstation/code/game/machinery/telecomms/machines/server.dm
+++ b/yogstation/code/game/machinery/telecomms/machines/server.dm
@@ -2,7 +2,7 @@
 
 /obj/item/radio/server/can_receive(frequency,levels)
 	return FALSE // The server's radio isn't for receiving, it's for outputting. For now.
-	
+
 /obj/machinery/telecomms/server
 	//NTSL-related stuffs
 	var/datum/TCS_Compiler/Compiler	// the compiler that compiles and runs the code
@@ -11,8 +11,9 @@
 	var/rawcode = ""	// the code to compile (raw-ass text)
 	var/obj/item/radio/server/server_radio // Allows the server to talk on the radio, via broadcast() in NTSL
 	var/last_signal = 0 // Marks the last time an NTSL script called signal() from this server, to stop spam.
+	var/list/compile_warnings = list()
 	//End-NTSL
-	
+
 //NTSL-related procs
 /obj/machinery/telecomms/server/Initialize()
 	Compiler = new()

--- a/yogstation/code/modules/scripting/AST/AST Nodes.dm
+++ b/yogstation/code/modules/scripting/AST/AST Nodes.dm
@@ -16,7 +16,7 @@
 /*
 	Macros: Operator Precedence
 	The higher the value, the lower the priority in the precedence.
-	
+
 	OOP_OR				- Logical or
 	OOP_AND				- Logical and
 	OOP_BIT				- Bitwise operations
@@ -28,6 +28,7 @@
 	OOP_UNARY			- Unary Operators
 	OOP_GROUP			- Parentheses
 */
+#define OOP_ASSIGN 0
 #define OOP_OR 1			//||
 #define OOP_AND 2			//&&
 #define OOP_BIT 3			//&, |

--- a/yogstation/code/modules/scripting/AST/AST Nodes.dm
+++ b/yogstation/code/modules/scripting/AST/AST Nodes.dm
@@ -147,6 +147,13 @@
 	ToString()
 		return src.id.ToString()
 
+/node/expression/value/list_init
+	var/list/init_list
+
+	New(token)
+		. = ..()
+		src.token = token
+
 /*
 	Class: reference
 */

--- a/yogstation/code/modules/scripting/AST/AST Nodes.dm
+++ b/yogstation/code/modules/scripting/AST/AST Nodes.dm
@@ -92,6 +92,7 @@
 
 /node/expression/member/brackets
 	var/node/expression/index
+	var/tmp/temp_index
 
 
 /*

--- a/yogstation/code/modules/scripting/AST/AST Nodes.dm
+++ b/yogstation/code/modules/scripting/AST/AST Nodes.dm
@@ -83,15 +83,24 @@
 	ToString()
 		return "operator: [name]"
 
+/node/expression/member
+	var/node/expression/object
+	var/tmp/temp_object // so you can pre-eval it, used for function calls and assignments
+
+/node/expression/member/dot
+	var/node/identifier/id
+
+/node/expression/member/brackets
+	var/node/expression/index
+
+
 /*
 	Class: FunctionCall
 */
 /node/expression/FunctionCall
 	//Function calls can also be expressions or statements.
-	var
-		func_name
-		node/identifier/object
-		list/parameters=new
+	var/node/expression/function
+	var/list/parameters=list()
 
 /*
 	Class: literal

--- a/yogstation/code/modules/scripting/AST/AST Nodes.dm
+++ b/yogstation/code/modules/scripting/AST/AST Nodes.dm
@@ -44,6 +44,7 @@
 	Class: node
 */
 /node
+	var/token/token // for line number informatino
 	proc
 		ToString()
 			return "[src.type]"
@@ -54,9 +55,10 @@
 	var
 		id_name
 
-	New(id)
+	New(id, token)
 		.=..()
 		src.id_name=id
+		src.token = token
 
 	ToString()
 		return id_name
@@ -76,9 +78,11 @@
 			name
 			precedence
 
-	New()
+	New(token, exp)
 		.=..()
 		if(!src.name) src.name="[src.type]"
+		src.token = token
+		src.exp = exp
 
 	ToString()
 		return "operator: [name]"
@@ -86,6 +90,9 @@
 /node/expression/member
 	var/node/expression/object
 	var/tmp/temp_object // so you can pre-eval it, used for function calls and assignments
+	New(token)
+		src.token = token
+		return ..()
 
 /node/expression/member/dot
 	var/node/identifier/id
@@ -102,6 +109,9 @@
 	//Function calls can also be expressions or statements.
 	var/node/expression/function
 	var/list/parameters=list()
+	New(token)
+		.=..()
+		src.token = token
 
 /*
 	Class: literal
@@ -128,8 +138,9 @@
 			id
 
 
-	New(ident)
+	New(ident, token)
 		.=..()
+		src.token = token
 		id=ident
 		if(istext(id))id=new(id)
 
@@ -143,8 +154,9 @@
 	var
 		datum/value
 
-	New(value)
+	New(value, token)
 		.=..()
+		src.token = token
 		src.value=value
 
 	ToString()

--- a/yogstation/code/modules/scripting/AST/Operators/Binary Operators.dm
+++ b/yogstation/code/modules/scripting/AST/Operators/Binary Operators.dm
@@ -172,3 +172,15 @@
 //
 	Modulo
 		precedence=OOP_MULTIPLY
+
+	Assign
+		precedence=OOP_ASSIGN
+		BitwiseAnd
+		BitwiseOr
+		BitwiseXor
+		Add
+		Subtract
+		Multiply
+		Divide
+		Power
+		Modulo

--- a/yogstation/code/modules/scripting/AST/Operators/Unary Operators.dm
+++ b/yogstation/code/modules/scripting/AST/Operators/Unary Operators.dm
@@ -45,7 +45,3 @@
 //
 	group
 		precedence=OOP_GROUP
-
-	New(node/expression/exp)
-		src.exp=exp
-		return ..()

--- a/yogstation/code/modules/scripting/AST/Statements.dm
+++ b/yogstation/code/modules/scripting/AST/Statements.dm
@@ -6,9 +6,9 @@
 	An object representing a single instruction run by an interpreter.
 */
 /node/statement
-	New(value)
+	New(token)
 		.=..()
-		src.value=value
+		src.token=token
 
 /*
 	Class: FunctionDefinition

--- a/yogstation/code/modules/scripting/AST/Statements.dm
+++ b/yogstation/code/modules/scripting/AST/Statements.dm
@@ -6,16 +6,6 @@
 	An object representing a single instruction run by an interpreter.
 */
 /node/statement
-/*
-	Class: FunctionCall
-	Represents a call to a function.
-*/
-//
-	FunctionCall
-		var
-			func_name
-			node/identifier/object
-			list/parameters=new
 
 /*
 	Class: FunctionDefinition

--- a/yogstation/code/modules/scripting/AST/Statements.dm
+++ b/yogstation/code/modules/scripting/AST/Statements.dm
@@ -6,6 +6,9 @@
 	An object representing a single instruction run by an interpreter.
 */
 /node/statement
+	New(value)
+		.=..()
+		src.value=value
 
 /*
 	Class: FunctionDefinition

--- a/yogstation/code/modules/scripting/Errors.dm
+++ b/yogstation/code/modules/scripting/Errors.dm
@@ -122,6 +122,11 @@
 		New(variable)
 			message="Variable '[variable]' has not been declared."
 
+	IndexOutOfRange
+		name="IndexOutOfRangeError"
+		New(obj, idx)
+			message="Index [obj]\[[idx]] is out of range."
+
 	UndefinedFunction
 		name="UndefinedFunctionError"
 		New(function)

--- a/yogstation/code/modules/scripting/Errors.dm
+++ b/yogstation/code/modules/scripting/Errors.dm
@@ -114,7 +114,8 @@
 
 	UnknownInstruction
 		name="UnknownInstructionError"
-		message="Unknown instruction type. This may be due to incompatible compiler and interpreter versions or a lack of implementation."
+		New(node/op)
+			message="Unknown instruction type '[op.type]'. This may be due to incompatible compiler and interpreter versions or a lack of implementation."
 
 	UndefinedVariable
 		name="UndefinedVariableError"
@@ -150,3 +151,8 @@
 		name="MaxComputationalUse"
 		New(maxcycles)
 			message="Maximum amount of computational cycles reached (>= [maxcycles])."
+
+	Internal
+		name="InternalError"
+		New(exception/E)
+			message = E.name

--- a/yogstation/code/modules/scripting/Errors.dm
+++ b/yogstation/code/modules/scripting/Errors.dm
@@ -72,6 +72,9 @@
 	InvalidAssignment
 		message="Left side of assignment cannot be assigned to."
 
+	OutdatedScript
+		message = "Your script looks like it was for an older version of NTSL! Your script may not work as intended. See documentation for new syntax and API."
+
 /*
 	Class: runtimeError
 	An error thrown by the interpreter in running the script.

--- a/yogstation/code/modules/scripting/Errors.dm
+++ b/yogstation/code/modules/scripting/Errors.dm
@@ -84,7 +84,8 @@
 	A basic description as to what went wrong.
 */
 		message
-		stack/stack
+		scope/scope
+		token/token
 
 	proc
 /*
@@ -93,11 +94,25 @@
 */
 		ToString()
 			. = "[name]: [message]"
-			//if(!stack.Top()) return
-			//.+="\nStack:"
-			//while(stack.Top())
-			//	var/node/statement/FunctionCall/stmt=stack.Pop()
-			//	. += "\n\t [stmt.function.ToString]()"
+			if(!scope) return
+			var/last_line
+			var/last_col
+			if(token)
+				last_line = token.line
+				last_col = token.col
+			var/scope/cur_scope = scope
+			while(cur_scope)
+				if(cur_scope.function)
+				. += "\n\tat [cur_scope.function.func_name]([last_line]:[last_col])"
+				cur_scope = scope.parent
+					if(cur_scope.call_node && cur_scope.call_node.token)
+						last_line = cur_scope.call_node.token.line
+						last_col = cur_scope.call_node.token.col
+					else
+						last_line = null
+						last_col = null
+			if(last_line)
+				. += "\n\tat \[global]([last_line]:[last_col])"
 
 	TypeMismatch
 		name="TypeMismatchError"

--- a/yogstation/code/modules/scripting/Errors.dm
+++ b/yogstation/code/modules/scripting/Errors.dm
@@ -69,6 +69,9 @@
 				line = t.line
 			message = "[line]: [message]"
 
+	InvalidAssignment
+		message="Left side of assignment cannot be assigned to."
+
 /*
 	Class: runtimeError
 	An error thrown by the interpreter in running the script.
@@ -139,6 +142,9 @@
 	DivisionByZero
 		name="DivideByZeroError"
 		message="Division by zero (or a NULL value) attempted."
+
+	InvalidAssignment
+		message="Left side of assignment cannot be assigned to."
 
 	MaxCPU
 		name="MaxComputationalUse"

--- a/yogstation/code/modules/scripting/Errors.dm
+++ b/yogstation/code/modules/scripting/Errors.dm
@@ -99,20 +99,22 @@
 			var/last_col
 			if(token)
 				last_line = token.line
-				last_col = token.col
+				last_col = token.column
 			var/scope/cur_scope = scope
 			while(cur_scope)
 				if(cur_scope.function)
-				. += "\n\tat [cur_scope.function.func_name]([last_line]:[last_col])"
-				cur_scope = scope.parent
+					. += "\n\tat [cur_scope.function.func_name]([last_line]:[last_col])"
 					if(cur_scope.call_node && cur_scope.call_node.token)
 						last_line = cur_scope.call_node.token.line
-						last_col = cur_scope.call_node.token.col
+						last_col = cur_scope.call_node.token.column
 					else
 						last_line = null
 						last_col = null
+				cur_scope = cur_scope.parent
 			if(last_line)
 				. += "\n\tat \[global]([last_line]:[last_col])"
+			else
+				. += "\n\tat \[internal](null:null)"
 
 	TypeMismatch
 		name="TypeMismatchError"

--- a/yogstation/code/modules/scripting/Errors.dm
+++ b/yogstation/code/modules/scripting/Errors.dm
@@ -114,7 +114,7 @@
 			if(last_line)
 				. += "\n\tat \[global]([last_line]:[last_col])"
 			else
-				. += "\n\tat \[internal](null:null)"
+				. += "\n\tat \[internal]"
 
 	TypeMismatch
 		name="TypeMismatchError"

--- a/yogstation/code/modules/scripting/Errors.dm
+++ b/yogstation/code/modules/scripting/Errors.dm
@@ -93,11 +93,11 @@
 */
 		ToString()
 			. = "[name]: [message]"
-			if(!stack.Top()) return
-			.+="\nStack:"
-			while(stack.Top())
-				var/node/statement/FunctionCall/stmt=stack.Pop()
-				. += "\n\t [stmt.func_name]()"
+			//if(!stack.Top()) return
+			//.+="\nStack:"
+			//while(stack.Top())
+			//	var/node/statement/FunctionCall/stmt=stack.Pop()
+			//	. += "\n\t [stmt.function.ToString]()"
 
 	TypeMismatch
 		name="TypeMismatchError"

--- a/yogstation/code/modules/scripting/IDE.dm
+++ b/yogstation/code/modules/scripting/IDE.dm
@@ -86,6 +86,17 @@
 								M << output("<font color = blue>TCS compilation successful!</font color>", "tcserror")
 								M << output("Time of compile: [gameTimestamp("hh:mm:ss")]","tcserror")
 								M << output("(0 errors)", "tcserror")
+					if(Server.compile_warnings.len)
+						src << output("<b>Compile Warnings</b>", "tcserror")
+						for(var/scriptError/e in Server.compile_warnings)
+							src << output("<font color = yellow>\t>[e.message]</font color>", "tcserror")
+						src << output("([Server.compile_warnings.len] warnings)", "tcserror")
+						for(var/mob/M in Machine.viewingcode)
+							if(M.client)
+								M << output("<b>Compile Warnings</b>", "tcserror")
+								for(var/scriptError/e in Server.compile_warnings)
+									M << output("<font color = yellow>\t>[e.message]</font color>", "tcserror")
+								M << output("([Server.compile_warnings.len] warnings)", "tcserror")
 
 			else
 				src << output(null, "tcserror")

--- a/yogstation/code/modules/scripting/IDE.dm
+++ b/yogstation/code/modules/scripting/IDE.dm
@@ -91,7 +91,8 @@
 						for(var/scriptError/e in Server.compile_warnings)
 							src << output("<font color = yellow>\t>[e.message]</font color>", "tcserror")
 						src << output("([Server.compile_warnings.len] warnings)", "tcserror")
-						for(var/mob/M in Machine.viewingcode)
+						for(var/fuck_you_for_making_me_do_this_altoids in Machine.viewingcode)
+							var/mob/M = fuck_you_for_making_me_do_this_altoids
 							if(M.client)
 								M << output("<b>Compile Warnings</b>", "tcserror")
 								for(var/scriptError/e in Server.compile_warnings)

--- a/yogstation/code/modules/scripting/Implementations/Telecomms.dm
+++ b/yogstation/code/modules/scripting/Implementations/Telecomms.dm
@@ -118,6 +118,11 @@ GLOBAL_LIST_INIT(allowed_custom_spans,list(SPAN_ROBOT,SPAN_YELL,SPAN_ITALICS,SPA
 
 	interpreter.Run() // run the thing
 
+	if(Holder)
+		Holder.compile_warnings = parser.warnings || list()
+		if(!interpreter.ProcExists("process_signal")) // yell at the user if they need to update their scripts
+			Holder.compile_warnings += new /scriptError/OutdatedScript()
+
 	return returnerrors
 
 	/* -- Execute the compiled code -- */

--- a/yogstation/code/modules/scripting/Implementations/Telecomms.dm
+++ b/yogstation/code/modules/scripting/Implementations/Telecomms.dm
@@ -279,8 +279,8 @@ GLOBAL_LIST_INIT(allowed_custom_spans,list(SPAN_ROBOT,SPAN_YELL,SPAN_ITALICS,SPA
 	name = "mem"
 	interp_type = /n_Interpreter/TCS_Interpreter
 /datum/n_function/default/mem/execute(this_obj, list/params, scope/scope, n_Interpreter/TCS_Interpreter/interp)
-	var/address = params.len >= 1 ? params[1] : 1459
-	var/value = params.len >= 2 ? params[2] : 30
+	var/address = params.len >= 1 ? params[1] : null
+	var/value = params.len >= 2 ? params[2] : null
 	if(istext(address))
 		var/obj/machinery/telecomms/server/S = interp.Compiler.Holder
 

--- a/yogstation/code/modules/scripting/Implementations/Telecomms.dm
+++ b/yogstation/code/modules/scripting/Implementations/Telecomms.dm
@@ -127,7 +127,7 @@ GLOBAL_LIST_INIT(allowed_custom_spans,list(SPAN_ROBOT,SPAN_YELL,SPAN_ITALICS,SPA
 	But having them be bitflags inside of NTSL makes more sense in its context
 	So, when we get the signal back from NTSL, if the language has been altered, we'll set it to a new language datum,
 	based on the bitflag the guy used.
-	
+
 	However, I think the signal can only have one language
 	So, the lowest bit set within $language overrides any higher ones that are set.
 	*/
@@ -151,7 +151,7 @@ GLOBAL_LIST_INIT(allowed_custom_spans,list(SPAN_ROBOT,SPAN_YELL,SPAN_ITALICS,SPA
 		oldlang = SLIME
 	else if(oldlang == /datum/language/drone)
 		oldlang = DRONE
-	
+
 	//And then if none of these work, $language will just straight-up store the datum
 	interpreter.SetVar("$language", oldlang)
 
@@ -194,66 +194,11 @@ GLOBAL_LIST_INIT(allowed_custom_spans,list(SPAN_ROBOT,SPAN_YELL,SPAN_ITALICS,SPA
 				@param value:		The value to store to the memory address
 	*/
 	interpreter.SetProc("mem", "mem", signal, list("address", "value"))
-	
+
 	/*
 		-> Wipe all the mem() variables on this server (for garbage collection purposes)
 	*/
 	interpreter.SetProc("clearmem","clearmem",signal, list())
-	
-	
-	/*
-	General NTSL procs
-	Should probably be moved to its own place
-	*/
-	// Vector
-	interpreter.SetProc("vector", /proc/n_list)
-	interpreter.SetProc("at", /proc/n_listpos)
-	interpreter.SetProc("copy", /proc/n_listcopy)
-	interpreter.SetProc("push_back", /proc/n_listadd)
-	interpreter.SetProc("remove", /proc/n_listremove)
-	interpreter.SetProc("cut", /proc/n_listcut)
-	interpreter.SetProc("swap", /proc/n_listswap)
-	interpreter.SetProc("insert", /proc/n_listinsert)
-	interpreter.SetProc("pick", /proc/n_pick)
-	interpreter.SetProc("prob", /proc/n_prob)
-	interpreter.SetProc("substr", /proc/n_substr)
-	interpreter.SetProc("find", /proc/n_smartfind)
-	interpreter.SetProc("length", /proc/n_smartlength)
-
-	// Strings
-	interpreter.SetProc("lower", /proc/n_lower)
-	interpreter.SetProc("upper", /proc/n_upper)
-	interpreter.SetProc("explode", /proc/n_explode)
-	interpreter.SetProc("implode", /proc/n_implode)
-	interpreter.SetProc("repeat", /proc/n_repeat)
-	interpreter.SetProc("reverse", /proc/n_reverse)
-	interpreter.SetProc("tonum", /proc/n_str2num)
-	interpreter.SetProc("replace", /proc/n_replace)
-	interpreter.SetProc("proper", /proc/n_proper)
-
-	// Numbers
-	interpreter.SetProc("tostring", /proc/n_num2str)
-	interpreter.SetProc("sqrt", /proc/n_sqrt)
-	interpreter.SetProc("abs", /proc/n_abs)
-	interpreter.SetProc("floor", /proc/n_floor)
-	interpreter.SetProc("ceil", /proc/n_ceil)
-	interpreter.SetProc("round", /proc/n_round)
-	interpreter.SetProc("clamp", /proc/n_clamp)
-	interpreter.SetProc("inrange", /proc/n_inrange)
-	interpreter.SetProc("rand", /proc/n_rand)
-	interpreter.SetProc("randseed", /proc/n_randseed)
-	interpreter.SetProc("min", /proc/n_min)
-	interpreter.SetProc("max", /proc/n_max)
-	interpreter.SetProc("sin", /proc/n_sin)
-	interpreter.SetProc("cos", /proc/n_cos)
-	interpreter.SetProc("asin", /proc/n_asin)
-	interpreter.SetProc("acos", /proc/n_acos)
-	interpreter.SetProc("log", /proc/n_log)
-
-	// Time
-	interpreter.SetProc("time", /proc/n_time)
-	interpreter.SetProc("sleep", /proc/n_delay)
-	interpreter.SetProc("timestamp", /proc/gameTimestamp)
 
 	// Run the compiled code
 	interpreter.Run()
@@ -267,8 +212,8 @@ GLOBAL_LIST_INIT(allowed_custom_spans,list(SPAN_ROBOT,SPAN_YELL,SPAN_ITALICS,SPA
 	else if(!msg)
 		msg = "*beep*"
 	signal.data["message"] = msg
-	
-	
+
+
 	signal.frequency 		= interpreter.GetCleanVar("$freq", signal.frequency)
 
 	var/setname = interpreter.GetCleanVar("$source", signal.data["name"])
@@ -317,7 +262,7 @@ GLOBAL_LIST_INIT(allowed_custom_spans,list(SPAN_ROBOT,SPAN_YELL,SPAN_ITALICS,SPA
 			return /datum/language/slime
 		if(DRONE)
 			return /datum/language/drone
-	
+
 /datum/signal/proc/mem(address, value)
 
 	if(istext(address))
@@ -371,7 +316,7 @@ GLOBAL_LIST_INIT(allowed_custom_spans,list(SPAN_ROBOT,SPAN_YELL,SPAN_ITALICS,SPA
 
 /datum/signal/proc/tcombroadcast(message, freq, source, job, spans, say = "says", ask = "asks", yell = "yells", exclaim = "exclaims", language = /datum/language/common)
 	//languages &= allowed_translateable_langs //we can only translate to certain languages
-	
+
 	var/obj/machinery/telecomms/server/S = data["server"]
 	var/obj/item/radio/server/hradio = S.server_radio
 
@@ -413,7 +358,7 @@ GLOBAL_LIST_INIT(allowed_custom_spans,list(SPAN_ROBOT,SPAN_YELL,SPAN_ITALICS,SPA
 	virt.verb_ask = ask
 	virt.verb_exclaim = exclaim
 	virt.verb_yell = yell
-	
+
 	var/datum/signal/subspace/vocal/newsign = new(hradio,freq,virt,language,message,spans,list(S.z))
 	/*
 	virt.languages_spoken = language

--- a/yogstation/code/modules/scripting/Implementations/_Logic.dm
+++ b/yogstation/code/modules/scripting/Implementations/_Logic.dm
@@ -4,15 +4,6 @@
 
 // --- List operations (lists known as vectors in n_script) ---
 
-// Creates a list out of all the arguments
-/datum/n_function/default/vector
-	name = "vector"
-/datum/n_function/default/vector/execute(this_obj, list/params)
-	var/list/returnlist = list()
-	for(var/e in params)
-		returnlist.Add(e)
-	return returnlist
-
 // Picks one random item from the list
 /datum/n_function/default/pick
 	name = "pick"
@@ -28,100 +19,6 @@
 		finalpick.Add(e)
 
 	return pick(finalpick)
-
-// Gets/Sets a value at a key in the list
-/datum/n_function/default/at
-	name = "at"
-/datum/n_function/default/at/execute(this_obj, list/params)
-	var/list/L = LAZYACCESS(params,1)
-	var/pos = LAZYACCESS(params,2)
-	var/value = LAZYACCESS(params,3)
-	if(!istype(L, /list)) return
-	if(isnum(pos))
-		if(!value)
-			if(L.len >= pos)
-				return L[pos]
-		else
-			if(L.len >= pos)
-				L[pos] = value
-	else if(istext(pos))
-		if(!value)
-			return L[pos]
-		else
-			L[pos] = value
-
-// Copies the list into a new one
-/datum/n_function/default/copy
-	name = "copy"
-/datum/n_function/default/copy/execute(this_obj, list/params)
-	var/list/L = params.len >= 1 ? params[1] : null
-	var/start = params.len >= 2 ? params[2] : null
-	var/end = params.len >= 3 ? params[3] : null
-	if(!istype(L, /list)) return
-	return L.Copy(start, end)
-
-// Adds arg 2,3,4,5... to the end of list at arg 1
-/datum/n_function/default/push_back
-	name = "push_back"
-/datum/n_function/default/push_back/execute(this_obj, list/params)
-	var/list/chosenlist
-	var/i = 1
-	for(var/e in params)
-		if(i == 1)
-			if(isobject(e))
-				if(istype(e, /list))
-					chosenlist = e
-			i = 2
-		else
-			if(chosenlist)
-				chosenlist.Add(e)
-
-// Removes arg 2,3,4,5... from list at arg 1
-/datum/n_function/default/remove
-	name = "remove"
-/datum/n_function/default/remove/execute(this_obj, list/params)
-	var/list/chosenlist
-	var/i = 1
-	for(var/e in params)
-		if(i == 1)
-			if(isobject(e))
-				if(istype(e, /list))
-					chosenlist = e
-			i = 2
-		else
-			if(chosenlist)
-				chosenlist.Remove(e)
-
-// Cuts out a copy of a list
-/datum/n_function/default/cut
-	name = "cut"
-/datum/n_function/default/cut/execute(this_obj, list/params)
-	var/list/L = params.len >= 1 ? params[1] : null
-	var/start = params.len >= 2 ? params[2] : null
-	var/end = params.len >= 3 ? params[3] : null
-	if(!istype(L, /list)) return
-	return L.Cut(start, end)
-
-// Swaps two values in the list
-/datum/n_function/default/swap
-	name = "swap"
-/datum/n_function/default/swap/execute(this_obj, list/params)
-	var/list/L = params.len >= 1 ? params[1] : null
-	var/firstindex = params.len >= 2 ? params[2] : null
-	var/secondindex = params.len >= 3 ? params[3] : null
-	if(!istype(L, /list)) return
-	if(L.len >= secondindex && L.len >= firstindex)
-		return L.Swap(firstindex, secondindex)
-
-// Inserts a value into the list
-/datum/n_function/default/insert
-	name = "insert"
-/datum/n_function/default/insert/execute(this_obj, list/params)
-	var/list/L = params.len >= 1 ? params[1] : null
-	var/index = params.len >= 2 ? params[2] : null
-	var/element = params.len >= 3 ? params[3] : null
-	if(!istype(L, /list)) return
-	return L.Insert(index, element)
 
 // --- String methods ---
 
@@ -293,9 +190,9 @@
 	var/seed = params.len >= 1 ? params[1] : null
 	rand_seed(seed)
 
-/datum/n_function/default/n_rand
-	name = "n_rand"
-/datum/n_function/default/n_rand/execute(this_obj, list/params)
+/datum/n_function/default/rand
+	name = "rand"
+/datum/n_function/default/rand/execute(this_obj, list/params)
 	var/low = params.len >= 1 ? params[1] : null
 	var/high = params.len >= 2 ? params[2] : null
 	if(isnull(low) && isnull(high))
@@ -457,3 +354,8 @@
 /datum/n_function/default/sleep/execute(this_obj, list/params)
 	var/time = params.len >= 1 ? params[1] : null
 	sleep(time)
+
+/datum/n_function/default/timestamp
+	name = "timestamp"
+/datum/n_function/default/timestamp/execute(this_obj, list/params)
+	return gameTimestamp(arglist(params))

--- a/yogstation/code/modules/scripting/Implementations/_Logic.dm
+++ b/yogstation/code/modules/scripting/Implementations/_Logic.dm
@@ -5,16 +5,20 @@
 // --- List operations (lists known as vectors in n_script) ---
 
 // Creates a list out of all the arguments
-/proc/n_list()
+/datum/n_function/default/vector
+	name = "vector"
+/datum/n_function/default/vector/execute(this_obj, list/params)
 	var/list/returnlist = list()
-	for(var/e in args)
+	for(var/e in params)
 		returnlist.Add(e)
 	return returnlist
 
 // Picks one random item from the list
-/proc/n_pick()
+/datum/n_function/default/pick
+	name = "pick"
+/datum/n_function/default/pick/execute(this_obj, list/params)
 	var/list/finalpick = list()
-	for(var/e in args)
+	for(var/e in params)
 		if(isobject(e))
 			if(istype(e, /list))
 				var/list/sublist = e
@@ -26,7 +30,12 @@
 	return pick(finalpick)
 
 // Gets/Sets a value at a key in the list
-/proc/n_listpos(list/L, pos, value)
+/datum/n_function/default/at
+	name = "at"
+/datum/n_function/default/at/execute(this_obj, list/params)
+	var/list/L = LAZYACCESS(params,1)
+	var/pos = LAZYACCESS(params,2)
+	var/value = LAZYACCESS(params,3)
 	if(!istype(L, /list)) return
 	if(isnum(pos))
 		if(!value)
@@ -42,15 +51,22 @@
 			L[pos] = value
 
 // Copies the list into a new one
-/proc/n_listcopy(list/L, start, end)
+/datum/n_function/default/copy
+	name = "copy"
+/datum/n_function/default/copy/execute(this_obj, list/params)
+	list/L = params.len >= 1 ? params[1] : null
+	start = params.len >= 2 ? params[2] : null
+	end = params.len >= 3 ? params[3] : null
 	if(!istype(L, /list)) return
 	return L.Copy(start, end)
 
 // Adds arg 2,3,4,5... to the end of list at arg 1
-/proc/n_listadd()
+/datum/n_function/default/push_back
+	name = "push_back"
+/datum/n_function/default/push_back/execute(this_obj, list/params)
 	var/list/chosenlist
 	var/i = 1
-	for(var/e in args)
+	for(var/e in params)
 		if(i == 1)
 			if(isobject(e))
 				if(istype(e, /list))
@@ -61,10 +77,10 @@
 				chosenlist.Add(e)
 
 // Removes arg 2,3,4,5... from list at arg 1
-/proc/n_listremove()
+/proc/remove()
 	var/list/chosenlist
 	var/i = 1
-	for(var/e in args)
+	for(var/e in params)
 		if(i == 1)
 			if(isobject(e))
 				if(istype(e, /list))
@@ -75,25 +91,46 @@
 				chosenlist.Remove(e)
 
 // Cuts out a copy of a list
-/proc/n_listcut(list/L, start, end)
+/datum/n_function/default/cut
+	name = "cut"
+/datum/n_function/default/cut/execute(this_obj, list/params)
+	list/L = params.len >= 1 ? params[1] : null
+	start = params.len >= 2 ? params[2] : null
+	end = params.len >= 3 ? params[3] : null
 	if(!istype(L, /list)) return
 	return L.Cut(start, end)
 
 // Swaps two values in the list
-/proc/n_listswap(list/L, firstindex, secondindex)
+/datum/n_function/default/swap
+	name = "swap"
+/datum/n_function/default/swap/execute(this_obj, list/params)
+	list/L = params.len >= 1 ? params[1] : null
+	firstindex = params.len >= 2 ? params[2] : null
+	secondindex = params.len >= 3 ? params[3] : null
 	if(!istype(L, /list)) return
 	if(L.len >= secondindex && L.len >= firstindex)
 		return L.Swap(firstindex, secondindex)
 
 // Inserts a value into the list
-/proc/n_listinsert(list/L, index, element)
+/datum/n_function/default/insert
+	name = "insert"
+/datum/n_function/default/insert/execute(this_obj, list/params)
+	list/L = params.len >= 1 ? params[1] : null
+	index = params.len >= 2 ? params[2] : null
+	element = params.len >= 3 ? params[3] : null
 	if(!istype(L, /list)) return
 	return L.Insert(index, element)
 
 // --- String methods ---
 
 //If list, finds a value in it, if text, finds a substring in it
-/proc/n_smartfind(haystack, needle, start = 1, end = 0)
+/datum/n_function/default/find
+	name = "find"
+/datum/n_function/default/find/execute(this_obj, list/params)
+	haystack = params.len >= 1 ? params[1] : null
+	needle = params.len >= 2 ? params[2] : null
+	start  = params.len >= 3 ? params[3] :  1
+	end  = params.len >= 4 ? params[4] :  0
 	if(haystack && needle)
 		if(isobject(haystack))
 			if(istype(haystack, /list))
@@ -107,40 +144,66 @@
 					return findtext(haystack, needle, start, end)
 
 //Returns a substring of the string
-/proc/n_substr(string, start = 1, end = 0)
+/datum/n_function/default/substr
+	name = "substr"
+/datum/n_function/default/substr/execute(this_obj, list/params)
+	string = params.len >= 1 ? params[1] : null
+	start  = params.len >= 2 ? params[2] :  1
+	end  = params.len >= 3 ? params[3] :  0
 	if(istext(string) && isnum(start) && isnum(end))
 		if(start > 0)
 			return copytext(string, start, end)
 
 //Returns the length of the string or list
-/proc/n_smartlength(container)
+/datum/n_function/default/length
+	name = "length"
+/datum/n_function/default/length/execute(this_obj, list/params)
+	container = params.len >= 1 ? params[1] : null
 	if(container)
 		if(istype(container, /list) || istext(container))
 			return length(container)
 	return 0
 
 //Lowercase all characters
-/proc/n_lower(string)
+/datum/n_function/default/lower
+	name = "lower"
+/datum/n_function/default/lower/execute(this_obj, list/params)
+	string = params.len >= 1 ? params[1] : null
 	if(istext(string))
 		return lowertext(string)
 
 //Uppercase all characters
-/proc/n_upper(string)
+/datum/n_function/default/upper
+	name = "upper"
+/datum/n_function/default/upper/execute(this_obj, list/params)
+	string = params.len >= 1 ? params[1] : null
 	if(istext(string))
 		return uppertext(string)
 
 //Converts a string to a list
-/proc/n_explode(string, separator = "")
+/datum/n_function/default/explode
+	name = "explode"
+/datum/n_function/default/explode/execute(this_obj, list/params)
+	string = params.len >= 1 ? params[1] : null
+	separator  = params.len >= 2 ? params[2] :  ""
 	if(istext(string) && (istext(separator) || isnull(separator)))
 		return splittext(string, separator)
 
 //Converts a list to a string
-/proc/n_implode(list/li, separator)
+/datum/n_function/default/implode
+	name = "implode"
+/datum/n_function/default/implode/execute(this_obj, list/params)
+	var/list/li = LAZYACCESS(params, 1)
+	var/separator = LAZYACCESS(params, 2)
 	if(istype(li) && (istext(separator) || isnull(separator)))
 		return jointext(li, separator)
 
 //Repeats the string x times
-/proc/n_repeat(string, amount)
+/datum/n_function/default/repeat
+	name = "repeat"
+/datum/n_function/default/repeat/execute(this_obj, list/params)
+	string = params.len >= 1 ? params[1] : null
+	amount = params.len >= 2 ? params[2] : null
 	if(istext(string) && isnum(amount))
 		var/i
 		var/newstring = ""
@@ -154,7 +217,10 @@
 		return newstring
 
 //Reverses the order of the string. "Clown" becomes "nwolC"
-/proc/n_reverse(string)
+/datum/n_function/default/reverse
+	name = "reverse"
+/datum/n_function/default/reverse/execute(this_obj, list/params)
+	string = params.len >= 1 ? params[1] : null
 	if(istext(string))
 		var/newstring = ""
 		var/i
@@ -166,11 +232,17 @@
 		return newstring
 
 // String -> Number
-/proc/n_str2num(string)
+/datum/n_function/default/tonum
+	name = "tonum"
+/datum/n_function/default/tonum/execute(this_obj, list/params)
+	string = params.len >= 1 ? params[1] : null
 	if(istext(string))
 		return text2num(string)
 
-/proc/n_proper(string)
+/datum/n_function/default/proper
+	name = "proper"
+/datum/n_function/default/proper/execute(this_obj, list/params)
+	string = params.len >= 1 ? params[1] : null
 	if(!istext(string))
 		return ""
 
@@ -180,75 +252,112 @@
 
 //Returns the highest value of the arguments
 //Need custom functions here cause byond's min and max runtimes if you give them a string or list.
-/proc/n_max()
-	if(args.len == 0)
+/datum/n_function/default/max
+	name = "max"
+/datum/n_function/default/max/execute(this_obj, list/params)
+	if(params.len == 0)
 		return 0
 
-	var/max = args[1]
-	for(var/e in args)
+	var/max = params[1]
+	for(var/e in params)
 		if(isnum(e) && e > max)
 			max = e
 
 	return max
 
 //Returns the lowest value of the arguments
-/proc/n_min()
-	if(args.len == 0)
+/datum/n_function/default/min
+	name = "min"
+/datum/n_function/default/min/execute(this_obj, list/params)
+	if(params.len == 0)
 		return 0
 
-	var/min = args[1]
-	for(var/e in args)
+	var/min = params[1]
+	for(var/e in params)
 		if(isnum(e) && e < min)
 			min = e
 
 	return min
 
-/proc/n_prob(chance)
+/datum/n_function/default/prob
+	name = "prob"
+/datum/n_function/default/prob/execute(this_obj, list/params)
+	chance = params.len >= 1 ? params[1] : null
 	return prob(chance)
 
-/proc/n_randseed(seed)
+/datum/n_function/default/randseed
+	name = "randseed"
+/datum/n_function/default/randseed/execute(this_obj, list/params)
+	seed = params.len >= 1 ? params[1] : null
 	rand_seed(seed)
 
-/proc/n_rand(low, high)
+/datum/n_function/default/n_rand
+	name = "n_rand"
+/datum/n_function/default/n_rand/execute(this_obj, list/params)
+	low = params.len >= 1 ? params[1] : null
+	high = params.len >= 2 ? params[2] : null
 	if(isnull(low) && isnull(high))
 		return rand()
 
 	return rand(low, high)
 
 // Number -> String
-/proc/n_num2str(num)
+/datum/n_function/default/tostring
+	name = "tostring"
+/datum/n_function/default/tostring/execute(this_obj, list/params)
+	num = params.len >= 1 ? params[1] : null
 	if(isnum(num))
 		return num2text(num)
 
 // Squareroot
-/proc/n_sqrt(num)
+/datum/n_function/default/sqrt
+	name = "sqrt"
+/datum/n_function/default/sqrt/execute(this_obj, list/params)
+	num = params.len >= 1 ? params[1] : null
 	if(isnum(num))
 		return sqrt(num)
 
 // Magnitude of num
-/proc/n_abs(num)
+/datum/n_function/default/abs
+	name = "abs"
+/datum/n_function/default/abs/execute(this_obj, list/params)
+	num = params.len >= 1 ? params[1] : null
 	if(isnum(num))
 		return abs(num)
 
 // Round down
-/proc/n_floor(num)
+/datum/n_function/default/floor
+	name = "floor"
+/datum/n_function/default/floor/execute(this_obj, list/params)
+	num = params.len >= 1 ? params[1] : null
 	if(isnum(num))
 		return round(num)
 
 // Round up
-/proc/n_ceil(num)
+/datum/n_function/default/ceil
+	name = "ceil"
+/datum/n_function/default/ceil/execute(this_obj, list/params)
+	num = params.len >= 1 ? params[1] : null
 	if(isnum(num))
 		return round(num)+1
 
 // Round to nearest integer
-/proc/n_round(num)
+/datum/n_function/default/round
+	name = "round"
+/datum/n_function/default/round/execute(this_obj, list/params)
+	num = params.len >= 1 ? params[1] : null
 	if(isnum(num))
 		if(num-round(num)<0.5)
 			return round(num)
 		return n_ceil(num)
 
 // Clamps N between min and max
-/proc/n_clamp(num, min=-1, max=1)
+/datum/n_function/default/clamp
+	name = "clamp"
+/datum/n_function/default/clamp/execute(this_obj, list/params)
+	num = params.len >= 1 ? params[1] : null
+	min = params.len >= 2 ? params[2] : -1
+	max = params.len >= 3 ? params[3] : 1
 	if(isnum(num)&&isnum(min)&&isnum(max))
 		if(num<=min)
 			return min
@@ -257,37 +366,62 @@
 		return num
 
 // Returns 1 if N is inbetween Min and Max
-/proc/n_inrange(num, min=-1, max=1)
+/datum/n_function/default/inrange
+	name = "inrange"
+/datum/n_function/default/inrange/execute(this_obj, list/params)
+	num = params.len >= 1 ? params[1] : null
+	min = params.len >= 2 ? params[2] : -1
+	max = params.len >= 3 ? params[3] : 1
 	if(isnum(num)&&isnum(min)&&isnum(max))
 		return ((min <= num) && (num <= max))
 
 // Returns the sine of num
-/proc/n_sin(num)
+/datum/n_function/default/sin
+	name = "sin"
+/datum/n_function/default/sin/execute(this_obj, list/params)
+	num = params.len >= 1 ? params[1] : null
 	if(isnum(num))
 		return sin(num)
 
 // Returns the cosine of num
-/proc/n_cos(num)
+/datum/n_function/default/cos
+	name = "cos"
+/datum/n_function/default/cos/execute(this_obj, list/params)
+	num = params.len >= 1 ? params[1] : null
 	if(isnum(num))
 		return cos(num)
 
 // Returns the arcsine of num
-/proc/n_asin(num)
+/datum/n_function/default/asin
+	name = "asin"
+/datum/n_function/default/asin/execute(this_obj, list/params)
+	num = params.len >= 1 ? params[1] : null
 	if(isnum(num)&&-1<=num&&num<=1)
 		return arcsin(num)
 
 // Returns the arccosine of num
-/proc/n_acos(num)
+/datum/n_function/default/acos
+	name = "acos"
+/datum/n_function/default/acos/execute(this_obj, list/params)
+	num = params.len >= 1 ? params[1] : null
 	if(isnum(num)&&-1<=num&&num<=1)
 		return arccos(num)
 
 // Returns the natural log of num
-/proc/n_log(num)
+/datum/n_function/default/log
+	name = "log"
+/datum/n_function/default/log/execute(this_obj, list/params)
+	num = params.len >= 1 ? params[1] : null
 	if(isnum(num)&&0<num)
 		return log(num)
 
 // Replace text
-/proc/n_replace(text, find, replacement)
+/datum/n_function/default/replace
+	name = "replace"
+/datum/n_function/default/replace/execute(this_obj, list/params)
+	text = params.len >= 1 ? params[1] : null
+	find = params.len >= 2 ? params[2] : null
+	replacement = params.len >= 3 ? params[3] : null
 	if(istext(text) && istext(find) && istext(replacement))
 		var/find_len = length(find)
 		if(find_len < 1)	return text
@@ -310,9 +444,14 @@
 
 // --- Miscellaneous functions ---
 
-/proc/n_time()
+/datum/n_function/default/time
+	name = "time"
+/datum/n_function/default/time/execute(this_obj, list/params)
 	return world.timeofday
 
 // Clone of sleep()
-/proc/n_delay(time)
+/datum/n_function/default/sleep
+	name = "sleep"
+/datum/n_function/default/sleep/execute(this_obj, list/params)
+	time = params.len >= 1 ? params[1] : null
 	sleep(time)

--- a/yogstation/code/modules/scripting/Implementations/_Logic.dm
+++ b/yogstation/code/modules/scripting/Implementations/_Logic.dm
@@ -54,9 +54,9 @@
 /datum/n_function/default/copy
 	name = "copy"
 /datum/n_function/default/copy/execute(this_obj, list/params)
-	list/L = params.len >= 1 ? params[1] : null
-	start = params.len >= 2 ? params[2] : null
-	end = params.len >= 3 ? params[3] : null
+	var/list/L = params.len >= 1 ? params[1] : null
+	var/start = params.len >= 2 ? params[2] : null
+	var/end = params.len >= 3 ? params[3] : null
 	if(!istype(L, /list)) return
 	return L.Copy(start, end)
 
@@ -77,7 +77,9 @@
 				chosenlist.Add(e)
 
 // Removes arg 2,3,4,5... from list at arg 1
-/proc/remove()
+/datum/n_function/default/remove
+	name = "remove"
+/datum/n_function/default/remove/execute(this_obj, list/params)
 	var/list/chosenlist
 	var/i = 1
 	for(var/e in params)
@@ -94,9 +96,9 @@
 /datum/n_function/default/cut
 	name = "cut"
 /datum/n_function/default/cut/execute(this_obj, list/params)
-	list/L = params.len >= 1 ? params[1] : null
-	start = params.len >= 2 ? params[2] : null
-	end = params.len >= 3 ? params[3] : null
+	var/list/L = params.len >= 1 ? params[1] : null
+	var/start = params.len >= 2 ? params[2] : null
+	var/end = params.len >= 3 ? params[3] : null
 	if(!istype(L, /list)) return
 	return L.Cut(start, end)
 
@@ -104,9 +106,9 @@
 /datum/n_function/default/swap
 	name = "swap"
 /datum/n_function/default/swap/execute(this_obj, list/params)
-	list/L = params.len >= 1 ? params[1] : null
-	firstindex = params.len >= 2 ? params[2] : null
-	secondindex = params.len >= 3 ? params[3] : null
+	var/list/L = params.len >= 1 ? params[1] : null
+	var/firstindex = params.len >= 2 ? params[2] : null
+	var/secondindex = params.len >= 3 ? params[3] : null
 	if(!istype(L, /list)) return
 	if(L.len >= secondindex && L.len >= firstindex)
 		return L.Swap(firstindex, secondindex)
@@ -115,9 +117,9 @@
 /datum/n_function/default/insert
 	name = "insert"
 /datum/n_function/default/insert/execute(this_obj, list/params)
-	list/L = params.len >= 1 ? params[1] : null
-	index = params.len >= 2 ? params[2] : null
-	element = params.len >= 3 ? params[3] : null
+	var/list/L = params.len >= 1 ? params[1] : null
+	var/index = params.len >= 2 ? params[2] : null
+	var/element = params.len >= 3 ? params[3] : null
 	if(!istype(L, /list)) return
 	return L.Insert(index, element)
 
@@ -127,10 +129,10 @@
 /datum/n_function/default/find
 	name = "find"
 /datum/n_function/default/find/execute(this_obj, list/params)
-	haystack = params.len >= 1 ? params[1] : null
-	needle = params.len >= 2 ? params[2] : null
-	start  = params.len >= 3 ? params[3] :  1
-	end  = params.len >= 4 ? params[4] :  0
+	var/haystack = params.len >= 1 ? params[1] : null
+	var/needle = params.len >= 2 ? params[2] : null
+	var/start  = params.len >= 3 ? params[3] :  1
+	var/end  = params.len >= 4 ? params[4] :  0
 	if(haystack && needle)
 		if(isobject(haystack))
 			if(istype(haystack, /list))
@@ -147,9 +149,9 @@
 /datum/n_function/default/substr
 	name = "substr"
 /datum/n_function/default/substr/execute(this_obj, list/params)
-	string = params.len >= 1 ? params[1] : null
-	start  = params.len >= 2 ? params[2] :  1
-	end  = params.len >= 3 ? params[3] :  0
+	var/string = params.len >= 1 ? params[1] : null
+	var/start  = params.len >= 2 ? params[2] :  1
+	var/end  = params.len >= 3 ? params[3] :  0
 	if(istext(string) && isnum(start) && isnum(end))
 		if(start > 0)
 			return copytext(string, start, end)
@@ -158,7 +160,7 @@
 /datum/n_function/default/length
 	name = "length"
 /datum/n_function/default/length/execute(this_obj, list/params)
-	container = params.len >= 1 ? params[1] : null
+	var/container = params.len >= 1 ? params[1] : null
 	if(container)
 		if(istype(container, /list) || istext(container))
 			return length(container)
@@ -168,7 +170,7 @@
 /datum/n_function/default/lower
 	name = "lower"
 /datum/n_function/default/lower/execute(this_obj, list/params)
-	string = params.len >= 1 ? params[1] : null
+	var/string = params.len >= 1 ? params[1] : null
 	if(istext(string))
 		return lowertext(string)
 
@@ -176,7 +178,7 @@
 /datum/n_function/default/upper
 	name = "upper"
 /datum/n_function/default/upper/execute(this_obj, list/params)
-	string = params.len >= 1 ? params[1] : null
+	var/string = params.len >= 1 ? params[1] : null
 	if(istext(string))
 		return uppertext(string)
 
@@ -184,8 +186,8 @@
 /datum/n_function/default/explode
 	name = "explode"
 /datum/n_function/default/explode/execute(this_obj, list/params)
-	string = params.len >= 1 ? params[1] : null
-	separator  = params.len >= 2 ? params[2] :  ""
+	var/string = params.len >= 1 ? params[1] : null
+	var/separator  = params.len >= 2 ? params[2] :  ""
 	if(istext(string) && (istext(separator) || isnull(separator)))
 		return splittext(string, separator)
 
@@ -202,8 +204,8 @@
 /datum/n_function/default/repeat
 	name = "repeat"
 /datum/n_function/default/repeat/execute(this_obj, list/params)
-	string = params.len >= 1 ? params[1] : null
-	amount = params.len >= 2 ? params[2] : null
+	var/string = params.len >= 1 ? params[1] : null
+	var/amount = params.len >= 2 ? params[2] : null
 	if(istext(string) && isnum(amount))
 		var/i
 		var/newstring = ""
@@ -220,7 +222,7 @@
 /datum/n_function/default/reverse
 	name = "reverse"
 /datum/n_function/default/reverse/execute(this_obj, list/params)
-	string = params.len >= 1 ? params[1] : null
+	var/string = params.len >= 1 ? params[1] : null
 	if(istext(string))
 		var/newstring = ""
 		var/i
@@ -235,14 +237,14 @@
 /datum/n_function/default/tonum
 	name = "tonum"
 /datum/n_function/default/tonum/execute(this_obj, list/params)
-	string = params.len >= 1 ? params[1] : null
+	var/string = params.len >= 1 ? params[1] : null
 	if(istext(string))
 		return text2num(string)
 
 /datum/n_function/default/proper
 	name = "proper"
 /datum/n_function/default/proper/execute(this_obj, list/params)
-	string = params.len >= 1 ? params[1] : null
+	var/string = params.len >= 1 ? params[1] : null
 	if(!istext(string))
 		return ""
 
@@ -282,20 +284,20 @@
 /datum/n_function/default/prob
 	name = "prob"
 /datum/n_function/default/prob/execute(this_obj, list/params)
-	chance = params.len >= 1 ? params[1] : null
+	var/chance = params.len >= 1 ? params[1] : null
 	return prob(chance)
 
 /datum/n_function/default/randseed
 	name = "randseed"
 /datum/n_function/default/randseed/execute(this_obj, list/params)
-	seed = params.len >= 1 ? params[1] : null
+	var/seed = params.len >= 1 ? params[1] : null
 	rand_seed(seed)
 
 /datum/n_function/default/n_rand
 	name = "n_rand"
 /datum/n_function/default/n_rand/execute(this_obj, list/params)
-	low = params.len >= 1 ? params[1] : null
-	high = params.len >= 2 ? params[2] : null
+	var/low = params.len >= 1 ? params[1] : null
+	var/high = params.len >= 2 ? params[2] : null
 	if(isnull(low) && isnull(high))
 		return rand()
 
@@ -305,7 +307,7 @@
 /datum/n_function/default/tostring
 	name = "tostring"
 /datum/n_function/default/tostring/execute(this_obj, list/params)
-	num = params.len >= 1 ? params[1] : null
+	var/num = params.len >= 1 ? params[1] : null
 	if(isnum(num))
 		return num2text(num)
 
@@ -313,7 +315,7 @@
 /datum/n_function/default/sqrt
 	name = "sqrt"
 /datum/n_function/default/sqrt/execute(this_obj, list/params)
-	num = params.len >= 1 ? params[1] : null
+	var/num = params.len >= 1 ? params[1] : null
 	if(isnum(num))
 		return sqrt(num)
 
@@ -321,7 +323,7 @@
 /datum/n_function/default/abs
 	name = "abs"
 /datum/n_function/default/abs/execute(this_obj, list/params)
-	num = params.len >= 1 ? params[1] : null
+	var/num = params.len >= 1 ? params[1] : null
 	if(isnum(num))
 		return abs(num)
 
@@ -329,7 +331,7 @@
 /datum/n_function/default/floor
 	name = "floor"
 /datum/n_function/default/floor/execute(this_obj, list/params)
-	num = params.len >= 1 ? params[1] : null
+	var/num = params.len >= 1 ? params[1] : null
 	if(isnum(num))
 		return round(num)
 
@@ -337,7 +339,7 @@
 /datum/n_function/default/ceil
 	name = "ceil"
 /datum/n_function/default/ceil/execute(this_obj, list/params)
-	num = params.len >= 1 ? params[1] : null
+	var/num = params.len >= 1 ? params[1] : null
 	if(isnum(num))
 		return round(num)+1
 
@@ -345,19 +347,19 @@
 /datum/n_function/default/round
 	name = "round"
 /datum/n_function/default/round/execute(this_obj, list/params)
-	num = params.len >= 1 ? params[1] : null
+	var/num = params.len >= 1 ? params[1] : null
 	if(isnum(num))
 		if(num-round(num)<0.5)
 			return round(num)
-		return n_ceil(num)
+		return round(num) + 1
 
 // Clamps N between min and max
 /datum/n_function/default/clamp
 	name = "clamp"
 /datum/n_function/default/clamp/execute(this_obj, list/params)
-	num = params.len >= 1 ? params[1] : null
-	min = params.len >= 2 ? params[2] : -1
-	max = params.len >= 3 ? params[3] : 1
+	var/num = params.len >= 1 ? params[1] : null
+	var/min = params.len >= 2 ? params[2] : -1
+	var/max = params.len >= 3 ? params[3] : 1
 	if(isnum(num)&&isnum(min)&&isnum(max))
 		if(num<=min)
 			return min
@@ -369,9 +371,9 @@
 /datum/n_function/default/inrange
 	name = "inrange"
 /datum/n_function/default/inrange/execute(this_obj, list/params)
-	num = params.len >= 1 ? params[1] : null
-	min = params.len >= 2 ? params[2] : -1
-	max = params.len >= 3 ? params[3] : 1
+	var/num = params.len >= 1 ? params[1] : null
+	var/min = params.len >= 2 ? params[2] : -1
+	var/max = params.len >= 3 ? params[3] : 1
 	if(isnum(num)&&isnum(min)&&isnum(max))
 		return ((min <= num) && (num <= max))
 
@@ -379,7 +381,7 @@
 /datum/n_function/default/sin
 	name = "sin"
 /datum/n_function/default/sin/execute(this_obj, list/params)
-	num = params.len >= 1 ? params[1] : null
+	var/num = params.len >= 1 ? params[1] : null
 	if(isnum(num))
 		return sin(num)
 
@@ -387,7 +389,7 @@
 /datum/n_function/default/cos
 	name = "cos"
 /datum/n_function/default/cos/execute(this_obj, list/params)
-	num = params.len >= 1 ? params[1] : null
+	var/num = params.len >= 1 ? params[1] : null
 	if(isnum(num))
 		return cos(num)
 
@@ -395,7 +397,7 @@
 /datum/n_function/default/asin
 	name = "asin"
 /datum/n_function/default/asin/execute(this_obj, list/params)
-	num = params.len >= 1 ? params[1] : null
+	var/num = params.len >= 1 ? params[1] : null
 	if(isnum(num)&&-1<=num&&num<=1)
 		return arcsin(num)
 
@@ -403,7 +405,7 @@
 /datum/n_function/default/acos
 	name = "acos"
 /datum/n_function/default/acos/execute(this_obj, list/params)
-	num = params.len >= 1 ? params[1] : null
+	var/num = params.len >= 1 ? params[1] : null
 	if(isnum(num)&&-1<=num&&num<=1)
 		return arccos(num)
 
@@ -411,7 +413,7 @@
 /datum/n_function/default/log
 	name = "log"
 /datum/n_function/default/log/execute(this_obj, list/params)
-	num = params.len >= 1 ? params[1] : null
+	var/num = params.len >= 1 ? params[1] : null
 	if(isnum(num)&&0<num)
 		return log(num)
 
@@ -419,9 +421,9 @@
 /datum/n_function/default/replace
 	name = "replace"
 /datum/n_function/default/replace/execute(this_obj, list/params)
-	text = params.len >= 1 ? params[1] : null
-	find = params.len >= 2 ? params[2] : null
-	replacement = params.len >= 3 ? params[3] : null
+	var/text = params.len >= 1 ? params[1] : null
+	var/find = params.len >= 2 ? params[2] : null
+	var/replacement = params.len >= 3 ? params[3] : null
 	if(istext(text) && istext(find) && istext(replacement))
 		var/find_len = length(find)
 		if(find_len < 1)	return text
@@ -453,5 +455,5 @@
 /datum/n_function/default/sleep
 	name = "sleep"
 /datum/n_function/default/sleep/execute(this_obj, list/params)
-	time = params.len >= 1 ? params[1] : null
+	var/time = params.len >= 1 ? params[1] : null
 	sleep(time)

--- a/yogstation/code/modules/scripting/Interpreter/Evaluation.dm
+++ b/yogstation/code/modules/scripting/Interpreter/Evaluation.dm
@@ -17,20 +17,12 @@
 				. = ref.value
 			else if(istype(exp, /node/expression/value/variable))
 				var/node/expression/value/variable/v=exp
-				if(!v.object)
-					. = scope.get_var(v.id.id_name)
-				else
-					var/datum/D
-					if(istype(v.object, /node/identifier))
-						D=scope.get_var(v.object:id_name)
-					else
-						D=v.object
-					if(isnull(D))
-						return null
-					if(!D.vars.Find(v.id.id_name))
-						RaiseError(new/runtimeError/UndefinedVariable("[v.object.ToString()].[v.id.id_name]"))
-						return null
-					. = Eval(D.vars[v.id.id_name], scope)
+				. = scope.get_var(v.id.id_name)
+			else if(istype(exp, /node/expression/member/dot))
+				var/node/expression/member/dot/D = exp
+				var/object = D.temp_object || Eval(D.object, scope)
+				D.temp_object = null
+				. = get_property(object, D.id.id_name, scope)
 			else if(istype(exp, /node/expression))
 				RaiseError(new/runtimeError/UnknownInstruction())
 			else

--- a/yogstation/code/modules/scripting/Interpreter/Evaluation.dm
+++ b/yogstation/code/modules/scripting/Interpreter/Evaluation.dm
@@ -23,6 +23,12 @@
 				var/object = D.temp_object || Eval(D.object, scope)
 				D.temp_object = null
 				. = get_property(object, D.id.id_name, scope)
+			else if(istype(exp, /node/expression/member/brackets))
+				var/node/expression/member/brackets/B = exp
+				var/object = B.temp_object || Eval(B.object, scope)
+				B.temp_object = null
+				var/index = B.temp_index || Eval(B.index, scope)
+				. = get_index(object, index, scope)
 			else if(istype(exp, /node/expression))
 				RaiseError(new/runtimeError/UnknownInstruction(exp))
 			else
@@ -34,6 +40,7 @@
 			if(istype(exp, /node/expression/operator/binary/Assign))
 				var/node/expression/operator/binary/Assign/ass=exp
 				var/member_obj
+				var/member_idx
 				if(istype(ass.exp, /node/expression/value/variable))
 					var/node/expression/value/variable/var_exp = ass.exp
 					if(!scope.get_scope(var_exp.id.id_name))
@@ -41,12 +48,18 @@
 				else if(istype(ass.exp, /node/expression/member))
 					var/node/expression/member/M = ass.exp
 					member_obj = Eval(M.object, scope)
+					if(istype(M, /node/expression/member/brackets))
+						var/node/expression/member/brackets/B = M
+						member_idx = Eval(B.index, scope)
 				var/out_value
 				var/in_value
 				if(ass.type != /node/expression/operator/binary/Assign)
 					if(istype(ass.exp, /node/expression/member))
 						var/node/expression/member/M = ass.exp
 						M.temp_object = member_obj
+						if(istype(M, /node/expression/member/brackets))
+							var/node/expression/member/brackets/B = M
+							B.temp_index = member_idx
 					in_value = Eval(ass.exp, scope)
 					if(islist(in_value))
 						out_value = in_value
@@ -94,6 +107,8 @@
 					else if(istype(ass.exp, /node/expression/member/dot))
 						var/node/expression/member/dot/dot_exp = ass.exp
 						set_property(member_obj, dot_exp.id.id_name, out_value, scope)
+					else if(istype(ass.exp, /node/expression/member/brackets))
+						set_index(member_obj, member_idx, out_value, scope)
 					else
 						RaiseError(new/runtimeError/InvalidAssignment())
 				return out_value

--- a/yogstation/code/modules/scripting/Interpreter/Evaluation.dm
+++ b/yogstation/code/modules/scripting/Interpreter/Evaluation.dm
@@ -17,7 +17,7 @@
 				. = ref.value
 			else if(istype(exp, /node/expression/value/variable))
 				var/node/expression/value/variable/v=exp
-				. = scope.get_var(v.id.id_name)
+				. = scope.get_var(v.id.id_name, src, v.id)
 			else if(istype(exp, /node/expression/member/dot))
 				var/node/expression/member/dot/D = exp
 				var/object = D.temp_object || Eval(D.object, scope)
@@ -30,7 +30,7 @@
 				var/index = B.temp_index || Eval(B.index, scope)
 				. = get_index(object, index, scope)
 			else if(istype(exp, /node/expression))
-				RaiseError(new/runtimeError/UnknownInstruction(exp))
+				RaiseError(new/runtimeError/UnknownInstruction(exp), scope, exp)
 			else
 				. = exp
 
@@ -44,7 +44,7 @@
 				if(istype(ass.exp, /node/expression/value/variable))
 					var/node/expression/value/variable/var_exp = ass.exp
 					if(!scope.get_scope(var_exp.id.id_name))
-						scope.init_var(var_exp.id.id_name, null)
+						scope.init_var(var_exp.id.id_name, null, src, var_exp.id)
 				else if(istype(ass.exp, /node/expression/member))
 					var/node/expression/member/M = ass.exp
 					member_obj = Eval(M.object, scope)
@@ -81,90 +81,90 @@
 						if(/node/expression/operator/binary/Assign)
 							out_value = Eval(ass.exp2, scope)
 						if(/node/expression/operator/binary/Assign/BitwiseAnd)
-							out_value = BitwiseAnd(in_value, Eval(ass.exp2, scope))
+							out_value = BitwiseAnd(in_value, Eval(ass.exp2, scope), scope, ass)
 						if(/node/expression/operator/binary/Assign/BitwiseOr)
-							out_value = BitwiseOr(in_value, Eval(ass.exp2, scope))
+							out_value = BitwiseOr(in_value, Eval(ass.exp2, scope), scope, ass)
 						if(/node/expression/operator/binary/Assign/BitwiseXor)
-							out_value = BitwiseXor(in_value, Eval(ass.exp2, scope))
+							out_value = BitwiseXor(in_value, Eval(ass.exp2, scope), scope, ass)
 						if(/node/expression/operator/binary/Assign/Add)
-							out_value = Add(in_value, Eval(ass.exp2, scope))
+							out_value = Add(in_value, Eval(ass.exp2, scope), scope, ass)
 						if(/node/expression/operator/binary/Assign/Subtract)
-							out_value = Subtract(in_value, Eval(ass.exp2, scope))
+							out_value = Subtract(in_value, Eval(ass.exp2, scope), scope, ass)
 						if(/node/expression/operator/binary/Assign/Multiply)
-							out_value = Multiply(in_value, Eval(ass.exp2, scope))
+							out_value = Multiply(in_value, Eval(ass.exp2, scope), scope, ass)
 						if(/node/expression/operator/binary/Assign/Divide)
-							out_value = Divide(in_value, Eval(ass.exp2, scope))
+							out_value = Divide(in_value, Eval(ass.exp2, scope), scope, ass)
 						if(/node/expression/operator/binary/Assign/Power)
-							out_value = Power(in_value, Eval(ass.exp2, scope))
+							out_value = Power(in_value, Eval(ass.exp2, scope), scope, ass)
 						if(/node/expression/operator/binary/Assign/Modulo)
-							out_value = Modulo(in_value, Eval(ass.exp2, scope))
+							out_value = Modulo(in_value, Eval(ass.exp2, scope), scope, ass)
 						else
-							RaiseError(new/runtimeError/UnknownInstruction(ass))
+							RaiseError(new/runtimeError/UnknownInstruction(ass),scope, ass)
 					// write it to the var
 					if(istype(ass.exp, /node/expression/value/variable))
 						var/node/expression/value/variable/var_exp = ass.exp
-						scope.set_var(var_exp.id.id_name, out_value)
+						scope.set_var(var_exp.id.id_name, out_value, src, var_exp.id)
 					else if(istype(ass.exp, /node/expression/member/dot))
 						var/node/expression/member/dot/dot_exp = ass.exp
 						set_property(member_obj, dot_exp.id.id_name, out_value, scope)
 					else if(istype(ass.exp, /node/expression/member/brackets))
 						set_index(member_obj, member_idx, out_value, scope)
 					else
-						RaiseError(new/runtimeError/InvalidAssignment())
+						RaiseError(new/runtimeError/InvalidAssignment(), scope, ass)
 				return out_value
 			else if(istype(exp, /node/expression/operator/binary))
 				var/node/expression/operator/binary/bin=exp
 				switch(bin.type)
 					if(/node/expression/operator/binary/Equal)
-						return Equal(Eval(bin.exp, scope), Eval(bin.exp2, scope))
+						return Equal(Eval(bin.exp, scope), Eval(bin.exp2, scope), scope, bin)
 					if(/node/expression/operator/binary/NotEqual)
-						return NotEqual(Eval(bin.exp, scope), Eval(bin.exp2, scope))
+						return NotEqual(Eval(bin.exp, scope), Eval(bin.exp2, scope), scope, bin)
 					if(/node/expression/operator/binary/Greater)
-						return Greater(Eval(bin.exp, scope), Eval(bin.exp2, scope))
+						return Greater(Eval(bin.exp, scope), Eval(bin.exp2, scope), scope, bin)
 					if(/node/expression/operator/binary/Less)
-						return Less(Eval(bin.exp, scope), Eval(bin.exp2, scope))
+						return Less(Eval(bin.exp, scope), Eval(bin.exp2, scope), scope, bin)
 					if(/node/expression/operator/binary/GreaterOrEqual)
-						return GreaterOrEqual(Eval(bin.exp, scope), Eval(bin.exp2, scope))
+						return GreaterOrEqual(Eval(bin.exp, scope), Eval(bin.exp2, scope), scope, bin)
 					if(/node/expression/operator/binary/LessOrEqual)
-						return LessOrEqual(Eval(bin.exp, scope), Eval(bin.exp2, scope))
+						return LessOrEqual(Eval(bin.exp, scope), Eval(bin.exp2, scope), scope, bin)
 					if(/node/expression/operator/binary/LogicalAnd)
-						return LogicalAnd(Eval(bin.exp, scope), Eval(bin.exp2, scope))
+						return LogicalAnd(Eval(bin.exp, scope), Eval(bin.exp2, scope), scope, bin)
 					if(/node/expression/operator/binary/LogicalOr)
-						return LogicalOr(Eval(bin.exp, scope), Eval(bin.exp2, scope))
+						return LogicalOr(Eval(bin.exp, scope), Eval(bin.exp2, scope), scope, bin)
 					if(/node/expression/operator/binary/LogicalXor)
-						return LogicalXor(Eval(bin.exp, scope), Eval(bin.exp2, scope))
+						return LogicalXor(Eval(bin.exp, scope), Eval(bin.exp2, scope), scope, bin)
 					if(/node/expression/operator/binary/BitwiseAnd)
-						return BitwiseAnd(Eval(bin.exp, scope), Eval(bin.exp2, scope))
+						return BitwiseAnd(Eval(bin.exp, scope), Eval(bin.exp2, scope), scope, bin)
 					if(/node/expression/operator/binary/BitwiseOr)
-						return BitwiseOr(Eval(bin.exp, scope), Eval(bin.exp2, scope))
+						return BitwiseOr(Eval(bin.exp, scope), Eval(bin.exp2, scope), scope, bin)
 					if(/node/expression/operator/binary/BitwiseXor)
-						return BitwiseXor(Eval(bin.exp, scope), Eval(bin.exp2, scope))
+						return BitwiseXor(Eval(bin.exp, scope), Eval(bin.exp2, scope), scope, bin)
 					if(/node/expression/operator/binary/Add)
-						return Add(Eval(bin.exp, scope), Eval(bin.exp2, scope))
+						return Add(Eval(bin.exp, scope), Eval(bin.exp2, scope), scope, bin)
 					if(/node/expression/operator/binary/Subtract)
-						return Subtract(Eval(bin.exp, scope), Eval(bin.exp2, scope))
+						return Subtract(Eval(bin.exp, scope), Eval(bin.exp2, scope), scope, bin)
 					if(/node/expression/operator/binary/Multiply)
-						return Multiply(Eval(bin.exp, scope), Eval(bin.exp2, scope))
+						return Multiply(Eval(bin.exp, scope), Eval(bin.exp2, scope), scope, bin)
 					if(/node/expression/operator/binary/Divide)
-						return Divide(Eval(bin.exp, scope), Eval(bin.exp2, scope))
+						return Divide(Eval(bin.exp, scope), Eval(bin.exp2, scope), scope, bin)
 					if(/node/expression/operator/binary/Power)
-						return Power(Eval(bin.exp, scope), Eval(bin.exp2, scope))
+						return Power(Eval(bin.exp, scope), Eval(bin.exp2, scope), scope, bin)
 					if(/node/expression/operator/binary/Modulo)
-						return Modulo(Eval(bin.exp, scope), Eval(bin.exp2, scope))
+						return Modulo(Eval(bin.exp, scope), Eval(bin.exp2, scope), scope, bin)
 					else
-						RaiseError(new/runtimeError/UnknownInstruction(bin))
+						RaiseError(new/runtimeError/UnknownInstruction(bin), scope, bin)
 			else
 				switch(exp.type)
 					if(/node/expression/operator/unary/Minus)
-						return Minus(Eval(exp.exp, scope))
+						return Minus(Eval(exp.exp, scope), scope, exp)
 					if(/node/expression/operator/unary/LogicalNot)
-						return LogicalNot(Eval(exp.exp, scope))
+						return LogicalNot(Eval(exp.exp, scope), scope, exp)
 					if(/node/expression/operator/unary/BitwiseNot)
-						return BitwiseNot(Eval(exp.exp, scope))
+						return BitwiseNot(Eval(exp.exp, scope), scope, exp)
 					if(/node/expression/operator/unary/group)
 						return Eval(exp.exp, scope)
 					else
-						RaiseError(new/runtimeError/UnknownInstruction(exp))
+						RaiseError(new/runtimeError/UnknownInstruction(exp), scope, exp)
 
 
 	//Binary//
@@ -184,44 +184,44 @@
 		BitwiseOr(a, b)			return a|b
 		BitwiseXor(a, b)		return a^b
 		//Arithmetic Operators
-		Add(a, b)
+		Add(a, b, scope, node)
 			if(istext(a)&&!istext(b))
 				b="[b]"
 			else if(istext(b)&&!istext(a)&&!islist(a))
 				a="[a]"
 			if(isnull(a) || isnull(b))
-				RaiseError(new/runtimeError/TypeMismatch("+", a, b))
+				RaiseError(new/runtimeError/TypeMismatch("+", a, b), scope, node)
 				return null
 			return a+b
-		Subtract(a, b)
+		Subtract(a, b, scope, node)
 			if(isnull(a) || isnull(b))
-				RaiseError(new/runtimeError/TypeMismatch("-", a, b))
+				RaiseError(new/runtimeError/TypeMismatch("-", a, b), scope, node)
 				return null
 			return a-b
-		Divide(a, b)
+		Divide(a, b, scope, node)
 			if(isnull(a) || isnull(b))
-				RaiseError(new/runtimeError/TypeMismatch("/", a, b))
+				RaiseError(new/runtimeError/TypeMismatch("/", a, b), scope, node)
 				return null
 			if(b)
 				return a/b
 			// If $b is 0 or Null or whatever, then the above if statement fails,
 			// and we got a divison by zero.
-			RaiseError(new/runtimeError/DivisionByZero())
+			RaiseError(new/runtimeError/DivisionByZero(), scope, node)
 			//ReleaseSingularity()
 			return null
-		Multiply(a, b)
+		Multiply(a, b, scope, node)
 			if(isnull(a) || isnull(b))
-				RaiseError(new/runtimeError/TypeMismatch("*", a, b))
+				RaiseError(new/runtimeError/TypeMismatch("*", a, b), scope, node)
 				return null
 			return a*b
-		Modulo(a, b)
+		Modulo(a, b, scope, node)
 			if(isnull(a) || isnull(b))
-				RaiseError(new/runtimeError/TypeMismatch("%", a, b))
+				RaiseError(new/runtimeError/TypeMismatch("%", a, b), scope, node)
 				return null
 			return a%b
-		Power(a, b)
+		Power(a, b, scope, node)
 			if(isnull(a) || isnull(b))
-				RaiseError(new/runtimeError/TypeMismatch("**", a, b))
+				RaiseError(new/runtimeError/TypeMismatch("**", a, b), scope, node)
 				return null
 			return a**b
 

--- a/yogstation/code/modules/scripting/Interpreter/Evaluation.dm
+++ b/yogstation/code/modules/scripting/Interpreter/Evaluation.dm
@@ -17,7 +17,17 @@
 				. = ref.value
 			else if(istype(exp, /node/expression/value/variable))
 				var/node/expression/value/variable/v=exp
-				. = scope.get_var(v.id.id_name, src, v.id)
+				. = scope.get_var(v.id.id_name, src, v)
+			else if(istype(exp, /node/expression/value/list_init))
+				var/node/expression/value/list_init/list_exp = exp
+				. = list()
+				for(var/key in list_exp.init_list)
+					var/key_eval = Eval(key, scope)
+					var/val = list_exp.init_list[key]
+					if(val)
+						set_index(., key_eval, Eval(val, scope), scope, key)
+					else
+						. += list(key_eval)
 			else if(istype(exp, /node/expression/member/dot))
 				var/node/expression/member/dot/D = exp
 				var/object = D.temp_object || Eval(D.object, scope)
@@ -44,7 +54,7 @@
 				if(istype(ass.exp, /node/expression/value/variable))
 					var/node/expression/value/variable/var_exp = ass.exp
 					if(!scope.get_scope(var_exp.id.id_name))
-						scope.init_var(var_exp.id.id_name, null, src, var_exp.id)
+						scope.init_var(var_exp.id.id_name, null, src, var_exp)
 				else if(istype(ass.exp, /node/expression/member))
 					var/node/expression/member/M = ass.exp
 					member_obj = Eval(M.object, scope)
@@ -103,7 +113,7 @@
 					// write it to the var
 					if(istype(ass.exp, /node/expression/value/variable))
 						var/node/expression/value/variable/var_exp = ass.exp
-						scope.set_var(var_exp.id.id_name, out_value, src, var_exp.id)
+						scope.set_var(var_exp.id.id_name, out_value, src, var_exp)
 					else if(istype(ass.exp, /node/expression/member/dot))
 						var/node/expression/member/dot/dot_exp = ass.exp
 						set_property(member_obj, dot_exp.id.id_name, out_value, scope)

--- a/yogstation/code/modules/scripting/Interpreter/Evaluation.dm
+++ b/yogstation/code/modules/scripting/Interpreter/Evaluation.dm
@@ -4,11 +4,11 @@
 
 /n_Interpreter
 	proc
-		Eval(node/expression/exp)
+		Eval(node/expression/exp, scope/scope)
 			if(istype(exp, /node/expression/FunctionCall))
-				. = RunFunction(exp)
+				. = RunFunction(exp, scope)
 			else if(istype(exp, /node/expression/operator))
-				. = EvalOperator(exp)
+				. = EvalOperator(exp, scope)
 			else if(istype(exp, /node/expression/value/literal))
 				var/node/expression/value/literal/lit=exp
 				. = lit.value
@@ -18,20 +18,19 @@
 			else if(istype(exp, /node/expression/value/variable))
 				var/node/expression/value/variable/v=exp
 				if(!v.object)
-					. = Eval(GetVariable(v.id.id_name))
+					. = scope.get_var(v.id.id_name)
 				else
 					var/datum/D
 					if(istype(v.object, /node/identifier))
-						D=GetVariable(v.object:id_name)
+						D=scope.get_var(v.object:id_name)
 					else
 						D=v.object
-					D=Eval(D)
 					if(isnull(D))
 						return null
 					if(!D.vars.Find(v.id.id_name))
 						RaiseError(new/runtimeError/UndefinedVariable("[v.object.ToString()].[v.id.id_name]"))
 						return null
-					. = Eval(D.vars[v.id.id_name])
+					. = Eval(D.vars[v.id.id_name], scope)
 			else if(istype(exp, /node/expression))
 				RaiseError(new/runtimeError/UnknownInstruction())
 			else
@@ -39,58 +38,114 @@
 
 			return Trim(.)
 
-		EvalOperator(node/expression/operator/exp)
-			if(istype(exp, /node/expression/operator/binary))
+		EvalOperator(node/expression/operator/exp, scope/scope)
+			if(istype(exp, /node/expression/operator/binary/Assign))
+				var/node/expression/operator/binary/Assign/ass=exp
+				if(istype(ass.exp, /node/expression/value/variable))
+					var/node/expression/value/variable/var_exp = ass.exp
+					if(!scope.get_scope(var_exp.id.id_name))
+						scope.init_var(var_exp.id.id_name, null)
+				var/out_value
+				var/in_value
+				if(ass.type != /node/expression/operator/binary/Assign)
+					in_value = Eval(ass.exp, scope)
+					if(islist(in_value))
+						out_value = in_value
+						switch(ass.type)
+							if(/node/expression/operator/binary/Assign/BitwiseAnd)
+								in_value &= Eval(ass.exp2, scope)
+							if(/node/expression/operator/binary/Assign/BitwiseOr)
+								in_value |= Eval(ass.exp2, scope)
+							if(/node/expression/operator/binary/Assign/BitwiseXor)
+								in_value ^= Eval(ass.exp2, scope)
+							if(/node/expression/operator/binary/Assign/Add)
+								in_value += Eval(ass.exp2, scope)
+							if(/node/expression/operator/binary/Assign/Subtract)
+								in_value -= Eval(ass.exp2, scope)
+							else
+								out_value = null
+				if(!out_value)
+					switch(ass.type)
+						if(/node/expression/operator/binary/Assign)
+							out_value = Eval(ass.exp2, scope)
+						if(/node/expression/operator/binary/Assign/BitwiseAnd)
+							out_value = BitwiseAnd(in_value, Eval(ass.exp2, scope))
+						if(/node/expression/operator/binary/Assign/BitwiseOr)
+							out_value = BitwiseOr(in_value, Eval(ass.exp2, scope))
+						if(/node/expression/operator/binary/Assign/BitwiseXor)
+							out_value = BitwiseXor(in_value, Eval(ass.exp2, scope))
+						if(/node/expression/operator/binary/Assign/Add)
+							out_value = Add(in_value, Eval(ass.exp2, scope))
+						if(/node/expression/operator/binary/Assign/Subtract)
+							out_value = Subtract(in_value, Eval(ass.exp2, scope))
+						if(/node/expression/operator/binary/Assign/Multiply)
+							out_value = Multiply(in_value, Eval(ass.exp2, scope))
+						if(/node/expression/operator/binary/Assign/Divide)
+							out_value = Divide(in_value, Eval(ass.exp2, scope))
+						if(/node/expression/operator/binary/Assign/Power)
+							out_value = Power(in_value, Eval(ass.exp2, scope))
+						if(/node/expression/operator/binary/Assign/Modulo)
+							out_value = Modulo(in_value, Eval(ass.exp2, scope))
+						else
+							RaiseError(new/runtimeError/UnknownInstruction())
+					// write it to the var
+					if(istype(ass.exp, /node/expression/value/variable))
+						var/node/expression/value/variable/var_exp = ass.exp
+						scope.set_var(var_exp.id.id_name, out_value)
+					else
+						RaiseError(new/runtimeError/InvalidAssignment())
+				return out_value
+			else if(istype(exp, /node/expression/operator/binary))
 				var/node/expression/operator/binary/bin=exp
 				switch(bin.type)
 					if(/node/expression/operator/binary/Equal)
-						return Equal(Eval(bin.exp), Eval(bin.exp2))
+						return Equal(Eval(bin.exp, scope), Eval(bin.exp2, scope))
 					if(/node/expression/operator/binary/NotEqual)
-						return NotEqual(Eval(bin.exp), Eval(bin.exp2))
+						return NotEqual(Eval(bin.exp, scope), Eval(bin.exp2, scope))
 					if(/node/expression/operator/binary/Greater)
-						return Greater(Eval(bin.exp), Eval(bin.exp2))
+						return Greater(Eval(bin.exp, scope), Eval(bin.exp2, scope))
 					if(/node/expression/operator/binary/Less)
-						return Less(Eval(bin.exp), Eval(bin.exp2))
+						return Less(Eval(bin.exp, scope), Eval(bin.exp2, scope))
 					if(/node/expression/operator/binary/GreaterOrEqual)
-						return GreaterOrEqual(Eval(bin.exp), Eval(bin.exp2))
+						return GreaterOrEqual(Eval(bin.exp, scope), Eval(bin.exp2, scope))
 					if(/node/expression/operator/binary/LessOrEqual)
-						return LessOrEqual(Eval(bin.exp), Eval(bin.exp2))
+						return LessOrEqual(Eval(bin.exp, scope), Eval(bin.exp2, scope))
 					if(/node/expression/operator/binary/LogicalAnd)
-						return LogicalAnd(Eval(bin.exp), Eval(bin.exp2))
+						return LogicalAnd(Eval(bin.exp, scope), Eval(bin.exp2, scope))
 					if(/node/expression/operator/binary/LogicalOr)
-						return LogicalOr(Eval(bin.exp), Eval(bin.exp2))
+						return LogicalOr(Eval(bin.exp, scope), Eval(bin.exp2, scope))
 					if(/node/expression/operator/binary/LogicalXor)
-						return LogicalXor(Eval(bin.exp), Eval(bin.exp2))
+						return LogicalXor(Eval(bin.exp, scope), Eval(bin.exp2, scope))
 					if(/node/expression/operator/binary/BitwiseAnd)
-						return BitwiseAnd(Eval(bin.exp), Eval(bin.exp2))
+						return BitwiseAnd(Eval(bin.exp, scope), Eval(bin.exp2, scope))
 					if(/node/expression/operator/binary/BitwiseOr)
-						return BitwiseOr(Eval(bin.exp), Eval(bin.exp2))
+						return BitwiseOr(Eval(bin.exp, scope), Eval(bin.exp2, scope))
 					if(/node/expression/operator/binary/BitwiseXor)
-						return BitwiseXor(Eval(bin.exp), Eval(bin.exp2))
+						return BitwiseXor(Eval(bin.exp, scope), Eval(bin.exp2, scope))
 					if(/node/expression/operator/binary/Add)
-						return Add(Eval(bin.exp), Eval(bin.exp2))
+						return Add(Eval(bin.exp, scope), Eval(bin.exp2, scope))
 					if(/node/expression/operator/binary/Subtract)
-						return Subtract(Eval(bin.exp), Eval(bin.exp2))
+						return Subtract(Eval(bin.exp, scope), Eval(bin.exp2, scope))
 					if(/node/expression/operator/binary/Multiply)
-						return Multiply(Eval(bin.exp), Eval(bin.exp2))
+						return Multiply(Eval(bin.exp, scope), Eval(bin.exp2, scope))
 					if(/node/expression/operator/binary/Divide)
-						return Divide(Eval(bin.exp), Eval(bin.exp2))
+						return Divide(Eval(bin.exp, scope), Eval(bin.exp2, scope))
 					if(/node/expression/operator/binary/Power)
-						return Power(Eval(bin.exp), Eval(bin.exp2))
+						return Power(Eval(bin.exp, scope), Eval(bin.exp2, scope))
 					if(/node/expression/operator/binary/Modulo)
-						return Modulo(Eval(bin.exp), Eval(bin.exp2))
+						return Modulo(Eval(bin.exp, scope), Eval(bin.exp2, scope))
 					else
 						RaiseError(new/runtimeError/UnknownInstruction())
 			else
 				switch(exp.type)
 					if(/node/expression/operator/unary/Minus)
-						return Minus(Eval(exp.exp))
+						return Minus(Eval(exp.exp, scope))
 					if(/node/expression/operator/unary/LogicalNot)
-						return LogicalNot(Eval(exp.exp))
+						return LogicalNot(Eval(exp.exp, scope))
 					if(/node/expression/operator/unary/BitwiseNot)
-						return BitwiseNot(Eval(exp.exp))
+						return BitwiseNot(Eval(exp.exp, scope))
 					if(/node/expression/operator/unary/group)
-						return Eval(exp.exp)
+						return Eval(exp.exp, scope)
 					else
 						RaiseError(new/runtimeError/UnknownInstruction())
 
@@ -115,7 +170,7 @@
 		Add(a, b)
 			if(istext(a)&&!istext(b))
 				b="[b]"
-			else if(istext(b)&&!istext(a))
+			else if(istext(b)&&!istext(a)&&!islist(a))
 				a="[a]"
 			if(isnull(a) || isnull(b))
 				RaiseError(new/runtimeError/TypeMismatch("+", a, b))

--- a/yogstation/code/modules/scripting/Interpreter/Interaction.dm
+++ b/yogstation/code/modules/scripting/Interpreter/Interaction.dm
@@ -32,7 +32,7 @@
 			cur_statements = 0 // reset CPU tracking
 
 			ASSERT(src.program)
-			RunBlock(src.program)
+			. = RunBlock(src.program)
 
 /*
 	Proc: SetVar
@@ -49,7 +49,7 @@
 			if(!istext(name))
 				//CRASH("Invalid variable name")
 				return
-			AssignVariable(name, value)
+			globalScope.variables[name] = value
 
 /*
 	Proc: SetProc
@@ -108,7 +108,7 @@
 				//CRASH("No variable named '[name]'.")
 				return
 			var/x = globalScope.variables[name]
-			return Eval(x)
+			return x
 
 /*
 	Proc: GetCleanVar

--- a/yogstation/code/modules/scripting/Interpreter/Interaction.dm
+++ b/yogstation/code/modules/scripting/Interpreter/Interaction.dm
@@ -118,6 +118,8 @@
 		CallProc(name, list/params)
 			var/datum/n_function/func = globalScope.get_var(name)
 			if(istype(func))
+				cur_recursion = 0 // reset recursion
+				cur_statements = 0 // reset CPU tracking
 				func.execute(null, params, new /scope(program, null), src)
 			//CRASH("Unknown function type '[name]'.")
 

--- a/yogstation/code/modules/scripting/Interpreter/Interaction.dm
+++ b/yogstation/code/modules/scripting/Interpreter/Interaction.dm
@@ -120,7 +120,7 @@
 			if(istype(func))
 				cur_recursion = 0 // reset recursion
 				cur_statements = 0 // reset CPU tracking
-				func.execute(null, params, new /scope(program, null), src)
+				return func.execute(null, params, new /scope(program, null), src)
 			//CRASH("Unknown function type '[name]'.")
 
 /*

--- a/yogstation/code/modules/scripting/Interpreter/Interpreter.dm
+++ b/yogstation/code/modules/scripting/Interpreter/Interpreter.dm
@@ -95,8 +95,9 @@
 		CreateGlobalScope()
 			var/scope/S = new(program, null)
 			globalScope = S
-			for(var/datum/n_function/default/functype in subtypesof(/datum/n_function/default))
-				if(!istype(src, initial(functype.interp_type))
+			for(var/functype in subtypesof(/datum/n_function/default))
+				var/datum/n_function/default/god_damn_it_byond = functype
+				if(!istype(src, initial(god_damn_it_byond.interp_type)))
 					continue
 				var/datum/n_function/default/func = new functype()
 				globalScope.init_var(func.name, func)
@@ -181,12 +182,12 @@
 			var/this_obj
 			if(istype(stmt.function, /node/expression/member))
 				var/node/expression/member/M = stmt.function
-				this_obj = M.temp_object = Eval(M.object)
-				func = Eval(M)
+				this_obj = M.temp_object = Eval(M.object, scope)
+				func = Eval(M, scope)
 			else
-				func = Eval(stmt.function)
+				func = Eval(stmt.function, scope)
 			if(!istype(func))
-				RaiseError(new/runtimeError/UndefinedFunction("[stmt.object.ToString()]"))
+				RaiseError(new/runtimeError/UndefinedFunction("[stmt.function.ToString()]"))
 				return
 			var/list/params = list()
 			for(var/node/expression/P in stmt.parameters)

--- a/yogstation/code/modules/scripting/Interpreter/Interpreter.dm
+++ b/yogstation/code/modules/scripting/Interpreter/Interpreter.dm
@@ -87,9 +87,13 @@
 	Proc: RaiseError
 	Raises a runtime error.
 */
-		RaiseError(runtimeError/e)
-			e.stack=functions.Copy()
-			e.stack.Push(curFunction)
+		RaiseError(runtimeError/e, scope/scope, token/token)
+			e.scope = scope
+			if(istype(token))
+				e.token = token
+			else if(istype(token, /node))
+				var/node/N = token
+				e.token = N.token
 			src.HandleError(e)
 
 		CreateGlobalScope()
@@ -194,7 +198,7 @@
 				params+=list(Eval(P, scope))
 
 			try
-				return func.execute(this_obj, params, scope, src)
+				return func.execute(this_obj, params, scope, src, stmt)
 			catch(var/exception/E)
 				RaiseError(new /runtimeError/Internal(E))
 

--- a/yogstation/code/modules/scripting/Interpreter/Interpreter.dm
+++ b/yogstation/code/modules/scripting/Interpreter/Interpreter.dm
@@ -9,10 +9,12 @@
 	RETURNING  - Indicates that the current function is returning a value.
 	BREAKING   - Indicates that the current loop is being terminated.
 	CONTINUING - Indicates that the rest of the current iteration of a loop is being skipped.
+	RESET_STATUS - Indicates that we are entering a new function and the allowed_status var should be cleared
 */
 #define RETURNING  1
 #define BREAKING   2
 #define CONTINUING 4
+#define RESET_STATUS 8
 
 /*
 	Macros: Maximums
@@ -28,13 +30,11 @@
 /n_Interpreter
 	var
 		scope
-			curScope
 			globalScope
 		node
 			BlockDefinition/program
 			statement/FunctionDefinition/curFunction
 		stack
-			scopes		= new()
 			functions	= new()
 
 		datum/container // associated container for interpeter
@@ -44,7 +44,7 @@
 */
 		status=0
 		returnVal
-		
+
 		cur_statements=0    // current amount of statements called
 		alertadmins=0		// set to 1 if the admins shouldn't be notified of anymore issues
 		cur_recursion=0	   	// current amount of recursion
@@ -92,14 +92,7 @@
 			e.stack.Push(curFunction)
 			src.HandleError(e)
 
-		CreateScope(node/BlockDefinition/B)
-			var/scope/S = new(B, curScope)
-			scopes.Push(curScope)
-			curScope = S
-			return S
-
 		CreateGlobalScope()
-			scopes.Clear()
 			var/scope/S = new(program, null)
 			globalScope = S
 			return S
@@ -121,21 +114,10 @@
 	Proc: RunBlock
 	Runs each statement in a block of code.
 */
-		RunBlock(node/BlockDefinition/Block, scope/scope = null)
-			var/is_global = istype(Block, /node/BlockDefinition/GlobalBlock)
-			if(!is_global)
-				if(scope)
-					curScope = scope
-				else
-					CreateScope(Block)
-			else
-				if(!persist)
-					CreateGlobalScope()
-				curScope = globalScope
+		RunBlock(node/BlockDefinition/Block, scope/scope = globalScope)
 
 			if(cur_statements < MAX_STATEMENTS)
-
-				for(var/node/statement/S in Block.statements)
+				for(var/node/S in Block.statements)
 					while(paused) sleep(10)
 
 					cur_statements++
@@ -144,104 +126,90 @@
 						AlertAdmins()
 						break
 
-					if(istype(S, /node/statement/VariableAssignment))
-						var/node/statement/VariableAssignment/stmt = S
-						var/name = stmt.var_name.id_name
-						if(!stmt.object)
-							// Below we assign the variable first to null if it doesn't already exist.
-							// This is necessary for assignments like +=, and when the variable is used in a function
-							// If the variable already exists in a different block, then AssignVariable will automatically use that one.
-							if(!IsVariableAccessible(name))
-								AssignVariable(name, null)
-							AssignVariable(name, Eval(stmt.value))
-						else
-							var/datum/D = Eval(GetVariable(stmt.object.id_name))
-							if(!D) return
-							D.vars[stmt.var_name.id_name] = Eval(stmt.value)
-					else if(istype(S, /node/statement/VariableDeclaration))
+					if(istype(S, /node/expression))
+						. =Eval(S, scope)
+					if(istype(S, /node/statement/VariableDeclaration))
 						//VariableDeclaration nodes are used to forcibly declare a local variable so that one in a higher scope isn't used by default.
 						var/node/statement/VariableDeclaration/dec=S
-						if(!dec.object)
-							AssignVariable(dec.var_name.id_name, null, curScope)
-						else
-							var/datum/D = Eval(GetVariable(dec.object.id_name))
-							if(!D) return
-							D.vars[dec.var_name.id_name] = null
-					else if(istype(S, /node/statement/FunctionCall))
-						RunFunction(S)
+						scope.init_var(dec.var_name.id_name)
 					else if(istype(S, /node/statement/FunctionDefinition))
 						//do nothing
 					else if(istype(S, /node/statement/WhileLoop))
-						RunWhile(S)
+						. = RunWhile(S, scope)
+					else if(istype(S, /node/statement/ForLoop))
+						. = RunFor(S, scope)
 					else if(istype(S, /node/statement/IfStatement))
-						RunIf(S)
+						. = RunIf(S, scope)
 					else if(istype(S, /node/statement/ReturnStatement))
-						if(!curFunction)
+						if(!scope.allowed_status & RETURNING)
 							RaiseError(new/runtimeError/UnexpectedReturn())
 							continue
-						status |= RETURNING
-						returnVal=Eval(S:value)
+						scope.status |= RETURNING
+						. = (returnVal=Eval(S:value, scope))
 						break
 					else if(istype(S, /node/statement/BreakStatement))
-						status |= BREAKING
+						if(!scope.allowed_status & BREAKING)
+							//RaiseError(new/runtimeError/UnexpectedReturn())
+							continue
+						scope.status |= BREAKING
 						break
 					else if(istype(S, /node/statement/ContinueStatement))
-						status |= CONTINUING
+						if(!scope.allowed_status & CONTINUING)
+							//RaiseError(new/runtimeError/UnexpectedReturn())
+							continue
+						scope.status |= CONTINUING
 						break
 					else
 						RaiseError(new/runtimeError/UnknownInstruction())
-					if(status)
+					if(scope.status)
 						break
-
-			curScope = scopes.Pop()
 
 /*
 	Proc: RunFunction
 	Runs a function block or a proc with the arguments specified in the script.
 */
-		RunFunction(node/statement/FunctionCall/stmt)
+		RunFunction(node/statement/FunctionCall/stmt, scope/scope)
 			//Note that anywhere /node/statement/FunctionCall/stmt is used so may /node/expression/FunctionCall
 
 			// If recursion gets too high (max 50 nested functions) throw an error
-			if(cur_recursion >= MAX_RECURSION)
+			if(scope.recursion >= MAX_RECURSION)
 				AlertAdmins()
 				RaiseError(new/runtimeError/RecursionLimitReached())
 				return 0
 
 			var/node/statement/FunctionDefinition/def
 			if(!stmt.object)							//A scope's function is being called, stmt.object is null
-				def = GetFunction(stmt.func_name)
+				def = scope.get_function(stmt.func_name)
 			else if(istype(stmt.object))				//A method of an object exposed as a variable is being called, stmt.object is a /node/identifier
-				var/O = GetVariable(stmt.object.id_name)	//Gets a reference to the object which is the target of the function call.
+				var/O = scope.get_var(stmt.object.id_name)	//Gets a reference to the object which is the target of the function call.
 				if(!O) return							//Error already thrown in GetVariable()
-				def = Eval(O)
+				def = Eval(O, scope)
 
 			if(!def) return
 
 			cur_recursion++ // add recursion
 			if(istype(def))
 				if(curFunction) functions.Push(curFunction)
-				var/scope/S = CreateScope(def.block)
+				scope = scope.push(def.block, globalScope, RESET_STATUS | RETURNING)
 				for(var/i=1 to def.parameters.len)
 					var/val
 					if(stmt.parameters.len>=i)
 						val = stmt.parameters[i]
 					//else
 					//	unspecified param
-					AssignVariable(def.parameters[i], new/node/expression/value/literal(Eval(val)), S)
+					scope.init_var(def.parameters[i], Eval(val, scope))
 				curFunction=stmt
-				RunBlock(def.block, S)
+				RunBlock(def.block, scope)
 				//Handle return value
-				. = returnVal
-				status &= ~RETURNING
-				returnVal=null
+				. = scope.return_val
+				scope = scope.pop(0) // keep nothing
 				curFunction=functions.Pop()
 				cur_recursion--
 			else
 				cur_recursion--
 				var/list/params=new
 				for(var/node/expression/P in stmt.parameters)
-					params+=list(Eval(P))
+					params+=list(Eval(P, scope))
 				if(isobject(def))	//def is an object which is the target of a function call
 					if( !hascall(def, stmt.func_name) )
 						RaiseError(new/runtimeError/UndefinedFunction("[stmt.object.id_name].[stmt.func_name]"))
@@ -256,10 +224,11 @@
 	Proc: RunIf
 	Checks a condition and runs either the if block or else block.
 */
-		RunIf(node/statement/IfStatement/stmt)
+		RunIf(node/statement/IfStatement/stmt, scope/scope)
 			if(!stmt.skip)
-				if(Eval(stmt.cond))
-					RunBlock(stmt.block)
+				scope = scope.push(stmt.block)
+				if(Eval(stmt.cond, scope))
+					. = RunBlock(stmt.block, scope)
 					// Loop through the if else chain and tell them to be skipped.
 					var/node/statement/IfStatement/i = stmt.else_if
 					var/fail_safe = 800
@@ -269,7 +238,8 @@
 						i = i.else_if
 
 				else if(stmt.else_block)
-					RunBlock(stmt.else_block)
+					. = RunBlock(stmt.else_block, scope)
+				scope = scope.pop()
 			// We don't need to skip you anymore.
 			stmt.skip = 0
 
@@ -277,18 +247,30 @@
 	Proc: RunWhile
 	Runs a while loop.
 */
-		RunWhile(node/statement/WhileLoop/stmt)
+		RunWhile(node/statement/WhileLoop/stmt, scope/scope)
 			var/i=1
-			while(Eval(stmt.cond) && Iterate(stmt.block, i++))
+			scope = scope.push(stmt.block, allowed_status = CONTINUING | BREAKING)
+			while(Eval(stmt.cond, scope) && Iterate(stmt.block, scope, i++))
 				continue
-			status &= ~BREAKING
+			scope = scope.pop(RETURNING)
+
+		RunFor(node/statement/ForLoop/stmt, scope/scope)
+			var/i=1
+			scope = scope.push(stmt.block)
+			Eval(stmt.init, scope)
+			while(Eval(stmt.test, scope))
+				if(Iterate(stmt.block, scope, i++))
+					Eval(stmt.increment, scope)
+				else
+					break
+			scope = scope.pop(RETURNING)
 
 /*
 	Proc:Iterate
 	Runs a single iteration of a loop. Returns a value indicating whether or not to continue looping.
 */
-		Iterate(node/BlockDefinition/block, count)
-			RunBlock(block)
+		Iterate(node/BlockDefinition/block, scope/scope, count)
+			RunBlock(block, scope)
 			if(MAX_ITERATIONS > 0 && count >= MAX_ITERATIONS)
 				RaiseError(new/runtimeError/IterationLimitReached())
 				return 0
@@ -297,70 +279,8 @@
 			status &= ~CONTINUING
 			return 1
 
-/*
-	Proc: GetFunction
-	Finds a function in an accessible scope with the given name. Returns a <FunctionDefinition>.
-*/
-		GetFunction(name)
-			var/scope/S = curScope
-			while(S)
-				if(S.functions.Find(name))
-					return S.functions[name]
-				S = S.parent
-			RaiseError(new/runtimeError/UndefinedFunction(name))
-
-/*
-	Proc: GetVariable
-	Finds a variable in an accessible scope and returns its value.
-*/
-		GetVariable(name)
-			var/scope/S = curScope
-			while(S)
-				if(S.variables.Find(name))
-					return S.variables[name]
-				S = S.parent
-			RaiseError(new/runtimeError/UndefinedVariable(name))
-
-		GetVariableScope(name) //needed for when you reassign a variable in a higher scope
-			var/scope/S = curScope
-			while(S)
-				if(S.variables.Find(name))
-					return S
-				S = S.parent
-
-
-		IsVariableAccessible(name)
-			var/scope/S = curScope
-			while(S)
-				if(S.variables.Find(name))
-					return TRUE
-				S = S.parent
-			return FALSE
-
-
-/*
-	Proc: AssignVariable
-	Assigns a value to a variable in a specific block.
-
-	Parameters:
-	name  - The name of the variable to assign.
-	value - The value to assign to it.
-	S     - The scope the variable resides in. If it is null, a scope with the variable already existing is found. If no scopes have a variable of the given name, the current scope is used.
-*/
-		AssignVariable(name, node/expression/value, scope/S=null)
-			if(!S) S = GetVariableScope(name)
-			if(!S) S = curScope
-			if(!S) S = globalScope
-			ASSERT(istype(S))
-			if(istext(value) || isnum(value) || isnull(value))
-				value = new/node/expression/value/literal(value)
-			else if(!istype(value) && isobject(value))
-				value = new/node/expression/value/reference(value)
-			//TODO: check for invalid name
-			S.variables["[name]"] = Trim(value)
-
 #undef MAX_STATEMENTS
 #undef MAX_ITERATIONS
 #undef MAX_RECURSION
 #undef MAX_STRINGLEN
-#undef MAX_LISTLEN 
+#undef MAX_LISTLEN

--- a/yogstation/code/modules/scripting/Interpreter/Objects.dm
+++ b/yogstation/code/modules/scripting/Interpreter/Objects.dm
@@ -1,0 +1,49 @@
+/n_Interpreter/proc/get_property(object, propertyname, scope/scope)
+
+
+/n_Interpreter/proc/set_property(object, propertyname, val, scope/scope)
+
+
+
+/datum/n_function
+	var/name = ""
+
+/datum/n_function/proc/execute(this_obj, list/params, scope/scope, n_Interpreter/interp)
+	return
+
+/datum/n_function/defined
+	var/n_Interpreter/context
+	var/scope/closure
+	var/node/statement/FunctionDefinition/def
+
+/datum/n_function/defined/New(node/statement/FunctionDefinition/D, scope/S, n_Interpreter/C)
+	def = D
+	closure = S
+	context = C
+
+/datum/n_function/defined/execute(this_obj, list/params, scope/scope, n_Interpreter/interp)
+	if(scope.recursion >= 10)
+		AlertAdmins()
+		interp.RaiseError(new/runtimeError/RecursionLimitReached())
+		return 0
+	scope = scope.push(def.block, closure, RESET_STATUS | RETURNING)
+	scope.recursion++
+	scope.
+	for(var/i=1 to def.parameters.len)
+		var/val
+		if(params.len>=i)
+			val = params[i]
+		//else
+		//	unspecified param
+		scope.init_var(def.parameters[i], val)
+	scope.init_var("src", this_obj);
+	RunBlock(def.block, scope)
+	//Handle return value
+	. = scope.return_val
+	scope = scope.pop(0) // keep nothing
+
+/datum/n_function/default
+	// functions included on compilation
+	var/interp_type = /n_Interpreter // include this function in this kind of interpreter.
+	var/list/aliases // in case you want to give it multiple "names"
+

--- a/yogstation/code/modules/scripting/Interpreter/Objects.dm
+++ b/yogstation/code/modules/scripting/Interpreter/Objects.dm
@@ -1,27 +1,60 @@
+GLOBAL_LIST_EMPTY(ntsl_methods)
+
 /n_Interpreter/proc/get_property(object, key, scope/scope)
 	if(islist(object))
 		var/list/L = object
 		if(key == "len")
 			return L.len
-	else if(isdatum(object))
+	else if(istype(object, /datum))
 		var/datum/D = object
 		return D.ntsl_get(key, scope, src)
-	interp.RaiseError(new/runtimeError/UndefinedVariable("[object].[key]"))
+	RaiseError(new/runtimeError/UndefinedVariable("[object].[key]"))
 
 /n_Interpreter/proc/set_property(object, key, val, scope/scope)
-	if(isdatum(object))
+	if(istype(object, /datum))
 		var/datum/D = object
 		D.ntsl_set(key, val, scope, src)
 		return
-	interp.RaiseError(new/runtimeError/UndefinedVariable("[object].[key]"))
+	RaiseError(new/runtimeError/UndefinedVariable("[object].[key]"))
 
-/datum/ntsl_get(key, scope/scope, n_Interpreter/interp)
+/datum/proc/ntsl_get(key, scope/scope, n_Interpreter/interp)
 	interp.RaiseError(new/runtimeError/UndefinedVariable("[src].[key]"))
 	return
 
-/datum/ntsl_set(key, val, scope/scope, n_Interpreter/interp)
+/datum/proc/ntsl_set(key, val, scope/scope, n_Interpreter/interp)
 	interp.RaiseError(new/runtimeError/UndefinedVariable("[src].[key]"))
 	return
+
+/datum/n_enum
+	var/list/entries
+/datum/n_enum/New(list/E)
+	entries = E
+/datum/n_enum/ntsl_get(key)
+	if(entries.Find(key))
+		return entries[key]
+	return ..()
+
+/datum/n_struct
+	var/list/properties
+/datum/n_struct/New(list/P)
+	properties = P
+/datum/n_struct/proc/get_clean_property(name, compare)
+	var/x = properties[name]
+	if(istext(x) && compare && x != compare) // Was changed
+		x = sanitize(x)
+		if(isnotpretty(x)) // Pretty filter stuff
+			message_admins("An NTSL script just tripped the pretty filter, setting variable [name] to value [x]!")
+			return FALSE
+	return x
+/datum/n_struct/ntsl_get(key)
+	if(properties.Find(key))
+		return properties[key]
+	return ..()
+/datum/n_struct/ntsl_set(key, val)
+	if(properties.Find(key))
+		properties[key] = val
+		return
+	..()
 
 /datum/n_function
 	var/name = ""
@@ -64,3 +97,24 @@
 	// functions included on compilation
 	var/interp_type = /n_Interpreter // include this function in this kind of interpreter.
 	var/list/aliases // in case you want to give it multiple "names"
+
+/proc/ntsl_method(path, proc_ref, N)
+	var/list/path_methods = GLOB.ntsl_methods[path]
+	if(!path_methods)
+		path_methods = list()
+		GLOB.ntsl_methods[path] = path_methods
+	path_methods[proc_ref] = new /datum/n_function/default_method(path, proc_ref, N)
+
+/datum/n_function/default_method
+	var/obj_type
+	var/proc_ref
+
+/datum/n_function/default_method/New(path, ref, N)
+	obj_type = path
+	proc_ref = ref
+	name = N
+
+/datum/n_function/default_method/execute(this_obj, list/params, scope/scope, n_Interpreter/interp)
+	if(!istype(this_obj, obj_type))
+		return
+	return call(this_obj, proc_ref)(params, scope, interp)

--- a/yogstation/code/modules/scripting/Interpreter/Objects.dm
+++ b/yogstation/code/modules/scripting/Interpreter/Objects.dm
@@ -108,7 +108,7 @@ GLOBAL_LIST_EMPTY(ntsl_methods)
 	closure = S
 	context = C
 
-/datum/n_function/defined/execute(this_obj, list/params, scope/scope, n_Interpreter/interp)
+/datum/n_function/defined/execute(this_obj, list/params, scope/scope, n_Interpreter/interp, node/node)
 	if(scope.recursion >= 10)
 		interp.AlertAdmins()
 		interp.RaiseError(new/runtimeError/RecursionLimitReached())
@@ -116,6 +116,7 @@ GLOBAL_LIST_EMPTY(ntsl_methods)
 	scope = scope.push(def.block, closure, RESET_STATUS | RETURNING)
 	scope.recursion++
 	scope.function = def
+	scope.token = node.token
 	for(var/i=1 to def.parameters.len)
 		var/val
 		if(params.len>=i)

--- a/yogstation/code/modules/scripting/Interpreter/Objects.dm
+++ b/yogstation/code/modules/scripting/Interpreter/Objects.dm
@@ -1,9 +1,27 @@
-/n_Interpreter/proc/get_property(object, propertyname, scope/scope)
+/n_Interpreter/proc/get_property(object, key, scope/scope)
+	if(islist(object))
+		var/list/L = object
+		if(key == "len")
+			return L.len
+	else if(isdatum(object))
+		var/datum/D = object
+		return D.ntsl_get(key, scope, src)
+	interp.RaiseError(new/runtimeError/UndefinedVariable("[object].[key]"))
 
+/n_Interpreter/proc/set_property(object, key, val, scope/scope)
+	if(isdatum(object))
+		var/datum/D = object
+		D.ntsl_set(key, val, scope, src)
+		return
+	interp.RaiseError(new/runtimeError/UndefinedVariable("[object].[key]"))
 
-/n_Interpreter/proc/set_property(object, propertyname, val, scope/scope)
+/datum/ntsl_get(key, scope/scope, n_Interpreter/interp)
+	interp.RaiseError(new/runtimeError/UndefinedVariable("[src].[key]"))
+	return
 
-
+/datum/ntsl_set(key, val, scope/scope, n_Interpreter/interp)
+	interp.RaiseError(new/runtimeError/UndefinedVariable("[src].[key]"))
+	return
 
 /datum/n_function
 	var/name = ""
@@ -23,12 +41,12 @@
 
 /datum/n_function/defined/execute(this_obj, list/params, scope/scope, n_Interpreter/interp)
 	if(scope.recursion >= 10)
-		AlertAdmins()
+		interp.AlertAdmins()
 		interp.RaiseError(new/runtimeError/RecursionLimitReached())
 		return 0
 	scope = scope.push(def.block, closure, RESET_STATUS | RETURNING)
 	scope.recursion++
-	scope.
+	scope.function = def
 	for(var/i=1 to def.parameters.len)
 		var/val
 		if(params.len>=i)
@@ -37,7 +55,7 @@
 		//	unspecified param
 		scope.init_var(def.parameters[i], val)
 	scope.init_var("src", this_obj);
-	RunBlock(def.block, scope)
+	interp.RunBlock(def.block, scope)
 	//Handle return value
 	. = scope.return_val
 	scope = scope.pop(0) // keep nothing
@@ -46,4 +64,3 @@
 	// functions included on compilation
 	var/interp_type = /n_Interpreter // include this function in this kind of interpreter.
 	var/list/aliases // in case you want to give it multiple "names"
-

--- a/yogstation/code/modules/scripting/Interpreter/Objects.dm
+++ b/yogstation/code/modules/scripting/Interpreter/Objects.dm
@@ -3,8 +3,24 @@ GLOBAL_LIST_EMPTY(ntsl_methods)
 /n_Interpreter/proc/get_property(object, key, scope/scope)
 	if(islist(object))
 		var/list/L = object
-		if(key == "len")
-			return L.len
+		switch(key)
+			if("len")
+				return L.len
+			if("Copy")
+				return ntsl_method(/list, /datum/n_function/list_copy)
+			if("Cut")
+				return ntsl_method(/list, /datum/n_function/list_cut)
+			if("Find")
+				return ntsl_method(/list, /datum/n_function/list_find)
+			if("Insert")
+				return ntsl_method(/list, /datum/n_function/list_insert)
+			if("Join")
+				return ntsl_method(/list, /datum/n_function/list_join)
+			if("Remove")
+				return ntsl_method(/list, /datum/n_function/list_remove)
+			if("Swap")
+				return ntsl_method(/list, /datum/n_function/list_swap)
+
 	else if(istype(object, /datum))
 		var/datum/D = object
 		return D.ntsl_get(key, scope, src)
@@ -103,7 +119,15 @@ GLOBAL_LIST_EMPTY(ntsl_methods)
 	if(!path_methods)
 		path_methods = list()
 		GLOB.ntsl_methods[path] = path_methods
-	path_methods[proc_ref] = new /datum/n_function/default_method(path, proc_ref, N)
+	var/datum/n_function/func = path_methods[proc_ref]
+	if(func)
+		return func
+	if(ispath(proc_ref, /datum/n_function) && !ispath(path, /datum/n_function))
+		func = new proc_ref()
+	else
+		func = new /datum/n_function/default_method(path, proc_ref, N)
+	path_methods[proc_ref] = func
+	return func
 
 /datum/n_function/default_method
 	var/obj_type
@@ -118,3 +142,51 @@ GLOBAL_LIST_EMPTY(ntsl_methods)
 	if(!istype(this_obj, obj_type))
 		return
 	return call(this_obj, proc_ref)(params, scope, interp)
+
+/datum/n_function/list_add
+	name = "Add"
+/datum/n_function/list_add/execute(list/this_obj, list/params)
+	for(var/param in params)
+		this_obj.Add(param)
+
+/datum/n_function/list_copy
+	name = "Copy"
+/datum/n_function/list_copy/execute(list/this_obj, list/params)
+	return this_obj.Copy(params.len >= 1 ? params[1] : 1, params.len >= 2 ? params[2] : 0)
+
+/datum/n_function/list_cut
+	name = "Cut"
+/datum/n_function/list_cut/execute(list/this_obj, list/params)
+	this_obj.Cut(params.len >= 1 ? params[1] : 1, params.len >= 2 ? params[2] : 0)
+
+/datum/n_function/list_find
+	name = "Find"
+/datum/n_function/list_find/execute(list/this_obj, list/params)
+	return this_obj.Find(params[1], params.len >= 2 ? params[2] : 1, params.len >= 3 ? params[3] : 0)
+
+/datum/n_function/list_insert
+	name = "Insert"
+/datum/n_function/list_insert/execute(list/this_obj, list/params)
+	if(params.len >= 2)
+		if(params[1] == 0)
+			for(var/I in 2 to params.len)
+				this_obj.Add(params[I])
+		else
+			for(var/I = params.len; I >= 2; I--)
+				this_obj.Insert(params[1], params[I])
+
+/datum/n_function/list_join
+	name = "Join"
+/datum/n_function/list_join/execute(list/this_obj, list/params)
+	return this_obj.Join(params[1], params.len >= 2 ? params[2] : 1, params.len >= 3 ? params[3] : 0)
+
+/datum/n_function/list_remove
+	name = "Remove"
+/datum/n_function/list_remove/execute(list/this_obj, list/params)
+	for(var/param in params)
+		this_obj.Remove(param)
+
+/datum/n_function/list_swap
+	name = "Swap"
+/datum/n_function/list_swap/execute(list/this_obj, list/params)
+	this_obj.Swap(params[1], params[2])

--- a/yogstation/code/modules/scripting/Interpreter/Objects.dm
+++ b/yogstation/code/modules/scripting/Interpreter/Objects.dm
@@ -20,7 +20,9 @@ GLOBAL_LIST_EMPTY(ntsl_methods)
 				return ntsl_method(/list, /datum/n_function/list_remove)
 			if("Swap")
 				return ntsl_method(/list, /datum/n_function/list_swap)
-
+	else if(istext(object))
+		if(key == "len")
+			return length(object)
 	else if(istype(object, /datum))
 		var/datum/D = object
 		return D.ntsl_get(key, scope, src)
@@ -32,6 +34,24 @@ GLOBAL_LIST_EMPTY(ntsl_methods)
 		D.ntsl_set(key, val, scope, src)
 		return
 	RaiseError(new/runtimeError/UndefinedVariable("[object].[key]"))
+
+/n_Interpreter/proc/get_index(object, index, scope/scope)
+	if(islist(object))
+		var/list/L = object
+		if(!isnum(index) || (index <= L.len && index >= 1))
+			return L[index]
+	else if(istext(object))
+		if(isnum(index) && index >= 1 && index <= length(object))
+			return object[index]
+	RaiseError(new/runtimeError/IndexOutOfRange(object, index))
+
+/n_Interpreter/proc/set_index(object, index, val, scope/scope)
+	if(islist(object))
+		var/list/L = object
+		if(!isnum(index) || (index <= L.len && index >= 1))
+			L[index] = val
+			return
+	RaiseError(new/runtimeError/IndexOutOfRange(object, index))
 
 /datum/proc/ntsl_get(key, scope/scope, n_Interpreter/interp)
 	interp.RaiseError(new/runtimeError/UndefinedVariable("[src].[key]"))

--- a/yogstation/code/modules/scripting/Interpreter/Scope.dm
+++ b/yogstation/code/modules/scripting/Interpreter/Scope.dm
@@ -12,6 +12,7 @@
 	var/allowed_status = 0
 	var/recursion = 0
 	var/node/statement/FunctionDefinition/function
+	var/node/expression/FunctionCall/call_node
 	var/return_val
 
 /scope/New(node/BlockDefinition/B, scope/parent, scope/variables_parent, allowed_status = 0)

--- a/yogstation/code/modules/scripting/Interpreter/Scope.dm
+++ b/yogstation/code/modules/scripting/Interpreter/Scope.dm
@@ -51,12 +51,12 @@
 		parent.return_val = return_val
 	return parent
 
-/scope/proc/get_var(name, n_Interpreter/interp)
+/scope/proc/get_var(name, n_Interpreter/interp, node/node)
 	var/scope/S = get_scope(name)
 	if(S)
 		return S.variables[name]
 	else if(interp)
-		interp.RaiseError(new/runtimeError/UndefinedVariable(name))
+		interp.RaiseError(new/runtimeError/UndefinedVariable(name), src, node)
 
 /scope/proc/get_function(name)
 	var/scope/S = src
@@ -66,15 +66,15 @@
 			return
 		S = S.variables_parent
 
-/scope/proc/set_var(name, val)
+/scope/proc/set_var(name, val, n_Interpreter/interp, node/node)
 	var/scope/S = get_scope(name)
 	if(S)
 		S.variables[name] = val
 	else
-		init_var(name, val)
+		init_var(name, val, interp, node)
 	return val
 
-/scope/proc/init_var(name, val, n_Interpreter/interp)
+/scope/proc/init_var(name, val, n_Interpreter/interp, node/node)
 	if(variables.Find(name) && interp)
-		interp.RaiseError(new/runtimeError/DuplicateVariableDeclaration(name))
+		interp.RaiseError(new/runtimeError/DuplicateVariableDeclaration(name), src, node)
 	variables[name] = val

--- a/yogstation/code/modules/scripting/Interpreter/Scope.dm
+++ b/yogstation/code/modules/scripting/Interpreter/Scope.dm
@@ -3,16 +3,75 @@
 	A runtime instance of a block. Used internally by the interpreter.
 */
 /scope
-	var
-		scope/parent = null
-		node/BlockDefinition/block
-		list
-			functions
-			variables
+	var/scope/parent
+	var/scope/variables_parent
+	var/node/BlockDefinition/block
+	var/list/functions
+	var/list/variables
+	var/status = 0
+	var/allowed_status = 0
+	var/recursion = 0
+	var/return_val
 
-	New(node/BlockDefinition/B, scope/parent)
-		src.block = B
-		src.parent = parent
+/scope/New(node/BlockDefinition/B, scope/parent, scope/variables_parent, allowed_status = 0)
+	src.block = B
+	src.parent = parent
+	src.variables_parent = variables_parent || parent
+	if(B)
 		src.variables = B.initial_variables.Copy()
 		src.functions = B.functions.Copy()
-		.=..()
+	else
+		src.variables = list()
+		src.functions = list()
+	if(parent)
+		src.status = parent.status
+		recursion = parent.recursion + 1
+	if(allowed_status & RESET_STATUS || !parent)
+		src.allowed_status = allowed_status & ~RESET_STATUS
+	else
+		src.allowed_status = allowed_status | parent.allowed_status
+	.=..()
+
+/scope/proc/get_scope(name)
+	var/scope/S = src
+	while(S)
+		if(S.variables.Find(name))
+			return S
+		S = S.variables_parent
+
+/scope/proc/push(node/BlockDefinition/B, scope/variables_parent = src, allowed_status = 0)
+	return new /scope(B, src, variables_parent, allowed_status)
+
+/scope/proc/pop(keep_status = (BREAKING | CONTINUING | RETURNING)) // keep_status is which flags you want to copy to the parent.
+	parent.status = (parent.status & ~keep_status) | (status & keep_status)
+	if(parent.status & RETURNING)
+		parent.return_val = return_val
+	return parent
+
+/scope/proc/get_var(name, n_Interpreter/interp)
+	var/scope/S = get_scope(name)
+	if(S)
+		return S.variables[name]
+	else if(interp)
+		interp.RaiseError(new/runtimeError/UndefinedVariable(name))
+
+/scope/proc/get_function(name)
+	var/scope/S = src
+	while(S)
+		. = S.functions[name]
+		if(.)
+			return
+		S = S.variables_parent
+
+/scope/proc/set_var(name, val)
+	var/scope/S = get_scope(name)
+	if(S)
+		S.variables[name] = val
+	else
+		init_var(name, val)
+	return val
+
+/scope/proc/init_var(name, val, n_Interpreter/interp)
+	if(variables.Find(name) && interp)
+		interp.RaiseError(new/runtimeError/DuplicateVariableDeclaration(name))
+	variables[name] = val

--- a/yogstation/code/modules/scripting/Interpreter/Scope.dm
+++ b/yogstation/code/modules/scripting/Interpreter/Scope.dm
@@ -11,6 +11,7 @@
 	var/status = 0
 	var/allowed_status = 0
 	var/recursion = 0
+	var/node/statement/FunctionDefinition/function
 	var/return_val
 
 /scope/New(node/BlockDefinition/B, scope/parent, scope/variables_parent, allowed_status = 0)
@@ -25,7 +26,8 @@
 		src.functions = list()
 	if(parent)
 		src.status = parent.status
-		recursion = parent.recursion + 1
+		recursion = parent.recursion
+
 	if(allowed_status & RESET_STATUS || !parent)
 		src.allowed_status = allowed_status & ~RESET_STATUS
 	else

--- a/yogstation/code/modules/scripting/Options.dm
+++ b/yogstation/code/modules/scripting/Options.dm
@@ -19,7 +19,7 @@ n_scriptOptions
 	An implementation of <n_scriptOptions> for the n_Script language.
 */
 	nS_Options
-		var/list/symbols = list("(", ")", "\[", "]", ";", ",", "{", "}")  //scanner - Characters that can be in symbols
+		var/list/symbols = list("(", ")", "\[", "]", ";", ",", "{", "}", ".")  //scanner - Characters that can be in symbols
 /*
 	Var: keywords
 	An associative list used by the parser to parse keywords. Indices are strings which will trigger the keyword when parsed and the
@@ -27,16 +27,8 @@ n_scriptOptions
 */
 		var/list/keywords	= list(	"if" = /n_Keyword/nS_Keyword/kwIf,  "else"  = /n_Keyword/nS_Keyword/kwElse, "elseif" = /n_Keyword/nS_Keyword/kwElseIf, \
 											"while"	  = /n_Keyword/nS_Keyword/kwWhile,		"break"	= /n_Keyword/nS_Keyword/kwBreak, \
-											"continue" = /n_Keyword/nS_Keyword/kwContinue, \
+											"continue" = /n_Keyword/nS_Keyword/kwContinue, "for"	  = /n_Keyword/nS_Keyword/kwFor,\
 											"return" = /n_Keyword/nS_Keyword/kwReturn, 		"def"   = /n_Keyword/nS_Keyword/kwDef)
-
-		var/list/assign_operators = list(	"="  = null, 					 "&=" = "&",
-												 		"|=" = "|",					 	 "`=" = "`",
-														"+=" = "+",						 "-=" = "-",
-														"*=" = "*",						 "/=" = "/",
-														"^=" = "^",
-														"%=" = "%")
-
 		var/list/unary_operators = list(	"!"  = /node/expression/operator/unary/LogicalNot,	 "~"  = /node/expression/operator/unary/BitwiseNot,
 													"-"  = /node/expression/operator/unary/Minus)
 
@@ -48,12 +40,18 @@ n_scriptOptions
 													"`"  = /node/expression/operator/binary/BitwiseXor,  		"+" 	= /node/expression/operator/binary/Add,
 													"-"  = /node/expression/operator/binary/Subtract, 			"*" 	= /node/expression/operator/binary/Multiply,
 													"/"  = /node/expression/operator/binary/Divide, 			"^" 	= /node/expression/operator/binary/Power,
-													"%"  = /node/expression/operator/binary/Modulo)
+													"%"  = /node/expression/operator/binary/Modulo,
+													"="  = /node/expression/operator/binary/Assign, 					 "&=" = /node/expression/operator/binary/Assign/BitwiseAnd,
+													"|=" = /node/expression/operator/binary/Assign/BitwiseOr,					 	 "`=" = /node/expression/operator/binary/Assign/BitwiseXor,
+													"+=" = /node/expression/operator/binary/Assign/Add,						 "-=" = /node/expression/operator/binary/Assign/Subtract,
+													"*=" = /node/expression/operator/binary/Assign/Multiply,						 "/=" = /node/expression/operator/binary/Assign/Divide,
+													"^=" = /node/expression/operator/binary/Assign/Power,
+													"%=" = /node/expression/operator/binary/Assign/Modulo)
 		New()
 			.=..()
-			for(var/O in assign_operators+binary_operators+unary_operators)
+			for(var/O in binary_operators+unary_operators)
 				if(!symbols.Find(O)) symbols+=O
-				
+
 n_scriptOptions/proc/CanStartID(char) //returns true if the character can start a variable, function, or keyword name (by default letters or an underscore)
 	if(!isnum(char))
 		char=text2ascii(char)
@@ -72,7 +70,7 @@ n_scriptOptions/proc/IsDigit(char)
 n_scriptOptions/proc/IsValidID(id)    //returns true if all the characters in the string are okay to be in an identifier name
 	if(!CanStartID(id)) //don't need to grab first char in id, since text2ascii does it automatically
 		return 0
-	if(lentext(id)==1) 
+	if(lentext(id)==1)
 		return 1
 	for(var/i=2 to lentext(id))
 		if(!IsValidIDChar(copytext(id, i, i+1)))

--- a/yogstation/code/modules/scripting/Parser/Expressions.dm
+++ b/yogstation/code/modules/scripting/Parser/Expressions.dm
@@ -194,6 +194,7 @@
 						NextToken()
 						continue
 					val.Push(ParseParenExpression())
+				else if(istype(curToken, /token/symbol) && curToken.value == ".")
 
 				else if(istype(curToken, /token/symbol))												//Operator found.
 					var/node/expression/operator/curOperator											//Figure out whether it is unary or binary and get a new instance.

--- a/yogstation/code/modules/scripting/Parser/Expressions.dm
+++ b/yogstation/code/modules/scripting/Parser/Expressions.dm
@@ -36,7 +36,7 @@
 			if(istype(top))
 				top=top.precedence
 			if(istype(input))
-				input=input:precedence
+				input=input.precedence
 			if(top>=input)
 				return REDUCE
 			return SHIFT
@@ -52,26 +52,6 @@
 			switch(T.type)
 				if(/token/word)
 					return new/node/expression/value/variable(T.value)
-				if(/token/accessor)
-					var
-						token/accessor/A=T
-						node/expression/value/variable/E//=new(A.member)
-						stack/S=new()
-					while(istype(A.object, /token/accessor))
-						S.Push(A)
-						A=A.object
-					ASSERT(istext(A.object))
-
-					while(A)
-						var/node/expression/value/variable/V=new()
-						V.id=new(A.member)
-						if(E)
-							V.object=E
-						else
-							V.object=new/node/identifier(A.object)
-						E=V
-						A=S.Pop()
-					return E
 
 				if(/token/number, /token/string)
 					return new/node/expression/value/literal(T.value)
@@ -143,6 +123,8 @@
 				B.exp2=val.Pop()
 				B.exp =val.Pop()
 				val.Push(B)
+				if(istype(B, /node/expression/operator/binary/Assign) && !istype(B.exp, /node/expression/value/variable))
+					errors += new/scriptError/InvalidAssignment()
 			else
 				O.exp=val.Pop()
 				val.Push(O)

--- a/yogstation/code/modules/scripting/Parser/Expressions.dm
+++ b/yogstation/code/modules/scripting/Parser/Expressions.dm
@@ -204,6 +204,16 @@
 					NextToken()
 					E.id = new(curToken.value)
 					val.Push(E)
+				else if(istype(curToken, /token/symbol) && curToken.value == "\[")
+					if(expecting == VALUE)
+						errors+=new/scriptError/ExpectedToken("expression", curToken)
+						NextToken()
+						continue
+					var/node/expression/member/brackets/B = new()
+					B.object = val.Pop()
+					NextToken()
+					B.index = ParseExpression(list("]"))
+					val.Push(B)
 				else if(istype(curToken, /token/symbol))												//Operator found.
 					var/node/expression/operator/curOperator											//Figure out whether it is unary or binary and get a new instance.
 					if(src.expecting==OPERATOR)
@@ -224,7 +234,7 @@
 						continue
 					opr.Push(curOperator)
 					src.expecting=VALUE
-				
+
 				else if(istype(curToken, /token/keyword)) 										//inline keywords
 					var/n_Keyword/kw=options.keywords[curToken.value]
 					kw=new kw(inline=1)

--- a/yogstation/code/modules/scripting/Parser/Expressions.dm
+++ b/yogstation/code/modules/scripting/Parser/Expressions.dm
@@ -123,7 +123,7 @@
 				B.exp2=val.Pop()
 				B.exp =val.Pop()
 				val.Push(B)
-				if(istype(B, /node/expression/operator/binary/Assign) && !istype(B.exp, /node/expression/value/variable))
+				if(istype(B, /node/expression/operator/binary/Assign) && !istype(B.exp, /node/expression/value/variable) && !istype(B.exp, /node/expression/member))
 					errors += new/scriptError/InvalidAssignment()
 			else
 				O.exp=val.Pop()
@@ -224,7 +224,7 @@
 						continue
 					opr.Push(curOperator)
 					src.expecting=VALUE
-
+				
 				else if(istype(curToken, /token/keyword)) 										//inline keywords
 					var/n_Keyword/kw=options.keywords[curToken.value]
 					kw=new kw(inline=1)

--- a/yogstation/code/modules/scripting/Parser/Keywords.dm
+++ b/yogstation/code/modules/scripting/Parser/Keywords.dm
@@ -54,7 +54,7 @@ Represents a special statement in the code triggered by a keyword.
 				if(istype(parser.curBlock, /node/BlockDefinition/GlobalBlock)) // Exit out of the program by setting the tokens list size to the same as index.
 					parser.tokens.len = parser.index
 					return
-				var/node/statement/ReturnStatement/stmt=new(curToken)
+				var/node/statement/ReturnStatement/stmt=new(parser.curToken)
 				parser.NextToken()   //skip 'return' token
 				stmt.value=parser.ParseExpression()
 				parser.curBlock.statements+=stmt
@@ -62,7 +62,7 @@ Represents a special statement in the code triggered by a keyword.
 		kwIf
 			Parse(n_Parser/nS_Parser/parser)
 				.=KW_PASS
-				var/node/statement/IfStatement/stmt=new(curToken)
+				var/node/statement/IfStatement/stmt=new(parser.curToken)
 				parser.NextToken()  //skip 'if' token
 				stmt.cond=parser.ParseParenExpression()
 				if(!parser.CheckToken(")", /token/symbol))
@@ -85,7 +85,7 @@ Represents a special statement in the code triggered by a keyword.
 					parser.errors += new/scriptError/ExpectedToken("if statement", parser.curToken)
 					return KW_FAIL
 
-				var/node/statement/IfStatement/ElseIf/stmt = new(curToken)
+				var/node/statement/IfStatement/ElseIf/stmt = new(parser.curToken)
 				parser.NextToken()  //skip 'if' token
 				stmt.cond = parser.ParseParenExpression()
 				if(!parser.CheckToken(")", /token/symbol))
@@ -116,7 +116,7 @@ Represents a special statement in the code triggered by a keyword.
 		kwWhile
 			Parse(n_Parser/nS_Parser/parser)
 				.=KW_PASS
-				var/node/statement/WhileLoop/stmt=new(curToken)
+				var/node/statement/WhileLoop/stmt=new(parser.curToken)
 				parser.NextToken()  //skip 'while' token
 				stmt.cond=parser.ParseParenExpression()
 				if(!parser.CheckToken(")", /token/symbol))
@@ -130,7 +130,7 @@ Represents a special statement in the code triggered by a keyword.
 		kwFor
 			Parse(n_Parser/nS_Parser/parser)
 				.=KW_PASS
-				var/node/statement/ForLoop/stmt = new(curToken)
+				var/node/statement/ForLoop/stmt = new(parser.curToken)
 				parser.NextToken()
 				if(!parser.CheckToken("(", /token/symbol))
 					return KW_FAIL
@@ -155,7 +155,7 @@ Represents a special statement in the code triggered by a keyword.
 				if(istype(parser.curBlock, /node/BlockDefinition/GlobalBlock))
 					parser.errors+=new/scriptError/BadToken(parser.curToken)
 					. = KW_WARN
-				var/node/statement/BreakStatement/stmt=new(curToken)
+				var/node/statement/BreakStatement/stmt=new(parser.curToken)
 				parser.NextToken()   //skip 'break' token
 				parser.curBlock.statements+=stmt
 
@@ -165,14 +165,14 @@ Represents a special statement in the code triggered by a keyword.
 				if(istype(parser.curBlock, /node/BlockDefinition/GlobalBlock))
 					parser.errors+=new/scriptError/BadToken(parser.curToken)
 					. = KW_WARN
-				var/node/statement/ContinueStatement/stmt=new(curToken)
+				var/node/statement/ContinueStatement/stmt=new(parser.curToken)
 				parser.NextToken()   //skip 'break' token
 				parser.curBlock.statements+=stmt
 
 		kwDef
 			Parse(n_Parser/nS_Parser/parser)
 				.=KW_PASS
-				var/node/statement/FunctionDefinition/def=new(curToken)
+				var/node/statement/FunctionDefinition/def=new(parser.curToken)
 				parser.NextToken() //skip 'def' token
 				if(!parser.options.IsValidID(parser.curToken.value))
 					parser.errors+=new/scriptError/InvalidID(parser.curToken)

--- a/yogstation/code/modules/scripting/Parser/Keywords.dm
+++ b/yogstation/code/modules/scripting/Parser/Keywords.dm
@@ -205,7 +205,7 @@ Represents a special statement in the code triggered by a keyword.
 					parser.curBlock.statements+=def
 				else if(parser.curToken.value=="{" && istype(parser.curToken, /token/symbol))
 					def.block = new
-					parser.curBlock.statements+=def
+					parser.curBlock.statements.Insert(1, def) // insert into the beginning so that all functions are defined first
 					parser.curBlock.functions[def.func_name]=def
 					parser.AddBlock(def.block)
 				else

--- a/yogstation/code/modules/scripting/Parser/Keywords.dm
+++ b/yogstation/code/modules/scripting/Parser/Keywords.dm
@@ -54,7 +54,7 @@ Represents a special statement in the code triggered by a keyword.
 				if(istype(parser.curBlock, /node/BlockDefinition/GlobalBlock)) // Exit out of the program by setting the tokens list size to the same as index.
 					parser.tokens.len = parser.index
 					return
-				var/node/statement/ReturnStatement/stmt=new
+				var/node/statement/ReturnStatement/stmt=new(curToken)
 				parser.NextToken()   //skip 'return' token
 				stmt.value=parser.ParseExpression()
 				parser.curBlock.statements+=stmt
@@ -62,7 +62,7 @@ Represents a special statement in the code triggered by a keyword.
 		kwIf
 			Parse(n_Parser/nS_Parser/parser)
 				.=KW_PASS
-				var/node/statement/IfStatement/stmt=new
+				var/node/statement/IfStatement/stmt=new(curToken)
 				parser.NextToken()  //skip 'if' token
 				stmt.cond=parser.ParseParenExpression()
 				if(!parser.CheckToken(")", /token/symbol))
@@ -85,7 +85,7 @@ Represents a special statement in the code triggered by a keyword.
 					parser.errors += new/scriptError/ExpectedToken("if statement", parser.curToken)
 					return KW_FAIL
 
-				var/node/statement/IfStatement/ElseIf/stmt = new
+				var/node/statement/IfStatement/ElseIf/stmt = new(curToken)
 				parser.NextToken()  //skip 'if' token
 				stmt.cond = parser.ParseParenExpression()
 				if(!parser.CheckToken(")", /token/symbol))
@@ -116,7 +116,7 @@ Represents a special statement in the code triggered by a keyword.
 		kwWhile
 			Parse(n_Parser/nS_Parser/parser)
 				.=KW_PASS
-				var/node/statement/WhileLoop/stmt=new
+				var/node/statement/WhileLoop/stmt=new(curToken)
 				parser.NextToken()  //skip 'while' token
 				stmt.cond=parser.ParseParenExpression()
 				if(!parser.CheckToken(")", /token/symbol))
@@ -130,7 +130,7 @@ Represents a special statement in the code triggered by a keyword.
 		kwFor
 			Parse(n_Parser/nS_Parser/parser)
 				.=KW_PASS
-				var/node/statement/ForLoop/stmt = new
+				var/node/statement/ForLoop/stmt = new(curToken)
 				parser.NextToken()
 				if(!parser.CheckToken("(", /token/symbol))
 					return KW_FAIL
@@ -155,7 +155,7 @@ Represents a special statement in the code triggered by a keyword.
 				if(istype(parser.curBlock, /node/BlockDefinition/GlobalBlock))
 					parser.errors+=new/scriptError/BadToken(parser.curToken)
 					. = KW_WARN
-				var/node/statement/BreakStatement/stmt=new
+				var/node/statement/BreakStatement/stmt=new(curToken)
 				parser.NextToken()   //skip 'break' token
 				parser.curBlock.statements+=stmt
 
@@ -165,14 +165,14 @@ Represents a special statement in the code triggered by a keyword.
 				if(istype(parser.curBlock, /node/BlockDefinition/GlobalBlock))
 					parser.errors+=new/scriptError/BadToken(parser.curToken)
 					. = KW_WARN
-				var/node/statement/ContinueStatement/stmt=new
+				var/node/statement/ContinueStatement/stmt=new(curToken)
 				parser.NextToken()   //skip 'break' token
 				parser.curBlock.statements+=stmt
 
 		kwDef
 			Parse(n_Parser/nS_Parser/parser)
 				.=KW_PASS
-				var/node/statement/FunctionDefinition/def=new
+				var/node/statement/FunctionDefinition/def=new(curToken)
 				parser.NextToken() //skip 'def' token
 				if(!parser.options.IsValidID(parser.curToken.value))
 					parser.errors+=new/scriptError/InvalidID(parser.curToken)

--- a/yogstation/code/modules/scripting/Parser/Keywords.dm
+++ b/yogstation/code/modules/scripting/Parser/Keywords.dm
@@ -127,6 +127,28 @@ Represents a special statement in the code triggered by a keyword.
 				stmt.block=new
 				parser.AddBlock(stmt.block)
 
+		kwFor
+			Parse(n_Parser/nS_Parser/parser)
+				.=KW_PASS
+				var/node/statement/ForLoop/stmt = new
+				parser.NextToken()
+				if(!parser.CheckToken("(", /token/symbol))
+					return KW_FAIL
+				stmt.init = parser.ParseExpression()
+				if(!parser.CheckToken(";", /token/end))
+					return KW_FAIL
+				stmt.test = parser.ParseExpression()
+				if(!parser.CheckToken(";", /token/end))
+					return KW_FAIL
+				stmt.increment = parser.ParseExpression(list(")"))
+				if(!parser.CheckToken(")", /token/symbol))
+					return KW_FAIL
+				if(!parser.CheckToken("{", /token/symbol, skip=0))
+					return KW_ERR
+				parser.curBlock.statements += stmt
+				stmt.block = new
+				parser.AddBlock(stmt.block)
+
 		kwBreak
 			Parse(n_Parser/nS_Parser/parser)
 				.=KW_PASS

--- a/yogstation/code/modules/scripting/Scanner/Tokens.dm
+++ b/yogstation/code/modules/scripting/Scanner/Tokens.dm
@@ -24,15 +24,5 @@
 			if(!isnum(value))
 				value=text2num(value)
 				ASSERT(!isnull(value))
-	accessor
-		var/object
-		var/member
-
-		New(object, member, l=0, c=0)
-			src.object=object
-			src.member=member
-			src.value="[object].[member]" //for debugging only
-			src.line=l
-			src.column=c
 
 	end


### PR DESCRIPTION
# DOCUMENTATION: https://wiki.yogstation.net/wiki/NT_Script
# Don't tell me there's no documentation.

This will break your scripts, here's how you make a script now:
```js
// you can initialize associative lists
replacements = list(
  "A" = "fuck",
  "B" = "shit"
);
// signal processing occurs in a function now, and the global scope is only executed once, immediately after compilation
def process_signal(sig) {
  sig.source += " OwO"; // you can modify the signal like before
  // you can use []
  if(replacements.Find(sig.content)) {
    sig.content = replacements[sig.content];
  }
  sleep(2); // sleeping will no longer confuse the absolute shit out of the interpreter.
  return sig; // you have to return the signal object, you can even create a new one!
}
// broadcast a message
broadcast_sig = signal("Compilation successful!", channels.common, "NTSL script");
broadcast_sig.say = "states";
channels_to_broadcast = list(channels.common, channels.command, channels.security);
for(i = 1; i <= channels_to_broadcast.len; i++) {
  broadcast_sig.freq = channels_to_broadcast;
  broadcast(broadcast_sig); // broadcasts the signal
}

// I can't be bothered to make an example for this, but there's also closures, like in JS.
```

- [X] Refactor assignments to be operators
- [X] Refactor the scope to be passed around as paremeters so `sleep()` doesn't fuck shit up horribly
- [X] Add for loops
- [x] Add the "." operator, and the related interactions
- [x] Add the "[]" operator
- [x] Add support for creating assoc lists easily
- [x] Refactor functions
- [x] Move signal processing from the global scope into a function

:cl: monster860
tweak: Assignemts in NTSL are now operators
fix: sleep() in NTSL no longer breaks things horribly
add: Adds for loops to NTSL
add: Adds the "." and "[]" operator to NTSL. You can do "sig.content" or "some_list[3]" now.
add: You can now create associative lists in NTSL using list()
tweak: Signal processing is done in a function called "process_signal" that must be defined by the user - one argument is passed, the signal argument, change properties on it to change the signal.
fix: The stack traces in the runtime errors for NTSL actually contain line numbers now.
tweak: Broadcasting in NTSL is now done by calling broadcast() with an argument of a signal object, which can be created with a signal() function. Remote signalling is done with remote_signal().
fix: You can do mem() in NTSL with the second argument null and it will remove the property
tweak: several global vars in NTSL have been moved to objects. Languages are in the "languages" object, filters are in the "filter_types" object, and channels are in the "channels" object.
/:cl: