### PR TITLE
shuts up a runtime

### DIFF
--- a/yogstation/code/modules/research/techweb/all_nodes.dm
+++ b/yogstation/code/modules/research/techweb/all_nodes.dm
@@ -92,7 +92,7 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 4500)
 	export_price = 4500
 	prereq_ids = list("spacepod_pseat", "high_efficiency")
-	design_ids = list("podcargo_lootbox", "podcargo_crate", "podcargo_ore")
+	design_ids = list("podcargo_crate", "podcargo_ore")
 
 /datum/techweb_node/spacepod_lockbuster
 	id = "spacepod_lockbuster"


### PR DESCRIPTION
G: Invalid research design with ID podcargo_lootbox detected in node Spacepod Storage[spacepod_storage] removed. in code/controllers/subsystem/research.dm at line 178 src: Research usr: .