### PR TITLE
Makes Shadowling and Battle Royale actually log the round's result into the database

### DIFF
--- a/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
@@ -22,6 +22,7 @@ GLOBAL_LIST_EMPTY(battleroyale_players) //reduce iteration cost
 	var/stage_interval = 1200 //Copied from Nich's homework. Storm shrinks every 2 minutes
 	var/borderstage = 0
 	var/finished = FALSE
+	var/mob/living/winner // Holds the wiener of the victory royale battle fortnight.
 
 /datum/game_mode/fortnite/pre_setup()
 	var/area/hallway/secondary/A = locate(/area/hallway/secondary) in GLOB.sortedAreas //Assuming we've gotten this far, let's spawn the battle bus.
@@ -96,9 +97,9 @@ GLOBAL_LIST_EMPTY(battleroyale_players) //reduce iteration cost
 	if(royalers.len == 1) //We have a wiener!
 		SSticker.mode.check_finished(TRUE)
 		SSticker.force_ending = 1
-		var/mob/living/dub = pick(royalers)
+		winner = pick(royalers)
 		to_chat(world, "<img src='https://cdn.discordapp.com/attachments/351367327184584704/539903688857092106/victoryroyale.png'>")
-		to_chat(world, "<span_class='bigbold'>#1 VICTORY ROYALE: [dub] </span>")
+		to_chat(world, "<span_class='bigbold'>#1 VICTORY ROYALE: [winner] </span>")
 		SEND_SOUND(world, 'yogstation/sound/effects/battleroyale/greet_br.ogg')
 		finished = TRUE
 		return
@@ -106,8 +107,8 @@ GLOBAL_LIST_EMPTY(battleroyale_players) //reduce iteration cost
 
 /datum/game_mode/fortnite/set_round_result()
 	..()
-	if(royalers.len)
-		SSticker.mode_result = "win - [royalers[1]] won the battle royale"
+	if(winner)
+		SSticker.mode_result = "win - [winner] won the battle royale"
 	else
 		SSticker.mode_result = "loss - nobody won the battle royale!"
 

--- a/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
@@ -107,7 +107,7 @@ GLOBAL_LIST_EMPTY(battleroyale_players) //reduce iteration cost
 /datum/game_mode/fortnite/set_round_result()
 	..()
 	if(royalers.len)
-		SSticker.mode_result = "win - [pick(royalers)] won the battle royale"
+		SSticker.mode_result = "win - [royalers[1]] won the battle royale"
 	else
 		SSticker.mode_result = "loss - nobody won the battle royale!"
 

--- a/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
@@ -104,6 +104,13 @@ GLOBAL_LIST_EMPTY(battleroyale_players) //reduce iteration cost
 		return
 	addtimer(CALLBACK(src, .proc/check_win), 300) //Check win every 30 seconds. This is so it doesn't fuck the processing time up
 
+/datum/game_mode/fortnite/set_round_result()
+	..()
+	if(royalers.len)
+		SSticker.mode_result = "win - [pick(royalers)] won the battle royale"
+	else
+		SSticker.mode_result = "loss - nobody won the battle royale!"
+
 /datum/game_mode/fortnite/proc/shrinkborders()
 	loot_spawn()
 	switch(borderstage)

--- a/yogstation/code/game/gamemodes/shadowling/shadowling.dm
+++ b/yogstation/code/game/gamemodes/shadowling/shadowling.dm
@@ -129,9 +129,9 @@ Made by Xhuis
 /datum/game_mode/shadowling/set_round_result()
 	..()
 	if(check_shadow_victory())
-		SSticker.mode_result = "win - shadowling has ascended"
+		SSticker.mode_result = "win - shadowlings have ascended"
 	else
-		SSticker.mode_result = "loss - staff stopped the shadowling"
+		SSticker.mode_result = "loss - staff stopped the shadowlings"
 
 /*
 	MISCELLANEOUS

--- a/yogstation/code/game/gamemodes/shadowling/shadowling.dm
+++ b/yogstation/code/game/gamemodes/shadowling/shadowling.dm
@@ -126,6 +126,13 @@ Made by Xhuis
 	text += "<br>"
 	to_chat(world, text)
 
+/datum/game_mode/shadowling/set_round_result()
+	..()
+	if(check_shadow_victory())
+		SSticker.mode_result = "win - shadowling has ascended"
+	else
+		SSticker.mode_result = "loss - staff stopped the shadowling"
+
 /*
 	MISCELLANEOUS
 */


### PR DESCRIPTION
@fluffe9911 recently asked me get some statistics on the winrates of shadowlings. Unfortunately, after looking thru the database on the host, I realized that shadowlings were not actually logging the result of their game. So, I've decided to go ahead and fix that.

#### Changelog
:cl:  Altoids
rscadd: Altoids can now more easily determine how broken shadowlings are.
/:cl:
