### PR TITLE
Fixes a runtime that I probably caused in the first place

### DIFF
--- a/yogstation/code/modules/atmospherics/unary_devices/vent_pump.dm
+++ b/yogstation/code/modules/atmospherics/unary_devices/vent_pump.dm
@@ -30,6 +30,6 @@
 	..()
 
 /obj/machinery/atmospherics/components/unary/vent_pump/examine(mob/user)
-	..()
+	.=..()
 	if(cover)
 		. += "Its cover is open."


### PR DESCRIPTION

runtime error: Cannot execute null.Join().
--
  |   | - verb name: Examine (/mob/verb/examinate)
  |   | - source file: mob.dm,309
  |   | - usr: (src)
  |   | - src: Nitryl IV (/mob/living/carbon/human)
  |   | - src.loc: the carpet (126,160,2) (/turf/open/floor/carpet)
  |   | - call stack:
  |   | - Nitryl IV (/mob/living/carbon/human): Examine(the Dormitories vent pump #4 (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1))
  |   | - the Dormitories vent pump #4 (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1): ShiftClick(Nitryl IV (/mob/living/carbon/human))
  |   | - Nitryl IV (/mob/living/carbon/human): ShiftClickOn(the Dormitories vent pump #4 (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1))
  |   | - Nitryl IV (/mob/living/carbon/human): ClickOn(the Dormitories vent pump #4 (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1), "icon-x=25;icon-y=12;left=1;shi...")
  |   | - the Dormitories vent pump #4 (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1): Click(the carpet (127,159,2) (/turf/open/floor/carpet), "mapwindow.map", "icon-x=25;icon-y=12;left=1;shi...")
  |   | - SunoPerson (/client): Click(the Dormitories vent pump #4 (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1), the carpet (127,159,2) (/turf/open/floor/carpet), "mapwindow.map", "icon-x=25;icon-y=12;left=1;shi...")
  |   | - SunoPerson (/client): Click(the Dormitories vent pump #4 (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1), the carpet (127,159,2) (/turf/open/floor/carpet), "mapwindow.map", "icon-x=25;icon-y=12;left=1;shi...")
  |   | -

