### PR TITLE
Fixes mentorpurple color, makes mentorhelps more legible in darkmode

### DIFF
--- a/yogstation/code/modules/mentor/mentorhelp.dm
+++ b/yogstation/code/modules/mentor/mentorhelp.dm
@@ -21,7 +21,7 @@
 	if(!mob)	return						//this doesn't happen
 
 	var/show_char = CONFIG_GET(flag/mentors_mobname_only)
-	var/mentor_msg = "<span class='mentornotice'><b><font color='purple'>MENTORHELP:</b> <b>[key_name_mentor(src, 1, 0, 1, show_char)]</b>: [msg]</font></span>"
+	var/mentor_msg = "<span class='mentornotice purple'><b>MENTORHELP:</b> <b>[key_name_mentor(src, 1, 0, 1, show_char)]</b>: [msg]</span>"
 	log_mentor("MENTORHELP: [key_name_mentor(src, 0, 0, 0, 0)]: [msg]")
 
 	for(var/client/X in GLOB.mentors | GLOB.admins)
@@ -29,7 +29,7 @@
 			SEND_SOUND(X, sound('sound/items/bikehorn.ogg'))
 		to_chat(X, mentor_msg)
 
-	to_chat(src, "<span class='mentornotice'><font color='purple'>PM to-<b>Mentors</b>: [msg]</font></span>")
+	to_chat(src, "<span class='mentornotice purple'>PM to-<b>Mentors</b>: [msg]</span>")
 
 	var/datum/mentorticket/mt
 	if(ckey in SSYogs.mentortickets)

--- a/yogstation/code/modules/mentor/mentorpm.dm
+++ b/yogstation/code/modules/mentor/mentorpm.dm
@@ -66,7 +66,7 @@
 	var/show_char = CONFIG_GET(flag/mentors_mobname_only)
 	if(!C || C.is_mentor())
 		if(C)
-			to_chat(C, "<font color='purple'>Reply PM from-<b>[key_name_mentor(src, C, 1, 0, show_char)]</b>: [msg]</font>")
+			to_chat(C, "<span class='purple'>Reply PM from-<b>[key_name_mentor(src, C, 1, 0, show_char)]</b>: [msg]</span>")
 		if(discord_id)
 			to_chat(src, "<font color='green'>Mentor PM to-<b>[discord_mentor_link(whom, discord_id)]</b>: [msg]</font>")
 		else
@@ -78,7 +78,7 @@
 	else
 		if(is_mentor())	//sender is an mentor but recipient is not.
 			if(C)
-				to_chat(C, "<font color='purple'>Mentor PM from-<b>[key_name_mentor(src, C, 1, 0, 0)]</b>: [msg]</font>")
+				to_chat(C, "<span class='purple'>Mentor PM from-<b>[key_name_mentor(src, C, 1, 0, 0)]</b>: [msg]</span>")
 			to_chat(src, "<font color='green'>Mentor PM to-<b>[key_name_mentor(C, C, 1, 0, show_char)]</b>: [msg]</font>")
 			if(C.ckey in SSYogs.mentortickets)
 				var/datum/mentorticket/T = SSYogs.mentortickets[C.ckey]


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/58286552-9ae6b500-7d74-11e9-934c-1a691d902151.png)

The single most important darkmode fix

Fixes #5311 

#### Changelog

:cl:  Altoids
bugfix: Mentorhelps should now be much easier to see, especially in darkmode.
/:cl:
