### PR TITLE
adds oxygen to tower caps and allows the chemical godsblood to be created

### DIFF
--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -14,6 +14,7 @@
 	growthstages = 3
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	icon_dead = "towercap-dead"
+	reagents_add = list("oxygen" = 0.5)
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism)
 	mutatelist = list(/obj/item/seeds/tower/steel)
 

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -601,3 +601,9 @@
 	id = "pax"
 	results = list("pax" = 3)
 	required_reagents  = list("mindbreaker" = 1, "synaptizine" = 1, "water" = 1)
+	
+	/datum/chemical_reaction/godblood
+	name = "Godblood"
+	id = "godblood"
+	results = list("godblood" = 2)
+	required_reagents = list("earthsblood" = 1, "omnizine" = 1)


### PR DESCRIPTION
### Intent of your Pull Request
if you combine omnizine and earthsblood you make godblood which is omnizine with a much higher overdose rate.

also adds oxygen reagant to tower caps

this is a webedit
#### Changelog

:cl:  
rscadd: new chemistry recipe and adds oxygen reagant to tower caps
/:cl:
