### PR TITLE
Miners and mining medics can no longer start as rev heads

### DIFF
--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -13,7 +13,7 @@
 	report_type = "revolution"
 	antag_flag = ROLE_REV
 	false_report_weight = 10
-	restricted_jobs = list("Security Officer", "Warden", "Detective", "AI", "Cyborg","Captain", "Head of Personnel", "Head of Security", "Chief Engineer", "Research Director", "Chief Medical Officer")
+	restricted_jobs = list("Security Officer", "Warden", "Detective", "AI", "Cyborg","Captain", "Head of Personnel", "Head of Security", "Chief Engineer", "Research Director", "Chief Medical Officer", "Shaft Miner", "Mining Medic") //Yogs - Added miner and mining medic
 	required_players = 30
 	required_enemies = 2
 	recommended_enemies = 3


### PR DESCRIPTION
As funny as it is seeing a round end in a minute, it wastes a lovely fun rev round. Also we had this before we rebased.

:cl:  
tweak: Miners and Mining Medics can no longer start as rev heads.
/:cl: