### PR TITLE
[admin] Allows admins to vary the pitch of their AI Vox messages

### DIFF
--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -140,7 +140,7 @@
 		play_vox_word(word, src.z, null, voxType) //yogs - male vox
 
 
-/proc/play_vox_word(word, z_level, mob/only_listener, voxType = "female")
+/proc/play_vox_word(word, z_level, mob/only_listener, voxType = "female", pitch = 0) // Yogs -- Pitch variation
 
 	word = lowertext(word)
 
@@ -155,6 +155,7 @@
 
 		var/sound/voice = sound(sound_file, wait = 1, channel = CHANNEL_VOX)
 		voice.status = SOUND_STREAM
+		voice.frequency = pitch //Yogs -- Pitch variation
 
  		// If there is no single listener, broadcast to everyone in the same z level
 		if(!only_listener)

--- a/yogstation/code/modules/admin/verbs/adminvox.dm
+++ b/yogstation/code/modules/admin/verbs/adminvox.dm
@@ -10,10 +10,12 @@
 
 	var/message = input(src, "WARNING: Misuse of this verb can result in you being yelled at by Ross.", "Announcement") as text
 	//^ Remember to replace "Ross" with whoever owns the server in 20,000 years after Ross either dies of natural causes or is assassinated by Oakboscage
-	var/voxType = input(src, "Male or female VOX?", "VOX-gender") in list("male", "female")
-
+	
 	if(!message)
 		return
+	
+	var/voxType = input(src, "Male or female VOX?", "VOX-gender") in list("male", "female")
+
 
 	var/list/words = splittext(trim(message), " ")//Turns the received text into an array of words
 	var/list/incorrect_words = list()//Stores all the words that we can't say, so we can complain about it later
@@ -33,6 +35,7 @@
 	else
 		to_chat(src,"<span class='notice'>Unknown or unsupported vox type. Yell at a coder about this.</span>")
 		return
+	
 	for(var/word in words) // For each word
 		word = lowertext(trim(word)) // We store the words as lowercase, so lowercase the word and trim off any weirdness like newlines
 		if(!word) // If we accidentally captured a space or something weird like that
@@ -45,6 +48,11 @@
 		to_chat(src, "<span class='notice'>These words are not available on the announcement system: [english_list(incorrect_words)].</span>")
 		return
 
+	var/pitch = 0
+	if(alert("Select a playback speed: ",,"Default","Custom...") == "Custom")
+		pitch = input("Input a custom playback speed (preferably as a number between -1 and 2)","AI Vox Command") as num
+		if(!pitch) pitch = 0
+	
 	log_admin("[key_name(src)] made an admin AI vocal announcement with the following message: [message].")
 	message_admins("[key_name(src)] made an admin AI vocal announcement with the following message: [message].")
 	var/z_level = 2 // Default value should be the station's z-level
@@ -52,4 +60,4 @@
 	if(src.mob && src.mob.loc) // If the admin has a mob who exists somewhere
 		z_level = src.mob.loc.z // Play it on their mob's z-level
 	for(var/word in words) // The forloop that actually plays the sounds, hopefully
-		play_vox_word(word, z_level, null, voxType)
+		play_vox_word(word, z_level, null, voxType, pitch)

--- a/yogstation/code/modules/admin/verbs/adminvox.dm
+++ b/yogstation/code/modules/admin/verbs/adminvox.dm
@@ -49,9 +49,9 @@
 		return
 
 	var/pitch = 0
-	if(alert("Select a playback speed: ",,"Default","Custom...") == "Custom")
-		pitch = input("Input a custom playback speed (preferably as a number between -1 and 2)","AI Vox Command") as num
-		if(!pitch) pitch = 0
+	if(alert("Select a playback speed: ",,"Default","Custom...") == "Custom...")
+		pitch = input("Input a custom playback speed (preferably as a number between 0 and 2)","AI Vox Command") as num
+		if(isnull(pitch)) pitch = 0
 	
 	log_admin("[key_name(src)] made an admin AI vocal announcement with the following message: [message].")
 	message_admins("[key_name(src)] made an admin AI vocal announcement with the following message: [message].")


### PR DESCRIPTION
I noticed that the admin AI Vox wasn't really differentiable from the normal AI messages, which made it annoying whenever I wanted to use Admin AI Vox for central command announcements. So, here we are.

#### Changelog
:cl:  Altoids
rscadd: Admins can now play AI Vox messages at arbitrary speeds!
/:cl:
