### PR TITLE
Surgical Clothing change

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -9,7 +9,7 @@
 	var/location = BODY_ZONE_CHEST							//Surgery location
 	var/requires_bodypart_type = BODYPART_ORGANIC			//Prevents you from performing an operation on incorrect limbs. 0 for any limb type
 	var/list/possible_locs = list() 						//Multiple locations
-	var/ignore_clothes = 0									//This surgery ignores clothes
+	var/ignore_clothes = 1									//This surgery ignores clothes
 	var/mob/living/carbon/target							//Operation target mob
 	var/obj/item/bodypart/operated_bodypart					//Operable body part
 	var/requires_bodypart = TRUE							//Surgery available only when a bodypart is present, or only when it is missing.


### PR DESCRIPTION
### Intent of your Pull Request
After a discussion about surgery on discord, A few things came to mind
Medbay has too much downtime, and no real purpose unless maxcapmcbuddyretard goes wild that round.
Surgery is too slow and risky.

So I decided to take a crack at fixing that, or at least making surgery a viable method for a possible series of PRS that shifts med bays downtime into RND like gameplay, in which you upgrade your fellow crewmembers with surgery.
You may say "THIS MAKES SURGERY SUPER OP AND PPWOERGAMEY WTF??!?!?!?!" 2 things
1-You are laying down, you are still slowed and most of all, open for attacks
2-You can't read what surgery is being done on you; I could take your heart out, or give you a CNS rebooter.

This may come along with a possible medbay mapping change, but anyhow, basically, (as of current)surgery is an unfocused, clunky, risky practice that gives no advantage and will be used to patch in the "an AFK medic would be doing the same job as me" rounds.

Future PRS may include
Reintroduction of Surgery Speedup chems/stasis bed upgrade surgery modifiers
Introduction of an upgraded round-start only medkit for medical doctors
Medbay layout changes, courtesy of Nickvr628
#### Changelog

:cl:  
tweak: You no longer have to full strip for surgery  
/:cl: