### PR TITLE
Fixes conscription kit encryption key

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -279,6 +279,6 @@
 	new /obj/item/t_scanner/adv_mining_scanner/lesser(src)
 	new /obj/item/storage/bag/ore(src)
 	new /obj/item/clothing/suit/hooded/explorer(src)
-	new /obj/item/encryptionkey/headset_cargo(src)
+	new /obj/item/encryptionkey/headset_mining(src)
 	new /obj/item/clothing/mask/gas/explorer(src)
 	new /obj/item/card/mining_access_card(src)


### PR DESCRIPTION
Port of https://github.com/tgstation/tgstation/pull/45300.
Credits to Swagile

:cl: Swagile
tweak: Cargo key in mining conscript kit is now a mining key.
/:cl:
