### PR TITLE
Readds high functioning zombies and vampires to halloween holiday

### DIFF
--- a/yogstation/code/modules/mob/living/carbon/human/species_types/halloween.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/halloween.dm
@@ -1,9 +1,2 @@
 /datum/species/shadow/check_roundstart_eligible()
           return FALSE
-		  
-/datum/species/vampire/check_roundstart_eligible()
-          return FALSE
-
-/datum/species/zombie/check_roundstart_eligible()
-          return FALSE
-


### PR DESCRIPTION
🆑
tweak: High functioning zombies and vampires are readded to the halloween holiday!
/🆑

The main reasons they got removed were because they were too annoying for admemes for a holiday that lasted a whole month now that its back to what it originally was might as well revert this as well (except for shadowlings cause ehhhhhhhh)