### PR TITLE
IAA Change #4 - IAAs have to leave under an assumed name when last man standing, instead of Die Glorious

### DIFF
--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -108,9 +108,9 @@
 			continue
 		remove_objective(objective_)
 
-	var/datum/objective/martyr/martyr_objective = new
-	martyr_objective.owner = owner
-	add_objective(martyr_objective)
+	var/datum/objective/escape/assumed_identity/assumed = new // Yogs -- IAA have to escape under an assumed identity if they "win"
+	assumed.owner = owner
+	add_objective(assumed)
 
 /datum/antagonist/traitor/proc/reinstate_escape_objective()
 	if(!owner||!objectives.len)
@@ -168,9 +168,9 @@
 			return
 	if(last_man_standing)
 		if(syndicate)
-			to_chat(owner.current,"<span class='userdanger'> All the loyalist agents are dead, and no more is required of you. Die a glorious death, agent. </span>")
+			to_chat(owner.current,"<span class='userdanger'> All the loyalist agents are dead, and no more is required of you. Escape on the shuttle under an assumed name, and await further instructions, agent. </span>")
 		else
-			to_chat(owner.current,"<span class='userdanger'> All the other agents are dead, and you're the last loose end. Stage a Syndicate terrorist attack to cover up for today's events. You no longer have any limits on collateral damage.</span>")
+			to_chat(owner.current,"<span class='userdanger'> All the other agents are dead, and you're job is complete. To preserve secrecy, escape on the shuttle under an assumed name, and await further instructions upon return to Central Command, agent.</span>")
 		replace_escape_objective(owner)
 
 /datum/antagonist/traitor/internal_affairs/proc/iaa_process()

--- a/yogstation/code/game/gamemodes/objective.dm
+++ b/yogstation/code/game/gamemodes/objective.dm
@@ -1,2 +1,18 @@
 /datum/objective/assassinate/internal/check_completion()
 	return !considered_alive(target)
+
+/datum/objective/escape/assumed_identity
+	name = "escape with assumed identity"
+	explanation_text = "Escape on the shuttle or an escape pod alive under an assumed name."
+	team_explanation_text = "Have all members of your team escape on a shuttle or pod alive, without being in custody, under an assumed name."
+
+
+/datum/objective/escape/escape_with_identity/check_completion()
+	var/list/datum/mind/owners = get_owners()
+	for(var/datum/mind/M in owners)
+		if(!ishuman(M.current) || !considered_escaped(M))
+			continue
+		var/mob/living/carbon/human/H = M.current
+		if(H.name != H.dna.real_name && H.name != "Unknown")
+			return TRUE
+	return FALSE


### PR DESCRIPTION
Based on something @aaqe suggested in #staff-council

#### Changelog
:cl:  Altoids
tweak: IA agents are no longer being told by Central Command or the Syndicate to "kys," but instead must now, at the end of their duties, leave the station under an alternative identity.
/:cl:
