### PR TITLE
IAA Change #1 - Silicons are no longer eligible to be IAA.

### DIFF
--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -17,6 +17,7 @@
 	traitors_possible = 10 //hard limit on traitors if scaling is turned off
 	num_modifier = 4 // Four additional traitors
 	antag_datum = /datum/antagonist/traitor/internal_affairs
+	restricted_jobs = list("AI", "Cyborg")//Yogs -- Silicons can no longer be IAA
 
 	announce_text = "There are Nanotrasen Internal Affairs Agents trying to kill each other!\n\
 	<span class='danger'>IAA</span>: Eliminate your targets and protect yourself!\n\


### PR DESCRIPTION
Based on a conversation that happened today in #staff-council.

#### Changelog
:cl:  Altoids
tweak: AIs and Cyborgs are no longer eligible for the Nanotransen Internal Affairs division.
/:cl:
