### PR TITLE
Improves BZ, makes the amount of halluc it gives actually vary based on pressure

### DIFF
--- a/code/__DEFINES/~yogs_defines/reactions.dm
+++ b/code/__DEFINES/~yogs_defines/reactions.dm
@@ -1,2 +1,7 @@
+//Cold Fusion
 #define FUSION_TEMPERATURE_THRESHOLD_MINIMUM 4000 // This is the minimum possible required temperature that dilithium can lower fusion to.
 #define DILITHIUM_LAMBDA 0.0087 // Affects how much Dilithium is required to get the required fusion temperature down to FUSION_TEMPERATURE_THRESHOLD_MINIMUM
+
+//BZ Stuff
+#define BZ_MAX_HALLUCINATION 20 // The maximum amount of hallucination stacks that BZ can give to a mob per life tick.
+#define BZ_LAMBDA 0.0364 // Affects how quickly BZ reaches its maximum

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -237,10 +237,13 @@
 	//BZ (Facepunch port of their Agent B)
 	if(breath_gases[/datum/gas/bz])
 		var/bz_partialpressure = (breath_gases[/datum/gas/bz][MOLES]/breath.total_moles())*breath_pressure
+		/* Yogs comment-out: Smoothed BZ hallucination levels
 		if(bz_partialpressure > 1)
 			hallucination += 10
 		else if(bz_partialpressure > 0.01)
 			hallucination += 5
+		*/
+		hallucination += round(BZ_MAX_HALLUCINATION * (1 - NUM_E ** (-BZ_LAMBDA * bz_partialpressure))) // Yogs -- Better BZ hallucination values. Keep in mind that hallucination has to be an integer value, due to how it's handled in handle_hallucination()
 
 	//TRITIUM
 	if(breath_gases[/datum/gas/tritium])


### PR DESCRIPTION
## Overview
The current way BZ handles determining how many halluc stacks it was going to give you looked a bit lackluster to me:
https://github.com/yogstation13/Yogstation-TG/blob/fcee50f4a4f5843a045d8beb28c4406c1b4f34d3/code/modules/mob/living/carbon/life.dm#L237-L244
The previous way it worked was that you get 5 halluc stacks per breath when there's anywhere between 0.0001 atmospheres to 0.01 atmospheres of BZ pressure, and 10 halluc stacks if it was anything higher.

I felt this was unrealistic and prone to shitty rounding errors where just 10 Pascal worth of BZ in Central Primary would be enough to leave the entire station tripping somewhat. Conversely, this also meant that  not much different in effect occurred than when you opened up a can of fun in a BZ huffing room.

## What does this PR do, then?

![desmos-graph (3)](https://user-images.githubusercontent.com/29939414/60390275-a9716c00-9a98-11e9-959b-e9923187fd26.png)
*Red denotes the previous system, Green denotes this PR's new system*

This PR makes the halluc stacks you get out of BZ actually vary a reasonable amount, based on the amount of pressure, up to 1 atm where the effect maximizes. The calculations are analogous to how https://github.com/yogstation13/Yogstation-TG/pull/5847 calculates Cold Fusion temperatures.

## Is this a buff to BZ?
Yes and no.
Sneaky atmos traitors putting an almost undetectable amount of BZ into the air to get everyone tripping can no longer do so as effectively; you now need at least 700 Pascal (as opposed to 10 Pascal) of BZ in a tile before it starts having *any* effect at all.

But then also, AIs dumping large vats of the shit into distro will now see it act much more effectively, since the users will now be receiving significantly greater amounts of hallucination (which is something that can be deadly on its own, especially if https://github.com/yogstation13/Yogstation-TG/pull/6157 is merged). For Malf AIs, this means that BZ can become a viable alternative to Plasmaflooding, if enough is available.

#### Changelog
:cl:  Altoids
tweak: BZ's hallucinogenic properties now actually vary based on concentration. Maximum effect (double the previous maximum) occurs at 1 atm of BZ pressure. Additionally, it now takes 700 Pascal (up from 10 Pascal) of BZ pressure before BZ has any hallucinogenic effect at all.
/:cl: