### PR TITLE
Ups the antag rep cap

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -253,10 +253,10 @@ ALLOW_LATEJOIN_ANTAGONISTS
 ANTAG_REP_MAXIMUM 300
 
 ## The default amount of tickets all users use while rolling
-DEFAULT_ANTAG_TICKETS 200
+DEFAULT_ANTAG_TICKETS 100
 
 ## The maximum amount of extra tickets a user may use from their ticket bank in addition to the default tickets
-MAX_TICKETS_PER_ROLL 200
+MAX_TICKETS_PER_ROLL 100
 
 ## Uncomment to allow players to see the set odds of different rounds in secret/random in the get server revision screen. This will NOT tell the current roundtype.
 #SHOW_GAME_TYPE_ODDS

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -250,13 +250,13 @@ ALLOW_LATEJOIN_ANTAGONISTS
 # USE_ANTAG_REP
 
 ## The maximum amount of antagonist reputation tickets a player can bank (not use at once)
-ANTAG_REP_MAXIMUM 200
+ANTAG_REP_MAXIMUM 300
 
 ## The default amount of tickets all users use while rolling
-DEFAULT_ANTAG_TICKETS 100
+DEFAULT_ANTAG_TICKETS 200
 
 ## The maximum amount of extra tickets a user may use from their ticket bank in addition to the default tickets
-MAX_TICKETS_PER_ROLL 100
+MAX_TICKETS_PER_ROLL 200
 
 ## Uncomment to allow players to see the set odds of different rounds in secret/random in the get server revision screen. This will NOT tell the current roundtype.
 #SHOW_GAME_TYPE_ODDS


### PR DESCRIPTION
Amount of cap increase is open to suggestion and discussion

The current antag rep is earned in about 3-4 rounds and only provides 2x antag chance

Some users (like theos) are very unlucky, and would benefit from this, and people are less likely to roll antag multiple rounds in a row this way.

council vote pls

#### Changelog

:cl:  
tweak: Antag rep cap has been increased
/:cl:
