### PR TITLE
Stops ghosts from manipulating storage items

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -535,7 +535,7 @@
 	set waitfor = FALSE
 	. = COMPONENT_NO_MOUSEDROP
 	var/atom/A = parent
-	if(ismob(M)) //all the check for item manipulation are in other places, you can safely open any storages as anything and its not buggy, i checked
+	if(isliving(M)) //all the check for item manipulation are in other places, you can safely open any storages as anything and its not buggy, i checked //yogs -- Makes ghosts not be able to interact with storage shit
 		A.add_fingerprint(M)
 		if(!over_object)
 			return FALSE


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/59228203-e256a900-8b9c-11e9-823c-040a45c713a1.png)

Why has this *never* come up before? What the *fuck?*

#### Changelog

:cl:  Altoids
bugfix: Ghosts are no longer able to operate storage items, in any way.
/:cl:
