### PR TITLE
Reverts some of a /TG/ PR, making epipens cap oxygen damage again.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -804,7 +804,11 @@
 		M.adjustToxLoss(-0.5*REM, 0)
 		M.adjustBruteLoss(-0.5*REM, 0)
 		M.adjustFireLoss(-0.5*REM, 0)
-		M.adjustOxyLoss(-0.5*REM, 0)
+	//yogs start -- Reverts some of #4740, adds old oxy-capping behavior
+		//M.adjustOxyLoss(-0.5*REM, 0)
+	if(M.oxyloss > 40)
+		M.setOxyLoss(40, 0)
+	//yogs end
 	if(M.losebreath >= 4)
 		M.losebreath -= 2
 	if(M.losebreath < 0)


### PR DESCRIPTION
Reverts parts of #4740.

Just want to note that this sets the oxygen damage cap to
# 40

Instead of the previous value of 

# 35

#### Changelog
:cl:  Altoids
tweak: Epipens now cap oxygen damage again! They no longer heal oxygen damage besides setting this cap, though.
/:cl:
