### PR TITLE
makes honk staff bullets ricochet

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -544,7 +544,7 @@
 			return FALSE
 	if(!ignore_loc && (loc != target.loc))
 		return FALSE
-	if(target in passthrough)
+	if(target in passthrough && !multiple_hit) //yogs - multiple hit bullets.
 		return FALSE
 	if(target.density)		//This thing blocks projectiles, hit it regardless of layer/mob stuns/etc.
 		return TRUE

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3110,6 +3110,7 @@
 #include "yogstation\code\modules\power\hugbox.dm"
 #include "yogstation\code\modules\power\lighting.dm"
 #include "yogstation\code\modules\power\validhunter.dm"
+#include "yogstation\code\modules\projectiles\projectile.dm"
 #include "yogstation\code\modules\projectiles\ammunition\caseless\misc.dm"
 #include "yogstation\code\modules\projectiles\boxes_magazines\internal\misc.dm"
 #include "yogstation\code\modules\projectiles\guns\ballistic\launchers.dm"

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3113,6 +3113,7 @@
 #include "yogstation\code\modules\projectiles\ammunition\caseless\misc.dm"
 #include "yogstation\code\modules\projectiles\boxes_magazines\internal\misc.dm"
 #include "yogstation\code\modules\projectiles\guns\ballistic\launchers.dm"
+#include "yogstation\code\modules\projectiles\projectile\bullets\special.dm"
 #include "yogstation\code\modules\projectiles\reusable\kineticspear.dm"
 #include "yogstation\code\modules\reagents\chemistry\reagents\food_reagents.dm"
 #include "yogstation\code\modules\reagents\chemistry\reagents\other_reagents.dm"

--- a/yogstation/code/modules/projectiles/projectile.dm
+++ b/yogstation/code/modules/projectiles/projectile.dm
@@ -1,0 +1,2 @@
+/obj/item/projectile
+	var/multiple_hit = FALSE

--- a/yogstation/code/modules/projectiles/projectile/bullets/special.dm
+++ b/yogstation/code/modules/projectiles/projectile/bullets/special.dm
@@ -1,6 +1,7 @@
 /obj/item/projectile/bullet/honker
 	ricochets_max = INFINITY
 	reflect_range_decrease = 5
+	multiple_hit = TRUE
 
 /obj/item/projectile/bullet/honker/check_ricochet(atom/A)
 	if(istype(A, /turf/closed))

--- a/yogstation/code/modules/projectiles/projectile/bullets/special.dm
+++ b/yogstation/code/modules/projectiles/projectile/bullets/special.dm
@@ -1,0 +1,11 @@
+/obj/item/projectile/bullet/honker
+	ricochets_max = INFINITY
+	reflect_range_decrease = 5
+
+/obj/item/projectile/bullet/honker/check_ricochet(atom/A)
+	if(istype(A, /turf/closed))
+		return TRUE
+	return FALSE
+
+/obj/item/projectile/bullet/honker/check_ricochet_flag(atom/A)
+	return TRUE


### PR DESCRIPTION
### Intent of your Pull Request

Makes the honkstaff ricochet instead of going through walls. It loses 5 range every time it ricochets and has a range of 200, so assuming that it doesn't travel on any tiles but just ricochets, it can ricochet a maximum of 40 times.

#### Changelog

:cl:  
tweak: honk staff now ricochets around.  
/:cl:
