### PR TITLE
[admin] Allows admins to view and manipulate the server queue

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -83,7 +83,8 @@ GLOBAL_PROTECT(admin_verbs_admin)
 	/client/proc/show_mentors, // yogs - mentors
 	/client/proc/reset_all_tcs, // yogs - NTSL, resets all NTSL scripts in world
 	/client/proc/subtlemessage_faction, // yogs -- SM to entire factions/antag types
-	/client/proc/nerf_or_nothing // yogs -- Groudon's meme nerf verb
+	/client/proc/nerf_or_nothing, // yogs -- Groudon's meme nerf verb
+	/client/proc/queue_check // Yogs -- Some queue manipulation/debuggin kinda verbs
 	)
 GLOBAL_LIST_INIT(admin_verbs_ban, list(/client/proc/unban_panel, /client/proc/ban_panel, /client/proc/stickybanpanel))
 GLOBAL_PROTECT(admin_verbs_ban)
@@ -137,7 +138,8 @@ GLOBAL_PROTECT(admin_verbs_server)
 	/client/proc/adminchangemap,
 	/client/proc/panicbunker,
 	/client/proc/toggle_hub,
-	/client/proc/mentor_memo /* YOGS - something stupid about "Mentor memos" */
+	/client/proc/mentor_memo, /* YOGS - something stupid about "Mentor memos" */
+	/client/proc/release_queue // Yogs -- Adds some queue-manipulation verbs
 	)
 GLOBAL_LIST_INIT(admin_verbs_debug, world.AVerbsDebug())
 GLOBAL_PROTECT(admin_verbs_debug)

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2985,6 +2985,7 @@
 #include "yogstation\code\modules\admin\verbs\adminvox.dm"
 #include "yogstation\code\modules\admin\verbs\fix_air.dm"
 #include "yogstation\code\modules\admin\verbs\one_click_antag.dm"
+#include "yogstation\code\modules\admin\verbs\queue.dm"
 #include "yogstation\code\modules\admin\verbs\spawnfloorcluwne.dm"
 #include "yogstation\code\modules\admin\verbs\telecomms.dm"
 #include "yogstation\code\modules\antagonists\_common\antag_datum.dm"

--- a/yogstation/code/modules/admin/verbs/queue.dm
+++ b/yogstation/code/modules/admin/verbs/queue.dm
@@ -7,9 +7,9 @@
 		return
 	
 	listclearnulls(SSticker.queued_players)
-	to_chat(usr,"<span class='notice'>List of queued players:</span>")
+	to_chat(usr,"<span class='notice'><b>List of queued players:/<b></span>")
 	for(var/mob/dead/new_player/guy in SSticker.queued_players)
-		to_chat(usr,"[guy]")
+		to_chat(usr,"\t[guy]")
 
 /client/proc/release_queue()
 	set category = "Server"

--- a/yogstation/code/modules/admin/verbs/queue.dm
+++ b/yogstation/code/modules/admin/verbs/queue.dm
@@ -1,0 +1,38 @@
+/client/proc/queue_check()
+	set category = "Server"
+	set name = "List Server Queue"
+	set desc = "Gives a list of all the people who are waiting in the queue to join the game."
+
+	if(!check_rights(R_ADMIN))
+		return
+	
+	listclearnulls(SSticker.queued_players)
+	to_chat(usr,"<span class='notice'>List of queued players:</span>")
+	for(var/mob/dead/new_player/guy in SSticker.queued_players)
+		to_chat(usr,"[guy]")
+
+/client/proc/release_queue()
+	set category = "Server"
+	set name = "Free Server Queue"
+	set desc = "Allows everyone in the current queue to play the game."
+	
+	if(!check_rights(R_SERVER))
+		return
+	
+	listclearnulls(SSticker.queued_players)
+	var/list/queue = SSticker.queued_players
+	
+	if(!queue.len)
+		to_chat(usr,"<span class='warning'>There is nobody in the server queue!</span>")
+		return
+	
+	if(alert("Are you sure you want to allow [queue.len] people to skip the queue and join the game?",,"Yes","No") != "Yes")
+		return
+	
+	//Below is basically a clone of whatever's in that one part of check_queue()
+	for (var/mob/dead/new_player/NP in queue)
+		to_chat(NP, "<span class='userdanger'>The alive players limit has been released!<br><a href='?src=[REF(NP)];late_join=override'>[html_encode(">>Join Game<<")]</a></span>")
+		SEND_SOUND(NP, sound('sound/misc/notice1.ogg'))
+		NP.LateChoices()
+	queue.len = 0
+	SSticker.queue_delay = 0


### PR DESCRIPTION
So as it stands, there's no real easy way of viewing the queue and interacting with it as an admin in a live game without fancy varediting, so I thought it'd be convenient if there were some additional verbs to viewing the server queue and emptying it in the case of a bug.

All-in-all this is mostly just to help me debug this so that the 20-man queues that we used to have don't last for nearly as long as they did ever again.

#### Changelog
:cl:  Altoids
rscadd: Admins can now view how many people are in the server queue, as well as empty the queue to let'em all in.
/:cl:
