### PR TITLE
Removes the flamethrower from the hacked autolathe

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -676,13 +676,6 @@
 	category = list("initial", "Misc")
 
 //hacked autolathe recipes
-/datum/design/flamethrower
-	name = "Flamethrower"
-	id = "flamethrower"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 500)
-	build_path = /obj/item/flamethrower/full
-	category = list("hacked", "Security")
 
 /datum/design/rcd
 	name = "Rapid Construction Device (RCD)"


### PR DESCRIPTION
### Intent of your Pull Request

Let's remove weapons from machines that p much anyone has access too, yay

#### Changelog

:cl:  
tweak: flamethrower is no longer obtainable through the autolathe
/:cl:
