### PR TITLE
Fixes Heralds beacon so it turns off five minutes after round start

### DIFF
--- a/code/modules/antagonists/clockcult/clock_structures/heralds_beacon.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/heralds_beacon.dm
@@ -37,7 +37,7 @@
 		if(servants)
 			votes_needed = round(servants * 0.66)
 	time_remaining--
-	if(!time_remaining)
+	if((SSticker.round_start_time + time_remaining) > world.time)
 		hierophant_message("<span class='bold sevtug_small'>[src] has lost its power, and can no longer be activated.</span>")
 		for(var/mob/M in GLOB.player_list)
 			if(isobserver(M) || is_servant_of_ratvar(M))

--- a/code/modules/antagonists/clockcult/clock_structures/heralds_beacon.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/heralds_beacon.dm
@@ -36,8 +36,7 @@
 		var/servants = SSticker.mode.servants_of_ratvar.len
 		if(servants)
 			votes_needed = round(servants * 0.66)
-	time_remaining--
-	if(!time_remaining)
+	if((SSticker.round_start_time + time_remaining) > world.time)
 		hierophant_message("<span class='bold sevtug_small'>[src] has lost its power, and can no longer be activated.</span>")
 		for(var/mob/M in GLOB.player_list)
 			if(isobserver(M) || is_servant_of_ratvar(M))


### PR DESCRIPTION
Fixes heralds beacon to stop working after 5 minitus of actual playtime
pointed out in issue #4260

well ruins not rounds start clockies but when that happens?
NOTE: heralds beacon only works if game mode is clockies anyway(if i understand the code corectly that is)

UNTESTED!!
but should work in theory

:cl:  
bugfix: Heralds beacon turns off 5 minutes of game not after being created
/:cl:
