### PR TITLE
Allows for dual-sabers to also make use of the high ground

### DIFF
--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -368,7 +368,7 @@
 	else
 		user.adjustStaminaLoss(25)
 
-/obj/item/twohanded/dualsaber/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+/obj/item/twohanded/dualsaber/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK) //yogs -- mirrored to allow for use of the high ground
 	if(wielded)
 		return ..()
 	return 0

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2886,6 +2886,7 @@
 #include "yogstation\code\game\objects\items\sharpener.dm"
 #include "yogstation\code\game\objects\items\tool_switcher.dm"
 #include "yogstation\code\game\objects\items\toys.dm"
+#include "yogstation\code\game\objects\items\twohanded.dm"
 #include "yogstation\code\game\objects\items\weaponry.dm"
 #include "yogstation\code\game\objects\items\circuitboards\computer_circuitboards.dm"
 #include "yogstation\code\game\objects\items\circuitboards\machine_circuitboards.dm"

--- a/yogstation/code/game/objects/items/twohanded.dm
+++ b/yogstation/code/game/objects/items/twohanded.dm
@@ -1,0 +1,11 @@
+/obj/item/twohanded/dualsaber/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+	if(wielded)
+		var/turf/T = get_turf(src)
+		for(var/obj/structure/table/X in T)
+			if(X)
+				final_block_chance = 99
+				owner.say(pick("IT'S OVER!!", "I HAVE THE HIGH GROUND!!"))
+				return ..()
+		return ..()
+	else
+		return 0


### PR DESCRIPTION
## Anakin!

An extension of #1930, which works for all deswords.

#### Changelog

:cl:  Altoids
bugfix: Dual-sabers can now make use of the high ground.
/:cl:
