### PR TITLE
Runtime fix

### DIFF
--- a/code/game/turfs/simulated/floor/mineral_floor.dm
+++ b/code/game/turfs/simulated/floor/mineral_floor.dm
@@ -214,7 +214,7 @@
 
 /turf/open/floor/mineral/uranium/proc/radiate()
 	if(!active)
-		if(world.time > last_event+15)
+		if((SSticker.current_state == GAME_STATE_PLAYING) && (world.time > last_event+15))
 			active = 1
 			radiation_pulse(src, 10)
 			for(var/turf/open/floor/mineral/uranium/T in orange(1,src))


### PR DESCRIPTION

runtime error: Cannot read null.gases
--
  |   | - proc name: rad act (/turf/open/rad_act)
  |   | - source file: open.dm,277
  |   | - usr: null
  |   | - src: the uranium floor (197,145,3) (/turf/open/floor/mineral/uranium)
  |   | - call stack:
  |   | - the uranium floor (197,145,3) (/turf/open/floor/mineral/uranium): rad act(10)
  |   | - radiation pulse(the uranium floor (197,145,3) (/turf/open/floor/mineral/uranium), 10, null, 0, 1)
  |   | - the uranium floor (197,145,3) (/turf/open/floor/mineral/uranium): radiate()
  |   | - the uranium floor (198,144,3) (/turf/open/floor/mineral/uranium): radiate()
  |   | - the uranium floor (198,144,3) (/turf/open/floor/mineral/uranium): Entered(Space Bat (/mob/living/simple_animal/hostile/retaliate/bat))
  |   | - the uranium floor (198,144,3) (/turf/open/floor/mineral/uranium): Initialize(1)
  |   | - the uranium floor (198,144,3) (/turf/open/floor/mineral/uranium): Initialize(1)
  |   | - the uranium floor (198,144,3) (/turf/open/floor/mineral/uranium): Initialize(1)
  |   | - the uranium floor (198,144,3) (/turf/open/floor/mineral/uranium): Initialize(1)
  |   | - Atoms (/datum/controller/subsystem/atoms): InitAtom(the uranium floor (198,144,3) (/turf/open/floor/mineral/uranium), /list (/list))
  |   | - Atoms (/datum/controller/subsystem/atoms): InitializeAtoms(null)
  |   | - Atoms (/datum/controller/subsystem/atoms): Initialize(109150)
  |   | - Master (/datum/controller/master): Initialize(10, 0, 1)
  |   | -

