### PR TITLE
Removes hybrid tasers from the armory

### DIFF
--- a/_maps/yogstation/map_files/YogStation/YogStation.dmm
+++ b/_maps/yogstation/map_files/YogStation/YogStation.dmm
@@ -13038,14 +13038,14 @@
 	},
 /obj/effect/turf_decal/bot_red,
 /obj/structure/rack,
-/obj/item/gun/energy/e_gun/advtaser{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/gun/energy/e_gun/advtaser,
-/obj/item/gun/energy/e_gun/advtaser{
+/obj/item/gun/energy/disabler{
 	pixel_x = -3;
 	pixel_y = 3
+	},
+/obj/item/gun/energy/disabler,
+/obj/item/gun/energy/disabler{
+	pixel_x = 3;
+	pixel_y = -3;
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)

--- a/_maps/yogstation/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/yogstation/map_files/YogsDelta/YogsDelta.dmm
@@ -37770,12 +37770,12 @@
 /area/engine/break_room)
 "big" = (
 /obj/structure/rack,
-/obj/item/gun/energy/e_gun/advtaser{
+/obj/item/gun/energy/disabler{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/gun/energy/e_gun/advtaser,
-/obj/item/gun/energy/e_gun/advtaser{
+/obj/item/gun/energy/disabler,
+/obj/item/gun/energy/disabler{
 	pixel_x = 3;
 	pixel_y = -3
 	},

--- a/_maps/yogstation/map_files/YogsDonut/YogsDonut.dmm
+++ b/_maps/yogstation/map_files/YogsDonut/YogsDonut.dmm
@@ -14293,12 +14293,12 @@
 /area/ai_monitored/security/armory)
 "aEM" = (
 /obj/structure/rack,
-/obj/item/gun/energy/e_gun/advtaser{
+/obj/item/gun/energy/disabler{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/gun/energy/e_gun/advtaser,
-/obj/item/gun/energy/e_gun/advtaser{
+/obj/item/gun/energy/disabler,
+/obj/item/gun/energy/disabler{
 	pixel_x = 3;
 	pixel_y = -3
 	},

--- a/_maps/yogstation/map_files/YogsPubby/YogsPubby.dmm
+++ b/_maps/yogstation/map_files/YogsPubby/YogsPubby.dmm
@@ -5384,12 +5384,12 @@
 /area/security/brig)
 "akL" = (
 /obj/structure/rack,
-/obj/item/gun/energy/e_gun/advtaser{
+/obj/item/gun/energy/disabler{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/gun/energy/e_gun/advtaser,
-/obj/item/gun/energy/e_gun/advtaser{
+/obj/item/gun/energy/disabler,
+/obj/item/gun/energy/disabler{
 	pixel_x = 3;
 	pixel_y = -3
 	},

--- a/_maps/yogstation/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/yogstation/map_files/Yogsmeta/Yogsmeta.dmm
@@ -2858,12 +2858,12 @@
 /area/crew_quarters/heads/hos)
 "afj" = (
 /obj/structure/rack,
-/obj/item/gun/energy/e_gun/advtaser{
+/obj/item/gun/energy/disabler{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/gun/energy/e_gun/advtaser,
-/obj/item/gun/energy/e_gun/advtaser{
+/obj/item/gun/energy/disabler,
+/obj/item/gun/energy/disabler{
 	pixel_x = 3;
 	pixel_y = -3
 	},
@@ -15817,7 +15817,7 @@
 /obj/item/storage/backpack/duffelbag/syndie/hitman,
 /obj/item/card/id/silver/reaper,
 /obj/item/lazarus_injector,
-/obj/item/gun/energy/e_gun/advtaser,
+/obj/item/gun/energy/disabler,
 /obj/item/gun/ballistic/revolver/russian,
 /obj/item/ammo_box/a357,
 /obj/item/clothing/neck/stethoscope,


### PR DESCRIPTION
Making this PR was on my bucket list.  I've wanted to do this for years.

Completes #4718 by removing hybrid tasers from the yogstation armory.
Flashbangs, your days are numbered.
#### Changelog
:cl:  
rscdel: NT brand hybrid tasers have been subject to a massive recall for "safety reasons".
/:cl:
