### PR TITLE
Disables pacifism for syndrones, scarabs, and FREEDRONES

### DIFF
--- a/yogstation/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/yogstation/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -8,6 +8,9 @@
 /mob/living/simple_animal/drone/cogscarab
 	pacifism = FALSE
 
+/mob/living/simple_animal/drone/polymorphed
+	pacifism = FALSE
+
 /mob/living/simple_animal/drone/Initialize()
 	.=..()
 	if(pacifism)

--- a/yogstation/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/yogstation/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -1,7 +1,15 @@
 /mob/living/simple_animal/drone
 	ignores_capitalism = TRUE // Yogs -- Lets drones buy a damned smoke for christ's sake
+	var/pacifism = TRUE // Marks whether pacifism should be enabled for this drone type
+
+/mob/living/simple_animal/drone/syndrone
+	pacifism = FALSE
+	
+/mob/living/simple_animal/drone/cogscarab
+	pacifism = FALSE
 
 /mob/living/simple_animal/drone/Initialize()
 	.=..()
-	add_trait(TRAIT_PACIFISM, JOB_TRAIT)
-	add_trait(TRAIT_NOGUNS, JOB_TRAIT) //fuck drones t. nich
+	if(pacifism)
+		add_trait(TRAIT_PACIFISM, JOB_TRAIT)
+		add_trait(TRAIT_NOGUNS, JOB_TRAIT) //love drones t. Altoids <3


### PR DESCRIPTION
Nich is bad

#### Changelog
:cl:  Altoids
bugfix: Syndrones, Cogscarabs, and FREEDRONES are no longer forced into pacifism.
/:cl:
