### PR TITLE
Fireaxe Cabinet Improvements ported from Legacy Yogstation Codebase!

### DIFF
--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -1,6 +1,6 @@
 /obj/structure/fireaxecabinet
 	name = "fire axe cabinet"
-	desc = "There is a small label that reads \"For Emergency use only\" along with details for safe use of the axe. As if."
+	desc = "There is a small label that reads \"For Emergency use only\" along with details for safe use of the axe. As if.<BR>There are bolts under it's glass cover for easy disassembly using a wrench."
 	icon = 'icons/obj/wallmounts.dmi'
 	icon_state = "fireaxe"
 	anchored = TRUE
@@ -56,7 +56,7 @@
 			broken = 0
 			obj_integrity = max_integrity
 			update_icon()
-	//yogs start - warns you if you try to fix it with regular glass
+	//yogs start - warn user if they use the wrong type of glass to repair
 	else if(istype(I, /obj/item/stack/sheet/glass) && broken)
 		to_chat(user, "<span class='warning'>You need reinforced glass sheets to fix [src]!</span>")
 	//yogs end

--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -12,11 +12,15 @@
 	var/open = FALSE
 	var/obj/item/twohanded/fireaxe/fireaxe
 
+//yogs NOTICE - Initialize() function MIRRORED to yogstation/code/game/objects/structure/fireaxe.dm
+//changes made to the below function will have no effect
 /obj/structure/fireaxecabinet/Initialize()
 	. = ..()
 	fireaxe = new
 	update_icon()
 
+//yogs NOTICE - Destroy() function MIRRORED to yogstation/code/game/objects/structure/fireaxe.dm
+//changes made to the below function will have no effect
 /obj/structure/fireaxecabinet/Destroy()
 	if(fireaxe)
 		QDEL_NULL(fireaxe)
@@ -74,8 +78,11 @@
 			toggle_open()
 	//yogs start - adds unlock if authorized
 	else if (I.GetID())
+		if(obj_flags & EMAGGED)
+			to_chat(user, "<span class='notice'>The [name]'s locking modules are unresponsive.</span>")
+			return
 		if (allowed(user))
-			toggle_lock()
+			toggle_lock(user)
 		else
 			to_chat(user, "<span class='danger'>Access denied.</span>")
 	//yogs end
@@ -93,6 +100,10 @@
 			playsound(src.loc, 'sound/items/welder.ogg', 100, 1)
 
 /obj/structure/fireaxecabinet/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
+	//yogs start - adds sparks on damage
+	if(prob(30))
+		spark_system.start()
+	//yogs end
 	if(open)
 		return
 	. = ..()
@@ -174,8 +185,15 @@
 	else
 		add_overlay("glass_raised")
 
-//yogs NOTICE - toggle_lock function MIRRORED to yogstation/code/game/objects/structure/fireaxe.dm
-//obj/structure/fireaxecabinet/proc/toggle_lock(mob/user)
+//yogs NOTICE - toggle_lock() function MIRRORED to yogstation/code/game/objects/structure/fireaxe.dm
+//changes made to the below function will have no effect
+/obj/structure/fireaxecabinet/proc/toggle_lock(mob/user)
+	to_chat(user, "<span class = 'caution'> Resetting circuitry...</span>")
+	playsound(src, 'sound/machines/locktoggle.ogg', 50, 1)
+	if(do_after(user, 20, target = src))
+		to_chat(user, "<span class='caution'>You [locked ? "disable" : "re-enable"] the locking modules.</span>")
+		locked = !locked
+		update_icon()
 
 /obj/structure/fireaxecabinet/verb/toggle_open()
 	set name = "Open/Close"

--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -52,6 +52,10 @@
 			broken = 0
 			obj_integrity = max_integrity
 			update_icon()
+	//yogs start - warns you if you try to fix it with regular glass
+	else if(istype(I, /obj/item/stack/sheet/glass) && broken)
+		to_chat(user, "<span class='warning'>You need reinforced glass sheets to fix [src]!</span>")
+	//yogs end
 	else if(open || broken)
 		//Fireaxe cabinet is open or broken, so we can access it's axe slot
 		if(istype(I, /obj/item/twohanded/fireaxe) && !fireaxe)
@@ -102,6 +106,8 @@
 		playsound(src, 'sound/effects/glassbr3.ogg', 100, 1)
 		new /obj/item/shard(loc)
 		new /obj/item/shard(loc)
+		new /obj/item/stack/rods(loc)//yogs - adds metal rods for reinforced glass
+		new /obj/item/stack/rods(loc)//yogs - adds metal rods for reinforced glass
 
 /obj/structure/fireaxecabinet/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2905,6 +2905,7 @@
 #include "yogstation\code\game\objects\items\storage\toolbox.dm"
 #include "yogstation\code\game\objects\items\storage\uplink_kits.dm"
 #include "yogstation\code\game\objects\structures\bedsheet_bin.dm"
+#include "yogstation\code\game\objects\structures\fireaxe.dm"
 #include "yogstation\code\game\objects\structures\ghost_role_spawners.dm"
 #include "yogstation\code\game\objects\structures\table_frames.dm"
 #include "yogstation\code\game\objects\structures\tables_racks.dm"

--- a/yogstation/code/game/objects/structures/fireaxe.dm
+++ b/yogstation/code/game/objects/structures/fireaxe.dm
@@ -19,6 +19,10 @@
 
 /obj/structure/fireaxecabinet/proc/check_deconstruct(obj/item/I, mob/user)
 	if(istype(I, /obj/item/wrench) && !(flags_1 & NODECONSTRUCT_1) && !fireaxe && (open || broken || obj_integrity >= max_integrity))
+		//User is attempting to wrench an open/broken fireaxe cabinet with NO fireaxe in it
+		user.visible_message("<span class='warning'>[user] disassembles the [name].</span>", \
+							 "You start to disassemble the [name]...", \
+							 "<span class='italics'>You hear wrenching.</span>")
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 		if(do_after(user, 40/I.toolspeed, target = src))
 			to_chat(user, "<span class='notice'>You disassemble the [name].</span>")
@@ -29,7 +33,17 @@
 			if (prob(50))
 				G.add_fingerprint(user)
 			deconstruct()//deconstruct then spawns an additional 2 metal, so you recover more mats using a wrench to decon than just destroying it.
+			playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 			return
+	else if(istype(I, /obj/item/wrench) && !(flags_1 & NODECONSTRUCT_1) && !broken && !open)
+		//User is attempting to wrench a closed & non-broken fireaxe cab
+		to_chat(user, "<span class='warning'>You need to open the door first to access the [src]'s bolts!</span>")
+		//Still allow damage to pass through, in case they are trying to destroy the cab's window with the wrench.
+		return ..()
+	else if(istype(I, /obj/item/wrench) && !(flags_1 & NODECONSTRUCT_1) && (open || broken) && fireaxe)
+		//User is attempting to wrench an open and ready fireaxe cabinet, but the axe is still in it's slot.
+		to_chat(user, "<span class='warning'>You need to remove the fireaxe first to deconstruct the [src]!</span>")
+		return
 
 /obj/structure/fireaxecabinet/proc/reset_lock(mob/user)
 	//this happens when you hack the lock as a synthetic/AI, or with a multitool.
@@ -73,8 +87,9 @@
 	if(obj_flags & EMAGGED)
 		return
 	if(!open && locked)
-		to_chat(user, "<span class='caution'>You short out the [name]'s locking modules.</span>")
-		visible_message("Sparks fly out of the [src]'s locking modules!")
+		user.visible_message("<span class='warning'>Sparks fly out of the [src]'s locking modules!</span>", \
+							 "<span class='caution'>You short out the [name]'s locking modules.</span>", \
+							 "<span class='italics'>You hear electricity arcing.</span>")
 		spark_system.start()
 
 		src.add_fingerprint(user)

--- a/yogstation/code/game/objects/structures/fireaxe.dm
+++ b/yogstation/code/game/objects/structures/fireaxe.dm
@@ -12,20 +12,34 @@
 			var/obj/item/stack/sheet/rglass/G = new (loc, 2)//spawn two reinforced glass for it's window
 			if (prob(50))
 				G.add_fingerprint(user)
-			deconstruct()
+			deconstruct()//deconstruct then spawns an additional 2 metal, so you recover more mats using a wrench to decon than just destroying it.
 			return
 
 /obj/structure/fireaxecabinet/proc/reset_lock(mob/user)
-	//this happens when you hack the lock with a multitool, synthetic/AI, or an emag.
+	//this happens when you hack the lock as a synthetic/AI, or with a multitool or an emag.
 	if(!open)
 		to_chat(user, "<span class = 'caution'>Resetting circuitry...</span>")
-		if(do_after(user, 60, target = src))
+		if(do_after(user, 100, target = src))
 			to_chat(user, "<span class='caution'>You [locked ? "disable" : "re-enable"] the locking modules.</span>")
 			src.add_fingerprint(user)
 			toggle_lock(user)
 
+
+/obj/structure/fireaxecabinet/AltClick(mob/user)
+	//Alt-Click can be used to unlock without swiping your ID (assuming you have access), or open/close an unlocked cabinet
+	//This has the side-effect of allowing borgs to open it, once they unlock it. They still can't remove the axe from it though.
+	if(!broken)
+		if (locked)
+			if (allowed(user))
+				toggle_lock()
+			else
+				to_chat(user, "<span class='danger'>Access denied.</span>")
+		else
+			//open the cabinet normally.
+			toggle_open()
+
 /obj/structure/fireaxecabinet/proc/toggle_lock(mob/user)//<-- mirrored/overwritten proc
-	//this happens when you actuate the lock normally (e.g., you have access to the fireaxe cab)
+	//this happens when you actuate the lock status.
 	if(!open)
 		audible_message("You hear an audible clunk as the [name]'s bolt [locked ? "retracts" : "locks into place"].")
 		playsound(loc, "sound/machines/locktoggle.ogg", 30, 1, -3)

--- a/yogstation/code/game/objects/structures/fireaxe.dm
+++ b/yogstation/code/game/objects/structures/fireaxe.dm
@@ -1,0 +1,33 @@
+/obj/structure/fireaxecabinet
+	req_access = list(ACCESS_ATMOSPHERICS)
+
+/obj/structure/fireaxecabinet/proc/check_deconstruct(obj/item/I, mob/user)
+	if(istype(I, /obj/item/wrench) && !(flags_1 & NODECONSTRUCT_1) && !fireaxe && (open || broken || obj_integrity >= max_integrity))
+		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+		if(do_after(user, 40/I.toolspeed, target = src))
+			to_chat(user, "<span class='notice'>You disassemble the [name].</span>")
+			var/obj/item/stack/sheet/metal/M = new (loc, 3)//spawn three metal for deconstruction
+			if (prob(50))
+				M.add_fingerprint(user)
+			var/obj/item/stack/sheet/rglass/G = new (loc, 2)//spawn two reinforced glass for it's window
+			if (prob(50))
+				G.add_fingerprint(user)
+			deconstruct()
+			return
+
+/obj/structure/fireaxecabinet/proc/reset_lock(mob/user)
+	//this happens when you hack the lock with a multitool, synthetic/AI, or an emag.
+	if(!open)
+		to_chat(user, "<span class = 'caution'>Resetting circuitry...</span>")
+		if(do_after(user, 60, target = src))
+			to_chat(user, "<span class='caution'>You [locked ? "disable" : "re-enable"] the locking modules.</span>")
+			src.add_fingerprint(user)
+			toggle_lock(user)
+
+/obj/structure/fireaxecabinet/proc/toggle_lock(mob/user)//<-- mirrored/overwritten proc
+	//this happens when you actuate the lock normally (e.g., you have access to the fireaxe cab)
+	if(!open)
+		audible_message("You hear an audible clunk as the [name]'s bolt [locked ? "retracts" : "locks into place"].")
+		playsound(loc, "sound/machines/locktoggle.ogg", 30, 1, -3)
+		locked = !locked
+		update_icon()


### PR DESCRIPTION
This is a port of an old Yogstation PR, with some added features: https://github.com/yogstation13/yogstation/pull/3098

### Fire Axe Cabinet Improvements

![fireaxe](https://user-images.githubusercontent.com/2159739/36022293-394ff104-0d4e-11e8-8c13-5bef6357dd8e.PNG)

The Fire Axe is a truly robust and powerful weapon, and as such the Cabinet that holds it should be equally as robust and well-built. 

As is only reasonable, I have made some slight modifications to improve the Fire Axe Cabinet:

- Cabinet can now be deconstructed, using a wrench. But only if it's open or broken, and the axe is removed. Useful for those who are rebuilding areas where the axe cabinet is.
- Cabinet can now be unlocked/locked using an ID card with Atmospherics access (includes CE & Cap obviously)
- Old mechanic of unlocking by "resetting the locking mechanism" has been moved into a separate action: it can still be performed with the multitool item, but it takes longer than swiping an ID. It is however, faster than breaking the glass due to the increased durability. Instead of the AI and borg performing the reset action, they now just simply unlock it with no wait time.
- Cabinet has been made marginally stronger to incentivize using an ID or hacking it with the multitool, and the hack time has been increased to incentivize using an ID to open it.
- Fingerprints are added to the metal/rglass when deconstructing, to the cabinet when the axe is removed, and to the cabinet when it's hacked or broken into.
- Cabinet now uses Reinforced Glass instead of Glass as a material for it's window, owing to it's increased robustness due to this PR. Cabinet warns you if you try to repair it with the wrong type.
- Cabinet can now be EMAGGED. Emagging the cabinet will result in sparks, and a damaging of it's circuitry. It unlocks, and can never be locked again. Trying to lock it or examining it closely displays a suspicious message.
- You can now ALT-CLICK the cabinet, and this will cause it to act identically to a locked closet/locker (open/close if unlocked, unlock if locked).
- Other minor bugfixes, such as removing the ability to lock/unlock it when it's already open with the multitool.

#### Testing

All of this has been tested fairly extensively. I tried every access permutation, and being a Borg, and an AI, along with trying to deconstruct it in various edge cases. It seems to perform correctly. 

Thanks for reading, and happy axing!

#### Changelog

:cl:  
bugfix: Fire Axe Cabinet cannot be locked/unlocked when already open
bugfix: Fire Axe Cabinet use will result in fingerprints
bugfix: Fire Axe Cabinet can be alt-clicked to open, similar to how lockers work
tweak: Fire Axe Cabinet can be deconstructed with a wrench!
tweak: Fire Axe Cabinet made more robust: durability increased, hack time increased
tweak: Fire Axe Cabinet can be unlocked/locked with an ID with Atmospherics access
tweak: Fire Axe Cabinet can be emagged
/:cl: