### PR TITLE
clerk's hat typo

### DIFF
--- a/yogstation/code/modules/clothing/head/jobs.dm
+++ b/yogstation/code/modules/clothing/head/jobs.dm
@@ -1,6 +1,6 @@
 //Clerk
 /obj/item/clothing/head/yogs/clerkcap
 	name = "clerk's hat"
-	desc = "It's a hat used by clerk's to help keep dust out of thier eyes."
+	desc = "It's a hat used by clerk's to help keep dust out of their eyes."
 	icon_state = "clerkcap"
 	item_state = "clerkcap"


### PR DESCRIPTION
fixes typo 'thier' in the clerk hat description.

:cl: Identification
spellcheck: fixes clerkhat desc typo
/:cl: