### PR TITLE
(Revert PR) re-adds speed potions for Red Slimes

### DIFF
--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -380,13 +380,10 @@
 	required_reagents = list("water" = 1)
 	required_container = /obj/item/slime_extract/red
 	required_other = TRUE
-// yogs start
-/*
+
 /datum/chemical_reaction/slime/slimespeed/on_reaction(datum/reagents/holder)
 	new /obj/item/slimepotion/speed(get_turf(holder.my_atom))
 	..()
-*/
-// yogs end
 
 //Pink
 /datum/chemical_reaction/slime/docility


### PR DESCRIPTION
Reverts yogstation13/Yogstation-TG#4178

```dm
/obj/item/slimepotion/speed/afterattack(obj/C, mob/user)
    . = ..()
    if(!istype(C))
        to_chat(user, "<span class='warning'>The potion can only be used on items or vehicles!</span>")
        return
    if(isitem(C))
        // yogs start - change speed potion
        var/obj/item/I = C
        if(I.slowdown <= 2 || I.obj_flags & IMMUTABLE_SLOW)
            to_chat(user, "<span class='warning'>The [C] can't be made any faster!</span>")
            return ..()
        I.slowdown--
        // yogs end

    if(istype(C, /obj/vehicle))
        var/obj/vehicle/V = C
        var/datum/component/riding/R = V.GetComponent(/datum/component/riding)
        if(R)
            // yogs start - change speed potion
            if(R.vehicle_move_delay <= 2 )
                to_chat(user, "<span class='warning'>The [C] can't be made any faster!</span>")
                return ..()
            R.vehicle_move_delay--
            // yogs end
```
Considering that ThatLing had already nerfed the speed potion plenty in #4149, and nobody's yet to find a replacement for the Red & Water reaction, we might as well put this back in.

Closes #5164

### Changelog
:cl: Altoids
rscadd: Red slimes are now capable of making speed potions again!
/:cl: