### PR TITLE
Fixes antags getting 'Nothing' objectives

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -110,8 +110,11 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 			try_target_late_joiners = TRUE
 	for(var/datum/mind/possible_target in get_crewmember_minds())
 		if(!(possible_target in owners) && ishuman(possible_target.current) && (possible_target.current.stat != DEAD) && is_unique_objective(possible_target,dupe_search_range))
-			if(!((possible_target.current.client.prefs.toggles & QUIET_ROUND) && !possible_target.antag_datums.len))//Yogs -- Fixes Quiet Rounds (the second bit allows quiet rounders chosen to be antags, to be targetted)
+			//yogs start -- Quiet Rounds
+			var/mob/living/carbon/human/guy = possible_target.current
+			if(possible_target.antag_datums.len || (guy.client && (guy.client.prefs.toggles & QUIET_ROUND)))
 				possible_targets += possible_target//yogs indent
+			//yogs end
 	if(try_target_late_joiners)
 		var/list/all_possible_targets = possible_targets.Copy()
 		for(var/I in all_possible_targets)

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -112,7 +112,7 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 		if(!(possible_target in owners) && ishuman(possible_target.current) && (possible_target.current.stat != DEAD) && is_unique_objective(possible_target,dupe_search_range))
 			//yogs start -- Quiet Rounds
 			var/mob/living/carbon/human/guy = possible_target.current
-			if(possible_target.antag_datums.len || (guy.client && (guy.client.prefs.toggles & QUIET_ROUND)))
+			if(possible_target.antag_datums.len || !(guy.client && (guy.client.prefs.toggles & QUIET_ROUND)))
 				possible_targets += possible_target//yogs indent
 			//yogs end
 	if(try_target_late_joiners)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/56546518-559a5200-6540-11e9-8199-bb39f5f910a4.png)

Fixes #5170 

I, in the previous code, incorrectly make the assumption that all crewmember minds have a client. This is not always true, especially for mid-game antags spawned on highpop rounds.

This has been fixed. I've also improved the logic of the if-statement some to be a bit more readable.

#### Changelog

:cl:  Altoids
bugfix: Antags should now properly receive their objectives!
/:cl:
