### PR TITLE
.38 rounds deal 35 instead of 60 stamina damage

### DIFF
--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -15,8 +15,7 @@
 /obj/item/projectile/bullet/c38
 	name = ".38 bullet"
 	damage = 15 // yogs - Nerfed revolver damage
-	//knockdown = 60 //yogs - commented out
-	stamina = 60 // yogs - Buffed revolver 
+	stamina = 35 // yogs - Buffed revolver 
 
 /obj/item/projectile/bullet/c38/trac
 	name = ".38 TRAC bullet"


### PR DESCRIPTION
This brings the detective's revolver relatively in line with stamina based weapons, since the 60 stamina damage was from when tasers still existed.
:cl:  
tweak: Detective revolver deals less stamina damage, takes roughly 3 shots to stamcrit someone now
/:cl:
