### PR TITLE
[admin] Admins now aghost when following mentorhelps, instead of using the Mentorfollow system

### DIFF
--- a/yogstation/code/modules/mentor/follow.dm
+++ b/yogstation/code/modules/mentor/follow.dm
@@ -8,6 +8,18 @@
 	if(!ismob(usr))
 		return
 
+	if(check_rights(R_ADMIN)) // If they're an admin, then just do an aghost
+		//Basically a copy of Yogstation-TG\code\modules\admin\topic.dm, line 960, from 24 Feb 2019
+		if(!isobserver(usr))
+			admin_ghost()
+		var/mob/dead/observer/A = mob
+		var/mob/living/silicon/ai/I = M
+		if(istype(I) && I.eyeobj)
+			A.ManualFollow(I.eyeobj)
+		else
+			A.ManualFollow(M)
+		return
+		
 	usr.reset_perspective(M)
 	verbs += /client/proc/mentor_unfollow
 	if(mentor_datum)

--- a/yogstation/code/modules/mentor/mentorhelp.dm
+++ b/yogstation/code/modules/mentor/mentorhelp.dm
@@ -3,7 +3,7 @@
 	set name = "Mentorhelp"
 
 	if(is_mentor())
-		to_chat(src, "<notice>Mentors cannot mentorhelp, use msay instead!</notice>")
+		to_chat(src, "<span class='notice'>Mentors cannot mentorhelp, use msay instead!</span>")
 		return
 
 	//clean the input msg


### PR DESCRIPTION
With this, admins will, instead of using the restricted movement of the mentorfollow system, just simply aghost whenever they press the [F] link on a mentorhelp. I cannot be the only person who has been annoyed before at clicking to follow a mentorhelp only to be confused when I couldn't WASD away from them to check the scene.

This PR also includes a little formatting fix on a warning given to mentors.


#### Changelog
:cl:  Altoids
tweak: Admins now aghost when following mentorhelps, instead of using the Mentorfollow system
/:cl:
