### PR TITLE
FIxes virology camera names to be unique

### DIFF
--- a/_maps/yogstation/map_files/YogStation/YogStation.dmm
+++ b/_maps/yogstation/map_files/YogStation/YogStation.dmm
@@ -46539,7 +46539,7 @@
 /area/medical/virology)
 "bOn" = (
 /obj/machinery/camera{
-	c_tag = "Virology Module";
+	c_tag = "Virology Airlock Backup";
 	dir = 2;
 	network = list("ss13","medbay")
 	},

--- a/_maps/yogstation/map_files/YogStation/YogStation.dmm
+++ b/_maps/yogstation/map_files/YogStation/YogStation.dmm
@@ -46539,7 +46539,7 @@
 /area/medical/virology)
 "bOn" = (
 /obj/machinery/camera{
-	c_tag = "Virology Module";
+	c_tag = "Virology Monkey Pen";
 	dir = 2;
 	network = list("ss13","medbay")
 	},


### PR DESCRIPTION
Changes name of the northwest virology camera to Virology Monkey Pen, which had previously duplicate name #4508

:cl:  
tweak: Virology cameras now have unique names  
/:cl:
