### PR TITLE
Nitroglycerine Changes

### DIFF
--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -21,7 +21,7 @@
 	color = "#808080" // rgb: 128, 128, 128
 	taste_description = "oil"
 
-/datum/reagent/unstableglycerin/on_mob_life(mob/living/carbon/M)
+/datum/reagent/nitroglycerin/on_mob_life(mob/living/carbon/M)
 	if(HAS_TRAIT(M, TRAIT_FAT)) //Fat boy go boom
 		addtimer(CALLBACK(src, .proc/nitro_big_mob_explosion, M), 50)
 	..()

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -21,16 +21,38 @@
 	color = "#808080" // rgb: 128, 128, 128
 	taste_description = "oil"
 
-/datum/reagent/nitroglycerin/on_mob_life(mob/living/carbon/M)
-	addtimer(CALLBACK(src, .proc/nitro_mob_boom, M), 50)
+/datum/reagent/unstableglycerin/on_mob_life(mob/living/carbon/M)
+	if(HAS_TRAIT(M, TRAIT_FAT)) //Fat boy go boom
+		addtimer(CALLBACK(src, .proc/nitro_big_mob_explosion, M), 50)
 	..()
-	return TRUE
 
-/datum/reagent/nitroglycerin/proc/nitro_mob_boom(M)
+/datum/reagent/unstableglycerin
+	name = "Unstable Glycerin"
+	description = "Unstable Glycerin is a heavy, oily, unstable explosive liquid obtained by overnitrating glycerol."
+	color = "#555555" // rgb: 128, 128, 128
+	taste_description = "oil"
+
+/datum/reagent/unstableglycerin/on_mob_life(mob/living/carbon/M)
+	if(volume>=14)
+		addtimer(CALLBACK(src, .proc/nitro_big_mob_explosion, M), 50)
+	else
+		addtimer(CALLBACK(src, .proc/nitro_mini_mob_explosion, M), 50)
+	..()
+
+/datum/reagent/proc/nitro_big_mob_explosion(mob/living/M)
 	var/location = get_turf(holder.my_atom)
 	var/datum/effect_system/reagents_explosion/e = new()
 	e.set_up(1 + round(volume/2, 1), location, 0, 0, message = 0) //Big boom
 	e.start()
+	M.reagents.remove_all_type(/datum/reagent/unstableglycerin, 100, 0, 1)
+	M.gib()
+
+/datum/reagent/proc/nitro_mini_mob_explosion(mob/living/M)
+	var/location = get_turf(holder.my_atom)
+	var/datum/effect_system/reagents_explosion/e = new()
+	e.set_up(1 + round(volume/20, 1), location, 0, 0, message = 0) //Small boom
+	e.start()
+	M.reagents.remove_all_type(/datum/reagent/unstableglycerin, 100, 0, 1)
 
 /datum/reagent/stabilizing_agent
 	name = "Stabilizing Agent"

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -21,6 +21,17 @@
 	color = "#808080" // rgb: 128, 128, 128
 	taste_description = "oil"
 
+/datum/reagent/nitroglycerin/on_mob_life(mob/living/carbon/M)
+	addtimer(CALLBACK(src, .proc/nitro_mob_boom, M), 50)
+	..()
+	return TRUE
+
+/datum/reagent/nitroglycerin/proc/nitro_mob_boom(M)
+	var/location = get_turf(holder.my_atom)
+	var/datum/effect_system/reagents_explosion/e = new()
+	e.set_up(1 + round(volume/2, 1), location, 0, 0, message = 0) //Big boom
+	e.start()
+
 /datum/reagent/stabilizing_agent
 	name = "Stabilizing Agent"
 	description = "Keeps unstable chemicals stable. This does not work on everything."

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -43,6 +43,24 @@
 	required_temp = 474
 	strengthdiv = 2
 
+/datum/chemical_reaction/reagent_explosion/unstableglycerin
+	id = /datum/reagent/unstableglycerin
+	results = list(/datum/reagent/unstableglycerin = 2)
+	required_reagents = list(/datum/reagent/glycerol = 1, /datum/reagent/toxin/acid/fluacid = 1, /datum/reagent/clf3 = 1)
+	strengthdiv = 4
+
+/datum/chemical_reaction/reagent_explosion/unstableglycerin/on_reaction(datum/reagents/holder, created_volume)
+	if(holder.has_reagent(/datum/reagent/stabilizing_agent))
+		return
+	holder.remove_reagent(/datum/reagent/unstableglycerin, created_volume*2)
+	..()
+
+/datum/chemical_reaction/reagent_explosion/unstableglycerin_explosion
+	name = "Nitroglycerin explosion"
+	id = "nitroglycerin_explosion"
+	required_reagents = list(/datum/reagent/unstableglycerin = 1)
+	required_temp = 424
+	strengthdiv = 4
 
 /datum/chemical_reaction/reagent_explosion/potassium_explosion
 	name = "Explosion"

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -409,3 +409,17 @@
 /obj/item/reagent_containers/glass/bottle/bromine
 	name = "bromine bottle"
 	list_reagents = list(/datum/reagent/bromine = 30)
+
+/obj/item/reagent_containers/glass/bottle/glycerol
+	name = "glycerol bottle"
+	list_reagents = list(/datum/reagent/glycerol = 30)
+
+/obj/item/reagent_containers/glass/bottle/nitroglycerin
+	name = "nitroglycerin bottle"
+	desc = "A small bottle. Contains nitroglycerin - a potent explosive."
+	list_reagents = list(/datum/reagent/nitroglycerin = 30)
+
+/obj/item/reagent_containers/glass/bottle/unstableglycerin
+	name = "unstable glycerin bottle"
+	desc = "A small bottle. Contains unstable glycerin - a potent explosive."
+	list_reagents = list(/datum/reagent/unstableglycerin = 30)


### PR DESCRIPTION
### Intent of your Pull Request
Seperates Nitroglycerin into Nitroglycerin and Unstable glycerin.
Nitroglycerin mostly the same, except now explodes when inside fat people.
New chemical, Unstable glycerin, which is a weaker nitroglycerin except it explodes when inside any carbon mob.
Unstable glycerin can be applied to bees, creating a lethal army.

#### Changelog

:cl:  
Small change to nitroglycerin.
New Unstable glycerin chemical.
New bottles for spawning in nitroglycerin and unstable glycerin.
/:cl:
