### PR TITLE
Makes preternis and ethereals not lose charge while dead

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -88,6 +88,8 @@
 
 /datum/species/ethereal/spec_life(mob/living/carbon/human/H)
 	.=..()
+	if(H.stat == DEAD)
+		return
 	handle_charge(H)
 
 /datum/species/ethereal/spec_fully_heal(mob/living/carbon/human/H)

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -144,6 +144,8 @@ adjust_charge - take a positive or negative value to adjust the charge level
 
 /datum/species/preternis/spec_life(mob/living/carbon/human/H)
 	. = ..()
+	if(H.stat == DEAD)
+		return
 	handle_charge(H)
 
 /datum/species/preternis/proc/handle_charge(mob/living/carbon/human/H)


### PR DESCRIPTION
### Intent of your Pull Request

Fixes #5094. 

The issue mentions that spec_life works while mobs are dead, but I'm reasonably sure that (at least based on plasma golem code) this is intended and required for existing behavior, so I just added specific checks to each of their spec_life procs.

#### Changelog

:cl: Putnam
bugfix: Makes dead preternis and ethereals no longer lose charge.
/:cl:
