### PR TITLE
Fixes rad_examine formatting weirdness

### DIFF
--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -57,7 +57,7 @@
 	else
 		strength = max(strength, arguments[1])
 
-/datum/component/radioactive/proc/rad_examine(datum/source, mob/user, atom/thing)
+/datum/component/radioactive/proc/rad_examine(datum/source, mob/user, atom/thing) //Yogs -- Mirrored!!
 	var/atom/master = parent
 	var/list/out = list()
 	if(get_dist(master, user) <= 1)

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2836,6 +2836,7 @@
 #include "yogstation\code\datums\antagonists\vampire.dm"
 #include "yogstation\code\datums\components\crawl.dm"
 #include "yogstation\code\datums\components\daniel.dm"
+#include "yogstation\code\datums\components\radioactive.dm"
 #include "yogstation\code\datums\components\uplink.dm"
 #include "yogstation\code\datums\components\walks.dm"
 #include "yogstation\code\datums\components\storage\storage.dm"

--- a/yogstation/code/datums/components/radioactive.dm
+++ b/yogstation/code/datums/components/radioactive.dm
@@ -1,0 +1,24 @@
+#define RAD_AMOUNT_LOW 50
+#define RAD_AMOUNT_MEDIUM 200
+#define RAD_AMOUNT_HIGH 500
+#define RAD_AMOUNT_EXTREME 1000
+
+/datum/component/radioactive/rad_examine(datum/source, mob/user, atom/thing)
+	var/atom/master = parent
+	switch(strength)
+		if(0 to RAD_AMOUNT_LOW)
+			if(get_dist(master, user) <= 1)
+				to_chat(user,"The air around [master] feels warm.")
+		if(RAD_AMOUNT_LOW to RAD_AMOUNT_MEDIUM)
+			to_chat(user, "[master] feels weird to look at.")
+		if(RAD_AMOUNT_MEDIUM to RAD_AMOUNT_HIGH)
+			to_chat(user, "[master] seems to be glowing a bit.")
+		if(RAD_AMOUNT_HIGH to RAD_AMOUNT_EXTREME) //At this level the object can contaminate other objects
+			to_chat(user, "<span class='warning'>[master] hurts to look at.</span>")
+		if(RAD_AMOUNT_EXTREME to INFINITY)
+			to_chat(user, "<span class='warning'>[master] burns to look at!</span>")
+	
+#undef RAD_AMOUNT_LOW
+#undef RAD_AMOUNT_MEDIUM
+#undef RAD_AMOUNT_HIGH
+#undef RAD_AMOUNT_EXTREME


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/29939414/57345989-7f43a380-7112-11e9-9ba9-73a420b83537.png)


#### Changelog

:cl:  Altoids
spellcheck: The examine messages for radioactive things should be clearer and better-formatted now.
/:cl:
