### PR TITLE
buffs holy explosion anti-cult blast

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -56,8 +56,8 @@
 	required_reagents = list(/datum/reagent/water/holywater = 1, /datum/reagent/potassium = 1)
 
 /datum/chemical_reaction/reagent_explosion/potassium_explosion/holyboom/on_reaction(datum/reagents/holder, created_volume)
-	if(created_volume >= 150)
-		playsound(get_turf(holder.my_atom), 'sound/effects/pray.ogg', 80, 0, round(created_volume/48))
+	if(created_volume >= 100)
+		playsound(get_turf(holder.my_atom), 'sound/effects/pray.ogg', 80, 0, round(created_volume/20))
 		strengthdiv = 8
 		for(var/mob/living/simple_animal/revenant/R in get_hearers_in_view(7,get_turf(holder.my_atom)))
 			var/deity
@@ -70,7 +70,7 @@
 			R.reveal(100)
 			R.adjustHealth(50)
 		sleep(20)
-		for(var/mob/living/carbon/C in get_hearers_in_view(round(created_volume/48,1),get_turf(holder.my_atom)))
+		for(var/mob/living/carbon/C in get_hearers_in_view(round(created_volume/20,1),get_turf(holder.my_atom))) //roughly 5 tiles with 100/100 potwat
 			if(iscultist(C))
 				to_chat(C, "<span class='userdanger'>The divine explosion sears you!</span>")
 				C.Paralyze(40)


### PR DESCRIPTION
Now triggers at 100/100 potwat and has a range of created volume/20 instead of created volume/48

:cl:  
tweak: Holy hand grenades are more viable, and the holy hand grenade item will now trigger the holy explosion effect
/:cl:
