### PR TITLE
adds atmos accses requirement to viro windoor

### DIFF
--- a/_maps/yogstation/map_files/YogStation/YogStation.dmm
+++ b/_maps/yogstation/map_files/YogStation/YogStation.dmm
@@ -25588,7 +25588,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/window/southleft{
 	name = "Virology";
-	req_access_txt = "39"
+	req_access_txt = "39;24"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)


### PR DESCRIPTION
Adds atmosphrics accses requirement to virology windoor
reported in issue #3729

#### Changelog

:cl:  
tweak: Virologi windoor now needs atmos acsses as well
/:cl:
