### PR TITLE
Creates multi-exit & multi-entrance one-way portals

### DIFF
--- a/yogstation/code/controllers/subsystem/yogs.dm
+++ b/yogstation/code/controllers/subsystem/yogs.dm
@@ -12,16 +12,36 @@ SUBSYSTEM_DEF(Yogs)
 
 /datum/controller/subsystem/Yogs/Initialize()
 	mentortickets = list()
+	
+	//PRIZEPOOL MODIFIER THING
 	GLOB.arcade_prize_pool[/obj/item/grenade/plastic/glitterbomb/pink] = 1
 	GLOB.arcade_prize_pool[/obj/item/toy/plush/goatplushie/angry] = 2
 	GLOB.arcade_prize_pool[/obj/item/stack/tile/ballpit] = 2
+	
+	//MULTI-PORTAL HANDLER
+	var/list/enters = list()
+	var/list/exits_by_id = list()
+	for(var/obj/effect/portal/permanent/one_way/multi/portal in GLOB.portals)
+		if(portal.is_entry) // If an entry portal
+			enters += portal
+		else
+			if(!exits_by_id[portal.id])
+				exits_by_id[portal.id] = list()
+			exits_by_id[portal.id] += get_turf(portal)
+			qdel(portal)
+	for(var/obj/effect/portal/permanent/one_way/multi/portal in enters)
+		if(exits_by_id[portal.id])
+			portal.linked_targets = exits_by_id[portal.id]
+
 	return ..()
 
 /datum/controller/subsystem/Yogs/fire(resumed = 0)
+	//END OF SHIFT ANNOUNCER
 	if(world.time > (ROUND_END_ANNOUNCEMENT_TIME*600) && !endedshift)
 		priority_announce("Crew, your shift has come to an end. \n You may call the shuttle whenever you find it appropriate.", "End of shift announcement", 'sound/ai/commandreport.ogg')
 		endedshift = TRUE
 	
+	//UNCLAIMED TICKET BWOINKER
 	if(world.time - last_rebwoink > REBWOINK_TIME*10)
 		last_rebwoink = world.time
 		for(var/datum/admin_help/bwoink in GLOB.unclaimed_tickets)

--- a/yogstation/code/game/objects/effects/portals.dm
+++ b/yogstation/code/game/objects/effects/portals.dm
@@ -19,3 +19,26 @@
 			P.ignore_source_check = TRUE
 		return TRUE
 	return FALSE
+
+/obj/effect/portal/permanent/one_way/multi // Portals that have multiple entry points and multiple exit points
+	name = "strange portal"
+	desc = "You're not really sure where this could possibly go."
+	var/is_entry // Marks whether this is an entry portal or not
+	var/list/linked_targets = list() // List of ***TURFS*** that mark where exit portals were on mapboot
+
+/obj/effect/portal/permanent/one_way/multi/entry
+	is_entry = TRUE
+
+/obj/effect/portal/permanent/one_way/multi/exit
+	is_entry = FALSE
+
+/obj/effect/portal/permanent/one_way/multi/set_linked()
+	return
+
+/obj/effect/portal/permanent/one_way/multi/get_link_target_turf()
+	while(linked_targets.len)
+		var/turf/target = pick(linked_targets)
+		if(!istype(target))
+			linked_targets -= target
+			continue
+		return target


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/58386803-daa6da00-7fca-11e9-9ff1-8c90c3d9c687.png)

This is a feature necessary for something DotLyna wanted to do with #5519.

#### Changelog
:cl:  Altoids
rscadd: One-way portals can now sometimes send you to multiple different places, from multiple different entry points!
/:cl:
