### PR TITLE
Adds three headsets to cloning spare clothes locker

### DIFF
--- a/_maps/yogstation/map_files/YogStation/YogStation.dmm
+++ b/_maps/yogstation/map_files/YogStation/YogStation.dmm
@@ -36548,6 +36548,9 @@
 /area/maintenance/aft)
 "btk" = (
 /obj/structure/closet/wardrobe/white,
+/obj/item/radio/headset,
+/obj/item/radio/headset,
+/obj/item/radio/headset,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "btl" = (

--- a/_maps/yogstation/map_files/YogsDonut/YogsDonut.dmm
+++ b/_maps/yogstation/map_files/YogsDonut/YogsDonut.dmm
@@ -15276,6 +15276,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/radio/headset,
+/obj/item/radio/headset,
+/obj/item/radio/headset,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "aGJ" = (
@@ -53573,6 +53576,9 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/item/radio/headset,
+/obj/item/radio/headset,
+/obj/item/radio/headset,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "cbT" = (

--- a/_maps/yogstation/map_files/YogsPubby/YogsPubby.dmm
+++ b/_maps/yogstation/map_files/YogsPubby/YogsPubby.dmm
@@ -34627,6 +34627,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/item/radio/headset,
+/obj/item/radio/headset,
+/obj/item/radio/headset,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "boz" = (


### PR DESCRIPTION
Adds three headsets to the spare clothes locker in case all your stuff was lost/confiscated/left elsewhere.
Changed on YogStation, YogsPubby, YogsDonut.

:cl:  
rscadd: Adds three headsets to cloning spare clothes locker on YogStation, YogsPubby, YogsDonut.
/:cl:
