### PR TITLE
[admin] Allows all mobs of type /mob/living to be (SMITE)'d, even non-humanoids

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1169,9 +1169,9 @@
 		if(!check_rights(R_ADMIN|R_FUN))
 			return
 
-		var/mob/living/carbon/human/H = locate(href_list["adminsmite"]) in GLOB.mob_list
+		var/mob/living/H = locate(href_list["adminsmite"]) in GLOB.mob_list // Yogs -- mob/living instead of mob/living/carbon/human
 		if(!H || !istype(H))
-			to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human")
+			to_chat(usr, "This can only be used on instances of type /mob/living") // Yogs -- mob/living instead of mob/living/carbon/human
 			return
 
 		usr.client.smite(H)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/57296554-e0c42d80-7092-11e9-8150-1813b2243ae0.png)
![image](https://user-images.githubusercontent.com/29939414/57420254-5bdd2f00-71cc-11e9-9c8f-a5a8e6bd7cd4.png)


#### Changelog

:cl:  Altoids
rscadd: Admins can now smite any mob capable of life.
/:cl:
