### PR TITLE
Lawyer headset defaults to sec

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -67,7 +67,7 @@
 /obj/item/encryptionkey/headset_srvsec
 	name = "law and order radio encryption key"
 	icon_state = "srvsec_cypherkey"
-	channels = list(RADIO_CHANNEL_SERVICE = 1, RADIO_CHANNEL_SECURITY = 1)
+	channels = list(RADIO_CHANNEL_SECURITY = 1, RADIO_CHANNEL_SERVICE = 1) //yogs - changed order
 
 /obj/item/encryptionkey/headset_com
 	name = "command radio encryption key"


### PR DESCRIPTION
:h goes to security channel not service channel
Fixes issue #5290

:cl:  
tweak: Service-Security headset defaults to Security.
/:cl:
