### PR TITLE
[admin] Makes nonstandard radio frequencies have a colour different from Common

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -15,7 +15,10 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	"[FREQ_SYNDICATE]" = "syndradio",
 	"[FREQ_CENTCOM]" = "centcomradio",
 	"[FREQ_CTF_RED]" = "redteamradio",
-	"[FREQ_CTF_BLUE]" = "blueteamradio"
+	//yogs start -- alternative radio freqs being a different color
+	"[FREQ_CTF_BLUE]" = "blueteamradio",
+	"[FREQ_COMMON]" = "commonradio"
+	//yogs end
 	))
 
 /atom/movable/proc/say(message, bubble_type, var/list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)

--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -276,7 +276,8 @@ em						{font-style: normal;	font-weight: bold;}
 .binarysay    			{color: #20c20e; background-color: #000000; display: block;}
 .binarysay a  			{color: #00ff00;}
 .binarysay a:active, .binarysay a:visited {color: #88ff88;}
-.radio					{color: #008000;}
+.radio					{color: #839e85;} /* yogs -- general radio usage, noncommon*/
+.commonradio			{color: #008000;} /* yogs -- Standard green radio chatter, for common only*/
 .sciradio				{color: #993399;}
 .comradio				{color: #204090;}  /* yogs */
 .secradio				{color: #a30000;}

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -41,7 +41,8 @@ em						{font-style: normal;	font-weight: bold;}
 .binarysay    			{color: #20c20e; background-color: #000000; display: block;}
 .binarysay a  			{color: #00ff00;}
 .binarysay a:active, .binarysay a:visited {color: #88ff88;}
-.radio					{color: #008000;}
+.radio					{color: #839e85;} /* yogs -- general radio usage, noncommon*/
+.commonradio			{color: #008000;} /* yogs -- Standard green radio chatter, for common only*/
 .sciradio				{color: #993399;}
 .comradio				{color: #204090;} /* yogs */
 .secradio				{color: #a30000;}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/55602903-85b6b800-572d-11e9-8470-37491472ce17.png)
Now, any radio frequency that does not have a solid purpose or name (like 1451 or something) now have their own colour to mark their miscellaneousness.

Hopefully this makes adminning while someone's running a consolidating NTSL script a whole lot easier.

I'm probably going to have to tinker with this later to get #4857 merged and working but, eh.

#### Changelog

:cl:  Altoids
rscadd: Nonstandard radio frequencies now have their own colour!
/:cl:
