### PR TITLE
allows janniborg to click on glass with lightreplacer to refil it

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -67,7 +67,7 @@ GLOBAL_LIST_INIT(glass_recipes, list ( \
 		else
 			to_chat(user, "<span class='warning'>You need one rod and one sheet of glass to make reinforced glass!</span>")
 			return
-	else if(istype(W, /obj/item/lightreplacer/cyborg))
+	else if(istype(W, /obj/item/lightreplacer/cyborg)) //yogs start janiborgs can refill lightreplacers with glass now
 		var/obj/item/lightreplacer/cyborg/G = W
 		if(G.uses >= G.max_uses)
 			to_chat(user, "<span class='warning'>[W.name] is full.</span>")
@@ -77,7 +77,7 @@ GLOBAL_LIST_INIT(glass_recipes, list ( \
 			to_chat(user, "<span class='notice'>You insert a piece of glass into \the [G.name]. You have [G.uses] light\s remaining.</span>")
 			return
 		else
-			to_chat(user, "<span class='warning'>You need one sheet of glass to replace lights!</span>")
+			to_chat(user, "<span class='warning'>You need one sheet of glass to replace lights!</span>") //yogs end
 	else
 		return ..()
 

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -67,6 +67,17 @@ GLOBAL_LIST_INIT(glass_recipes, list ( \
 		else
 			to_chat(user, "<span class='warning'>You need one rod and one sheet of glass to make reinforced glass!</span>")
 			return
+	else if(istype(W, /obj/item/lightreplacer/cyborg))
+		var/obj/item/lightreplacer/cyborg/G = W
+		if(G.uses >= G.max_uses)
+			to_chat(user, "<span class='warning'>[W.name] is full.</span>")
+			return
+		else if(src.use(1))
+			G.AddUses(G.increment)
+			to_chat(user, "<span class='notice'>You insert a piece of glass into \the [G.name]. You have [G.uses] light\s remaining.</span>")
+			return
+		else
+			to_chat(user, "<span class='warning'>You need one sheet of glass to replace lights!</span>")
 	else
 		return ..()
 


### PR DESCRIPTION
Janniborgs could not use glass to refill their lightreplacer as the description said.
They now can click on stacks of glass to refill their lightreplacer as they cant pick up glass to do so.
This PR was tested on empty server.
Can move parts of the code to lightreplacer file if needed.

:cl:  
rscadd:  Janniborgs can now refil lightreplacer by clicking on glass stacks.
/:cl:
