### PR TITLE
Swaps the incinerator vent pump for a scrubber.

### DIFF
--- a/_maps/yogstation/map_files/YogStation/YogStation.dmm
+++ b/_maps/yogstation/map_files/YogStation/YogStation.dmm
@@ -50866,6 +50866,10 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "cSf" = (
+/obj/structure/sign/warning/vacuum{
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = 32
+	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},

--- a/_maps/yogstation/map_files/YogStation/YogStation.dmm
+++ b/_maps/yogstation/map_files/YogStation/YogStation.dmm
@@ -50866,18 +50866,8 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "cSf" = (
-/obj/structure/sign/warning/vacuum{
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8;
-	external_pressure_bound = 0;
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	on = 0;
-	pressure_checks = 2;
-	pump_direction = 0
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)


### PR DESCRIPTION
### Intent of your Pull Request
Atmos techs that want to use the incinerator as a burn chamber have to swap out the vent pump in the chamber for a scrubber every round.  This takes a few minutes and requires a spacewalk (and thus stealing the one hardsuit before the other guy gets it.)  

This replaces that vent pump with a scrubber by default, removing 2-3 minutes of pointless busywork from the round of every atmos tech that doesn't just grab the axe and run off into maint.

#### Balance Considerations
TG box already does this, as does the incinerator in Science.  Malicious atmos techs may complete their nefarious plans 2-3 minutes earlier, and be a little less irritated as they do so.

![dreamseeker_2019-02-25_20-40-04](https://user-images.githubusercontent.com/12868789/53381172-e89e7d80-393d-11e9-89aa-438814ad8573.png)

:cl:  
tweak: The Incinerator now comes equipped with a configurable scrubber by default.
/:cl:
