### PR TITLE
Decreases the item size of the deodorant from normal to small.

### DIFF
--- a/yogstation/code/game/objects/items/deodorant.dm
+++ b/yogstation/code/game/objects/items/deodorant.dm
@@ -4,6 +4,7 @@
 	icon = 'yogstation/icons/obj/items.dmi'
 	icon_state = "deodorant"
 	item_flags = NOBLUDGEON
+	w_class = WEIGHT_CLASS_SMALL
 	var/uses = 15
 
 /obj/item/deodorant/attack_self(mob/living/carbon/human/user)


### PR DESCRIPTION
normal is for items like swords n shit.

deodorant is obviously not the size of a sword, and being small allows it to be put into pockets and take up less bag space.


#### Changelog

:cl:   Identification
tweak: Deodorant is now a small item rather than a normal-sized item.
/:cl:
