### PR TITLE
Fixes Photo Bags not being able to hold photos

### DIFF
--- a/yogstation/code/modules/paperwork/photography.dm
+++ b/yogstation/code/modules/paperwork/photography.dm
@@ -6,7 +6,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
 
-obj/item/storage/photobook/ComponentInitialize()
+/obj/item/storage/photobook/ComponentInitialize()
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
@@ -22,10 +22,10 @@ obj/item/storage/photobook/ComponentInitialize()
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
 
-obj/item/storage/bag/photo/ComponentInitialize()
+/obj/item/storage/bag/photo/ComponentInitialize()
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
 	STR.max_combined_w_class = 50
 	STR.max_items = 50
-	STR.can_hold = typecacheof(/obj/item/camera_film,/obj/item/photo,/obj/item/storage/photo_album,/obj/item/camera,/obj/item/storage/photobook)
+	STR.can_hold = typecacheof(list(/obj/item/camera_film,/obj/item/photo,/obj/item/storage/photo_album,/obj/item/camera,/obj/item/storage/photobook))


### PR DESCRIPTION
Related to https://github.com/yogstation13/Yogstation-TG/pull/5334 , found it by doing a regex search for ``/typecacheof\((?!list)/`` to see if I could find this bug anywhere else.

#### Changelog

:cl:  Altoids
bugfix: Photo bags should now actually be able to store photos.
/:cl:
