### PR TITLE
Order NanoGene Refill added to Supply Request Console

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1379,6 +1379,13 @@
 	crate_type = /obj/structure/closet/crate/secure/science
 	dangerous = TRUE
 
+/datum/supply_pack/science/genetics
+	name = "Genetics Resupply Crate"
+	desc = "It's got what geneticists crave, its got Monkey Cubes!."
+	cost = 750
+	contains = list(/obj/item/vending_refill/wallgene)
+	crate_name = "Genetics Crate"
+
 //////////////////////////////////////////////////////////////////////////////
 /////////////////////////////// Service //////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Adds NanoGene refills to cargo order list

### Order NanoGene Refill added to Supply Request Console

Keep those geneticists (and the xenobiologists who will steal from the geneticists) in style with NanoGene Refills.

**The Monkey Cubes must flow!!!**

#### Changelog

:cl:  
rscadd: Adds NanoGene Refills to Supply Request Console 
/:cl:
