### PR TITLE
Makes gang-domming require the nuke-disk

### DIFF
--- a/yogstation/code/game/gamemodes/gangs/dominator.dm
+++ b/yogstation/code/game/gamemodes/gangs/dominator.dm
@@ -20,6 +20,7 @@
 	var/spam_prevention = DOM_BLOCKED_SPAM_CAP //first message is immediate
 	var/datum/effect_system/spark_spread/spark_system
 	var/obj/effect/countdown/dominator/countdown
+	var/obj/item/disk/nuclear/nukedisk
 
 /obj/machinery/dominator/Initialize()
 	set_light(2)
@@ -38,6 +39,9 @@
 	QDEL_NULL(spark_system)
 	QDEL_NULL(countdown)
 	STOP_PROCESSING(SSmachines, src)
+	if(nukedisk)
+		nukedisk.forceMove(drop_location())
+		nukedisk = null
 	return ..()
 
 /obj/machinery/dominator/emp_act(severity)
@@ -78,6 +82,8 @@
 			to_chat(user, "<span class='notice'>Hostile Takeover of [station_name()] successful. Have a great day.</span>")
 	else
 		to_chat(user, "<span class='notice'>System on standby.</span>")
+	if(nukedisk)
+		to_chat(user, "<span class='notice'>[nukedisk] seems to be stuck inside.</span>")
 	to_chat(user, "<span class='danger'>System Integrity: [round((obj_integrity/max_integrity)*100,1)]%</span>")
 
 /obj/machinery/dominator/process()
@@ -171,6 +177,10 @@
 		to_chat(user, "<span class='warning'>Error: Unable to breach station network. Firewall has logged our signature and is blocking all further attempts.</span>")
 		return
 
+	if(!nukedisk)
+		to_chat(user, "<span class='warning'>Error: Nuclear Authentication Disk required to breach station network.</span>")
+		return
+
 	var/time = round(tempgang.determine_domination_time()/60,0.1)
 	if(alert(user,"A takeover will require [time] minutes.\nYour gang will be unable to gain influence while it is active.\nThe entire station will likely be alerted to it once it starts.\nYou have [tempgang.dom_attempts] attempt(s) remaining. Are you ready?","Confirm","Ready","Later") == "Ready")
 		if((tempgang.domination_time != NOT_DOMINATING) || !tempgang.dom_attempts || !in_range(src, user) || !isturf(loc))
@@ -236,6 +246,28 @@
 	stat |= BROKEN
 	update_icon()
 	STOP_PROCESSING(SSmachines, src)
+	if(nukedisk)
+		nukedisk.forceMove(drop_location())
+		nukedisk = null
+
+/obj/machinery/dominator/attackby(obj/item/I, mob/user, params)
+	if (istype(I, /obj/item/disk/nuclear))
+		if(!disk_check(I))
+			return
+		if(!user.transferItemToLoc(I, src))
+			return
+		nukedisk = I
+		add_fingerprint(user)
+		return
+
+	.=..()
+
+/obj/machinery/dominator/proc/disk_check(obj/item/disk/nuclear/D)
+	if(D.fake)
+		say("Authentication failure; disk not recognised.")
+		return FALSE
+	else
+		return TRUE
 
 #undef DOM_BLOCKED_SPAM_CAP
 #undef DOM_REQUIRED_TURFS

--- a/yogstation/code/game/gamemodes/gangs/gang_items.dm
+++ b/yogstation/code/game/gamemodes/gangs/gang_items.dm
@@ -234,6 +234,12 @@
 	var/obj/item/O = new item_path(user.loc, gang)
 	user.put_in_hands(O)
 
+/datum/gang_item/equipment/pinpointer
+	name = "Pinpointer"
+	id = "pinpointer"
+	cost = 2
+	item_path = /obj/item/pinpointer/nuke
+
 /datum/gang_item/equipment/sharpener
 	name = "Sharpener"
 	id = "whetstone"


### PR DESCRIPTION
### Intent of your Pull Request

see: https://github.com/yogstation13/yogstation/pull/3033

The intent is to make gangs/security actually need to fight over something (that being the disk), and to give security a more pro-active role in defending the disk rather than a purely reactive role. Oh and preventing situations where two gangs have a dominator each and they just sit around.

#### Changelog

:cl:  
tweak: gang dominators now require the nuclear authentication disk, so only 1 gang can dominate at a time, and security can have a more pro-active role in the conflict.
rscadd: gangs can now buy a pinpointer for 3 influence, since they kinda need to find the nuke disk.
/:cl:
