### PR TITLE
Brings riotshields back to their prebase status, probably significantly nerfing them

### DIFF
--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2901,6 +2901,7 @@
 #include "yogstation\code\game\objects\items\plushes.dm"
 #include "yogstation\code\game\objects\items\premadepapers.dm"
 #include "yogstation\code\game\objects\items\sharpener.dm"
+#include "yogstation\code\game\objects\items\shields.dm"
 #include "yogstation\code\game\objects\items\tool_switcher.dm"
 #include "yogstation\code\game\objects\items\toys.dm"
 #include "yogstation\code\game\objects\items\weaponry.dm"

--- a/yogstation/code/game/objects/items/shields.dm
+++ b/yogstation/code/game/objects/items/shields.dm
@@ -1,0 +1,8 @@
+/obj/item/shield/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+	SEND_SIGNAL(src, COMSIG_ITEM_HIT_REACT, args)
+	if(transparent && (hitby.pass_flags & PASSGLASS))
+		return FALSE
+	if(!is_A_facing_B(owner, hitby))
+		return FALSE
+	owner.visible_message("<span class='danger'>[owner] blocks [attack_text] with [src]!</span>")
+	return TRUE


### PR DESCRIPTION
### Intent of your Pull Request

Basically makes it so you have to face people in order to block their shots/attacks. You know, like prebase.

#### Changelog

:cl:  
tweak: riotshields now only block attacks from the front. Like shields usually do.
/:cl:
