### PR TITLE
fixes a runtime I caused

### DIFF
--- a/yogstation/code/modules/clothing/clothing.dm
+++ b/yogstation/code/modules/clothing/clothing.dm
@@ -89,7 +89,7 @@
 	return "<span class='warning'>[src] falls apart and breaks!</span>"
 
 /obj/item/clothing/under/examine(mob/user)
-	..()
+	.=..()
 	if(tearhealth)
 		switch (tearhealth)
 			if (100)


### PR DESCRIPTION
[2019-07-22 11:53:36.769] runtime error: Cannot execute "It appears to be in pristine c...".Join().
 - proc name: Examine (/mob/verb/examinate)
 -   source file: mob.dm,309
 -   usr: (src)
 -   src: Nick Sanders (/mob/living/carbon/human)
 -   src.loc: the carpet (128,131,2) (/turf/open/floor/carpet/blue)
 -   call stack:
 - Nick Sanders (/mob/living/carbon/human): Examine(the very fancy captain uniform (/obj/item/clothing/under/yogs/victoriouscaptainuniform))
