### PR TITLE
Changes the Hub status around

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -246,7 +246,7 @@ GLOBAL_VAR(restart_counter)
 	shutdown_logging() // Past this point, no logging procs can be used, at risk of data loss.
 	..()
 
-/world/proc/update_status()
+/world/proc/update_status() //yogs -- Mirrored in the Yogs folder in March 2019. Do not edit, swallow, or submerge in acid
 
 	var/list/features = list()
 
@@ -262,20 +262,18 @@ GLOBAL_VAR(restart_counter)
 		var/server_name = CONFIG_GET(string/servername)
 		if (server_name)
 			s += "<b>[server_name]</b> &#8212; "
-		if(!CONFIG_GET(flag/norespawn)) features += "respawn" //Yogs -- Makes this not display when it's no-respawn (as per usual)
-		/* Yogs start -- removes these old-ass hub tags
+		features += "[CONFIG_GET(flag/norespawn) ? "no " : ""]respawn"
 		if(CONFIG_GET(flag/allow_vote_mode))
 			features += "vote"
 		if(CONFIG_GET(flag/allow_ai))
 			features += "AI allowed"
-		Yogs end */
 		hostedby = CONFIG_GET(string/hostedby)
 
 	s += "<b>[station_name()]</b>";
-	s += " (" //yog start hub message
-	s += "<a href=\"https://forums.yogstation.net/index.php\">" //Change this to wherever you want the hub to link to.
-	s += "Forums"
-	s += "</a>" //yog end
+	s += " ("
+	s += "<a href=\"http://\">" //Change this to wherever you want the hub to link to.
+	s += "Default"  //Replace this with something else. Or ever better, delete it and uncomment the game version.
+	s += "</a>"
 	s += ")"
 	
 	var/players = GLOB.clients.len

--- a/yogstation/code/game/world.dm
+++ b/yogstation/code/game/world.dm
@@ -35,42 +35,40 @@ GLOBAL_LIST_EMPTY(donators)
 
 /world/update_status()
 
-	var/list/features = list()
-
-	if(GLOB.master_mode)
-		features += GLOB.master_mode
-
-	if (!GLOB.enter_allowed)
-		features += "closed"
-
+	//BASIC SHIT
 	var/s = ""
-	var/hostedby
-	if(config)
-		var/server_name = CONFIG_GET(string/servername)
-		if (server_name)
-			s += "<b>[server_name]</b> &#8212; "
-		if(!CONFIG_GET(flag/norespawn)) features += "<b>respawn</b>" // Bold it since it will be an amazing(ly questionable) event
-		hostedby = CONFIG_GET(string/hostedby)
-
-	s += "<b>[station_name()]</b>]<br>"; // The station & server name
-	s += "(<a href=\"https://forums.yogstation.net/index.php\">Forums</a>|<a href=\"https://discord.gg/8hphvMe\">Discord</a>)<br>" // The Forum & Discord links
-	s += "Mode: <b>[GLOB.master_mode]</b><br>" // The Gamemode
+	var/server_name = CONFIG_GET(string/servername)
+	if (server_name)
+		s += "<b>[server_name]</b> &#8212; "
 	
+	s += "<b>[station_name()]</b>]<br>"; // The station & server name line
+	s += "(<a href=\"https://forums.yogstation.net/index.php\">Forums</a>|<a href=\"https://discord.gg/8hphvMe\">Discord</a>)<br>" // The Forum & Discord links line
+	s += "Mode: <b>[GLOB.master_mode]</b><br>" // The Gamemode line
+	
+	//FEATURES
+	var/list/features = list()
+	if(!CONFIG_GET(flag/norespawn)) 
+		features += "<b>Respawn Enabled</b>" // Bold it since it will be an amazing(ly questionable) event
+	
+	if(features.len)
+		s += "[jointext(features,", ")]<br>" // The features line
+	
+	//PLAYER COUNT
 	var/players = GLOB.clients.len
-	var/popcap = max(CONFIG_GET(number/extreme_popcap), CONFIG_GET(number/hard_popcap), CONFIG_GET(number/soft_popcap))
 	var/popcaptext = ""
-	if (players > 1)
-		popcaptext = "~[players][popcaptext] players"
-	else if (players)
-		popcaptext = "~[players][popcaptext] player"
+	if(players)
+		popcaptext = "~[players] player\s"
 	var/queuetext = ""
 	if(SSticker && SSticker.queued_players.len)
 		queuetext = " ([SSticker.queued_players.len] in queue)"
-	s += "[popcaptext][queuetext]<br>"
 	
-	game_state = (CONFIG_GET(number/extreme_popcap) && players >= CONFIG_GET(number/extreme_popcap)) //tells the hub if we are full
+	s += "\[[popcaptext][queuetext]"
 	
-	if (!host && hostedby)
-		s += "hosted by <b>[hostedby]</b>"
-
+	//HOST
+	if (!host && CONFIG_GET(string/hostedby))
+		s += " hosted by <b>[hostedby]</b>"
+	
+	//RETURN
 	status = s
+	game_state = (CONFIG_GET(number/extreme_popcap) && players >= CONFIG_GET(number/extreme_popcap)) //tells the hub if we are full
+	return s

--- a/yogstation/code/game/world.dm
+++ b/yogstation/code/game/world.dm
@@ -65,7 +65,8 @@ GLOBAL_LIST_EMPTY(donators)
 	s += "\[[popcaptext][queuetext]"
 	
 	//HOST
-	if (!host && CONFIG_GET(string/hostedby))
+	var/hostedby = CONFIG_GET(string/hostedby)
+	if (!host && hostedby)
 		s += " hosted by <b>[hostedby]</b>"
 	
 	//RETURN

--- a/yogstation/code/game/world.dm
+++ b/yogstation/code/game/world.dm
@@ -32,3 +32,45 @@ GLOBAL_LIST_EMPTY(donators)
 		P = GLOB.preferences_datums[ckey]
 		if(P)
 			P.unlock_content |= 2
+
+/world/update_status()
+
+	var/list/features = list()
+
+	if(GLOB.master_mode)
+		features += GLOB.master_mode
+
+	if (!GLOB.enter_allowed)
+		features += "closed"
+
+	var/s = ""
+	var/hostedby
+	if(config)
+		var/server_name = CONFIG_GET(string/servername)
+		if (server_name)
+			s += "<b>[server_name]</b> &#8212; "
+		if(!CONFIG_GET(flag/norespawn)) features += "<b>respawn</b>" // Bold it since it will be an amazing(ly questionable) event
+		hostedby = CONFIG_GET(string/hostedby)
+
+	s += "<b>[station_name()]</b>]<br>"; // The station & server name
+	s += "(<a href=\"https://forums.yogstation.net/index.php\">Forums</a>|<a href=\"https://discord.gg/8hphvMe\">Discord</a>)<br>" // The Forum & Discord links
+	s += "Mode: <b>[GLOB.master_mode]</b><br>" // The Gamemode
+	
+	var/players = GLOB.clients.len
+	var/popcap = max(CONFIG_GET(number/extreme_popcap), CONFIG_GET(number/hard_popcap), CONFIG_GET(number/soft_popcap))
+	var/popcaptext = ""
+	if (players > 1)
+		popcaptext = "~[players][popcaptext] players"
+	else if (players)
+		popcaptext = "~[players][popcaptext] player"
+	var/queuetext = ""
+	if(SSticker && SSticker.queued_players.len)
+		queuetext = " ([SSticker.queued_players.len] in queue)"
+	s += "[popcaptext][queuetext]<br>"
+	
+	game_state = (CONFIG_GET(number/extreme_popcap) && players >= CONFIG_GET(number/extreme_popcap)) //tells the hub if we are full
+	
+	if (!host && hostedby)
+		s += "hosted by <b>[hostedby]</b>"
+
+	status = s

--- a/yogstation/code/game/world.dm
+++ b/yogstation/code/game/world.dm
@@ -44,6 +44,7 @@ GLOBAL_LIST_EMPTY(donators)
 	s += "<b>[station_name()]</b>]<br>"; // The station & server name line
 	s += "(<a href=\"https://forums.yogstation.net/index.php\">Forums</a>|<a href=\"https://discord.gg/8hphvMe\">Discord</a>)<br>" // The Forum & Discord links line
 	s += "Mode: <b>[GLOB.master_mode]</b><br>" // The Gamemode line
+	s += "Map: <b>[SSmapping.config?.map_name || "Loading..."]</b><br>" // The map line
 	
 	//FEATURES
 	var/list/features = list()

--- a/yogstation/code/game/world.dm
+++ b/yogstation/code/game/world.dm
@@ -60,7 +60,7 @@ GLOBAL_LIST_EMPTY(donators)
 		popcaptext = "~[players] player\s"
 	var/queuetext = ""
 	if(SSticker && SSticker.queued_players.len)
-		queuetext = " ([SSticker.queued_players.len] in queue)"
+		queuetext = ", [SSticker.queued_players.len] in queue"
 	
 	s += "\[[popcaptext][queuetext]"
 	


### PR DESCRIPTION
``world/update_status()`` is old as dirt and honestly makes us look a bit copycat and, y'know, just *any* other /tg/ server, so I've gone ahead and just made our own version of the proc.

Now, our status on the Hub goes like:
**[Yogstation 13 — Big Dick 17]**
Mode: **secret**
Map: **Deltastation**
[~87 players, 3 in queue]

#### Changelog
:cl:  Altoids
experimental: Our Hub status has been changed around! You can now see how many players are in the queue to play before you attempt to join, for example.
/:cl:
