### PR TITLE
Allows prisoners to access perma vendors with no ID

### DIFF
--- a/_maps/yogstation/map_files/MinskyStation/MinskyStation.dmm
+++ b/_maps/yogstation/map_files/MinskyStation/MinskyStation.dmm
@@ -760,7 +760,9 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "abP" = (
-/obj/machinery/vending/coffee,
+/obj/machinery/vending/coffee{
+	onstation = 0
+	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -1181,6 +1183,7 @@
 /obj/machinery/vending/sustenance{
 	desc = "A vending machine normally reserved for work camps.";
 	name = "\improper sustenance vendor";
+	onstation = 0;
 	product_slogans = "Enjoy your meal.;Enough calories to support any worker."
 	},
 /obj/effect/turf_decal/tile/brown,

--- a/_maps/yogstation/map_files/YogStation/YogStation.dmm
+++ b/_maps/yogstation/map_files/YogStation/YogStation.dmm
@@ -22924,7 +22924,9 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aTy" = (
-/obj/machinery/vending/sustenance,
+/obj/machinery/vending/sustenance{
+	onstation = 0
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -23219,8 +23221,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
 "aUg" = (
-/obj/machinery/vending/cola/random,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/cola{
+	onstation = 0
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aUh" = (

--- a/_maps/yogstation/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/yogstation/map_files/YogsDelta/YogsDelta.dmm
@@ -25342,7 +25342,9 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "aPs" = (
-/obj/machinery/vending/coffee,
+/obj/machinery/vending/coffee{
+	onstation = 0
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/yellow{
@@ -25351,7 +25353,9 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aPt" = (
-/obj/machinery/vending/sustenance,
+/obj/machinery/vending/sustenance{
+	onstation = 0
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},

--- a/_maps/yogstation/map_files/YogsPubby/YogsPubby.dmm
+++ b/_maps/yogstation/map_files/YogsPubby/YogsPubby.dmm
@@ -2948,7 +2948,9 @@
 	},
 /area/maintenance/department/engine)
 "afZ" = (
-/obj/machinery/vending/sustenance,
+/obj/machinery/vending/sustenance{
+	onstation = 0
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aga" = (
@@ -3065,7 +3067,9 @@
 /turf/open/floor/wood,
 /area/medical/medbay/central)
 "agn" = (
-/obj/machinery/vending/cola,
+/obj/machinery/vending/cola{
+	onstation = 0
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "ago" = (

--- a/_maps/yogstation/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/yogstation/map_files/Yogsmeta/Yogsmeta.dmm
@@ -919,6 +919,7 @@
 /obj/machinery/vending/sustenance{
 	desc = "A vending machine normally reserved for work camps.";
 	name = "\improper sustenance vendor";
+	onstation = 0;
 	product_slogans = "Enjoy your meal.;Enough calories to support any worker."
 	},
 /obj/effect/decal/cleanable/dirt,


### PR DESCRIPTION
Removes economy from the vendors in perma. I figure this is the best (easiest) way of doing this.

:cl:  
bugfix: Perma prisoners now have access to the perma vendors.
/:cl: