### PR TITLE
Minsky Sign Update / Fix #5757

### DIFF
--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -5983,6 +5983,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/sign/departments/minsky/security/security{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "ajl" = (
@@ -8533,6 +8536,7 @@
 "ann" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/sign/departments/minsky/supply/cargo,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "ano" = (
@@ -8851,6 +8855,9 @@
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
+	},
+/obj/structure/sign/departments/minsky/supply/hydroponics{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -10583,6 +10590,7 @@
 "aqp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/sign/departments/minsky/medical/clone/cloning2,
 /turf/open/floor/plating,
 /area/medical)
 "aqq" = (
@@ -18967,6 +18975,7 @@
 /obj/structure/cable/white{
 	icon_state = "0-4"
 	},
+/obj/structure/sign/departments/minsky/engineering/atmospherics,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "aCI" = (
@@ -22113,6 +22122,7 @@
 /obj/structure/cable/white{
 	icon_state = "0-4"
 	},
+/obj/structure/sign/departments/minsky/engineering/engineering,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aHx" = (
@@ -24343,6 +24353,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/sign/departments/minsky/engineering/telecommmunications{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aLK" = (
@@ -25468,10 +25481,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/hydroponics)
-"aOk" = (
-/obj/structure/sign/departments/botany,
-/turf/closed/wall,
-/area/hydroponics)
 "aOm" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
@@ -25793,6 +25802,9 @@
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
+	},
+/obj/structure/sign/departments/minsky/supply/hydroponics{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -29181,6 +29193,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/sign/departments/minsky/medical/chemistry/chemical2,
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "aWP" = (
@@ -29248,6 +29261,7 @@
 "aWV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/sign/departments/minsky/research/research,
 /turf/open/floor/plating,
 /area/science/lab)
 "aWW" = (
@@ -30824,6 +30838,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/sign/departments/minsky/research/robotics,
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "baV" = (
@@ -33087,9 +33102,6 @@
 	name = "Xenobiology Lab";
 	req_access_txt = "47"
 	},
-/obj/structure/sign/departments/xenobio{
-	pixel_x = 32
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -33102,6 +33114,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
+	},
+/obj/structure/sign/departments/minsky/research/xenobiology{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -34935,6 +34950,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/sign/departments/minsky/research/xenobiology{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bjc" = (
@@ -37535,6 +37553,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"emY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/departments/minsky/supply/mining,
+/turf/open/floor/plating,
+/area/hallway/primary/starboard)
 "eva" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -38478,6 +38501,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
+"jtg" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/departments/minsky/medical/medical2,
+/turf/open/floor/plating,
+/area/medical)
 "jtZ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -43517,10 +43545,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"xFw" = (
-/obj/structure/sign/departments/xenobio,
-/turf/closed/wall,
-/area/science/xenobiology)
 "xIm" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -79741,7 +79765,7 @@ abO
 agF
 ajc
 ajc
-aip
+agF
 ajc
 ajc
 anG
@@ -84139,7 +84163,7 @@ aJU
 aLd
 aMs
 aNw
-aOk
+aHM
 aPh
 aQk
 aRf
@@ -84150,10 +84174,10 @@ aRf
 aRg
 aRf
 aph
-art
+jtg
 atA
 aut
-art
+jtg
 aph
 aph
 aqn
@@ -89308,7 +89332,7 @@ ibv
 psq
 bgZ
 bgm
-xFw
+ibv
 bjb
 bju
 bjH
@@ -89512,7 +89536,7 @@ ado
 adp
 ajD
 ajO
-lFi
+emY
 sOF
 sOG
 atq

--- a/_maps/yogstation/RandomRuins/LavaRuins/miningbase.dmm
+++ b/_maps/yogstation/RandomRuins/LavaRuins/miningbase.dmm
@@ -529,6 +529,9 @@
 /obj/item/reagent_containers/blood/APlus,
 /obj/item/reagent_containers/blood/random,
 /obj/machinery/light,
+/obj/structure/sign/departments/minsky/medical/medical2{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel/white,
 /area/mine/living_quarters)
 "bk" = (
@@ -672,6 +675,9 @@
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
+	},
+/obj/structure/sign/departments/minsky/supply/mining{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
@@ -1322,6 +1328,9 @@
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
+	},
+/obj/structure/sign/departments/minsky/engineering/engineering{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
@@ -2466,6 +2475,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"Cu" = (
+/obj/structure/sign/departments/minsky/supply/mining,
+/turf/closed/wall,
+/area/mine/eva)
+"LN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/sign/departments/minsky/engineering/telecommmunications{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 
 (1,1,1) = {"
 ab
@@ -2706,7 +2731,7 @@ bT
 ck
 cB
 cU
-dj
+LN
 dK
 el
 an
@@ -3975,11 +4000,11 @@ ab
 ac
 ac
 ak
-ao
+Cu
 ap
 bd
 ap
-ao
+Cu
 bI
 aw
 aw

--- a/_maps/yogstation/map_files/YogStation/YogStation.dmm
+++ b/_maps/yogstation/map_files/YogStation/YogStation.dmm
@@ -8444,6 +8444,9 @@
 	icon_state = "pipe11-1";
 	dir = 9
 	},
+/obj/structure/sign/departments/minsky/engineering/atmospherics{
+	pixel_x = 32
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aqg" = (
@@ -8930,6 +8933,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	icon_state = "manifold-1";
 	dir = 4
+	},
+/obj/structure/sign/departments/minsky/supply/cargo{
+	pixel_x = 32
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -14632,6 +14638,9 @@
 	icon_state = "vent_map_on-1";
 	dir = 1
 	},
+/obj/structure/sign/departments/minsky/medical/clone/cloning2{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "aCG" = (
@@ -17966,6 +17975,9 @@
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/structure/sign/departments/minsky/security/security{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -28530,6 +28542,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/sign/departments/minsky/medical/medical2{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "beC" = (
@@ -29092,7 +29107,7 @@
 /turf/open/floor/plating,
 /area/medical/medbay/central)
 "bfH" = (
-/obj/structure/sign/departments/medbay/alt,
+/obj/structure/sign/departments/minsky/medical/medical2,
 /turf/closed/wall,
 /area/medical/medbay/central)
 "bfI" = (
@@ -29240,13 +29255,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bfY" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/structure/sign/departments/minsky/research/research{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -34513,6 +34527,9 @@
 	req_access_txt = "33"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/sign/departments/minsky/medical/chemistry/chemical2{
+	pixel_x = 32
+	},
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "bpG" = (
@@ -36519,6 +36536,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/sign/departments/minsky/research/genetics{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "btn" = (
@@ -37929,6 +37949,9 @@
 	c_tag = "Genetics Access";
 	dir = 8;
 	pixel_y = -22
+	},
+/obj/structure/sign/departments/minsky/research/research{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -40279,6 +40302,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/sign/departments/minsky/security/security{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "bAe" = (
@@ -40548,6 +40574,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	icon_state = "pipe11-1";
 	dir = 8
+	},
+/obj/structure/sign/departments/minsky/engineering/atmospherics{
+	pixel_y = 32
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -41232,6 +41261,9 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/structure/sign/departments/minsky/security/security{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
@@ -42622,11 +42654,11 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bEO" = (
-/obj/structure/sign/warning/securearea{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
+	},
+/obj/structure/sign/departments/minsky/research/research{
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -43923,6 +43955,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner,
+/obj/structure/sign/warning/securearea{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bHt" = (
@@ -44486,11 +44521,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/sign/warning/securearea{
-	pixel_x = 32
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/sign/departments/minsky/research/xenobiology{
+	pixel_x = 32
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bIN" = (
@@ -44537,7 +44572,7 @@
 /area/maintenance/port/aft)
 "bIT" = (
 /obj/effect/spawner/structure/window,
-/obj/structure/sign/departments/xenobio{
+/obj/structure/sign/departments/minsky/research/xenobiology{
 	pixel_y = -32
 	},
 /turf/open/floor/plating,
@@ -46227,7 +46262,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
 "bNf" = (
-/obj/structure/sign/warning/biohazard,
+/obj/structure/sign/departments/minsky/medical/virology/virology2,
 /turf/closed/wall,
 /area/medical/virology)
 "bNg" = (
@@ -47519,6 +47554,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/sign/departments/minsky/engineering/atmospherics{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bUd" = (
@@ -48258,6 +48296,9 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/structure/sign/departments/minsky/engineering/engineering{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -49090,6 +49131,9 @@
 /obj/machinery/camera{
 	c_tag = "Aft Starboard Solar Access";
 	dir = 1
+	},
+/obj/structure/sign/departments/minsky/engineering/engineering{
+	pixel_y = -32
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -52472,6 +52516,16 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"cKA" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/sign/departments/minsky/engineering/engineering{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "cKY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -53014,6 +53068,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"cUm" = (
+/obj/structure/sign/departments/minsky/security/security,
+/turf/closed/wall,
+/area/security/detectives_office)
 "cVb" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
@@ -53188,6 +53246,26 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space)
+"dXe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/obj/structure/sign/departments/minsky/medical/medical2{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "dXK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54115,6 +54193,26 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"hrL" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 4
+	},
+/obj/structure/sign/departments/minsky/supply/janitorial{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "htC" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -54157,6 +54255,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"hzb" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/sign/departments/minsky/engineering/telecommmunications{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/lounge)
 "hAt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -54164,6 +54271,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/tcommsat/entrance)
+"hCB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/sign/departments/minsky/research/research{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "hCS" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -54300,6 +54419,16 @@
 "ihS" = (
 /turf/closed/wall/r_wall,
 /area/medical/sleeper)
+"iiM" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/sign/departments/minsky/engineering/engineering{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "imE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -55005,6 +55134,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"lcL" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/sign/departments/minsky/security/security{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "leB" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/r_wall,
@@ -55083,6 +55221,9 @@
 	pixel_y = -26
 	},
 /obj/item/twohanded/required/kirbyplants/random,
+/obj/structure/sign/departments/minsky/engineering/telecommmunications{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel,
 /area/tcommsat/entrance)
 "lpF" = (
@@ -55813,12 +55954,33 @@
 /obj/machinery/bookbinder,
 /turf/open/floor/wood,
 /area/medical/medbay/central)
+"omA" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/obj/structure/sign/departments/minsky/medical/medical2{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "omY" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"ond" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/sign/departments/minsky/security/security{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "opj" = (
 /mob/living/simple_animal/moonrat{
 	name = "Joe"
@@ -55958,6 +56120,9 @@
 "oRZ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/small,
+/obj/structure/sign/departments/minsky/engineering/atmospherics{
+	pixel_y = -32
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "oSz" = (
@@ -56282,6 +56447,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/space/basic,
 /area/maintenance/disposal/incinerator)
+"qkv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/departments/minsky/supply/janitorial{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qky" = (
 /obj/effect/turf_decal/stripes{
 	icon_state = "warningline";
@@ -56432,6 +56606,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
+/obj/structure/sign/departments/minsky/engineering/atmospherics{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "qLj" = (
@@ -56475,6 +56652,14 @@
 "qQV" = (
 /turf/template_noop,
 /area/template_noop)
+"qTh" = (
+/obj/structure/sign/departments/minsky/supply/mining,
+/turf/closed/wall,
+/area/quartermaster/miningdock)
+"qUr" = (
+/obj/structure/sign/departments/minsky/security/security,
+/turf/closed/wall,
+/area/maintenance/fore/secondary)
 "qWw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -56602,6 +56787,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
+"rxR" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/sign/departments/minsky/supply/cargo{
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
+"ryf" = (
+/obj/structure/sign/departments/minsky/research/research,
+/turf/closed/wall/r_wall,
+/area/science/lab)
 "rEl" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -56878,6 +57076,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"stF" = (
+/obj/structure/sign/departments/minsky/engineering/engineering{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "szl" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -57235,6 +57439,10 @@
 	},
 /turf/open/floor/plasteel/stairs,
 /area/escapepodbay)
+"trL" = (
+/obj/structure/sign/departments/minsky/supply/cargo,
+/turf/closed/wall,
+/area/security/checkpoint/supply)
 "tsI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57245,6 +57453,15 @@
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/chapel,
 /area/escapepodbay)
+"txa" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/sign/departments/minsky/medical/medical2{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "txj" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/junction/flipped{
@@ -57315,6 +57532,26 @@
 /obj/structure/chair/wood/wings,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"tFC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 4
+	},
+/obj/structure/sign/departments/minsky/supply/mining{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "tIs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
@@ -57324,6 +57561,17 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"tMm" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "tMI" = (
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
@@ -57573,7 +57821,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/sign/warning/fire{
+/obj/structure/sign/departments/minsky/engineering/atmospherics{
 	pixel_y = -32
 	},
 /turf/open/floor/plating,
@@ -57926,6 +58174,10 @@
 "wcB" = (
 /turf/closed/wall/r_wall,
 /area/tcommsat/entrance)
+"wdD" = (
+/obj/structure/sign/departments/minsky/supply/cargo,
+/turf/closed/wall,
+/area/quartermaster/storage)
 "weD" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -58111,6 +58363,12 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"wGT" = (
+/obj/structure/sign/departments/minsky/medical/medical2{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "wIv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -81697,7 +81955,7 @@ aWB
 aSg
 aSg
 aSg
-aWA
+rxR
 gjl
 fHT
 cBi
@@ -81707,7 +81965,7 @@ baS
 baS
 bbS
 gjl
-aZE
+wdD
 bkJ
 bjj
 bmH
@@ -81980,7 +82238,7 @@ boV
 bxx
 bxu
 bxy
-bxy
+qTh
 bGj
 bHA
 bHA
@@ -83778,7 +84036,7 @@ byL
 bpn
 byT
 bwe
-bqD
+tFC
 bHE
 bCq
 bHD
@@ -84543,7 +84801,7 @@ bqu
 bqu
 bnK
 bnK
-bwe
+trL
 bwe
 bwe
 bwe
@@ -85012,7 +85270,7 @@ anu
 alq
 anX
 apc
-apS
+ond
 aoc
 apS
 apS
@@ -85352,7 +85610,7 @@ cdj
 cdv
 cem
 cem
-cem
+iiM
 cfe
 cfD
 cgv
@@ -88609,7 +88867,7 @@ amR
 anw
 anz
 aov
-apd
+cUm
 apd
 bON
 bON
@@ -88920,7 +89178,7 @@ boU
 bCu
 bAO
 bSA
-bSA
+cKA
 bsJ
 bSA
 bSA
@@ -89637,7 +89895,7 @@ amT
 anw
 anv
 aoz
-ahn
+qUr
 ahn
 ahn
 ahn
@@ -90715,7 +90973,7 @@ bsh
 bqH
 aJq
 aJq
-aXf
+qkv
 bCv
 bDL
 aDv
@@ -91492,7 +91750,7 @@ apG
 bFk
 bDs
 bCv
-btC
+hrL
 leB
 mmQ
 mmQ
@@ -92810,7 +93068,7 @@ bvA
 aaa
 aKz
 hbC
-ajS
+hzb
 mfN
 ajS
 hbC
@@ -93537,7 +93795,7 @@ azI
 aLY
 aJq
 aJq
-aJq
+wGT
 bne
 bxL
 byX
@@ -93545,7 +93803,7 @@ aJq
 aJq
 bCA
 bzs
-bFr
+txa
 bDA
 bHW
 ccM
@@ -94509,7 +94767,7 @@ adR
 ahl
 ahn
 aiC
-ahT
+lcL
 ahT
 ahT
 ahT
@@ -94836,7 +95094,7 @@ bIc
 bvj
 btU
 oRZ
-aCV
+avy
 aJk
 aSJ
 aUu
@@ -100470,7 +100728,7 @@ bfS
 bfS
 ueh
 rZt
-bjM
+dXe
 bon
 bpG
 bqZ
@@ -100488,7 +100746,7 @@ bCY
 bsd
 bFN
 bBN
-bKQ
+omA
 btT
 bNd
 jLB
@@ -105836,7 +106094,7 @@ anf
 aty
 anf
 awN
-anf
+stF
 asA
 apE
 arx
@@ -105862,7 +106120,7 @@ aCR
 bcs
 aXq
 aYV
-bfX
+tMm
 bfV
 bfV
 bfV
@@ -106093,7 +106351,7 @@ asB
 asB
 avo
 awN
-avo
+asB
 asB
 asB
 asB
@@ -107918,7 +108176,7 @@ bbF
 aYV
 aXq
 aYV
-bgc
+ryf
 bgc
 biX
 bhV
@@ -109752,7 +110010,7 @@ cOe
 cOe
 alZ
 aMC
-aMF
+hCB
 aMF
 aMS
 cOe

--- a/_maps/yogstation/map_files/YogsPubby/YogsPubby.dmm
+++ b/_maps/yogstation/map_files/YogsPubby/YogsPubby.dmm
@@ -12227,7 +12227,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "axJ" = (
-/obj/structure/sign/departments/security{
+/obj/structure/sign/departments/minsky/security/security{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
@@ -13116,11 +13116,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "azB" = (
-/obj/structure/sign/departments/cargo{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
+	},
+/obj/structure/sign/departments/minsky/supply/cargo{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -16700,10 +16700,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/sign/departments/custodian{
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/sign/departments/minsky/supply/janitorial{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aGB" = (
@@ -17536,6 +17536,9 @@
 	c_tag = "Central Primary Hallway Genetics";
 	dir = 1
 	},
+/obj/structure/sign/departments/minsky/medical/medical2{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aId" = (
@@ -17547,13 +17550,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/medical/paramedic)
-"aIe" = (
-/obj/structure/sign/departments/medbay/alt{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aIf" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/blue,
@@ -18611,6 +18607,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/structure/sign/departments/minsky/supply/cargo{
+	pixel_x = -32
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aKl" = (
@@ -18959,18 +18958,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"aKX" = (
-/obj/structure/sign/departments/xenobio{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/xenobiology)
 "aKY" = (
 /turf/closed/wall/r_wall,
 /area/storage/eva)
@@ -18983,9 +18970,6 @@
 	c_tag = "Xenobiology Starboard";
 	dir = 2;
 	network = list("ss13","rd")
-	},
-/obj/structure/sign/departments/xenobio{
-	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -21638,15 +21622,15 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "aQa" = (
-/obj/structure/sign/departments/cargo{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	icon_state = "vent_map_on-1";
 	dir = 8
+	},
+/obj/structure/sign/departments/minsky/supply/cargo{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -22006,6 +21990,9 @@
 	dir = 4
 	},
 /obj/effect/landmark/blobstart,
+/obj/structure/sign/departments/minsky/supply/hydroponics{
+	pixel_y = -32
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -25408,12 +25395,12 @@
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
 "aWL" = (
-/obj/structure/sign/departments/engineering{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
+	},
+/obj/structure/sign/departments/minsky/engineering/engineering{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -26122,9 +26109,6 @@
 /area/hydroponics)
 "aXY" = (
 /obj/machinery/hydroponics/constructable,
-/obj/structure/sign/departments/botany{
-	pixel_y = 32
-	},
 /obj/machinery/light{
 	dir = 1;
 	light_color = "#e8eaff"
@@ -27427,10 +27411,10 @@
 	dir = 1;
 	start_active = 1
 	},
-/obj/structure/sign/departments/engineering{
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/sign/departments/minsky/engineering/engineering{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bas" = (
@@ -27519,10 +27503,10 @@
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-02"
 	},
-/obj/structure/sign/departments/engineering{
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/sign/departments/minsky/engineering/engineering{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "baB" = (
@@ -27923,7 +27907,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering";
-	req_one_access_txt = "10;24"
+	req_one_access_txt = "32"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -28563,6 +28547,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
+/obj/structure/sign/departments/minsky/engineering/engineering{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bcI" = (
@@ -30541,6 +30528,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/sign/departments/minsky/engineering/telecommmunications{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bgB" = (
@@ -30916,7 +30906,8 @@
 	dir = 8
 	},
 /obj/structure/sign/poster/official/random{
-	pixel_y = 32
+	pixel_x = 32;
+	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31894,7 +31885,7 @@
 /turf/open/floor/plating,
 /area/medical/medbay/central)
 "bje" = (
-/obj/structure/sign/departments/medbay/alt,
+/obj/structure/sign/departments/minsky/medical/medical2,
 /turf/closed/wall,
 /area/medical/medbay/central)
 "bjf" = (
@@ -35260,11 +35251,11 @@
 	dir = 8
 	},
 /obj/effect/landmark/xeno_spawn,
-/obj/structure/sign/departments/xenobio{
-	pixel_x = -32
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/structure/sign/departments/minsky/research/xenobiology{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bpH" = (
@@ -40087,6 +40078,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/sign/departments/minsky/engineering/telecommmunications{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bwM" = (
@@ -42062,7 +42056,7 @@
 /turf/open/floor/plating,
 /area/chapel/main/monastery)
 "bzY" = (
-/obj/structure/sign/departments/medbay/alt,
+/obj/structure/sign/departments/minsky/medical/medical2,
 /turf/closed/wall,
 /area/crew_quarters/heads/cmo)
 "bzZ" = (
@@ -42569,7 +42563,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bAY" = (
-/obj/structure/sign/warning/biohazard,
+/obj/structure/sign/departments/minsky/medical/virology/virology2,
 /turf/closed/wall,
 /area/medical/virology)
 "bAZ" = (
@@ -43243,6 +43237,10 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/structure/sign/departments/minsky/research/genetics{
+	pixel_x = -32;
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bCd" = (
@@ -43339,15 +43337,7 @@
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bCk" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering{
-	name = "Gravity Generator";
-	req_access_txt = "11"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/sign/departments/minsky/engineering/atmospherics,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bCl" = (
@@ -43397,7 +43387,7 @@
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engine Room";
-	req_access_txt = "10"
+	req_access_txt = "10; 61"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -45875,7 +45865,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bGa" = (
-/obj/structure/sign/departments/science,
+/obj/structure/sign/departments/minsky/research/research,
 /turf/closed/wall,
 /area/hallway/primary/aft)
 "bGb" = (
@@ -46042,9 +46032,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/sign/departments/xenobio{
-	pixel_x = 32
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -46053,6 +46040,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/sign/departments/minsky/research/xenobiology,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bGr" = (
@@ -56148,6 +56136,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"cPK" = (
+/obj/structure/lattice,
+/obj/structure/sign/departments/minsky/medical/virology/virology2{
+	pixel_y = 32
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "cPO" = (
 /obj/item/chair/stool,
 /turf/open/floor/wood{
@@ -56322,6 +56317,16 @@
 /obj/structure/sign/warning/vacuum/external,
 /turf/open/floor/plating,
 /area/science/mixing)
+"dES" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/sign/departments/minsky/research/robotics{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "dJm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -56370,6 +56375,15 @@
 /obj/machinery/shieldwallgen/xenobiologyaccess,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"dRF" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/sign/departments/minsky/supply/hydroponics{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "dSr" = (
 /obj/item/chair,
 /turf/open/floor/wood,
@@ -56626,6 +56640,18 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
+"fsM" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/departments/minsky/security/security{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "ftp" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -56866,6 +56892,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"gnB" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/sign/departments/minsky/engineering/atmospherics{
+	pixel_x = -32;
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "gpC" = (
 /obj/structure/chair,
 /obj/machinery/light{
@@ -57094,6 +57132,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"hkU" = (
+/obj/structure/sign/departments/minsky/supply/hydroponics{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hvW" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
@@ -57472,6 +57516,10 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
+"jqN" = (
+/obj/structure/sign/departments/minsky/supply/mining,
+/turf/closed/wall,
+/area/quartermaster/miningdock)
 "jrG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -57606,10 +57654,6 @@
 /obj/structure/chair,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"jSA" = (
-/obj/structure/sign/departments/science,
-/turf/closed/wall,
-/area/maintenance/department/engine)
 "jTu" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -57939,6 +57983,10 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"llI" = (
+/obj/structure/sign/departments/minsky/engineering/atmospherics,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "lqc" = (
 /obj/item/toy/gun,
 /obj/effect/decal/cleanable/oil,
@@ -58343,6 +58391,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"nvg" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/sign/departments/minsky/medical/clone/cloning2{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/zone2)
 "nxT" = (
 /obj/machinery/smartfridge/extract/preloaded,
 /turf/open/floor/plasteel,
@@ -58809,6 +58866,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"pcg" = (
+/obj/structure/sign/departments/minsky/engineering/atmospherics,
+/turf/closed/wall/r_wall,
+/area/engine/gravity_generator)
 "pdq" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
@@ -59040,6 +59101,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/department/engine)
+"qbb" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/obj/structure/sign/departments/minsky/security/security{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/security/brig)
 "qbp" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -59080,10 +59154,31 @@
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"qmn" = (
+/obj/structure/sign/departments/minsky/engineering/engineering,
+/turf/closed/wall,
+/area/maintenance/department/engine)
 "qnT" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"qoj" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/obj/structure/sign/departments/minsky/security/security{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/security/brig)
 "qAM" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/item/cigbutt,
@@ -79134,7 +79229,7 @@ ajH
 ajH
 ajH
 ajH
-ape
+qbb
 aiu
 aiu
 aaa
@@ -80163,7 +80258,7 @@ akA
 akA
 akA
 akA
-anG
+qoj
 aiu
 aaa
 aaa
@@ -85634,7 +85729,7 @@ bKn
 bKn
 bKn
 bEr
-aht
+cPK
 bva
 bxl
 bva
@@ -86375,7 +86470,7 @@ aVS
 aVS
 aVS
 aRL
-aDZ
+hkU
 awN
 aDZ
 bjL
@@ -86387,7 +86482,7 @@ aJM
 aJW
 bpL
 aLs
-aLs
+nvg
 bfV
 aPf
 aQC
@@ -86405,7 +86500,7 @@ bKn
 bKn
 bKn
 bEr
-aht
+cPK
 bva
 bxu
 bva
@@ -86846,7 +86941,7 @@ amN
 aiR
 akT
 aiR
-apd
+fsM
 ajM
 aqC
 ask
@@ -86891,7 +86986,7 @@ bfk
 bdm
 aDZ
 awN
-aIe
+aDZ
 bjL
 aIK
 aJe
@@ -86935,7 +87030,7 @@ bBI
 bxF
 bxF
 bCB
-bva
+qmn
 gMO
 kCc
 bva
@@ -87442,7 +87537,7 @@ anZ
 bbq
 bbJ
 bAn
-bPB
+pcg
 bPB
 bPB
 bPB
@@ -88941,7 +89036,7 @@ aYQ
 aXS
 bbe
 bcd
-bdo
+dRF
 bhb
 bdo
 bdo
@@ -93849,7 +93944,7 @@ aSR
 aTh
 bDA
 bEQ
-jSA
+bva
 aVe
 bvo
 aWL
@@ -95143,7 +95238,7 @@ bLV
 bMX
 bOf
 bON
-bJN
+llI
 bQE
 bQE
 bSa
@@ -95394,7 +95489,7 @@ bEV
 bBp
 aVr
 bvo
-aWZ
+gnB
 bKO
 bLW
 bMY
@@ -97429,7 +97524,7 @@ bgC
 bgC
 bhQ
 bgC
-bjm
+dES
 bku
 blG
 bmN
@@ -102046,7 +102141,7 @@ aXy
 aYB
 cCT
 baF
-bbI
+jqN
 bcG
 bdM
 beP
@@ -107459,7 +107554,7 @@ bnj
 bnj
 bnj
 bnj
-aKX
+gIG
 bqA
 aNw
 bnj

--- a/_maps/yogstation/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/yogstation/map_files/Yogsmeta/Yogsmeta.dmm
@@ -10024,6 +10024,9 @@
 	icon_state = "pipe11-3";
 	dir = 4
 	},
+/obj/structure/sign/departments/minsky/engineering/engineering{
+	pixel_y = -32
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "arM" = (
@@ -14246,17 +14249,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"azw" = (
-/obj/structure/sign/map/left{
-	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
-	icon_state = "map-left-MS";
-	pixel_y = 32
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "azx" = (
 /obj/machinery/nuclearbomb/selfdestruct,
 /obj/effect/turf_decal/tile/neutral{
@@ -14278,11 +14270,6 @@
 /obj/machinery/camera{
 	c_tag = "Cargo Bay - Fore";
 	dir = 2
-	},
-/obj/structure/sign/map/right{
-	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
-	icon_state = "map-right-MS";
-	pixel_y = 32
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -15251,6 +15238,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/blobstart,
+/obj/structure/sign/departments/minsky/supply/cargo{
+	pixel_y = 32
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aBd" = (
@@ -18771,6 +18761,9 @@
 	icon_state = "vent_map_on-1";
 	dir = 4
 	},
+/obj/structure/sign/departments/minsky/medical/medical2{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "aHw" = (
@@ -19134,9 +19127,6 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aId" = (
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = 28
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -19144,6 +19134,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	icon_state = "scrub_map_on-3";
 	dir = 8
+	},
+/obj/structure/sign/departments/minsky/medical/clone/cloning2{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -29811,11 +29804,11 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "baY" = (
-/obj/structure/sign/warning/securearea{
-	pixel_x = 32
-	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/structure/sign/departments/minsky/engineering/telecommmunications{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -30205,6 +30198,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	icon_state = "scrub_map_on-3";
 	dir = 1
+	},
+/obj/structure/sign/departments/minsky/engineering/telecommmunications{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -33089,6 +33085,9 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
+	},
+/obj/structure/sign/departments/minsky/engineering/atmospherics{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -39196,10 +39195,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "brv" = (
-/obj/structure/sign/departments/botany{
-	pixel_x = 32;
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -42619,6 +42614,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/structure/sign/departments/minsky/medical/medical2{
+	pixel_y = -32
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bxN" = (
@@ -43131,6 +43129,9 @@
 	name = "Engineering Security Doors"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/sign/departments/minsky/engineering/engineering{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "byL" = (
@@ -45215,20 +45216,17 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bCI" = (
-/obj/structure/sign/departments/chemistry{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/structure/sign/departments/minsky/medical/chemistry/chemical2{
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bCJ" = (
 /obj/machinery/light{
 	dir = 4
-	},
-/obj/structure/sign/departments/science{
-	pixel_x = 32
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 2
@@ -47190,6 +47188,9 @@
 	},
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
+	},
+/obj/structure/sign/departments/minsky/research/research{
+	pixel_y = 32
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
@@ -52082,12 +52083,11 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/sign/departments/science{
-	name = "\improper ROBOTICS!";
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
+	},
+/obj/structure/sign/departments/minsky/research/robotics{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -57212,7 +57212,7 @@
 /turf/open/floor/plating,
 /area/medical/medbay/central)
 "bZb" = (
-/obj/structure/sign/departments/medbay/alt,
+/obj/structure/sign/departments/minsky/medical/medical2,
 /turf/closed/wall,
 /area/medical/medbay/central)
 "bZc" = (
@@ -57305,7 +57305,7 @@
 /turf/open/floor/plating,
 /area/science/research)
 "bZk" = (
-/obj/structure/sign/departments/science,
+/obj/structure/sign/departments/minsky/research/research,
 /turf/closed/wall,
 /area/science/research)
 "bZl" = (
@@ -61513,7 +61513,7 @@
 /turf/closed/wall,
 /area/medical/chemistry)
 "cfW" = (
-/obj/structure/sign/departments/chemistry,
+/obj/structure/sign/departments/minsky/medical/chemistry/chemical2,
 /turf/closed/wall,
 /area/medical/chemistry)
 "cfX" = (
@@ -64708,6 +64708,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	icon_state = "manifold-1";
 	dir = 1
+	},
+/obj/structure/sign/departments/minsky/supply/hydroponics{
+	pixel_y = 32
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -74812,6 +74815,9 @@
 /area/science/mixing)
 "cEz" = (
 /obj/structure/closet/wardrobe/grey,
+/obj/structure/sign/departments/minsky/research/research{
+	pixel_y = 32
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cEA" = (
@@ -75295,9 +75301,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "cHB" = (
-/obj/structure/sign/warning/biohazard{
-	pixel_x = -32
-	},
 /obj/item/storage/box/gloves{
 	pixel_x = 3;
 	pixel_y = 4
@@ -75306,6 +75309,9 @@
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
+	},
+/obj/structure/sign/departments/minsky/medical/virology/virology2{
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -75621,6 +75627,9 @@
 /area/science/robotics/lab)
 "cIP" = (
 /obj/effect/spawner/structure/window,
+/obj/structure/sign/departments/minsky/research/robotics{
+	pixel_y = -32
+	},
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "cIQ" = (
@@ -77720,7 +77729,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cRu" = (
-/obj/structure/sign/warning/biohazard,
+/obj/structure/sign/departments/minsky/research/xenobiology,
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "cRw" = (
@@ -81949,6 +81958,10 @@
 /obj/structure/sign/directions/evac,
 /turf/closed/wall,
 /area/maintenance/department/science/central)
+"eoq" = (
+/obj/structure/sign/departments/minsky/research/xenobiology,
+/turf/closed/wall,
+/area/science/xenobiology)
 "eqG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -82049,6 +82062,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"gZY" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/sign/departments/minsky/research/research{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/secondary)
+"her" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/sign/departments/minsky/medical/medical2{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "hfn" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -82130,6 +82162,15 @@
 /obj/structure/table,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"iZd" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/sign/departments/minsky/supply/mining{
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "jeV" = (
 /obj/machinery/conveyor/inverted{
 	dir = 10;
@@ -82377,6 +82418,10 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"mNI" = (
+/obj/structure/sign/departments/minsky/supply/hydroponics,
+/turf/closed/wall,
+/area/hallway/primary/central)
 "mWg" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -82616,6 +82661,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"rpI" = (
+/obj/structure/sign/departments/minsky/research/genetics,
+/turf/closed/wall,
+/area/medical/paramedic)
 "rrB" = (
 /turf/closed/wall,
 /area/vacant_room/commissary)
@@ -82677,6 +82726,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
+"sAy" = (
+/obj/structure/sign/departments/minsky/supply/cargo,
+/turf/closed/wall,
+/area/quartermaster/office)
 "sGh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -82818,6 +82871,10 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/starboard/secondary)
+"uZK" = (
+/obj/structure/sign/departments/minsky/supply/mining,
+/turf/closed/wall,
+/area/quartermaster/miningoffice)
 "vgd" = (
 /obj/item/taperecorder,
 /obj/item/camera,
@@ -82851,6 +82908,10 @@
 	dir = 8
 	},
 /area/engine/storage_shared)
+"vEI" = (
+/obj/structure/sign/departments/minsky/supply/cargo,
+/turf/closed/wall,
+/area/quartermaster/warehouse)
 "vKx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -82971,6 +83032,10 @@
 	},
 /turf/open/floor/plating,
 /area/medical/surgery)
+"xuZ" = (
+/obj/structure/sign/departments/minsky/research/research,
+/turf/closed/wall/r_wall,
+/area/science/lab)
 "xwG" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Library Maintenance";
@@ -100880,7 +100945,7 @@ auI
 aop
 dnk
 dnk
-doJ
+iZd
 ayj
 azp
 aAI
@@ -100888,8 +100953,8 @@ aBX
 aDj
 aEz
 aFJ
-ayj
-azw
+uZK
+aYM
 bLL
 aMu
 aMv
@@ -102194,7 +102259,7 @@ aPL
 bdt
 biK
 bkn
-bat
+sAy
 aXW
 bqc
 bcq
@@ -102680,7 +102745,7 @@ awb
 auL
 avS
 awU
-ayl
+vEI
 ayl
 ayl
 ayl
@@ -105072,7 +105137,7 @@ crn
 bMP
 cBX
 cxU
-bUU
+her
 cxU
 cxU
 cGL
@@ -108921,7 +108986,7 @@ azi
 azi
 azi
 azi
-azi
+rpI
 cqQ
 ctA
 ctA
@@ -110966,7 +111031,7 @@ cge
 cgd
 cge
 cgd
-cgd
+xuZ
 cpb
 cpb
 cqv
@@ -113563,7 +113628,7 @@ cJO
 cKI
 bVi
 cQR
-cRa
+eoq
 cSd
 cRe
 cRe
@@ -115834,7 +115899,7 @@ bOP
 bOP
 bOP
 bKe
-bSS
+mNI
 bUd
 bVq
 bVq
@@ -117914,7 +117979,7 @@ dwL
 bGO
 bxH
 bxH
-bxH
+gZY
 bJE
 dzR
 cqU

--- a/_maps/yogstation/map_files/mining/Lavaland.dmm
+++ b/_maps/yogstation/map_files/mining/Lavaland.dmm
@@ -1679,6 +1679,12 @@
 	},
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
+"nB" = (
+/obj/structure/sign/departments/minsky/security/security{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/mine/laborcamp)
 "Uq" = (
 /obj/docking_port/stationary{
 	area_type = /area/lavaland/surface/outdoors;
@@ -7335,7 +7341,7 @@ az
 az
 az
 az
-az
+nB
 aq
 cb
 bh

--- a/code/game/objects/structures/signs/signs_departments.dm
+++ b/code/game/objects/structures/signs/signs_departments.dm
@@ -99,7 +99,7 @@
 	icon_state = "minskyengi"
 
 /obj/structure/sign/departments/minsky/engineering/telecommmunications
-	name = "Engineering Department"
+	name = "Telecommunications Department"
 	desc = "A sign labeling telecommunications division of the station. 'Nuff said."
 	icon_state = "minskytcom"
 
@@ -129,22 +129,22 @@
 	icon_state = "minskycloneb"
 
 /obj/structure/sign/departments/minsky/medical/chemistry/chemical1
-	name = "Chemicals Division"
+	name = "Chemistry Division"
 	desc = "A sign labeling the chemicals division of the station. Similar to the kitchens, just don't lick the spoon."
 	icon_state = "minskychem"
 
 /obj/structure/sign/departments/minsky/medical/chemistry/chemical2
-	name = "Chemicals Division"
+	name = "Chemistry Division"
 	desc = "A sign labeling the chemicals division of the station. Similar to the kitchens, just don't lick the spoon."
 	icon_state = "minskychemb"
 
 /obj/structure/sign/departments/minsky/medical/virology/virology1
-	name = "Chemicals Division"
+	name = "Virology Division"
 	desc = "A sign labeling the virology division of the station. Free hugs!!!."
 	icon_state = "minskyviro"
 
 /obj/structure/sign/departments/minsky/medical/virology/virology2
-	name = "Chemicals Division"
+	name = "Virology Division"
 	desc = "A sign labeling the virology division of the station. Free hugs!!!."
 	icon_state = "minskyvirob"
 


### PR DESCRIPTION
Adds minsky signs to various stations

Updates various maps with Minsky signs

### Sign Update

Updates in-rotation maps with Minsky Signs, see changelog for details. Additionally #5757 is corrected, providing signal technicians with access through engineering. You can view the signs in #6667.

###Changelog

🆑
rscadd: Added Minsky Signs to YogStation, YogsPubby, YogsMeta, Omega, Mining Outpost & Labor Prison & removes old signs
bugfix: fixes #5757
spellcheck: fixed a few typos in signs_departments.dm introduced in #6667 

/🆑
