### PR TITLE
adds air alarm in cargo office

### DIFF
--- a/_maps/yogstation/map_files/YogStation/YogStation.dmm
+++ b/_maps/yogstation/map_files/YogStation/YogStation.dmm
@@ -29520,6 +29520,9 @@
 "bgz" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bgA" = (
@@ -81759,7 +81762,7 @@ baS
 uvN
 gjl
 gjl
-aZE
+bgv
 bju
 biv
 bjk
@@ -82016,7 +82019,7 @@ cCn
 aYh
 aZK
 eYN
-aZE
+bgv
 bgz
 biT
 bjl


### PR DESCRIPTION
Added air alarm to cargo office on Yogstation which was reported missind in issue #4997
tested on empty server.

:cl:  
rscadd: Added air alarm to Cargo Office on yogbox
/:cl:
