### PR TITLE
Buffs Shadowling Thralls

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -297,15 +297,7 @@ GENE SCANNER
 			mutant = TRUE
 
 		to_chat(user, "<span class='info'>Species: [S.name][mutant ? "-derived mutant" : ""]</span>")
-
-	//Health analyzers warn you about very cold people, like thralls or victims of shadowlings. //yogs start
-	if(M.mind?.has_antag_datum(ANTAG_DATUM_THRALL) || M.bodytemperature < (11 + T0C))
-		//Thralls get a fake temperature so they always read as too cold.
-		var/faketemp = (M.mind?.has_antag_datum(ANTAG_DATUM_THRALL) ? M.bodytemperature - rand(25, 26) : M.bodytemperature)
-		to_chat(user, "<span class='danger'>Body temperature: [round(faketemp - T0C,0.1)] &deg;C ([round(faketemp*1.8-459.67,0.1)] &deg;F)</span>")
-		to_chat(user, "<span class='danger'>Internal temperature hazardously low.</span>")
-	else
-		to_chat(user, "<span class='info'>Body temperature: [round(M.bodytemperature-T0C,0.1)] &deg;C ([round(M.bodytemperature*1.8-459.67,0.1)] &deg;F)</span>") //yogs end
+	to_chat(user, "<span class='info'>Body temperature: [round(M.bodytemperature-T0C,0.1)] &deg;C ([round(M.bodytemperature*1.8-459.67,0.1)] &deg;F)</span>")
 
 	// Time of death
 	if(M.tod && (M.stat == DEAD || ((HAS_TRAIT(M, TRAIT_FAKEDEATH)) && !advanced)))

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -237,6 +237,9 @@
 			if(stun_absorption[i]["end_time"] > world.time && stun_absorption[i]["examine_message"])
 				msg += "[t_He] [t_is][stun_absorption[i]["examine_message"]]\n"
 
+	if(!glasses && mind && mind.has_antag_datum(ANTAG_DATUM_THRALL))
+		msg += "[t_His] eyes seem unnaturally dark and soulless.\n" // I'VE BECOME SO NUMB, I CAN'T FEEL YOU THERE
+
 	if(!appears_dead)
 		if(drunkenness && !skipface) //Drunkenness
 			switch(drunkenness)

--- a/yogstation/code/game/objects/items/devices/scanners.dm
+++ b/yogstation/code/game/objects/items/devices/scanners.dm
@@ -130,15 +130,6 @@ proc/lesserhealthscan(mob/user, mob/living/M)
 	var/fire_loss = M.getFireLoss()
 	var/brute_loss = M.getBruteLoss()
 
-	//Health analyzers (and thus tricorders) warn you about very cold people, like thralls or victims of shadowlings.
-	if(M.mind?.has_antag_datum(ANTAG_DATUM_THRALL) || M.bodytemperature < (11 + T0C))
-		//Thralls get a fake temperature so they always read as too cold.
-		var/faketemp = (M.mind?.has_antag_datum(ANTAG_DATUM_THRALL) ? M.bodytemperature - rand(25, 26) : M.bodytemperature)
-		to_chat(user, "<span class='danger'>Body temperature: [round(faketemp - T0C,0.1)] &deg;C ([round(faketemp*1.8-459.67,0.1)] &deg;F)</span>")
-		to_chat(user, "<span class='danger'>Internal temperature hazardously low.</span>")
-	else
-		to_chat(user, "<span class='info'>Body temperature: [round(M.bodytemperature-T0C,0.1)] &deg;C ([round(M.bodytemperature*1.8-459.67,0.1)] &deg;F)</span>")
-
 	// Damage descriptions
 	// Tricorder can detect damage but can only give estimates in most cases
 	if(brute_loss > 5)


### PR DESCRIPTION
🆑
tweak: Shadowling thralls are now discovered by looking at there eyes instead of scanning there body temp
/🆑

The whole reason the whole body temp scan thing became a thing in the first place was to give thralls a better chance of not being discovered but honestly I think it did the opposite and made finding thralls a ton easier so now its semi reverted but instead of a mask its eyes so they can hide it a bit better that is all