### PR TITLE
Illegally modifying a shower head now sprays a burst of water during the process

### DIFF
--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -1,6 +1,6 @@
-#define SHOWER_FREEZING "freezing"
-#define SHOWER_NORMAL "normal"
-#define SHOWER_BOILING "boiling"
+#define SHOWER_FREEZING "numbingly cold"
+#define SHOWER_NORMAL "comfortable"
+#define SHOWER_BOILING "searing"
 
 /obj/machinery/shower
 	name = "shower"
@@ -49,7 +49,7 @@
 		return ..()
 
 /obj/machinery/shower/wrench_act(mob/living/user, obj/item/I)
-	to_chat(user, "<span class='notice'>You begin to adjust the temperature valve with \the [I]...</span>")
+	to_chat(user, "<span class='notice'>You begin to force the temperature valve with \the [I]...</span>")
 	if(I.use_tool(src, user, 50))
 		switch(current_temperature)
 			if(SHOWER_NORMAL)
@@ -64,7 +64,7 @@
 				current_temperature = SHOWER_NORMAL
 				var/turf/T = get_turf(src)
 				T.atmos_spawn_air("water_vapor=150;TEMP=273") //Blast of normal air as you hack the shower
-		user.visible_message("<span class='danger'>[user] adjusts the shower with \the [I] causing a spray of [current_temperature] water!</span>", "<span class='danger'>A blast of [current_temperature] water sprays out as you adjust the shower with \the [I]!</span>")
+		user.visible_message("<span class='danger'>[user] forces the shower with \the [I] causing a spray of [current_temperature] water!</span>", "<span class='danger'>A blast of [current_temperature] water sprays out as you force the shower with \the [I]!</span>")
 		user.log_message("has wrenched a shower at [AREACOORD(src)] to [current_temperature].", LOG_ATTACK)
 		add_hiddenprint(user)
 	handle_mist()

--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -54,11 +54,17 @@
 		switch(current_temperature)
 			if(SHOWER_NORMAL)
 				current_temperature = SHOWER_FREEZING
+				var/turf/T = get_turf(src)
+				T.atmos_spawn_air("water_vapor=200;TEMP=100") //Blast of cold air as you hack the shower
 			if(SHOWER_FREEZING)
 				current_temperature = SHOWER_BOILING
+				var/turf/T = get_turf(src)
+				T.atmos_spawn_air("water_vapor=200;TEMP=450") //Blast of hot air as you hack the shower
 			if(SHOWER_BOILING)
 				current_temperature = SHOWER_NORMAL
-		user.visible_message("<span class='notice'>[user] adjusts the shower with \the [I].</span>", "<span class='notice'>You adjust the shower with \the [I] to [current_temperature] temperature.</span>")
+				var/turf/T = get_turf(src)
+				T.atmos_spawn_air("water_vapor=150;TEMP=273") //Blast of normal air as you hack the shower
+		user.visible_message("<span class='danger'>[user] adjusts the shower with \the [I] causing a spray of [current_temperature] water!</span>", "<span class='danger'>A blast of [current_temperature] water sprays out as you adjust the shower with \the [I]!</span>")
 		user.log_message("has wrenched a shower at [AREACOORD(src)] to [current_temperature].", LOG_ATTACK)
 		add_hiddenprint(user)
 	handle_mist()


### PR DESCRIPTION
Currently you can convert a shower into a murder weapon in about 5 seconds using a wrench with zero danger, evidence, or drawbacks, and so now attempting to modify the shower into having lethal temperatures will spray water around it, injuring you if you are not careful and leaving behind evidence that the shower was tampered with and that it might have been used to kill someone. And, poor safety and workplace accidents are a theme in ss13, attempting to modify the showers to extreme temperatures should be a bit hazardous.

Aspiring atmos techs can also try  to use this to harvest water vapor if they build a setup in the shower room.

:cl:  
tweak: Illegally modifying a shower head to dangerous temperatures now sprays water of that temperature during the process.
/:cl:
