### PR TITLE
Legion core effects now wear off

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -578,7 +578,7 @@
 	return TRUE
 
 /datum/status_effect/regenerative_core/on_remove()
-	REMOVE_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, "regenerative_core")
+	REMOVE_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, id)
 
 /datum/status_effect/antimagic
 	id = "antimagic"


### PR DESCRIPTION
### Intent of your Pull Request
This somehow got rebroke.  Legion cores don't make you permanently immune to damage slowdown anymore (again.)

Sorry megafauna hunters, it's back to farming cores.  This just gets too powerful if it makes it back on station.

#### Changelog

:cl:  
bugfix: Legion cores won't hold you together forever anymore.
/:cl:
