### PR TITLE
Runtime 3

### DIFF
--- a/yogstation/code/datums/mutations.dm
+++ b/yogstation/code/datums/mutations.dm
@@ -56,7 +56,7 @@
 					"<span class='danger'>Your brain feels like it's being torn apart, and after a short while, you notice that you've become a cluwne!</span>")
 	flash_act()
 
-/datum/mutation/human/tourettes/on_life(mob/living/carbon/human/owner)
+/datum/mutation/human/tourettes/on_life()
 	if(prob(10) && owner.stat == CONSCIOUS)
 		owner.Stun(20)
 		switch(rand(1, 3))


### PR DESCRIPTION

runtime error: Cannot read null.stat
--
  |   | - proc name: on life (/datum/mutation/human/tourettes/on_life)
  |   | - source file: mutations.dm,60
  |   | - usr: null
  |   | - src: Tourette\'s Syndrome (/datum/mutation/human/tourettes)
  |   | - call stack:
  |   | - Tourette\'s Syndrome (/datum/mutation/human/tourettes): on life(null)
  |   | - Lauren Burris (/mob/living/carbon/human): Life(2, 273)
  |   | - Lauren Burris (/mob/living/carbon/human): Life(2, 273)
  |   | - Mobs (/datum/controller/subsystem/mobs): fire(0)
  |   | - Mobs (/datum/controller/subsystem/mobs): ignite(0)
  |   | - Master (/datum/controller/master): RunQueue()
  |   | - Master (/datum/controller/master): Loop()
  |   | - Master (/datum/controller/master): StartProcessing(0)

