### PR TITLE
Lowers cost of mindslave Implant to 7 tc

### DIFF
--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -84,5 +84,5 @@
 	name = "Mindslave Implant"
 	desc = "An implant injected into another body, forcing the victim to obey any command by the user."
 	item = /obj/item/storage/box/syndie_kit/imp_mindslave
-	cost = 6
+	cost = 8
 	surplus = 20

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -84,5 +84,5 @@
 	name = "Mindslave Implant"
 	desc = "An implant injected into another body, forcing the victim to obey any command by the user."
 	item = /obj/item/storage/box/syndie_kit/imp_mindslave
-	cost = 8
+	cost = 6
 	surplus = 20

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -84,5 +84,5 @@
 	name = "Mindslave Implant"
 	desc = "An implant injected into another body, forcing the victim to obey any command by the user."
 	item = /obj/item/storage/box/syndie_kit/imp_mindslave
-	cost = 8
+	cost = 7
 	surplus = 20

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -84,5 +84,5 @@
 	name = "Mindslave Implant"
 	desc = "An implant injected into another body, forcing the victim to obey any command by the user."
 	item = /obj/item/storage/box/syndie_kit/imp_mindslave
-	cost = 12
+	cost = 8
 	surplus = 20


### PR DESCRIPTION
🆑
tweak: Mindslave Implant is now 7tc down from 12
/🆑

I mean 12 tc seems pretty overpriced since it takes a couple seconds to use and the fact its 4 tc more then much better items like the emag for example then theres the brainwash surgery which in some cases objectively better since you can use it to brainwash as many people as you want for only 5 tc with the only downside being its restricted to med staff  you need more time and you need to do it with one area so I think 7 tc would be a much more fair price for this that is all