### PR TITLE
Removes an instance of an accessible hybrid tazer.

### DIFF
--- a/yogstation/code/modules/ruins/lavaland_ruin_code.dm
+++ b/yogstation/code/modules/ruins/lavaland_ruin_code.dm
@@ -45,7 +45,7 @@
 	suit = /obj/item/clothing/suit/armor/vest
 	gloves = /obj/item/clothing/gloves/combat
 	back = /obj/item/gun/ballistic/shotgun/lethal
-	belt = /obj/item/gun/energy/e_gun/advtaser
+	belt = /obj/item/gun/energy/disabler
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	head = /obj/item/clothing/head/helmet/swat
 	mask = /obj/item/clothing/mask/gas


### PR DESCRIPTION
yeah so orion sec officer has a hybrid taser so i gave them a disabler instead speedmerge electrodes really make my ass sore.

#### Changelog

:cl:  Identification
bugfix: Orion Sec Officers no longer spawn with hybrid tasers.  
/:cl:
