### PR TITLE
[MANUAL MIRROR] Trash from food no longer teleports

### DIFF
--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -71,9 +71,11 @@ All foods are distributed among various categories. Use common sense.
 	if(!eater)
 		return
 	if(!reagents.total_volume)
-		var/obj/item/trash_item = generate_trash(eater)
+		var/mob/living/location = loc
+		var/obj/item/trash_item = generate_trash(location)
 		qdel(src)
-		eater.put_in_hands(trash_item)
+		if(istype(location))
+			location.put_in_hands(trash_item)
 
 
 /obj/item/reagent_containers/food/snacks/attack_self(mob/user)


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/45018
Also fixes #6132

:cl:  nemvar
bugfix: Trash from food now gets generated at the location of the food item, instead of in the hands of the eater.
/:cl:
