### PR TITLE
Fixes weird focusing issues with the Comms Console's browser window

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -379,7 +379,9 @@
 		if("ai-status")
 			aistate = STATE_STATUSDISPLAY
 		if("ai-announce")
+			is_announcing = TRUE
 			make_announcement(usr, 1)
+			is_announcing = FALSE
 		if("ai-securitylevel")
 			tmp_alertlevel = text2num( href_list["newalertlevel"] )
 			if(!tmp_alertlevel)
@@ -417,7 +419,7 @@
 			deadchat_broadcast("<span class='deadsay bold'>[usr.real_name] disabled emergency maintenance access.</span>", usr)
 			aistate = STATE_DEFAULT
 
-	updateUsrDialog()
+	if(!is_announcing) updateUsrDialog() // Yogs -- fixes AI flickery weirdness
 
 /obj/machinery/computer/communications/attackby(obj/I, mob/user, params)
 	if(istype(I, /obj/item/card/id))

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -580,8 +580,8 @@
 
 	popup.set_content(dat)
 	popup.open()
-	popup.set_content(dat)
-	popup.open()
+	//popup.set_content(dat) //Yogs comment-out, was causing weird issues for AIs.
+	//popup.open()
 
 /obj/machinery/computer/communications/proc/get_javascript_header(form_id)
 	var/dat = {"<script type="text/javascript">

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2886,6 +2886,7 @@
 #include "yogstation\code\game\machinery\suit_storage_unit.dm"
 #include "yogstation\code\game\machinery\computer\arcade.dm"
 #include "yogstation\code\game\machinery\computer\atmos_sim.dm"
+#include "yogstation\code\game\machinery\computer\communications.dm"
 #include "yogstation\code\game\machinery\computer\crew.dm"
 #include "yogstation\code\game\machinery\computer\medical.dm"
 #include "yogstation\code\game\machinery\computer\Operating.dm"

--- a/yogstation/code/game/machinery/computer/communications.dm
+++ b/yogstation/code/game/machinery/computer/communications.dm
@@ -1,0 +1,2 @@
+/obj/machinery/computer/communications
+	var/is_announcing = FALSE // Fixes a weird flickering bug for AIs with the comms console


### PR DESCRIPTION
So TheSlipperyCarp informed me today that there was some weird issue with the Comms console browser window randomly focusing while AIs operated it, forcing them to engage in a focus battle.

When I wandered on over to the Comms console code, I saw this in Topic():
```dm
	popup.set_content(dat)
	popup.open()
	popup.set_content(dat)
	popup.open()
```
which meant that the window was updating itself twice over every time it updated.

I checked the PR that caused this, and it happened to be the one that implemented alternative shuttles: https://github.com/tgstation/tgstation/pull/21398

However OP is a f't and doesn't provide explanation nor comment on why it was duplicated, so I didn't know for sure if it was intentional.

However, I did come across Nich's port of this PR, over here: https://github.com/yogstation13/yogstation/pull/2728/files

Which did not have the same duplication, and I believe that PR worked fine. Ergo, I can conclude this is some dumb /TG/ bullshit that ought to be snipped out.

#### Changelog

:cl:  Altoids
bugfix: The Comms Console browser window should no longer get into fights with you when you operate it as an AI.
/:cl:
