### PR TITLE
Prevents syndiborgs from using donor skins

### DIFF
--- a/yogstation/code/modules/mob/living/silicon/robot/robot.dm
+++ b/yogstation/code/modules/mob/living/silicon/robot/robot.dm
@@ -2,14 +2,14 @@
 	icon = initial(icon) //Redundancy in case they repick a skin after modulechange
 	if(!GLOB.DonorBorgHolder)
 		message_admins("[client.ckey] just tried to change their borg skin, but there is no borg skin holder datum! (Has the game not started yet?)")
-		to_chat(src, "An error occured, if the game has not started yet, please try again after it has. The admins have been notified about this")
+		to_chat(src, "<span class='warning'>An error occured, if the game has not started yet, please try again after it has. The admins have been notified about this.</span>")
 		return FALSE
 	if(forced || is_donator(client))//First off, are we even meant to have this verb? or is an admin bruteforcing it onto a non donator for some reason?
 		if(module.name == "Default")
 			to_chat(src, "Please choose a module first! (Standard works too)")
 			return FALSE
-		if(module.name == "Syndicate")
-			to_chat(src, "You cannot reskin a syndicate cyborg :(")
+		if(ROLE_SYNDICATE in faction)
+			to_chat(src, "<span class='warning'>You cannot reskin as a syndicate cyborg!</span>")
 			return FALSE
 		var/datum/borg_skin/skins = list("default" = icon(icon = src.icon, icon_state = module.cyborg_base_icon))
 		for(var/T in GLOB.DonorBorgHolder.skins)
@@ -23,7 +23,7 @@
 		if(!A)
 			return FALSE
 		if(!istype(A))
-			to_chat(src, "You've chosen to use the standard skinset instead of a custom one")
+			to_chat(src, "You've chosen to use the standard skinset instead of a custom one.")
 			special_skin = FALSE
 			return FALSE
 		icon =  A.icon
@@ -32,7 +32,7 @@
 		eye_lights.icon = A.icon
 		eye_lights.icon_state = "[icon_state]_e[is_servant_of_ratvar(src) ? "_r" : ""]"
 		add_overlay(eye_lights)
-		to_chat(src, "You have successfully applied the skin: [A.name]")
+		to_chat(src, "<span class='notice'>You have successfully applied the skin: [A.name]</span>")
 		special_skin = TRUE
 		return TRUE
 
@@ -53,4 +53,4 @@
 
 /mob/living/silicon/robot/examine(mob/user)
 	. = ..()
-	to_chat(user, "It seems to have the [module.name] module loaded")
+	to_chat(user, "It seems to have the <b>[module.name] module</b> loaded.")


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/29939414/55850875-dd816480-5b1b-11e9-9756-3747dd406c1f.png)

Apparently KMC was doing the "Are you syndicate?" check with this:
```dm
        if(module.name == "Syndicate")
            to_chat(src, "You cannot reskin a syndicate cyborg :(")
            return FALSE
```
Which doesn't work when the borg is a syndiborg that does not have the generic Syndiborg module (like the saboteur or medical ones).

So, uh, fixed that. Also tweaked some of the dialogue to make it look nicer.

#### Changelog

:cl:  Altoids
bugfix: Syndicate Cyborgs can no longer use donor skins.
spellcheck: Tweaked some of the Donorborg dialogue, added some spans and grammar fixes.
/:cl:
