### PR TITLE
Fixes another runtime

### DIFF
--- a/code/game/objects/items/RSF.dm
+++ b/code/game/objects/items/RSF.dm
@@ -141,7 +141,7 @@ RSF
 	if((obj_flags & EMAGGED)&&!toxin)
 		toxin = 1
 		to_chat(user, "Cookie Synthesizer Hacked")
-	else if(P.emagged&&!toxin)
+	else if(P && P.emagged && !toxin)
 		toxin = 1
 		to_chat(user, "Cookie Synthesizer Hacked")
 	else


### PR DESCRIPTION

runtime error: Cannot read null.emagged
--
  |   | - proc name: attack self (/obj/item/cookiesynth/attack_self)
  |   | - source file: RSF.dm,144
  |   | - usr: Anton Govno (/mob/living/carbon/human)
  |   | - src: Cookie Synthesizer (/obj/item/cookiesynth)
  |   | - usr.loc: the floor (112,142,5) (/turf/open/floor/wood)
  |   | - src.loc: Anton Govno (/mob/living/carbon/human)
  |   | - call stack:
  |   | - Cookie Synthesizer (/obj/item/cookiesynth): attack self(Anton Govno (/mob/living/carbon/human))
  |   | - Anton Govno (/mob/living/carbon/human): Activate Held Object()
  |   | - Anton Govno (/mob/living/carbon/human): key down(/datum/keyinfo (/datum/keyinfo), Oraclession (/client))
  |   | - Anton Govno (/mob/living/carbon/human): key down(/datum/keyinfo (/datum/keyinfo), Oraclession (/client))
  |   | - Anton Govno (/mob/living/carbon/human): key down(/datum/keyinfo (/datum/keyinfo), Oraclession (/client))
  |   | - Anton Govno (/mob/living/carbon/human): key down(/datum/keyinfo (/datum/keyinfo), Oraclession (/client))
  |   | - Oraclession (/client): keyDown("Z")
  |   | -

