### PR TITLE
[admin] Slightly Improves the Admin Viewrange Verb, Allows for Custom Viewranges

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -742,9 +742,8 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	if(view == CONFIG_GET(string/default_view))
 		//yogs start -- Adds customization and warnings
-		var/defview = CONFIG_GET(string/default_view)
-		var/newview = input("Select view range:", "FUCK YE", defview) in list(defview,10,12,14,32,64,128,"Custom...")
-		if(newview == "Custom")
+		var/newview = input("Select view range:", "FUCK YE", 7) in list(7,10,12,14,32,64,128,"Custom...")
+		if(newview == "Custom...")
 			newview = input("Enter custom view range:","FUCK YEEEEE") as num
 			if(!newview)
 				return

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -748,7 +748,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 			if(!newview)
 				return
 		if(newview > 64)
-			if(!alert("Warning: Setting your view range to that large size may cause horrendous lag, visual bugs, and/or game crashes. Are you sure?","Yes","No") != "Yes")
+			if(alert("Warning: Setting your view range to that large size may cause horrendous lag, visual bugs, and/or game crashes. Are you sure?",,"Yes","No") != "Yes")
 				return
 		change_view(newview)
 		//yogs end

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -741,7 +741,18 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	set desc = "switches between 1x and custom views"
 
 	if(view == CONFIG_GET(string/default_view))
-		change_view(input("Select view range:", "FUCK YE", 7) in list(1,2,3,4,5,6,7,8,9,10,11,12,13,14,128))
+		//yogs start -- Adds customization and warnings
+		var/defview = CONFIG_GET(string/default_view)
+		var/newview = input("Select view range:", "FUCK YE", defview) in list(defview,10,12,14,32,64,128,"Custom...")
+		if(newview == "Custom")
+			newview = input("Enter custom view range:","FUCK YEEEEE") as num
+			if(!newview)
+				return
+		if(newview > 64)
+			if(!alert("Warning: Setting your view range to that large size may cause horrendous lag, visual bugs, and/or game crashes. Are you sure?","Yes","No") != "Yes")
+				return
+		change_view(newview)
+		//yogs end
 	else
 		change_view(CONFIG_GET(string/default_view))
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -497,6 +497,11 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set name = "View Range"
 	set desc = "Change your view range."
 
+	//yogs start -- Divert this verb to the admin variant if this guy has it
+	if(hascall(usr,"toggle_view_range"))
+		call(usr,"toggle_view_range")()
+		return
+	//yogs end
 	var/max_view = client.prefs.unlock_content ? GHOST_MAX_VIEW_RANGE_MEMBER : GHOST_MAX_VIEW_RANGE_DEFAULT
 	if(client.view == CONFIG_GET(string/default_view))
 		var/list/views = list()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -498,8 +498,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set desc = "Change your view range."
 
 	//yogs start -- Divert this verb to the admin variant if this guy has it
-	if(hascall(usr,"toggle_view_range"))
-		call(usr,"toggle_view_range")()
+	if(hascall(usr.client,"toggle_view_range"))
+		call(usr.client,"toggle_view_range")()
 		return
 	//yogs end
 	var/max_view = client.prefs.unlock_content ? GHOST_MAX_VIEW_RANGE_MEMBER : GHOST_MAX_VIEW_RANGE_DEFAULT


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/55599073-9eb66d80-571b-11e9-9bd5-8c7bb878da38.png)


So ghosted admins ATM get two different verbs for changing their view range, one from the ghost tab and one in the Special Verbs tab. I have now effectively merged those two verbs together, by having any attempt to use the ghost version just send you to the admin version instead.

Additionally, I've spruced up the admin version by changing the default list of options and allowing a custom view range, in case you for some reason wanted a view range between 14 and motherfucking 128.

There's also now an actual warning for when you try to set your view range to something absurdly high.

#### Changelog

:cl:  Altoids
bugfix: Admins should no longer have two basically-equivalent versions of the same verb when observing, with one of them being objectively worse.
/:cl:
