### PR TITLE
fixes perma cameras on Yogstation

### DIFF
--- a/_maps/yogstation/map_files/YogStation/YogStation.dmm
+++ b/_maps/yogstation/map_files/YogStation/YogStation.dmm
@@ -193,7 +193,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
-	c_tag = "Prison Common Room";
+	c_tag = "Prison Common Room North";
 	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel,
@@ -15164,7 +15164,7 @@
 /obj/machinery/camera{
 	c_tag = "Permabrig Holodeck";
 	dir = 8;
-	network = list("ss13","rd")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/engine{
 	name = "Holodeck Projector Floor"
@@ -26321,8 +26321,9 @@
 /area/security/prison)
 "bab" = (
 /obj/machinery/camera{
-	c_tag = "EVA South";
-	dir = 1
+	c_tag = "Prison Common Room South";
+	dir = 1;
+	network = list("ss13","prison")
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,


### PR DESCRIPTION
Fix permas camera names and network since that is not where EVA south is.
fixes #5858

#### Changelog

:cl:  
bugfix: Perma cameras on Yogstation are on the right network and properly named.
/:cl:
