### PR TITLE
Shuffles donor item list and adds a few other items.

### DIFF
--- a/yogstation/code/modules/donor/donor_items.dm
+++ b/yogstation/code/modules/donor/donor_items.dm
@@ -72,7 +72,6 @@ var/list/donor_start_tools = list(\
 						/obj/item/bedsheet/centcom, \
 						/obj/item/bedsheet/syndie, \
 						/obj/item/bikehorn/airhorn, \
-						/obj/item/bikehorn/rubber_pigeon, \
 						/obj/item/camera, \
 						/obj/item/cane, \
 						/obj/item/clothing/shoes/sneakers/rainbow, \

--- a/yogstation/code/modules/donor/donor_items.dm
+++ b/yogstation/code/modules/donor/donor_items.dm
@@ -57,7 +57,27 @@ var/list/donor_start_items = list(\
 						/obj/item/clothing/head/wizard/fake/red, \
 						/obj/item/clothing/head/wizard/fake/yellow, \
 						/obj/item/clothing/head/wizard/fake/black, \
-						/obj/item/clothing/head/wizard/marisa/fake, \
+						/obj/item/clothing/head/wizard/marisa/fake
+						)
+
+var/list/donor_pdas = list("Normal", "Transparent", "Pip Boy", "Rainbow")
+
+var/list/donor_start_tools = list(\
+						/obj/item/storage/backpack/snail/green, \
+						/obj/item/banhammer, \
+						/obj/item/bedsheet/cosmos, \
+						/obj/item/bedsheet/wiz, \
+						/obj/item/bedsheet/cult, \
+						/obj/item/bedsheet/nanotrasen, \
+						/obj/item/bedsheet/centcom, \
+						/obj/item/bedsheet/syndie, \
+						/obj/item/bikehorn/airhorn, \
+						/obj/item/bikehorn/rubber_pigeon, \
+						/obj/item/camera, \
+						/obj/item/cane, \
+						/obj/item/clothing/shoes/sneakers/rainbow, \
+						/obj/item/clothing/gloves/color/rainbow, \
+						/obj/item/clothing/under/color/rainbow, \
 						/obj/item/clothing/neck/yogs/sith_cloak, \
 						/obj/item/clothing/suit/yogs/armor/sith_suit, \
 						/obj/item/clothing/suit/yogs/armor/hardsuit_clown, \
@@ -69,24 +89,8 @@ var/list/donor_start_items = list(\
 						/obj/item/clothing/shoes/yogs/trainers/black, \
 						/obj/item/clothing/suit/yogs/zebrasweat, \
 						/obj/item/clothing/suit/yogs/blackwhitesweat, \
-						/obj/item/clothing/shoes/yogs/fuzzy_slippers
-						)
-
-var/list/donor_pdas = list("Normal", "Transparent", "Pip Boy", "Rainbow")
-
-var/list/donor_start_tools = list(\
-						/obj/item/storage/backpack/snail/green, \
-						/obj/item/banhammer, \
-						/obj/item/bedsheet/cosmos, \
-						/obj/item/bedsheet/wiz, \
-						/obj/item/bedsheet/nanotrasen, \
-						/obj/item/bedsheet/syndie, \
-						/obj/item/bikehorn/airhorn, \
-						/obj/item/camera, \
-						/obj/item/cane, \
-						/obj/item/clothing/shoes/sneakers/rainbow, \
-						/obj/item/clothing/gloves/color/rainbow, \
-						/obj/item/clothing/under/color/rainbow, \
+						/obj/item/clothing/shoes/yogs/fuzzy_slippers, \
+						/obj/item/clothing/suit/xenos, \
 						/obj/item/grown/sunflower, \
 						/obj/item/hot_potato/harmless/toy, \
 						/obj/item/instrument/accordion, \


### PR DESCRIPTION
The hats section is now purely hats, with the others being moved to the item section. This allows you to have both the clown hardsuit helm and suit, and the sith suit and hood. 
No new hats were added but to the items section:
- Cult bedsheet
- Centcom bedsheet
- xenos suit(to go with the collectable helmet)

if anyone wants anything else added ill happily do so.
#### Changelog

:cl:  Identification
rscadd: There are new donor items!
tweak: All non-hats from the donor hat section have been moved to items.
/:cl:
