### PR TITLE
Decrease R&D single-server income by 15%

### DIFF
--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -30,7 +30,7 @@ SUBSYSTEM_DEF(research)
 	var/list/errored_datums = list()
 	var/list/point_types = list()				//typecache style type = TRUE list
 	//----------------------------------------------
-	var/list/single_server_income = list(TECHWEB_POINT_TYPE_GENERIC = 54.3)
+	var/list/single_server_income = list(TECHWEB_POINT_TYPE_GENERIC = 46.2)
 	var/multiserver_calculation = FALSE
 	var/last_income = 0
 	//^^^^^^^^ ALL OF THESE ARE PER SECOND! ^^^^^^^^


### PR DESCRIPTION
Partial revert of tgstation/tgstation#33857

Research has more ways of generating points now, and the passive cookie clicker gain should reflect that.

:cl:  
tweak: Decrease R&D single-server income by 15% 
/:cl:
