### PR TITLE
limit bank_card_talk to 1 tile range.

### DIFF
--- a/yogstation/code/modules/economy/account.dm
+++ b/yogstation/code/modules/economy/account.dm
@@ -3,4 +3,4 @@
 		return
 	for(var/obj/A in bank_cards)
 		playsound(A, 'sound/machines/twobeep.ogg', 50, TRUE)
-		A.send_speech(message, 1, src, , get_spans(), message_language=get_default_language())
+		A.send_speech(message, 1, src, , A.get_spans(), message_language = A.get_default_language())

--- a/yogstation/code/modules/economy/account.dm
+++ b/yogstation/code/modules/economy/account.dm
@@ -3,4 +3,4 @@
 		return
 	for(var/obj/A in bank_cards)
 		playsound(A, 'sound/machines/twobeep.ogg', 50, TRUE)
-		A.say(message);
+		A.send_speech(message, 1, src, , get_spans(), message_language=get_default_language())


### PR DESCRIPTION
Fixes #4601

:cl: monster860
tweak: bank_card_talk is now limited to 1 tile in range, to reduce spam.
/:cl: