### PR TITLE
Adds Traffic Control Console to the techweb

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -400,7 +400,7 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 	design_ids = list("s-receiver", "s-bus", "s-broadcaster", "s-processor", "s-hub", "s-server", "s-relay", "comm_monitor", "comm_server",
-	"s-ansible", "s-filter", "s-amplifier", "ntnet_relay", "s-treatment", "s-analyzer", "s-crystal", "s-transmitter")
+	"s-ansible", "s-filter", "s-amplifier", "ntnet_relay", "s-treatment", "s-analyzer", "s-crystal", "s-transmitter","s-traffic")//Yogs -- Adds traffic console, for NTSL
 
 /datum/techweb_node/integrated_HUDs
 	id = "integrated_HUDs"

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3212,6 +3212,7 @@
 #include "yogstation\code\modules\research\designs\comp_board_designs.dm"
 #include "yogstation\code\modules\research\designs\spacepod_designs.dm"
 #include "yogstation\code\modules\research\designs\stock_parts_designs.dm"
+#include "yogstation\code\modules\research\designs\telecomms_designs.dm"
 #include "yogstation\code\modules\research\designs\tool_designs.dm"
 #include "yogstation\code\modules\research\techweb\_techweb_node.dm"
 #include "yogstation\code\modules\research\techweb\all_nodes.dm"

--- a/yogstation/code/modules/research/designs/telecomms_designs.dm
+++ b/yogstation/code/modules/research/designs/telecomms_designs.dm
@@ -1,0 +1,7 @@
+/datum/design/board/traffic
+	name = "Computer Design (Traffic Console)"
+	desc = "Allows for the construction of Traffic Control Console."
+	id = "s-traffic"
+	build_path = /obj/item/circuitboard/computer/telecomms/comm_traffic
+	category = list("Subspace Telecomms")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE


### PR DESCRIPTION
Apparently I forgot to do this during my NTSL port.

#### Changelog

:cl:  Altoids
bugfix: The Traffic Control Console is now available on the techweb!
/:cl:
