### PR TITLE
Being fat as fuck will now PROPERLY cause heart damage

### DIFF
--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -83,7 +83,12 @@
 			H.stop_sound_channel(CHANNEL_HEARTBEAT)
 			beat = BEAT_NONE
 	if(HAS_TRAIT(owner, TRAIT_FAT) && owner.stat != DEAD) //yogs: being fat causes heart damage
-		owner.adjustOrganLoss(ORGAN_SLOT_HEART, decay_factor) //eat happy, eat healthy //yogs end
+		owner.adjustOrganLoss(ORGAN_SLOT_HEART, maxHealth * STANDARD_ORGAN_DECAY, 85) //eat happy, eat healthy
+		if(damage >= 80 && beating)
+			if(prob(1))
+				if(owner.stat == CONSCIOUS)
+					owner.visible_message("<span class='userdanger'>[owner] clutches at [owner.p_their()] chest as if [owner.p_their()] heart is stopping!</span>")
+				owner.set_heartattack(TRUE) //yogs end
 	if(organ_flags & ORGAN_FAILING)	//heart broke, stopped beating, death imminent
 		if(owner.stat == CONSCIOUS)
 			owner.visible_message("<span class='userdanger'>[owner] clutches at [owner.p_their()] chest as if [owner.p_their()] heart is stopping!</span>")


### PR DESCRIPTION
The heart damage from obesity will cap at 85 and has a small chance to cause heart attacks at 80 and above, the damage is the base decay rate, but it's somewhat offset by the natural healing of the heart.

:cl:  
rscadd: Eat happy, eat healthy 
/:cl:
