### PR TITLE
Removes devour will summon channel time for darkspawn

### DIFF
--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/devour_will.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/devour_will.dm
@@ -21,15 +21,7 @@
 	return ..()
 
 /datum/action/innate/darkspawn/devour_will/Activate()
-	in_use = TRUE
-	owner.visible_message("<span class='warning'>[owner]'s hand begins to shimmer...</span>", "<span class='velvet'><b>pwga...</b><br>\
-	You begin forming a dark bead...</span>")
-	playsound(owner, 'yogstation/sound/magic/devour_will_begin.ogg', 50, 1)
-	if(!do_after(owner, 10, target = owner))
-		in_use = FALSE
-		return
-	in_use = FALSE
-	owner.visible_message("<span class='warning'>A glowing black orb appears in [owner]'s hand!</span>", "<span class='velvet'><b>...iejz</b><br>\
+	owner.visible_message("<span class='warning'>A glowing black orb appears in [owner]'s hand!</span>", "<span class='velvet'><b>pwga...iejz</b><br>\
 	You form a dark bead in your hand.</span>")
 	playsound(owner, 'yogstation/sound/magic/devour_will_form.ogg', 50, 1)
 	var/obj/item/dark_bead/B = new


### PR DESCRIPTION
This will push it more towards acting as a main ability but it should make it easier to use
:cl:  
tweak: Devour will spawns the dark bead instantly
/:cl:
