### PR TITLE
ports taglines from citadel, sort of

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -457,4 +457,3 @@
 	min_val = 30
 
 /datum/config_entry/flag/reopen_roundstart_suicide_roles_command_report
-

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -39,11 +39,11 @@ GLOBAL_VAR(restart_counter)
 	load_yogs_stuff() // yogs - Donators
 	refresh_admin_files() //yogs - DB support
 	load_admins()
-	
+
 	LoadVerbs(/datum/verbs/menu)
 	if(CONFIG_GET(flag/usewhitelist))
 		load_whitelist()
-		
+
 	setup_pretty_filter() //yogs
 
 	GLOB.timezoneOffset = text2num(time2text(0,"hh")) * 36000
@@ -277,26 +277,28 @@ GLOBAL_VAR(restart_counter)
 	s += "Forums"
 	s += "</a>" //yog end
 	s += ")"
-	
+
 	var/players = GLOB.clients.len
-	
+
 	var/popcaptext = ""
 	var/popcap = max(CONFIG_GET(number/extreme_popcap), CONFIG_GET(number/hard_popcap), CONFIG_GET(number/soft_popcap))
 	if (popcap)
 		popcaptext = "/[popcap]"
-	
+
 	if (players > 1)
 		features += "[players][popcaptext] players"
 	else if (players > 0)
 		features += "[players][popcaptext] player"
-	
+
 	game_state = (CONFIG_GET(number/extreme_popcap) && players >= CONFIG_GET(number/extreme_popcap)) //tells the hub if we are full
-	
+
 	if (!host && hostedby)
 		features += "hosted by <b>[hostedby]</b>"
 
 	if (features)
 		s += ": [jointext(features, ", ")]"
+
+	s += "<br>[pick(world.file2list("yogstation/strings/taglines.txt"))]<br>" //yogs - server tagline, ported from citadel
 
 	status = s
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -296,8 +296,6 @@ GLOBAL_VAR(restart_counter)
 	if (features)
 		s += ": [jointext(features, ", ")]"
 
-	s += "<br>[pick(world.file2list("yogstation/strings/taglines.txt"))]<br>" //yogs - server tagline, ported from citadel
-
 	status = s
 
 /world/proc/update_hub_visibility(new_visibility)

--- a/yogstation/code/game/world.dm
+++ b/yogstation/code/game/world.dm
@@ -45,7 +45,7 @@ GLOBAL_LIST_EMPTY(donators)
 	s += "(<a href=\"https://forums.yogstation.net/index.php\">Forums</a>|<a href=\"https://discord.gg/8hphvMe\">Discord</a>)<br>" // The Forum & Discord links line
 	
 	//TAGLINE
-	s += "<br>[pick(world.file2list("yogstation/strings/taglines.txt"))]<br>"
+	s += "<br><i>[pick(world.file2list("yogstation/strings/taglines.txt"))]</i><br>"
 	
 	//MAP AND GAMEMODE
 	if(GLOB.master_mode != "secret")

--- a/yogstation/code/game/world.dm
+++ b/yogstation/code/game/world.dm
@@ -43,6 +43,12 @@ GLOBAL_LIST_EMPTY(donators)
 	
 	s += "<b>[station_name()]</b>]<br>"; // The station & server name line
 	s += "(<a href=\"https://forums.yogstation.net/index.php\">Forums</a>|<a href=\"https://discord.gg/8hphvMe\">Discord</a>)<br>" // The Forum & Discord links line
+	
+	//TAGLINE
+	s += "<br>[pick(world.file2list("yogstation/strings/taglines.txt"))]<br>"
+	
+	if(GLOB.master_mode != "secret")
+		s += "Mode: <b>[GLOB.master_mode]</b><br>" // The Gamemode line
 	s += "Map: <b>[SSmapping.config?.map_name || "Loading..."]</b><br>" // The map line
 	
 	//FEATURES
@@ -53,8 +59,7 @@ GLOBAL_LIST_EMPTY(donators)
 	if(features.len)
 		s += "[jointext(features,", ")]<br>" // The features line
 	
-	//TAGLINE
-	s += "<br>[pick(world.file2list("yogstation/strings/taglines.txt"))]<br>"
+	
 	
 	//PLAYER COUNT
 	var/players = GLOB.clients.len

--- a/yogstation/code/game/world.dm
+++ b/yogstation/code/game/world.dm
@@ -47,6 +47,7 @@ GLOBAL_LIST_EMPTY(donators)
 	//TAGLINE
 	s += "<br>[pick(world.file2list("yogstation/strings/taglines.txt"))]<br>"
 	
+	//MAP AND GAMEMODE
 	if(GLOB.master_mode != "secret")
 		s += "Mode: <b>[GLOB.master_mode]</b><br>" // The Gamemode line
 	s += "Map: <b>[SSmapping.config?.map_name || "Loading..."]</b><br>" // The map line

--- a/yogstation/code/game/world.dm
+++ b/yogstation/code/game/world.dm
@@ -43,7 +43,6 @@ GLOBAL_LIST_EMPTY(donators)
 	
 	s += "<b>[station_name()]</b>]<br>"; // The station & server name line
 	s += "(<a href=\"https://forums.yogstation.net/index.php\">Forums</a>|<a href=\"https://discord.gg/8hphvMe\">Discord</a>)<br>" // The Forum & Discord links line
-	s += "Mode: <b>[GLOB.master_mode]</b><br>" // The Gamemode line
 	s += "Map: <b>[SSmapping.config?.map_name || "Loading..."]</b><br>" // The map line
 	
 	//FEATURES
@@ -53,6 +52,9 @@ GLOBAL_LIST_EMPTY(donators)
 	
 	if(features.len)
 		s += "[jointext(features,", ")]<br>" // The features line
+	
+	//TAGLINE
+	s += "<br>[pick(world.file2list("yogstation/strings/taglines.txt"))]<br>"
 	
 	//PLAYER COUNT
 	var/players = GLOB.clients.len

--- a/yogstation/strings/taglines.txt
+++ b/yogstation/strings/taglines.txt
@@ -1,3 +1,4 @@
 now 100% snail-free
 10% MORE LAG FOR THE SAME PRICE
 Yoghurt Station 13
+We have deoderant!

--- a/yogstation/strings/taglines.txt
+++ b/yogstation/strings/taglines.txt
@@ -1,0 +1,2 @@
+now 100% snail-free
+10% MORE LAG FOR THE SAME PRICE

--- a/yogstation/strings/taglines.txt
+++ b/yogstation/strings/taglines.txt
@@ -10,5 +10,3 @@ Praise the Clockwork Justicar!
 Ssethfugee tolerant!
 Fast and bulbous!
 People play on this server!
-F R E E D R O N E
-Democratic and Spastic!

--- a/yogstation/strings/taglines.txt
+++ b/yogstation/strings/taglines.txt
@@ -1,4 +1,5 @@
-now 100% snail-free
+Now 100% snail-free
 10% MORE LAG FOR THE SAME PRICE
 Yoghurt Station 13
-We have deoderant!
+We have deodorant!
+Yoga Station 13

--- a/yogstation/strings/taglines.txt
+++ b/yogstation/strings/taglines.txt
@@ -1,2 +1,3 @@
 now 100% snail-free
 10% MORE LAG FOR THE SAME PRICE
+YoghurtStation 13

--- a/yogstation/strings/taglines.txt
+++ b/yogstation/strings/taglines.txt
@@ -1,3 +1,3 @@
 now 100% snail-free
 10% MORE LAG FOR THE SAME PRICE
-YoghurtStation 13
+Yoghurt Station 13

--- a/yogstation/strings/taglines.txt
+++ b/yogstation/strings/taglines.txt
@@ -1,5 +1,14 @@
-Now 100% snail-free
-10% MORE LAG FOR THE SAME PRICE
-Yoghurt Station 13
+Now 100% snail-free!
+10% MORE LAG FOR THE SAME PRICE!
+Yoghurt Station 13!
 We have deodorant!
 Yoga Station 13
+Mostly tolerant to lizardpeople!
+Mostly murderbone-free!
+WARNING: CONTAINS NTSL
+Praise the Clockwork Justicar!
+Ssethfugee tolerant!
+Fast and bulbous!
+People play on this server!
+F R E E D R O N E
+Democratic and Spastic!


### PR DESCRIPTION
The idea is [this](https://github.com/Citadel-Station-13/Citadel-Station-13/commit/104a3406a0ae94b18b6bb5cf2590985af2588d9e), but I implented it differently, having a list of taglines that it would pick from whenever world.update_status() is called

#### I would very much appreciate new taglines.

:cl:  deathride58
rscadd: the server now has a tagline on the byond hub
/:cl:
