### PR TITLE
Replaces tcomms monitoring consoles to traffic ones

### DIFF
--- a/_maps/yogstation/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/yogstation/map_files/YogsDelta/YogsDelta.dmm
@@ -60527,9 +60527,6 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bOO" = (
-/obj/machinery/computer/telecomms/monitor{
-	dir = 8
-	},
 /obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
@@ -60542,6 +60539,10 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/computer/telecomms/traffic{
+	dir = 8;
+	network = "tcommsat"
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)

--- a/_maps/yogstation/map_files/YogsDonut/YogsDonut.dmm
+++ b/_maps/yogstation/map_files/YogsDonut/YogsDonut.dmm
@@ -53144,12 +53144,12 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "caX" = (
-/obj/machinery/computer/telecomms/monitor{
-	icon_state = "computer";
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/computer/telecomms/traffic{
+	dir = 8;
+	network = "tcommsat"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)

--- a/_maps/yogstation/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/yogstation/map_files/Yogsmeta/Yogsmeta.dmm
@@ -42417,7 +42417,7 @@
 	network = list("tcomms");
 	pixel_x = 26
 	},
-/obj/machinery/computer/telecomms/monitor{
+/obj/machinery/computer/telecomms/traffic{
 	dir = 8;
 	network = "tcommsat"
 	},


### PR DESCRIPTION
Replace monitoring consoles with traffic ones since trafic ones allow sig techs to do what crew percieves as their job.
(done on YogsDonut, YogsDelta, Yogsmeta)

:cl:  
rscadd: Added trafic consoles to Tcomms on YogsDonut, YogsDelta, Yogsmeta
rscdel: Removed monitoring consoles from Tcomms on YogsDonut, YogsDelta, Yogsmeta
/:cl:
