### PR TITLE
Made most of the halloween races visual only and added some new ones! (also turned the date back to start on the 24th)

### DIFF
--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -350,7 +350,7 @@
 
 /datum/holiday/halloween
 	name = HALLOWEEN
-	begin_day = 26
+	begin_day = 10 // yogs - Changed halloween start day
 	begin_month = OCTOBER
 	end_day = 2
 	end_month = NOVEMBER

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -350,7 +350,7 @@
 
 /datum/holiday/halloween
 	name = HALLOWEEN
-	begin_day = 10 // yogs - Changed halloween start day
+	begin_day = 24 // yogs - Changed halloween start day
 	begin_month = OCTOBER
 	end_day = 2
 	end_month = NOVEMBER

--- a/code/modules/mob/living/carbon/human/species_types/abductors.dm
+++ b/code/modules/mob/living/carbon/human/species_types/abductors.dm
@@ -17,3 +17,19 @@
 	. = ..()
 	var/datum/atom_hud/abductor_hud = GLOB.huds[DATA_HUD_ABDUCTOR]
 	abductor_hud.remove_hud_from(C)
+
+/datum/species/fakeabductor //yogs start
+	name = "Fake Abductor"
+	id = "fakeabductor"
+	limbs_id = "abductor"
+	say_mod = "gibbers"
+	sexes = FALSE
+	changesource_flags = MIRROR_BADMIN
+
+/datum/species/fakeabductor/qualifies_for_rank(rank, list/features)
+	return TRUE	//They are just humans in very detailed costumes.
+
+/datum/species/fakeabductor/check_roundstart_eligible()
+	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
+		return TRUE
+	return ..() //yogs end

--- a/code/modules/mob/living/carbon/human/species_types/flypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/flypeople.dm
@@ -34,3 +34,8 @@
 	if(istype(weapon, /obj/item/melee/flyswatter))
 		return 29 //Flyswatters deal 30x damage to flypeople.
 	return 0
+
+/datum/species/fly/check_roundstart_eligible()
+	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
+		return TRUE
+	return ..() //yogs end

--- a/code/modules/mob/living/carbon/human/species_types/mushpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mushpeople.dm
@@ -59,3 +59,26 @@
 /datum/species/mush/handle_mutant_bodyparts(mob/living/carbon/human/H, forced_colour)
 	forced_colour = FALSE
 	..()
+
+/datum/species/fakemush //yogs what mush? this is just a midget in a super glued costume.
+	name = "Fake Mushroomperson"
+	id = "fakemush"
+	limbs_id = "mush"
+	mutant_bodyparts = list("caps")
+	default_features = list("caps" = "Round")
+	changesource_flags = MIRROR_BADMIN
+	species_traits = list(MUTCOLORS, NOEYESPRITES, NO_UNDERWEAR)
+	fixed_mut_color = "DBBF92"
+	hair_color = "FF4B19" //cap color, spot color uses eye color
+	nojumpsuit = TRUE
+	say_mod = "poofs" //what does a mushroom sound like
+	no_equip = list(SLOT_WEAR_MASK, SLOT_WEAR_SUIT, SLOT_GLOVES, SLOT_SHOES, SLOT_W_UNIFORM)
+	use_skintones = FALSE
+
+/datum/species/fakemush/qualifies_for_rank(rank, list/features)
+	return TRUE	//They are just humans in very detailed costumes.
+
+/datum/species/fakemush/check_roundstart_eligible()
+	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
+		return TRUE
+	return ..() //yogs end

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -216,5 +216,22 @@
 		O.burn()
 	playsound(src, 'sound/items/welder.ogg', 50, 1)
 
+/datum/species/fakeshadow //yogs start
+	// Humans wearing extremely detailed full body makeup. Very spooky
+	name = "Fake shadowling"
+	id = "fakeshadow"
+	limbs_id = "shadow"
+	species_traits = list(NOEYESPRITES)
+	sexes = 0
+	changesource_flags = MIRROR_BADMIN
+
+/datum/species/fakeshadow/qualifies_for_rank(rank, list/features)
+	return TRUE	//They are just humans in very detailed costumes.
+
+/datum/species/fakeshadow/check_roundstart_eligible()
+	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
+		return TRUE
+	return ..() //yogs end
+
 #undef HEART_SPECIAL_SHADOWIFY
 #undef HEART_RESPAWN_THRESHHOLD

--- a/code/modules/mob/living/carbon/human/species_types/skeletons.dm
+++ b/code/modules/mob/living/carbon/human/species_types/skeletons.dm
@@ -19,3 +19,24 @@
 	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
 		return TRUE
 	return ..()
+
+/datum/species/fakeskeleton //yogs start
+	// 2spooky?
+	name = "Fake Spooky Scary Skeleton"
+	id = "fakeskeleton"
+	limbs_id = "skeleton"
+	say_mod = "rattles"
+	sexes = 0
+	mutanttongue = /obj/item/organ/tongue/bone
+	damage_overlay_type = ""
+	disliked_food = GROSS | RAW
+	liked_food = JUNKFOOD | FRIED
+	changesource_flags = MIRROR_BADMIN
+
+/datum/species/fakeskeleton/qualifies_for_rank(rank, list/features)
+	return TRUE	//They are just humans in very detailed costumes.
+
+/datum/species/fakeskeleton/check_roundstart_eligible()
+	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
+		return TRUE
+	return ..() //yogs end

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -48,7 +48,7 @@
 /datum/species/zombie/infectious/spec_life(mob/living/carbon/C)
 	. = ..()
 	C.a_intent = INTENT_HARM // THE SUFFERING MUST FLOW
-	
+
 	//Zombies never actually die, they just fall down until they regenerate enough to rise back up.
 	//They must be restrained, beheaded or gibbed to stop being a threat.
 	if(regen_cooldown < world.time)
@@ -59,7 +59,7 @@
 		C.adjustToxLoss(-heal_amt)
 	if(!C.InCritical() && prob(4))
 		playsound(C, pick(spooks), 50, TRUE, 10)
-		
+
 //Congrats you somehow died so hard you stopped being a zombie
 /datum/species/zombie/infectious/spec_death(mob/living/carbon/C)
 	. = ..()
@@ -90,5 +90,22 @@
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/zombie
 	mutanttongue = /obj/item/organ/tongue/zombie
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | ERT_SPAWN
+
+/datum/species/fakezombie //yogs start
+	name = "Fake Zombie"
+	id = "fakezombies"
+	limbs_id = "zombie" //They look like zombies
+	sexes = 0
+	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/zombie
+	mutanttongue = /obj/item/organ/tongue/zombie
+	changesource_flags = MIRROR_BADMIN
+
+/datum/species/fakezombie/qualifies_for_rank(rank, list/features)
+	return TRUE	//They are just humans in very detailed costumes.
+
+/datum/species/fakezombie/check_roundstart_eligible()
+	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
+		return TRUE
+	return ..() //yogs end
 
 #undef REGENERATION_DELAY

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/halloween.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/halloween.dm
@@ -1,9 +1,14 @@
 /datum/species/shadow/check_roundstart_eligible()
           return FALSE
-		  
+
 /datum/species/vampire/check_roundstart_eligible()
           return FALSE
 
 /datum/species/zombie/check_roundstart_eligible()
           return FALSE
 
+/datum/species/skeleton/check_roundstart_eligible()
+          return FALSE
+
+/datum/species/golem/cloth/check_roundstart_eligible()
+          return FALSE


### PR DESCRIPTION
🆑
tweak: All the Halloween races except for the one race that can take there head off are now visual only!
tweak: Halloween now starting early once more!
tweak: Now heads of staff can also join in the Halloween spirit!
tweak: Removed cloth golem from the halloween race list
/🆑
Vampire is also still removed because they arnt unique enough visually and added fly people, visual only mush people and visual only abductors as valid halloween races