### PR TITLE
Fixes deltas airlocks access in engineering

### DIFF
--- a/_maps/yogstation/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/yogstation/map_files/YogsDelta/YogsDelta.dmm
@@ -10189,15 +10189,15 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Access";
-	req_one_access_txt = "24;10"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Access";
+	req_one_access_txt = "24"
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "arU" = (
@@ -27686,16 +27686,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Engine Access";
-	req_one_access_txt = "24;10"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Engine Access";
+	req_one_access_txt = "24"
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "aTb" = (
@@ -32814,16 +32814,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Access";
-	req_one_access_txt = "24;10"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Access";
+	req_one_access_txt = "24"
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "baJ" = (
@@ -34635,10 +34635,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Access";
-	req_one_access_txt = "24;10"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -34647,6 +34643,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Access";
+	req_one_access_txt = "24"
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bdv" = (
@@ -40594,7 +40594,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
 	name = "Gravity Generator Chamber";
-	req_access_txt = "19; 61"
+	req_access_txt = "11"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -41779,7 +41779,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/highsecurity{
 	name = "Gravity Generator Room";
-	req_access_txt = "19;23"
+	req_access_txt = "11"
 	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -42448,7 +42448,7 @@
 	},
 /obj/machinery/door/airlock/highsecurity{
 	name = "Gravity Generator Foyer";
-	req_access_txt = "10"
+	req_access_txt = "32"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -112931,7 +112931,7 @@
 	},
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Access";
-	req_one_access_txt = "24;10"
+	req_one_access_txt = "24"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -112952,7 +112952,7 @@
 	},
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Engine Access";
-	req_one_access_txt = "24;10"
+	req_one_access_txt = "24"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1

--- a/_maps/yogstation/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/yogstation/map_files/YogsDelta/YogsDelta.dmm
@@ -10189,15 +10189,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Access";
-	req_one_access_txt = "24;10"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Access";
+	req_access_txt = "24";
+	req_one_access_txt = "0"
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "arU" = (
@@ -27686,16 +27687,17 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Engine Access";
-	req_one_access_txt = "24;10"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Engine Access";
+	req_access_txt = "24";
+	req_one_access_txt = "0"
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "aTb" = (
@@ -32814,16 +32816,17 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Access";
-	req_one_access_txt = "24;10"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Access";
+	req_access_txt = "24";
+	req_one_access_txt = "0"
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "baJ" = (
@@ -34635,10 +34638,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Access";
-	req_one_access_txt = "24;10"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -34647,6 +34646,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Access";
+	req_access_txt = "24";
+	req_one_access_txt = "0"
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bdv" = (
@@ -40594,7 +40598,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
 	name = "Gravity Generator Chamber";
-	req_access_txt = "19; 61"
+	req_access_txt = "11"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -41779,7 +41783,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/highsecurity{
 	name = "Gravity Generator Room";
-	req_access_txt = "19;23"
+	req_access_txt = "11"
 	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -42448,7 +42452,7 @@
 	},
 /obj/machinery/door/airlock/highsecurity{
 	name = "Gravity Generator Foyer";
-	req_access_txt = "10"
+	req_access_txt = "32"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -112929,10 +112933,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Access";
-	req_one_access_txt = "24;10"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -112940,6 +112940,11 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Access";
+	req_access_txt = "24";
+	req_one_access_txt = "0"
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "dos" = (
@@ -112952,7 +112957,8 @@
 	},
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Engine Access";
-	req_one_access_txt = "24;10"
+	req_access_txt = "24";
+	req_one_access_txt = "0"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1


### PR DESCRIPTION
fixes #5649
On delta only:
grav gen is now accsessible to engineers
atmos is now not accesible to engineers
engineers can still access the SM trough the maintnance

:cl: 
bugfix: Engineers now can access gravity generator on delta
tweak: Engineers now cant access atmos on delta
/:cl:
