### PR TITLE
[admin] Gives admins more time to cancel events

### DIFF
--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -60,8 +60,10 @@
 
 	triggering = TRUE
 	if (alert_observers)
-		message_admins("Random Event triggering in 10 seconds: [name] (<a href='?src=[REF(src)];cancel=1'>CANCEL</a>)")
-		sleep(100)
+		//Yogs start -- 15 seconds instead of 10
+		message_admins("Random Event triggering in 15 seconds: [name] (<a href='?src=[REF(src)];cancel=1'>CANCEL</a>)")
+		sleep(150)
+		//Yogs end
 		var/gamemode = SSticker.mode.config_tag
 		var/players_amt = get_active_player_count(alive_check = TRUE, afk_check = TRUE, human_check = TRUE)
 		if(!canSpawnEvent(players_amt, gamemode))


### PR DESCRIPTION
## God damn shitty Valentine events gosh diddily darnit

Ten seconds isn't a lot of time; I've had a lot of situations where I wanted to cancel something and it failed because I was too late. This should fix that, some.

#### Changelog
:cl:  Altoids
tweak: It should now be slightly easier for admins to cancel shitty events.
/:cl:
