### PR TITLE
Buying crates directly no longer overrides the access requirements for opening said crates

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates/secure.dm
+++ b/code/game/objects/structures/crates_lockers/crates/secure.dm
@@ -84,25 +84,20 @@
 	buyer_account = _buyer_account
 
 /obj/structure/closet/crate/secure/owned/togglelock(mob/living/user, silent)
-	if(privacy_lock)
-		if(!broken)
-			var/obj/item/card/id/id_card = user.get_idcard(TRUE)
-			if(id_card)
-				if(id_card.registered_account)
-					if(id_card.registered_account == buyer_account)
-						if(iscarbon(user))
-							add_fingerprint(user)
-						locked = !locked
-						user.visible_message("<span class='notice'>[user] unlocks [src]'s privacy lock.</span>",
-										"<span class='notice'>You unlock [src]'s privacy lock.</span>")
-						privacy_lock = FALSE
-						update_icon()
-					else if(!silent)
-						to_chat(user, "<span class='notice'>Bank account does not match with buyer!</span>")
-				else if(!silent)
-					to_chat(user, "<span class='notice'>No linked bank account detected!</span>")
-			else if(!silent)
-				to_chat(user, "<span class='notice'>No ID detected!</span>")
+	if(secure && !broken)
+		if(allowed(user))
+			if(privacy_lock)
+				var/obj/item/card/id/id_card = user.get_idcard(TRUE)
+				if(!id_card || id_card.registered_account || (id_card.registered_account == buyer_account))
+					to_chat(user, "<span class='notice'>Bank account does not match with buyer!</span>")
+					return false
+			if(iscarbon(user))
+				add_fingerprint(user)
+			locked = !locked
+			user.visible_message("<span class='notice'>[user] [locked ? null : "un"]locks [src].</span>",
+							"<span class='notice'>You [locked ? null : "un"]lock [src].</span>")
+			update_icon()
 		else if(!silent)
-			to_chat(user, "<span class='warning'>[src] is broken!</span>")
-	else ..()
+			to_chat(user, "<span class='notice'>Access Denied</span>")
+	else if(secure && broken)
+		to_chat(user, "<span class='warning'>\The [src] is broken!</span>")

--- a/code/game/objects/structures/crates_lockers/crates/secure.dm
+++ b/code/game/objects/structures/crates_lockers/crates/secure.dm
@@ -88,7 +88,7 @@
 		if(allowed(user))
 			if(privacy_lock)
 				var/obj/item/card/id/id_card = user.get_idcard(TRUE)
-				if(!id_card || id_card.registered_account || (id_card.registered_account == buyer_account))
+				if(!id_card || !id_card.registered_account || (id_card.registered_account != buyer_account))
 					to_chat(user, "<span class='notice'>Bank account does not match with buyer!</span>")
 					return
 			if(iscarbon(user))

--- a/code/game/objects/structures/crates_lockers/crates/secure.dm
+++ b/code/game/objects/structures/crates_lockers/crates/secure.dm
@@ -90,7 +90,7 @@
 				var/obj/item/card/id/id_card = user.get_idcard(TRUE)
 				if(!id_card || id_card.registered_account || (id_card.registered_account == buyer_account))
 					to_chat(user, "<span class='notice'>Bank account does not match with buyer!</span>")
-					return false
+					return
 			if(iscarbon(user))
 				add_fingerprint(user)
 			locked = !locked


### PR DESCRIPTION
### Intent of your Pull Request

meaning cargo can't buy whatever they want using the cargo budget and then open it using the budget card, now they have to use emitters like the good old days

#### Changelog

:cl:  
fix: buying crates directly no longer overrides the access requirements for opening said crates
/:cl:
