### PR TITLE
Fixes runtime when lights are cleaned

### DIFF
--- a/yogstation/code/modules/power/lighting.dm
+++ b/yogstation/code/modules/power/lighting.dm
@@ -2,7 +2,7 @@
 	. = ..()
 	AddComponent(/datum/component/redirect, list(COMSIG_COMPONENT_CLEAN_ACT= CALLBACK(src, .proc/clean_light)))
 
-/obj/machinery/light/proc/clean_light(strength)
+/obj/machinery/light/proc/clean_light(O,strength)
 	if(strength < CLEAN_STRENGTH_BLOOD)
 		return
 	bulb_colour = initial(bulb_colour)


### PR DESCRIPTION
Fixes bug caused by #798 and Nich being a bad coder in general

#### Changelog

:cl:  Altoids
bugfix: Lightbulbs discoloured by spraycans can now actually be cleaned by space cleaner, as intended.
/:cl:
