### PR TITLE
Allows nuclear operatives to buy loud headsets

### DIFF
--- a/yogstation/code/game/objects/items/devices/radio/headset.dm
+++ b/yogstation/code/game/objects/items/devices/radio/headset.dm
@@ -4,3 +4,7 @@
 	icon_state = "med_headset"
 	item_state = "headset"
 	keyslot = new /obj/item/encryptionkey/headset_medsup
+
+/obj/item/radio/headset/syndicate/alt/leader/loud
+	name = "loud headset"	//An operative buying a headset wouldn't be the commander now would they?
+	desc = "A syndicate headset with a volume setting"

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -3,7 +3,7 @@
 	var/list/exclude_objectives = list() //objectives to disallow the buyer from buying this item
 	var/surplus_nullcrates
 
-/datum/uplink_item/New()	
+/datum/uplink_item/New()
 	. = ..()
 	if(isnull(surplus_nullcrates))
 		surplus_nullcrates = surplus
@@ -80,7 +80,7 @@
 	cost = 5
 	surplus = 0
 	exclude_modes = list(/datum/game_mode/nuclear)
-	
+
 /datum/uplink_item/device_tools/arm/nuke
 	cost = 15
 	exclude_modes = list()
@@ -118,3 +118,10 @@
 	item = /obj/item/melee/fryingpan/bananium
 	cost = 40
 	cant_discount = TRUE
+
+/datum/uplink_item/device_tools/loud_headset
+	name = "Loud Headset"
+	desc = "A syndicate headset with a volume setting"
+	item = /obj/item/radio/headset/syndicate/alt/leader/loud
+	cost = 1
+	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)


### PR DESCRIPTION
Loud headsets can now be bought for 1 TC by nuclear operatives, which is a syndicate headset with a volume setting. Communication has been an issue with nukies and while this won't fix the issue, it will help operatives differentiate between crew comms and operative comms.