### PR TITLE
Replaced paramedic spawn in cargo with mining medic spawn on yogsDelta map.

### DIFF
--- a/_maps/yogstation/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/yogstation/map_files/YogsDelta/YogsDelta.dmm
@@ -30755,11 +30755,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/landmark/start/yogs/paramedic,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	icon_state = "vent_map_on-1";
 	dir = 8
 	},
+/obj/effect/landmark/start/yogs/mining_medic,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "aXv" = (


### PR DESCRIPTION
### Intent of your Pull Request

Just replaced the paramedic start location in cargo with a mining medic start as one currently doesn't exist on yogsDelta map.

#### Changelog

:cl:  
rscdel: Removed cargo paramedic spawn  
rscadd: Added cargo mining medic spawn
/:cl:
