### PR TITLE
runtime boogaloo

### DIFF
--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -133,7 +133,8 @@
 		var/mob/living/carbon/M = L
 		. = TRUE
 		for(var/I in M.held_items)
-			wash_obj(I)
+			if(isobj(I))
+				wash_obj(I)
 
 		if(M.back && wash_obj(M.back))
 			M.update_inv_back(0)


### PR DESCRIPTION

runtime error: Cannot read null.comp_lookup
--
  |   | - proc name: wash obj (/obj/machinery/shower/proc/wash_obj)
  |   | - source file: shower.dm,115
  |   | - usr: Bingford Bongo (/mob/living/carbon/human)
  |   | - src: the shower (/obj/machinery/shower)
  |   | - usr.loc: the floor (137,159,2) (/turf/open/floor/plasteel/freezer)
  |   | - src.loc: the floor (137,159,2) (/turf/open/floor/plasteel/freezer)
  |   | - call stack:
  |   | - the shower (/obj/machinery/shower): wash obj(null)
  |   | - the shower (/obj/machinery/shower): wash mob(Bingford Bongo (/mob/living/carbon/human))
  |   | - the shower (/obj/machinery/shower): wash atom(Bingford Bongo (/mob/living/carbon/human))
  |   | - the shower (/obj/machinery/shower): Crossed(Bingford Bongo (/mob/living/carbon/human))
  |   | - Bingford Bongo (/mob/living/carbon/human): Move(the floor (137,159,2) (/turf/open/floor/plasteel/freezer), 1)
  |   | - Bingford Bongo (/mob/living/carbon/human): Move(the floor (137,159,2) (/turf/open/floor/plasteel/freezer), 1)
  |   | - Bingford Bongo (/mob/living/carbon/human): Move(the floor (137,159,2) (/turf/open/floor/plasteel/freezer), 1)
  |   | - Bingford Bongo (/mob/living/carbon/human): Move(the floor (137,159,2) (/turf/open/floor/plasteel/freezer), 1)
  |   | - Bingford Bongo (/mob/living/carbon/human): Move(the floor (137,159,2) (/turf/open/floor/plasteel/freezer), 1)
  |   | - Exdav2 (/client): Move(the floor (137,159,2) (/turf/open/floor/plasteel/freezer), 1)
  |   | - Bingford Bongo (/mob/living/carbon/human): keyLoop(Exdav2 (/client))
  |   | - Bingford Bongo (/mob/living/carbon/human): keyLoop(Exdav2 (/client))
  |   | - Exdav2 (/client): keyLoop()
  |   | - Input (/datum/controller/subsystem/input): fire(0)
  |   | - Input (/datum/controller/subsystem/input): ignite(0)
  |   | - Master (/datum/controller/master): RunQueue()
  |   | - Master (/datum/controller/master): Loop()
  |   | - Master (/datum/controller/master): StartProcessing(0)
  |   | -

