### PR TITLE
Atmos Runtimes

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -49,6 +49,10 @@
 	for(var/direction in GLOB.cardinals_multiz)
 		var/turf/T = get_step_multiz(src, direction)
 		if(!isopenturf(T))
+			if(atmos_adjacent_turfs[T])
+				atmos_adjacent_turfs -= T
+			if(T.atmos_adjacent_turfs[src])
+				T.atmos_adjacent_turfs -= src
 			continue
 		if(!(blocks_air || T.blocks_air) && ((direction & (UP|DOWN))? (canvpass && CANVERTICALATMOSPASS(T, src)) : (canpass && CANATMOSPASS(T, src))) )
 			LAZYINITLIST(atmos_adjacent_turfs)


### PR DESCRIPTION
This is a terrible idea.


runtime error: undefined variable /turf/closed/wall/mineral/titanium/survival/pod/var/air
--
  |   | - proc name: process cell (/turf/open/process_cell)
  |   | - source file: LINDA_turf_tile.dm,186
  |   | - usr: null
  |   | - src: the volcanic floor (58,55,5) (/turf/open/floor/plating/asteroid/basalt/lava_land_surface)
  |   | - call stack:
  |   | - the volcanic floor (58,55,5) (/turf/open/floor/plating/asteroid/basalt/lava_land_surface): process cell(1053)
  |   | - Atmospherics (/datum/controller/subsystem/air): process active turfs(0)
  |   | - Atmospherics (/datum/controller/subsystem/air): fire(0)
  |   | - Atmospherics (/datum/controller/subsystem/air): ignite(0)
  |   | - Master (/datum/controller/master): RunQueue()
  |   | - Master (/datum/controller/master): Loop()
  |   | - Master (/datum/controller/master): StartProcessing(0)
  |   | -

