### PR TITLE
Adds cosmos bedsheet as donor item

### DIFF
--- a/yogstation/code/modules/donor/donor_items.dm
+++ b/yogstation/code/modules/donor/donor_items.dm
@@ -77,6 +77,7 @@ var/list/donor_pdas = list("Normal", "Transparent", "Pip Boy", "Rainbow")
 var/list/donor_start_tools = list(\
 						/obj/item/storage/backpack/snail/green, \
 						/obj/item/banhammer, \
+						/obj/item/bedsheet/cosmos, \
 						/obj/item/bedsheet/wiz, \
 						/obj/item/bedsheet/nanotrasen, \
 						/obj/item/bedsheet/syndie, \


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/29939414/53783707-5a477000-3ed8-11e9-836d-8653e1905b5e.png)

They're fancy and animated and they glow like a zippo and have special dream messages about Hans Zimmer. And now, it can be *yours*, if you donate!

#### Changelog
:cl:  Altoids
rscadd: Fancy animated cosmos blankets are now available as a donor item!
/:cl:
