### PR TITLE
Give blood-brothers their own pinpointer

### DIFF
--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -21,6 +21,8 @@
 	SSticker.mode.brothers += owner
 	objectives += team.objectives
 	owner.special_role = special_role
+	if(owner.current)
+		give_pinpointer()
 	finalize_brother()
 	return ..()
 
@@ -28,6 +30,7 @@
 	SSticker.mode.brothers -= owner
 	if(owner.current)
 		to_chat(owner.current,"<span class='userdanger'>You are no longer the [special_role]!</span>")
+		owner.current.remove_status_effect(/datum/status_effect/agent_pinpointer/brother)
 	owner.special_role = null
 	return ..()
 
@@ -85,6 +88,16 @@
 	T.update_name()
 	message_admins("[key_name_admin(admin)] made [key_name_admin(new_owner)] and [key_name_admin(bro)] into blood brothers.")
 	log_admin("[key_name(admin)] made [key_name(new_owner)] and [key_name(bro)] into blood brothers.")
+
+/datum/antagonist/brother/proc/give_pinpointer(var/datum/mind/target_brother)
+	if(owner && owner.current)
+		var/datum/status_effect/agent_pinpointer/brother/P = owner.current.apply_status_effect(/datum/status_effect/agent_pinpointer/brother)
+		P.preset_target = determine_other_brother()
+
+/datum/antagonist/brother/proc/determine_other_brother()
+	var/datum/mind/list/other_brother = team.members - owner
+	for(var/i = 1 to other_brother.len)
+		return other_brother[1]
 
 /datum/team/brother_team
 	name = "brotherhood"

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -92,12 +92,7 @@
 /datum/antagonist/brother/proc/give_pinpointer(var/datum/mind/target_brother)
 	if(owner && owner.current)
 		var/datum/status_effect/agent_pinpointer/brother/P = owner.current.apply_status_effect(/datum/status_effect/agent_pinpointer/brother)
-		P.preset_target = determine_other_brother()
-
-/datum/antagonist/brother/proc/determine_other_brother()
-	var/datum/mind/list/other_brother = team.members - owner
-	for(var/i = 1 to other_brother.len)
-		return other_brother[1]
+		P.allowed_targets = team.members - owner
 
 /datum/team/brother_team
 	name = "brotherhood"

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -89,7 +89,7 @@
 	message_admins("[key_name_admin(admin)] made [key_name_admin(new_owner)] and [key_name_admin(bro)] into blood brothers.")
 	log_admin("[key_name(admin)] made [key_name(new_owner)] and [key_name(bro)] into blood brothers.")
 
-/datum/antagonist/brother/proc/give_pinpointer(var/datum/mind/target_brother)
+/datum/antagonist/brother/proc/give_pinpointer()
 	if(owner && owner.current)
 		var/datum/status_effect/agent_pinpointer/brother/P = owner.current.apply_status_effect(/datum/status_effect/agent_pinpointer/brother)
 		P.allowed_targets = team.members - owner

--- a/code/modules/antagonists/traitor/brother/traitor_bro.dm
+++ b/code/modules/antagonists/traitor/brother/traitor_bro.dm
@@ -19,10 +19,8 @@
 	if(set_target)
 		scan_target = set_target.current
 		return
-	if(allowed_targets.len == 1)
-		var/datum/mind/picked = pick(allowed_targets)
-		scan_target = picked.current
-		return
+	var/datum/mind/picked = pick(allowed_targets)
+	scan_target = picked.current
 
 /obj/screen/alert/status_effect/agent_pinpointer/brother/Click()
 	if(attached_effect)

--- a/code/modules/antagonists/traitor/brother/traitor_bro.dm
+++ b/code/modules/antagonists/traitor/brother/traitor_bro.dm
@@ -1,13 +1,12 @@
 /datum/status_effect/agent_pinpointer/brother
 	id = "brother_pinpointer"
 	alert_type = /obj/screen/alert/status_effect/agent_pinpointer/brother
-	var/datum/mind/preset_target
+	var/datum/mind/set_target
+	var/datum/mind/list/allowed_targets
 
 	//ree magic numbers
 	minimum_range = 2
 	range_fuzz_factor = 0
-	range_mid = 8
-	range_far = 16
 
 /obj/screen/alert/status_effect/agent_pinpointer/brother
 	name = "Blood Brother Integrated Pinpointer"
@@ -17,15 +16,16 @@
 
 /datum/status_effect/agent_pinpointer/brother/scan_for_target()
 	scan_target = null
-
-	if(preset_target)
-		scan_target = preset_target.current
+	if(set_target)
+		scan_target = set_target.current
+		return
+	if(allowed_targets.len == 1)
+		var/datum/mind/picked = pick(allowed_targets)
+		scan_target = picked.current
 		return
 
-	//fallback method
-	if(owner && owner.mind)
-		for(var/datum/antagonist/brother/Q in owner.mind.has_antag_datum(/datum/antagonist/brother))
-			var/datum/mind/list/other_brother = Q.team.members - owner.mind
-			for(var/i = 1 to other_brother.len)
-				scan_target = other_brother[1].current
-				break
+/obj/screen/alert/status_effect/agent_pinpointer/brother/Click()
+	if(attached_effect)
+		var/datum/status_effect/agent_pinpointer/brother/E = attached_effect
+		E.set_target = input(usr,"Select target to track","Pinpointer") as null|anything in E.allowed_targets
+	..()

--- a/code/modules/antagonists/traitor/brother/traitor_bro.dm
+++ b/code/modules/antagonists/traitor/brother/traitor_bro.dm
@@ -1,0 +1,31 @@
+/datum/status_effect/agent_pinpointer/brother
+	id = "brother_pinpointer"
+	alert_type = /obj/screen/alert/status_effect/agent_pinpointer/brother
+	var/datum/mind/preset_target
+
+	//ree magic numbers
+	minimum_range = 2
+	range_fuzz_factor = 0
+	range_mid = 8
+	range_far = 16
+
+/obj/screen/alert/status_effect/agent_pinpointer/brother
+	name = "Blood Brother Integrated Pinpointer"
+	desc = "Even stealthier than a normal implant."
+	icon = 'icons/obj/device.dmi'
+	icon_state = "pinon"
+
+/datum/status_effect/agent_pinpointer/brother/scan_for_target()
+	scan_target = null
+
+	if(preset_target)
+		scan_target = preset_target.current
+		return
+
+	//fallback method
+	if(owner && owner.mind)
+		for(var/datum/antagonist/brother/Q in owner.mind.has_antag_datum(/datum/antagonist/brother))
+			var/datum/mind/list/other_brother = Q.team.members - owner.mind
+			for(var/i = 1 to other_brother.len)
+				scan_target = other_brother[1].current
+				break

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -1393,6 +1393,7 @@
 #include "code\modules\antagonists\swarmer\swarmer.dm"
 #include "code\modules\antagonists\traitor\datum_traitor.dm"
 #include "code\modules\antagonists\traitor\syndicate_contract.dm"
+#include "code\modules\antagonists\traitor\brother\traitor_bro.dm"
 #include "code\modules\antagonists\traitor\equipment\Malf_Modules.dm"
 #include "code\modules\antagonists\traitor\IAA\internal_affairs.dm"
 #include "code\modules\antagonists\valentines\heartbreaker.dm"


### PR DESCRIPTION
### Intent of your Pull Request
![image](https://user-images.githubusercontent.com/13056792/61290956-69ff8b00-a7cd-11e9-8a07-dbb7c971810a.png) (#5310)

I was reading this while deleting the blood brother bundles and I figured this could be a good replacement for it.

Basically gives blood brothers their own pinpointer, just like the IAA pinpointer. It'll show the direction to their brother.

Also I hacked this code together while drinking profusely, so if I made a glaring error, please tell me.
#### Changelog

:cl:  
rscadd: Blood brothers now spawn with an integrated pinpointer that shows the direction to their teammate.
/:cl:
