### PR TITLE
Adds in a auto label bot for issues

### DIFF
--- a/.github/issue_label_bot.yaml
+++ b/.github/issue_label_bot.yaml
@@ -1,0 +1,4 @@
+label-alias:
+  bug: 'Bug'
+  feature_request: 'Feature Request'
+  question: 'Question'

--- a/code/modules/vending/megaseed.dm
+++ b/code/modules/vending/megaseed.dm
@@ -47,7 +47,7 @@
 					  /obj/item/seeds/reishi = 2,
 					  /obj/item/seeds/cannabis = 3,
 					  /obj/item/seeds/starthistle = 2,
-					  /obj/item/seeds/random = 4) //yogs -- now with 4 seeds instead of 2
+					  /obj/item/seeds/random = 2)
 	premium = list(/obj/item/reagent_containers/spray/waterflower = 1)
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF

--- a/code/modules/vending/megaseed.dm
+++ b/code/modules/vending/megaseed.dm
@@ -47,7 +47,7 @@
 					  /obj/item/seeds/reishi = 2,
 					  /obj/item/seeds/cannabis = 3,
 					  /obj/item/seeds/starthistle = 2,
-					  /obj/item/seeds/random = 2)
+					  /obj/item/seeds/random = 4) //yogs -- now with 4 seeds instead of 2
 	premium = list(/obj/item/reagent_containers/spray/waterflower = 1)
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF


### PR DESCRIPTION
This PR adds the config file for a bot that uses machine learning to label issues into three categories: Bug,Feature Request or Question(never encountered that tag in tests tho).

To use the bot,you obviously need to add it first: https://github.com/marketplace/issue-label-bot

You can see an example of its doing at https://github.com/alexkar598/testinglabelbot/issues where I took random issues from this github and copied them over(il save you a click,out of 11 issues,it sorted 10 correctly and didn't take action for one issue due to uncertainty)

This bot will create a Question label tho i think,or it might just not label stuff it considers as a "Question".