### PR TITLE
removes spiderman from the game

### DIFF
--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -60,6 +60,7 @@
 	item = /obj/item/flashlight //doesn't actually spawn a flashlight, but it needs an object to show up in the menu :^)
 	cost = 5
 	surplus = 0
+	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/device_tools/arm/spawn_item(spawn_item, mob/user)
 	var/limbs = user.held_items.len


### PR DESCRIPTION
I don't feel so good...
alternative to #5381
:cl:  
rscdel: nuke ops can no longer buy extra arms
/:cl:
