### PR TITLE
Removes xenobiology console from spawning at round start, must now be constructed

### DIFF
--- a/_maps/yogstation/map_files/MinskyStation/MinskyStation.dmm
+++ b/_maps/yogstation/map_files/MinskyStation/MinskyStation.dmm
@@ -85171,9 +85171,8 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/computer/camera_advanced/xenobio{
-	dir = 1
-	},
+/obj/structure/table/glass,
+/obj/item/extinguisher,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "dpv" = (
@@ -85218,9 +85217,8 @@
 	req_access_txt = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/computer/camera_advanced/xenobio{
-	dir = 1
-	},
+/obj/structure/table/glass,
+/obj/item/extinguisher,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "dpA" = (

--- a/_maps/yogstation/map_files/YogStation/YogStation.dmm
+++ b/_maps/yogstation/map_files/YogStation/YogStation.dmm
@@ -46778,15 +46778,15 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bPA" = (
-/obj/machinery/computer/camera_advanced/xenobio{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/table/glass,
+/obj/item/extinguisher,
+/obj/item/extinguisher,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bPB" = (
@@ -52531,6 +52531,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"cLv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/table/glass,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "cLJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -103577,7 +103587,7 @@ bLa
 bMi
 buu
 bPy
-bPA
+cLv
 bJN
 bRW
 bTb

--- a/_maps/yogstation/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/yogstation/map_files/YogsDelta/YogsDelta.dmm
@@ -101011,12 +101011,11 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cXm" = (
-/obj/machinery/computer/camera_advanced/xenobio{
-	dir = 8
-	},
 /obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
+/obj/structure/table/reinforced,
+/obj/item/extinguisher,
 /turf/open/floor/circuit/green,
 /area/science/xenobiology)
 "cXn" = (
@@ -125718,6 +125717,15 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/space,
 /area/space/nearstation)
+"hFQ" = (
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
+/obj/structure/table/reinforced,
+/obj/item/extinguisher,
+/obj/item/extinguisher,
+/turf/open/floor/circuit/green,
+/area/science/xenobiology)
 "hLm" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -159244,7 +159252,7 @@ cTV
 cVT
 cXm
 cZb
-cXm
+hFQ
 dcu
 ddV
 cMY

--- a/_maps/yogstation/map_files/YogsDonut/YogsDonut.dmm
+++ b/_maps/yogstation/map_files/YogsDonut/YogsDonut.dmm
@@ -33690,7 +33690,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bqg" = (
-/obj/machinery/computer/camera_advanced/xenobio,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bqh" = (
@@ -49103,9 +49102,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bSe" = (
-/obj/structure/chair/comfy/black{
-	dir = 1
-	},
 /turf/open/floor/plasteel/white/side,
 /area/science/xenobiology)
 "bSf" = (
@@ -53342,13 +53338,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"cbz" = (
-/obj/machinery/computer/camera_advanced/xenobio{
-	icon_state = "computer";
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "cbA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -73102,7 +73091,7 @@ aAI
 bXK
 aAI
 cfc
-cbz
+bqg
 aAH
 aTp
 cca

--- a/_maps/yogstation/map_files/YogsPubby/YogsPubby.dmm
+++ b/_maps/yogstation/map_files/YogsPubby/YogsPubby.dmm
@@ -33398,13 +33398,14 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "blZ" = (
-/obj/machinery/computer/camera_advanced/xenobio,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/structure/table/glass,
+/obj/item/extinguisher,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bma" = (
@@ -35925,14 +35926,12 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bqF" = (
-/obj/machinery/computer/camera_advanced/xenobio{
-	dir = 1
-	},
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/structure/table/glass,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bqG" = (

--- a/_maps/yogstation/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/yogstation/map_files/Yogsmeta/Yogsmeta.dmm
@@ -56216,10 +56216,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/computer/camera_advanced/xenobio,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/structure/table/glass,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bXh" = (
@@ -56360,13 +56360,13 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "bXw" = (
-/obj/machinery/computer/camera_advanced/xenobio,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/table/glass,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bXx" = (

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -180,7 +180,7 @@
 	display_name = "Basic Bluespace Theory"
 	description = "Basic studies into the mysterious alternate dimension known as bluespace."
 	prereq_ids = list("base")
-	design_ids = list("beacon", "xenobioconsole", "telesci_gps", "bluespace_crystal")
+	design_ids = list("beacon", "telesci_gps", "bluespace_crystal")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
@@ -216,7 +216,7 @@
 	display_name = "Applied Bluespace Research"
 	description = "Using bluespace to make things faster and better."
 	prereq_ids = list("bluespace_basic", "engineering")
-	design_ids = list("bs_rped","minerbag_holding", "bluespacebeaker", "bluespacesyringe", "phasic_scanning", "roastingstick", "ore_silo")
+	design_ids = list("bs_rped","minerbag_holding", "bluespacebeaker", "bluespacesyringe", "phasic_scanning", "roastingstick", "ore_silo", "xenobioconsole")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	export_price = 5000
 


### PR DESCRIPTION
Requested by @Oakboscage 

Should serve to slow down xenobiology in the early-game and provide some incentive to get the research completed quicker, if it hasn't been already.

The consoles are still availiable, they can be printed in R&D as soon as the practical bluespace theory research has been completed.

:cl:  
tweak: The Xenobiology console must now be constructed, it no longer spawns at round start.
/:cl:
