### PR TITLE
AI is not eligible to be a traitor anymore.

### DIFF
--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -11,7 +11,7 @@
 	report_type = "traitor"
 	antag_flag = ROLE_TRAITOR
 	false_report_weight = 20 //Reports of traitors are pretty common.
-	restricted_jobs = list("Cyborg")//They are part of the AI if he is traitor so are they, they use to get double chances
+	restricted_jobs = list("Cyborg", "AI")//They are part of the AI if he is traitor so are they, they use to get double chances
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel") //YOGS -  added the hop
 	required_players = 0
 	required_enemies = 1


### PR DESCRIPTION
### Intent of your Pull Request

As it stands, if an AI is a traitor with no borgs, they're totally fucked and forced to murderbone to get their objectives done. There is a simple solution to fix that, delete tatorAI.

#### Changelog

:cl:  
rscdel: AI no longer eligible for tator.
/:cl:
