### PR TITLE
Implements Nitrogen Narcosis

### DIFF
--- a/code/__DEFINES/~yogs_defines/atmospherics.dm
+++ b/code/__DEFINES/~yogs_defines/atmospherics.dm
@@ -1,0 +1,2 @@
+#define NITROGEN_NARCOSIS_PRESSURE_LOW 160 // Low-level Nitrogen Narcosis, laughter and tunnel vision
+#define NITROGEN_NARCOSIS_PRESSURE_HIGH 480 // High-level nitrogen narcosis, with hallucinations

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -216,6 +216,16 @@
 	else
 		SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "chemical_euphoria")
 
+	//yogs start -- Adds Nitrogen Narcosis https://en.wikipedia.org/wiki/Nitrogen_narcosis
+	//NITROGEN
+	if(breath_gases[/datum/gas/nitrogen])
+		var/SA_partialpressure = (breath_gases[/datum/gas/nitrogen][MOLES]/breath.total_moles())*breath_pressure
+		if(SA_partialpressure > NITROGEN_NARCOSIS_PRESSURE_LOW) // Giggles
+			if(prob(20))
+				emote(pick("giggle","laugh"))
+			if(SA_partialpressure > NITROGEN_NARCOSIS_PRESSURE_HIGH) // Hallucinations
+				hallucination += 5
+	//yogs end
 	//BZ (Facepunch port of their Agent B)
 	if(breath_gases[/datum/gas/bz])
 		var/bz_partialpressure = (breath_gases[/datum/gas/bz][MOLES]/breath.total_moles())*breath_pressure

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -224,6 +224,9 @@
 			if(prob(20))
 				emote(pick("giggle","laugh"))
 			if(SA_partialpressure > NITROGEN_NARCOSIS_PRESSURE_HIGH) // Hallucinations
+				if(prob(15))
+					to_chat(src, "<span class='userdanger'>You can't think straight!</span>")
+					confused = min(SA_partialpressure/10, confused + 12)
 				hallucination += 5
 	//yogs end
 	//BZ (Facepunch port of their Agent B)

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -108,6 +108,7 @@
 #include "code\__DEFINES\~yogs_defines\access.dm"
 #include "code\__DEFINES\~yogs_defines\admin.dm"
 #include "code\__DEFINES\~yogs_defines\antagonists.dm"
+#include "code\__DEFINES\~yogs_defines\atmospherics.dm"
 #include "code\__DEFINES\~yogs_defines\atom_hud.dm"
 #include "code\__DEFINES\~yogs_defines\components.dm"
 #include "code\__DEFINES\~yogs_defines\DNA.dm"


### PR DESCRIPTION
## *Raptures of The Deep*

https://en.wikipedia.org/wiki/Nitrogen_narcosis

![image](https://user-images.githubusercontent.com/29939414/54079820-77e65200-42a9-11e9-8c36-92e8470d4cee.png)

So I was googling about the maximum pressure humans can survive when I discovered that, apparently, nitrogen at high enough pressures can cause a giddy, hallucinogenic high. I thought this was really cool, and decided to add it into my video game.

I think this will help buff high-pressure environments, making their danger more resemble how it is in real life.

#### Changelog
:cl:  Altoids
rscadd: Nitrogen Narcosis has been added! Now N2O isn't the only thing that can get you giddy, and BZ ain't the only thing that can get you high.
/:cl:
