### PR TITLE
runtime

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -230,7 +230,8 @@
 								"<span class='userdanger'>[usr] [internal ? "opens" : "closes"] the valve on [src]'s [ITEM.name].</span>")
 
 /mob/living/carbon/fall(forced)
-    loc.handle_fall(src, forced)//it's loc so it doesn't call the mob's handle_fall which does nothing
+    if(loc)
+		loc.handle_fall(src, forced)//it's loc so it doesn't call the mob's handle_fall which does nothing
 
 /mob/living/carbon/is_muzzled()
 	return(istype(src.wear_mask, /obj/item/clothing/mask/muzzle))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -230,7 +230,7 @@
 								"<span class='userdanger'>[usr] [internal ? "opens" : "closes"] the valve on [src]'s [ITEM.name].</span>")
 
 /mob/living/carbon/fall(forced)
-    if(loc)
+	if(loc)
 		loc.handle_fall(src, forced)//it's loc so it doesn't call the mob's handle_fall which does nothing
 
 /mob/living/carbon/is_muzzled()


### PR DESCRIPTION

runtime error: Cannot execute null.handle fall().
--
  |   | - proc name: fall (/mob/living/carbon/fall)
  |   | - source file: carbon.dm,233
  |   | - usr: LewdElf (/mob/dead/new_player)
  |   | - src: Cody Shots (/mob/living/carbon/human/dummy)
  |   | - usr.loc: the plating (8,174,1) (/turf/open/floor/plating)
  |   | - src.loc: null
  |   | - call stack:
  |   | - Cody Shots (/mob/living/carbon/human/dummy): fall(1)
  |   | - Cody Shots (/mob/living/carbon/human/dummy): update mobility()
  |   | - Cody Shots (/mob/living/carbon/human/dummy): update mobility()
  |   | - /datum/status_effect/incapacit... (/datum/status_effect/incapacitating/paralyzed): on creation(Cody Shots (/mob/living/carbon/human/dummy), 1, 1)
  |   | - /datum/status_effect/incapacit... (/datum/status_effect/incapacitating/paralyzed): New(/list (/list))
  |   | - Cody Shots (/mob/living/carbon/human/dummy): apply status effect(/datum/status_effect/incapacit... (/datum/status_effect/incapacitating/paralyzed), 1, 1)
  |   | - Cody Shots (/mob/living/carbon/human/dummy): Paralyze(1, 1, 1)
  |   | - Cody Shots (/mob/living/carbon/human/dummy): Paralyze(1, 1, 1)
  |   | - Cody Shots (/mob/living/carbon/human/dummy): AIize(1, LewdElf (/client))
  |   | - Cody Shots (/mob/living/carbon/human/dummy): AIize(1, LewdElf (/client))
  |   | - /datum/job/ai (/datum/job/ai): equip(Cody Shots (/mob/living/carbon/human/dummy), 1, null, null, null, LewdElf (/client))
  |   | - /datum/preferences (/datum/preferences): update preview icon()
  |   | - /datum/preferences (/datum/preferences): ShowChoices(LewdElf (/mob/dead/new_player))
  |   | - /datum/preferences (/datum/preferences): process link(LewdElf (/mob/dead/new_player), /list (/list))
  |   | - LewdElf (/client): Topic("_src_=prefs;preference=save", /list (/list), null)
  |   | - LewdElf (/client): Topic("_src_=prefs;preference=save", /list (/list), null)
  |   | - LewdElf (/client): Topic("_src_=prefs;preference=save", /list (/list), null)

