### PR TITLE
[s] Stops cyborgs from being able to move wheelchairs

### DIFF
--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -35,6 +35,13 @@
 	return ..()
 
 /obj/vehicle/ridden/wheelchair/driver_move(mob/living/user, direction)
+	//yogs start -- Fixes cyborgs operating wheelchairs like what the fuck
+	if(iscyborg(user))
+		to_chat(user, "<span class='warning'>You can't move the wheels without arms!</span>")
+		canmove = FALSE
+		addtimer(VARSET_CALLBACK(src, canmove , TRUE), 20)
+		return FALSE
+	//yogs end
 	var/mob/living/carbon/human/H = user
 	if(istype(H))
 		if(!H.get_num_arms() && canmove)

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -37,7 +37,7 @@
 /obj/vehicle/ridden/wheelchair/driver_move(mob/living/user, direction)
 	if(istype(user))
 		if(!user.get_num_arms() && canmove)
-			to_chat(H, "<span class='warning'>You can't move the wheels without arms!</span>")
+			to_chat(user, "<span class='warning'>You can't move the wheels without arms!</span>")
 			canmove = FALSE
 			addtimer(VARSET_CALLBACK(src, canmove, TRUE), 20)
 			return FALSE

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -35,24 +35,16 @@
 	return ..()
 
 /obj/vehicle/ridden/wheelchair/driver_move(mob/living/user, direction)
-	//yogs start -- Fixes cyborgs operating wheelchairs like what the fuck
-	if(iscyborg(user))
-		to_chat(user, "<span class='warning'>You can't move the wheels without arms!</span>")
-		canmove = FALSE
-		addtimer(VARSET_CALLBACK(src, canmove , TRUE), 20)
-		return FALSE
-	//yogs end
-	var/mob/living/carbon/human/H = user
-	if(istype(H))
-		if(!H.get_num_arms() && canmove)
+	if(istype(user))
+		if(!user.get_num_arms() && canmove)
 			to_chat(H, "<span class='warning'>You can't move the wheels without arms!</span>")
 			canmove = FALSE
-			addtimer(VARSET_CALLBACK(src, canmove , TRUE), 20)
+			addtimer(VARSET_CALLBACK(src, canmove, TRUE), 20)
 			return FALSE
 		var/datum/component/riding/D = GetComponent(/datum/component/riding)
 		//1.5 (movespeed as of this change) multiplied by 6.7 gets ABOUT 10 (rounded), the old constant for the wheelchair that gets divided by how many arms they have
 		//if that made no sense this simply makes the wheelchair speed change along with movement speed delay
-		D.vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * 6.7) / min(H.get_num_arms(), 2)
+		D.vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * 6.7) / min(user.get_num_arms(), 2)
 	..()
 
 /obj/vehicle/ridden/wheelchair/Moved()
@@ -111,8 +103,7 @@
 	return FALSE
 
 /obj/vehicle/ridden/wheelchair/the_whip/driver_move(mob/living/user, direction)
-	var/mob/living/carbon/human/H = user
-	if(istype(H))
+	if(istype(user))
 		var/datum/component/riding/D = GetComponent(/datum/component/riding)
-		D.vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * 6.7) / H.get_num_arms()
+		D.vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * 6.7) / user.get_num_arms()
 	..()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/57857767-65aaf780-77b5-11e9-802a-f70bac59ebdf.png)

You don't have arms, dipshit.

Fixes https://github.com/yogstation13/yogstation/pull/3178

#### Changelog
:cl:  Altoids
bugfix: Cyborgs can no longer move wheelchairs around, as they do not have arms.
bugfix: Fixed a speed exploit.
/:cl:
