### PR TITLE
Adds reminders to some MMI transitions

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -966,7 +966,7 @@
 	update_icon()
 	setDir(dir_in)
 	log_message("[mmi_as_oc] moved in as pilot.", LOG_MECHA)
-	if(istype(mmi_as_oc, obj/item/mmi/posibrain))											//yogs start reminder to posibrain to not be shitlers
+	if(istype(mmi_as_oc, /obj/item/mmi/posibrain))											//yogs start reminder to posibrain to not be shitlers
 		to_chat(brainmob, "<b>As a synthetic intelligence, you answer to all crewmembers and the AI.\n\
 		Remember, the purpose of your existence is to serve the crew and the station. Above all else, do no harm.</b>")
 	else

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -968,7 +968,9 @@
 	log_message("[mmi_as_oc] moved in as pilot.", LOG_MECHA)
 	if(istype(mmi_as_oc, obj/item/mmi/posibrain))											//yogs start reminder to posibrain to not be shitlers
 		to_chat(brainmob, "<b>As a synthetic intelligence, you answer to all crewmembers and the AI.\n\
-		Remember, the purpose of your existence is to serve the crew and the station. Above all else, do no harm.</b>")		//yogs end
+		Remember, the purpose of your existence is to serve the crew and the station. Above all else, do no harm.</b>")
+	else
+		to_chat(brainmob, "<b>Remember, you are still member of the crew act like it</b>")//yogs end
 	if(!internal_damage)
 		SEND_SOUND(occupant, sound('sound/mecha/nominal.ogg',volume=50))
 	GrantActions(brainmob)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -89,7 +89,7 @@
 	var/enclosed = TRUE //Set to false for open-cockpit mechs
 	var/silicon_icon_state = null //if the mech has a different icon when piloted by an AI or MMI
 	var/is_currently_ejecting = FALSE //Mech cannot use equiptment when true, set to true if pilot is trying to exit mech
-	
+
 	//Action datums
 	var/datum/action/innate/mecha/mech_eject/eject_action = new
 	var/datum/action/innate/mecha/mech_toggle_internals/internals_action = new
@@ -966,6 +966,9 @@
 	update_icon()
 	setDir(dir_in)
 	log_message("[mmi_as_oc] moved in as pilot.", LOG_MECHA)
+	if(istype(mmi_as_oc, obj/item/mmi/posibrain))											//yogs start reminder to posibrain to not be shitlers
+		to_chat(brainmob, "<b>As a synthetic intelligence, you answer to all crewmembers and the AI.\n\
+		Remember, the purpose of your existence is to serve the crew and the station. Above all else, do no harm.</b>")		//yogs end
 	if(!internal_damage)
 		SEND_SOUND(occupant, sound('sound/mecha/nominal.ogg',volume=50))
 	GrantActions(brainmob)

--- a/yogstation/code/modules/mob/living/brain/MMI.dm
+++ b/yogstation/code/modules/mob/living/brain/MMI.dm
@@ -6,6 +6,7 @@
 
 			brain = newbrain
 			name = "[initial(name)]: [brain.real_name]"
+			to_chat(brainmob, "(<span class='notice'>You do not remember your death, how you died, or who killed you. <a href='https://forums.yogstation.net/index.php?pages/rules/'>See rule 1.7</a>.</span>") //yogs
 			update_icon()
 			return
 

--- a/yogstation/code/modules/mob/living/brain/MMI.dm
+++ b/yogstation/code/modules/mob/living/brain/MMI.dm
@@ -6,7 +6,7 @@
 
 			brain = newbrain
 			name = "[initial(name)]: [brain.real_name]"
-			to_chat(brainmob, "(<span class='notice'>You do not remember your death, how you died, or who killed you. <a href='https://forums.yogstation.net/index.php?pages/rules/'>See rule 1.7</a>.</span>") //yogs
+			to_chat(brainmob, "(<span class='notice'>If your brain was removed after your death you don't remeber how you died, or who killed you. <a href='https://forums.yogstation.net/index.php?pages/rules/'>See rule 1.7</a>.</span>") //yogs
 			update_icon()
 			return
 


### PR DESCRIPTION
add reminders of rules to some transitions in MMI state
when MMI is revived rule 1,7 reminder was added
when inserted into mech most of the posi brain boot up lines will play to remind them their function 

:cl: 
tweak: people revived by MMI will be reminded that they don't remember their death
tweak: posibrain inserted to mecha is reminded that they still serve the crew and ai.
/:cl:
