### PR TITLE
malf-hacking no longer makes APCs blue

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -947,7 +947,7 @@
 		to_chat(src, "<span class='danger'>Hack aborted. \The [apc] is no longer responding to our systems.</span>")
 		playsound(get_turf(src), 'sound/machines/buzz-sigh.ogg', 50, 1, ignore_walls = FALSE)
 	else
-		malf_picker.processing_time += 10
+		malf_picker.processing_time += 5
 
 		apc.malfai = parent || src
 		apc.malfhack = TRUE

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -363,7 +363,7 @@
 			update_state |= UPSTATE_OPENED1
 		if(opened==APC_COVER_REMOVED)
 			update_state |= UPSTATE_OPENED2
-	else if((obj_flags & EMAGGED) || malfai)
+	else if(obj_flags & EMAGGED)
 		update_state |= UPSTATE_BLUESCREEN
 	else if(panel_open)
 		update_state |= UPSTATE_WIREEXP

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1003,7 +1003,7 @@
 		return
 	to_chat(malf, "Beginning override of APC systems. This takes some time, and you cannot perform other actions during the process.")
 	malf.malfhack = src
-	malf.malfhacking = addtimer(CALLBACK(malf, /mob/living/silicon/ai/.proc/malfhacked, src), 600, TIMER_STOPPABLE)
+	malf.malfhacking = addtimer(CALLBACK(malf, /mob/living/silicon/ai/.proc/malfhacked, src), 300, TIMER_STOPPABLE)
 
 	var/obj/screen/alert/hackingapc/A
 	A = malf.throw_alert("hackingapc", /obj/screen/alert/hackingapc)


### PR DESCRIPTION
### Intent of your Pull Request

However, it still blocks crew from interacting with the APC, so there's still a way to tell.
![image](https://user-images.githubusercontent.com/20558591/62124066-95a06c00-b2c9-11e9-9600-30fadd3f592f.png)

This rule is dumb, IMO. With all other metashields, it's more like "you're not allowed to investigate whether or not this item that looks just like any other regular normal item is actually secretly a traitor item", compared to this rule, which is essentially "the AI is obviously malf, but let's give it 5 minutes till it's discovered by making you investigate whether there's fingerprints first"

In order to offset the fact that AIs would never get discovered at all, I've halfed the hackspeed and pointgan for APCs, meaning you need to get twice as many APCs, without disturbing the time-investment. This means the AI will have to spread its hacking further, making it more likely to get discovered

#### Changelog

:cl:  
tweak: Malf AIs hacking APCs no longer turns them blue.
tweak: Hacking APCs as a malf AI now gives you half as many points, but is twice as fast.
/:cl:
