### PR TITLE
Plasmamen can no longer take the blood deficiency quirk, as they have no blood to begin with

### DIFF
--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -58,6 +58,8 @@
 /datum/quirk/proc/clone_data() //return additional data that should be remembered by cloning
 /datum/quirk/proc/on_clone(data) //create the quirk from clone data
 
+/datum/quirk/proc/check_quirk(datum/preferences/prefs) // Yogs -- allows quirks to check the preferences of the user who may acquire it
+
 /datum/quirk/process()
 	if(QDELETED(quirk_holder))
 		quirk_holder = null

--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -11,9 +11,13 @@
 	var/mood_quirk = FALSE //if true, this quirk affects mood and is unavailable if moodlets are disabled
 	var/mob_trait //if applicable, apply and remove this mob trait
 	var/mob/living/quirk_holder
+	var/not_init = FALSE // Yogs -- Allows quirks to be instantiated without all the song & dance below happening
 
-/datum/quirk/New(mob/living/quirk_mob, spawn_effects)
+/datum/quirk/New(mob/living/quirk_mob, spawn_effects, no_init = FALSE)
 	..()
+	if(no_init) // Yogs -- Allows quirks to be instantiated without all the song & dance below happening
+		not_init = TRUE
+		return
 	if(!quirk_mob || (human_only && !ishuman(quirk_mob)) || quirk_mob.has_quirk(type))
 		qdel(src)
 	quirk_holder = quirk_mob
@@ -29,6 +33,8 @@
 		addtimer(CALLBACK(src, .proc/post_add), 30)
 
 /datum/quirk/Destroy()
+	if(not_init) // Yogs -- Allows quirks to be instantiated without all the song & dance below happening
+		return ..()
 	STOP_PROCESSING(SSquirks, src)
 	remove()
 	if(quirk_holder)
@@ -59,6 +65,7 @@
 /datum/quirk/proc/on_clone(data) //create the quirk from clone data
 
 /datum/quirk/proc/check_quirk(datum/preferences/prefs) // Yogs -- allows quirks to check the preferences of the user who may acquire it
+	return FALSE
 
 /datum/quirk/process()
 	if(QDELETED(quirk_holder))

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1067,6 +1067,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			else
 				var/datum/quirk/t = new T(no_init = TRUE)
 				lock_reason = t.check_quirk(src) // Yogs -- allows for specific denial of quirks based on current preferences
+				qdel(t)
 			if(has_quirk)
 				if(lock_reason)
 					all_quirks -= quirk_name

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1065,7 +1065,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			if(initial(T.mood_quirk) && (CONFIG_GET(flag/disable_human_mood) && !(yogtoggles & PREF_MOOD)))//Yogs -- Adds mood to preferences
 				lock_reason = "Mood is disabled."
 			else
-				lock_reason = T.check_quirk(src)
+				var/datum/quirk/t = new T(no_init = TRUE)
+				lock_reason = t.check_quirk(src) // Yogs -- allows for specific denial of quirks based on current preferences
 			if(has_quirk)
 				if(lock_reason)
 					all_quirks -= quirk_name

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1058,16 +1058,16 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			var/quirk_name = initial(T.name)
 			var/has_quirk
 			var/quirk_cost = initial(T.value) * -1
-			var/lock_reason = "This trait is unavailable."
-			var/quirk_conflict = FALSE
+			var/lock_reason = FALSE // Also marks whether this quirk ought to be locked at all; FALSE implies it's OK for this person to have this quirk
 			for(var/_V in all_quirks)
 				if(_V == quirk_name)
 					has_quirk = TRUE
 			if(initial(T.mood_quirk) && (CONFIG_GET(flag/disable_human_mood) && !(yogtoggles & PREF_MOOD)))//Yogs -- Adds mood to preferences
 				lock_reason = "Mood is disabled."
-				quirk_conflict = TRUE
+			else
+				lock_reason = T.check_quirk(src)
 			if(has_quirk)
-				if(quirk_conflict)
+				if(lock_reason)
 					all_quirks -= quirk_name
 					has_quirk = FALSE
 				else
@@ -1077,7 +1077,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			var/font_color = "#AAAAFF"
 			if(initial(T.value) != 0)
 				font_color = initial(T.value) > 0 ? "#AAFFAA" : "#FFAAAA"
-			if(quirk_conflict)
+			if(lock_reason)
 				dat += "<font color='[font_color]'>[quirk_name]</font> - [initial(T.desc)] \
 				<font color='red'><b>LOCKED: [lock_reason]</b></font><br>"
 			else

--- a/yogstation/code/datums/traits/negative.dm
+++ b/yogstation/code/datums/traits/negative.dm
@@ -1,3 +1,8 @@
 /datum/quirk/family_heirloom
 	value = 0 // Yogs Made It Free and no longer mood locked
 	mood_quirk = FALSE // Just Incase
+
+/datum/quirk/blooddeficiency/check_quirk(datum/preferences/prefs)
+	if(prefs.pref_species && (NOBLOOD in prefs.pref_species.species_traits)) //can't lose blood if your species doesn't have any
+		return "You don't have blood as [prefs.pref_species]!"
+	return FALSE


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/29939414/61794894-d1c65f00-ade7-11e9-92ec-cc0afd4cd5ea.png)

While working on my *other* blood PR, I realized that plasmamen (and all other roundstart NOBLOOD species) can take a blood deficiency trait. This is goofy, so I've bothered to fix it.

## Coder Warnings
I added a new proc, ``/datum/quirk/proc/check_quirk(datum/preferences/prefs)``, which decides whether a quirk ought to be available to a given user, based on their current preferences. Either it returns ``FALSE`` which marks it as okay, or returns a string describing why it's not OK, for view by the user.

I also added a way of initializing a ``/datum/quirk`` without signing it up for ``SSquirk``, by calling its ``new()`` with the 3rd arg, ``no_init``, set to ``TRUE``.

#### Changelog

:cl:  Altoids
bugfix: Plasmamen can no longer be diagnosed with blood deficiency, as they are not a blooded creature to begin with.
/:cl:
