### PR TITLE
Removes auto-blue alert, removes antag message

### DIFF
--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2852,6 +2852,7 @@
 #include "yogstation\code\game\world.dm"
 #include "yogstation\code\game\area\areas.dm"
 #include "yogstation\code\game\area\Space_Station_13_areas.dm"
+#include "yogstation\code\game\gamemodes\game_mode.dm"
 #include "yogstation\code\game\gamemodes\objective.dm"
 #include "yogstation\code\game\gamemodes\objective_items.dm"
 #include "yogstation\code\game\gamemodes\battle_royale\battleroyale.dm"

--- a/yogstation/code/game/gamemodes/game_mode.dm
+++ b/yogstation/code/game/gamemodes/game_mode.dm
@@ -1,0 +1,9 @@
+/datum/game_mode/send_intercept()
+	var/intercepttext = "<b><i>Central Command Status Summary</i></b><hr>"
+	if(station_goals.len)
+		intercepttext += "<b>Special Orders for [station_name()]:</b><br>"
+		for(var/datum/station_goal/G in station_goals)
+			G.on_report()
+			intercepttext += G.get_report()
+	print_command_report(intercepttext, "Central Command Status Summary", announce=FALSE)
+	priority_announce("A summary has been copied and printed to all communications consoles.", "Station orders received.", 'sound/ai/commandreport.ogg')


### PR DESCRIPTION
#### Changelog

:cl:  
tweak: the roundstart report no longer specifies that antags exist or whether they exist at all, and it now doesn't escalate to blue alert either.
/:cl:
