### PR TITLE
Revert "Forces IAA to get good and removes their access to ez mulligan"

### DIFF
--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -39,9 +39,6 @@
 /datum/uplink_item/role_restricted/his_grace
 	include_objectives = list(/datum/objective/hijack)
 
-/datum/uplink_item/stealthy_tools/mulligan
-	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops, /datum/game_mode/traitor/internal_affairs)
-
 //////////////////////////
 /////////New Items////////
 //////////////////////////


### PR DESCRIPTION
Reverts yogstation13/Yogstation-TG#5183

Fix the tracker to always track the target instead of removing a traitor item altogether from a gamemode. 
