### PR TITLE
CentCom Test Chamber v2

### DIFF
--- a/_maps/yogstation/map_files/generic/CentCom.dmm
+++ b/_maps/yogstation/map_files/generic/CentCom.dmm
@@ -19709,7 +19709,9 @@
 	dir = 1;
 	light_color = "#c1caff"
 	},
-/mob/living/simple_animal/hostile/megafauna/colossus,
+/mob/living/simple_animal/hostile/megafauna/colossus{
+	true_spawn = 0
+	},
 /turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
 "MM" = (
@@ -19731,7 +19733,9 @@
 	dir = 1;
 	light_color = "#c1caff"
 	},
-/mob/living/simple_animal/hostile/megafauna/bubblegum,
+/mob/living/simple_animal/hostile/megafauna/bubblegum{
+	true_spawn = 0
+	},
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
 "MO" = (
@@ -19749,7 +19753,9 @@
 	dir = 1;
 	light_color = "#c1caff"
 	},
-/mob/living/simple_animal/hostile/megafauna/dragon,
+/mob/living/simple_animal/hostile/megafauna/dragon{
+	true_spawn = 0
+	},
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
 "MP" = (
@@ -20430,19 +20436,6 @@
 	dir = 8
 	},
 /obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/centcom/testchamber)
-"Ob" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/portal/permanent/one_way/destroy{
-	id = "testing chamber";
-	teleport_channel = "testing"
-	},
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
 "Oc" = (
@@ -65978,7 +65971,7 @@ Iv
 pT
 Mp
 td
-Ob
+wq
 yP
 Aa
 BW

--- a/_maps/yogstation/map_files/generic/CentCom.dmm
+++ b/_maps/yogstation/map_files/generic/CentCom.dmm
@@ -2248,6 +2248,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/tdome/arena_source)
+"fR" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/window/reinforced,
+/obj/effect/portal/permanent/one_way/keep{
+	desc = "A portal to a land of absolute chaos and unknowns!";
+	id = "testchamber";
+	name = "Test Chamber Portal";
+	teleport_channel = "testchamber"
+	},
+/turf/open/floor/grass,
+/area/centcom/evac)
 "fS" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -2935,6 +2947,9 @@
 /obj/machinery/capture_the_flag/red,
 /turf/open/floor/circuit/green/anim,
 /area/ctf)
+"hH" = (
+/turf/closed/indestructible/riveted,
+/area/centcom/testchamber)
 "hI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -3709,6 +3724,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
+"jA" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/pointybush,
+/turf/open/floor/grass,
+/area/centcom/testchamber)
 "jB" = (
 /obj/structure/noticeboard{
 	dir = 8;
@@ -4813,6 +4837,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
+"lS" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/genericbush,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/grass,
+/area/centcom/testchamber)
 "lT" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
@@ -6490,6 +6526,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/tdomeobserve)
+"oU" = (
+/obj/item/reagent_containers/food/snacks/egg/rainbow{
+	desc = "I bet you think you're pretty clever... well you are.";
+	name = "easter egg"
+	},
+/turf/open/space/basic,
+/area/space)
 "oV" = (
 /obj/machinery/vr_sleeper{
 	dir = 4
@@ -6849,6 +6892,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
+"px" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/grille/indestructable,
+/turf/open/floor/plating,
+/area/tdome/tdomeadmin)
 "py" = (
 /obj/machinery/smartfridge,
 /turf/closed/indestructible{
@@ -6857,6 +6905,60 @@
 	smooth = 1
 	},
 /area/centcom/holding)
+"pz" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"pA" = (
+/obj/structure/table/wood,
+/obj/item/storage/fancy/cigarettes/cigars/havana,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"pB" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/chair,
+/obj/item/soapstone/infinite,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"pC" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/item/throwing_star/ninja,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"pD" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/vending/magivend,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "pE" = (
 /obj/machinery/plantgenes/seedvault,
 /obj/effect/turf_decal/tile/green{
@@ -7024,6 +7126,37 @@
 /obj/item/stack/packageWrap,
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
+"pT" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"pU" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/vending/liberationstation,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "pV" = (
 /obj/machinery/light{
 	dir = 4
@@ -7143,6 +7276,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
+"qh" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/item/switchblade,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "qi" = (
 /obj/structure/table/wood,
 /obj/item/storage/secure/briefcase{
@@ -7399,6 +7547,26 @@
 "qE" = (
 /turf/closed/indestructible/riveted/uranium,
 /area/wizard_station)
+"qF" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/chair,
+/obj/item/storage/briefcase/sniperbundle,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"qG" = (
+/obj/structure/table/wood,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "qH" = (
 /obj/structure/urinal{
 	pixel_y = 28
@@ -7542,6 +7710,22 @@
 /obj/machinery/computer/shuttle,
 /turf/open/floor/engine/cult,
 /area/wizard_station)
+"rb" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/bananalamp,
+/obj/item/reagent_containers/pill/adminordrazine,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"rc" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/pointybush,
+/obj/item/toy/plush/awakenedplushie,
+/turf/open/floor/grass,
+/area/centcom/testchamber)
 "rd" = (
 /obj/structure/flora/grass/brown,
 /obj/effect/light_emitter{
@@ -8075,11 +8259,13 @@
 /turf/open/floor/grass,
 /area/centcom/evac)
 "rU" = (
-/obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/genericbush,
 /turf/open/floor/grass,
-/area/centcom/evac)
+/area/centcom/testchamber)
 "rV" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -8098,6 +8284,25 @@
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
+"rY" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/pointybush,
+/obj/item/toy/plush/goatplushie,
+/turf/open/floor/grass,
+/area/centcom/testchamber)
+"rZ" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/genericbush,
+/obj/item/rupee,
+/turf/open/floor/grass,
+/area/centcom/testchamber)
 "sa" = (
 /obj/structure/table/wood,
 /obj/item/lighter,
@@ -8108,6 +8313,20 @@
 /obj/machinery/vending/snack,
 /turf/open/floor/plasteel,
 /area/centcom/supplypod)
+"sc" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/pointybush,
+/obj/item/clothing/neck/stripedbluescarf,
+/turf/open/floor/grass,
+/area/centcom/testchamber)
+"sd" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/centcom/testchamber)
 "se" = (
 /obj/machinery/light{
 	dir = 8
@@ -8607,6 +8826,84 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
+"sZ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/recharge_station,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"ta" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"tb" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/portal/permanent/one_way/destroy{
+	id = "testchamber";
+	teleport_channel = "testchamber"
+	},
+/turf/open/floor/plasteel/recharge_floor,
+/area/centcom/testchamber)
+"tc" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/revolver/mateba,
+/obj/item/gun/ballistic/revolver/nagant{
+	pixel_y = -8
+	},
+/obj/item/gun/ballistic/revolver/reverse{
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"td" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "te" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/pizzaslice/mushroom,
@@ -8650,6 +8947,71 @@
 	},
 /turf/open/floor/plating/airless,
 /area/syndicate_mothership/control)
+"tj" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/uplink/debug,
+/obj/item/uplink/debug,
+/obj/item/uplink/nuclear/debug,
+/obj/item/uplink/nuclear/debug,
+/obj/item/uplink/clownop,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"tk" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/item/storage/pill_bottle/stimulant,
+/obj/item/encryptionkey/syndicate,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"tl" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/item/switchblade,
+/obj/item/reagent_containers/pill/adminordrazine,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"tm" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/spirit_board,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "tn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -8712,6 +9074,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
+"tv" = (
+/obj/structure/destructible/cult/forge,
+/obj/item/tome,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"tw" = (
+/obj/structure/destructible/cult/talisman,
+/obj/item/sharpener/cult,
+/obj/item/cult_shift,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "tx" = (
 /obj/structure/table/wood,
 /obj/item/storage/pill_bottle/dice,
@@ -8999,12 +9372,53 @@
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
+"tY" = (
+/obj/structure/destructible/cult/tome,
+/obj/item/shuttle_curse,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "tZ" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien5";
 	opacity = 0
 	},
 /area/bluespace_locker)
+"ua" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/mirror/magic/badmin{
+	pixel_y = 30
+	},
+/obj/structure/healingfountain,
+/obj/item/skub,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"ub" = (
+/obj/structure/destructible/cult/pylon,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"uc" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cursed_slot_machine,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "ud" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "nukeop_ready";
@@ -9018,6 +9432,59 @@
 	},
 /turf/open/floor/plating/airless,
 /area/syndicate_mothership/control)
+"uf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/structure/cursed_money,
+/obj/structure/cursed_money,
+/obj/structure/cursed_money,
+/obj/structure/cursed_money,
+/obj/structure/cursed_money,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"ug" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/sacrificealtar,
+/obj/item/station_charter/admin,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"uh" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/teleportation_scroll{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/teleportation_scroll,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "ui" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -9301,12 +9768,106 @@
 /obj/structure/chair/wood/wings,
 /turf/open/floor/carpet,
 /area/wizard_station)
+"uG" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/structure/glowshroom/single,
+/obj/item/upgradescroll/unlimited{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/upgradescroll/unlimited,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"uH" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/structure/glowshroom/single,
+/obj/item/pizzabox/infinite,
+/obj/item/book/granter/martial/carp{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/book/granter/martial/plasma_fist,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"uI" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/automatic/pistol/APS{
+	pixel_y = -10
+	},
+/obj/item/gun/ballistic/automatic/pistol/deagle,
+/obj/item/gun/ballistic/revolver/grenadelauncher/unrestricted{
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "uJ" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "150"
 	},
 /turf/open/floor/plating,
 /area/syndicate_mothership/control)
+"uK" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/magazine/m12g,
+/obj/item/ammo_box/magazine/m12g,
+/obj/item/ammo_box/magazine/m12g/bioterror,
+/obj/item/ammo_box/magazine/m12g/bioterror,
+/obj/item/ammo_box/magazine/m12g/dragon,
+/obj/item/ammo_box/magazine/m12g/dragon,
+/obj/item/ammo_box/magazine/m12g/meteor,
+/obj/item/ammo_box/magazine/m12g/meteor,
+/obj/item/ammo_box/magazine/m12g/slug,
+/obj/item/ammo_box/magazine/m12g/slug,
+/obj/item/ammo_box/magazine/m12g/stun,
+/obj/item/ammo_box/magazine/m12g/stun,
+/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/m75,
+/obj/item/ammo_box/magazine/m75,
+/obj/item/ammo_box/magazine/tommygunm45,
+/obj/item/ammo_box/magazine/tommygunm45,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "uL" = (
 /obj/machinery/button/door/indestructible{
 	id = "nukeop_ready";
@@ -9327,6 +9888,46 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/syndicate_mothership/control)
+"uN" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/magazine/m10mm,
+/obj/item/ammo_box/magazine/m10mm,
+/obj/item/ammo_box/magazine/m10mm/ap,
+/obj/item/ammo_box/magazine/m10mm/ap,
+/obj/item/ammo_box/magazine/m10mm/fire,
+/obj/item/ammo_box/magazine/m10mm/fire,
+/obj/item/ammo_box/magazine/m10mm/hp,
+/obj/item/ammo_box/magazine/m10mm/hp,
+/obj/item/ammo_box/magazine/m10mm/rifle,
+/obj/item/ammo_box/magazine/m10mm/rifle,
+/obj/item/ammo_box/magazine/m45,
+/obj/item/ammo_box/magazine/m45,
+/obj/item/ammo_box/magazine/mm712x82,
+/obj/item/ammo_box/magazine/mm712x82,
+/obj/item/ammo_box/magazine/mm712x82/ap,
+/obj/item/ammo_box/magazine/mm712x82/ap,
+/obj/item/ammo_box/magazine/mm712x82/hollow,
+/obj/item/ammo_box/magazine/mm712x82/hollow,
+/obj/item/ammo_box/magazine/mm712x82/incen,
+/obj/item/ammo_box/magazine/mm712x82/incen,
+/obj/item/ammo_box/magazine/wt550m9,
+/obj/item/ammo_box/magazine/wt550m9,
+/obj/item/ammo_box/magazine/wt550m9/wtap,
+/obj/item/ammo_box/magazine/wt550m9/wtap,
+/obj/item/ammo_box/magazine/wt550m9/wtic,
+/obj/item/ammo_box/magazine/wt550m9/wtic,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "uO" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Shuttle Control Office";
@@ -9602,6 +10203,62 @@
 	},
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/basketball)
+"vp" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/gun/energy/e_gun/nuclear{
+	pin = /obj/item/firing_pin
+	},
+/obj/item/gun/energy/e_gun/nuclear{
+	pin = /obj/item/firing_pin
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"vq" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/gun/energy/decloner{
+	pin = /obj/item/firing_pin
+	},
+/obj/item/gun/energy/decloner{
+	pin = /obj/item/firing_pin
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"vr" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/shotgun/automatic/dual_tube,
+/obj/item/gun/ballistic/shotgun/automatic/dual_tube,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "vs" = (
 /obj/machinery/vending/hydronutrients,
 /obj/effect/turf_decal/tile/green{
@@ -9646,6 +10303,42 @@
 /obj/item/toy/nuke,
 /turf/open/floor/wood,
 /area/syndicate_mothership/control)
+"vy" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/automatic/wt550,
+/obj/item/gun/ballistic/automatic/wt550,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"vz" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/automatic/m90/unrestricted{
+	pixel_y = 6
+	},
+/obj/item/gun/ballistic/automatic/m90/unrestricted{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "vA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/directions/engineering{
@@ -10004,6 +10697,32 @@
 	},
 /turf/open/floor/carpet,
 /area/wizard_station)
+"we" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/automatic/gyropistol{
+	pixel_y = -8
+	},
+/obj/item/gun/ballistic/automatic/gyropistol{
+	pixel_y = -8
+	},
+/obj/item/gun/ballistic/automatic/l6_saw/unrestricted{
+	pixel_y = 6
+	},
+/obj/item/gun/ballistic/automatic/l6_saw/unrestricted{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "wf" = (
 /obj/structure/closet{
 	anchored = 1;
@@ -10021,6 +10740,38 @@
 /obj/item/clothing/head/helmet/space/plasmaman,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"wg" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/gun/medbeam,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"wh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/centcom/testchamber)
+"wi" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "wj" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien24";
@@ -10060,6 +10811,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/syndicate_mothership/control)
+"wq" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "wr" = (
 /obj/structure/chair{
 	dir = 4
@@ -10301,6 +11061,100 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/carpet,
 /area/wizard_station)
+"wR" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"wS" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/glowshroom/shadowshroom,
+/obj/item/reagent_containers/pill/shadowtoxin,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"wT" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/dnainjector/chameleonmut,
+/obj/item/dnainjector/chavmut,
+/obj/item/dnainjector/clumsymut,
+/obj/item/dnainjector/coughmut,
+/obj/item/dnainjector/cryokinesis,
+/obj/item/dnainjector/deafmut,
+/obj/item/dnainjector/dwarf,
+/obj/item/dnainjector/elvismut,
+/obj/item/dnainjector/epimut,
+/obj/item/dnainjector/extendoarm,
+/obj/item/dnainjector/firemut,
+/obj/item/dnainjector/geladikinesis,
+/obj/item/dnainjector/glassesmut,
+/obj/item/dnainjector/hulkmut,
+/obj/item/dnainjector/insulated,
+/obj/item/dnainjector/lasereyesmut,
+/obj/item/dnainjector/mindread,
+/obj/item/dnainjector/mutemut,
+/obj/item/dnainjector/olfaction,
+/obj/item/dnainjector/radioactive,
+/obj/item/dnainjector/shock,
+/obj/item/dnainjector/smilemut,
+/obj/item/dnainjector/stuttmut,
+/obj/item/dnainjector/swedishmut,
+/obj/item/dnainjector/telemut,
+/obj/item/dnainjector/thermal,
+/obj/item/dnainjector/tourmut,
+/obj/item/dnainjector/unintelligiblemut,
+/obj/item/dnainjector/void,
+/obj/item/dnainjector/wackymut,
+/obj/item/dnainjector/xraymut,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"wU" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/gun/energy/mindflayer{
+	pixel_y = -8
+	},
+/obj/item/gun/energy/xray{
+	pin = /obj/item/firing_pin;
+	pixel_y = 8
+	},
+/obj/item/gun/energy/tesla_revolver{
+	pin = /obj/item/firing_pin
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "wV" = (
 /obj/machinery/computer/telecrystals/boss{
 	dir = 1
@@ -10346,6 +11200,53 @@
 	},
 /turf/open/floor/plasteel,
 /area/syndicate_mothership/control)
+"wZ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/n762,
+/obj/item/ammo_box/c9mm,
+/obj/item/ammo_box/c45,
+/obj/item/ammo_box/c10mm,
+/obj/item/ammo_box/a40mm,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"xa" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/c38,
+/obj/item/ammo_box/c38/hotshot,
+/obj/item/ammo_box/c38/iceblox,
+/obj/item/ammo_box/c38/trac,
+/obj/item/ammo_box/a357,
+/obj/item/ammo_box/a762,
+/obj/item/ammo_box/magazine/m50,
+/obj/item/ammo_box/magazine/m50,
+/obj/item/ammo_box/magazine/sniper_rounds,
+/obj/item/ammo_box/magazine/sniper_rounds,
+/obj/item/ammo_box/magazine/sniper_rounds/penetrator,
+/obj/item/ammo_box/magazine/sniper_rounds/penetrator,
+/obj/item/ammo_box/magazine/sniper_rounds/soporific,
+/obj/item/ammo_box/magazine/sniper_rounds/soporific,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "xb" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -10555,6 +11456,25 @@
 /obj/machinery/light,
 /turf/open/floor/carpet,
 /area/wizard_station)
+"xA" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/gun/energy/e_gun/hos,
+/obj/item/gun/energy/e_gun/hos,
+/obj/item/gun/energy/laser/captain{
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "xB" = (
 /mob/living/simple_animal/bot/medbot{
 	desc = "When engaged in combat, the vanquishing of thine enemy can be the warrior's only concern.";
@@ -10564,6 +11484,37 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"xC" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/gun/energy/beam_rifle/debug,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"xD" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/shotgun/bulldog/unrestricted,
+/obj/item/gun/ballistic/shotgun/bulldog/unrestricted,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "xE" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -10574,6 +11525,22 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/firingrange)
+"xF" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/automatic/tommygun,
+/obj/item/gun/ballistic/automatic/tommygun,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "xG" = (
 /turf/open/floor/plasteel/dark,
 /area/syndicate_mothership/control)
@@ -10740,6 +11707,28 @@
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
+"yc" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/automatic/proto/unrestricted{
+	pixel_y = 12
+	},
+/obj/item/gun/ballistic/automatic/proto/unrestricted{
+	pixel_y = 12
+	},
+/obj/item/gun/ballistic/automatic/sniper_rifle,
+/obj/item/gun/ballistic/automatic/sniper_rifle,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "yd" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -10751,6 +11740,28 @@
 	},
 /turf/open/floor/grass,
 /area/centcom/holding)
+"ye" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/automatic/ar,
+/obj/item/gun/ballistic/automatic/ar,
+/obj/item/gun/ballistic/automatic/c20r/unrestricted{
+	pixel_y = 8
+	},
+/obj/item/gun/ballistic/automatic/c20r/unrestricted{
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "yf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -10758,6 +11769,41 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
+"yg" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/gun/grenadelauncher,
+/obj/item/gun/grenadelauncher,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"yh" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"yi" = (
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "yj" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
@@ -11019,12 +12065,123 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/grass,
 /area/wizard_station)
+"yL" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/item/throwing_star/ninja,
+/obj/item/throwing_star/ninja,
+/obj/item/encryptionkey/binary,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "yM" = (
 /obj/structure/table/wood/bar,
 /obj/structure/safe/floor,
 /obj/item/seeds/cherry/bomb,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"yN" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/closed/indestructible/riveted,
+/area/centcom/testchamber)
+"yO" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/centcom/testchamber)
+"yP" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/grille,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"yQ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/item/switchblade,
+/obj/item/reagent_containers/pill/adminordrazine,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"yR" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"yS" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/constructshell,
+/obj/structure/constructshell,
+/obj/structure/constructshell,
+/obj/item/soulstone/anybody,
+/obj/item/soulstone/anybody,
+/obj/item/soulstone/anybody,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"yT" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/glowshroom/glowcap,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "yU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
@@ -11058,6 +12215,19 @@
 /obj/item/tank/internals/plasmaman/belt/full,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"yW" = (
+/obj/structure/table/wood,
+/obj/item/seeds/kudzu,
+/obj/item/seeds/kudzu{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/seeds/kudzu{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/turf/open/floor/wood,
+/area/centcom/testchamber)
 "yX" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/dark,
@@ -11140,6 +12310,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
+"zc" = (
+/obj/structure/table/wood,
+/obj/item/ship_in_a_bottle,
+/turf/open/floor/wood,
+/area/centcom/testchamber)
 "zd" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
@@ -11249,6 +12424,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/evac)
+"zn" = (
+/obj/structure/table/wood,
+/obj/item/staff/storm,
+/obj/item/lava_staff,
+/obj/item/gun/magic/staff/animate,
+/obj/item/gun/magic/staff/change,
+/obj/item/gun/magic/staff/chaos,
+/obj/item/gun/magic/staff/door,
+/obj/item/gun/magic/staff/flying,
+/obj/item/gun/magic/staff/healing,
+/obj/item/gun/magic/staff/honk,
+/obj/item/gun/magic/staff/necropotence,
+/obj/item/gun/magic/staff/sapping,
+/obj/item/gun/magic/staff/wipe,
+/turf/open/floor/wood,
+/area/centcom/testchamber)
 "zo" = (
 /obj/structure/destructible/cult/tome,
 /turf/open/floor/engine/cult,
@@ -11280,6 +12471,70 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/two)
+"zt" = (
+/obj/structure/table/wood,
+/obj/item/gun/magic/staff/locker,
+/obj/item/rod_of_asclepius,
+/turf/open/floor/wood,
+/area/centcom/testchamber)
+"zu" = (
+/obj/structure/table/wood,
+/obj/item/twohanded/required/cult_bastard{
+	pixel_y = 3
+	},
+/obj/item/twohanded/cult_spear,
+/obj/item/kitchen/knife/envy,
+/turf/open/floor/wood,
+/area/centcom/testchamber)
+"zv" = (
+/obj/structure/table/wood,
+/obj/item/twohanded/dualsaber/purple{
+	pixel_y = 3
+	},
+/obj/item/twohanded/dualsaber/green{
+	pixel_y = 6
+	},
+/obj/item/twohanded/dualsaber/blue,
+/obj/item/twohanded/dualsaber/red{
+	pixel_y = 9
+	},
+/obj/item/melee/transforming/energy/blade,
+/obj/item/melee/transforming/energy/blade/hardlight,
+/obj/item/melee/transforming/energy/sword/bananium,
+/turf/open/floor/wood,
+/area/centcom/testchamber)
+"zw" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/box/syndie_kit/chameleon,
+/obj/item/storage/box/syndie_kit/cluwnification,
+/obj/item/storage/box/syndie_kit/chemical,
+/obj/item/storage/box/syndie_kit/emp,
+/obj/item/storage/box/syndie_kit/ez_clean,
+/obj/item/storage/box/syndie_kit/guardian,
+/obj/item/storage/box/syndie_kit/imp_adrenal,
+/obj/item/storage/box/syndie_kit/imp_freedom,
+/obj/item/storage/box/syndie_kit/imp_macrobomb,
+/obj/item/storage/box/syndie_kit/imp_microbomb,
+/obj/item/storage/box/syndie_kit/imp_radio,
+/obj/item/storage/box/syndie_kit/imp_mindslave,
+/obj/item/storage/box/syndie_kit/imp_storage,
+/obj/item/storage/box/syndie_kit/mimery,
+/obj/item/storage/box/syndie_kit/origami_bundle,
+/obj/item/storage/box/syndie_kit/romerol,
+/obj/item/storage/box/syndie_kit/throwing_weapons,
+/obj/item/storage/box/syndie_kit/tuberculosisgrenade,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "zx" = (
 /obj/structure/closet/syndicate/personal,
 /obj/effect/turf_decal/stripes/line{
@@ -11477,6 +12732,42 @@
 	},
 /turf/open/floor/grass,
 /area/wizard_station)
+"zR" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/gun/energy/ionrifle/carbine,
+/obj/item/gun/energy/laser/instakill{
+	pin = /obj/item/firing_pin/clown;
+	pixel_y = -8
+	},
+/obj/item/gun/energy/pulse{
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"zS" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "zT" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -11484,6 +12775,24 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/basketball)
+"zU" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/door/airlock/centcom{
+	armor = list("melee" = 90, "bullet" = 90, "laser" = 90, "energy" = 90, "bomb" = 90, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 90);
+	name = "Test Chamber Blast Doors"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "zV" = (
 /obj/structure/closet/secure_closet/freezer/meat{
 	locked = 0
@@ -11495,6 +12804,15 @@
 /obj/item/reagent_containers/food/snacks/carpmeat,
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
+"zW" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "zX" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -11503,6 +12821,18 @@
 /obj/item/soap/deluxe,
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
+"zY" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/pointybush,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/centcom/testchamber)
 "zZ" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -11510,6 +12840,16 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/three)
+"Aa" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/pointybush,
+/obj/item/reagent_containers/glass/bottle/adminordrazine,
+/turf/open/floor/grass,
+/area/centcom/testchamber)
 "Ab" = (
 /obj/machinery/photocopier,
 /turf/open/floor/plasteel/grimy,
@@ -11745,6 +13085,57 @@
 /obj/effect/decal/remains/xeno,
 /turf/open/floor/grass,
 /area/wizard_station)
+"AC" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/pointybush,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/centcom/testchamber)
+"AD" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"AE" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/door/airlock/centcom{
+	armor = list("melee" = 90, "bullet" = 90, "laser" = 90, "energy" = 90, "bomb" = 90, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 90);
+	name = "Test Chamber Blast Doors"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"AF" = (
+/obj/structure/glowshroom/single,
+/obj/structure/table/wood,
+/obj/item/slime_extract/rainbow,
+/obj/item/slime_extract/rainbow{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/slime_extract/rainbow{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/turf/open/floor/wood,
+/area/centcom/testchamber)
 "AG" = (
 /obj/structure/ladder/unbreakable/binary/space,
 /turf/open/indestructible/airblock,
@@ -11752,6 +13143,38 @@
 "AH" = (
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/one)
+"AI" = (
+/obj/item/slimepotion/spaceproof,
+/obj/item/slimepotion/spaceproof{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/slimepotion/speed{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/slimepotion/speed{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/slimepotion/transference{
+	pixel_x = -10
+	},
+/obj/item/slimepotion/transference{
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/obj/item/slimepotion/lavaproof{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/slimepotion/lavaproof{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/centcom/testchamber)
 "AJ" = (
 /obj/structure/chair/comfy/brown{
 	color = "#596479";
@@ -11961,6 +13384,56 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/xeno,
 /turf/open/floor/grass,
 /area/wizard_station)
+"Bj" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/glowshroom/single,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"Bk" = (
+/obj/structure/glowshroom/single,
+/obj/structure/table/wood,
+/obj/item/gun/magic/wand/death,
+/obj/item/gun/magic/wand/door,
+/obj/item/gun/magic/wand/fireball,
+/obj/item/gun/magic/wand/polymorph,
+/obj/item/gun/magic/wand/resurrection/debug,
+/obj/item/gun/magic/wand/safety,
+/obj/item/gun/magic/wand/teleport,
+/turf/open/floor/wood,
+/area/centcom/testchamber)
+"Bl" = (
+/obj/structure/table/wood,
+/obj/item/hierophant_club,
+/turf/open/floor/wood,
+/area/centcom/testchamber)
+"Bm" = (
+/obj/structure/table/wood,
+/obj/item/twohanded/mjollnir{
+	pixel_y = 3
+	},
+/obj/item/twohanded/singularityhammer,
+/obj/item/melee/transforming/cleaving_saw,
+/turf/open/floor/wood,
+/area/centcom/testchamber)
+"Bn" = (
+/obj/structure/table/wood,
+/obj/item/rune_scimmy,
+/obj/item/twohanded/vibro_weapon,
+/obj/item/melee/ghost_sword,
+/obj/item/katana,
+/obj/item/energy_katana,
+/obj/item/gun/magic/staff/spellblade,
+/turf/open/floor/wood,
+/area/centcom/testchamber)
 "Bo" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -11977,17 +13450,79 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
+"Bp" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/clothing/suit/space/space_ninja,
+/obj/item/clothing/shoes/space_ninja,
+/obj/item/clothing/mask/gas/space_ninja,
+/obj/item/clothing/head/helmet/space/space_ninja,
+/obj/item/clothing/gloves/space_ninja,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "Bq" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien18";
 	opacity = 0
 	},
 /area/bluespace_locker)
+"Br" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/gun/energy/gravity_gun,
+/obj/item/gun/energy/laser/captain/scattershot{
+	pixel_y = 8
+	},
+/obj/item/gun/energy/wormhole_projector{
+	pixel_y = -8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "Bs" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/libraryconsole/bookmanagement,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Bt" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/automatic/pistol/deagle/gold{
+	pixel_y = -6
+	},
+/obj/item/gun/ballistic/revolver/golden,
+/obj/item/gun/energy/kinetic_accelerator/crossbow/halloween,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "Bu" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -12310,6 +13845,11 @@
 	opacity = 0
 	},
 /area/bluespace_locker)
+"BU" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/item/storage/pill_bottle/stimulant,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "BV" = (
 /obj/machinery/chem_dispenser/drinks/beer,
 /turf/closed/indestructible{
@@ -12318,6 +13858,26 @@
 	smooth = 1
 	},
 /area/centcom/holding)
+"BW" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/centcom/testchamber)
+"BX" = (
+/obj/structure/grille,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/centcom/testchamber)
 "BY" = (
 /obj/item/toy/figure/syndie,
 /turf/open/floor/plating/asteroid/snow/airless,
@@ -12453,12 +14013,50 @@
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
+"Cj" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/item/reagent_containers/pill/adminordrazine,
+/obj/item/malf_upgrade,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Ck" = (
+/obj/structure/sign/warning/electricshock{
+	desc = "A warning sign which reads 'HIGH MAGICAL PRESENCE'.";
+	name = "\improper HIGH MAGICAL PRESENCE"
+	},
+/turf/closed/indestructible/riveted,
+/area/centcom/testchamber)
+"Cl" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/glowshroom/shadowshroom,
+/obj/machinery/anomalous_crystal,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "Cm" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien7";
 	opacity = 0
 	},
 /area/bluespace_locker)
+"Cn" = (
+/obj/structure/table/wood,
+/obj/item/spellbook{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/spellbook,
+/obj/item/dice/d20/fate,
+/turf/open/floor/wood,
+/area/centcom/testchamber)
 "Co" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -12863,6 +14461,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
+"CQ" = (
+/obj/structure/table/wood,
+/obj/structure/glowshroom/single,
+/obj/item/storage/backpack/holding{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/backpack/holding,
+/obj/item/desynchronizer,
+/turf/open/floor/wood,
+/area/centcom/testchamber)
 "CR" = (
 /obj/machinery/computer/security{
 	dir = 8
@@ -12882,16 +14491,54 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
+"CS" = (
+/obj/structure/table/wood,
+/obj/item/antag_spawner/nuke_ops/borg_tele/medical{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/antag_spawner/nuke_ops/borg_tele/saboteur{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/antag_spawner/nuke_ops/borg_tele/assault,
+/turf/open/floor/wood,
+/area/centcom/testchamber)
 "CT" = (
 /obj/machinery/vr_sleeper{
 	dir = 4
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"CU" = (
+/obj/structure/glowshroom/glowcap,
+/obj/structure/table/wood,
+/obj/item/book/granter/spell/barnyard,
+/obj/item/book/granter/spell/blind,
+/obj/item/book/granter/spell/charge,
+/obj/item/book/granter/spell/fireball,
+/obj/item/book/granter/spell/forcewall,
+/obj/item/book/granter/spell/knock,
+/obj/item/book/granter/spell/mimery_blockade,
+/obj/item/book/granter/spell/mimery_guns,
+/obj/item/book/granter/spell/mindswap,
+/obj/item/book/granter/spell/sacredflame,
+/obj/item/book/granter/spell/smoke,
+/obj/item/book/granter/spell/summonitem,
+/obj/item/book/granter/action/origami,
+/obj/item/book_of_babel,
+/turf/open/floor/wood,
+/area/centcom/testchamber)
 "CV" = (
 /obj/structure/chair/stool,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"CW" = (
+/obj/structure/table/wood,
+/obj/item/twohanded/pitchfork/demonic/ascended,
+/obj/item/melee/powerfist,
+/turf/open/floor/wood,
+/area/centcom/testchamber)
 "CX" = (
 /obj/structure/closet/secure_closet/security,
 /obj/item/storage/belt/security/full,
@@ -13086,12 +14733,96 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Dk" = (
+/obj/structure/glowshroom/glowcap,
+/obj/structure/table/wood,
+/obj/item/twohanded/required/chainsaw/doomslayer,
+/obj/item/melee/fryingpan/bananium,
+/obj/item/kitchen/knife/rainbowknife,
+/turf/open/floor/wood,
+/area/centcom/testchamber)
+"Dl" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/clothing/suit/space/hardsuit/wizard,
+/obj/item/clothing/suit/space/freedom,
+/obj/item/clothing/suit/space/hardsuit/ert/jani,
+/obj/item/clothing/suit/space/hardsuit/ert/paranormal,
+/obj/item/clothing/suit/space/hardsuit/ert/paranormal/beserker,
+/obj/item/clothing/suit/space/hardsuit/ert/paranormal/inquisitor,
+/obj/item/clothing/suit/space/hardsuit/shielded/wizard,
+/obj/item/clothing/suit/space/hardsuit/shielded/swat,
+/obj/item/clothing/suit/space/hardsuit/syndi/owl,
+/obj/item/clothing/suit/space/hardsuit/syndi/elite,
+/obj/item/clothing/suit/space/hostile_environment,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Dm" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/rocketlauncher/unrestricted,
+/obj/item/gun/ballistic/rocketlauncher/unrestricted,
+/obj/item/gun/energy/meteorgun{
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "Dn" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien17";
 	opacity = 0
 	},
 /area/bluespace_locker)
+"Do" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/gun/energy/kinetic_accelerator/crossbow/large{
+	pin = /obj/item/firing_pin;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Dp" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/jukebox/disco/indestructible,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "Dq" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/turf_decal/stripes/line{
@@ -13149,6 +14880,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
+"Dw" = (
+/obj/structure/table/wood,
+/obj/item/nullrod,
+/obj/item/nullrod,
+/turf/open/floor/wood,
+/area/centcom/testchamber)
 "Dx" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/neutral{
@@ -13163,6 +14900,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
+"Dy" = (
+/obj/structure/table/wood,
+/obj/item/storage/belt/wands/full{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/belt/wands/full,
+/obj/item/dragons_blood,
+/turf/open/floor/wood,
+/area/centcom/testchamber)
 "Dz" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -13925,11 +15672,31 @@
 /obj/structure/chair/stool,
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
+"Fd" = (
+/obj/structure/table/wood,
+/obj/item/clothing/suit/wizrobe,
+/obj/item/clothing/suit/wizrobe,
+/obj/item/clothing/suit/wizrobe,
+/obj/item/clothing/glasses/prism_glasses,
+/turf/open/floor/wood,
+/area/centcom/testchamber)
 "Fe" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/sashimi,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Ff" = (
+/obj/structure/table/wood,
+/obj/item/clothing/gloves/rapid,
+/obj/item/clothing/gloves/krav_maga/sec,
+/turf/open/floor/wood,
+/area/centcom/testchamber)
+"Fg" = (
+/obj/structure/table/wood,
+/obj/item/veilrender/honkrender/honkhulkrender,
+/obj/item/melee/baseball_bat/homerun,
+/turf/open/floor/wood,
+/area/centcom/testchamber)
 "Fh" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
@@ -13946,6 +15713,31 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Fk" = (
+/obj/structure/table/wood,
+/obj/item/twohanded/required/adamantineshield,
+/obj/item/shield/mirror,
+/obj/item/shield/energy/bananium,
+/obj/item/shield/energy,
+/turf/open/floor/wood,
+/area/centcom/testchamber)
+"Fl" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/card/emag,
+/obj/item/card/emag/halloween,
+/obj/item/card/emag/bluespace,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "Fm" = (
 /obj/machinery/shower{
 	dir = 4
@@ -14090,6 +15882,51 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/tdome/tdomeobserve)
+"FA" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/mecha/combat/phazon,
+/turf/open/floor/engine,
+/area/centcom/testchamber)
+"FB" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/mecha/combat/gygax,
+/turf/open/floor/engine,
+/area/centcom/testchamber)
+"FC" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/mecha/combat/marauder/seraph{
+	internals_req_access = list(303,302)
+	},
+/obj/item/card/id/centcom,
+/turf/open/floor/engine,
+/area/centcom/testchamber)
 "FD" = (
 /obj/machinery/shower{
 	dir = 4
@@ -14227,6 +16064,39 @@
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
+"FU" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/mecha/combat/gygax/dark{
+	internals_req_access = list(303,302)
+	},
+/obj/item/card/id/syndicate,
+/turf/open/floor/engine,
+/area/centcom/testchamber)
+"FV" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/mecha/combat/reticence{
+	internals_req_access = list(303,302)
+	},
+/turf/open/floor/engine,
+/area/centcom/testchamber)
 "FW" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -14239,6 +16109,36 @@
 "FX" = (
 /turf/open/floor/plasteel/stairs,
 /area/centcom/holding)
+"FY" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/sign/warning/radiation/rad_area,
+/turf/closed/indestructible/riveted,
+/area/centcom/testchamber)
+"FZ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "Ga" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien3";
@@ -14401,6 +16301,18 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Gt" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "Gu" = (
 /obj/machinery/door/airlock/silver{
 	name = "Shower"
@@ -14444,6 +16356,25 @@
 	},
 /turf/open/lava/airless,
 /area/wizard_station)
+"GA" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"GB" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "GC" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -14779,6 +16710,36 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"GZ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/sign/warning/radiation,
+/turf/closed/indestructible/riveted,
+/area/centcom/testchamber)
+"Ha" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/voodoo,
+/obj/item/warpwhistle,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "Hb" = (
 /obj/structure/sink{
 	dir = 8;
@@ -14851,6 +16812,43 @@
 	opacity = 0
 	},
 /area/bluespace_locker)
+"Hj" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/glowshroom/shadowshroom,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"Hk" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/clothing/shoes/magboots/advance,
+/obj/structure/table/reinforced,
+/obj/item/paint/anycolor,
+/obj/item/construction/rld,
+/obj/item/construction/rcd/arcd,
+/obj/item/construction/rcd/combat/admin,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Hl" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/centcom/testchamber)
 "Hm" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -15002,6 +17000,34 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/tdome/tdomeobserve)
+"Hy" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/mecha/medical/odysseus,
+/turf/open/floor/engine,
+/area/centcom/testchamber)
+"Hz" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/mecha/combat/durand,
+/turf/open/floor/engine,
+/area/centcom/testchamber)
 "HA" = (
 /obj/structure/sink{
 	dir = 8;
@@ -15061,6 +17087,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
+"HE" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/mecha/combat/marauder{
+	internals_req_access = list(303,302)
+	},
+/obj/item/card/id/centcom,
+/turf/open/floor/engine,
+/area/centcom/testchamber)
 "HF" = (
 /obj/structure/sink{
 	dir = 4;
@@ -15129,6 +17172,23 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
+"HL" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/mecha/combat/marauder/mauler{
+	internals_req_access = list(303,302)
+	},
+/obj/item/card/id/syndicate,
+/turf/open/floor/engine,
+/area/centcom/testchamber)
 "HM" = (
 /obj/structure/chair,
 /obj/effect/landmark/thunderdome/observe,
@@ -15482,6 +17542,42 @@
 "Il" = (
 /turf/closed/indestructible/fakeglass,
 /area/tdome/tdomeobserve)
+"Im" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/mecha/combat/honker{
+	internals_req_access = list(303,302)
+	},
+/turf/open/floor/engine,
+/area/centcom/testchamber)
+"In" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/item/storage/firstaid/tactical{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/tactical,
+/obj/item/storage/pill_bottle/floorpill/full,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "Io" = (
 /obj/item/storage/box/matches{
 	pixel_x = -3;
@@ -15689,6 +17785,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/tdome/arena)
+"IK" = (
+/obj/machinery/power/supermatter_crystal,
+/turf/open/floor/engine,
+/area/centcom/testchamber)
 "IL" = (
 /obj/effect/landmark/thunderdome/one,
 /obj/effect/turf_decal/stripes/line{
@@ -15710,6 +17810,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/tdome/arena)
+"IO" = (
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "IP" = (
 /obj/structure/rack,
 /obj/item/clothing/under/color/green,
@@ -16079,6 +18182,41 @@
 "JI" = (
 /turf/closed/indestructible/fakeglass,
 /area/tdome/tdomeadmin)
+"JJ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/structure/glowshroom/single,
+/obj/item/wisp_lantern{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/wisp_lantern,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"JK" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/prisoncube,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "JL" = (
 /obj/structure/rack,
 /obj/item/clothing/under/color/green,
@@ -16210,6 +18348,37 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/tdomeadmin)
+"JV" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/immortality_talisman,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"JW" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/glasses/godeye,
+/obj/item/clothing/glasses/godeye,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "JX" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -16271,6 +18440,68 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/tdomeadmin)
+"Kd" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/guardiancreator,
+/obj/item/guardiancreator{
+	pixel_y = 3
+	},
+/obj/item/guardiancreator{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Ke" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/mayhem,
+/obj/item/antag_spawner/slaughter_demon,
+/obj/item/antag_spawner/slaughter_demon,
+/obj/item/antag_spawner/slaughter_demon/laughter,
+/obj/item/antag_spawner/slaughter_demon/laughter,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Kf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/organ/heart/demon,
+/obj/item/organ/heart/nightmare{
+	pixel_x = 5
+	},
+/obj/item/organ/heart/cursed/wizard{
+	pixel_x = 3;
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "Kg" = (
 /turf/closed/indestructible/fakedoor{
 	name = "Thunderdome Admin"
@@ -16288,6 +18519,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/tdome/tdomeadmin)
+"Ki" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/bottle/potion/flight,
+/obj/item/reagent_containers/glass/bottle/potion/flight,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "Kj" = (
 /obj/machinery/door/airlock/external{
 	name = "Backup Emergency Escape Shuttle"
@@ -16307,6 +18554,50 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"Kl" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/bottle/beesease{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bottle/gbs{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/glass/bottle/pierrot_throat,
+/obj/item/reagent_containers/glass/bottle/romerol{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/glass/bottle/wizarditis,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Km" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/spray/waterflower/lube,
+/obj/item/clothing/head/peaceflower,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "Kn" = (
 /obj/structure/bookcase/random,
 /obj/effect/turf_decal/tile/neutral{
@@ -16534,6 +18825,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/tdomeadmin)
+"Kz" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/structure/glowshroom/single,
+/obj/item/sharpener/super,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "KA" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -16560,6 +18867,22 @@
 /obj/machinery/status_display/ai,
 /turf/closed/indestructible/riveted,
 /area/tdome/tdomeadmin)
+"KE" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/brass/prefilled/ratvar/admin,
+/obj/item/storage/toolbox/syndicate,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "KF" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -17096,15 +19419,95 @@
 	},
 /turf/open/floor/plasteel,
 /area/tdome/arena)
+"Mj" = (
+/obj/machinery/door/poddoor{
+	id = "mixvent";
+	name = "Mixer Room Vent"
+	},
+/turf/open/floor/engine/vacuum,
+/area/centcom/testchamber)
+"Mk" = (
+/obj/machinery/door/airlock/centcom{
+	armor = list("melee" = 90, "bullet" = 90, "laser" = 90, "energy" = 90, "bomb" = 90, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 90);
+	name = "Test Chamber Blast Doors"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Ml" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "Mm" = (
 /turf/open/floor/grass,
 /area/centcom/holding)
+"Mn" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/melee/supermatter_sword,
+/obj/structure/table/wood/fancy,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"Mo" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"Mp" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Mq" = (
+/turf/open/floor/engine/vacuum,
+/area/centcom/testchamber)
+"Mr" = (
+/obj/machinery/sparker/toxmix{
+	dir = 2;
+	id = "mixingsparker";
+	pixel_x = 25
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/engine/vacuum,
+/area/centcom/testchamber)
 "Ms" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-10"
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Mt" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/closed/indestructible/riveted,
+/area/centcom/testchamber)
 "Mu" = (
 /obj/machinery/light{
 	dir = 1
@@ -17121,6 +19524,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
+"Mv" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/bluespace,
+/area/centcom/testchamber)
 "Mw" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -17155,9 +19568,32 @@
 	},
 /turf/open/floor/plating/asteroid/snow/airless,
 /area/syndicate_mothership)
+"Mz" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"MA" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4;
+	name = "mix to port"
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "MB" = (
 /turf/open/indestructible/binary,
 /area/fabric_of_reality)
+"MC" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "MD" = (
 /obj/effect/light_emitter{
 	set_cap = 1;
@@ -17176,6 +19612,21 @@
 	},
 /turf/open/floor/wood,
 /area/wizard_station)
+"MF" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/syndicatebomb,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "MG" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -17198,26 +19649,181 @@
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
+"MJ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/syndicatebomb/self_destruct,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "MK" = (
 /obj/structure/mineral_door/paperframe{
 	name = "Dojo"
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"ML" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#c1caff"
+	},
+/mob/living/simple_animal/hostile/megafauna/colossus,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "MM" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
+"MN" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#c1caff"
+	},
+/mob/living/simple_animal/hostile/megafauna/bubblegum,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"MO" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#c1caff"
+	},
+/mob/living/simple_animal/hostile/megafauna/dragon,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"MP" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/bluespace,
+/area/centcom/testchamber)
+"MQ" = (
+/obj/machinery/portable_atmospherics/canister/miasma,
+/turf/open/floor/bluespace,
+/area/centcom/testchamber)
 "MR" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
+"MS" = (
+/obj/machinery/portable_atmospherics/canister/nitryl,
+/turf/open/floor/bluespace,
+/area/centcom/testchamber)
 "MT" = (
 /obj/machinery/processor,
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
+"MU" = (
+/obj/machinery/portable_atmospherics/canister/nob,
+/turf/open/floor/bluespace,
+/area/centcom/testchamber)
+"MV" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/bluespace,
+/area/centcom/testchamber)
+"MW" = (
+/obj/machinery/portable_atmospherics/canister/pluoxium,
+/turf/open/floor/bluespace,
+/area/centcom/testchamber)
+"MX" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxins_mixing_input{
+	dir = 4
+	},
+/turf/open/floor/engine/vacuum,
+/area/centcom/testchamber)
+"MY" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/door/airlock/centcom{
+	armor = list("melee" = 90, "bullet" = 90, "laser" = 90, "energy" = 90, "bomb" = 90, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 90);
+	name = "Test Chamber Blast Doors"
+	},
+/obj/structure/fans/tiny,
+/turf/closed/wall/r_wall,
+/area/centcom/testchamber)
+"MZ" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8
+	},
+/turf/open/floor/bluespace,
+/area/centcom/testchamber)
+"Na" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10;
+	initialize_directions = 10
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Nb" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/tank_dispenser,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Nc" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/chem_dispenser/fullupgrade,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/obj/item/reagent_containers/glass/beaker/noreact,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "Nd" = (
 /turf/closed/indestructible{
 	icon = 'icons/turf/walls/wood_wall.dmi';
@@ -17225,12 +19831,73 @@
 	smooth = 1
 	},
 /area/centcom/holding)
+"Ne" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Nf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/belt/grenade/full,
+/obj/item/storage/belt/grenade/full{
+	pixel_y = 3
+	},
+/obj/item/storage/belt/grenade/full{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Ng" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "Nh" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/drinkingglasses,
 /obj/item/reagent_containers/food/drinks/shaker,
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
+"Ni" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Nj" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "Nk" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Thunderdome";
@@ -17245,6 +19912,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
+"Nl" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "Nm" = (
 /obj/structure/closet/crate,
 /obj/item/vending_refill/autodrobe,
@@ -17272,6 +19949,71 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
+"No" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"Np" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Nq" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/sign/warning/xeno_mining,
+/turf/closed/indestructible/riveted,
+/area/centcom/testchamber)
+"Nt" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/miasma,
+/turf/open/floor/plasteel/dark,
+/area/centcom/testchamber)
+"Nu" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/nitryl,
+/turf/open/floor/bluespace,
+/area/centcom/testchamber)
 "Nv" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/cafeteria{
@@ -17282,6 +20024,20 @@
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
+"Nx" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/nob,
+/turf/open/floor/plasteel/dark,
+/area/centcom/testchamber)
 "Ny" = (
 /obj/machinery/modular_computer/console/preset/research,
 /obj/machinery/light{
@@ -17289,6 +20045,62 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Nz" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/bluespace,
+/area/centcom/testchamber)
+"NA" = (
+/turf/open/floor/bluespace,
+/area/centcom/testchamber)
+"NB" = (
+/obj/machinery/meter,
+/obj/machinery/button/door{
+	id = "mixvent";
+	name = "Mixing Room Vent Control";
+	pixel_x = -25;
+	pixel_y = 5;
+	req_access_txt = "7"
+	},
+/obj/machinery/button/ignition{
+	id = "mixingsparker";
+	pixel_x = -25;
+	pixel_y = -5
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"NC" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4;
+	name = "port to mix"
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"ND" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/bluespace,
+/area/centcom/testchamber)
 "NE" = (
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/podStorage)
@@ -17310,6 +20122,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
+"NH" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/testchamber)
+"NI" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/bluespace,
+/area/centcom/testchamber)
 "NJ" = (
 /obj/structure/table,
 /obj/item/book/manual/hydroponics_pod_people,
@@ -17327,9 +20159,136 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
+"NK" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/grenade/syndieminibomb,
+/obj/item/grenade/syndieminibomb{
+	pixel_x = 4
+	},
+/obj/item/grenade/syndieminibomb{
+	pixel_x = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"NL" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/grenade/spawnergrenade/clown,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"NM" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/item/implanter/explosive_macro,
+/obj/item/implanter/explosive_macro{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/implanter/explosive_macro{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"NN" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/sign/warning/explosives,
+/turf/closed/indestructible/riveted,
+/area/centcom/testchamber)
 "NO" = (
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
+"NP" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"NQ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"NR" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/item/pneumatic_cannon/pie/selfcharge,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"NS" = (
+/obj/structure/sign/warning/explosives,
+/turf/closed/indestructible/riveted,
+/area/centcom/testchamber)
 "NT" = (
 /obj/structure/window/paperframe{
 	CanAtmosPass = 0
@@ -17349,6 +20308,84 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
+"NV" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/item/hot_potato/syndicate,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"NW" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"NX" = (
+/obj/structure/sign/warning/xeno_mining,
+/turf/closed/indestructible/riveted,
+/area/centcom/testchamber)
+"Oa" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Oe" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/item/reagent_containers/hypospray/medipen/stimpack/large,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Og" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/syndicatebomb/badmin/clown,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Oh" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/pointybush,
+/obj/item/reagent_containers/pill/adminordrazine,
+/obj/machinery/nuclearbomb/syndicate/bananium,
+/turf/open/floor/grass,
+/area/centcom/testchamber)
+"Oi" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/pointybush,
+/obj/machinery/nuclearbomb/beer,
+/turf/open/floor/grass,
+/area/centcom/testchamber)
 "Oj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
@@ -17363,6 +20400,61 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
+"Ok" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/bluespace,
+/area/centcom/testchamber)
+"Ol" = (
+/obj/structure/sign/warning/biohazard,
+/turf/closed/indestructible/riveted,
+/area/centcom/testchamber)
+"Om" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/item/orion_ship,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"On" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/antigravity{
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/obj/item/grenade/antigravity{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/grenade/antigravity{
+	pixel_x = 9;
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"Oo" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/chem_grenade/holy,
+/obj/item/grenade/chem_grenade/holy{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/grenade/chem_grenade/holy{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "Op" = (
 /obj/structure/sink{
 	dir = 8;
@@ -17386,10 +20478,151 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/two)
+"Or" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/plastic/x4,
+/obj/item/grenade/plastic/x4,
+/obj/item/grenade/plastic/x4,
+/obj/item/grenade/plastic/c4{
+	pixel_x = 7
+	},
+/obj/item/grenade/plastic/c4{
+	pixel_x = 7
+	},
+/obj/item/grenade/plastic/c4{
+	pixel_x = 7
+	},
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"Os" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/spawnergrenade/syndiesoap,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"Ot" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Ou" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Ov" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/item/storage/box/syndie_kit/bee_grenades,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "Ow" = (
 /obj/effect/landmark/bluespace_locker_origin,
 /turf/open/floor/plasteel/dark,
 /area/bluespace_locker)
+"Ox" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/item/uplink/nuclear/debug{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/uplink/debug,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Oy" = (
+/obj/machinery/portable_atmospherics/canister/bz,
+/turf/open/floor/bluespace,
+/area/centcom/testchamber)
+"Oz" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/stimulum,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/portable_atmospherics/canister/stimulum,
+/turf/open/floor/plasteel/dark,
+/area/centcom/testchamber)
+"OA" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/bluespace,
+/area/centcom/testchamber)
+"OB" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/tritium,
+/turf/open/floor/plasteel/dark,
+/area/centcom/testchamber)
+"OC" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/water_vapor,
+/turf/open/floor/bluespace,
+/area/centcom/testchamber)
 "OD" = (
 /obj/machinery/microwave{
 	desc = "Cooks and boils stuff, somehow.";
@@ -17399,6 +20632,29 @@
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
+"OE" = (
+/obj/machinery/portable_atmospherics/scrubber/huge/movable,
+/turf/open/floor/bluespace,
+/area/centcom/testchamber)
+"OF" = (
+/obj/item/assembly/prox_sensor{
+	pixel_x = -4;
+	pixel_y = 1
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = 9;
+	pixel_y = -2
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_y = 2
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "OG" = (
 /obj/structure/dresser,
 /obj/machinery/light{
@@ -17406,6 +20662,92 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"OH" = (
+/obj/structure/chair,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"OI" = (
+/obj/structure/table/reinforced,
+/obj/item/wrench,
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/obj/item/analyzer,
+/obj/item/pipe_dispenser,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"OJ" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/chem_grenade/bioterrorfoam,
+/obj/item/grenade/chem_grenade/bioterrorfoam{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/grenade/chem_grenade/bioterrorfoam{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"OK" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/chem_grenade/teargas/moustache,
+/obj/item/grenade/chem_grenade/teargas/moustache{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/grenade/chem_grenade/teargas/moustache{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"OL" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/clusterbuster/cleaner,
+/obj/item/grenade/clusterbuster/emp{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/grenade/clusterbuster/facid{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"OM" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/clusterbuster/inferno,
+/obj/item/grenade/clusterbuster/spawner_spesscarp{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/grenade/clusterbuster/spawner_manhacks{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"ON" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"OO" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "OP" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -17413,6 +20755,31 @@
 "OQ" = (
 /turf/open/space/bluespace_locker_mirage,
 /area/bluespace_locker)
+"OR" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/item/storage/pill_bottle/stimulant,
+/obj/item/reagent_containers/pill/adminordrazine,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"OS" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/item/storage/pill_bottle/aranesp,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"OT" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "OU" = (
 /obj/item/clothing/under/jabroni,
 /obj/item/clothing/under/geisha,
@@ -17421,14 +20788,184 @@
 /obj/item/clothing/under/roman,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"OV" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/ertCom,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"OW" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/robot_debris/gib,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"OX" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/oil/streak,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"OY" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/energy/pulse,
+/obj/machinery/recharger,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"OZ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/ertSec,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "Pa" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
+"Pb" = (
+/obj/machinery/portable_atmospherics/canister/stimulum,
+/turf/open/floor/bluespace,
+/area/centcom/testchamber)
+"Pc" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/bluespace,
+/area/centcom/testchamber)
+"Pd" = (
+/obj/machinery/portable_atmospherics/canister/tritium,
+/turf/open/floor/bluespace,
+/area/centcom/testchamber)
+"Pe" = (
+/obj/machinery/portable_atmospherics/canister/water_vapor,
+/turf/open/floor/bluespace,
+/area/centcom/testchamber)
+"Pf" = (
+/obj/item/assembly/signaler{
+	pixel_y = 8
+	},
+/obj/item/assembly/signaler{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/assembly/signaler{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/assembly/signaler{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Pg" = (
+/obj/item/transfer_valve{
+	pixel_x = -5
+	},
+/obj/item/transfer_valve{
+	pixel_x = -5
+	},
+/obj/item/transfer_valve,
+/obj/item/transfer_valve,
+/obj/item/transfer_valve{
+	pixel_x = 5
+	},
+/obj/item/transfer_valve{
+	pixel_x = 5
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "Ph" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Pi" = (
+/obj/structure/table,
+/obj/item/assembly/igniter{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 2;
+	pixel_y = -1
+	},
+/obj/item/assembly/timer{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/assembly/timer{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/assembly/timer{
+	pixel_x = -3;
+	pixel_y = -8
+	},
+/obj/item/assembly/timer{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Pj" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Pk" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "Pl" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -17440,17 +20977,73 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/four)
+"Pn" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/vending/syndichem,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "Po" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
+"Pp" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/vending/medical/syndicate_access,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Pq" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/food_cart,
+/obj/item/reagent_containers/food/snacks/pizza/arnold,
+/obj/item/guardiancreator/carp/choose,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "Pr" = (
 /obj/structure/table,
 /obj/item/book/manual/chef_recipes,
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
+"Ps" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/vending/autodrobe/all_access,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Pt" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/vending/toyliberationstation,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Pu" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "Pv" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -17460,10 +21053,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/four)
+"Pw" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "Px" = (
 /obj/machinery/vr_sleeper,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Py" = (
+/obj/structure/table/reinforced,
+/obj/item/modular_computer/laptop/preset/civillian,
+/obj/item/reagent_containers/syringe/gluttony,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "Pz" = (
 /obj/structure/table/reinforced,
 /obj/item/paper/pamphlet/centcom/visitor_info,
@@ -17475,12 +21090,71 @@
 	},
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
+"PB" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/item/reagent_containers/pill/adminordrazine,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"PC" = (
+/obj/structure/table/reinforced,
+/obj/item/modular_computer/laptop/preset/civillian,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"PD" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"PE" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/part_replacer/bluespace/tier4,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "PF" = (
 /obj/machinery/vr_sleeper{
 	dir = 1
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"PG" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/item/storage/pill_bottle/zoom,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"PH" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/item/reagent_containers/pill/adminordrazine,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "PI" = (
 /obj/machinery/biogenerator,
 /obj/effect/turf_decal/tile/green{
@@ -17495,6 +21169,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
+"PJ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/grille/ratvar,
+/turf/open/floor/plating,
+/area/centcom/testchamber)
 "PK" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -17506,6 +21185,21 @@
 /obj/machinery/autolathe,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"PM" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/genericbush,
+/obj/machinery/light,
+/turf/open/floor/grass,
+/area/centcom/testchamber)
+"PN" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "PO" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green{
@@ -17520,6 +21214,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
+"PP" = (
+/obj/machinery/doppler_array/research/science{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/turf/open/floor/plasteel{
+	dir = 2
+	},
+/area/centcom/testchamber)
 "PQ" = (
 /obj/structure/chair/wood/wings{
 	dir = 4
@@ -17529,6 +21234,55 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"PR" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"PS" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/genericbush,
+/obj/item/orion_ship,
+/obj/machinery/light,
+/turf/open/floor/grass,
+/area/centcom/testchamber)
+"PT" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"PU" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/item/his_grace,
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "PV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -17555,9 +21309,33 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
+"Qa" = (
+/obj/structure/lattice/catwalk/swarmer_catwalk,
+/obj/effect/decal/cleanable/shreds,
+/turf/open/space/basic,
+/area/centcom/testchamber)
+"Qb" = (
+/obj/structure/lattice/catwalk/swarmer_catwalk,
+/turf/open/space/basic,
+/area/centcom/testchamber)
+"Qc" = (
+/obj/structure/lattice/catwalk/swarmer_catwalk,
+/obj/effect/decal/cleanable/leaper_sludge,
+/turf/open/space/basic,
+/area/centcom/testchamber)
+"Qd" = (
+/obj/structure/lattice/catwalk/swarmer_catwalk,
+/obj/effect/decal/cleanable/robot_debris/old,
+/turf/open/space/basic,
+/area/centcom/testchamber)
 "Qe" = (
 /turf/open/ai_visible,
 /area/ai_multicam_room)
+"Qf" = (
+/obj/structure/grille/indestructable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/centcom/testchamber)
 "Qg" = (
 /obj/structure/closet,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -17569,6 +21347,16 @@
 /obj/item/reagent_containers/medspray/synthflesh,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Qh" = (
+/obj/structure/lattice/catwalk/swarmer_catwalk,
+/mob/living/simple_animal/hostile/carp/ranged/chaos,
+/turf/open/space/basic,
+/area/centcom/testchamber)
+"Qi" = (
+/obj/structure/light_prism,
+/obj/structure/lattice/catwalk/swarmer_catwalk,
+/turf/open/space/basic,
+/area/centcom/testchamber)
 "Qj" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/sake,
@@ -17581,10 +21369,51 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/centcom/holding)
+"Ql" = (
+/obj/structure/lattice/catwalk/swarmer_catwalk,
+/obj/effect/decal/cleanable/blood/gibs/core,
+/turf/open/space/basic,
+/area/centcom/testchamber)
 "Qm" = (
 /obj/singularity/wizard/mapped,
 /turf/open/indestructible/binary,
 /area/fabric_of_reality)
+"Qn" = (
+/obj/structure/lattice/catwalk/swarmer_catwalk,
+/mob/living/simple_animal/hostile/carp/ranged,
+/turf/open/space/basic,
+/area/centcom/testchamber)
+"Qo" = (
+/obj/structure/lattice/catwalk/swarmer_catwalk,
+/obj/structure/light_prism,
+/turf/open/space/basic,
+/area/centcom/testchamber)
+"Qp" = (
+/obj/structure/lattice/catwalk/swarmer_catwalk,
+/mob/living/simple_animal/hostile/retaliate/goat/king,
+/turf/open/space/basic,
+/area/centcom/testchamber)
+"Qq" = (
+/obj/structure/lattice/catwalk/swarmer_catwalk,
+/obj/effect/decal/cleanable/leaper_sludge,
+/mob/living/simple_animal/hostile/carp/ranged/chaos,
+/turf/open/space/basic,
+/area/centcom/testchamber)
+"Qr" = (
+/obj/structure/lattice/catwalk/swarmer_catwalk,
+/obj/effect/decal/cleanable/blood/gibs/bubblegum,
+/turf/open/space/basic,
+/area/centcom/testchamber)
+"Qs" = (
+/obj/structure/lattice/catwalk/swarmer_catwalk,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/space/basic,
+/area/centcom/testchamber)
+"Qt" = (
+/obj/structure/lattice/catwalk/swarmer_catwalk,
+/obj/effect/decal/cleanable/blood/gibs/body,
+/turf/open/space/basic,
+/area/centcom/testchamber)
 "Qu" = (
 /obj/machinery/vr_sleeper{
 	dir = 8
@@ -17594,6 +21423,11 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Qv" = (
+/obj/structure/lattice/catwalk/swarmer_catwalk,
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/space/basic,
+/area/centcom/testchamber)
 "QA" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria,
@@ -54841,15 +58675,15 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
 aa
 aa
 aa
@@ -55098,15 +58932,15 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+MP
+MP
+NA
+NA
+Ok
+Oy
+Oy
+hH
 aa
 aa
 aa
@@ -55355,15 +59189,15 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+MQ
+Nt
+ND
+NH
+ND
+Oz
+Pb
+hH
 aa
 aa
 aa
@@ -55612,15 +59446,15 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+MS
+Nu
+NH
+ND
+NH
+OA
+Pc
+hH
 aa
 aa
 aa
@@ -55869,15 +59703,15 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+MU
+Nx
+ND
+NH
+ND
+OB
+Pd
+hH
 aa
 aa
 aa
@@ -56126,15 +59960,15 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+MV
+Nz
+NH
+ND
+NH
+OC
+Pe
+hH
 aa
 aa
 aa
@@ -56383,15 +60217,15 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+MW
+MW
+NI
+NA
+NA
+OE
+OE
+hH
 aa
 aa
 aa
@@ -56628,29 +60462,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+Mk
+Ol
+hH
+hH
+hH
+hH
+hH
 aa
 aa
 aa
@@ -56885,29 +60719,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+jA
+sd
+tc
+uI
+wU
+zR
+Br
+Dm
+BW
+Hl
+Mj
+Mq
+Mq
+BW
+NK
+ta
+Om
+OF
+Pf
+sd
+jA
+hH
 aa
 aa
 aa
@@ -57142,29 +60976,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+lS
+sd
+td
+td
+td
+td
+td
+td
+yO
+Hl
+Mj
+Mq
+Mq
+yO
+NL
+Ne
+ta
+OH
+Pg
+sd
+PM
+hH
 aa
 aa
 aa
@@ -57399,29 +61233,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+jA
+sd
+td
+uK
+wZ
+td
+Bt
+Do
+yO
+Hl
+Mj
+Mr
+MX
+yO
+NM
+Og
+ta
+OI
+Pi
+sd
+jA
+hH
 aa
 aa
 aa
@@ -57656,29 +61490,29 @@ Kg
 Iv
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+hH
+hH
+td
+uN
+xa
+td
+yN
+yN
+yN
+yN
+hH
+Mt
+MY
+yN
+yN
+yN
+AE
+yN
+yN
+hH
+hH
+hH
 aa
 aa
 aa
@@ -57913,29 +61747,29 @@ JG
 Iv
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+jA
+sd
+td
+vp
+xA
+td
+yN
+td
+td
+zS
+hH
+Mv
+MZ
+NA
+BW
+wi
+zW
+zW
+OO
+Np
+PN
+hH
 aa
 aa
 aa
@@ -58170,29 +62004,29 @@ JG
 Iv
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+lS
+sd
+td
+vq
+xC
+td
+yN
+td
+FA
+Hy
+hH
+Mt
+MY
+yN
+NN
+wq
+On
+OJ
+Ni
+PE
+PP
+hH
 aa
 aa
 aa
@@ -58427,29 +62261,29 @@ JX
 Iv
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+jA
+sd
+td
+vr
+xD
+td
+yO
+td
+FB
+Hz
+hH
+Mz
+Na
+NB
+NP
+wq
+Oo
+OK
+Ni
+PD
+PR
+hH
 aa
 aa
 aa
@@ -58684,29 +62518,29 @@ JG
 Iv
 Iv
 Iv
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+hH
+hH
+td
+vy
+xF
+td
+yO
+td
+td
+zS
+hH
+MA
+Nb
+NC
+NQ
+wq
+Or
+OL
+Ni
+hH
+hH
+hH
 aa
 aa
 aa
@@ -58941,29 +62775,29 @@ JG
 IR
 KA
 Iv
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+jA
+sd
+td
+vz
+yc
+td
+yO
+td
+FC
+HE
+hH
+MC
+ta
+MC
+ta
+wq
+Os
+OM
+Ni
+sd
+jA
+hH
 aa
 aa
 aa
@@ -59198,29 +63032,29 @@ JG
 IR
 KB
 Iv
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+lS
+sd
+td
+we
+ye
+td
+yN
+td
+FU
+HL
+hH
+MF
+Nc
+ta
+ta
+wR
+AD
+AD
+OT
+sd
+PS
+hH
 aa
 aa
 aa
@@ -59455,29 +63289,29 @@ JG
 IR
 KA
 Iv
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+jA
+sd
+td
+td
+td
+zS
+yN
+td
+td
+zS
+hH
+MF
+Ne
+ta
+ta
+ta
+Ot
+ON
+Pj
+sd
+jA
+hH
 aa
 aa
 aa
@@ -59712,29 +63546,29 @@ JG
 Iv
 Iv
 Iv
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+hH
+hH
+tj
+wg
+yg
+td
+yN
+td
+FV
+Im
+hH
+MJ
+Nf
+ta
+NR
+ta
+Ou
+MC
+Pk
+hH
+hH
+hH
 aa
 aa
 aa
@@ -59968,29 +63802,29 @@ Iv
 Kh
 Iv
 Iv
+oU
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+hH
+wh
+hH
+zU
+hH
+zU
+hH
+hH
+hH
+hH
+hH
+AE
+NS
+AE
+hH
+wh
+hH
+hH
+hH
 aa
 aa
 aa
@@ -60227,28 +64061,28 @@ Kn
 Iv
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+hH
+tk
+ta
+yh
+td
+BU
+td
+ta
+In
+yh
+ta
+ta
+td
+NV
+td
+Ov
+ta
+ta
+PG
+hH
+hH
 aa
 aa
 aa
@@ -60484,28 +64318,28 @@ Ko
 KC
 Iv
 Iv
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+sZ
+ta
+td
+td
+td
+td
+td
+td
+td
+td
+td
+td
+td
+td
+td
+td
+td
+td
+ta
+PT
+hH
 aa
 aa
 aa
@@ -60740,29 +64574,29 @@ JG
 Kp
 IR
 KG
-Iv
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+px
+pz
+ta
+td
+td
+yi
+zW
+zW
+td
+zW
+zW
+zW
+zW
+zW
+td
+zW
+zW
+zW
+OO
+td
+td
+PU
+Qf
 aa
 aa
 aa
@@ -60997,29 +64831,29 @@ JG
 Kq
 IR
 KA
-Iv
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+px
+pA
+ta
+td
+wi
+yL
+yN
+yN
+zU
+FY
+yO
+yO
+yO
+GZ
+zU
+yN
+yN
+yN
+OR
+OO
+td
+sZ
+Qf
 aa
 aa
 aa
@@ -61255,28 +65089,28 @@ Kr
 Iv
 IR
 Iv
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+pB
+ta
+td
+wq
+yN
+yN
+yN
+td
+FZ
+td
+Dp
+td
+td
+td
+yN
+Oh
+yN
+yN
+Ni
+td
+ta
+Qf
 aa
 aa
 aa
@@ -61512,28 +65346,28 @@ Kc
 IR
 KA
 Iv
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+pC
+ta
+td
+wq
+yN
+zY
+BW
+td
+Gt
+zW
+Ml
+zW
+Ng
+td
+BW
+rU
+zY
+yN
+Pn
+td
+Oa
+hH
 aa
 aa
 aa
@@ -61769,28 +65603,28 @@ Ks
 IR
 KG
 Iv
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+pD
+ta
+td
+wq
+yO
+rU
+BW
+td
+wq
+IK
+IO
+IK
+Ni
+td
+BW
+jA
+rU
+yO
+Pp
+td
+sZ
+hH
 aa
 aa
 aa
@@ -62026,28 +65860,28 @@ Kt
 KD
 IR
 Iv
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+pT
+tb
+td
+wq
+yP
+Aa
+BW
+Dp
+GA
+IO
+Mn
+IO
+Nj
+Dp
+BW
+rU
+jA
+yO
+Pq
+td
+Mp
+hH
 aa
 aa
 aa
@@ -62283,28 +66117,28 @@ Ku
 IR
 KG
 Iv
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+pU
+ta
+td
+wq
+yO
+rU
+BW
+td
+wq
+IK
+IO
+IK
+Ni
+td
+BW
+jA
+rU
+yO
+Ps
+td
+sZ
+hH
 aa
 aa
 aa
@@ -62540,28 +66374,28 @@ Kc
 IR
 KA
 Iv
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+qh
+ta
+td
+wq
+yN
+AC
+BX
+td
+GB
+AD
+Mo
+AD
+Nl
+td
+BW
+rU
+AC
+yN
+Pt
+td
+Oa
+hH
 aa
 aa
 aa
@@ -62797,28 +66631,28 @@ Kv
 Iv
 IR
 Iv
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+qF
+ta
+td
+wq
+yN
+yN
+yN
+td
+td
+td
+Dp
+td
+No
+td
+yN
+Oi
+yN
+yN
+Ni
+td
+ta
+Qf
 aa
 aa
 aa
@@ -63053,29 +66887,29 @@ JG
 Kw
 IR
 KG
-Iv
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+px
+qG
+ta
+td
+wR
+yQ
+yN
+yN
+zU
+GZ
+yO
+yO
+yO
+FY
+zU
+yN
+yN
+yN
+OS
+OT
+td
+sZ
+Qf
 aa
 aa
 aa
@@ -63310,29 +67144,29 @@ JG
 Kx
 IR
 KA
-Iv
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+px
+rb
+ta
+td
+td
+wR
+AD
+AD
+td
+AD
+AD
+AD
+AD
+AD
+td
+AD
+AD
+AD
+OT
+td
+td
+Ne
+Qf
 aa
 aa
 aa
@@ -63568,28 +67402,28 @@ Ky
 KC
 Iv
 Iv
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+sZ
+ta
+td
+td
+td
+td
+td
+td
+td
+td
+td
+td
+td
+td
+td
+td
+td
+td
+ta
+PT
+hH
 aa
 aa
 aa
@@ -63825,28 +67659,28 @@ Kn
 Iv
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+hH
+tl
+ta
+yR
+td
+Cj
+td
+ta
+ta
+yR
+In
+ta
+td
+NW
+td
+Ox
+ta
+ta
+PH
+hH
+hH
 aa
 aa
 aa
@@ -64083,26 +67917,26 @@ Iv
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+hH
+wh
+hH
+AE
+Ck
+AE
+hH
+hH
+hH
+hH
+hH
+zU
+NX
+zU
+hH
+wh
+hH
+hH
+hH
 aa
 aa
 aa
@@ -64338,31 +68172,31 @@ JG
 Iv
 Iv
 Iv
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+hH
+hH
+tm
+ta
+yS
+td
+Cl
+td
+Ha
+JJ
+hH
+IO
+yN
+td
+td
+td
+yN
+OV
+sZ
+hH
+hH
+hH
+hH
+hH
 aa
 aa
 aa
@@ -64595,31 +68429,31 @@ JG
 IR
 KA
 Iv
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+rc
+sd
+tv
+td
+yT
+td
+td
+td
+td
+JK
+hH
+ML
+yO
+td
+Oa
+td
+yN
+OW
+Pu
+PJ
+Qa
+Qh
+Qq
+hH
 aa
 aa
 aa
@@ -64852,31 +68686,31 @@ JG
 IR
 KB
 Iv
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+rU
+sd
+tw
+td
+yW
+AF
+Cn
+Dw
+Bj
+JV
+hH
+IO
+yN
+td
+td
+td
+zU
+OX
+Pw
+PJ
+Qb
+Qi
+Qr
+hH
 aa
 aa
 aa
@@ -65109,31 +68943,31 @@ JG
 IR
 KA
 Iv
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+rY
+sd
+tY
+td
+zc
+AI
+CQ
+Dy
+td
+JW
+hH
+yN
+Nq
+td
+Oa
+td
+yN
+OY
+Py
+PJ
+Qc
+Qa
+Qh
+hH
 aa
 aa
 aa
@@ -65366,31 +69200,31 @@ JG
 Iv
 Iv
 Iv
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+hH
+hH
+ua
+td
+td
+Bj
+td
+td
+td
+Kd
+hH
+IO
+yN
+td
+td
+zS
+yN
+yN
+yN
+hH
+hH
+hH
+hH
+hH
 aa
 aa
 aa
@@ -65623,31 +69457,31 @@ JX
 Iv
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+jA
+sd
+ub
+td
+zn
+Bk
+CS
+Fd
+td
+Ke
+hH
+MN
+yO
+td
+ta
+td
+yN
+OZ
+PB
+PJ
+Qb
+Ql
+Qn
+hH
 aa
 aa
 aa
@@ -65880,31 +69714,31 @@ JG
 Iv
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+rZ
+sd
+uc
+td
+zt
+Bl
+CU
+Ff
+Hj
+Kf
+hH
+IO
+yN
+td
+td
+td
+zU
+td
+Pw
+PJ
+Qb
+Qi
+Qn
+hH
 aa
 aa
 aa
@@ -66137,31 +69971,31 @@ JG
 Iv
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+jA
+sd
+uf
+td
+td
+yT
+td
+td
+td
+Ki
+hH
+yN
+Nq
+td
+Oa
+td
+yN
+OY
+PC
+PJ
+Qb
+Qn
+Qs
+hH
 aa
 aa
 aa
@@ -66394,31 +70228,31 @@ Kg
 Iv
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+hH
+hH
+ug
+wS
+zu
+Bm
+CW
+Fg
+td
+Kl
+hH
+IO
+yN
+td
+td
+td
+yN
+yN
+yN
+hH
+hH
+hH
+hH
+hH
 aa
 aa
 aa
@@ -66651,31 +70485,31 @@ JG
 Iv
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+sc
+sd
+uh
+td
+zv
+Bn
+Dk
+Fk
+td
+Km
+hH
+MO
+yO
+td
+Oe
+td
+yN
+OZ
+PB
+PJ
+Qc
+Qb
+Qb
+hH
 aa
 aa
 aa
@@ -66908,31 +70742,31 @@ JG
 Iv
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+rU
+sd
+uG
+td
+td
+td
+td
+yT
+td
+Kz
+hH
+IO
+yN
+td
+No
+td
+zU
+td
+Pw
+PJ
+Qb
+Qo
+Qt
+hH
 aa
 aa
 aa
@@ -67165,31 +70999,31 @@ JG
 Iv
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+jA
+sd
+uH
+wT
+zw
+Bp
+Dl
+Fl
+Hk
+KE
+hH
+yN
+Nq
+yN
+yN
+yN
+yN
+OY
+PC
+PJ
+Qd
+Qp
+Qv
+hH
 aa
 aa
 aa
@@ -67422,31 +71256,31 @@ JG
 Iv
 aa
 aa
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
 aa
 aa
 aa
@@ -68913,7 +72747,7 @@ ps
 io
 qC
 qX
-rU
+fR
 sO
 tT
 uB

--- a/_maps/yogstation/map_files/generic/CentCom.dmm
+++ b/_maps/yogstation/map_files/generic/CentCom.dmm
@@ -2252,12 +2252,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/window/reinforced,
-/obj/effect/portal/permanent/one_way/keep{
-	desc = "A portal to a land of absolute chaos and unknowns!";
-	id = "testchamber";
-	name = "Test Chamber Portal";
-	teleport_channel = "testchamber"
-	},
 /turf/open/floor/grass,
 /area/centcom/evac)
 "fS" = (
@@ -8854,8 +8848,16 @@
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
 "tb" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/effect/portal/permanent/one_way/multi/entry{
+	alpha = 55;
+	color = "7D7D7D";
+	desc = "for when the clock hits one thirty and keeps ticking...";
+	id = "testchamber";
+	name = "Test Chamber Portal";
+	teleport_channel = "bluespace"
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -8864,12 +8866,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/portal/permanent/one_way/destroy{
-	id = "testchamber";
-	teleport_channel = "testchamber"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/turf/open/floor/plasteel/recharge_floor,
-/area/centcom/testchamber)
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/evac)
 "tc" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -13334,11 +13335,28 @@
 /turf/open/floor/plasteel,
 /area/centcom/evac)
 "Ba" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/obj/effect/portal/permanent/one_way/multi/entry{
+	alpha = 55;
+	color = "7D7D7D";
+	desc = "for when the clock hits one thirty and keeps ticking...";
+	id = "testchamber";
+	name = "Test Chamber Portal";
+	teleport_channel = "bluespace"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/bluespace,
 /area/centcom/evac)
 "Bb" = (
 /obj/effect/turf_decal/stripes/line,
@@ -19421,8 +19439,8 @@
 /area/tdome/arena)
 "Mj" = (
 /obj/machinery/door/poddoor{
-	id = "mixvent";
-	name = "Mixer Room Vent"
+	id = "testvent";
+	name = "Testing Chamber Vent"
 	},
 /turf/open/floor/engine/vacuum,
 /area/centcom/testchamber)
@@ -19479,7 +19497,13 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/light,
+/obj/effect/portal/permanent/one_way/multi/exit{
+	alpha = 0;
+	desc = "You can't seem to go through this portal...";
+	id = "testchamber";
+	name = "Exit Portal";
+	teleport_channel = "bluespace"
+	},
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
 "Mq" = (
@@ -19777,7 +19801,7 @@
 	name = "Test Chamber Blast Doors"
 	},
 /obj/structure/fans/tiny,
-/turf/closed/wall/r_wall,
+/turf/open/floor/plasteel,
 /area/centcom/testchamber)
 "MZ" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -19986,6 +20010,52 @@
 /obj/structure/sign/warning/xeno_mining,
 /turf/closed/indestructible/riveted,
 /area/centcom/testchamber)
+"Nr" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/portal/permanent/one_way/multi/exit{
+	alpha = 0;
+	desc = "You can't seem to go through this portal...";
+	id = "testchamber";
+	name = "Exit Portal";
+	teleport_channel = "bluespace"
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Ns" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/portal/permanent/one_way/multi/exit{
+	alpha = 0;
+	desc = "You can't seem to go through this portal...";
+	id = "testchamber";
+	name = "Exit Portal";
+	teleport_channel = "bluespace"
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "Nt" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -20064,18 +20134,6 @@
 /area/centcom/testchamber)
 "NB" = (
 /obj/machinery/meter,
-/obj/machinery/button/door{
-	id = "mixvent";
-	name = "Mixing Room Vent Control";
-	pixel_x = -25;
-	pixel_y = 5;
-	req_access_txt = "7"
-	},
-/obj/machinery/button/ignition{
-	id = "mixingsparker";
-	pixel_x = -25;
-	pixel_y = -5
-	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
 	},
@@ -20160,24 +20218,20 @@
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
 "NK" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/machinery/button/door{
+	id = "testvent";
+	name = "Testing Chamber Vent Control";
+	pixel_x = -25;
+	pixel_y = 5;
+	req_access_txt = "7"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/button/ignition{
+	id = "mixingsparker";
+	pixel_x = -25;
+	pixel_y = -5
 	},
 /obj/structure/table/reinforced,
-/obj/item/grenade/syndieminibomb,
-/obj/item/grenade/syndieminibomb{
-	pixel_x = 4
-	},
-/obj/item/grenade/syndieminibomb{
-	pixel_x = 8
-	},
+/obj/item/orion_ship,
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
 "NL" = (
@@ -20321,6 +20375,49 @@
 /obj/structure/sign/warning/xeno_mining,
 /turf/closed/indestructible/riveted,
 /area/centcom/testchamber)
+"NY" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/effect/portal/permanent/one_way/multi/exit{
+	alpha = 0;
+	desc = "You can't seem to go through this portal...";
+	id = "testchamber";
+	name = "Exit Portal";
+	teleport_channel = "bluespace"
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"NZ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/portal/permanent/one_way/multi/entry{
+	alpha = 55;
+	color = "7D7D7D";
+	desc = "for when the clock hits one thirty and keeps ticking...";
+	id = "testchamber";
+	name = "Test Chamber Portal";
+	teleport_channel = "bluespace"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/evac)
 "Oa" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -20334,6 +20431,37 @@
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Ob" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/portal/permanent/one_way/destroy{
+	id = "testing chamber";
+	teleport_channel = "testing"
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Oc" = (
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/bluespace,
+/area/centcom/testchamber)
+"Od" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plasteel/dark,
 /area/centcom/testchamber)
 "Oe" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -20350,7 +20478,7 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpack/large,
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
-"Og" = (
+"Of" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -20363,7 +20491,25 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/syndicatebomb/badmin/clown,
+/obj/machinery/airalarm/mixingchamber{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel,
+/area/centcom/testchamber)
+"Og" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/stimulum,
+/turf/open/floor/plasteel/dark,
 /area/centcom/testchamber)
 "Oh" = (
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -20410,21 +20556,6 @@
 "Ol" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/indestructible/riveted,
-/area/centcom/testchamber)
-"Om" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/item/orion_ship,
-/turf/open/floor/plasteel,
 /area/centcom/testchamber)
 "On" = (
 /obj/structure/table/reinforced,
@@ -20564,22 +20695,6 @@
 "Oy" = (
 /obj/machinery/portable_atmospherics/canister/bz,
 /turf/open/floor/bluespace,
-/area/centcom/testchamber)
-"Oz" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/stimulum,
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/portable_atmospherics/canister/stimulum,
-/turf/open/floor/plasteel/dark,
 /area/centcom/testchamber)
 "OA" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -58936,7 +59051,7 @@ hH
 MP
 MP
 NA
-NA
+Oc
 Ok
 Oy
 Oy
@@ -59193,9 +59308,9 @@ hH
 MQ
 Nt
 ND
-NH
+Od
 ND
-Oz
+Og
 Pb
 hH
 aa
@@ -60736,7 +60851,7 @@ Mq
 BW
 NK
 ta
-Om
+Oa
 OF
 Pf
 sd
@@ -61249,7 +61364,7 @@ Mr
 MX
 yO
 NM
-Og
+Of
 ta
 OI
 Pi
@@ -64069,16 +64184,16 @@ yh
 td
 BU
 td
-ta
+Mp
 In
-yh
+Nr
 ta
-ta
+Mp
 td
 NV
 td
 Ov
-ta
+Mp
 ta
 PG
 hH
@@ -64320,7 +64435,7 @@ Iv
 Iv
 hH
 sZ
-ta
+Mp
 td
 td
 td
@@ -64337,7 +64452,7 @@ td
 td
 td
 td
-ta
+Mp
 PT
 hH
 aa
@@ -65109,7 +65224,7 @@ yN
 yN
 Ni
 td
-ta
+Mp
 Qf
 aa
 aa
@@ -65861,9 +65976,9 @@ KD
 IR
 Iv
 pT
-tb
+Mp
 td
-wq
+Ob
 yP
 Aa
 BW
@@ -65880,7 +65995,7 @@ jA
 yO
 Pq
 td
-Mp
+NY
 hH
 aa
 aa
@@ -66651,7 +66766,7 @@ yN
 yN
 Ni
 td
-ta
+Mp
 Qf
 aa
 aa
@@ -67404,7 +67519,7 @@ Iv
 Iv
 hH
 sZ
-ta
+Mp
 td
 td
 td
@@ -67667,16 +67782,16 @@ yR
 td
 Cj
 td
+Mp
 ta
-ta
-yR
+Ns
 In
-ta
+Mp
 td
 NW
 td
 Ox
-ta
+Mp
 ta
 PH
 hH
@@ -70952,13 +71067,13 @@ qx
 sN
 tS
 uA
-uA
+Ba
 vV
 wK
 xs
 wK
 vV
-uA
+Ba
 uA
 tS
 AV
@@ -72748,7 +72863,7 @@ io
 qC
 qX
 fR
-sO
+tb
 tT
 uB
 vh
@@ -72760,7 +72875,7 @@ yB
 vh
 uB
 At
-Ba
+NZ
 BO
 Cg
 Cc

--- a/code/game/area/areas/centcom.dm
+++ b/code/game/area/areas/centcom.dm
@@ -23,6 +23,10 @@
 /area/centcom/ferry
 	name = "CentCom Transport Shuttle Dock"
 
+/area/centcom/testchamber
+	name = "CentCom Test Chamber"
+
+
 /area/centcom/prison
 	name = "Admin Prison"
 


### PR DESCRIPTION
### Intent of your Pull Request

An Alternative to my previous test chamber #5383 pr.

It's not only much bigger but it's completely isolated from the rest of centcom and can easily be disabled by removing the portal from centcom during the game at any point.

Things that were added;
 - Megafauna 
 - Toxins Testing
 - All of the available gasses
 - A lot more explosives
 - A generally more nicer look


#### Changelog

:cl:  
rscadd: Added the Centcom Test Chamber which is accessible by a portal after arriving at centcom.
/:cl:
