### PR TITLE
Deeper Fire Protection

### DIFF
--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -9,6 +9,7 @@
 	cold_protection = CHEST|GROIN|LEGS|ARMS
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	heat_protection = CHEST|GROIN|LEGS|ARMS
+	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	hoodtype = /obj/item/clothing/head/hooded/explorer
 	armor = list("melee" = 30, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 50, "bio" = 100, "rad" = 50, "fire" = 50, "acid" = 50)
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/resonator, /obj/item/mining_scanner, /obj/item/t_scanner/adv_mining_scanner, /obj/item/gun/energy/kinetic_accelerator, /obj/item/pickaxe)


### PR DESCRIPTION
### Intent of your Pull Request

Right now being on fire catches every non-fireproof item you're wearing on fire, even if you're wearing a fireproof suit.  There's no good way to put the burning clothing out, even if you extinguish the original fire.  Miners and firefighters lose their IDs a lot because their jumpsuit somehow burns to ash even though they're taking no damage.

With this PR clothing can't catch fire if it's located under a fireproof suit.  That mostly means fireproof items that go in the suit slot, but there are a few weird exceptions (reactive teleport armor, captain's carapace) so it gets its own flag.

Balance implications: Massive fires will be less dangerous.  Accidentally stepping in lava is easier to recover from.  The Ash Drake, while no weaker, will be less annoying.

#### Changelog

:cl:  
tweak: Items worn under fireproof suits will no longer catch fire.
/:cl:
