### PR TITLE
You can no longer get a BoH from presents.

### DIFF
--- a/code/game/objects/items/gift.dm
+++ b/code/game/objects/items/gift.dm
@@ -56,7 +56,6 @@ GLOBAL_LIST_EMPTY(possible_gifts)
 		/obj/item/storage/photo_album,
 		/obj/item/storage/box/snappops,
 		/obj/item/storage/crayons,
-		/obj/item/storage/backpack/holding,
 		/obj/item/storage/belt/champion,
 		/obj/item/soap/deluxe,
 		/obj/item/pickaxe/diamond,


### PR DESCRIPTION
### Intent of your Pull Request
Let's face it, even if it's on a very low chance, getting a BoH at the start of a round or from any present is dumb.


#### Changelog

:cl:  
rscdel: You can no longer get a bag of holding from presents.  
/:cl:
