### PR TITLE
Fixes the weighted headrole assignment thing not working at all

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -189,7 +189,7 @@ SUBSYSTEM_DEF(job)
 			var/list/candidates = FindOccupationCandidates(job, level)
 			if(!candidates.len)
 				continue
-			var/mob/dead/new_player/candidate = pick(candidates)
+			var/mob/dead/new_player/candidate = PickCommander(candidates) // Yogs -- makes command jobs weighted towards players of greater experience
 			if(AssignRole(candidate, command_position))
 				return 1
 	return 0

--- a/yogstation/code/controllers/subsystem/jobs.dm
+++ b/yogstation/code/controllers/subsystem/jobs.dm
@@ -1,8 +1,8 @@
 /datum/controller/subsystem/job/proc/PickCommander(candidates,jobname) 
 	// Takes in a list of potential command role candidates from CheckHeadPositions and FindOccupation Candidates, and picks one weightedly based on hours.
 	var/list/pickweightfood = list() // The list we'll be feeding to pickweights()
-	for(var/i in candidates)
-		var/mob/dead/new_player/candidate = candidates[i]
+	for(var/x in candidates)
+		var/mob/dead/new_player/candidate = x
 		var/minutes = candidate.client.prefs.exp[jobname]
 		if(!minutes || minutes < 600) 
 			minutes = 600 // Prevents fresh new guys from causing undefined errors or being 1000x less likely to get a role, when using log scale


### PR DESCRIPTION
Caused by https://github.com/yogstation13/Yogstation-TG/pull/4732

There were two problems:
- There was a runtime inside of ``PickCommander()`` that stopped it from working
- There are actually *two* procs responsible for dishing out headroles (one of which was actually the only one that's been working for like month due to the aforementioned runtime), and ``PickCommander()`` was only placed in the (ergo broken) one.

I fixed these two problems.

#### Changelog

:cl:  Altoids
bugfix: Weighted headrole assignment should now actually properly work.
/:cl:
