### PR TITLE
removes additional arm from nukie

### DIFF
--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -80,10 +80,6 @@
 	cost = 5
 	surplus = 0
 	exclude_modes = list(/datum/game_mode/nuclear)
-	
-/datum/uplink_item/device_tools/arm/nuke
-	cost = 15
-	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/device_tools/arm/spawn_item(spawn_item, mob/user)
 	var/limbs = user.held_items.len


### PR DESCRIPTION
this pr exists in case it's still a problem even after the nerf (that was recently fixed)

🆑
remove: Additional Arm has been removed from nuclear operatives' uplink
/🆑