### PR TITLE
Removes donator status from mentors

### DIFF
--- a/yogstation/code/__HELPERS/mobs.dm
+++ b/yogstation/code/__HELPERS/mobs.dm
@@ -25,16 +25,12 @@
 	if(ismob(user))
 		var/mob/temp = user
 		if(temp && temp.client)
-			if(temp.client.is_mentor())
-				return TRUE
 			if(temp.client.prefs)
 				return (temp.client.prefs.unlock_content & 2)
 
 	else if(istype(user, /client))
 		var/client/temp = user
 		if(temp)
-			if(temp.is_mentor())
-				return TRUE
 			if(temp.prefs)
 				return (temp.prefs.unlock_content & 2)
 


### PR DESCRIPTION
## Why?
The way I see it, I don't think it's absolutely necessary to give these people donor perks. All that does is make the jump from Mentor to Moderator less desirable, which is a problem with the current admin shortage affecting us this month.

#### Changelog

:cl:  Altoids
rscdel: Mentors no longer receive free donator. Become an actual admin or coder if you want the funny hats.
/:cl:
