### PR TITLE
Revert "[MIRROR] Removes stun and item drop from all slips. They will…

### DIFF
--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -1,19 +1,15 @@
 /datum/component/slippery
-	var/force_drop_items = FALSE
-	var/knockdown_time = 0
-	var/paralyze_time = 0
+	var/intensity
 	var/lube_flags
 	var/datum/callback/callback
 
-/datum/component/slippery/Initialize(_knockdown, _lube_flags = NONE, datum/callback/_callback, _paralyze, _force_drop = FALSE)
-	knockdown_time = max(_knockdown, 0)
-	paralyze_time = max(_paralyze, 0)
-	force_drop_items = _force_drop
+/datum/component/slippery/Initialize(_intensity, _lube_flags = NONE, datum/callback/_callback)
+	intensity = max(_intensity, 0)
 	lube_flags = _lube_flags
 	callback = _callback
 	RegisterSignal(parent, list(COMSIG_MOVABLE_CROSSED, COMSIG_ATOM_ENTERED), .proc/Slip)
 
 /datum/component/slippery/proc/Slip(datum/source, atom/movable/AM)
 	var/mob/victim = AM
-	if(istype(victim) && !victim.is_flying() && victim.slip(knockdown_time, parent, lube_flags, paralyze_time, force_drop_items) && callback)
+	if(istype(victim) && !victim.is_flying() && victim.slip(intensity, parent, lube_flags) && callback)
 		callback.Invoke(victim)

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -1,15 +1,15 @@
 /datum/component/slippery
-	var/intensity
+	var/intensity //Yogs
 	var/lube_flags
 	var/datum/callback/callback
 
-/datum/component/slippery/Initialize(_intensity, _lube_flags = NONE, datum/callback/_callback)
-	intensity = max(_intensity, 0)
+/datum/component/slippery/Initialize(_intensity, _lube_flags = NONE, datum/callback/_callback) //Yogs
+	intensity = max(_intensity, 0) //Yogs
 	lube_flags = _lube_flags
 	callback = _callback
 	RegisterSignal(parent, list(COMSIG_MOVABLE_CROSSED, COMSIG_ATOM_ENTERED), .proc/Slip)
 
 /datum/component/slippery/proc/Slip(datum/source, atom/movable/AM)
 	var/mob/victim = AM
-	if(istype(victim) && !victim.is_flying() && victim.slip(intensity, parent, lube_flags) && callback)
+	if(istype(victim) && !victim.is_flying() && victim.slip(intensity, parent, lube_flags) && callback) //Yogs
 		callback.Invoke(victim)

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -1,15 +1,35 @@
+/* /datum/component/slippery
+	var/force_drop_items = FALSE
+	var/knockdown_time = 0
+	var/paralyze_time = 0
+	var/lube_flags
+	var/datum/callback/callback */ // Yogs - Old(new?) code pre-revert of Kevinz butchering of slipping.
+	
 /datum/component/slippery
-	var/intensity //Yogs
+	var/intensity
 	var/lube_flags
 	var/datum/callback/callback
 
-/datum/component/slippery/Initialize(_intensity, _lube_flags = NONE, datum/callback/_callback) //Yogs
-	intensity = max(_intensity, 0) //Yogs
+/* /datum/component/slippery/Initialize(_knockdown, _lube_flags = NONE, datum/callback/_callback, _paralyze, _force_drop = FALSE)
+	knockdown_time = max(_knockdown, 0)
+	paralyze_time = max(_paralyze, 0)
+	force_drop_items = _force_drop
+	lube_flags = _lube_flags
+	callback = _callback
+	RegisterSignal(parent, list(COMSIG_MOVABLE_CROSSED, COMSIG_ATOM_ENTERED), .proc/Slip) */ //Yogs - Old(new?) code pre-revert of Kevinz butchering of slipping.
+	
+/datum/component/slippery/Initialize(_intensity, _lube_flags = NONE, datum/callback/_callback)
+	intensity = max(_intensity, 0)
 	lube_flags = _lube_flags
 	callback = _callback
 	RegisterSignal(parent, list(COMSIG_MOVABLE_CROSSED, COMSIG_ATOM_ENTERED), .proc/Slip)
 
+/* /datum/component/slippery/proc/Slip(datum/source, atom/movable/AM)
+	var/mob/victim = AM
+	if(istype(victim) && !victim.is_flying() && victim.slip(knockdown_time, parent, lube_flags, paralyze_time, force_drop_items) && callback)
+		callback.Invoke(victim) */ //Yogs - Old(new?) code pre-revert of kevinz butchering of slipping.
+
 /datum/component/slippery/proc/Slip(datum/source, atom/movable/AM)
 	var/mob/victim = AM
-	if(istype(victim) && !victim.is_flying() && victim.slip(intensity, parent, lube_flags) && callback) //Yogs
+	if(istype(victim) && !victim.is_flying() && victim.slip(intensity, parent, lube_flags) && callback)
 		callback.Invoke(victim)

--- a/code/datums/components/wet_floor.dm
+++ b/code/datums/components/wet_floor.dm
@@ -92,7 +92,9 @@
 			qdel(parent.GetComponent(/datum/component/slippery))
 			return
 
-	parent.LoadComponent(/datum/component/slippery, intensity, lube_flags, CALLBACK(src, .proc/AfterSlip))
+	var/datum/component/slippery/S = parent.LoadComponent(/datum/component/slippery, NONE, CALLBACK(src, .proc/AfterSlip))
+	S.intensity = intensity
+	S.lube_flags = lube_flags
 
 /datum/component/wet_floor/proc/dry(datum/source, strength = TURF_WET_WATER, immediate = FALSE, duration_decrease = INFINITY)
 	for(var/i in time_left_list)

--- a/code/datums/components/wet_floor.dm
+++ b/code/datums/components/wet_floor.dm
@@ -92,9 +92,9 @@
 			qdel(parent.GetComponent(/datum/component/slippery))
 			return
 
-	var/datum/component/slippery/S = parent.LoadComponent(/datum/component/slippery, NONE, CALLBACK(src, .proc/AfterSlip))
-	S.intensity = intensity
-	S.lube_flags = lube_flags
+	var/datum/component/slippery/S = parent.LoadComponent(/datum/component/slippery, NONE, CALLBACK(src, .proc/AfterSlip)) //Yogs
+	S.intensity = intensity //Yogs
+	S.lube_flags = lube_flags //Yogs, fuck kevinz btw
 
 /datum/component/wet_floor/proc/dry(datum/source, strength = TURF_WET_WATER, immediate = FALSE, duration_decrease = INFINITY)
 	for(var/i in time_left_list)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -325,7 +325,7 @@
 	if(AM && isturf(AM.loc))
 		step(AM, turn(AM.dir, 180))
 
-/atom/proc/handle_slip(mob/living/carbon/C, knockdown_amount, obj/O, lube, paralyze, force_drop)
+/atom/proc/handle_slip(mob/living/carbon/C, knockdown_amount, obj/O, lube)
 	return
 
 //returns the mob's dna info as a list, to be inserted in an object's blood_DNA list

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -325,7 +325,7 @@
 	if(AM && isturf(AM.loc))
 		step(AM, turn(AM.dir, 180))
 
-/atom/proc/handle_slip(mob/living/carbon/C, knockdown_amount, obj/O, lube)
+/atom/proc/handle_slip(mob/living/carbon/C, knockdown_amount, obj/O, lube) //Yogs
 	return
 
 //returns the mob's dna info as a list, to be inserted in an object's blood_DNA list

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -216,7 +216,7 @@
 			qdel(O)
 	return TRUE
 
-/turf/open/handle_slip(mob/living/carbon/C, knockdown_amount, obj/O, lube, paralyze_amount, force_drop)
+/turf/open/handle_slip(mob/living/carbon/C, knockdown_amount, obj/O, lube)
 	if(C.movement_type & FLYING)
 		return 0
 	if(has_gravity(src))
@@ -235,18 +235,16 @@
 			playsound(C.loc, 'sound/misc/slip.ogg', 50, 1, -3)
 
 		SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "slipped", /datum/mood_event/slipped)
-		if(force_drop)
-			for(var/obj/item/I in C.held_items)
-				C.accident(I)
+		for(var/obj/item/I in C.held_items)
+			C.accident(I)
 
 		var/olddir = C.dir
 		C.moving_diagonally = 0 //If this was part of diagonal move slipping will stop it.
 		if(!(lube & SLIDE_ICE))
-			C.Knockdown(knockdown_amount)
-			C.Paralyze(paralyze_amount)
+			C.Paralyze(knockdown_amount)
 			C.stop_pulling()
 		else
-			C.Knockdown(20)
+			C.Stun(20)
 
 		if(buckled_obj)
 			buckled_obj.unbuckle_mob(C)

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -216,7 +216,7 @@
 			qdel(O)
 	return TRUE
 
-/turf/open/handle_slip(mob/living/carbon/C, knockdown_amount, obj/O, lube)
+/turf/open/handle_slip(mob/living/carbon/C, knockdown_amount, obj/O, lube) //Yogs
 	if(C.movement_type & FLYING)
 		return 0
 	if(has_gravity(src))
@@ -235,16 +235,16 @@
 			playsound(C.loc, 'sound/misc/slip.ogg', 50, 1, -3)
 
 		SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "slipped", /datum/mood_event/slipped)
-		for(var/obj/item/I in C.held_items)
-			C.accident(I)
+		for(var/obj/item/I in C.held_items) //Yogs
+			C.accident(I) //Yogs
 
 		var/olddir = C.dir
 		C.moving_diagonally = 0 //If this was part of diagonal move slipping will stop it.
 		if(!(lube & SLIDE_ICE))
-			C.Paralyze(knockdown_amount)
+			C.Paralyze(knockdown_amount) //Yogs
 			C.stop_pulling()
 		else
-			C.Stun(20)
+			C.Stun(20) //Yogs
 
 		if(buckled_obj)
 			buckled_obj.unbuckle_mob(C)

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -10,12 +10,12 @@
 		if(legcuffed)
 			. += legcuffed.slowdown
 
-/mob/living/carbon/slip(knockdown_amount, obj/O, lube, paralyze, force_drop)
+/mob/living/carbon/slip(knockdown_amount, obj/O, lube)
 	if(movement_type & FLYING)
 		return 0
 	if(!(lube&SLIDE_ICE))
 		log_combat(src, (O ? O : get_turf(src)), "slipped on the", null, ((lube & SLIDE) ? "(LUBE)" : null))
-	return loc.handle_slip(src, knockdown_amount, O, lube, paralyze, force_drop)
+	return loc.handle_slip(src, knockdown_amount, O, lube)
 
 /mob/living/carbon/Process_Spacemove(movement_dir = 0)
 	if(..())

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -10,12 +10,12 @@
 		if(legcuffed)
 			. += legcuffed.slowdown
 
-/mob/living/carbon/slip(knockdown_amount, obj/O, lube)
+/mob/living/carbon/slip(knockdown_amount, obj/O, lube) //Yogs
 	if(movement_type & FLYING)
 		return 0
 	if(!(lube&SLIDE_ICE))
 		log_combat(src, (O ? O : get_turf(src)), "slipped on the", null, ((lube & SLIDE) ? "(LUBE)" : null))
-	return loc.handle_slip(src, knockdown_amount, O, lube)
+	return loc.handle_slip(src, knockdown_amount, O, lube) //Yogs slip and slide on this banana peel
 
 /mob/living/carbon/Process_Spacemove(movement_dir = 0)
 	if(..())

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -12,7 +12,7 @@
 	if(dna && dna.species)
 		. += dna.species.movement_delay(src)
 
-/mob/living/carbon/human/slip(knockdown_amount, obj/O, lube, paralyze, forcedrop)
+/mob/living/carbon/human/slip(knockdown_amount, obj/O, lube)
 	if(has_trait(TRAIT_NOSLIPALL))
 		return 0
 	if (!(lube&GALOSHES_DONT_HELP))

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -12,7 +12,7 @@
 	if(dna && dna.species)
 		. += dna.species.movement_delay(src)
 
-/mob/living/carbon/human/slip(knockdown_amount, obj/O, lube)
+/mob/living/carbon/human/slip(knockdown_amount, obj/O, lube) //Yogs
 	if(has_trait(TRAIT_NOSLIPALL))
 		return 0
 	if (!(lube&GALOSHES_DONT_HELP))

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -255,7 +255,7 @@
 	return FALSE
 
 
-/mob/proc/slip(s_amount, w_amount, obj/O, lube)
+/mob/proc/slip(s_amount, w_amount, obj/O, lube) //Yogs  you know its bad when its easier to revert it from ages ago than to try to fix it normally
 	return
 
 /mob/proc/update_gravity()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -255,7 +255,7 @@
 	return FALSE
 
 
-/mob/proc/slip(knockdown, paralyze, forcedrop, w_amount, obj/O, lube)
+/mob/proc/slip(s_amount, w_amount, obj/O, lube)
 	return
 
 /mob/proc/update_gravity()


### PR DESCRIPTION
_… instead knock people down (force crawling) for their duration."_

Interestingly, this worked just being outright reverted despite being a PR from a good while ago.
+fun
+pile of people slipping AND NOT MOVING AROUND WHEN SLIPPED
+clown buff

learn to walk instead of being a little bitch kevinz

#### Changelog

:cl:  
bugfix: You now slip and bang your head on the floor and get stunned when you slip, as intended.
/:cl:
