### PR TITLE
Removes the tribearder hair datum.

### DIFF
--- a/code/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories.dm
@@ -858,10 +858,6 @@
 	name = "Beard (Moonshiner)"
 	icon_state = "facial_moonshiner"
 
-/datum/sprite_accessory/facial_hair/tribearder
-	name = "Beard (Tribearder)"
-	icon_state = "facial_tribearder"
-
 /datum/sprite_accessory/facial_hair/longbeard
 	name = "Beard (Long)"
 	icon_state = "facial_longbeard"


### PR DESCRIPTION
No sprite exists for it so it shows a blue ERROR that breaks everyone's oh so important immersion.

Also fuck anyone that still used it even though it shows as an error.

If another option shows as an error please say.

Fixes issue #5945 

#### Changelog

:cl:   Identification
bugfix: removes a hairstyle option which had shown as an error. no sprite exists.
/:cl:
