### PR TITLE
Tanks now tell internal mol

### DIFF
--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -81,7 +81,7 @@
 			. += "<span class='notice'>If you want any more information you'll need to get closer.</span>"
 		return
 
-	. += "<span class='notice'>The pressure gauge reads [round(src.air_contents.return_pressure(),0.01)] kPa.</span>"
+	. += "<span class='notice'>The gauge reads [round(air_contents.total_moles(), 0.01)] mol at [round(src.air_contents.return_pressure(),0.01)] kPa.</span>"	//yogs can read mols
 
 	var/celsius_temperature = src.air_contents.temperature-T0C
 	var/descriptive


### PR DESCRIPTION
When observed tanks will show how many mols of gas they have inside them along side pressure. As it turns out that pressure doesn't actually tell you how much gas there is inside a tank without first knowing the volume of the tank and a bit of math, as such I believe it is a natural choice to make it so that someone can check the mols

![molage](https://user-images.githubusercontent.com/5571930/62797834-b11a2c80-baaa-11e9-8eb9-c983fcc244e8.PNG)

:cl:  
rscadd: Tanks now show internal mol 
/:cl:
