### PR TITLE
Makes blood brothers *actually* spawn with their bundle box

### DIFF
--- a/code/game/gamemodes/brother/traitor_bro.dm
+++ b/code/game/gamemodes/brother/traitor_bro.dm
@@ -54,6 +54,7 @@
 		team.forge_brother_objectives()
 		for(var/datum/mind/M in team.members)
 			M.add_antag_datum(/datum/antagonist/brother, team)
+			equip_brother(M.current) // Yogs -- Adds Bloodbro bundle thingies, because Fluffe fucked it up
 		team.update_name()
 	brother_teams += pre_brother_teams
 	return ..()
@@ -70,16 +71,3 @@
 	var/datum/atom_hud/antag/brotherhud = GLOB.huds[ANTAG_HUD_BROTHER]
 	brotherhud.leave_hud(brother_mind.current)
 	set_antag_hud(brother_mind.current, null)
-
-/datum/game_mode/proc/equip_brother(mob/living/M) //Yogs start gives the brothers a bundle
-	if(!M || !ishuman(M))
-		return FALSE
-	var/mob/living/carbon/human/L = M
-	var/obj/item/storage/box/syndicate/bundle_B/S = new
-	var/list/slots = list("in the dark depths of hell" = SLOT_IN_BACKPACK) // You know you can put *anything* as the key, yeah?
-	if(L.equip_in_one_of_slots(S, slots) == "in the dark depths of hell")
-		slots[1] = "in your [L.back.name]" // This accesses & edits the "dark depths" meme above.
-	if(S)
-		to_chat(L, "<span class='bold'>There is a syndicate bundle [slots[1]]! It'll help you get a slight leg up on your objectives but dont expect it to make things too easy!.</span>")
-		return TRUE
-	return FALSE //Yogs end gives the brothers a bundle

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2863,6 +2863,7 @@
 #include "yogstation\code\game\gamemodes\battle_royale\battleroyale.dm"
 #include "yogstation\code\game\gamemodes\battle_royale\loot.dm"
 #include "yogstation\code\game\gamemodes\battle_royale\storm.dm"
+#include "yogstation\code\game\gamemodes\brother\traitor_bro.dm"
 #include "yogstation\code\game\gamemodes\changeling\powers\abomination_powers.dm"
 #include "yogstation\code\game\gamemodes\gangs\dominator.dm"
 #include "yogstation\code\game\gamemodes\gangs\gang_items.dm"

--- a/yogstation/code/game/gamemodes/brother/traitor_bro.dm
+++ b/yogstation/code/game/gamemodes/brother/traitor_bro.dm
@@ -1,0 +1,12 @@
+/datum/game_mode/traitor/bros/proc/equip_brother(mob/living/M) //gives the brothers a bundle
+	if(!M || !ishuman(M))
+		return FALSE
+	var/mob/living/carbon/human/L = M
+	var/obj/item/storage/box/syndicate/bundle_B/S = new
+	var/list/slots = list("in the dark depths of hell" = SLOT_IN_BACKPACK) // You know you can put *anything* as the key, yeah?
+	if(L.equip_in_one_of_slots(S, slots) == "in the dark depths of hell")
+		slots[1] = "in your [L.back.name]" // This accesses & edits the "dark depths" meme above.
+	if(S)
+		to_chat(L, "<span class='bold'>There is a syndicate bundle [slots[1]]! It'll help you get a slight leg up on your objectives but dont expect it to make things too easy!.</span>")
+		return TRUE
+	return FALSE

--- a/yogstation/code/game/gamemodes/brother/traitor_bro.dm
+++ b/yogstation/code/game/gamemodes/brother/traitor_bro.dm
@@ -7,6 +7,6 @@
 	if(L.equip_in_one_of_slots(S, slots) == "in the dark depths of hell")
 		slots[1] = "in your [L.back.name]" // This accesses & edits the "dark depths" meme above.
 	if(S)
-		to_chat(L, "<span class='bold'>There is a syndicate bundle [slots[1]]! It'll help you get a slight leg up on your objectives but dont expect it to make things too easy!.</span>")
+		to_chat(L, "<span class='notice'>There is a syndicate bundle [slots[1]]! It'll help you get a slight leg-up on your objectives, but do not expect it to make things too easy!</span>")
 		return TRUE
 	return FALSE


### PR DESCRIPTION
Fixes #5310 not working.

Turns out, you can't just toss a proc into the (wrong) place in the code and call it a day. You gotta actually *call* the damned thing.

#### Changelog

:cl:  Altoids
bugfix: This be a big bugfix for bloodbrothers not born bearing their bloodbro box bundle.
/:cl:
