### PR TITLE
Makes Xenoes & Monkeys hold more/less blood in their bodies than humans

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -11,14 +11,27 @@
 #define MOVE_INTENT_WALK "walk"
 #define MOVE_INTENT_RUN  "run"
 
-//Blood levels
+//Blood volumes, in cL
+#define BLOOD_VOLUME_NORMAL			560 // The default amount of blood in a Carbon, in cL, based off IRL data about humans
+#define BLOOD_VOLUME_MONKEY			325 // Based on IRL data bout Chimpanzees
+#define BLOOD_VOLUME_XENO			700 // Based of data from my asshole
+
+#define BLOOD_VOLUME_SLIME_SPLIT	(2.0 * BLOOD_VOLUME_NORMAL) // Amount of blood needed by slimebois for splitting in twain
+
+//Blood multiplers -- Multiply the original default value of blood your Carbon has with these in order to get the actual blood tiers
+// i.e.	if(h.blood_volume < initial(h.blood_volume) * BLOOD_OKAY_MULTI) or whatever 
+#define BLOOD_MAXIMUM_MULTI 3.6 // 360%
+#define BLOOD_SAFE_MULTI 0.848	// 84.8%
+#define BLOOD_OKAY_MULTI 0.6	// 60%
+#define BLOOD_BAD_MULTI 0.4		// 40%
+#define BLOOD_SURVIVE_MULTI 0.2	// 20%
+
+//Legacy defines, based on the default human blood level. Left here just in case I forgot something somewhere
 #define BLOOD_VOLUME_MAXIMUM		2000
-#define BLOOD_VOLUME_SLIME_SPLIT	1120
-#define BLOOD_VOLUME_NORMAL			560
-#define BLOOD_VOLUME_SAFE			475
-#define BLOOD_VOLUME_OKAY			336
-#define BLOOD_VOLUME_BAD			224
-#define BLOOD_VOLUME_SURVIVE		122
+#define BLOOD_VOLUME_SAFE			475 // 84.8%
+#define BLOOD_VOLUME_OKAY			336 // 60%
+#define BLOOD_VOLUME_BAD			224 // 40%
+#define BLOOD_VOLUME_SURVIVE		122 // 20%
 
 //Sizes of mobs, used by mob/living/var/mob_size
 #define MOB_SIZE_TINY 0

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -20,11 +20,20 @@
 
 //Blood multiplers -- Multiply the original default value of blood your Carbon has with these in order to get the actual blood tiers
 // i.e.	if(h.blood_volume < initial(h.blood_volume) * BLOOD_OKAY_MULTI) or whatever 
+//used by :living/proc/get_blood_state()
 #define BLOOD_MAXIMUM_MULTI 3.6 // 360%
 #define BLOOD_SAFE_MULTI 0.848	// 84.8%
 #define BLOOD_OKAY_MULTI 0.6	// 60%
 #define BLOOD_BAD_MULTI 0.4		// 40%
 #define BLOOD_SURVIVE_MULTI 0.2	// 20%
+
+//Blood state enums, again used by get_blood_state()
+#define BLOOD_MAXIMUM 5
+#define BLOOD_SAFE 4
+#define BLOOD_OKAY 3
+#define BLOOD_BAD 2
+#define BLOOD_SURVIVE 1
+#define BLOOD_DEAD 0
 
 //Legacy defines, based on the default human blood level. Left here just in case I forgot something somewhere
 #define BLOOD_VOLUME_MAXIMUM		2000

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -16,7 +16,7 @@
 #define BLOOD_VOLUME_MONKEY			325 // Based on IRL data bout Chimpanzees
 #define BLOOD_VOLUME_XENO			700 // Based off data from my asshole
 
-#define BLOOD_VOLUME_SLIME_SPLIT	(2.0 * BLOOD_VOLUME_NORMAL) // Amount of blood needed by slimebois for splitting in twain
+#define BLOOD_VOLUME_SLIME_SPLIT	(2.0 * BLOOD_VOLUME_GENERIC) // Amount of blood needed by slimebois for splitting in twain
 
 //Blood multiplers -- Multiply the original default value of blood your Carbon has with these in order to get the actual blood tiers
 // i.e.	if(h.blood_volume < initial(h.blood_volume) * BLOOD_OKAY_MULTI) or whatever 
@@ -37,7 +37,7 @@
 
 //Defines to get the actual volumes for these varying states
 #define BLOOD_VOLUME_MAXIMUM(L)		(initial(##L.blood_volume) * BLOOD_MAXIMUM_MULTI)
-#define BLOOD_VOLUME_NORMAL(L)		(initial(##L.blood_volume)
+#define BLOOD_VOLUME_NORMAL(L)		(initial(##L.blood_volume))
 #define BLOOD_VOLUME_SAFE(L)		(initial(##L.blood_volume) * BLOOD_SAFE_MULTI)
 #define BLOOD_VOLUME_OKAY(L)		(initial(##L.blood_volume) * BLOOD_OKAY_MULTI)
 #define BLOOD_VOLUME_BAD(L)			(initial(##L.blood_volume) * BLOOD_BAD_MULTI)

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -12,9 +12,9 @@
 #define MOVE_INTENT_RUN  "run"
 
 //Blood volumes, in cL
-#define BLOOD_VOLUME_NORMAL			560 // The default amount of blood in a Carbon, in cL, based off IRL data about humans
+#define BLOOD_VOLUME_GENERIC		560 // The default amount of blood in a blooded creature, in cL, based off IRL data about humans
 #define BLOOD_VOLUME_MONKEY			325 // Based on IRL data bout Chimpanzees
-#define BLOOD_VOLUME_XENO			700 // Based of data from my asshole
+#define BLOOD_VOLUME_XENO			700 // Based off data from my asshole
 
 #define BLOOD_VOLUME_SLIME_SPLIT	(2.0 * BLOOD_VOLUME_NORMAL) // Amount of blood needed by slimebois for splitting in twain
 
@@ -37,6 +37,7 @@
 
 //Defines to get the actual volumes for these varying states
 #define BLOOD_VOLUME_MAXIMUM(L)		(initial(##L.blood_volume) * BLOOD_MAXIMUM_MULTI)
+#define BLOOD_VOLUME_NORMAL(L)		(initial(##L.blood_volume)
 #define BLOOD_VOLUME_SAFE(L)		(initial(##L.blood_volume) * BLOOD_SAFE_MULTI)
 #define BLOOD_VOLUME_OKAY(L)		(initial(##L.blood_volume) * BLOOD_OKAY_MULTI)
 #define BLOOD_VOLUME_BAD(L)			(initial(##L.blood_volume) * BLOOD_BAD_MULTI)

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -35,12 +35,12 @@
 #define BLOOD_SURVIVE 1
 #define BLOOD_DEAD 0
 
-//Legacy defines, based on the default human blood level. Left here just in case I forgot something somewhere
-#define BLOOD_VOLUME_MAXIMUM		2000
-#define BLOOD_VOLUME_SAFE			475 // 84.8%
-#define BLOOD_VOLUME_OKAY			336 // 60%
-#define BLOOD_VOLUME_BAD			224 // 40%
-#define BLOOD_VOLUME_SURVIVE		122 // 20%
+//Defines to get the actual volumes for these varying states
+#define BLOOD_VOLUME_MAXIMUM(L)		(initial(##L.blood_volume) * BLOOD_MAXIMUM_MULTI)
+#define BLOOD_VOLUME_SAFE(L)		(initial(##L.blood_volume) * BLOOD_SAFE_MULTI)
+#define BLOOD_VOLUME_OKAY(L)		(initial(##L.blood_volume) * BLOOD_OKAY_MULTI)
+#define BLOOD_VOLUME_BAD(L)			(initial(##L.blood_volume) * BLOOD_BAD_MULTI)
+#define BLOOD_VOLUME_SURVIVE(L)		(initial(##L.blood_volume) * BLOOD_SURVIVE_MULTI)
 
 //Sizes of mobs, used by mob/living/var/mob_size
 #define MOB_SIZE_TINY 0

--- a/code/__DEFINES/~yogs_defines/mobs.dm
+++ b/code/__DEFINES/~yogs_defines/mobs.dm
@@ -11,3 +11,5 @@
 #define PRETERNIS_NV_ON 8 
 
 #define BODYPART_ANY -1 //use this when healing with something that needs a specefied bodypart type for all
+
+#define REGEN_BLOOD_REQUIREMENT 40 // The amount of "blood" that a slimeperson consumes when regenerating a single limb.

--- a/code/datums/diseases/advance/symptoms/oxygen.dm
+++ b/code/datums/diseases/advance/symptoms/oxygen.dm
@@ -44,7 +44,7 @@ Bonus
 		if(4, 5)
 			M.adjustOxyLoss(-7, 0)
 			M.losebreath = max(0, M.losebreath - 4)
-			if(regenerate_blood && M.blood_volume < BLOOD_VOLUME_NORMAL)
+			if(regenerate_blood && M.blood_volume < BLOOD_VOLUME_NORMAL(M))
 				M.blood_volume += 1
 		else
 			if(prob(base_message_chance))

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -29,7 +29,7 @@
 	if(NOBLOOD in H.dna.species.species_traits) //can't lose blood if your species doesn't have any
 		return
 	else
-		if (H.blood_volume > (BLOOD_VOLUME_SAFE - 25)) // just barely survivable without treatment
+		if (H.blood_volume > (BLOOD_VOLUME_SAFE(H) - 25)) // just barely survivable without treatment
 			H.blood_volume -= 0.275
 
 /datum/quirk/blindness

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -149,7 +149,7 @@
 				return
 
 			// If the human is losing too much blood, beep.
-			if(attached.blood_volume < BLOOD_VOLUME_SAFE && prob(5))
+			if(attached.blood_volume < BLOOD_VOLUME_SAFE(attached) && prob(5))
 				visible_message("[src] beeps loudly.")
 				playsound(loc, 'sound/machines/twobeep_high.ogg', 50, 1)
 			attached.transfer_blood_to(beaker, amount)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -328,7 +328,7 @@ GENE SCANNER
 				var/mob/living/carbon/human/H = C
 				if(H.bleed_rate)
 					to_chat(user, "<span class='danger'>Subject is bleeding!</span>")
-			var/blood_percent =  round((C.blood_volume / BLOOD_VOLUME_NORMAL)*100)
+			var/blood_percent =  round((C.blood_volume / BLOOD_VOLUME_NORMAL(C))*100)
 			var/blood_type = C.dna.blood_type
 			if(blood_id != /datum/reagent/blood)//special blood substance
 				var/datum/reagent/R = GLOB.chemical_reagents_list[blood_id]

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -336,9 +336,9 @@ GENE SCANNER
 					blood_type = R.name
 				else
 					blood_type = blood_id
-			if(C.blood_volume <= BLOOD_VOLUME_SAFE && C.blood_volume > BLOOD_VOLUME_OKAY)
+			if(C.blood_volume <= BLOOD_VOLUME_SAFE(C) && C.blood_volume > BLOOD_VOLUME_OKAY(C))
 				to_chat(user, "<span class='danger'>LOW blood level [blood_percent] %, [C.blood_volume] cl,</span> <span class='info'>type: [blood_type]</span>")
-			else if(C.blood_volume <= BLOOD_VOLUME_OKAY)
+			else if(C.blood_volume <= BLOOD_VOLUME_OKAY(C))
 				to_chat(user, "<span class='danger'>CRITICAL blood level [blood_percent] %, [C.blood_volume] cl,</span> <span class='info'>type: [blood_type]</span>")
 			else
 				to_chat(user, "<span class='info'>Blood level [blood_percent] %, [C.blood_volume] cl, type: [blood_type]</span>")

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -670,15 +670,15 @@
 				if(H.stat == DEAD)
 					to_chat(user,"<span class='warning'>Only a revive rune can bring back the dead!</span>")
 					return
-				if(H.blood_volume < BLOOD_VOLUME_SAFE)
-					var/restore_blood = BLOOD_VOLUME_SAFE - H.blood_volume
+				if(H.blood_volume < BLOOD_VOLUME_SAFE(H))
+					var/restore_blood = BLOOD_VOLUME_SAFE(H) - H.blood_volume
 					if(uses*2 < restore_blood)
 						H.blood_volume += uses*2
 						to_chat(user,"<span class='danger'>You use the last of your blood rites to restore what blood you could!</span>")
 						uses = 0
 						return ..()
 					else
-						H.blood_volume = BLOOD_VOLUME_SAFE
+						H.blood_volume = BLOOD_VOLUME_SAFE(H)
 						uses -= round(restore_blood/2)
 						to_chat(user,"<span class='warning'>Your blood rites have restored [H == user ? "your" : "[H.p_their()]"] blood to safe levels!</span>")
 				var/overall_damage = H.getBruteLoss() + H.getFireLoss() + H.getToxLoss() + H.getOxyLoss()
@@ -713,7 +713,7 @@
 				if(H.cultslurring)
 					to_chat(user,"<span class='danger'>[H.p_their(TRUE)] blood has been tainted by an even stronger form of blood magic, it's no use to us like this!</span>")
 					return
-				if(H.blood_volume > BLOOD_VOLUME_SAFE)
+				if(H.blood_volume > BLOOD_VOLUME_SAFE(H))
 					H.blood_volume -= 100
 					uses += 50
 					user.Beam(H,icon_state="drainbeam",time=10)

--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -187,7 +187,7 @@
 						var/mob/living/simple_animal/M = L
 						if(M.health < M.maxHealth)
 							M.adjustHealth(-3)
-				if(ishuman(L) && L.blood_volume < BLOOD_VOLUME_NORMAL)
+				if(ishuman(L) && L.blood_volume < BLOOD_VOLUME_NORMAL(L))
 					L.blood_volume += 1.0
 			CHECK_TICK
 	if(last_corrupt <= world.time)

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -20,7 +20,7 @@
 		//Blood regeneration if there is some space
 		if(blood_volume < BLOOD_VOLUME_NORMAL)
 			blood_volume += 0.1 // regenerate blood VERY slowly
-			if(blood_volume < BLOOD_VOLUME_OKAY)
+			if(blood_volume < BLOOD_VOLUME_OKAY(src))
 				adjustOxyLoss(round((BLOOD_VOLUME_NORMAL - blood_volume) * 0.02, 1))
 
 // Takes care blood loss and regeneration
@@ -53,22 +53,22 @@
 
 		//Effects of bloodloss
 		var/word = pick("dizzy","woozy","faint")
-		switch(blood_volume)
-			if(BLOOD_VOLUME_OKAY to BLOOD_VOLUME_SAFE)
+		switch(get_blood_state())
+			if(BLOOD_OKAY)
 				if(prob(5))
 					to_chat(src, "<span class='warning'>You feel [word].</span>")
 				adjustOxyLoss(round((BLOOD_VOLUME_NORMAL - blood_volume) * 0.01, 1))
-			if(BLOOD_VOLUME_BAD to BLOOD_VOLUME_OKAY)
+			if(BLOOD_BAD)
 				adjustOxyLoss(round((BLOOD_VOLUME_NORMAL - blood_volume) * 0.02, 1))
 				if(prob(5))
 					blur_eyes(6)
 					to_chat(src, "<span class='warning'>You feel very [word].</span>")
-			if(BLOOD_VOLUME_SURVIVE to BLOOD_VOLUME_BAD)
+			if(BLOOD_SURVIVE)
 				adjustOxyLoss(5)
 				if(prob(15))
 					Unconscious(rand(20,60))
 					to_chat(src, "<span class='warning'>You feel extremely [word].</span>")
-			if(-INFINITY to BLOOD_VOLUME_SURVIVE)
+			if(BLOOD_DEAD) // This little bit of code here is pretty much the only reason why BLOOD_DEAD exists at all
 				if(!HAS_TRAIT(src, TRAIT_NODEATH))
 					death()
 
@@ -122,7 +122,7 @@
 /mob/living/proc/transfer_blood_to(atom/movable/AM, amount, forced)
 	if(!blood_volume || !AM.reagents)
 		return 0
-	if(blood_volume < BLOOD_VOLUME_BAD && !forced)
+	if(blood_volume < BLOOD_VOLUME_BAD(src) && !forced)
 		return 0
 
 	if(blood_volume < amount)
@@ -150,7 +150,7 @@
 					C.reagents.add_reagent(/datum/reagent/toxin, amount * 0.5)
 					return 1
 
-			C.blood_volume = min(C.blood_volume + round(amount, 0.1), BLOOD_VOLUME_MAXIMUM)
+			C.blood_volume = min(C.blood_volume + round(amount, 0.1), BLOOD_VOLUME_MAXIMUM(C))
 			return 1
 
 	AM.reagents.add_reagent(blood_id, amount, blood_data, bodytemperature)

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -18,10 +18,10 @@
 /mob/living/carbon/monkey/handle_blood()
 	if(bodytemperature >= TCRYO && !(HAS_TRAIT(src, TRAIT_HUSK))) //cryosleep or husked people do not pump the blood.
 		//Blood regeneration if there is some space
-		if(blood_volume < BLOOD_VOLUME_NORMAL)
+		if(blood_volume < BLOOD_VOLUME_NORMAL(src))
 			blood_volume += 0.1 // regenerate blood VERY slowly
 			if(blood_volume < BLOOD_VOLUME_OKAY(src))
-				adjustOxyLoss(round((BLOOD_VOLUME_NORMAL - blood_volume) * 0.02, 1))
+				adjustOxyLoss(round((BLOOD_VOLUME_NORMAL(src) - blood_volume) * 0.02, 1))
 
 // Takes care blood loss and regeneration
 /mob/living/carbon/human/handle_blood()
@@ -33,7 +33,7 @@
 	if(bodytemperature >= TCRYO && !(HAS_TRAIT(src, TRAIT_HUSK))) //cryosleep or husked people do not pump the blood.
 
 		//Blood regeneration if there is some space
-		if(blood_volume < BLOOD_VOLUME_NORMAL && !HAS_TRAIT(src, TRAIT_NOHUNGER))
+		if(blood_volume < BLOOD_VOLUME_NORMAL(src) && !HAS_TRAIT(src, TRAIT_NOHUNGER))
 			var/nutrition_ratio = 0
 			switch(nutrition)
 				if(0 to NUTRITION_LEVEL_STARVING)
@@ -49,7 +49,7 @@
 			if(satiety > 80)
 				nutrition_ratio *= 1.25
 			adjust_nutrition(-nutrition_ratio * HUNGER_FACTOR)
-			blood_volume = min(BLOOD_VOLUME_NORMAL, blood_volume + 0.5 * nutrition_ratio)
+			blood_volume = min(BLOOD_VOLUME_NORMAL(src), blood_volume + 0.5 * nutrition_ratio)
 
 		//Effects of bloodloss
 		var/word = pick("dizzy","woozy","faint")
@@ -57,9 +57,9 @@
 			if(BLOOD_OKAY)
 				if(prob(5))
 					to_chat(src, "<span class='warning'>You feel [word].</span>")
-				adjustOxyLoss(round((BLOOD_VOLUME_NORMAL - blood_volume) * 0.01, 1))
+				adjustOxyLoss(round((BLOOD_VOLUME_NORMAL(src) - blood_volume) * 0.01, 1))
 			if(BLOOD_BAD)
-				adjustOxyLoss(round((BLOOD_VOLUME_NORMAL - blood_volume) * 0.02, 1))
+				adjustOxyLoss(round((BLOOD_VOLUME_NORMAL(src) - blood_volume) * 0.02, 1))
 				if(prob(5))
 					blur_eyes(6)
 					to_chat(src, "<span class='warning'>You feel very [word].</span>")
@@ -108,10 +108,10 @@
 
 
 /mob/living/proc/restore_blood()
-	blood_volume = initial(blood_volume)
+	blood_volume = BLOOD_VOLUME_NORMAL(src)
 
 /mob/living/carbon/human/restore_blood()
-	blood_volume = BLOOD_VOLUME_NORMAL
+	blood_volume = BLOOD_VOLUME_NORMAL(src)
 	bleed_rate = 0
 
 /****************************************************

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -24,6 +24,7 @@
 	unique_name = 1
 
 	var/static/regex/alien_name_regex = new("alien (larva|sentinel|drone|hunter|praetorian|queen)( \\(\\d+\\))?")
+	blood_volume = BLOOD_VOLUME_XENO //Yogs -- Makes monkeys/xenos have different amounts of blood from normal carbonbois
 
 /mob/living/carbon/alien/Initialize()
 	verbs += /mob/living/proc/mob_sleep

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon
-	blood_volume = BLOOD_VOLUME_NORMAL
+	blood_volume = BLOOD_VOLUME_GENERIC
 
 /mob/living/carbon/Initialize()
 	. = ..()

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -218,7 +218,7 @@
 		if(DISGUST_LEVEL_DISGUSTED to INFINITY)
 			msg += "[t_He] look[p_s()] extremely disgusted.\n"
 
-	if(blood_volume < BLOOD_VOLUME_SAFE)
+	if(blood_volume < BLOOD_VOLUME_SAFE(src))
 		msg += "[t_He] [t_has] pale skin.\n"
 
 	if(bleedsuppress)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -951,7 +951,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 /datum/species/proc/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
 	if(chem.type == exotic_blood)
-		H.blood_volume = min(H.blood_volume + round(chem.volume, 0.1), BLOOD_VOLUME_MAXIMUM)
+		H.blood_volume = min(H.blood_volume + round(chem.volume, 0.1), BLOOD_VOLUME_MAXIMUM(H))
 		H.reagents.del_reagent(chem.type)
 		return 1
 	return FALSE

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -80,7 +80,7 @@
 		var/list/limbs_to_heal = H.get_missing_limbs()
 		if(limbs_to_heal.len < 1)
 			return 0
-		if(H.blood_volume >= BLOOD_VOLUME_OKAY+40)
+		if(H.blood_volume >= BLOOD_VOLUME_OKAY + REGEN_BLOOD_REQUIREMENT)
 			return 1
 		return 0
 
@@ -91,17 +91,17 @@
 		to_chat(H, "<span class='notice'>You feel intact enough as it is.</span>")
 		return
 	to_chat(H, "<span class='notice'>You focus intently on your missing [limbs_to_heal.len >= 2 ? "limbs" : "limb"]...</span>")
-	if(H.blood_volume >= 40*limbs_to_heal.len+BLOOD_VOLUME_OKAY)
+	if(H.blood_volume >= REGEN_BLOOD_REQUIREMENT*limbs_to_heal.len + BLOOD_VOLUME_OKAY)
 		H.regenerate_limbs()
-		H.blood_volume -= 40*limbs_to_heal.len
+		H.blood_volume -= REGEN_BLOOD_REQUIREMENT*limbs_to_heal.len
 		to_chat(H, "<span class='notice'>...and after a moment you finish reforming!</span>")
 		return
-	else if(H.blood_volume >= 40)//We can partially heal some limbs
-		while(H.blood_volume >= BLOOD_VOLUME_OKAY+40)
+	else if(H.blood_volume >= REGEN_BLOOD_REQUIREMENT)//We can partially heal some limbs
+		while(H.blood_volume >= BLOOD_VOLUME_OKAY + REGEN_BLOOD_REQUIREMENT)
 			var/healed_limb = pick(limbs_to_heal)
 			H.regenerate_limb(healed_limb)
 			limbs_to_heal -= healed_limb
-			H.blood_volume -= 40
+			H.blood_volume -= REGEN_BLOOD_REQUIREMENT
 		to_chat(H, "<span class='warning'>...but there is not enough of you to fix everything! You must attain more mass to heal completely!</span>")
 		return
 	to_chat(H, "<span class='warning'>...but there is not enough of you to go around! You must attain more mass to heal!</span>")

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -41,7 +41,7 @@
 		H.adjustBruteLoss(5)
 		to_chat(H, "<span class='danger'>You feel empty!</span>")
 
-	if(H.blood_volume < BLOOD_VOLUME_NORMAL)
+	if(H.blood_volume < BLOOD_VOLUME_NORMAL(H))
 		if(H.nutrition >= NUTRITION_LEVEL_STARVING)
 			H.blood_volume += 3
 			H.adjust_nutrition(-2.5)
@@ -131,7 +131,7 @@
 	bodies -= C // This means that the other bodies maintain a link
 	// so if someone mindswapped into them, they'd still be shared.
 	bodies = null
-	C.blood_volume = min(C.blood_volume, BLOOD_VOLUME_NORMAL)
+	C.blood_volume = min(C.blood_volume, BLOOD_VOLUME_NORMAL(C))
 	..()
 
 /datum/species/jelly/slime/on_species_gain(mob/living/carbon/C, datum/species/old_species)

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -45,10 +45,10 @@
 		if(H.nutrition >= NUTRITION_LEVEL_STARVING)
 			H.blood_volume += 3
 			H.adjust_nutrition(-2.5)
-	if(H.blood_volume < BLOOD_VOLUME_OKAY)
+	if(H.blood_volume < BLOOD_VOLUME_OKAY(H))
 		if(prob(5))
 			to_chat(H, "<span class='danger'>You feel drained!</span>")
-	if(H.blood_volume < BLOOD_VOLUME_BAD)
+	if(H.blood_volume < BLOOD_VOLUME_BAD(H))
 		Cannibalize_Body(H)
 	if(regenerate_limbs)
 		regenerate_limbs.UpdateButtonIcon()
@@ -80,7 +80,7 @@
 		var/list/limbs_to_heal = H.get_missing_limbs()
 		if(limbs_to_heal.len < 1)
 			return 0
-		if(H.blood_volume >= BLOOD_VOLUME_OKAY + REGEN_BLOOD_REQUIREMENT)
+		if(H.blood_volume >= BLOOD_VOLUME_OKAY(H) + REGEN_BLOOD_REQUIREMENT)
 			return 1
 		return 0
 
@@ -91,13 +91,13 @@
 		to_chat(H, "<span class='notice'>You feel intact enough as it is.</span>")
 		return
 	to_chat(H, "<span class='notice'>You focus intently on your missing [limbs_to_heal.len >= 2 ? "limbs" : "limb"]...</span>")
-	if(H.blood_volume >= REGEN_BLOOD_REQUIREMENT*limbs_to_heal.len + BLOOD_VOLUME_OKAY)
+	if(H.blood_volume >= REGEN_BLOOD_REQUIREMENT*limbs_to_heal.len + BLOOD_VOLUME_OKAY(H))
 		H.regenerate_limbs()
 		H.blood_volume -= REGEN_BLOOD_REQUIREMENT*limbs_to_heal.len
 		to_chat(H, "<span class='notice'>...and after a moment you finish reforming!</span>")
 		return
 	else if(H.blood_volume >= REGEN_BLOOD_REQUIREMENT)//We can partially heal some limbs
-		while(H.blood_volume >= BLOOD_VOLUME_OKAY + REGEN_BLOOD_REQUIREMENT)
+		while(H.blood_volume >= BLOOD_VOLUME_OKAY(H) + REGEN_BLOOD_REQUIREMENT)
 			var/healed_limb = pick(limbs_to_heal)
 			H.regenerate_limb(healed_limb)
 			limbs_to_heal -= healed_limb

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -110,7 +110,7 @@
 			to_chat(victim, "<span class='danger'>[H] is draining your blood!</span>")
 			to_chat(H, "<span class='notice'>You drain some blood!</span>")
 			playsound(H, 'sound/items/drink.ogg', 30, 1, -2)
-			victim.blood_volume = CLAMP(victim.blood_volume - drained_blood, 0, BLOOD_VOLUME_MAXIMUM(victum))
+			victim.blood_volume = CLAMP(victim.blood_volume - drained_blood, 0, BLOOD_VOLUME_MAXIMUM(victim))
 			H.blood_volume = CLAMP(H.blood_volume + drained_blood, 0, BLOOD_VOLUME_MAXIMUM(H))
 			if(!victim.blood_volume)
 				to_chat(H, "<span class='warning'>You finish off [victim]'s blood supply!</span>")

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -45,7 +45,7 @@
 		C.adjustCloneLoss(-4)
 		return
 	C.blood_volume -= 0.75
-	if(C.blood_volume <= BLOOD_VOLUME_SURVIVE)
+	if(C.blood_volume <= BLOOD_VOLUME_SURVIVE(C))
 		to_chat(C, "<span class='danger'>You ran out of blood!</span>")
 		var/obj/shapeshift_holder/H = locate() in C
 		if(H)
@@ -85,7 +85,7 @@
 			return
 		if(H.pulling && iscarbon(H.pulling))
 			var/mob/living/carbon/victim = H.pulling
-			if(H.blood_volume >= BLOOD_VOLUME_MAXIMUM)
+			if(H.blood_volume >= BLOOD_VOLUME_MAXIMUM(H))
 				to_chat(H, "<span class='notice'>You're already full!</span>")
 				return
 			if(victim.stat == DEAD)
@@ -105,13 +105,13 @@
 				return
 			if(!do_after(H, 30, target = victim))
 				return
-			var/blood_volume_difference = BLOOD_VOLUME_MAXIMUM - H.blood_volume //How much capacity we have left to absorb blood
+			var/blood_volume_difference = BLOOD_VOLUME_MAXIMUM(H) - H.blood_volume //How much capacity we have left to absorb blood
 			var/drained_blood = min(victim.blood_volume, VAMP_DRAIN_AMOUNT, blood_volume_difference)
 			to_chat(victim, "<span class='danger'>[H] is draining your blood!</span>")
 			to_chat(H, "<span class='notice'>You drain some blood!</span>")
 			playsound(H, 'sound/items/drink.ogg', 30, 1, -2)
-			victim.blood_volume = CLAMP(victim.blood_volume - drained_blood, 0, BLOOD_VOLUME_MAXIMUM)
-			H.blood_volume = CLAMP(H.blood_volume + drained_blood, 0, BLOOD_VOLUME_MAXIMUM)
+			victim.blood_volume = CLAMP(victim.blood_volume - drained_blood, 0, BLOOD_VOLUME_MAXIMUM(victum))
+			H.blood_volume = CLAMP(H.blood_volume + drained_blood, 0, BLOOD_VOLUME_MAXIMUM(H))
 			if(!victim.blood_volume)
 				to_chat(H, "<span class='warning'>You finish off [victim]'s blood supply!</span>")
 
@@ -130,7 +130,7 @@
 	. = ..()
 	if(iscarbon(owner))
 		var/mob/living/carbon/H = owner
-		to_chat(H, "<span class='notice'>Current blood level: [H.blood_volume]/[BLOOD_VOLUME_MAXIMUM].</span>")
+		to_chat(H, "<span class='notice'>Current blood level: [H.blood_volume]/[BLOOD_VOLUME_MAXIMUM(H)].</span>")
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/bat
 	name = "Bat Form"

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -15,6 +15,7 @@
 	bodyparts = list(/obj/item/bodypart/chest/monkey, /obj/item/bodypart/head/monkey, /obj/item/bodypart/l_arm/monkey,
 					 /obj/item/bodypart/r_arm/monkey, /obj/item/bodypart/r_leg/monkey, /obj/item/bodypart/l_leg/monkey)
 	hud_type = /datum/hud/monkey
+	blood_volume = BLOOD_VOLUME_MONKEY // Yogs -- Makes monkeys/xenos have different amounts of blood from normal carbonbois
 
 /mob/living/carbon/monkey/Initialize(mapload, cubespawned=FALSE, mob/spawner)
 	verbs += /mob/living/proc/mob_sleep

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -617,7 +617,7 @@
 		var/trail_type = getTrail()
 		if(trail_type)
 			var/brute_ratio = round(getBruteLoss() / maxHealth, 0.1)
-			if(blood_volume && blood_volume > max(BLOOD_VOLUME_NORMAL*(1 - brute_ratio * 0.25), 0))//don't leave trail if blood volume below a threshold
+			if(blood_volume && blood_volume > max(BLOOD_VOLUME_NORMAL(src)*(1 - brute_ratio * 0.25), 0))//don't leave trail if blood volume below a threshold
 				blood_volume = max(blood_volume - max(1, brute_ratio * 2), 0) 					//that depends on our brute damage.
 				var/newdir = get_dir(target_turf, start)
 				if(newdir != direction)

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -28,7 +28,7 @@
 	melee_damage_upper = 2
 	environment_smash = ENVIRONMENT_SMASH_NONE
 	stop_automated_movement_when_pulled = 1
-	blood_volume = BLOOD_VOLUME_NORMAL
+	blood_volume = BLOOD_VOLUME_GENERIC
 	var/obj/item/udder/udder = null
 
 	do_footstep = TRUE
@@ -134,7 +134,7 @@
 	maxHealth = 50
 	var/obj/item/udder/udder = null
 	gold_core_spawnable = FRIENDLY_SPAWN
-	blood_volume = BLOOD_VOLUME_NORMAL
+	blood_volume = BLOOD_VOLUME_GENERIC
 
 	do_footstep = TRUE
 

--- a/code/modules/mob/living/simple_animal/friendly/pet.dm
+++ b/code/modules/mob/living/simple_animal/friendly/pet.dm
@@ -2,7 +2,7 @@
 	icon = 'icons/mob/pets.dmi'
 	mob_size = MOB_SIZE_SMALL
 	mob_biotypes = list(MOB_ORGANIC, MOB_BEAST)
-	blood_volume = BLOOD_VOLUME_NORMAL
+	blood_volume = BLOOD_VOLUME_GENERIC
 	var/unique_pet = FALSE // if the mob can be renamed
 	var/obj/item/clothing/neck/petcollar/pcollar
 	var/collar_type //if the mob has collar sprites, define them.

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -43,7 +43,7 @@ Difficulty: Medium
 	loot = list(/obj/item/melee/transforming/cleaving_saw, /obj/item/gun/energy/kinetic_accelerator)
 	wander = FALSE
 	del_on_death = TRUE
-	blood_volume = BLOOD_VOLUME_NORMAL
+	blood_volume = BLOOD_VOLUME_GENERIC
 	internal_type = /obj/item/gps/internal/miner
 	medal_type = BOSS_MEDAL_MINER
 	var/obj/item/melee/transforming/cleaving_saw/miner/miner_saw

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -54,7 +54,7 @@ Difficulty: Hard
 	del_on_death = TRUE
 	crusher_loot = list(/obj/structure/closet/crate/necropolis/bubblegum/crusher)
 	loot = list(/obj/structure/closet/crate/necropolis/bubblegum)
-	blood_volume = BLOOD_VOLUME_MAXIMUM //BLEED FOR ME
+	blood_volume = BLOOD_VOLUME_NORMAL * 3.6 //BLEED FOR ME
 	var/charging = FALSE
 	var/enrage_till = 0
 	var/enrage_time = 70

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -54,7 +54,7 @@ Difficulty: Hard
 	del_on_death = TRUE
 	crusher_loot = list(/obj/structure/closet/crate/necropolis/bubblegum/crusher)
 	loot = list(/obj/structure/closet/crate/necropolis/bubblegum)
-	blood_volume = BLOOD_VOLUME_NORMAL * 3.6 //BLEED FOR ME
+	blood_volume = BLOOD_VOLUME_GENERIC * 3.6 //BLEED FOR ME
 	var/charging = FALSE
 	var/enrage_till = 0
 	var/enrage_time = 70

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -526,8 +526,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "Tomato juice, mixed with Vodka and a lil' bit of lime. Tastes like liquid murder."
 
 /datum/reagent/consumable/ethanol/bloody_mary/on_mob_life(mob/living/carbon/C)
-	if(C.blood_volume < BLOOD_VOLUME_NORMAL)
-		C.blood_volume = min(BLOOD_VOLUME_NORMAL, C.blood_volume + 3) //Bloody Mary quickly restores blood loss.
+	if(C.blood_volume < BLOOD_VOLUME_NORMAL(C))
+		C.blood_volume = min(BLOOD_VOLUME_NORMAL(C), C.blood_volume + 3) //Bloody Mary quickly restores blood loss.
 	..()
 
 /datum/reagent/consumable/ethanol/brave_bull

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -295,15 +295,17 @@
 	overdose_threshold = 60
 	taste_description = "sweetness and salt"
 	var/last_added = 0
-	var/maximum_reachable = BLOOD_VOLUME_GENERIC - 10	//So that normal blood regeneration can continue with salglu active
+	var/max_blood_decrement = 10 //Yogs -- How much less than BLOOD_VOLUME_NORMAL(M) is the point where salglu stops refilling blood?
+	//^ Used so that normal blood regeneration can continue with salglu active
 
 /datum/reagent/medicine/salglu_solution/on_mob_life(mob/living/carbon/M)
 	if(last_added)
 		M.blood_volume -= last_added
 		last_added = 0
-	if(M.blood_volume < maximum_reachable)	//Can only up to double your effective blood level.
+	var/max_blood = BLOOD_VOLUME_NORMAL(M) - max_blood_decrement // The highest blood volume that salglu will work at.
+	if(M.blood_volume < max_blood)
 		var/amount_to_add = min(M.blood_volume, volume*5)
-		var/new_blood_level = min(M.blood_volume + amount_to_add, maximum_reachable)
+		var/new_blood_level = min(M.blood_volume + amount_to_add, max_blood)
 		last_added = new_blood_level - M.blood_volume
 		M.blood_volume = new_blood_level
 	if(prob(33))

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -59,8 +59,8 @@
 	M.confused = 0
 	M.SetSleeping(0, 0)
 	M.jitteriness = 0
-	if(M.blood_volume < BLOOD_VOLUME_NORMAL)
-		M.blood_volume = BLOOD_VOLUME_NORMAL
+	if(M.blood_volume < BLOOD_VOLUME_NORMAL(M))
+		M.blood_volume = BLOOD_VOLUME_NORMAL(M)
 
 	M.cure_all_traumas(TRAUMA_RESILIENCE_MAGIC)
 	for(var/thing in M.diseases)
@@ -295,7 +295,7 @@
 	overdose_threshold = 60
 	taste_description = "sweetness and salt"
 	var/last_added = 0
-	var/maximum_reachable = BLOOD_VOLUME_NORMAL - 10	//So that normal blood regeneration can continue with salglu active
+	var/maximum_reachable = BLOOD_VOLUME_GENERIC - 10	//So that normal blood regeneration can continue with salglu active
 
 /datum/reagent/medicine/salglu_solution/on_mob_life(mob/living/carbon/M)
 	if(last_added)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -29,7 +29,7 @@
 			if(!data || !(data["blood_type"] in get_safe_blood(C.dna.blood_type)))
 				C.reagents.add_reagent(/datum/reagent/toxin, reac_volume * 0.5)
 			else
-				C.blood_volume = min(C.blood_volume + round(reac_volume, 0.1), BLOOD_VOLUME_MAXIMUM)
+				C.blood_volume = min(C.blood_volume + round(reac_volume, 0.1), BLOOD_VOLUME_MAXIMUM(C))
 
 
 /datum/reagent/blood/on_new(list/data)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -285,7 +285,7 @@
 		M.adjustOxyLoss(-2, 0)
 		M.adjustBruteLoss(-2, 0)
 		M.adjustFireLoss(-2, 0)
-		if(ishuman(M) && M.blood_volume < BLOOD_VOLUME_NORMAL)
+		if(ishuman(M) && M.blood_volume < BLOOD_VOLUME_NORMAL(M))
 			M.blood_volume += 3
 	else  // Will deal about 90 damage when 50 units are thrown
 		M.adjustBrainLoss(3, 150)
@@ -824,7 +824,7 @@
 	color = "#C8A5DC" // rgb: 200, 165, 220
 
 /datum/reagent/iron/on_mob_life(mob/living/carbon/C)
-	if(C.blood_volume < BLOOD_VOLUME_NORMAL)
+	if(C.blood_volume < BLOOD_VOLUME_NORMAL(C))
 		C.blood_volume += 0.5
 	..()
 

--- a/code/modules/research/nanites/nanite_programs/healing.dm
+++ b/code/modules/research/nanites/nanite_programs/healing.dm
@@ -89,7 +89,7 @@
 /datum/nanite_program/blood_restoring/check_conditions()
 	if(iscarbon(host_mob))
 		var/mob/living/carbon/C = host_mob
-		if(C.blood_volume >= BLOOD_VOLUME_SAFE)
+		if(C.blood_volume >= BLOOD_VOLUME_SAFE(C))
 			return FALSE
 	else
 		return FALSE

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -137,7 +137,7 @@
 		var/mob/living/carbon/human/H = owner
 		if(istype(H))
 			if(H.dna && !(NOBLOOD in H.dna.species.species_traits))
-				H.blood_volume = min(H.blood_volume + cursed_heart.blood_loss*0.5, BLOOD_VOLUME_MAXIMUM)
+				H.blood_volume = min(H.blood_volume + cursed_heart.blood_loss*0.5, BLOOD_VOLUME_MAXIMUM(H))
 				H.remove_client_colour(/datum/client_colour/cursed_heart_blood)
 				cursed_heart.add_colour = TRUE
 				H.adjustBruteLoss(-cursed_heart.heal_brute)

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3185,6 +3185,7 @@
 #include "yogstation\code\modules\mob\dead\new_player\new_player.dm"
 #include "yogstation\code\modules\mob\living\emote.dm"
 #include "yogstation\code\modules\mob\living\life.dm"
+#include "yogstation\code\modules\mob\living\living.dm"
 #include "yogstation\code\modules\mob\living\living_defines.dm"
 #include "yogstation\code\modules\mob\living\brain\brain_item.dm"
 #include "yogstation\code\modules\mob\living\brain\MMI.dm"

--- a/yogstation/code/game/objects/structures/ghost_role_spawners.dm
+++ b/yogstation/code/game/objects/structures/ghost_role_spawners.dm
@@ -90,7 +90,7 @@
 		ashwalker.forceMove(get_turf(src))
 		ashwalker.real_name = name
 		ashwalker.name = name
-		ashwalker.blood_volume = BLOOD_VOLUME_NORMAL
+		ashwalker.blood_volume = BLOOD_VOLUME_NORMAL(ashwalker)
 		reset_rebirth()
 		ashwalker.grab_ghost()
 		ashwalker = null

--- a/yogstation/code/modules/mob/living/carbon/human/human.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/human.dm
@@ -1,2 +1,7 @@
 /mob/living/carbon/human/species/gorilla
 	race = /datum/species/gorilla
+
+/mob/living/carbon/human/get_blood_state()
+	if(NOBLOOD in dna.species.species_traits) //Can't have blood problems if your species doesn't have any blood, innit?
+		return BLOOD_SAFE
+	. = ..()

--- a/yogstation/code/modules/mob/living/living.dm
+++ b/yogstation/code/modules/mob/living/living.dm
@@ -1,0 +1,29 @@
+#define bMAXIMUM	(initial(blood_volume)*BLOOD_MAXIMUM_MULTI)
+#define bSAFE		(initial(blood_volume)*BLOOD_SAFE_MULTI)
+#define bOKAY 		(initial(blood_volume)*BLOOD_OKAY_MULTI)
+#define bBAD		(initial(blood_volume)*BLOOD_BAD_MULTI)
+#define bSURVIVE	(initial(blood_volume)*BLOOD_SURVIVE_MULTI)
+
+/mob/living/proc/get_blood_state() // Returns how our good or bad our blood situation is, using the blood enums in Yogstation-TG\code\__DEFINES\mobs.dm
+	if(!initial(blood_volume))
+		return BLOOD_SAFE // I... guess we're fine?
+	
+	switch(blood_volume / initial(blood_volume))
+		if(bMAXIMUM to INFINITY)
+			return BLOOD_MAXIMUM
+		if(bSAFE to bMAXIMUM)
+			return BLOOD_SAFE
+		if(bOKAY to bSAFE)
+			return BLOOD_OKAY
+		if(bBAD to bOKAY)
+			return BLOOD_BAD
+		if(bSURVIVE to bBAD)
+			return BLOOD_SURVIVE
+		else
+			return BLOOD_DEAD
+	
+#undef bMAXIMUM
+#undef bSAFE
+#undef bOKAY
+#undef bBAD
+#undef bSURVIVE

--- a/yogstation/code/modules/mob/living/living.dm
+++ b/yogstation/code/modules/mob/living/living.dm
@@ -1,29 +1,17 @@
-#define bMAXIMUM	(initial(blood_volume)*BLOOD_MAXIMUM_MULTI)
-#define bSAFE		(initial(blood_volume)*BLOOD_SAFE_MULTI)
-#define bOKAY 		(initial(blood_volume)*BLOOD_OKAY_MULTI)
-#define bBAD		(initial(blood_volume)*BLOOD_BAD_MULTI)
-#define bSURVIVE	(initial(blood_volume)*BLOOD_SURVIVE_MULTI)
-
 /mob/living/proc/get_blood_state() // Returns how our good or bad our blood situation is, using the blood enums in Yogstation-TG\code\__DEFINES\mobs.dm
 	if(!initial(blood_volume))
 		return BLOOD_SAFE // I... guess we're fine?
 	
 	switch(blood_volume / initial(blood_volume))
-		if(bMAXIMUM to INFINITY)
+		if(BLOOD_VOLUME_MAXIMUM(src) to INFINITY)
 			return BLOOD_MAXIMUM
-		if(bSAFE to bMAXIMUM)
+		if(BLOOD_VOLUME_SAFE(src) to BLOOD_VOLUME_MAXIMUM(src))
 			return BLOOD_SAFE
-		if(bOKAY to bSAFE)
+		if(BLOOD_VOLUME_OKAY(src) to BLOOD_VOLUME_SAFE(src))
 			return BLOOD_OKAY
-		if(bBAD to bOKAY)
+		if(BLOOD_VOLUME_BAD(src) to BLOOD_VOLUME_OKAY(src))
 			return BLOOD_BAD
-		if(bSURVIVE to bBAD)
+		if(BLOOD_VOLUME_SURVIVE(src) to BLOOD_VOLUME_BAD(src))
 			return BLOOD_SURVIVE
 		else
 			return BLOOD_DEAD
-	
-#undef bMAXIMUM
-#undef bSAFE
-#undef bOKAY
-#undef bBAD
-#undef bSURVIVE

--- a/yogstation/code/modules/mob/living/living.dm
+++ b/yogstation/code/modules/mob/living/living.dm
@@ -2,7 +2,7 @@
 	if(!initial(blood_volume))
 		return BLOOD_SAFE // I... guess we're fine?
 	
-	switch(blood_volume / initial(blood_volume))
+	switch(blood_volume)
 		if(BLOOD_VOLUME_MAXIMUM(src) to INFINITY)
 			return BLOOD_MAXIMUM
 		if(BLOOD_VOLUME_SAFE(src) to BLOOD_VOLUME_MAXIMUM(src))


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/61707379-f9e28f00-ad0f-11e9-98e2-ca8e7da89496.png)

## Overview
Right now, every single ``/mob/living`` in the game that operates bloodcode has exactly 560 cL of blood floating around in its body by default. This includes monkeys, despite being half the size of humans, as well as xenoes, despite the fact they are massive & make a whole business out of having acid blood.

This PR changes that, and decreases the blood volume of monkeys by 40% and increases xeno blood volumes by 25%.

## So what does this accomplish, practically?
It's a slight chef nerf, since now their manhandling of monkeys will now produce slightly less blood.
It's a slight buff to detective, since now it's a bit easier to tell apart the blood trails of monkeys from those of human corpses.

The Xeno thing will also make their acid blood a bit more relevant when killing them.

## Coder Warnings
Doing this required doing a (minor) refactor of blood volume stuff. Now the blood volume defines are functions, that take in a ``/mob/living`` instance and return the blood volume associated with it being OKAY, BAD, SAFE, whatever. There's also a new function, ``/mob/living/proc/get_blood_state()`` that returns the current blood situation, which is useful for switch statements involving blood, as used in a switch statement edited in this PR.

#### Changelog

:cl:  Altoids
rscadd: Living creatures no longer have always exactly the blood volume of a human.
tweak: Monkeys now have 40% less blood.
tweak: Xenomorphs now have 25% more (acidic!) blood.
/:cl:
