### PR TITLE
Adds prettyfilter to msay and mentorpm

### DIFF
--- a/yogstation/code/modules/mentor/mentorpm.dm
+++ b/yogstation/code/modules/mentor/mentorpm.dm
@@ -60,6 +60,10 @@
 
 	log_mentor("Mentor PM: [key_name(src)]->[discord_id ? discord_id : key_name(C)]: [msg]")
 
+	if(mentor_datum && isnotpretty(msg)) // If this is, specifically, a mentor, and not an admin nor a normal player
+		to_chat(src,"<span class='danger'>You cannot send bigoted language as a mentor.</span>")
+		message_admins("[discord_id ? discord_id : key_name(src)] just tripped the pretty filter in a mentorpm: [msg]")
+		return
 	msg = emoji_parse(msg)
 	if(C)
 		SEND_SOUND(C, sound('sound/items/bikehorn.ogg'))

--- a/yogstation/code/modules/mentor/mentorsay.dm
+++ b/yogstation/code/modules/mentor/mentorsay.dm
@@ -12,6 +12,7 @@
 	if(!msg)
 		return
 
+	msg = pretty_filter(msg)
 	msg = emoji_parse(msg)
 	log_mentor("MSAY: [key_name(src)] : [msg]")
 


### PR DESCRIPTION
Apparently nobody bothered to set up the pretty filter for mentorstuffs, so, here we are.

#### Changelog

:cl:  Altoids
bugfix: Mentors can no longer call you racial slurs, neither at your face nor among themselves.
/:cl:
