### PR TITLE
Buffs the probabilistic anomaly

### DIFF
--- a/yogstation/code/modules/events/probabilistic_anomaly.dm
+++ b/yogstation/code/modules/events/probabilistic_anomaly.dm
@@ -14,7 +14,7 @@
 	priority_announce(alert)
 
 /datum/round_event/prob_anomaly/start()
-	endWhen = rand(45,120) // About 45 to 120 seconds, more or less
+	endWhen = rand(120,600) // About 2 to 10 minutes, more or less
 	seed = rand(1,1e9)
 	rand_seed(seed)
 	


### PR DESCRIPTION
I've yet to really see anything terribly wacky come out of this event yet, so I think it probably deserves some beefing up.

#### Changelog

:cl:  Altoids
tweak: The probabilistic anomaly now lasts typically 4x longer than it used to.
/:cl:
