### PR TITLE
Fixes Nightmares not having snazzy names

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -49,7 +49,7 @@
 	. = ..()
 	to_chat(C, "[info_text]")
 
-	C.fully_replace_character_name("[pick(GLOB.nightmare_names)]")
+	C.fully_replace_character_name("[C.real_name]","[pick(GLOB.nightmare_names)]") // Yogs -- fixes nightmares not having special spooky names. this proc takes the old name first, and *THEN* the new name!
 
 /datum/species/shadow/nightmare/bullet_act(obj/item/projectile/P, mob/living/carbon/human/H)
 	var/turf/T = H.loc


### PR DESCRIPTION
```dm
/mob/proc/fully_replace_character_name(oldname,newname)
```
So the thing is that this proc takes *two* arguments: The old name, and the new name.

Apparently /TG/ coded in Nightmares only giving it one argument, meaning it would sliently just give up and return ``0`` instead of giving the guy a new name, so, uh, fixed that then.

Fixes #5156.

### Changelog

:cl:  Altoids
bugfix: Nightmares should now have actually spooky names.
/:cl:
