### PR TITLE
Modify TGM so that Dream Maker doesn't completely shit itself when encountering a map with more than 65536 tiles in it

### DIFF
--- a/tools/mapmerge2/dmm.py
+++ b/tools/mapmerge2/dmm.py
@@ -283,12 +283,24 @@ def save_tgm(dmm, output):
 
     # thanks to YotaXP for finding out about this one
     max_x, max_y, max_z = dmm.size
+# yogs start - multi-column mode
+    columns_to_write = 1
+    total_tiles = max_x * max_y * max_z
+    while total_tiles > 65536:
+        columns_to_write += 1
+        total_tiles -= 65536
+# yogs end
     for z in range(1, max_z + 1):
         output.write("\n")
-        for x in range(1, max_x + 1):
+        for x in range(1, max_x + 1, columns_to_write): # yogs - make the step be columns_to_write
             output.write(f"({x},{1},{z}) = {{\"\n")
             for y in range(1, max_y + 1):
-                output.write(f"{num_to_key(dmm.grid[x, y, z], dmm.key_length)}\n")
+# yogs start - multi-column mode
+                for xo in range(0, columns_to_write):
+                    if (xo + x) <= max_x:
+                        output.write(f"{num_to_key(dmm.grid[x+xo, y, z], dmm.key_length)}")
+                output.write("\n")
+# yogs end
             output.write("\"}\n")
 
 # ----------


### PR DESCRIPTION
because BYOND is a piece of shit that can't handle map files with more than 65536 rows in it which is easily surpassed when using TGM.

Why? Because Fluffe is trying to port minsky station which is a 350x350 map and it's making DM shit itself.