### PR TITLE
Fixes diagonal box movement, makes stealth box reveal when damaged

### DIFF
--- a/code/game/objects/items/implants/implant_stealth.dm
+++ b/code/game/objects/items/implants/implant_stealth.dm
@@ -13,6 +13,7 @@
 	name = "inconspicious box"
 	desc = "It's so normal that you didn't notice it before."
 	icon_state = "agentbox"
+	max_integrity = 1 // "This dumb box shouldn't take more than one hit to make it vanish."
 	move_speed_multiplier = 0.5
 
 /obj/structure/closet/cardboard/agent/proc/go_invisible()

--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -69,3 +69,14 @@
 	open_sound = 'sound/machines/click.ogg'
 	material_drop = /obj/item/stack/sheet/plasteel
 #undef SNAKE_SPAM_TICKS
+
+/obj/structure/closet/cardboard/relaymove(mob/living/user, direction)
+	if(!istype(user) || opened || move_delay || user.incapacitated() || !isturf(loc) || !has_gravity(loc))
+		return
+	move_delay = TRUE
+	var/oldloc = loc
+	step(src, direction)
+	if(oldloc != loc)
+		addtimer(CALLBACK(src, .proc/ResetMoveDelay), CONFIG_GET(number/movedelay/walk_delay) * move_speed_multiplier)
+	else
+		move_delay = FALSE


### PR DESCRIPTION
Ports https://github.com/tgstation/tgstation/pull/45274, see reasons for this PR there.

Credits to: YakumoChen

#### Changelog

:cl: Chen Yakumo
balance: The stealth implant box is now flimsier than it was before.
fix: You can no longer zoom around in a box by hugging walls.
/:cl:
