### PR TITLE
Fixes thralls and slings not always getting the deconversion message

### DIFF
--- a/yogstation/code/modules/antagonists/shadowling/shadowling.dm
+++ b/yogstation/code/modules/antagonists/shadowling/shadowling.dm
@@ -38,16 +38,16 @@
 		owner.RemoveSpell(S)
 	var/mob/living/M = owner.current
 	if(issilicon(M))
-		M.audible_message("<span class='notice'>[M] lets out a short blip.</span>", \
-						  "<span class='userdanger'>You have been turned into a robot! You are no longer a shadowling! Though you try, you cannot remember anything about your time as one...</span>")
+		M.audible_message("<span class='notice'>[M] lets out a short blip.</span>")
+		to_chat(M,"<span class='userdanger'>You have been turned into a[ iscyborg(M) ? " cyborg" : "n AI" ]! You are no longer a shadowling! Though you try, you cannot remember anything about your time as one...</span>")
 	else
-		M.visible_message("<span class='big'>[M] screams and contorts!</span>", \
-						  "<span class='userdanger'>THE LIGHT-- YOUR MIND-- <i>BURNS--</i></span>")
+		M.visible_message("<span class='big'>[M] screams and contorts!</span>")
+		to_chat(M,"<span class='userdanger'>THE LIGHT-- YOUR MIND-- <i>BURNS--</i></span>")
 		spawn(30)
 			if(QDELETED(M))
 				return
-			M.visible_message("<span class='warning'>[M] suddenly bloats and explodes!</span>", \
-							  "<span class='warning bold'>AAAAAAAAA<font size=3>AAAAAAAAAAAAA</font><font size=4>AAAAAAAAAAAA----</font></span>")
+			M.visible_message("<span class='warning'>[M] suddenly bloats and explodes!</span>")
+			to_chat(M,"<span class='warning bold'>AAAAAAAAA<font size=3>AAAAAAAAAAAAA</font><font size=4>AAAAAAAAAAAA----</font></span>")
 			playsound(M, 'sound/magic/Disintegrate.ogg', 100, 1)
 			M.gib()
 	return ..()

--- a/yogstation/code/modules/antagonists/shadowling/thrall.dm
+++ b/yogstation/code/modules/antagonists/shadowling/thrall.dm
@@ -31,12 +31,11 @@ GLOBAL_LIST_INIT(thrall_spell_types, typecacheof(list(/obj/effect/proc_holder/sp
 			owner.RemoveSpell(S)
 	var/mob/living/M = owner.current
 	if(issilicon(M))
-		M.audible_message("<span class='notice'>[M] lets out a short blip, followed by a low-pitched beep.</span>", \
-						  "<span class='userdanger'>You have been turned into a robot! You are no longer a thrall! Though you try, you cannot remember anything about your servitude...</span>")
+		M.audible_message("<span class='notice'>[M] lets out a short blip, followed by a low-pitched beep.</span>")
+		to_chat(M,"<span class='userdanger'>You have been turned into a[ iscyborg(M) ? " cyborg" : "n AI" ]! You are no longer a thrall! Though you try, you cannot remember anything about your servitude...</span>")
 	else
-		M.visible_message("<span class='big'>[M] looks like their mind is their own again!</span>", \
-						  "<span class='userdanger'>A piercing white light floods your eyes. Your mind is your own again! Though you try, you cannot remember anything about the shadowlings or your time \
-						  under their command...</span>")
+		M.visible_message("<span class='big'>[M] looks like their mind is their own again!</span>")
+		to_chat(M,"<span class='userdanger'>A piercing white light floods your eyes. Your mind is your own again! Though you try, you cannot remember anything about the shadowlings or your time under their command...</span>")
 	M.update_sight()
 	return ..()
 


### PR DESCRIPTION
Recently, RearKing (as an ex-thrall) used his previous Thrall knowledge to walk over to one of the thralls he knew and instantly kill him. When I asked about it, he said he didn't actually receive any warning that he can't use Thrall knowledge after deconversion. After a whole lot of argument that eventually involved turning him into a fish, I was able to determine that this was actually a bug and ought to be fixed.

#### Changelog

:cl:  Altoids
bugfix: Fixed thralls and slings sometimes not receiving their deconversion message when blinded.
spellcheck: Borged thralls should now no longer be discriminated against by their deconversion message.
/:cl:
