### PR TITLE
IAA Change #3 - Makes IA agents spawn with a cyanide dental implant

### DIFF
--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -255,7 +255,7 @@
 		to_chat(owner.current, "<B><font size=5 color=red>While you have a license to kill, unneeded property damage or loss of employee life will lead to your contract being terminated.</font></B>")
 		to_chat(owner.current, "<span class='userdanger'>For the sake of plausible deniability, you have been equipped with an array of captured Syndicate weaponry available via uplink.</span>")
 
-	to_chat(owner.current, "<span class='userdanger'>If deemed necessary, you may use your cyanide-laced dental implant to ensure the secrecy of your operation.</span>")
+	to_chat(owner.current, "<span class='userdanger'>If your secrecy is compromised, you must use your cyanide-laced dental implant to ensure the secrecy of this operation.</span>")
 	to_chat(owner.current, "<span class='userdanger'>Finally, watch your back. Your target has friends in high places, and intel suggests someone may have taken out a contract of their own to protect them.</span>")
 	owner.announce_objectives()
 

--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -33,11 +33,11 @@
 	
 	//Gives Cyanide dental implant
 	var/obj/item/reagent_containers/pill/cyanide/cyan = new
-	owner.current.transferItemToLoc(cyan, target, TRUE)
+	owner.current.transferItemToLoc(cyan, owner, TRUE)
 	var/datum/action/item_action/hands_free/activate_pill/P = new(cyan)
 	P.button.name = "Activate [cyan.name]"
 	P.target = cyan
-	P.Grant(owner.curren)//The pill never actually goes in an inventory slot, so the owner doesn't inherit actions from it
+	P.Grant(owner.current)//The pill never actually goes in an inventory slot, so the owner doesn't inherit actions from it
 	
 	.=..()
 /datum/antagonist/traitor/internal_affairs/on_removal()

--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -255,7 +255,6 @@
 		to_chat(owner.current, "<B><font size=5 color=red>While you have a license to kill, unneeded property damage or loss of employee life will lead to your contract being terminated.</font></B>")
 		to_chat(owner.current, "<span class='userdanger'>For the sake of plausible deniability, you have been equipped with an array of captured Syndicate weaponry available via uplink.</span>")
 
-	to_chat(owner.current, "<span class='userdanger'>If your secrecy is compromised, you must use your cyanide-laced dental implant to ensure the secrecy of this operation.</span>")
 	to_chat(owner.current, "<span class='userdanger'>Finally, watch your back. Your target has friends in high places, and intel suggests someone may have taken out a contract of their own to protect them.</span>")
 	owner.announce_objectives()
 

--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -30,6 +30,15 @@
 
 /datum/antagonist/traitor/internal_affairs/on_gain()
 	START_PROCESSING(SSprocessing, src)
+	
+	//Gives Cyanide dental implant
+	var/obj/item/reagent_containers/pill/cyanide/cyan = new
+	owner.current.transferItemToLoc(cyan, target, TRUE)
+	var/datum/action/item_action/hands_free/activate_pill/P = new(cyan)
+	P.button.name = "Activate [cyan.name]"
+	P.target = cyan
+	P.Grant(owner.curren)//The pill never actually goes in an inventory slot, so the owner doesn't inherit actions from it
+	
 	.=..()
 /datum/antagonist/traitor/internal_affairs/on_removal()
 	STOP_PROCESSING(SSprocessing,src)
@@ -246,6 +255,7 @@
 		to_chat(owner.current, "<B><font size=5 color=red>While you have a license to kill, unneeded property damage or loss of employee life will lead to your contract being terminated.</font></B>")
 		to_chat(owner.current, "<span class='userdanger'>For the sake of plausible deniability, you have been equipped with an array of captured Syndicate weaponry available via uplink.</span>")
 
+	to_chat(owner.current, "<span class='userdanger'>If deemed necessary, you may use your cyanide-laced dental implant to ensure the secrecy of your operation.</span>")
 	to_chat(owner.current, "<span class='userdanger'>Finally, watch your back. Your target has friends in high places, and intel suggests someone may have taken out a contract of their own to protect them.</span>")
 	owner.announce_objectives()
 


### PR DESCRIPTION
Related to https://github.com/yogstation13/Yogstation-TG/pull/6474, makes it easier for them to enforce their secrecy.

I would also appreciate a rule change such that if an IA agent were to be caught & their cover blown, they'd have to use this. That isn't explicitly written into this PR anymore, though.

#### Changelog
:cl:  Altoids
rscadd: IAAs now spawn with a cyanide dental implant.
/:cl:
