### PR TITLE
add three headsets to cloning lockers on most station

### DIFF
--- a/_maps/yogstation/map_files/MinskyStation/MinskyStation.dmm
+++ b/_maps/yogstation/map_files/MinskyStation/MinskyStation.dmm
@@ -56372,6 +56372,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/item/radio/headset,
+/obj/item/radio/headset,
+/obj/item/radio/headset,
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
@@ -57282,6 +57285,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/item/radio/headset,
+/obj/item/radio/headset,
+/obj/item/radio/headset,
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
@@ -58715,6 +58721,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/item/radio/headset,
+/obj/item/radio/headset,
+/obj/item/radio/headset,
 /turf/open/floor/plasteel/white/side{
 	dir = 6
 	},

--- a/_maps/yogstation/map_files/YogStation/YogStation.dmm
+++ b/_maps/yogstation/map_files/YogStation/YogStation.dmm
@@ -36548,6 +36548,9 @@
 /area/maintenance/aft)
 "btk" = (
 /obj/structure/closet/wardrobe/white,
+/obj/item/radio/headset,
+/obj/item/radio/headset,
+/obj/item/radio/headset,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "btl" = (

--- a/_maps/yogstation/map_files/YogsDonut/YogsDonut.dmm
+++ b/_maps/yogstation/map_files/YogsDonut/YogsDonut.dmm
@@ -15276,6 +15276,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/radio/headset,
+/obj/item/radio/headset,
+/obj/item/radio/headset,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "aGJ" = (
@@ -53573,6 +53576,9 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/item/radio/headset,
+/obj/item/radio/headset,
+/obj/item/radio/headset,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "cbT" = (

--- a/_maps/yogstation/map_files/YogsDonut/YogsDonut.dmm
+++ b/_maps/yogstation/map_files/YogsDonut/YogsDonut.dmm
@@ -15276,6 +15276,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/radio/headset,
+/obj/item/radio/headset,
+/obj/item/radio/headset,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "aGJ" = (

--- a/_maps/yogstation/map_files/YogsPubby/YogsPubby.dmm
+++ b/_maps/yogstation/map_files/YogsPubby/YogsPubby.dmm
@@ -34627,6 +34627,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/item/radio/headset,
+/obj/item/radio/headset,
+/obj/item/radio/headset,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "boz" = (


### PR DESCRIPTION
add three headsets to clonings white lockers on most station(MinskyStation, YogStation, YogsDonut, YogsPubby)

tested all but misky.


:cl:  
rscadd: added three headsets to cloning lockers on most station
/:cl:
