### PR TITLE
Radball Tweaks

### DIFF
--- a/code/modules/projectiles/projectile/energy/nuclear_particle.dm
+++ b/code/modules/projectiles/projectile/energy/nuclear_particle.dm
@@ -1,11 +1,10 @@
-//Nuclear particle projectile - a deadly side effect of fusion
+//Nuclear particle projectile - a deadly side effect of fusion just kidding fuck that shit rads shouldn`t be a vomit ICBM
 /obj/item/projectile/energy/nuclear_particle
 	name = "nuclear particle"
 	icon_state = "nuclear_particle"
-	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
-	damage = 10
-	damage_type = TOX
-	irradiate = 2500 //enough to knockdown and induce vomiting
+	pass_flags = PASSTABLE | PASSGRILLE
+	damage = 3 
+	damage_type = BURN
 	speed = 0.4
 	hitsound = 'sound/weapons/emitter2.ogg'
 	impact_type = /obj/effect/projectile/impact/xray


### PR DESCRIPTION
### Intent of your Pull Request
Radballs have been a problem for most atmos techies, be it fusion engines outputting 120+ toxin damage and 25k+ rads a second, causing a problem. They even break the design of radiation with bringing 2500+ rads usually to another part of the station, this is mostly fixing that with making fusion reactions not something to stand in front of but something that won't flip over Medbay and spread their cheeks because the atmos tech got hit by a single ball.
If your mobile canister of griff machine is too weak I'm open to feedback.
#### Changelog

:cl:  
tweak: Radballs No longer go through glass, and now deal only 3 burn damage.  
/:cl:
