### PR TITLE
Conscription kit comes with a kinetic accelerator

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -275,6 +275,7 @@
 
 /obj/item/storage/backpack/duffelbag/mining_conscript/PopulateContents()
 	new /obj/item/pickaxe/mini(src)
+	new /obj/item/gun/energy/kinetic_accelerator(src)
 	new /obj/item/clothing/glasses/meson(src)
 	new /obj/item/t_scanner/adv_mining_scanner/lesser(src)
 	new /obj/item/storage/bag/ore(src)


### PR DESCRIPTION
Currently the only way to get more accelerators is to buy them from the mining vendor, which is counterintuitive when recruiting more miners since they will be lacking the most basic functional mining/defense tool

#### Changelog

:cl:  
rscadd: Conscription kit has a KA in it
/:cl:
