### PR TITLE
[FIX] Botany gets 3 strange seed packets instead of 2

### DIFF
--- a/yogstation/code/modules/vending/megaseed.dm
+++ b/yogstation/code/modules/vending/megaseed.dm
@@ -49,7 +49,7 @@
 					  /obj/item/seeds/reishi = 2,
 					  /obj/item/seeds/cannabis = 3,
 					  /obj/item/seeds/starthistle = 2,
-					  /obj/item/seeds/random = 2)
+					  /obj/item/seeds/random = 3)
 	premium = list(/obj/item/reagent_containers/spray/waterflower = 1)
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF


### PR DESCRIPTION
A fix for PR [yogstation13/Yogstation-TG/pull/4948](https://github.com/yogstation13/Yogstation-TG/pull/4948) which upped the random chem seed count to 3 from 2, but didn't actually take effect due to there being 2 different megaseed.dm files 