### PR TITLE
Makes the PA use a dynamic amount of power, depending on lvl

### DIFF
--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -208,6 +208,7 @@
 	log_game("PA Control Computer turned [active ?"ON":"OFF"] by [usr ? "[key_name(usr)]" : "outside forces"] at [AREACOORD(src)]")
 	if(active)
 		use_power = ACTIVE_POWER_USE
+		active_power_usage = initial(active_power_usage) * (1 + strength) // Yogs -- Makes the PA use different amounts of power depending on its power level.
 		for(var/CP in connected_parts)
 			var/obj/structure/particle_accelerator/part = CP
 			part.strength = strength

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3248,6 +3248,7 @@
 #include "yogstation\code\modules\power\antimatter\containment_jar.dm"
 #include "yogstation\code\modules\power\antimatter\control.dm"
 #include "yogstation\code\modules\power\antimatter\shielding.dm"
+#include "yogstation\code\modules\power\singularity\particle_accelerator\particle_control.dm"
 #include "yogstation\code\modules\projectiles\ammunition\caseless\misc.dm"
 #include "yogstation\code\modules\projectiles\boxes_magazines\internal\misc.dm"
 #include "yogstation\code\modules\projectiles\guns\ballistic\launchers.dm"

--- a/yogstation/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/yogstation/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -1,0 +1,2 @@
+/obj/machinery/particle_accelerator/control_box
+	active_power_usage = 5000 // The power usage when at lvl 0


### PR DESCRIPTION
Apparently PAs were just... using 10,000 kW or W or whatever, always, regardless of power level. This makes it use linearly more power depending on the power level.

#### Changelog
:cl:  Altoids
rscadd: PAs now consume variable amounts of power, depending on their power level.
/:cl:
