### PR TITLE
[admin] Allows admins to view the roundend report log & other .json logs

### DIFF
--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -3,7 +3,7 @@
 	for(var/file in args)
 		src << browse_rsc(file)
 
-/client/proc/browse_files(root="data/logs/", max_iterations=10, list/valid_extensions=list("txt","log","htm", "html"))
+/client/proc/browse_files(root="data/logs/", max_iterations=10, list/valid_extensions=list("txt","log","htm", "html","json")) // Yogs -- Allows admins to view Json's 
 	var/path = root
 
 	for(var/i=0, i<max_iterations, i++)


### PR DESCRIPTION
Apparently .json isn't a fully supported file type here, so I dunno exactly how it's going to respond if you try to do anything but download the .json, but, yeah.

#### Changelog

:cl:  Altoids
experimental: Admins can now acquire the roundend report data from rounds beyond the current and previous one.
/:cl:
