### PR TITLE
Mech wrecks can no longer drop solely cable coil

### DIFF
--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -63,8 +63,8 @@
 			if(type)
 				var/N = new type(get_turf(user))
 				user.visible_message("[user] cuts [N] from [src].", "<span class='notice'>You cut [N] from [src].</span>")
-				salvage_num--
 				wirecutters_salvage -= type
+				salvage_num--
 			else
 				to_chat(user, "<span class='warning'>You fail to salvage anything valuable from [src]!</span>")
 

--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -64,6 +64,7 @@
 				var/N = new type(get_turf(user))
 				user.visible_message("[user] cuts [N] from [src].", "<span class='notice'>You cut [N] from [src].</span>")
 				salvage_num--
+				wirecutters_salvage -= type
 			else
 				to_chat(user, "<span class='warning'>You fail to salvage anything valuable from [src]!</span>")
 


### PR DESCRIPTION
Closes #6059 
:cl:  
bugfix: mechs will now only be able to drop one cable coil instead of being able to drop solely coils
/:cl:
