### PR TITLE
Makes the Academy die of fate one-use

### DIFF
--- a/_maps/yogstation/RandomRuins/SpaceRuins/Academy.dmm
+++ b/_maps/yogstation/RandomRuins/SpaceRuins/Academy.dmm
@@ -2076,7 +2076,7 @@
 	pixel_y = 0
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/item/dice/d20/fate,
+/obj/item/dice/d20/fate/one_use,
 /turf/open/floor/plasteel/cafeteria,
 /area/awaymission/academy/classrooms)
 "gp" = (


### PR DESCRIPTION
### Intent of your Pull Request
Its really not a great idea to have an item that gives you a 5% chance to get wizard per roll, which you can roll multiple times. 


#### Changelog

:cl:  
tweak: Changed the Academy die of fate to a single use one.
/:cl:
