### PR TITLE
[admin] Makes the Eyeballs-popping-out symptom only usable through adminbus

### DIFF
--- a/code/datums/diseases/advance/symptoms/vision.dm
+++ b/code/datums/diseases/advance/symptoms/vision.dm
@@ -20,7 +20,7 @@ Bonus
 	name = "Hyphema"
 	desc = "The virus causes inflammation of the retina, leading to eye damage and eventually blindness."
 	stealth = -1
-	resistance = -9
+	resistance = -4
 	stage_speed = -4
 	transmittable = -3
 	level = 5
@@ -37,8 +37,10 @@ Bonus
 		return
 	if(A.properties["stealth"] >= 4)
 		suppress_warning = TRUE
-	if(A.properties["resistance"] >= 12) //goodbye eyes
-		remove_eyes = TRUE
+//yogs start - Makes eyeball popping not possible without admin intervention.
+//	if(A.properties["resistance"] >= 12) //goodbye eyes
+//		remove_eyes = TRUE
+//yogs end
 
 /datum/symptom/visionloss/Activate(datum/disease/advance/A)
 	if(!..())

--- a/code/datums/diseases/advance/symptoms/vision.dm
+++ b/code/datums/diseases/advance/symptoms/vision.dm
@@ -20,7 +20,7 @@ Bonus
 	name = "Hyphema"
 	desc = "The virus causes inflammation of the retina, leading to eye damage and eventually blindness."
 	stealth = -1
-	resistance = -4
+	resistance = -9
 	stage_speed = -4
 	transmittable = -3
 	level = 5

--- a/code/datums/diseases/advance/symptoms/vision.dm
+++ b/code/datums/diseases/advance/symptoms/vision.dm
@@ -29,8 +29,7 @@ Bonus
 	symptom_delay_min = 25
 	symptom_delay_max = 80
 	var/remove_eyes = FALSE
-	threshold_desc = "<b>Resistance 12:</b> Weakens extraocular muscles, eventually leading to complete detachment of the eyes.<br>\
-					  <b>Stealth 4:</b> The symptom remains hidden until active."
+	threshold_desc = "<b>Stealth 4:</b> The symptom remains hidden until active." // Yogs -- Eyeball removal... removal
 
 /datum/symptom/visionloss/Start(datum/disease/advance/A)
 	if(!..())


### PR DESCRIPTION
### Makes eyeball removal impossible without future changes to virology or admin intervention.

Staff consensus against having a virus removing the eyeball organ from players en masse.

#### Changelog

:cl:  Qe
tweak: Makes eyeball organ removal from Hyphema require admin intervention.
/:cl: