### PR TITLE
Makes roundstart command jobs logarithmically prefer players with more hours in the job

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -231,7 +231,7 @@
 			L[item] = 1
 		total += L[item]
 
-	total = rand(1, total)
+	total *= rand() // Yogs -- Allows for noninteger weights
 	for (item in L)
 		total -=L [item]
 		if (total <= 0)

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -207,7 +207,7 @@ SUBSYSTEM_DEF(job)
 		var/list/candidates = FindOccupationCandidates(job, level)
 		if(!candidates.len)
 			continue
-		var/mob/dead/new_player/candidate = pick(candidates)
+		var/mob/dead/new_player/candidate = PickCommander(candidates,command_position) // Yogs -- makes command jobs weighted towards players of greater experience
 		AssignRole(candidate, command_position)
 
 /datum/controller/subsystem/job/proc/FillAIPosition()

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2802,6 +2802,7 @@
 #include "yogstation\code\controllers\configuration\entries\yogstation_config.dm"
 #include "yogstation\code\controllers\subsystem\bluespace_locker.dm"
 #include "yogstation\code\controllers\subsystem\input.dm"
+#include "yogstation\code\controllers\subsystem\jobs.dm"
 #include "yogstation\code\controllers\subsystem\mapping.dm"
 #include "yogstation\code\controllers\subsystem\research.dm"
 #include "yogstation\code\controllers\subsystem\ticker.dm"

--- a/yogstation/code/controllers/subsystem/jobs.dm
+++ b/yogstation/code/controllers/subsystem/jobs.dm
@@ -1,0 +1,10 @@
+/datum/controller/subsystem/job/proc/PickCommander(candidates,jobname) 
+	// Takes in a list of potential command role candidates from CheckHeadPositions and FindOccupation Candidates, and picks one weightedly based on hours.
+	var/list/pickweightfood = list() // The list we'll be feeding to pickweights()
+	for(var/i in candidates)
+		var/mob/dead/new_player/candidate = candidates[i]
+		var/hours = candidate.client.prefs.exp[jobname] / 60
+		if(hours < 10) // Prevents fresh new guys from causing undefined errors or being 1000x less likely to get a role, when using log scale
+			hours = 10
+		pickweightfood[candidate] = log(10,hours) // Log base 10 of the hours
+	return pickweight(pickweightfood)

--- a/yogstation/code/controllers/subsystem/jobs.dm
+++ b/yogstation/code/controllers/subsystem/jobs.dm
@@ -3,8 +3,9 @@
 	var/list/pickweightfood = list() // The list we'll be feeding to pickweights()
 	for(var/i in candidates)
 		var/mob/dead/new_player/candidate = candidates[i]
-		var/hours = candidate.client.prefs.exp[jobname] / 60
-		if(hours < 10) // Prevents fresh new guys from causing undefined errors or being 1000x less likely to get a role, when using log scale
-			hours = 10
-		pickweightfood[candidate] = log(10,hours) // Log base 10 of the hours
+		var/minutes = candidate.client.prefs.exp[jobname]
+		if(!minutes || minutes < 600) 
+			minutes = 600 // Prevents fresh new guys from causing undefined errors or being 1000x less likely to get a role, when using log scale
+		pickweightfood[candidate] = log(10,minutes/60) // Log base 10 of the hours
+		//Yes, doing the log of the hours instead of the minutes does affect things.
 	return pickweight(pickweightfood)


### PR DESCRIPTION
## The New [ULTRA] Preference, now with more systemic oppression
![image](https://user-images.githubusercontent.com/29939414/54062577-7eeb6280-41cc-11e9-95e9-fc2feb6d9e43.png)

This makes command positions weightedly prefer players who have more hours in the the job. This weighting is logarithmic, **which means if you have 100x more hours in CE than the other guy, you are twice as likely to be picked for it.** This should help improve the quality of command staff without absolutely preventing the new guys from playing.

Players with less than 10 hours of playtime are "bumped up" to 10 for the purposes of the pick, to prevent out-of-bounds issues with log() and to keep 1000-hour players from being a thousand times more likely to get in than a guy who was Captain for 0.2 seconds.

These "raffle tickets" are calculated as floating-point, meaning you can have 1.5253x chance over the other guy instead, or whatever.

Closes #4620.

#### Changelog
:cl:  Altoids
rscadd: At roundstart, command jobs now slightly prefer people with more hours in said job.
/:cl:
