### PR TITLE
Attacking cardboard with hot things will now set it on fire

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -431,9 +431,12 @@ GLOBAL_LIST_INIT(cardboard_recipes, list (														\
 			to_chat(user, "<span class='notice'>You stamp the cardboard! It's a clown box! Honk!</span>")
 			if (amount >= 0)
 				new/obj/item/storage/box/clown(droploc) //bugfix
+				
+	else if(I.is_hot())
+		fire_act(I.is_hot())
+		
 	else
 		. = ..()
-
 
 /*
  * Runed Metal


### PR DESCRIPTION
### Intent of your Pull Request

IE lit welders, lit cigarettes, lit lighters, lit matches, so on

Supposed to make it slightly easier to get rid of the syndicate boxes since just folding them down into cardboard is still a *paper* trail

#### Changelog

:cl:  
tweak: cardboard now burns if you burn it
/:cl:
