### PR TITLE
Makes KDiff3 backup files not be affected by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,6 @@ tools/MapAtmosFixer/MapAtmosFixer/bin/*
 #extra map stuff
 /_maps/**/backup/
 /_maps/templates.dm
+
+#KDIFF3 files
+*.orig


### PR DESCRIPTION
See title

.orig files are no longer registered by git