### PR TITLE
Adds drone shells to the Spawner Menu

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -23,6 +23,7 @@
 	if(A)
 		notify_ghosts("A drone shell has been created in \the [A.name].", source = src, action=NOTIFY_ATTACK, flashwindow = FALSE, ignore_key = POLL_IGNORE_DRONE)
 	GLOB.poi_list |= src
+	LAZYADD(GLOB.mob_spawners[initial(name)], src)//Yogs -- Adds drone shells to Spawner Menu
 	if(isnull(possible_seasonal_hats))
 		build_seasonal_hats()
 
@@ -37,6 +38,7 @@
 
 /obj/item/drone_shell/Destroy()
 	GLOB.poi_list -= src
+	LAZYREMOVE(GLOB.mob_spawners[initial(name)], src)//Yogs -- Adds drone shells to Spawner Menu
 	. = ..()
 
 //ATTACK GHOST IGNORING PARENT RETURN VALUE


### PR DESCRIPTION
Based on Bob's request.

![image](https://user-images.githubusercontent.com/29939414/58215163-1d606d80-7cbe-11e9-88a7-0a02e54ae432.png)


#### Changelog

:cl:  Altoids
rscadd: Drone shells can now be found in the Spawner Menu!
/:cl:
