### PR TITLE
Fixes a hypothetical, rare bug where the AI Core or SM could be powered down during a Grid Check

### DIFF
--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -1,9 +1,11 @@
 #define BP_MAX_ROOM_SIZE 300
 
-GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/engine/engineering, \
-															    /area/engine/supermatter, \
-															    /area/engine/atmospherics_engine, \
-															    /area/ai_monitored/turret_protected/ai))
+//Yogs start -- Fixes a very esoteric, mostly-hypothetical bug involving the fact that the /TG/ version doesn't use list() here
+GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(list(/area/engine/engineering,
+															    /area/engine/supermatter,
+															    /area/engine/atmospherics_engine,
+															    /area/ai_monitored/turret_protected/ai)))
+//Yogs end
 
 // Gets an atmos isolated contained space
 // Returns an associative list of turf|dirs pairs


### PR DESCRIPTION
So I was just reading the code a bit for funsies, looking up the definition of ``typecacheof()`` since I didn't really know how it worked:
```dm
/proc/typecacheof(path, ignore_root_path, only_root_path = FALSE)
```
When, in my Notepad++ search list, I come across this thing:
```dm
GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/engine/engineering, \
						    /area/engine/supermatter, \
						    /area/engine/atmospherics_engine, \
						    /area/ai_monitored/turret_protected/ai))
```
Notice that ``typecacheof`` only takes all the paths in as its *first* argument, with the other args reserved for some boolean flags. This means that this call to the proc doesn't actually work, and would only store ``/area/engine/engineering`` as a Grid Check exclusion zone.

However, when I went on a test server to check, I found this bullshit:
![image](https://user-images.githubusercontent.com/29939414/57193265-c5c0b480-6efe-11e9-863a-c0b975282404.png)

My suspicions were confirmed, but why would the AI core still be protected?

I then realized that perhaps there was *something else* redundantly defending the AI!
And sure enough, looking at the code for the Grid Check event, I found this:
```dm
/datum/round_event/grid_check/start()
	for(var/P in GLOB.apcs_list)
		var/obj/machinery/power/apc/C = P
		if(C.cell && is_station_level(C.z))
			var/area/A = C.area
			if(GLOB.typecache_powerfailure_safe_areas[A.type])
				continue

			C.energy_fail(rand(30,120))
```
followed by this:
```dm
/obj/machinery/power/apc/proc/energy_fail(duration)
	for(var/obj/machinery/M in area.contents)
		if(M.critical_machine)
			return
	for(var/A in GLOB.ai_list)
		var/mob/living/silicon/ai/I = A
		if(get_area(I) == area)
			return

	failure_timer = max(failure_timer, round(duration))
```

So *that's* why this didn't cause a bug. However, there may be some esoteric circumstances where this second check fails and the bug is revealed, so, I've fixed it.

Fuck /TG/.

#### Changelog

:cl:  Altoids
bugfix: The AI Core and SM Chamber are now absolutely protected against Grid Checks.
/:cl:
