### PR TITLE
Makes derelict drones unblowable when not on-station

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -84,6 +84,8 @@
 	for(var/mob/living/simple_animal/drone/D in GLOB.drones_list)
 		if(D.hacked)
 			continue
+		if(istype(D,/mob/living/simple_animal/drone/derelict) && D.loc.z != src.loc.z) // Yogs -- Exempts derelict drones from being detonated while not on the same Z-level as the RD
+			continue // Yogs
 		if(drones)
 			dat += "<br><br>"
 		else


### PR DESCRIPTION
Xaxaxaxaxa

#### Changelog
:cl:  Altoids
tweak: Derelict drones can no longer be blown by the RD when they are not on the station.
/:cl:
