### PR TITLE
Various small map fixes/changes that were annoying me

### DIFF
--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -1084,24 +1084,15 @@
 /turf/closed/wall,
 /area/bridge)
 "abB" = (
-/obj/machinery/computer/robotics{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/ai_slipper{
+	uses = 10
 	},
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
+/turf/open/floor/circuit/green,
+/area/ai_monitored/turret_protected/ai)
 "abC" = (
 /obj/structure/cable/white{
 	icon_state = "2-4"
@@ -2615,20 +2606,25 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aej" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/newscaster{
+	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "aek" = (
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
@@ -3313,22 +3309,25 @@
 	},
 /area/crew_quarters/heads/captain/private)
 "afp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/obj/machinery/camera{
-	c_tag = "Bridge - Port Access";
-	dir = 8;
-	name = "command camera"
+/obj/item/storage/toolbox/electrical,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
+/obj/structure/table,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
-/area/bridge)
+/area/ai_monitored/turret_protected/aisat_interior)
 "afq" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/westright{
@@ -3397,26 +3396,20 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "aft" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/porta_turret/ai{
+	installation = /obj/item/gun/energy/e_gun/turret
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/camera{
-	c_tag = "Bridge - Starboard Access";
-	dir = 4;
-	name = "command camera"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
-/area/bridge)
+/area/ai_monitored/turret_protected/aisat_interior)
 "afu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3998,21 +3991,24 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
 "ago" = (
-/obj/structure/table/wood,
+/obj/machinery/computer/robotics{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26;
-	pixel_y = -32
-	},
-/obj/item/clipboard,
-/obj/item/stack/packageWrap,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/hand_labeler,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/hop)
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "agp" = (
 /obj/machinery/vending/cart,
 /obj/structure/cable/white{
@@ -4651,17 +4647,23 @@
 	},
 /area/maintenance/starboard/fore)
 "ahk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera{
+	c_tag = "Bridge - Port Access";
+	dir = 8;
+	name = "command camera"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = 26;
+	pixel_y = 0
 	},
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "ahl" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -4822,23 +4824,26 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ahy" = (
-/obj/machinery/suit_storage_unit/security,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/machinery/camera{
+	c_tag = "Bridge - Starboard Access";
+	dir = 4;
+	name = "command camera"
 	},
-/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/bridge)
 "ahz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
@@ -4857,20 +4862,21 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ahB" = (
-/obj/machinery/photocopier,
+/obj/structure/table/wood,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -26;
+	pixel_y = -32
+	},
+/obj/item/clipboard,
+/obj/item/stack/packageWrap,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/hand_labeler,
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+	dir = 1;
+	pixel_y = -26
 	},
-/obj/structure/cable/white{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/detectives_office)
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hop)
 "ahC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
@@ -4994,15 +5000,17 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/captain/private)
 "ahM" = (
-/obj/machinery/firealarm{
-	dir = 1;
+/obj/machinery/light_switch{
+	pixel_x = -24;
 	pixel_y = -24
 	},
-/obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
-/obj/item/lighter,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain/private)
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "ahN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/white,
@@ -5080,12 +5088,24 @@
 /turf/open/floor/circuit/green,
 /area/ai_monitored/nuke_storage)
 "ahU" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/machinery/suit_storage_unit/security,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
-/turf/open/floor/circuit/green,
-/area/ai_monitored/nuke_storage)
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "ahV" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/aimodule_neutral{
@@ -5989,16 +6009,20 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "ajl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/machinery/photocopier,
+/obj/structure/cable/white{
+	icon_state = "2-4"
 	},
+/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/detectives_office)
 "ajm" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -6111,18 +6135,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "ajv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/structure/table/wood,
+/obj/item/storage/fancy/donut_box,
+/obj/item/lighter,
 /obj/machinery/firealarm{
-	pixel_y = 24
+	dir = 1;
+	pixel_y = -26
 	},
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain/private)
 "ajw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -6182,21 +6203,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "ajB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Central Hallway North-West";
-	dir = 2
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/quartermaster/storage)
 "ajC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7999,20 +8009,12 @@
 	},
 /area/hallway/primary/starboard)
 "amu" = (
-/obj/machinery/vending/snack/random,
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+	dir = 1;
+	pixel_y = -26
 	},
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/starboard)
+/turf/open/floor/circuit/green,
+/area/ai_monitored/nuke_storage)
 "amv" = (
 /obj/machinery/computer/bounty{
 	dir = 4
@@ -8046,20 +8048,20 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "amy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/light,
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/area/hallway/primary/fore)
 "amz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/brown,
@@ -8321,25 +8323,18 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
 "amT" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/cable_coil/white,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Bridge - Teleporter";
-	dir = 4;
-	name = "command camera"
-	},
-/obj/effect/turf_decal/tile/neutral,
+/obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/teleporter)
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "amU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -8483,16 +8478,20 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "anj" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/machinery/light,
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
 	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
-/area/ai_monitored/storage/eva)
+/area/quartermaster/storage)
 "ank" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -8534,11 +8533,24 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "ann" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/sign/departments/minsky/supply/cargo,
-/turf/open/floor/plating,
-/area/quartermaster/storage)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Central Hallway North-West";
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/structure/sign/departments/minsky/supply/cargo{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "ano" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining/glass{
@@ -9103,27 +9115,25 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aod" = (
-/obj/machinery/vending/snack/random,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/item/stack/cable_coil/white,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
+/obj/machinery/camera{
+	c_tag = "Bridge - Teleporter";
+	dir = 4;
+	name = "command camera"
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
+/area/teleporter)
 "aoe" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
@@ -9299,25 +9309,17 @@
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
 "aos" = (
-/obj/item/storage/box/teargas{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
 	},
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/flashbangs{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/structure/table/reinforced,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+	pixel_x = 26;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/ai_monitored/storage/eva)
 "aot" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -10546,23 +10548,16 @@
 /turf/open/floor/plasteel/white,
 /area/medical)
 "aqm" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/bodybags{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/item/storage/box/bodybags,
-/obj/item/pen,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = -26
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
-/area/medical)
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "aqn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -10590,7 +10585,6 @@
 "aqp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/sign/departments/minsky/medical/clone/cloning2,
 /turf/open/floor/plating,
 /area/medical)
 "aqq" = (
@@ -10707,11 +10701,11 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
+	},
+/obj/structure/sign/departments/minsky/medical/clone/cloning2{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel/white,
 /area/medical)
@@ -10845,22 +10839,22 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aqP" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
+/obj/item/storage/box/teargas{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/flashbangs{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Security - Brig Aft";
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -11083,11 +11077,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical)
 "arj" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_x = 32
 	},
-/turf/open/floor/plasteel/white,
-/area/medical)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/smartfridge/chemistry/preloaded,
+/turf/closed/wall,
+/area/medical/chemistry)
 "ark" = (
 /obj/machinery/mineral/equipment_vendor,
 /turf/open/floor/plasteel,
@@ -11227,7 +11223,12 @@
 /area/medical)
 "art" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/departments/medbay/alt,
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_y = -28
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/medical)
 "aru" = (
@@ -12530,23 +12531,26 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
 "atj" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
 	},
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/camera{
+	c_tag = "Security - Brig Aft";
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar/atrium)
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "atk" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -13539,28 +13543,37 @@
 /turf/open/floor/plasteel,
 /area/medical)
 "auy" = (
-/obj/machinery/vending/medical,
-/obj/machinery/firealarm{
+/obj/machinery/airalarm{
 	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+	pixel_y = -22
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/medical)
-"auz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/departments/medbay/alt,
-/obj/structure/sign/warning/nosmoking/circle{
-	pixel_y = -28
+/obj/structure/closet/wardrobe/miner,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
+"auz" = (
+/obj/machinery/vending/coffee,
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/medical)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar/atrium)
 "auA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -14500,14 +14513,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "avX" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26;
+	pixel_y = 0
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "avY" = (
@@ -14515,15 +14529,15 @@
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
 /obj/machinery/cell_charger,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
 /obj/machinery/light_switch{
 	pixel_x = -24;
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "avZ" = (
@@ -14911,17 +14925,27 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "awD" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder{
+	desc = "Used to grind things up into raw materials and liquids.";
+	pixel_y = 5
 	},
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
-/area/medical)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar/atrium)
 "awE" = (
 /obj/item/retractor,
 /obj/item/hemostat,
@@ -15231,27 +15255,16 @@
 /turf/closed/wall,
 /area/crew_quarters/bar/atrium)
 "axb" = (
-/obj/structure/table/wood,
-/obj/machinery/reagentgrinder{
-	desc = "Used to grind things up into raw materials and liquids.";
-	pixel_y = 5
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26;
+	pixel_y = 0
 	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar/atrium)
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "axc" = (
 /obj/machinery/light,
 /obj/machinery/vending/wardrobe/bar_wardrobe,
@@ -16073,24 +16086,28 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ayl" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aym" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/structure/chair,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/hallway/secondary/exit)
 "ayn" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/delivery,
@@ -16217,29 +16234,20 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "ayD" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/machinery/door/window/eastright{
+	dir = 4;
+	name = "Theatre Stage"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical)
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "ayE" = (
 /obj/structure/table/wood,
 /obj/item/instrument/violin,
@@ -16558,35 +16566,43 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "aza" = (
-/obj/structure/chair,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/vending/snack/random,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/starboard)
 "azb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "azc" = (
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/toy/figure/chef,
+/obj/machinery/camera{
+	c_tag = "Kitchen";
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
-/area/medical)
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/kitchen)
 "azd" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable/white{
@@ -16619,17 +16635,21 @@
 /turf/open/floor/plasteel/dark,
 /area/medical)
 "azf" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -26;
-	pixel_y = -26
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
 	},
-/obj/structure/closet/secure_closet/paramedic,
-/obj/item/storage/firstaid/toxin,
-/obj/item/storage/firstaid/regular,
-/obj/item/borg/sight/hud/med,
-/turf/open/floor/plasteel/dark,
-/area/medical)
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/engine/break_room)
 "azg" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -16936,20 +16956,12 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "azH" = (
-/obj/machinery/door/window/eastright{
-	dir = 4;
-	name = "Theatre Stage"
-	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "azI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -18964,19 +18976,8 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "aCH" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "atmoslock";
-	name = "Atmospherics Lockdown Blast door"
-	},
-/obj/structure/sign/warning/electricshock{
-	pixel_x = -32
-	},
-/obj/structure/cable/white{
-	icon_state = "0-4"
-	},
 /obj/structure/sign/departments/minsky/engineering/atmospherics,
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/engine/atmos)
 "aCI" = (
 /obj/machinery/door/poddoor/preopen{
@@ -18989,9 +18990,6 @@
 	req_access_txt = "10"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
@@ -19174,23 +19172,24 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar/atrium)
 "aCV" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/toy/figure/chef,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/camera{
-	c_tag = "Kitchen";
-	dir = 2
+/obj/machinery/vending/clothing,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel/dark,
-/area/crew_quarters/kitchen)
+/area/crew_quarters/dorms)
 "aCW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral,
@@ -19471,21 +19470,29 @@
 /turf/closed/wall/r_wall,
 /area/engine/break_room)
 "aDw" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner{
+/obj/machinery/power/terminal{
 	dir = 1
 	},
-/area/engine/break_room)
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/camera{
+	c_tag = "SMES Access";
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "aDx" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -19537,6 +19544,10 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_x = 32;
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel/checker,
 /area/engine/break_room)
@@ -20270,24 +20281,19 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aEK" = (
-/obj/machinery/vending/clothing,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera{
+	c_tag = "Central Hallway West";
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/dorms)
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "aEL" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
@@ -20884,27 +20890,19 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aFy" = (
-/obj/machinery/power/terminal{
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+	pixel_y = 26
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/camera{
-	c_tag = "SMES Access";
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aFz" = (
 /obj/structure/closet/radiation,
@@ -21119,18 +21117,18 @@
 	},
 /area/hallway/primary/port)
 "aFL" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/bot,
 /obj/machinery/camera{
-	c_tag = "Central Hallway West";
-	dir = 8
+	c_tag = "Engineering Monitoring";
+	dir = 2
 	},
-/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/vending/wardrobe/engi_wardrobe,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/area/engine/engineering)
 "aFM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool,
@@ -21466,6 +21464,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/sign/departments/minsky/engineering/engineering{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
@@ -21520,6 +21521,10 @@
 	icon_state = "plant-22"
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/structure/sign/warning/electricshock{
+	pixel_x = 32;
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "aGv" = (
@@ -21629,6 +21634,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/central)
+"aGF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "0-4"
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "aGG" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -21907,6 +21921,64 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"aGY" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/landmark/start/station_engineer,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"aGZ" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/sign/departments/minsky/medical/chemistry/chemical2{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/white,
+/area/medical)
+"aHa" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/sign/departments/minsky/medical/medical2{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"aHb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/sign/departments/minsky/research/research{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"aHc" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/science/lab)
+"aHd" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/research)
 "aHe" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/effect/turf_decal/tile/neutral{
@@ -21921,6 +21993,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
+"aHf" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/structure/sign/departments/minsky/research/robotics{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/research)
 "aHg" = (
 /obj/machinery/camera{
 	c_tag = "Gravity Generator Room";
@@ -21976,6 +22065,13 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"aHk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/science/robotics/lab)
 "aHl" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -22072,20 +22168,26 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aHr" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
+/obj/structure/table,
+/obj/item/storage/pill_bottle/dice,
+/obj/machinery/light{
+	dir = 8
 	},
+/obj/effect/turf_decal/delivery,
 /obj/machinery/firealarm{
-	pixel_y = 24
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"aHs" = (
+/obj/machinery/smartfridge/extract/preloaded,
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "aHt" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -22101,6 +22203,16 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"aHu" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/sign/departments/minsky/supply/mining{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "aHv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -22108,23 +22220,18 @@
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "aHw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceblast";
-	name = "Engineering Lockdown Shutters"
-	},
-/obj/structure/sign/warning/electricshock{
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-8"
 	},
 /obj/structure/cable/white{
-	icon_state = "0-4"
+	icon_state = "4-8"
 	},
-/obj/structure/sign/departments/minsky/engineering/engineering,
+/obj/structure/sign/departments/botany{
+	pixel_y = -32
+	},
 /turf/open/floor/plating,
-/area/engine/engineering)
+/area/maintenance/starboard/aft)
 "aHx" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "ceblast";
@@ -22277,6 +22384,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/central)
+"aHG" = (
+/obj/structure/sign/poster/contraband/random,
+/turf/closed/wall/r_wall,
+/area/maintenance/starboard/aft)
 "aHH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -22304,6 +22415,32 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/central)
+"aHJ" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"aHK" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24;
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/camera{
+	c_tag = "Gravity Generator Entry";
+	dir = 2;
+	pixel_x = 23
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "aHL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
@@ -22350,23 +22487,22 @@
 /turf/closed/wall,
 /area/hydroponics)
 "aHR" = (
-/obj/structure/sign/departments/botany{
-	pixel_x = -32
-	},
+/obj/machinery/vending/snack/random,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
 "aHS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -22444,6 +22580,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
+"aHX" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "aHY" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -22534,6 +22682,19 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"aIg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
+/area/hallway/primary/starboard)
 "aIh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -22645,6 +22806,37 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"aIq" = (
+/obj/machinery/announcement_system,
+/obj/machinery/status_display/ai{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
+"aIr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "aIs" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/rods/fifty,
@@ -22664,18 +22856,27 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIu" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/machinery/vending/snack/random,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
-/obj/machinery/camera{
-	c_tag = "Engineering Monitoring";
-	dir = 2
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/machinery/vending/wardrobe/engi_wardrobe,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
 "aIv" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -22683,19 +22884,27 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIw" = (
-/obj/structure/chair/office/dark{
+/obj/structure/table/wood,
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/landmark/start/station_engineer,
-/obj/structure/cable/white{
-	icon_state = "1-2"
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/effect/turf_decal/bot,
-/obj/structure/cable/white{
-	icon_state = "2-4"
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/library)
 "aIx" = (
 /obj/machinery/light_switch{
 	pixel_x = 38;
@@ -23029,18 +23238,22 @@
 /turf/closed/wall,
 /area/hallway/primary/starboard)
 "aJa" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/dice,
+/obj/machinery/shower{
+	dir = 4;
+	name = "emergency shower"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
+/area/science/research)
 "aJb" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -23054,6 +23267,77 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit)
+"aJd" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/bodybags{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/bodybags,
+/obj/item/pen,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/white,
+/area/medical)
+"aJe" = (
+/obj/structure/table/glass,
+/obj/item/assembly/igniter,
+/obj/item/assembly/igniter,
+/obj/item/assembly/igniter,
+/obj/item/assembly/timer{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/assembly/timer{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/assembly/timer{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/chemistry)
+"aJf" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
+"aJg" = (
+/obj/structure/chair/comfy/brown{
+	buildstackamount = 0;
+	dir = 1
+	},
+/obj/effect/landmark/start/geneticist,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/lounge)
 "aJh" = (
 /obj/machinery/light{
 	dir = 8
@@ -23087,25 +23371,31 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"aJk" = (
+"aJj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24;
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/machinery/camera{
-	c_tag = "Gravity Generator Entry";
-	dir = 2;
-	pixel_x = 23
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/area/hallway/primary/aft)
+"aJk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/science/research)
 "aJl" = (
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
@@ -23211,6 +23501,29 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
+"aJv" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/research)
 "aJw" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -23219,6 +23532,33 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"aJx" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/storage/toolbox/electrical,
+/obj/item/screwdriver{
+	pixel_y = 5
+	},
+/obj/item/multitool,
+/obj/item/clothing/head/welding,
+/obj/machinery/camera{
+	c_tag = "Robotics Lab";
+	dir = 2;
+	network = list("ss13","rd")
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/robotics/lab)
 "aJy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23229,6 +23569,116 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"aJz" = (
+/obj/machinery/vending/medical,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/medical)
+"aJA" = (
+/obj/structure/filingcabinet/security,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24;
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint)
+"aJB" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-4"
+	},
+/obj/machinery/camera{
+	c_tag = "Mech Bay";
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/mechbay)
+"aJC" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/white,
+/area/medical)
+"aJD" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"aJE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical)
 "aJF" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -23370,6 +23820,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"aJN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical)
+"aJO" = (
+/obj/structure/closet/secure_closet/paramedic,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/regular,
+/obj/item/borg/sight/hud/med,
+/turf/open/floor/plasteel/dark,
+/area/medical)
 "aJP" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -23575,6 +24044,23 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/central)
+"aKg" = (
+/obj/machinery/computer/crew{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical)
 "aKh" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
@@ -23598,6 +24084,97 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"aKk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"aKl" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "xeno1";
+	name = "Containment Control";
+	req_access_txt = "55"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24;
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
+"aKm" = (
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/camera{
+	c_tag = "Chapel Office";
+	dir = 2
+	},
+/turf/open/floor/wood,
+/area/chapel/main)
+"aKn" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
+"aKo" = (
+/obj/structure/bookcase,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Chapel South";
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "aKp" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -24187,23 +24764,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/bar/atrium)
-"aLg" = (
-/obj/machinery/vending/snack/random,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
 "aLh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -25111,18 +25671,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"aNs" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "aNt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -25247,19 +25795,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"aNF" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
-/area/hallway/primary/starboard)
 "aNG" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -25317,26 +25852,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"aNT" = (
-/obj/machinery/announcement_system,
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "aNU" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -25683,16 +26198,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"aOG" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aOH" = (
@@ -26931,28 +27436,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
-"aRY" = (
-/obj/structure/table/wood,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/library)
 "aRZ" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -27189,23 +27672,6 @@
 "aSz" = (
 /turf/closed/wall,
 /area/science/lab)
-"aSA" = (
-/obj/machinery/shower{
-	dir = 4;
-	name = "emergency shower"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/science/research)
 "aSB" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -28823,37 +29289,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/medical/chemistry)
-"aWg" = (
-/obj/structure/table/glass,
-/obj/item/assembly/igniter,
-/obj/item/assembly/igniter,
-/obj/item/assembly/igniter,
-/obj/item/assembly/timer{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/assembly/timer{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/assembly/timer{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/chemistry)
 "aWh" = (
 /obj/structure/table/glass,
 /obj/item/clothing/glasses/science{
@@ -28936,15 +29371,6 @@
 	c_tag = "R&D";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel/white,
-/area/science/lab)
-"aWn" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/light,
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -29187,15 +29613,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
-"aWO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/nosmoking/circle{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/sign/departments/minsky/medical/chemistry/chemical2,
-/turf/open/floor/plating,
-/area/medical/chemistry)
 "aWP" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/chips,
@@ -29225,18 +29642,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/lounge)
-"aWS" = (
-/obj/structure/chair/comfy/brown{
-	buildstackamount = 0;
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/landmark/start/geneticist,
-/turf/open/floor/plasteel/grimy,
-/area/crew_quarters/lounge)
 "aWT" = (
 /obj/structure/table/wood,
 /obj/item/folder,
@@ -29257,12 +29662,6 @@
 	dir = 2
 	},
 /turf/open/floor/plasteel,
-/area/science/lab)
-"aWV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/sign/departments/minsky/research/research,
-/turf/open/floor/plating,
 /area/science/lab)
 "aWW" = (
 /obj/structure/sign/warning/nosmoking/circle,
@@ -29764,20 +30163,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
-"aYi" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/research)
 "aYj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -29853,29 +30238,6 @@
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
-/area/science/research)
-"aYq" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/research)
 "aYr" = (
 /obj/structure/chair/office/dark{
@@ -30146,29 +30508,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/robotics/mechbay)
-"aZf" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/science/research)
-"aZg" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/science/research)
-"aZh" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall/r_wall,
-/area/science/robotics/lab)
 "aZi" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/lab)
@@ -30424,33 +30763,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/robotics/lab)
-"bab" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/toolbox/electrical,
-/obj/item/screwdriver{
-	pixel_y = 5
-	},
-/obj/item/multitool,
-/obj/item/clothing/head/welding,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Robotics Lab";
-	dir = 2;
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/robotics/lab)
 "bac" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/effect/turf_decal/stripes/end{
@@ -30650,26 +30962,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"baI" = (
-/obj/structure/filingcabinet/security,
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24;
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint)
 "baJ" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -30723,29 +31015,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"baN" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/white{
-	icon_state = "1-4"
-	},
-/obj/machinery/camera{
-	c_tag = "Mech Bay";
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/science/robotics/mechbay)
 "baO" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable/white{
@@ -30833,14 +31102,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"baU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/sign/departments/minsky/research/robotics,
-/turf/open/floor/plating,
-/area/science/robotics/lab)
 "baV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -31822,23 +32083,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"bdr" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "bds" = (
 /turf/closed/wall/rust,
 /area/science/robotics/lab)
@@ -32516,21 +32760,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint)
-"beK" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "beL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -32780,16 +33009,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"bfr" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "bfs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -33346,23 +33565,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"bgp" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "xeno1";
-	name = "Containment Control";
-	req_access_txt = "55"
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24;
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "bgq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line,
@@ -33837,16 +34039,6 @@
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"bhn" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/structure/sign/departments/botany{
-	pixel_x = 32
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -34346,18 +34538,6 @@
 	},
 /turf/open/floor/wood,
 /area/chapel/main)
-"bie" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/machinery/camera{
-	c_tag = "Chapel Office";
-	dir = 2
-	},
-/turf/open/floor/wood,
-/area/chapel/main)
 "bif" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -34527,22 +34707,6 @@
 	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
-	},
-/area/hallway/secondary/entry)
-"bit" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
 	},
 /area/hallway/secondary/entry)
 "biu" = (
@@ -34841,35 +35005,6 @@
 	},
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
-"biT" = (
-/obj/structure/bookcase,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Chapel South";
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/main)
 "biU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -34942,17 +35077,6 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
-"bjb" = (
-/obj/machinery/smartfridge/extract/preloaded,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/sign/departments/minsky/research/xenobiology{
-	pixel_y = 32
-	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bjc" = (
@@ -37354,17 +37478,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"dai" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "ddI" = (
 /obj/machinery/air_sensor/atmos/toxin_tank,
 /turf/open/floor/engine/plasma,
@@ -37553,11 +37666,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"emY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/departments/minsky/supply/mining,
-/turf/open/floor/plating,
-/area/hallway/primary/starboard)
 "eva" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -37985,9 +38093,6 @@
 /obj/structure/closet/l3closet/security,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"glC" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/starboard/aft)
 "goT" = (
 /obj/effect/landmark/start/chief_engineer,
 /turf/open/floor/plasteel,
@@ -38501,11 +38606,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
-"jtg" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/departments/minsky/medical/medical2,
-/turf/open/floor/plating,
-/area/medical)
 "jtZ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -38963,19 +39063,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"mwX" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/wardrobe/miner,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "mJP" = (
 /obj/machinery/igniter{
 	id = "Incinerator"
@@ -40482,13 +40569,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"sHf" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "sHz" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/bot,
@@ -41302,16 +41382,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"sLT" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "sLV" = (
 /obj/item/radio/intercom{
@@ -42143,26 +42213,6 @@
 /obj/item/beacon,
 /turf/open/floor/carpet,
 /area/crew_quarters/lounge)
-"sNA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "sNB" = (
 /obj/structure/transit_tube,
 /obj/effect/turf_decal/bot,
@@ -42271,25 +42321,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"sNK" = (
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/toolbox/electrical,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/machinery/firealarm{
-	pixel_y = -26
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "sNM" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
@@ -42335,20 +42366,6 @@
 	pixel_y = -32
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"sNU" = (
-/obj/machinery/porta_turret/ai{
-	installation = /obj/item/gun/energy/e_gun/turret
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/firealarm{
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -43356,19 +43373,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"wAQ" = (
-/obj/machinery/computer/crew{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical)
 "wKi" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -71570,7 +71574,7 @@ wlU
 aKs
 aLG
 aMJ
-aNT
+aIq
 aOv
 rEd
 bxp
@@ -71823,7 +71827,7 @@ aad
 aCo
 afM
 bwY
-aJk
+aHK
 aKt
 aLH
 bxl
@@ -75160,7 +75164,7 @@ awF
 aCA
 uok
 aEw
-aFy
+aDw
 aGg
 aHq
 aIn
@@ -75419,7 +75423,7 @@ jDd
 aEt
 aEt
 aGg
-aHr
+aFy
 aIo
 aJw
 aKE
@@ -76197,7 +76201,7 @@ aLW
 aLW
 bln
 aOd
-aOG
+aIr
 cAX
 aQT
 aRR
@@ -76695,7 +76699,7 @@ auE
 avJ
 tkE
 scU
-ayl
+axb
 azr
 aAt
 aBB
@@ -76942,7 +76946,7 @@ akT
 alH
 amH
 aCh
-aos
+aqP
 akT
 vGO
 kvq
@@ -77209,16 +77213,16 @@ auG
 avL
 aqz
 axu
-aym
+ayl
 azt
 aAv
 aBD
 aCH
-aDw
+azf
 aEB
 aFC
 aGp
-aHw
+aGF
 aIs
 aEt
 aEt
@@ -77733,7 +77737,7 @@ aED
 aFE
 aGr
 aHh
-aIu
+aFL
 aAZ
 aKK
 aMa
@@ -78247,7 +78251,7 @@ aEF
 aFG
 aGt
 aHz
-aIw
+aGY
 aJF
 aKM
 aMa
@@ -78733,7 +78737,7 @@ arD
 arD
 aCB
 agF
-ahy
+ahU
 agF
 aiY
 ajY
@@ -78743,7 +78747,7 @@ ajY
 anF
 aow
 akl
-aqP
+atj
 arK
 asQ
 agF
@@ -79025,9 +79029,9 @@ aHA
 aEt
 aEt
 amE
-aod
+aIu
 aQW
-aRY
+aIw
 aTg
 sJX
 bxS
@@ -79529,7 +79533,7 @@ aBL
 geZ
 geZ
 aEJ
-aFL
+aEK
 aGx
 aHD
 aIA
@@ -80018,7 +80022,7 @@ aeq
 afd
 afP
 agI
-ahB
+ajl
 aiu
 ads
 afc
@@ -80042,7 +80046,7 @@ aAE
 aBN
 ayv
 ayv
-aEK
+aCV
 awQ
 aGy
 aHF
@@ -80333,7 +80337,7 @@ bfy
 bfT
 bgD
 bhq
-bie
+aKm
 biG
 bjk
 bjA
@@ -81350,7 +81354,7 @@ aph
 ars
 asD
 atD
-auy
+aJz
 aph
 awG
 axU
@@ -81604,10 +81608,10 @@ apB
 aqj
 aph
 aph
-art
+aqn
 asE
 atE
-auz
+art
 aph
 awH
 axV
@@ -81868,7 +81872,7 @@ avm
 aph
 awL
 axX
-ayD
+aJE
 aph
 aOL
 bfy
@@ -82337,7 +82341,7 @@ adM
 ahW
 alh
 alY
-amT
+aod
 anL
 aoF
 apK
@@ -82372,7 +82376,7 @@ apo
 aps
 apw
 aqi
-aqm
+aJd
 aqp
 aqB
 asm
@@ -82382,7 +82386,7 @@ avu
 avH
 axj
 axZ
-azc
+aJN
 azj
 beZ
 bfC
@@ -82647,7 +82651,7 @@ bgb
 bgM
 bhx
 bin
-biT
+aKo
 sLf
 aae
 aae
@@ -82847,7 +82851,7 @@ aga
 agR
 ahK
 abw
-aej
+amy
 ahZ
 alh
 ama
@@ -83134,7 +83138,7 @@ aIK
 aJP
 aKZ
 aMo
-aNs
+aHX
 aHM
 aoc
 aop
@@ -83143,7 +83147,7 @@ aSk
 aTr
 aUt
 aVl
-aWg
+aJe
 aRf
 ari
 asq
@@ -83359,7 +83363,7 @@ aex
 afo
 agc
 agT
-ahM
+ajv
 abw
 adM
 aib
@@ -83401,8 +83405,8 @@ aTs
 aUu
 aVl
 aWh
-aRh
-arj
+aRf
+aGZ
 asu
 atv
 aup
@@ -83410,8 +83414,8 @@ avC
 awy
 aqn
 ayb
-azf
-wAQ
+aJO
+aKg
 aph
 bfE
 aTb
@@ -83915,13 +83919,13 @@ aTu
 aUw
 aVn
 aWj
-aWO
+arj
 aro
 asz
 atz
 aus
 avF
-awD
+aJC
 axn
 ayd
 azh
@@ -84127,7 +84131,7 @@ ace
 acV
 adN
 aey
-afp
+ahk
 agf
 agW
 ahO
@@ -84149,7 +84153,7 @@ awi
 sDn
 sDn
 ayH
-azH
+ayD
 auZ
 aBX
 aCS
@@ -84174,10 +84178,10 @@ aRf
 aRg
 aRf
 aph
-jtg
+aqn
 atA
 aut
-jtg
+aqn
 aph
 aph
 aqn
@@ -84188,7 +84192,7 @@ bfH
 baj
 bgQ
 bhD
-bit
+aKn
 bgP
 aae
 aaa
@@ -84430,12 +84434,12 @@ aTw
 aTw
 aTw
 aTw
-dai
+aJj
 aYa
 aYU
 aZQ
 baG
-bbv
+aHa
 bbv
 baG
 baG
@@ -84636,7 +84640,7 @@ aaC
 aaP
 aba
 abm
-abB
+ago
 acg
 swJ
 adO
@@ -84671,7 +84675,7 @@ aAR
 asg
 aFN
 aAR
-aHR
+avi
 asg
 asg
 ase
@@ -85205,7 +85209,7 @@ tWh
 aYc
 iey
 sKB
-baI
+aJA
 bby
 bcn
 bde
@@ -85714,7 +85718,7 @@ aTB
 aUy
 aUy
 aUy
-aWS
+aJg
 lIM
 aYe
 hOc
@@ -85929,9 +85933,9 @@ aeE
 afr
 afr
 ahc
-ahU
+amu
 sOD
-ajv
+amT
 aky
 alr
 ndg
@@ -86198,7 +86202,7 @@ aoS
 apY
 ara
 asj
-atj
+auz
 aue
 avj
 awo
@@ -86216,7 +86220,7 @@ aGQ
 aHU
 aIQ
 aJX
-aLg
+aHR
 sJn
 ara
 aOr
@@ -86485,7 +86489,7 @@ aTE
 aTE
 aTE
 aTE
-aTE
+aHb
 aXw
 aYg
 aYZ
@@ -86495,7 +86499,7 @@ bbB
 bcr
 bdj
 bef
-beK
+aKk
 bfg
 bfO
 heQ
@@ -86697,7 +86701,7 @@ acm
 ade
 adS
 aeG
-aft
+ahy
 agl
 ahe
 agl
@@ -86722,7 +86726,7 @@ awX
 aue
 aAR
 aCc
-aCV
+azc
 aDS
 aEZ
 aFR
@@ -87001,10 +87005,10 @@ aVt
 aWk
 aTL
 aXy
-aYi
+aJk
 aZb
 aZU
-baN
+aJB
 bbC
 bct
 bdl
@@ -87449,7 +87453,7 @@ sMr
 sMG
 sMV
 sNl
-sNA
+aej
 sMr
 aaa
 aaa
@@ -87469,7 +87473,7 @@ adg
 adU
 abn
 afw
-ago
+ahB
 abs
 abP
 acA
@@ -87487,7 +87491,7 @@ atm
 auj
 avo
 awt
-axb
+awD
 ara
 ayQ
 azN
@@ -87513,7 +87517,7 @@ aTI
 aUC
 aVv
 aWm
-aWV
+aHc
 aXA
 aYk
 aZd
@@ -87769,7 +87773,7 @@ aSx
 aTJ
 aUD
 aVw
-aWn
+aJf
 aSz
 aXB
 aYl
@@ -87955,7 +87959,7 @@ adQ
 sLC
 sLJ
 ahQ
-sLT
+abB
 ahQ
 sMa
 sLC
@@ -88040,7 +88044,7 @@ aZe
 beL
 nKi
 bfP
-bgp
+aKl
 bhb
 bhO
 ibv
@@ -88287,7 +88291,7 @@ aWp
 aWW
 blr
 aYn
-aZf
+aHd
 aZY
 baS
 aYk
@@ -88505,7 +88509,7 @@ aeJ
 aiD
 alv
 ams
-anj
+aos
 anY
 aoY
 aqg
@@ -88536,7 +88540,7 @@ ayP
 blo
 aQy
 aRu
-aSA
+aJa
 aTM
 aUF
 aVy
@@ -88544,12 +88548,12 @@ aWq
 aWq
 aXD
 aYo
-aZg
+aHf
 aZZ
 baT
 bbH
 bcx
-bdr
+aJD
 bel
 beN
 bfm
@@ -88801,9 +88805,9 @@ aWr
 aWX
 aXE
 aYp
-aZh
+aZi
 baa
-baU
+aHk
 bbI
 baa
 bds
@@ -88992,7 +88996,7 @@ sMr
 sNb
 sNr
 sNG
-sNU
+aft
 sMq
 aad
 aad
@@ -89020,7 +89024,7 @@ aiF
 ajd
 ajg
 vkK
-ajl
+aqm
 ajG
 uqY
 akp
@@ -89045,7 +89049,7 @@ aIX
 udT
 aLm
 uqY
-aNF
+aIg
 vkK
 aPw
 aQz
@@ -89059,7 +89063,7 @@ aVA
 aXF
 aUH
 aZi
-bab
+aJx
 baV
 bbJ
 bcy
@@ -89314,7 +89318,7 @@ aVB
 aWs
 aWY
 aXG
-aYq
+aJv
 aZj
 bac
 baW
@@ -89333,7 +89337,7 @@ psq
 bgZ
 bgm
 ibv
-bjb
+aHs
 bju
 bjH
 bfP
@@ -89536,7 +89540,7 @@ ado
 adp
 ajD
 ajO
-emY
+lFi
 sOF
 sOG
 atq
@@ -89548,7 +89552,7 @@ aRz
 akR
 jqM
 alS
-amu
+aza
 rzn
 aEa
 sHz
@@ -89783,7 +89787,7 @@ adZ
 aeP
 afC
 agv
-ahk
+ahM
 ado
 aiI
 ajI
@@ -90019,7 +90023,7 @@ sMr
 sMQ
 sNf
 sNv
-sNK
+afp
 sMq
 aad
 aad
@@ -90352,7 +90356,7 @@ bdy
 ber
 aZl
 bxX
-glC
+aHG
 sdL
 bhj
 wbV
@@ -90560,9 +90564,9 @@ aiL
 ajJ
 akM
 alC
-amy
+anj
 adn
-ajB
+ann
 akd
 akm
 sJN
@@ -90818,7 +90822,7 @@ ajK
 akN
 alD
 amz
-ann
+ajB
 ajC
 ake
 akn
@@ -90865,8 +90869,8 @@ aUK
 bdz
 sPa
 sOZ
-bfr
-sOY
+aHw
+sOM
 bgv
 sPY
 bhU
@@ -91078,7 +91082,7 @@ amA
 ano
 ajE
 akf
-akj
+aHu
 aRz
 gwL
 bhk
@@ -91851,7 +91855,7 @@ aoi
 apj
 aqq
 ark
-mwX
+auy
 amC
 aac
 bvg
@@ -92153,7 +92157,7 @@ aad
 aad
 sOM
 bgA
-bhn
+aHJ
 bhY
 sON
 aad
@@ -92377,7 +92381,7 @@ bvg
 sFs
 sFX
 sGC
-sHf
+azH
 sHB
 blM
 sIy
@@ -93153,7 +93157,7 @@ aFk
 sIe
 bsO
 aHZ
-aJa
+aHr
 azb
 bta
 aMz
@@ -94171,7 +94175,7 @@ aaa
 aaa
 aae
 axW
-aza
+aym
 azZ
 aBg
 aCm

--- a/_maps/yogstation/map_files/YogStation/YogStation.dmm
+++ b/_maps/yogstation/map_files/YogStation/YogStation.dmm
@@ -498,23 +498,27 @@
 /turf/open/space,
 /area/space/nearstation)
 "abb" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Prison Wing APC";
+	areastring = "/area/security/prison";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Toxins Lab West";
-	dir = 2;
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/structure/closet/l3closet/scientist{
-	pixel_x = -2
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
-/area/science/mixing)
+/area/security/prison)
 "abc" = (
 /turf/closed/wall,
 /area/security/execution/transfer)
@@ -1115,25 +1119,16 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "acm" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/structure/table,
+/obj/item/stack/sheet/metal,
+/obj/item/storage/box/bodybags,
+/obj/item/pen,
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+	dir = 1;
+	pixel_y = -26
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/clerk)
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "acn" = (
 /obj/item/storage/secure/safe/HoS{
 	pixel_x = 35
@@ -2288,28 +2283,23 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aer" = (
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Prison Wing APC";
-	areastring = "/area/security/prison";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 4
+	dir = 8
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/main)
 "aes" = (
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
@@ -3224,16 +3214,17 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "agf" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal,
-/obj/item/storage/box/bodybags,
-/obj/item/pen,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "agg" = (
 /obj/structure/closet/secure_closet/injection,
 /obj/structure/cable,
@@ -4263,23 +4254,21 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ahZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
 	dir = 8
 	},
-/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel,
-/area/security/main)
+/area/security/brig)
 "aia" = (
 /obj/structure/noticeboard{
 	dir = 1;
@@ -4671,15 +4660,17 @@
 /turf/open/floor/engine,
 /area/science/misc_lab)
 "aiI" = (
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /obj/structure/sign/warning/electricshock{
-	pixel_x = -32
+	pixel_y = 32
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/warden)
+/turf/open/floor/plasteel,
+/area/security/brig)
 "aiJ" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable{
@@ -4856,22 +4847,15 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajb" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 2
+	},
 /obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 8
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/hallway/primary/fore)
 "ajc" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -4892,18 +4876,13 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aje" = (
+/obj/structure/table,
 /obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
+	dir = 1;
+	pixel_y = -26
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
 "ajf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7703,15 +7682,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoB" = (
+/obj/structure/filingcabinet/employment,
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+	dir = 8;
+	pixel_x = 26
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/turf/open/floor/wood,
+/area/lawoffice)
 "aoC" = (
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/tile/red{
@@ -7741,13 +7718,20 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoG" = (
-/obj/structure/table,
+/obj/structure/chair/comfy/brown{
+	buildstackamount = 0;
+	color = "#c45c57";
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -26
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/courtroom)
+/turf/open/floor/carpet,
+/area/security/detectives_office)
 "aoH" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law{
@@ -8918,24 +8902,7 @@
 /area/crew_quarters/fitness)
 "arm" = (
 /obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	icon_state = "manifold-3";
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	icon_state = "manifold-1";
-	dir = 4
-	},
-/obj/structure/sign/departments/minsky/supply/cargo{
-	pixel_x = 32
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -9358,13 +9325,18 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "asl" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/filingcabinet/employment,
-/turf/open/floor/wood,
-/area/lawoffice)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "asm" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -9372,13 +9344,17 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "asn" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel,
-/area/science/misc_lab)
+/area/crew_quarters/dorms)
 "aso" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -10193,20 +10169,12 @@
 /turf/open/floor/plasteel/white,
 /area/science/nanite)
 "aug" = (
+/obj/item/clothing/head/welding,
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
-/obj/structure/chair/comfy/brown{
-	buildstackamount = 0;
-	color = "#c45c57";
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/security/detectives_office)
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "auh" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder,
@@ -10537,18 +10505,23 @@
 /turf/open/floor/plasteel,
 /area/science/nanite)
 "auU" = (
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/crew_quarters/fitness)
 "auV" = (
 /obj/item/nanite_remote{
 	pixel_x = 8;
@@ -10675,18 +10648,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "avj" = (
+/obj/structure/table,
+/obj/item/wirecutters,
+/obj/item/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/storage/primary)
 "avk" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -10721,9 +10693,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "avo" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall,
-/area/maintenance/department/electrical)
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "avp" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "aux_base_shutters";
@@ -12676,13 +12656,15 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva)
 "ayM" = (
+/obj/structure/rack,
+/obj/item/electronics/apc,
+/obj/item/electronics/airlock,
 /obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/item/clothing/head/welding,
 /turf/open/floor/plasteel,
-/area/ai_monitored/storage/eva)
+/area/storage/tools)
 "ayN" = (
 /obj/structure/rack,
 /obj/machinery/light{
@@ -13401,23 +13383,23 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "aAm" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/stack/sheet/metal/five,
+/obj/item/circuitboard/machine/paystand,
+/obj/item/stack/cable_coil/random/five,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/vacant_room/commissary)
 "aAn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -14865,18 +14847,25 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "aDb" = (
-/obj/structure/table,
-/obj/item/wirecutters,
-/obj/item/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
 /obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
-/area/storage/primary)
+/area/clerk)
 "aDc" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -15186,19 +15175,22 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aDG" = (
+/obj/structure/table/glass,
+/obj/item/hatchet,
+/obj/item/cultivator,
+/obj/item/crowbar,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/plant_analyzer,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 2
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
-	dir = 8
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hydroponics/garden)
 "aDH" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -16395,24 +16387,17 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aFR" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/bot,
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/escapepodbay)
 "aFS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	icon_state = "scrub_map_on-3";
@@ -18029,22 +18014,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aIS" = (
-/obj/structure/table/glass,
-/obj/item/hatchet,
-/obj/item/cultivator,
-/obj/item/crowbar,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/plant_analyzer,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
-/area/hydroponics/garden)
+/area/hallway/secondary/entry)
 "aIT" = (
 /obj/item/storage/bag/plants/portaseeder,
 /obj/structure/table/glass,
@@ -19249,14 +19227,10 @@
 /area/construction/mining/aux_base)
 "aLv" = (
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "aLw" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -19446,8 +19420,7 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -19586,8 +19559,7 @@
 /area/crew_quarters/kitchen)
 "aMm" = (
 /obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -20577,15 +20549,20 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aOo" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/area/hydroponics)
 "aOp" = (
 /obj/machinery/camera{
 	c_tag = "Port Hallway 3";
@@ -20634,28 +20611,15 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "aOv" = (
-/obj/machinery/camera{
-	c_tag = "Genetics Cloning";
-	dir = 4;
-	network = list("ss13","medbay")
-	},
-/obj/structure/table,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/item/storage/box/rxglasses{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/bodybags,
-/obj/item/pen,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "aOw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -21783,11 +21747,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aQX" = (
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
 /obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aQY" = (
@@ -21840,15 +21803,11 @@
 /area/science/misc_lab)
 "aRe" = (
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "aRf" = (
 /obj/structure/table/glass,
 /obj/item/clothing/gloves/color/latex,
@@ -21891,14 +21850,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "aRh" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall,
+/area/maintenance/department/electrical)
 "aRi" = (
 /obj/machinery/computer/atmos_alert,
 /obj/effect/turf_decal/tile/yellow{
@@ -22268,11 +22222,11 @@
 /area/library)
 "aRR" = (
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+	dir = 1;
+	pixel_y = -26
 	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "aRS" = (
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
@@ -22346,12 +22300,25 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aSd" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = -24
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/bridge)
 "aSe" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel,
@@ -23799,20 +23766,20 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aVf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/filingcabinet/filingcabinet,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 8
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
-/area/hydroponics)
+/area/bridge)
 "aVg" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -25585,25 +25552,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "aYu" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
-/area/bridge)
+/area/hydroponics)
 "aYv" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -25701,18 +25660,10 @@
 "aYC" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -26
 	},
-/obj/structure/filingcabinet/filingcabinet,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
+/turf/open/floor/wood,
+/area/library)
 "aYD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -25945,12 +25896,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "aZd" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/open/floor/wood,
-/area/library)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 8
+	},
+/area/hallway/secondary/exit)
 "aZe" = (
 /obj/effect/turf_decal/stripes{
 	icon_state = "warningline";
@@ -26510,17 +26466,11 @@
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "bal" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
-/area/hydroponics)
+/area/hallway/primary/starboard)
 "bam" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -26954,6 +26904,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	icon_state = "pipe11-1";
 	dir = 8
+	},
+/obj/structure/sign/departments/restroom{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -27566,12 +27519,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bcs" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
 /obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/hallway/primary/central)
 "bct" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	icon_state = "pipe11-1";
@@ -27621,6 +27577,9 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/structure/sign/departments/evac{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -28875,10 +28834,6 @@
 	dir = 1;
 	layer = 2.9
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
 /obj/structure/table/reinforced,
 /obj/item/stack/wrapping_paper{
 	pixel_x = 3;
@@ -28893,6 +28848,10 @@
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -29233,9 +29192,14 @@
 /turf/open/floor/plating,
 /area/medical/medbay/central)
 "bfH" = (
-/obj/structure/sign/departments/minsky/medical/medical2,
-/turf/closed/wall,
-/area/medical/medbay/central)
+/obj/effect/turf_decal/tile/blue{
+	dir = 0
+	},
+/obj/structure/sign/departments/minsky/medical/medical2{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "bfI" = (
 /obj/machinery/button/door{
 	dir = 2;
@@ -29902,8 +29866,8 @@
 /area/quartermaster/sorting)
 "bgY" = (
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -29940,11 +29904,10 @@
 	dir = 2;
 	network = list("ss13","medbay")
 	},
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
 /obj/machinery/chem_heater,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bhd" = (
@@ -30845,25 +30808,15 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "biI" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
-	pixel_y = 27
+	dir = 1;
+	pixel_y = -26
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
 "biJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31344,15 +31297,25 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bjH" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "bjI" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -32369,26 +32332,21 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "blz" = (
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	freerange = 0;
+	frequency = 1485;
+	listening = 0;
+	name = "Station Intercom (Medbay)";
+	pixel_y = -30
+	},
+/obj/machinery/light,
 /obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	icon_state = "manifold-1";
-	dir = 1
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/white,
-/area/science/explab)
+/area/medical/medbay/central)
 "blA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -32641,24 +32599,23 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "bma" = (
-/obj/structure/table/glass,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/capacitor,
-/obj/item/stock_parts/capacitor,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/structure/table,
+/obj/item/stack/sheet/plasteel{
+	amount = 10
 	},
 /obj/item/stack/cable_coil,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+	dir = 8;
+	pixel_x = 26
 	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "bmb" = (
 /obj/machinery/holopad,
 /obj/structure/cable{
@@ -32974,21 +32931,24 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bmJ" = (
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	freerange = 0;
-	frequency = 1485;
-	listening = 0;
-	name = "Station Intercom (Medbay)";
-	pixel_y = -30
+/obj/structure/table/glass,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/capacitor,
+/obj/item/stock_parts/capacitor,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/machinery/light,
+/obj/item/stack/cable_coil,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/area/science/lab)
 "bmK" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/white,
@@ -33281,23 +33241,11 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "bnj" = (
-/obj/structure/table,
-/obj/item/stack/sheet/plasteel{
-	amount = 10
-	},
-/obj/item/stack/cable_coil,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
-/area/science/robotics/lab)
+/area/quartermaster/office)
 "bnk" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -33621,10 +33569,13 @@
 /area/quartermaster/office)
 "bnJ" = (
 /obj/machinery/firealarm{
-	pixel_y = 27
+	dir = 8;
+	pixel_x = 26
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
+/turf/open/floor/plasteel/white/corner{
+	dir = 8
+	},
+/area/science/research)
 "bnK" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -34667,9 +34618,6 @@
 	req_access_txt = "33"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/sign/departments/minsky/medical/chemistry/chemical2{
-	pixel_x = 32
-	},
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "bpG" = (
@@ -34850,14 +34798,14 @@
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "bpX" = (
+/obj/machinery/light{
+	dir = 1
+	},
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+	pixel_y = 26
 	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 8
-	},
-/area/science/research)
+/turf/open/floor/plasteel,
+/area/teleporter)
 "bpY" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Research Director";
@@ -35358,6 +35306,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/structure/sign/departments/minsky/medical/chemistry/chemical2{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -35901,9 +35852,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "brU" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_y = -32
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -36122,15 +36070,25 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "bsk" = (
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/teleporter)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	icon_state = "manifold-1";
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/science/explab)
 "bsl" = (
 /obj/item/radio/intercom{
 	broadcasting = 0;
@@ -36768,14 +36726,14 @@
 /area/quartermaster/storage)
 "btt" = (
 /obj/structure/table,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
 /obj/item/folder/yellow,
 /obj/item/storage/firstaid/regular{
 	pixel_x = 6;
 	pixel_y = -5
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -37108,12 +37066,15 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "btS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel/white,
-/area/science/research)
+/area/medical/medbay/central)
 "btT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37172,15 +37133,11 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "btX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/area/science/research)
 "btY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -37242,6 +37199,9 @@
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
+	},
+/obj/structure/sign/departments/minsky/supply/mining{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -37345,6 +37305,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	icon_state = "pipe11-3";
 	dir = 4
+	},
+/obj/structure/sign/departments/minsky/medical/virology/virology2{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -37689,6 +37652,9 @@
 	dir = 8
 	},
 /obj/machinery/light,
+/obj/structure/sign/departments/minsky/security/security{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "buK" = (
@@ -38060,17 +38026,24 @@
 /area/science/research)
 "bvy" = (
 /obj/machinery/camera{
-	c_tag = "Genetics Research";
-	dir = 1;
+	c_tag = "Genetics Cloning";
+	dir = 4;
 	network = list("ss13","medbay")
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/structure/table,
+/obj/item/storage/box/rxglasses{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/item/storage/box/bodybags,
+/obj/item/pen,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -38386,15 +38359,25 @@
 /turf/closed/wall,
 /area/security/checkpoint/supply)
 "bwf" = (
-/obj/machinery/camera{
-	c_tag = "Cargo Bay Entrance";
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	icon_state = "manifold-3";
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	icon_state = "manifold-1";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "bwg" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "hopqueue";
@@ -38911,16 +38894,21 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
 "bxd" = (
+/obj/machinery/camera{
+	c_tag = "Genetics Research";
+	dir = 1;
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+	dir = 1;
+	pixel_y = -26
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "bxe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39985,22 +39973,16 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
 "bzg" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 0
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics East";
+/obj/structure/closet/secure_closet/medical1,
+/obj/machinery/light{
 	dir = 8
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = -26
 	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "bzh" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6
@@ -40228,12 +40210,18 @@
 	},
 /area/science/research)
 "bzF" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1;
+	name = "Connector Port (Air Supply)"
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light,
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
+/area/medical/sleeper)
 "bzG" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -40434,22 +40422,25 @@
 /turf/open/space/basic,
 /area/engine/atmos_distro)
 "bAd" = (
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
-/obj/machinery/light{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/radio/off,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
 	dir = 4
 	},
 /obj/structure/sign/departments/minsky/security/security{
-	pixel_x = 32
+	pixel_y = -32
 	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/supply)
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "bAe" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=AIW";
@@ -40541,16 +40532,11 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
 "bAp" = (
-/obj/structure/closet/secure_closet/medical1,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/sleeper)
+/area/medical/medbay/central)
 "bAq" = (
 /obj/machinery/sleeper{
 	dir = 8
@@ -40567,18 +40553,15 @@
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bAs" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1;
-	name = "Connector Port (Air Supply)"
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 9
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -26
 	},
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/medical/sleeper)
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "bAt" = (
 /obj/structure/table/reinforced,
 /obj/item/wrench/medical,
@@ -41253,11 +41236,11 @@
 /area/quartermaster/miningdock)
 "bBJ" = (
 /obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
+	dir = 8;
+	pixel_x = 26
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "bBK" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -41360,15 +41343,22 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "bBU" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 9
+/obj/machinery/camera{
+	c_tag = "Toxins Lab West";
+	dir = 2;
+	network = list("ss13","rd")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/structure/closet/l3closet/scientist{
+	pixel_x = -2
 	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
-/turf/open/floor/plasteel/dark,
-/area/science/server)
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "bBV" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'SERVER ROOM'.";
@@ -41394,22 +41384,19 @@
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "bBY" = (
-/obj/item/radio/intercom{
-	pixel_x = -25
+/obj/item/screwdriver{
+	pixel_y = 10
 	},
-/obj/structure/filingcabinet,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/light{
+	dir = 4
 	},
+/obj/item/radio/off,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/sign/departments/minsky/security/security{
-	pixel_y = -32
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/security/checkpoint/science)
+/area/security/checkpoint/supply)
 "bBZ" = (
 /obj/item/screwdriver{
 	pixel_y = 10
@@ -42014,8 +42001,8 @@
 /area/quartermaster/miningdock)
 "bDl" = (
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 5
@@ -44221,6 +44208,12 @@
 "bHE" = (
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"bHF" = (
+/obj/structure/sign/departments/minsky/research/robotics{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "bHG" = (
 /obj/structure/rack,
 /obj/item/circuitboard/computer/crew{
@@ -44246,6 +44239,15 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
+"bHI" = (
+/obj/structure/sign/departments/minsky/research/xenobiology{
+	pixel_x = -32;
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/science/research)
 "bHJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -44297,6 +44299,20 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/storage/tech)
+"bHP" = (
+/obj/item/radio/intercom{
+	pixel_x = -25
+	},
+/obj/structure/filingcabinet,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/science)
 "bHQ" = (
 /obj/machinery/vending/assist,
 /turf/open/floor/plating,
@@ -44654,17 +44670,18 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bIM" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/camera{
+	c_tag = "Cargo Bay Entrance";
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/sign/departments/minsky/research/xenobiology{
-	pixel_x = 32
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/structure/sign/departments/minsky/supply/cargo{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bIN" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden/layer1{
 	icon_state = "pipe11-1";
@@ -44708,12 +44725,10 @@
 	},
 /area/maintenance/port/aft)
 "bIT" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/sign/departments/minsky/research/xenobiology{
-	pixel_y = -32
-	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/small,
 /turf/open/floor/plating,
-/area/science/xenobiology)
+/area/maintenance/aft)
 "bIU" = (
 /obj/structure/mineral_door/wood{
 	name = "The New Barmaid"
@@ -45158,6 +45173,10 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"bJX" = (
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/crew_quarters/heads/hop)
 "bJY" = (
 /obj/structure/closet/crate,
 /obj/item/coin/silver,
@@ -45372,6 +45391,48 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"bKA" = (
+/obj/machinery/camera{
+	c_tag = "Aft Port Solar Access";
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/closet/emcloset,
+/obj/structure/sign/warning/electricshock{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"bKB" = (
+/obj/structure/closet/emcloset,
+/obj/structure/sign/warning/electricshock{
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"bKC" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/loading_area,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"bKD" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 2
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "bKE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -45427,6 +45488,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"bKM" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/wood,
+/area/medical/medbay/central)
 "bKN" = (
 /obj/machinery/computer/atmos_control/tank/carbon_tank{
 	dir = 8;
@@ -45826,12 +45894,49 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"bLJ" = (
+/obj/machinery/monkey_recycler,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "bLK" = (
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "bLL" = (
 /obj/machinery/atmospherics/pipe/manifold/green/visible,
 /obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/engine/atmos_distro)
+"bLM" = (
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
+"bLN" = (
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
 "bLO" = (
@@ -45957,16 +46062,14 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
 "bMe" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+	pixel_y = 26
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "bMf" = (
 /turf/open/floor/engine/o2,
 /area/engine/atmos_distro)
@@ -46022,16 +46125,22 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bMm" = (
-/obj/machinery/monkey_recycler,
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
+/obj/effect/turf_decal/tile/blue{
+	dir = 0
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics East";
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
-/area/science/xenobiology)
+/area/engine/atmos_distro)
 "bMn" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -46081,6 +46190,35 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"bMu" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"bMv" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 2
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"bMw" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "bMx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -46182,6 +46320,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"bMM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 10
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "bMN" = (
 /obj/machinery/computer/atmos_control/tank/toxin_tank{
 	dir = 8;
@@ -46214,6 +46363,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"bMS" = (
+/obj/item/nanite_remote{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/nanite_scanner{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/storage/box/disks_nanite{
+	pixel_x = 8;
+	pixel_y = 4
+	},
+/obj/structure/table,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/white,
+/area/science/nanite)
 "bMT" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
 	dir = 1;
@@ -46259,6 +46431,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"bMY" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos_distro)
+"bMZ" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bNa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -46292,9 +46487,39 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
 "bNf" = (
-/obj/structure/sign/departments/minsky/medical/virology/virology2,
-/turf/closed/wall,
-/area/medical/virology)
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/vending/engivend,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"bNg" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/tile/red,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer3{
+	icon_state = "connector_map-3";
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
+/area/hallway/primary/aft)
 "bNh" = (
 /obj/machinery/computer/pandemic,
 /obj/effect/turf_decal/tile/green,
@@ -46308,6 +46533,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"bNj" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer3{
+	icon_state = "connector_map-3";
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
+/area/hallway/primary/aft)
 "bNk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	icon_state = "pipe11-3";
@@ -46315,6 +46551,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"bNl" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"bNm" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_smes)
 "bNn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
@@ -47358,15 +47614,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"bSV" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "bSW" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -47692,20 +47939,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"bUE" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/tile/red,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer3{
-	icon_state = "connector_map";
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 4
-	},
-/area/hallway/primary/aft)
 "bVa" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /obj/effect/turf_decal/tile/green{
@@ -48308,16 +48541,6 @@
 "bYH" = (
 /turf/closed/wall,
 /area/engine/break_room)
-"bYI" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "bYM" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -49363,18 +49586,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
-"cfd" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/engineering_electrical,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cfe" = (
 /obj/structure/sign/warning/radiation/rad_area{
 	pixel_x = -32
@@ -49550,15 +49761,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cfL" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cfM" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/engineering{
@@ -49673,21 +49875,6 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
-"cgD" = (
-/obj/machinery/camera{
-	c_tag = "Aft Port Solar Access";
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"cgE" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
 /area/maintenance/solars/port/aft)
 "cgF" = (
 /obj/effect/spawner/lootdrop/maintenance,
@@ -50320,10 +50507,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"cjG" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/maintenance/solars/starboard/aft)
 "cjH" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -50884,26 +51067,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cmG" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/vending/engivend,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cmL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -51126,16 +51289,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
-"cnU" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/sign/warning/electricshock{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/loading_area,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cnW" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/plasteel/dark,
@@ -51268,17 +51421,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
-/area/engine/engine_smes)
-"cpU" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "cpX" = (
@@ -53259,26 +53401,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space)
-"dXe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 8
-	},
-/obj/structure/sign/departments/minsky/medical/medical2{
-	pixel_y = 32
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical/morgue)
 "dXK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53294,29 +53416,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"eaI" = (
-/obj/item/nanite_remote{
-	pixel_x = -8;
-	pixel_y = 8
-	},
-/obj/item/nanite_scanner{
-	pixel_x = -6;
-	pixel_y = -6
-	},
-/obj/item/storage/box/disks_nanite{
-	pixel_x = 8;
-	pixel_y = 4
-	},
-/obj/structure/table,
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/white,
-/area/science/nanite)
 "efn" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -54206,26 +54305,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"hrL" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 4
-	},
-/obj/structure/sign/departments/minsky/supply/janitorial{
-	pixel_y = 32
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "htC" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -54284,18 +54363,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/tcommsat/entrance)
-"hCB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/sign/departments/minsky/research/research{
-	pixel_x = -32
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "hCS" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -54432,16 +54499,6 @@
 "ihS" = (
 /turf/closed/wall/r_wall,
 /area/medical/sleeper)
-"iiM" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/sign/departments/minsky/engineering/engineering{
-	pixel_x = 32
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "imE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -54713,14 +54770,6 @@
 /obj/item/clothing/gloves/color/fyellow,
 /turf/open/floor/plasteel,
 /area/storage/tools)
-"jci" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/structure/closet/secure_closet/atmospherics,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "jhU" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light_switch{
@@ -55157,15 +55206,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"lcL" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/sign/departments/minsky/security/security{
-	pixel_x = -32
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
 "leB" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/r_wall,
@@ -55301,24 +55341,6 @@
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
 /area/science/nanite)
-"lEj" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/item/stack/sheet/metal/five,
-/obj/item/circuitboard/machine/paystand,
-/obj/item/stack/cable_coil/random/five,
-/turf/open/floor/plasteel,
-/area/vacant_room/commissary)
 "lGF" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -55977,33 +55999,12 @@
 /obj/machinery/bookbinder,
 /turf/open/floor/wood,
 /area/medical/medbay/central)
-"omA" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
-/obj/structure/sign/departments/minsky/medical/medical2{
-	pixel_x = -32
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "omY" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"ond" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/sign/departments/minsky/security/security{
-	pixel_x = -32
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "opj" = (
 /mob/living/simple_animal/moonrat{
 	name = "Joe"
@@ -56051,10 +56052,6 @@
 "oyT" = (
 /turf/closed/wall/r_wall,
 /area/engine/break_room)
-"ozc" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/hallway/primary/central)
 "oBX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -56100,17 +56097,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"oIn" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer3{
-	icon_state = "connector_map";
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 4
-	},
-/area/hallway/primary/aft)
 "oKG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/wood,
@@ -56140,14 +56126,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"oRZ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/small,
-/obj/structure/sign/departments/minsky/engineering/atmospherics{
-	pixel_y = -32
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "oSz" = (
 /obj/machinery/door/airlock/maintenance{
 	id_tag = "commissarydoor";
@@ -56675,10 +56653,6 @@
 "qQV" = (
 /turf/template_noop,
 /area/template_noop)
-"qTh" = (
-/obj/structure/sign/departments/minsky/supply/mining,
-/turf/closed/wall,
-/area/quartermaster/miningdock)
 "qUr" = (
 /obj/structure/sign/departments/minsky/security/security,
 /turf/closed/wall,
@@ -56810,15 +56784,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
-"rxR" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/sign/departments/minsky/supply/cargo{
-	pixel_y = -32
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "ryf" = (
 /obj/structure/sign/departments/minsky/research/research,
 /turf/closed/wall/r_wall,
@@ -56883,20 +56848,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/construction)
-"rKY" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/open/floor/wood,
-/area/medical/medbay/central)
-"rOd" = (
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "rPk" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -57211,18 +57162,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"sJR" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 8
-	},
-/area/hallway/secondary/exit)
 "sKq" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -57462,10 +57401,6 @@
 	},
 /turf/open/floor/plasteel/stairs,
 /area/escapepodbay)
-"trL" = (
-/obj/structure/sign/departments/minsky/supply/cargo,
-/turf/closed/wall,
-/area/security/checkpoint/supply)
 "tsI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57476,15 +57411,6 @@
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/chapel,
 /area/escapepodbay)
-"txa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/sign/departments/minsky/medical/medical2{
-	pixel_y = 32
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "txj" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/junction/flipped{
@@ -57555,26 +57481,6 @@
 /obj/structure/chair/wood/wings,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"tFC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 4
-	},
-/obj/structure/sign/departments/minsky/supply/mining{
-	pixel_y = 32
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "tIs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
@@ -58148,18 +58054,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"vXI" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/escapepodbay)
 "vYE" = (
 /obj/machinery/telecomms/processor/preset_four,
 /obj/effect/turf_decal/tile/neutral{
@@ -58197,10 +58091,6 @@
 "wcB" = (
 /turf/closed/wall/r_wall,
 /area/tcommsat/entrance)
-"wdD" = (
-/obj/structure/sign/departments/minsky/supply/cargo,
-/turf/closed/wall,
-/area/quartermaster/storage)
 "weD" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -58218,16 +58108,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"wjE" = (
-/obj/structure/rack,
-/obj/item/electronics/apc,
-/obj/item/electronics/airlock,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
-/area/storage/tools)
 "wkN" = (
 /turf/closed/wall,
 /area/science/nanite)
@@ -58339,16 +58219,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"wAj" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "wCj" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -72975,7 +72845,7 @@ azz
 azz
 azz
 azz
-aLv
+aIS
 aBH
 azz
 aPu
@@ -74779,7 +74649,7 @@ aNf
 aNf
 aLA
 aWo
-aSd
+aRR
 czK
 aUQ
 aUW
@@ -76314,7 +76184,7 @@ aDg
 aAQ
 aAQ
 aHz
-aIS
+aDG
 aKn
 aLF
 aVl
@@ -77860,7 +77730,7 @@ qLM
 aJZ
 ayY
 aNo
-aOo
+aOv
 aPA
 aQQ
 aQN
@@ -78109,7 +77979,7 @@ ayx
 alU
 aBP
 aBQ
-aDb
+avj
 aDo
 sTv
 aMy
@@ -79418,7 +79288,7 @@ aPA
 bfc
 beT
 uHN
-arm
+bwf
 bkG
 biF
 bmj
@@ -79677,7 +79547,7 @@ bcb
 aZE
 aZE
 aZE
-biI
+bjH
 bmh
 bjr
 bjr
@@ -80423,7 +80293,7 @@ aaa
 aaa
 aPQ
 vIU
-wjE
+ayM
 aIs
 uiz
 aTL
@@ -80488,7 +80358,7 @@ bCq
 bCq
 bCq
 cfw
-cgE
+cfw
 chS
 cfw
 cfw
@@ -80745,7 +80615,7 @@ bSq
 cdW
 ceW
 bCq
-cgD
+bKA
 bUs
 bHE
 cjI
@@ -81199,7 +81069,7 @@ aPQ
 aPQ
 aPQ
 aPQ
-rOd
+aLv
 aLE
 aOl
 aPF
@@ -81978,7 +81848,7 @@ aWB
 aSg
 aSg
 aSg
-rxR
+arm
 gjl
 fHT
 cBi
@@ -81988,7 +81858,7 @@ baS
 baS
 bbS
 gjl
-wdD
+aZE
 bkJ
 bjj
 bmH
@@ -82261,7 +82131,7 @@ boV
 bxx
 bxu
 bxy
-qTh
+bxy
 bGj
 bHA
 bHA
@@ -82480,7 +82350,7 @@ kVU
 aye
 wUw
 hDi
-lEj
+aAm
 vVZ
 apW
 kVU
@@ -83069,7 +82939,7 @@ clE
 cnN
 bBF
 aHk
-cpU
+bNm
 cjJ
 aaf
 crn
@@ -83287,7 +83157,7 @@ eyM
 kSb
 bpg
 byE
-bzF
+bBJ
 bqm
 byE
 byE
@@ -83509,7 +83379,7 @@ ayG
 aDj
 aJW
 abN
-acm
+aDb
 aJa
 acF
 aLN
@@ -84059,7 +83929,7 @@ byL
 bpn
 byT
 bwe
-tFC
+bqD
 bHE
 bCq
 bHD
@@ -84249,7 +84119,7 @@ afv
 aeb
 aeI
 alv
-agf
+acm
 abc
 aaf
 aaa
@@ -84561,7 +84431,7 @@ bfR
 bgW
 bNH
 aZK
-bnJ
+bnj
 bbR
 bbR
 bbR
@@ -84570,7 +84440,7 @@ buJ
 bwe
 bxE
 byM
-bAd
+bBY
 bBf
 bwe
 bqI
@@ -84801,7 +84671,7 @@ aHP
 aHP
 aHP
 aJw
-ozc
+mlj
 cLJ
 hGh
 hGh
@@ -84824,7 +84694,7 @@ bqu
 bqu
 bnK
 bnK
-trL
+bwe
 bwe
 bwe
 bwe
@@ -85058,7 +84928,7 @@ aLI
 aKU
 aJq
 aJq
-aRh
+avo
 laH
 laH
 laH
@@ -85069,7 +84939,7 @@ laH
 laH
 jjW
 bbV
-wAj
+bcs
 bfo
 aBN
 bhq
@@ -85081,7 +84951,7 @@ aJq
 aJq
 bfo
 bfo
-bwf
+bIM
 bfo
 bfo
 bfo
@@ -85122,7 +84992,7 @@ bHE
 bHE
 cmD
 cnr
-cnU
+bKC
 bEP
 bjW
 bkl
@@ -85293,7 +85163,7 @@ anu
 alq
 anX
 apc
-ond
+apS
 aoc
 apS
 apS
@@ -85633,7 +85503,7 @@ cdj
 cdv
 cem
 cem
-iiM
+cem
 cfe
 cfD
 cgv
@@ -85893,7 +85763,7 @@ ccw
 ccw
 ccw
 ccw
-cfL
+bNl
 bES
 cBO
 cgR
@@ -86311,7 +86181,7 @@ ahp
 amb
 aiE
 acd
-ajb
+ahZ
 akg
 agj
 adL
@@ -86329,7 +86199,7 @@ auh
 aph
 avt
 ayL
-ayM
+aug
 aAj
 aAR
 aCA
@@ -86364,7 +86234,7 @@ bmr
 boZ
 bqx
 brU
-bmr
+bJX
 bmr
 bmr
 bmr
@@ -86837,7 +86707,7 @@ anZ
 ard
 aSq
 fCS
-asl
+aoB
 eQk
 fLq
 aph
@@ -87176,7 +87046,7 @@ cjb
 cjb
 cig
 cig
-cmG
+bNf
 aSn
 bEE
 bba
@@ -88147,7 +88017,7 @@ aSv
 aTV
 aYg
 aWP
-aYu
+aSd
 cva
 cva
 cva
@@ -88192,7 +88062,7 @@ btG
 bQd
 bwo
 aRT
-bxd
+bMM
 aGd
 btG
 bWC
@@ -88358,7 +88228,7 @@ bbx
 bbQ
 bdj
 acd
-aer
+abb
 afB
 agi
 agD
@@ -88381,7 +88251,7 @@ bLE
 bLE
 arX
 pws
-aug
+aoG
 apd
 avt
 ayW
@@ -88623,7 +88493,7 @@ agR
 agn
 agR
 agn
-ajc
+aiI
 ajH
 ako
 akQ
@@ -88879,7 +88749,7 @@ aeW
 agQ
 ahv
 ahQ
-aiI
+agR
 ajd
 ajB
 akm
@@ -89153,7 +89023,7 @@ anw
 anw
 anw
 aVh
-avj
+asl
 avC
 axF
 axr
@@ -89715,7 +89585,7 @@ aXf
 bzG
 bDG
 bCp
-aDG
+bKD
 bFq
 btx
 bHl
@@ -89731,7 +89601,7 @@ bQg
 bQg
 bQg
 bQg
-bYI
+bMv
 bDG
 bFq
 cbt
@@ -89984,8 +89854,8 @@ bQf
 vBd
 vBd
 bTK
-bUE
-oIn
+bNg
+bNj
 bWM
 bXJ
 bYH
@@ -90679,7 +90549,7 @@ agX
 ahy
 aij
 agn
-aje
+agf
 ajH
 alC
 akX
@@ -90688,7 +90558,7 @@ alC
 amI
 anz
 anv
-aoB
+ajb
 ahn
 apT
 arf
@@ -90717,7 +90587,7 @@ aSE
 aUc
 aYA
 aWY
-aYC
+aVf
 cva
 cva
 cva
@@ -91191,7 +91061,7 @@ afQ
 agw
 agY
 ahH
-ahZ
+aer
 adR
 aiQ
 ajH
@@ -91773,7 +91643,7 @@ apG
 bFk
 bDs
 bCv
-hrL
+btC
 leB
 mmQ
 mmQ
@@ -91784,7 +91654,7 @@ szl
 szl
 szl
 baf
-aRe
+bMu
 aJC
 bXP
 bxH
@@ -92017,7 +91887,7 @@ bmA
 bmx
 bmx
 bqH
-bsk
+bpX
 bmc
 buV
 bws
@@ -92058,7 +91928,7 @@ aSc
 cej
 ccw
 cet
-cfd
+bMZ
 aGO
 cfI
 cgQ
@@ -92237,7 +92107,7 @@ arf
 arf
 arf
 arf
-auU
+asn
 auj
 axO
 axO
@@ -92487,7 +92357,7 @@ amr
 amY
 amY
 ajp
-aoG
+aje
 ajo
 apt
 arf
@@ -92525,7 +92395,7 @@ bbw
 bbw
 bfq
 bbw
-bjH
+biI
 aZV
 bmx
 bmx
@@ -92547,7 +92417,7 @@ bHU
 btJ
 btL
 bLK
-jci
+bLM
 qtN
 bOd
 bvr
@@ -93826,7 +93696,7 @@ aJq
 aJq
 bCA
 bzs
-txa
+bFr
 bDA
 bHW
 ccM
@@ -94604,7 +94474,7 @@ bvj
 btU
 avy
 avy
-aFR
+bLN
 aRM
 aTO
 aYy
@@ -94790,7 +94660,7 @@ adR
 ahl
 ahn
 aiC
-lcL
+ahT
 ahT
 ahT
 ahT
@@ -94843,7 +94713,7 @@ biA
 aMR
 bjL
 nFF
-bjQ
+bfF
 bqT
 aWG
 bJG
@@ -95116,7 +94986,7 @@ aOY
 bIc
 bvj
 btU
-oRZ
+bIT
 avy
 aJk
 aSJ
@@ -95357,7 +95227,7 @@ daW
 bmI
 bod
 bpt
-bfF
+bjQ
 bqV
 bmv
 bBL
@@ -95582,7 +95452,7 @@ aut
 avz
 axI
 azm
-aAm
+auU
 arj
 aCr
 aFf
@@ -95862,13 +95732,13 @@ qQV
 qQV
 aYV
 aYV
-bet
 bfH
+bof
 bhf
 bhh
 bhh
 bhh
-bmJ
+blz
 bof
 bpu
 bqP
@@ -95878,7 +95748,7 @@ bvh
 bwC
 bxN
 bze
-bAp
+bzg
 bvh
 bCG
 bBd
@@ -96167,7 +96037,7 @@ bLC
 bLO
 bLV
 bMb
-bMe
+bMY
 bMx
 bMN
 bMT
@@ -96901,7 +96771,7 @@ boi
 bpw
 bhh
 bsx
-btX
+btS
 bvj
 bwG
 bxR
@@ -97404,8 +97274,8 @@ qQV
 qQV
 aYV
 aYV
-bet
 bfH
+bof
 bhh
 bhh
 bhg
@@ -97677,7 +97547,7 @@ bvh
 bwH
 bxS
 bzh
-bAs
+bzF
 bvj
 bCL
 bqW
@@ -97694,7 +97564,7 @@ avy
 bai
 bgu
 bvw
-bzg
+bMm
 bBs
 bDS
 bFu
@@ -97916,7 +97786,7 @@ qQV
 qQV
 qQV
 qQV
-bcs
+bal
 aYV
 aYV
 bfK
@@ -98713,7 +98583,7 @@ bcW
 epJ
 sKq
 aDR
-rKY
+bKM
 ygj
 bNd
 bNd
@@ -99473,11 +99343,11 @@ aXx
 aCF
 bua
 bvn
-aOv
+bvy
 bxX
 fcR
 bua
-bBJ
+bAp
 bhh
 bmv
 bof
@@ -100257,12 +100127,12 @@ bhh
 aPJ
 bhh
 bul
-bNf
+bRN
 bOp
 aEB
 bQH
 bNd
-bSV
+bMe
 bvW
 bNh
 xLv
@@ -100484,7 +100354,7 @@ aUi
 aVJ
 aOX
 aYP
-bal
+aYu
 bam
 aYV
 aYV
@@ -100751,7 +100621,7 @@ bfS
 bfS
 ueh
 rZt
-dXe
+bjM
 bon
 bpG
 bqZ
@@ -100769,7 +100639,7 @@ bCY
 bsd
 bFN
 bBN
-omA
+bKQ
 btT
 bNd
 jLB
@@ -101502,7 +101372,7 @@ aGV
 aJe
 aIp
 lZq
-aVf
+aOo
 aIp
 aOX
 aQm
@@ -101787,7 +101657,7 @@ bpK
 bpK
 bvu
 bns
-bvy
+bxd
 bon
 bon
 bBN
@@ -102314,7 +102184,7 @@ bLT
 bHq
 aRy
 bbt
-bIM
+bHq
 bHq
 bHq
 bHq
@@ -103846,7 +103716,7 @@ bnT
 byh
 bzv
 bAA
-bBU
+bAs
 bDb
 bEm
 bEm
@@ -104086,7 +103956,7 @@ bau
 aFu
 aYV
 aXq
-aYV
+bHF
 bfV
 bgm
 blA
@@ -104625,7 +104495,7 @@ bDb
 bDb
 bJN
 bJN
-bMm
+bLJ
 bPD
 bMi
 bMi
@@ -104874,7 +104744,7 @@ bnH
 byi
 bzz
 bAE
-bBY
+bHP
 bDc
 bEo
 bFI
@@ -105126,8 +104996,8 @@ bpT
 bqd
 biL
 box
-btS
-bnH
+btX
+bAd
 byi
 bwN
 aCU
@@ -105881,7 +105751,7 @@ aUE
 aVT
 aYW
 aYW
-aZd
+aYC
 aFu
 aYV
 aXq
@@ -105891,7 +105761,7 @@ bhy
 biP
 bko
 blE
-bnj
+bma
 bov
 bpU
 brq
@@ -106140,7 +106010,7 @@ aWe
 aWe
 aCR
 aCR
-bcs
+bal
 aXq
 aYV
 tMm
@@ -106169,7 +106039,7 @@ bDc
 bLe
 bMr
 bNr
-bIT
+bMr
 bJN
 bDb
 bDb
@@ -106372,7 +106242,7 @@ alP
 asB
 asB
 asB
-avo
+aRh
 awN
 asB
 asB
@@ -106389,7 +106259,7 @@ aKS
 aFw
 aPj
 aFz
-aRR
+aRe
 aTe
 aUG
 aFz
@@ -106426,7 +106296,7 @@ bHc
 bHK
 aEy
 bID
-bJo
+bHI
 bPK
 bQO
 bSb
@@ -106441,7 +106311,7 @@ wkN
 saK
 auf
 auy
-eaI
+bMS
 cbZ
 bSl
 atN
@@ -106921,7 +106791,7 @@ aMK
 blH
 bvx
 boz
-bpX
+bnJ
 bBD
 aNr
 bmT
@@ -108217,7 +108087,7 @@ bzM
 bya
 bCj
 bvK
-abb
+bBU
 fxI
 bsv
 abQ
@@ -108718,7 +108588,7 @@ bhF
 dEY
 bib
 bki
-bma
+bmJ
 bnl
 bpq
 boB
@@ -108749,7 +108619,7 @@ bQZ
 alX
 alX
 bwU
-asn
+bMw
 bQZ
 cOe
 cou
@@ -108966,7 +108836,7 @@ tCq
 qyQ
 qyQ
 baC
-sJR
+aZd
 aTk
 bdy
 beH
@@ -109493,7 +109363,7 @@ bjT
 boB
 bgc
 bgc
-blz
+bsk
 bsF
 aCN
 bxn
@@ -109982,7 +109852,7 @@ ptH
 fxr
 uVA
 uVA
-vXI
+aFR
 aMZ
 aOa
 tes
@@ -110033,7 +109903,7 @@ cOe
 cOe
 alZ
 aMC
-hCB
+aMF
 aMF
 aMS
 cOe
@@ -110815,8 +110685,8 @@ arE
 aue
 arE
 bCw
-cdR
-cjG
+bKB
+cjD
 cku
 clz
 cmx

--- a/_maps/yogstation/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/yogstation/map_files/YogsDelta/YogsDelta.dmm
@@ -801,14 +801,24 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "abI" = (
-/obj/structure/table/wood,
-/obj/item/bikehorn/rubberducky,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/newscaster{
+	pixel_y = -32
 	},
-/turf/open/floor/wood,
-/area/clerk)
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "abJ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -1370,24 +1380,12 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "acH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/machinery/firealarm{
+	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
+/turf/open/floor/wood,
+/area/vacant_room/office)
 "acI" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -2540,12 +2538,27 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "aeH" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/structure/table/wood,
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/item/radio/intercom{
+	pixel_y = 26
 	},
-/turf/open/floor/wood,
-/area/vacant_room/office)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "aeI" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -7776,11 +7789,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/electronic_marketing_den)
 "anW" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 32
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -8369,16 +8377,29 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "aoQ" = (
+/obj/machinery/status_display/ai{
+	pixel_y = 32
+	},
+/obj/machinery/light_switch{
+	pixel_x = 38
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26;
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+	dir = 8;
+	pixel_x = 26
 	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/engine/atmospherics_engine)
+/area/security/checkpoint/supply)
 "aoR" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -13170,26 +13191,16 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "awD" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
-/obj/machinery/light_switch{
-	pixel_x = 26;
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/firealarm{
+	dir = 1;
 	pixel_y = -26
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Theatre Backstage";
-	dir = 8;
-	name = "service camera"
-	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/crew_quarters/theatre)
+/area/engine/atmospherics_engine)
 "awE" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel,
@@ -15455,12 +15466,8 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aAh" = (
-/obj/structure/cable/white{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/departments/medbay/alt,
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/security/prison)
 "aAi" = (
 /obj/machinery/status_display/evac,
@@ -16166,28 +16173,19 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aBt" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = -32
-	},
 /obj/machinery/light_switch{
-	pixel_x = -26
+	pixel_x = 24;
+	pixel_y = 24
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/area/maintenance/disposal/incinerator)
 "aBu" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -16225,10 +16223,23 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aBx" = (
-/obj/machinery/vending/wardrobe/cargo_wardrobe,
-/obj/effect/turf_decal/bot,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/area/engine/atmospherics_engine)
 "aBy" = (
 /obj/machinery/status_display/ai{
 	pixel_y = -32
@@ -17043,16 +17054,19 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aCT" = (
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = 26
+/obj/structure/closet/radiation,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
 	},
+/obj/effect/turf_decal/bot,
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/kitchen)
+/area/engine/atmospherics_engine)
 "aCU" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -17423,9 +17437,6 @@
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = 11
-	},
-/obj/structure/sign/departments/botany{
-	pixel_x = 32
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -18171,19 +18182,24 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar/atrium)
 "aEM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/corner{
+/obj/structure/table/wood,
+/obj/item/camera,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/area/engine/atmos)
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar/atrium)
 "aEN" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -18206,23 +18222,32 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar/atrium)
 "aEO" = (
-/obj/structure/table/wood,
-/obj/structure/reagent_dispensers/beerkeg,
-/obj/item/radio/intercom{
-	pixel_y = 26
+/obj/structure/table,
+/obj/item/storage/box{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/item/storage/box/lights/mixed,
+/obj/machinery/light_switch{
+	pixel_x = -26;
+	pixel_y = -26
+	},
+/obj/machinery/newscaster{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "aEP" = (
 /obj/structure/closet/secure_closet/bar,
 /obj/machinery/power/apc{
@@ -19281,29 +19306,26 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aGw" = (
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/light_switch{
-	pixel_x = 38
-	},
-/obj/structure/extinguisher_cabinet{
 	pixel_x = 26;
-	pixel_y = 32
+	pixel_y = -26
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "Theatre Backstage";
+	dir = 8;
+	name = "service camera"
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
-/area/security/checkpoint/supply)
+/area/crew_quarters/theatre)
 "aGx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -19479,21 +19501,27 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "aGG" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 32
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/light_switch{
-	pixel_x = -7;
-	pixel_y = 26
+/obj/machinery/newscaster{
+	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/kitchen)
+/area/quartermaster/office)
 "aGH" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light/small{
@@ -20887,19 +20915,20 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "aIy" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
+	dir = 8
+	},
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+	dir = 1;
+	pixel_y = -26
 	},
-/obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = 24
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "aIz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
@@ -21049,10 +21078,25 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aIM" = (
-/obj/machinery/food_cart,
-/obj/effect/turf_decal/delivery,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/kitchen)
+/area/crew_quarters/bar/atrium)
 "aIN" = (
 /obj/structure/table/wood,
 /obj/structure/table/wood,
@@ -21704,21 +21748,9 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "aJS" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/structure/sign/departments/medbay/alt,
+/turf/closed/wall/r_wall,
+/area/security/execution/transfer)
 "aJT" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -22667,19 +22699,23 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "aLu" = (
-/obj/structure/closet/radiation,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/light_switch{
+	pixel_x = -26
 	},
 /obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+	dir = 1;
+	pixel_y = -22
 	},
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmospherics_engine)
+/area/quartermaster/storage)
 "aLv" = (
 /obj/structure/cable/white{
 	icon_state = "1-4"
@@ -24304,17 +24340,14 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aNU" = (
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/vending/wardrobe/cargo_wardrobe,
+/obj/effect/turf_decal/bot,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -26
 	},
-/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/quartermaster/storage)
 "aNV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24367,19 +24400,26 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aOa" = (
-/obj/machinery/light/small,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	icon_state = "manifold-1";
+	dir = 1
 	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/plaque{
-	icon_state = "L4"
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/security/prison)
 "aOb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24768,19 +24808,26 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aOB" = (
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/firealarm{
+/obj/machinery/autolathe,
+/obj/machinery/airalarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -22
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	pixel_x = -23
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/quartermaster/office)
 "aOC" = (
 /obj/structure/sign/poster/random,
 /turf/closed/wall,
@@ -25823,26 +25870,19 @@
 	},
 /area/crew_quarters/abandoned_gambling_den/secondary)
 "aQd" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
+/obj/machinery/airalarm{
+	pixel_y = 22
 	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
+/obj/machinery/chem_master/condimaster{
+	name = "BrewMaster 3000"
 	},
+/obj/effect/turf_decal/bot,
 /obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	icon_state = "manifold-1";
-	dir = 1
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/hydroponics)
 "aQe" = (
 /obj/structure/mirror{
 	pixel_x = -28
@@ -25934,24 +25974,16 @@
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
 "aQl" = (
-/obj/structure/table/wood,
+/obj/machinery/light_switch{
+	pixel_x = -26;
+	pixel_y = 26
+	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = -26
 	},
-/obj/item/camera,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar/atrium)
+/turf/open/floor/plasteel,
+/area/crew_quarters/kitchen)
 "aQm" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -26070,7 +26102,9 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aQv" = (
-/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/light{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -26128,31 +26162,22 @@
 /area/engine/break_room)
 "aQB" = (
 /obj/structure/table,
-/obj/item/storage/box{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/lights/mixed,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = -26
-	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clipboard,
+/obj/item/toy/figure/miner,
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+/obj/effect/turf_decal/bot,
+/obj/machinery/light_switch{
+	pixel_x = -38
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/sorting)
+/area/quartermaster/miningoffice)
 "aQC" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
@@ -26534,18 +26559,19 @@
 /turf/open/floor/plasteel/dark,
 /area/security/nuke_storage)
 "aRl" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/decal/cleanable/dirt,
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/engine/atmos)
 "aRm" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposaloutlet{
@@ -27615,23 +27641,12 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aSV" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
-	dir = 4
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmospherics_engine)
+/area/hydroponics)
 "aSW" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -28182,24 +28197,16 @@
 /turf/closed/wall,
 /area/quartermaster/office)
 "aTP" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/light_switch{
+	pixel_x = -7;
+	pixel_y = 26
 	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/crew_quarters/kitchen)
 "aTQ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -28508,12 +28515,14 @@
 /turf/open/floor/plating,
 /area/engine/storage_shared)
 "aUk" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/food_cart,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/crew_quarters/kitchen)
 "aUl" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow{
@@ -31216,26 +31225,24 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "aYg" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/structure/table/reinforced,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
 	},
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/quartermaster/miningoffice)
 "aYh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31527,25 +31534,17 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar/atrium)
 "aYF" = (
+/obj/machinery/light,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/bar/atrium)
+/area/hallway/primary/central)
 "aYG" = (
 /obj/effect/landmark/start/cook,
 /obj/structure/disposalpipe/segment{
@@ -31790,11 +31789,17 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aYZ" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/light/small,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L4"
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aZa" = (
@@ -31841,11 +31846,27 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aZc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
+/obj/structure/table/reinforced,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/item/folder/yellow,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -31893,17 +31914,14 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aZh" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/paper_bin,
 /obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/item/pen,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aZi" = (
@@ -32095,32 +32113,19 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "aZx" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/button/door{
-	id = "ceblast";
-	name = "Lockdown Control";
-	pixel_x = 26;
-	pixel_y = 26;
-	req_access_txt = "56"
-	},
+/obj/machinery/light,
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aZy" = (
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -32664,15 +32669,30 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bav" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "Head of Security's Office APC";
+	areastring = "/area/crew_quarters/heads/hos";
+	pixel_y = -26
+	},
+/obj/structure/cable/white,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "baw" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom{
@@ -32796,30 +32816,21 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "baH" = (
-/obj/machinery/autolathe,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -33
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_x = -23
-	},
-/obj/effect/turf_decal/tile/brown{
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/white/corner,
+/area/engine/atmos)
 "baI" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
@@ -33135,28 +33146,19 @@
 /area/security/main)
 "bbh" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/button/door{
-	id = "transitlock";
-	name = "Transit Tube Lockdown Control";
-	pixel_y = 26;
-	req_access_txt = "19"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/transit_tube)
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
 "bbi" = (
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
@@ -33680,19 +33682,20 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bbZ" = (
-/obj/machinery/airalarm{
-	pixel_y = 22
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/machinery/chem_master/condimaster{
-	name = "BrewMaster 3000"
-	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/hydroponics)
+/area/security/main)
 "bca" = (
 /obj/machinery/power/apc/highcap/ten_k{
 	dir = 1;
@@ -33989,23 +33992,26 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bcy" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clipboard,
-/obj/item/toy/figure/miner,
+/obj/machinery/disposal/bin,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	pixel_x = -38;
+	pixel_y = -8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/light_switch{
-	pixel_x = -38
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/miningoffice)
+/area/engine/atmos)
 "bcz" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -35578,24 +35584,33 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "beO" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
+"beP" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
-"beP" = (
-/obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/storage/tech)
+/area/security/brig)
 "beQ" = (
 /obj/machinery/camera{
 	c_tag = "Hydroponics Backroom";
@@ -36515,9 +36530,22 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "bgk" = (
-/obj/structure/sign/departments/botany,
-/turf/closed/wall,
-/area/hydroponics)
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 8
+	},
+/obj/structure/sign/departments/botany{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "bgl" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -36577,16 +36605,18 @@
 /turf/open/floor/plating,
 /area/security/detectives_office)
 "bgq" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/engine/storage_shared)
 "bgr" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/light{
@@ -37491,12 +37521,12 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bhF" = (
+/obj/effect/turf_decal/delivery,
 /obj/machinery/firealarm{
-	pixel_y = 24
+	pixel_y = 26
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/hydroponics)
+/area/engine/break_room)
 "bhG" = (
 /obj/machinery/smartfridge,
 /turf/closed/wall,
@@ -39208,23 +39238,23 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "bjM" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/structure/closet/emcloset,
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/machinery/button/door{
+	desc = "A remote control switch.";
+	id = "gulagdoor";
+	name = "Transfer Door Control";
+	normaldoorcontrol = 1;
+	pixel_x = -24;
+	pixel_y = -8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
 "bjN" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -39336,23 +39366,16 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bjY" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "bjZ" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -39446,26 +39469,26 @@
 /turf/open/floor/plating,
 /area/quartermaster/miningoffice)
 "bkg" = (
-/obj/structure/window/reinforced,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/light_switch{
+	pixel_y = 26
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "bkh" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -40456,24 +40479,19 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "blO" = (
+/obj/machinery/light_switch{
+	pixel_y = -26
+	},
 /obj/structure/table/reinforced,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
+/obj/item/stack/sheet/plasteel/twenty,
+/obj/item/wrench,
+/obj/effect/turf_decal/bot,
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/miningoffice)
+/area/engine/gravity_generator)
 "blP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/photocopier,
@@ -40679,10 +40697,18 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "bmg" = (
-/obj/structure/cable/white,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/departments/medbay/alt,
-/turf/open/floor/plating,
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "bmh" = (
 /obj/machinery/door/firedoor,
@@ -41695,17 +41721,13 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bnQ" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
+/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/hallway/primary/central)
 "bnR" = (
 /obj/structure/cable/white{
 	icon_state = "1-4"
@@ -42088,13 +42110,18 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "boy" = (
-/obj/machinery/hydroponics/constructable,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/sign/departments/botany{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/hydroponics)
+/area/hallway/primary/central)
 "boz" = (
 /obj/machinery/light_switch{
 	pixel_x = 26;
@@ -42124,18 +42151,32 @@
 /turf/closed/wall,
 /area/hydroponics)
 "boE" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/button/door{
+	id = "ceblast";
+	name = "Lockdown Control";
+	pixel_x = 26;
+	pixel_y = 26;
+	req_access_txt = "56"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+	pixel_y = 26
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "boF" = (
 /obj/item/radio/intercom{
 	pixel_x = 26;
@@ -44829,12 +44870,13 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bso" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bsp" = (
@@ -45670,16 +45712,29 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "bty" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/button/door{
+	id = "transitlock";
+	name = "Transit Tube Lockdown Control";
+	pixel_y = 26;
+	req_access_txt = "19"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = -32
+	dir = 8;
+	pixel_x = 26
 	},
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/crew_quarters/heads/hos)
+/turf/open/floor/plasteel/dark,
+/area/engine/transit_tube)
 "btz" = (
 /obj/machinery/status_display/ai{
 	pixel_y = 32
@@ -46468,16 +46523,15 @@
 /turf/open/floor/plating,
 /area/security/main)
 "buM" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel,
-/area/security/main)
+/area/hallway/primary/port)
 "buN" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -46551,25 +46605,13 @@
 /area/security/main)
 "buT" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "Head of Security's Office APC";
-	areastring = "/area/crew_quarters/heads/hos";
+/obj/effect/turf_decal/delivery,
+/obj/machinery/firealarm{
+	dir = 1;
 	pixel_y = -26
 	},
-/obj/structure/cable/white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
+/turf/open/floor/plasteel,
+/area/storage/tech)
 "buU" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -46792,21 +46834,29 @@
 /turf/open/floor/plasteel/white/corner,
 /area/engine/atmos)
 "bvh" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/item/radio{
+	pixel_x = 5;
+	pixel_y = 5
 	},
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/item/radio{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/radio,
+/obj/machinery/light_switch{
+	pixel_x = 26
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -26
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner,
-/area/engine/atmos)
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "bvi" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Security Maintenance";
@@ -47369,23 +47419,16 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "bwc" = (
-/obj/item/twohanded/required/kirbyplants/random,
+/obj/structure/bed,
+/obj/item/bedsheet/ce,
+/obj/machinery/light{
+	dir = 1
+	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+	pixel_y = 26
 	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/execution/transfer)
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/heads/chief)
 "bwd" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -47399,16 +47442,16 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bwe" = (
-/obj/item/twohanded/required/kirbyplants/random,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
-/area/security/main)
+/area/hallway/primary/starboard)
 "bwf" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -32
@@ -47683,37 +47726,65 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bwA" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+/obj/structure/rack,
+/obj/item/storage/box/rubbershot{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
+/obj/item/storage/box/rubbershot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/rubbershot,
+/obj/item/storage/box/rubbershot,
+/obj/item/storage/box/rubbershot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/storage/box/rubbershot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
-"bwB" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = -26
 	},
-/obj/machinery/light_switch{
-	pixel_x = -38;
-	pixel_y = -8
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
+"bwB" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
 	},
-/obj/structure/disposalpipe/trunk{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "bwC" = (
 /obj/machinery/camera{
 	c_tag = "Engineering - Power Tools";
@@ -49209,19 +49280,22 @@
 /area/security/execution/transfer)
 "byI" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/security/execution/transfer)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "byJ" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -52993,28 +53067,23 @@
 /turf/closed/wall,
 /area/security/execution/transfer)
 "bDW" = (
-/obj/structure/closet/emcloset,
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -32;
-	pixel_y = 6
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/button/door{
-	desc = "A remote control switch.";
-	id = "gulagdoor";
-	name = "Transfer Door Control";
-	normaldoorcontrol = 1;
-	pixel_x = -24;
-	pixel_y = -8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/security/execution/transfer)
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "bDX" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -53783,21 +53852,26 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/restrooms)
 "bEQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/light_switch{
-	pixel_x = -10;
-	pixel_y = 26
+/obj/structure/window/reinforced,
+/obj/machinery/light/small{
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/toilet/restrooms)
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "bER" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -55206,25 +55280,23 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "bHd" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/porta_turret/ai,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/cable/white{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
-/area/crew_quarters/locker)
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "bHe" = (
 /obj/structure/chair/comfy/brown{
 	color = "#596479";
@@ -55741,19 +55813,17 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bHS" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+	pixel_y = 26
 	},
-/obj/machinery/light_switch{
-	pixel_y = -26
-	},
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/plasteel/twenty,
-/obj/item/wrench,
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/area/engine/engineering)
 "bHT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -57313,15 +57383,24 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "bKd" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/library)
 "bKe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/plasticflaps/opaque,
@@ -57583,14 +57662,13 @@
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "bKE" = (
+/obj/machinery/vending/wardrobe/law_wardrobe,
 /obj/machinery/firealarm{
-	pixel_y = 24
+	dir = 8;
+	pixel_x = 26
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/wood,
+/area/lawoffice)
 "bKF" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -61570,29 +61648,18 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "bQu" = (
-/obj/structure/table/reinforced,
-/obj/item/radio{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/radio{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/radio,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/light_switch{
-	pixel_x = 26
-	},
 /obj/machinery/light{
-	dir = 4
+	dir = 8
 	},
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel,
-/area/storage/primary)
+/area/security/brig)
 "bQv" = (
 /turf/closed/wall,
 /area/storage/primary)
@@ -62698,13 +62765,22 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/chief)
 "bSf" = (
-/obj/structure/bed,
-/obj/item/bedsheet/ce,
-/obj/machinery/light{
+/obj/machinery/porta_turret/ai,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/turf/open/floor/plasteel/grimy,
-/area/crew_quarters/heads/chief)
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai_upload)
 "bSg" = (
 /obj/structure/dresser,
 /obj/machinery/status_display/evac{
@@ -63338,28 +63414,19 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "bTi" = (
-/obj/structure/rack,
-/obj/item/storage/box/rubbershot{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/machinery/status_display/evac{
+	pixel_y = -32
 	},
-/obj/item/storage/box/rubbershot{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/structure/cable/white{
+	icon_state = "0-8"
 	},
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot{
-	pixel_x = 3;
-	pixel_y = -3
+/obj/machinery/camera{
+	c_tag = "Engineering - Power Monitoring";
+	dir = 1;
+	name = "engineering camera"
 	},
-/obj/item/storage/box/rubbershot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -63372,7 +63439,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
+/area/engine/engineering)
 "bTj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -63449,16 +63516,9 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "bTn" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/light,
+/obj/machinery/computer/station_alert{
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -63470,8 +63530,12 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
 /turf/open/floor/plasteel/dark,
-/area/aisat)
+/area/engine/engineering)
 "bTo" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -65661,24 +65725,14 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "bWm" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -24;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bWn" = (
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/chief)
@@ -68517,23 +68571,18 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "caj" = (
+/obj/structure/table/wood,
+/obj/item/camera_film{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/camera_film,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 26
 	},
-/obj/machinery/porta_turret/ai,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/turf/open/floor/plasteel/grimy,
+/area/library)
 "cak" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/light_switch{
@@ -69376,6 +69425,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
+"cbK" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/item/pen/blue{
+	pixel_x = -4;
+	pixel_y = -2
+	},
+/obj/item/pen/red,
+/obj/item/stamp/qm{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "cbL" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 32
@@ -69756,12 +69828,14 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "ccs" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/item/stack/sheet/plasteel/twenty,
+/obj/item/stack/sheet/rglass{
+	amount = 30;
+	pixel_x = 2;
+	pixel_y = -2
 	},
+/obj/item/crowbar,
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -69772,8 +69846,12 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel/dark,
-/area/library)
+/area/ai_monitored/storage/eva)
 "cct" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -69977,17 +70055,21 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "ccH" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/sign/departments/science{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ccI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
@@ -70358,13 +70440,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cdk" = (
-/obj/machinery/vending/wardrobe/law_wardrobe,
+/obj/structure/table/wood,
+/obj/item/bikehorn/rubberducky,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 26
 	},
 /turf/open/floor/wood,
-/area/lawoffice)
+/area/clerk)
 "cdl" = (
 /turf/closed/wall/r_wall,
 /area/lawoffice)
@@ -70564,22 +70647,19 @@
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "cdA" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/porta_turret/ai,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai_upload)
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "cdB" = (
 /obj/structure/grille,
 /obj/effect/turf_decal/stripes/line{
@@ -72273,20 +72353,25 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "cfX" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/crew_quarters/locker)
 "cfY" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/light/small{
@@ -72422,23 +72507,21 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "cgl" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/light_switch{
+	pixel_x = -10;
+	pixel_y = 26
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/explab)
+/turf/open/floor/plasteel,
+/area/crew_quarters/toilet/restrooms)
 "cgm" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -72609,6 +72692,21 @@
 /obj/structure/cable/white,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/captain/private)
+"cgx" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window/westright{
+	name = "Monkey Pen";
+	req_access_txt = "9"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/mob/living/carbon/monkey,
+/turf/open/floor/plasteel,
+/area/medical/genetics)
 "cgy" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet,
@@ -73402,54 +73500,33 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "chF" = (
+/obj/structure/table,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24;
-	pixel_y = -32
+	pixel_x = -26
 	},
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
-/obj/structure/cable/white{
-	icon_state = "0-8"
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering - Power Monitoring";
-	dir = 1;
-	name = "engineering camera"
-	},
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
+/turf/open/floor/plasteel,
+/area/vacant_room/commissary)
 "chG" = (
-/obj/machinery/light,
-/obj/machinery/computer/station_alert{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
+/obj/structure/rack,
+/obj/item/storage/belt/utility,
+/obj/item/weldingtool,
+/obj/item/clothing/head/welding,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/storage)
 "chH" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 1
@@ -73586,19 +73663,18 @@
 /turf/open/floor/wood,
 /area/library)
 "chY" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/electricshock{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/bot,
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
-	dir = 8
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/engine/storage)
 "chZ" = (
 /obj/machinery/computer/security/mining{
 	dir = 4
@@ -74518,40 +74594,15 @@
 /turf/open/floor/wood,
 /area/library)
 "cjt" = (
-/obj/structure/table/reinforced,
-/obj/item/nanite_scanner{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/item/nanite_scanner{
-	pixel_x = 4;
-	pixel_y = -4
-	},
-/obj/item/nanite_remote{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/nanite_remote{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
 "cju" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -77230,18 +77281,14 @@
 /turf/open/floor/plasteel/grimy,
 /area/library)
 "cnV" = (
-/obj/structure/table/wood,
-/obj/item/camera_film{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/obj/item/camera_film,
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+	pixel_y = 26
 	},
-/turf/open/floor/plasteel/grimy,
-/area/library)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "cnW" = (
 /obj/structure/bed,
 /obj/machinery/newscaster{
@@ -77590,7 +77637,7 @@
 	dir = 8
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "coy" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -81899,21 +81946,29 @@
 /turf/open/floor/plasteel,
 /area/medical/morgue)
 "cvI" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/paper_bin,
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/closet/secure_closet/security/science,
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -26;
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/science/research)
 "cvJ" = (
 /obj/machinery/door/airlock/wood{
 	name = "Psychiatrists office";
@@ -82705,12 +82760,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cwQ" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/tile/green{
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/turf/open/space/basic,
+/area/space/nearstation)
 "cwR" = (
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -82984,14 +83040,30 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "cxp" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display/ai{
+	pixel_y = 32
+	},
+/obj/machinery/light_switch{
+	pixel_x = 38
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26;
+	pixel_y = 32
+	},
+/obj/structure/closet/secure_closet/security/med,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 26
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/science/misc_lab)
+/area/security/checkpoint/medical)
 "cxq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -83456,14 +83528,38 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cye" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/structure/table/glass,
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -3;
+	pixel_y = 2
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
+/area/medical/storage)
 "cyf" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -83529,30 +83625,18 @@
 /turf/open/floor/plasteel,
 /area/medical/morgue)
 "cyi" = (
-/obj/item/stack/sheet/plasteel/twenty,
-/obj/item/stack/sheet/rglass{
-	amount = 30;
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/crowbar,
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/storage/bag/bio,
+/obj/item/storage/bag/bio,
+/obj/effect/turf_decal/bot,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = -26
 	},
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/eva)
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "cyj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -86118,21 +86202,31 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "cCm" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
+/obj/structure/table/glass,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/reagent_containers/glass/bottle/charcoal{
+	pixel_x = 6
 	},
-/obj/machinery/shower{
-	dir = 8;
-	name = "emergency shower"
+/obj/item/reagent_containers/glass/bottle/epinephrine,
+/obj/item/reagent_containers/dropper,
+/obj/machinery/light{
+	dir = 4
 	},
+/obj/machinery/camera{
+	c_tag = "Medbay - Chemistry";
+	network = list("ss13","medbay");
+	dir = 8;
+	name = "medbay camera"
+	},
+/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+	dir = 8;
+	pixel_x = 26
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/medical/virology)
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "cCn" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -87262,19 +87356,20 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs/auxiliary)
 "cDS" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "cDT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -87712,13 +87807,6 @@
 /area/crew_quarters/theatre/abandoned)
 "cEA" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -87729,8 +87817,12 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/office)
+/area/science/explab)
 "cEB" = (
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/glass/fifty,
@@ -88621,19 +88713,23 @@
 /turf/open/floor/plating,
 /area/engine/storage)
 "cFV" = (
-/obj/structure/rack,
-/obj/item/storage/belt/utility,
-/obj/item/weldingtool,
-/obj/item/clothing/head/welding,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = -32
+/obj/machinery/camera{
+	c_tag = "Science - Lab Access";
+	dir = 8;
+	name = "science camera";
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
 /turf/open/floor/plasteel,
-/area/engine/storage)
+/area/science/research)
 "cFW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow,
@@ -89576,14 +89672,40 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "cHq" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/electricshock{
-	pixel_y = -32
+/obj/structure/table/reinforced,
+/obj/item/nanite_scanner{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/nanite_scanner{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/nanite_remote{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/nanite_remote{
+	pixel_x = 4;
+	pixel_y = 4
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/engine/storage)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "cHr" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/status_display/evac{
@@ -92449,33 +92571,16 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "cLs" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
+	pixel_x = 36
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/machinery/vending/assist,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
+/turf/open/floor/plasteel/white,
+/area/science/misc_lab/range)
 "cLt" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Chapel Maintenance";
@@ -93987,9 +94092,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cNo" = (
-/obj/structure/sign/departments/science,
-/turf/closed/wall,
-/area/hallway/primary/central)
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/sign/departments/science{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "cNp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -94600,13 +94711,14 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "cOr" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 8
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/turf/open/space/basic,
-/area/space)
+/obj/structure/sign/departments/minsky/engineering/telecommmunications{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
 "cOs" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /obj/effect/decal/cleanable/dirt,
@@ -95076,8 +95188,13 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cPi" = (
-/obj/structure/sign/departments/science,
-/turf/closed/wall,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/sign/departments/science{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "cPj" = (
 /obj/machinery/light_switch{
@@ -96006,29 +96123,29 @@
 /turf/closed/wall,
 /area/security/checkpoint/science/research)
 "cQE" = (
-/obj/structure/closet/secure_closet/security/science,
+/obj/structure/table,
+/obj/item/cartridge/signal/toxins{
+	pixel_x = 6
+	},
+/obj/item/cartridge/signal/toxins{
+	pixel_x = -6
+	},
+/obj/item/cartridge/signal/toxins{
+	pixel_y = 6
+	},
+/obj/machinery/camera{
+	c_tag = "Science - Research Director's Office";
+	dir = 8;
+	name = "science camera";
+	network = list("ss13","rd")
+	},
+/obj/effect/turf_decal/bot,
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26;
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
-/area/security/checkpoint/science/research)
+/area/crew_quarters/heads/hor)
 "cQF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -97604,30 +97721,25 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "cSO" = (
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/light,
 /obj/machinery/light_switch{
-	pixel_x = 38
+	pixel_x = 7;
+	pixel_y = -38
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26;
-	pixel_y = 32
+/obj/machinery/camera{
+	c_tag = "Medbay - Cloning Lab";
+	network = list("ss13","medbay");
+	dir = 1;
+	name = "medbay camera"
 	},
-/obj/structure/closet/secure_closet/security/med,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/medical)
+/turf/open/floor/plasteel/white,
+/area/medical/genetics/cloning)
 "cSP" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags{
@@ -99699,23 +99811,16 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "cVJ" = (
-/obj/machinery/camera{
-	c_tag = "Science - Lab Access";
-	dir = 8;
-	name = "science camera";
-	network = list("ss13","rd")
+/obj/structure/closet/bombcloset,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/obj/effect/turf_decal/bot,
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
-	dir = 8
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
-/area/science/research)
+/area/science/mixing)
 "cVK" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -100297,38 +100402,18 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "cWy" = (
-/obj/structure/table/glass,
-/obj/item/storage/belt/medical,
-/obj/item/storage/belt/medical,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
-/area/medical/storage)
+/turf/open/floor/plasteel/white,
+/area/medical/surgery)
 "cWz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -102345,9 +102430,8 @@
 /turf/open/floor/plasteel,
 /area/medical/paramedic)
 "cZi" = (
-/obj/structure/sign/departments/science,
-/turf/closed/wall/r_wall,
-/area/science/research)
+/turf/closed/wall,
+/area/science/lab)
 "cZj" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -102374,9 +102458,15 @@
 /turf/closed/wall/r_wall,
 /area/science/research)
 "cZl" = (
-/obj/structure/sign/departments/science,
-/turf/closed/wall,
-/area/science/lab)
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/sign/departments/science{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "cZm" = (
 /turf/closed/wall/r_wall,
 /area/science/lab)
@@ -102958,11 +103048,6 @@
 /area/science/robotics/mechbay)
 "dah" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24;
-	pixel_y = -26
-	},
 /obj/machinery/light_switch{
 	pixel_x = 26;
 	pixel_y = -38
@@ -104505,27 +104590,14 @@
 /turf/open/floor/plasteel,
 /area/medical/paramedic)
 "dcA" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/bot,
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24;
-	pixel_y = -26
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
+/turf/open/floor/plasteel,
+/area/medical/genetics)
 "dcB" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -105450,18 +105522,15 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "ddS" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+/obj/machinery/dna_scannernew,
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
 	},
-/obj/item/storage/bag/bio,
-/obj/item/storage/bag/bio,
-/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel,
-/area/science/xenobiology)
+/area/medical/genetics)
 "ddT" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/bot,
@@ -106256,9 +106325,15 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "dfc" = (
-/obj/structure/sign/departments/xenobio,
-/turf/closed/wall/r_wall,
-/area/science/xenobiology)
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/structure/sign/departments/xenobio{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "dfd" = (
 /obj/structure/cable/white{
 	icon_state = "0-4"
@@ -106524,9 +106599,13 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "dfv" = (
-/obj/structure/sign/departments/chemistry,
-/turf/closed/wall,
-/area/medical/chemistry)
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/sign/departments/chemistry{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "dfw" = (
 /obj/machinery/light{
 	dir = 8
@@ -106569,31 +106648,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dfz" = (
-/obj/structure/table/glass,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/reagent_containers/glass/bottle/charcoal{
-	pixel_x = 6
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/obj/item/reagent_containers/glass/bottle/epinephrine,
-/obj/item/reagent_containers/dropper,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Medbay - Chemistry";
-	network = list("ss13","medbay");
-	dir = 8;
-	name = "medbay camera"
-	},
-/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/genetics)
 "dfA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	icon_state = "pipe11-1";
@@ -106670,7 +106733,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "dfH" = (
-/obj/structure/sign/departments/examroom,
+/obj/structure/sign/nanotrasen,
 /turf/closed/wall,
 /area/medical/medbay/central)
 "dfI" = (
@@ -107166,12 +107229,18 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "dgu" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/mechbay)
 "dgv" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -112442,6 +112511,29 @@
 /obj/item/bedsheet/prisoner,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"dnt" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window/westleft{
+	name = "Monkey Pen";
+	req_access_txt = "9"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/medical/genetics)
+"dnu" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/sign/departments/minsky/medical/virology/virology1{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "dnv" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/tile/blue{
@@ -112653,6 +112745,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
+"dnL" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/sign/departments/science{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "dnM" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -112778,6 +112885,43 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
+"dnW" = (
+/obj/structure/table,
+/obj/machinery/status_display/ai{
+	pixel_y = -32
+	},
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/gun/syringe,
+/obj/item/clothing/glasses/eyepatch,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/surgery)
+"dnX" = (
+/obj/item/stack/sheet/plasteel{
+	amount = 15
+	},
+/obj/item/wrench,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/clothing/glasses/welding,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "dnY" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/cleanable/dirt,
@@ -112829,6 +112973,16 @@
 "dod" = (
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
+"doe" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/science/storage)
 "dof" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -113239,12 +113393,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "doG" = (
-/obj/structure/table/reinforced,
-/obj/structure/cable/white{
-	icon_state = "4-8"
+/obj/machinery/light_switch{
+	pixel_x = 26;
+	pixel_y = 26
 	},
-/obj/item/folder/yellow,
-/obj/item/stamp/qm,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -113255,16 +113407,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "doH" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -113952,20 +114096,23 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/construction)
 "dpJ" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
-	dir = 8
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/area/medical/morgue)
 "dpK" = (
 /obj/structure/closet/emcloset,
 /obj/item/clothing/mask/breath,
@@ -114174,6 +114321,26 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"dqc" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/paper_bin,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "dqd" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -114189,6 +114356,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"dqe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "dqf" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -114543,6 +114719,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hor)
+"dqD" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "dqE" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
@@ -114664,6 +114849,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
+"dqN" = (
+/obj/structure/filingcabinet/medical,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/customs/auxiliary)
 "dqO" = (
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
@@ -114698,6 +114898,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
+"dqS" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/machinery/shower{
+	dir = 8;
+	name = "emergency shower"
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/medical/virology)
 "dqT" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -114787,6 +115003,20 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"dqY" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "dqZ" = (
 /obj/machinery/door/window/eastright,
 /obj/machinery/status_display/ai{
@@ -114922,6 +115152,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"dri" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/work_for_a_future{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/virology)
 "drj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
@@ -115125,16 +115381,26 @@
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
 "drF" = (
-/obj/machinery/light_switch{
-	pixel_x = 36
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 26
 	},
-/obj/machinery/vending/assist,
-/turf/open/floor/plasteel/white,
-/area/science/misc_lab/range)
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "drG" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/stripes/line{
@@ -115183,6 +115449,21 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
+"drL" = (
+/obj/structure/chair/wood,
+/obj/machinery/camera{
+	c_tag = "Chapel - Starboard";
+	dir = 8;
+	name = "chapel camera"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel{
+	icon_state = "chapel"
+	},
+/area/chapel/main)
 "drM" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/disks_nanite{
@@ -115361,29 +115642,21 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "dsb" = (
-/obj/structure/table,
-/obj/item/cartridge/signal/toxins{
-	pixel_x = 6
+/obj/structure/closet/secure_closet/medical1,
+/obj/machinery/light_switch{
+	pixel_x = 26;
+	pixel_y = -26
 	},
-/obj/item/cartridge/signal/toxins{
-	pixel_x = -6
-	},
-/obj/item/cartridge/signal/toxins{
-	pixel_y = 6
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Science - Research Director's Office";
-	dir = 8;
-	name = "science camera";
-	network = list("ss13","rd")
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/heads/hor)
+/area/medical/virology)
 "dsc" = (
 /obj/item/radio/intercom{
 	pixel_x = 26
@@ -115482,6 +115755,24 @@
 	},
 /turf/open/floor/plating/airless,
 /area/medical/virology)
+"dsj" = (
+/obj/structure/bodycontainer/morgue,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "dsk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
@@ -115500,6 +115791,108 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
+"dsm" = (
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/obj/machinery/light_switch{
+	pixel_x = 26;
+	pixel_y = 26
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
+"dsn" = (
+/obj/structure/table/wood,
+/obj/item/camera_film{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/camera_film,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
+"dso" = (
+/obj/structure/filingcabinet/security,
+/obj/machinery/light_switch{
+	pixel_x = -26;
+	pixel_y = 26
+	},
+/obj/machinery/camera{
+	c_tag = "Security - Departures Port";
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/escape)
+"dsp" = (
+/obj/structure/table/wood,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/obj/item/clipboard,
+/obj/item/toy/figure/chaplain,
+/obj/structure/sign/poster/official/bless_this_spess{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "dst" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -115537,27 +115930,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics/cloning)
-"dsz" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 7;
-	pixel_y = -26
-	},
-/obj/machinery/light,
-/obj/machinery/light_switch{
-	pixel_x = 7;
-	pixel_y = -38
-	},
-/obj/machinery/camera{
-	c_tag = "Medbay - Cloning Lab";
-	network = list("ss13","medbay");
-	dir = 1;
-	name = "medbay camera"
-	},
-/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "dsC" = (
@@ -115705,17 +116077,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"dti" = (
-/obj/structure/closet/bombcloset,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "dtl" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/purple{
@@ -115806,19 +116167,6 @@
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
-"dtQ" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
@@ -116075,15 +116423,6 @@
 "dvc" = (
 /turf/closed/wall,
 /area/medical/genetics)
-"dvd" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/medical/genetics)
 "dve" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
@@ -116149,27 +116488,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/medical/genetics)
-"dvl" = (
-/obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/medical/genetics)
-"dvm" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/firealarm{
-	pixel_x = -26;
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "dvp" = (
 /obj/structure/window/reinforced{
@@ -116476,30 +116794,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
-"dwC" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/science/robotics/mechbay)
-"dwT" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window/westright{
-	name = "'Monkey Pen";
-	req_access_txt = "9"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/mob/living/carbon/monkey,
-/turf/open/floor/plasteel,
-/area/medical/genetics)
 "dwU" = (
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -116750,10 +117044,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/robotics/lab)
-"dye" = (
-/obj/structure/sign/departments/science,
-/turf/closed/wall,
-/area/science/robotics/lab)
 "dyf" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
@@ -116799,19 +117089,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"dyt" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window/westleft{
-	name = "'Monkey Pen";
-	req_access_txt = "9"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/medical/genetics)
 "dyu" = (
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -116856,26 +117133,6 @@
 	heat_capacity = 1e+006
 	},
 /area/crew_quarters/heads/cmo)
-"dyD" = (
-/obj/structure/table,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/item/clothing/glasses/blindfold,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/gun/syringe,
-/obj/item/clothing/glasses/eyepatch,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
 "dyE" = (
 /obj/machinery/computer/med_data{
 	dir = 1
@@ -117534,23 +117791,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
-"dAJ" = (
-/obj/item/stack/sheet/plasteel{
-	amount = 15
-	},
-/obj/item/wrench,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/clothing/glasses/welding,
-/obj/structure/table/reinforced,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
 "dAK" = (
 /obj/structure/cable/white{
 	icon_state = "2-4"
@@ -119030,16 +119270,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
-"dFQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/science/storage)
 "dFR" = (
 /obj/structure/cable/white{
 	icon_state = "0-4"
@@ -119460,24 +119690,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"dHC" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
 "dHV" = (
 /obj/structure/bed,
 /obj/item/bedsheet/cmo,
@@ -120651,21 +120863,6 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/customs/auxiliary)
-"dOC" = (
-/obj/structure/filingcabinet/medical,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs/auxiliary)
@@ -122025,32 +122222,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"dTU" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/sign/poster/official/work_for_a_future{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/virology)
 "dTW" = (
 /obj/item/clothing/neck/stethoscope,
 /obj/structure/table,
@@ -122848,21 +123019,6 @@
 	icon_state = "chapel"
 	},
 /area/chapel/main)
-"dXI" = (
-/obj/structure/chair/wood,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Chapel - Starboard";
-	dir = 8;
-	name = "chapel camera"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "chapel"
-	},
-/area/chapel/main)
 "dXL" = (
 /obj/structure/chair{
 	dir = 1
@@ -123179,22 +123335,6 @@
 	pixel_y = -32
 	},
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/medical/virology)
-"dYV" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/closet/secure_closet/medical1,
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = -26
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/medical/virology)
@@ -123858,24 +123998,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
-"ecw" = (
-/obj/structure/bodycontainer/morgue,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "ecx" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -124685,32 +124807,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"eez" = (
-/obj/structure/table/wood,
-/obj/item/camera_film{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/camera_film,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "eeA" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -124762,31 +124858,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"eeH" = (
-/obj/structure/filingcabinet/security,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = 26
-	},
-/obj/machinery/camera{
-	c_tag = "Security - Departures Port";
-	dir = 2
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/escape)
 "eeJ" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -125148,29 +125219,6 @@
 /area/chapel/office)
 "ega" = (
 /obj/machinery/vending/wardrobe/chap_wardrobe,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
-"egb" = (
-/obj/structure/table/wood,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/item/clipboard,
-/obj/item/toy/figure/chaplain,
-/obj/structure/sign/poster/official/bless_this_spess{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -126415,19 +126463,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"tbR" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
 "twt" = (
 /obj/machinery/vr_sleeper,
 /obj/effect/turf_decal/tile/neutral{
@@ -126465,25 +126500,6 @@
 	},
 /obj/structure/cable/white{
 	icon_state = "0-4"
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/vacant_room/commissary)
-"uMN" = (
-/obj/structure/table,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -132231,7 +132247,7 @@ byJ
 bNu
 bmH
 bRx
-bTn
+bwB
 diu
 bjB
 brL
@@ -133775,7 +133791,7 @@ bPC
 bRC
 bTs
 diB
-bjM
+byI
 cad
 bPC
 cdt
@@ -135832,9 +135848,9 @@ bRE
 bgE
 diE
 bgE
-caj
+bHd
 bPC
-cdA
+bSf
 cft
 bAU
 bZi
@@ -136345,7 +136361,7 @@ bPC
 bRF
 bgF
 diB
-bjY
+bDW
 cak
 bPC
 cdt
@@ -137887,7 +137903,7 @@ bmD
 bRN
 bgG
 diP
-bkg
+bEQ
 brS
 bmD
 boe
@@ -146360,7 +146376,7 @@ bAN
 aTF
 bnW
 aXF
-bHS
+blO
 bxC
 aad
 aad
@@ -147901,7 +147917,7 @@ qWg
 mHL
 aTR
 bpk
-bwA
+bjY
 fjK
 bLF
 cJi
@@ -148418,7 +148434,7 @@ bpV
 aXN
 fjK
 bLF
-bbh
+bty
 bRy
 ber
 bRV
@@ -149440,7 +149456,7 @@ buZ
 bws
 nBr
 bzi
-tbR
+bgq
 aUg
 brX
 bGh
@@ -150216,7 +150232,7 @@ aUi
 bti
 bGk
 bHV
-aZx
+boE
 bKJ
 bTQ
 bVL
@@ -150440,7 +150456,7 @@ aKf
 ahJ
 amt
 aFr
-aIy
+aBt
 arJ
 asx
 aMG
@@ -150736,7 +150752,7 @@ bNV
 bHV
 bSd
 bVP
-bWm
+bJQ
 bPW
 cas
 cbW
@@ -150983,7 +150999,7 @@ aMG
 bxE
 bzg
 bzg
-aUk
+bhF
 bLA
 bAR
 bHX
@@ -151248,7 +151264,7 @@ aZB
 bLC
 bNW
 bHV
-bSf
+bwc
 bWu
 bWo
 bYy
@@ -151482,7 +151498,7 @@ aAw
 aIf
 aTb
 aKn
-aEM
+aRl
 aMB
 aGh
 aHv
@@ -151981,7 +151997,7 @@ aCl
 awg
 aEo
 awF
-aoQ
+awD
 alT
 aJW
 aLq
@@ -152006,7 +152022,7 @@ bos
 bqb
 bse
 btV
-bvh
+baH
 aMG
 bxE
 bxE
@@ -153012,7 +153028,7 @@ awF
 aoX
 alT
 aKa
-aLu
+aCT
 aMG
 aOm
 aPR
@@ -153052,7 +153068,7 @@ bgY
 bWt
 bYC
 bSl
-bnQ
+bHS
 bsi
 brj
 chx
@@ -153071,8 +153087,8 @@ czv
 bED
 crE
 bGm
-cFV
-cHq
+chG
+chY
 cwo
 bUE
 cea
@@ -153292,13 +153308,13 @@ aVN
 aWe
 bqM
 aPM
-bwB
+bcy
 bxQ
 bzt
 bBa
 bCY
 aMG
-aYg
+bkg
 bzr
 aZE
 bLZ
@@ -153525,7 +153541,7 @@ aEv
 aAz
 api
 aqY
-aSV
+aBx
 aLv
 aMG
 aOn
@@ -153826,7 +153842,7 @@ bQg
 cch
 bsn
 bzH
-chF
+bTi
 car
 ckJ
 cme
@@ -153866,7 +153882,7 @@ djr
 saw
 doo
 cXo
-drF
+cLs
 saw
 dus
 cnN
@@ -154083,7 +154099,7 @@ caA
 cch
 bsy
 cfP
-chG
+bTn
 car
 ckK
 dig
@@ -154845,7 +154861,7 @@ bBU
 bab
 bab
 bab
-beO
+buM
 bab
 bab
 biC
@@ -156176,7 +156192,7 @@ dgs
 cMY
 djE
 dlr
-cgl
+cEA
 cWA
 ciW
 drI
@@ -156387,7 +156403,7 @@ bCo
 bae
 bbx
 bDg
-beP
+buT
 bss
 cKe
 bWD
@@ -156449,7 +156465,7 @@ gSi
 dFE
 dHd
 cCl
-cxp
+dqe
 dKC
 dLO
 gSi
@@ -156692,7 +156708,7 @@ djG
 dlt
 dmG
 cWC
-cjt
+cHq
 drM
 gFZ
 duz
@@ -156920,7 +156936,7 @@ cqM
 csh
 ctJ
 caG
-ccs
+bKd
 cxU
 czC
 cBa
@@ -157893,7 +157909,7 @@ aCw
 aCw
 aFQ
 aAb
-aOk
+bgk
 arB
 aLz
 aMT
@@ -157969,9 +157985,9 @@ cQg
 bXU
 daB
 dcp
-ddS
+cyi
+cMY
 dfc
-dgu
 dhV
 djL
 dfp
@@ -157979,7 +157995,7 @@ cyY
 cWI
 xOo
 drQ
-dti
+cVJ
 duF
 dwg
 dxP
@@ -158192,7 +158208,7 @@ cKh
 bWD
 bkT
 caG
-ccs
+bKd
 cei
 cfZ
 chQ
@@ -158427,7 +158443,7 @@ bhy
 bjp
 bld
 bng
-boy
+bwN
 bqy
 bsw
 bwN
@@ -158679,7 +158695,7 @@ bas
 bbS
 bdr
 bvB
-bgk
+bar
 bhz
 bjq
 ble
@@ -159003,7 +159019,7 @@ ccq
 cgu
 cqL
 dlz
-cVJ
+cFV
 iaF
 xOo
 drT
@@ -159237,7 +159253,7 @@ cwv
 cyc
 czK
 caG
-uMN
+chF
 cEx
 tQS
 cHE
@@ -159812,7 +159828,7 @@ cGY
 dsa
 ebd
 ebS
-ecw
+dsj
 dTw
 edm
 dTw
@@ -160058,7 +160074,7 @@ dQE
 cLI
 dTw
 cEt
-cEA
+drF
 cKo
 cNl
 cMR
@@ -160222,7 +160238,7 @@ bbY
 aDM
 beT
 bar
-bhF
+aSV
 aXM
 aIC
 bnm
@@ -160242,7 +160258,7 @@ bKv
 bKv
 bGM
 bOu
-bQu
+bvh
 bQv
 cKd
 bWD
@@ -160255,7 +160271,7 @@ chX
 bZS
 cxV
 chP
-cnV
+caj
 cpz
 cqU
 csl
@@ -160470,12 +160486,12 @@ aMX
 aOz
 aQh
 aDy
-awD
+aGw
 aVl
 aMX
 aAN
 bar
-bbZ
+aQd
 aDQ
 beU
 bar
@@ -160486,7 +160502,7 @@ bar
 boD
 bqD
 bsz
-bgk
+bar
 bvE
 bar
 bar
@@ -160558,7 +160574,7 @@ csd
 dCi
 dlE
 dEz
-dFQ
+doe
 dHp
 dIE
 dKd
@@ -160743,7 +160759,7 @@ bnn
 aKM
 aKP
 aKP
-aPu
+boy
 aKP
 aKP
 aQL
@@ -160788,7 +160804,7 @@ bZm
 bOQ
 bvI
 cOV
-cQE
+cvI
 bUq
 bWE
 bYi
@@ -160844,7 +160860,7 @@ ecz
 dTA
 dUu
 dTw
-eez
+dsn
 cRy
 ega
 dTw
@@ -161266,7 +161282,7 @@ aTt
 bik
 aTt
 aYl
-aYZ
+bnQ
 bap
 bap
 bap
@@ -161281,7 +161297,7 @@ blg
 blg
 bBg
 bsI
-aYZ
+bnQ
 bun
 bap
 bap
@@ -161291,7 +161307,7 @@ bJV
 aKY
 bCF
 aKY
-chY
+cdA
 aKY
 aKY
 aKY
@@ -161360,7 +161376,7 @@ edq
 dTw
 eeA
 cRL
-egb
+dsp
 dTw
 aad
 ajr
@@ -161470,7 +161486,7 @@ aaO
 aeY
 aei
 aky
-aeH
+acH
 ajI
 anc
 aob
@@ -161513,7 +161529,7 @@ aIK
 bcl
 aKP
 bfR
-aNU
+aYF
 bsW
 bvI
 bvK
@@ -161556,8 +161572,8 @@ cvo
 cHI
 cxf
 bZr
-aNY
-cNo
+ccH
+bsW
 cOV
 cOV
 cSl
@@ -161576,7 +161592,7 @@ dlI
 dmW
 chB
 cYf
-dsb
+cQE
 dtu
 duO
 dws
@@ -161745,7 +161761,7 @@ aAj
 akh
 arD
 aDL
-aEO
+aeH
 anW
 aFc
 aIU
@@ -161753,18 +161769,18 @@ aKu
 aDL
 aNa
 aOD
-aQl
+aEM
 aDK
 awP
 aVn
 aWV
 aYD
 bay
-aCT
+aQl
 cHP
 aFj
 aYC
-aGG
+aTP
 aYm
 aIL
 aYC
@@ -161804,7 +161820,7 @@ byX
 bJZ
 cvo
 cwB
-cyi
+ccs
 czQ
 cBj
 cCQ
@@ -162023,7 +162039,7 @@ beZ
 aYC
 bdJ
 aYz
-aIM
+aUk
 aYC
 bof
 bfX
@@ -162334,13 +162350,13 @@ cQJ
 bUr
 cnl
 cQQ
-cUe
-cZi
+cPi
+cOR
 bZq
 caw
 cbs
-cPi
-ccH
+dfm
+dnL
 cij
 cXW
 cYj
@@ -162632,7 +162648,7 @@ dUt
 cMA
 dVc
 dWR
-dXI
+drL
 dYz
 dZm
 dZU
@@ -162641,7 +162657,7 @@ dWN
 ebZ
 ecE
 dTA
-cLs
+dsm
 edW
 eeF
 efs
@@ -163106,7 +163122,7 @@ cXA
 cBR
 cQP
 cXv
-cZl
+cZi
 daP
 cZm
 cZm
@@ -163124,7 +163140,7 @@ cmq
 dnp
 dyc
 dzF
-dAJ
+dnX
 csG
 cvU
 dEH
@@ -163671,7 +163687,7 @@ dUx
 cLc
 cRm
 edZ
-eeH
+dso
 efu
 egh
 egE
@@ -163867,7 +163883,7 @@ czX
 cEJ
 cGn
 cvo
-bKE
+cnV
 bZp
 aOl
 cNp
@@ -163893,7 +163909,7 @@ cYV
 dtx
 duX
 dwy
-dye
+dyc
 dzI
 dAM
 dCs
@@ -164677,7 +164693,7 @@ dyg
 cyw
 cGA
 dNL
-dOC
+dqN
 dPf
 dPY
 dQN
@@ -164842,7 +164858,7 @@ aEN
 aLL
 aLL
 aLL
-aYF
+aIM
 baF
 aYD
 bdM
@@ -164920,7 +164936,7 @@ dqQ
 dsk
 dqQ
 dah
-dwC
+dgu
 dyg
 dyd
 dAP
@@ -165111,7 +165127,7 @@ aYC
 bnr
 aKP
 bgz
-aOa
+aYZ
 bsW
 aad
 bwU
@@ -165156,17 +165172,17 @@ bKI
 bZE
 bPn
 cNu
-cPi
+dfm
 cNp
 bUv
 cCz
 cNp
-cPi
+dfm
 cZq
 cZo
 cZm
 cZo
-cZl
+cZi
 dgR
 din
 dke
@@ -165413,17 +165429,17 @@ bKK
 bZF
 bPf
 bSk
-bTd
+cNo
 bTd
 bTd
 cDn
 bTd
-bTd
+cNo
 bYg
 bZs
 caC
 caC
-caC
+cZl
 caC
 caC
 caC
@@ -165937,11 +165953,11 @@ bYh
 bZt
 caD
 bZt
-bZt
+dfv
 ccO
 bZt
 bZt
-cfX
+cDS
 cgs
 cgs
 cYA
@@ -165958,7 +165974,7 @@ cxc
 cyg
 bXE
 bXE
-cye
+dqD
 cyz
 bXE
 cAQ
@@ -166169,7 +166185,7 @@ ccI
 coj
 cpM
 cqY
-bzq
+cOr
 bLR
 bMD
 abl
@@ -166194,7 +166210,7 @@ cPy
 dba
 dcM
 dba
-dfv
+dcM
 dgT
 dio
 dkf
@@ -166379,13 +166395,13 @@ aKE
 aLO
 aNl
 aOM
-aQB
+aEO
 aFe
-aTP
+aGG
 aVy
 aXg
 aYK
-baH
+aOB
 aTO
 bdO
 bfl
@@ -166461,7 +166477,7 @@ aaH
 aaK
 cZj
 aaq
-dvd
+dcA
 com
 dvc
 dzN
@@ -166470,7 +166486,7 @@ dCy
 dDI
 dER
 cyy
-dHC
+dpJ
 dIU
 dCy
 cyB
@@ -167993,7 +168009,7 @@ cZt
 dbh
 dcT
 deq
-dfz
+cCm
 dit
 cma
 cfl
@@ -168229,7 +168245,7 @@ bzz
 bMc
 drH
 bMh
-abI
+cdk
 ciu
 acg
 acj
@@ -168517,7 +168533,7 @@ dpo
 dpo
 dsv
 dtC
-dvl
+ddS
 coD
 dfn
 crx
@@ -168657,7 +168673,7 @@ aaX
 adX
 aey
 aaU
-acH
+abI
 abi
 aih
 aiC
@@ -168685,7 +168701,7 @@ awU
 aCX
 aDW
 aFi
-aGw
+aoQ
 aIq
 aRr
 dmC
@@ -168774,7 +168790,7 @@ cXb
 dpo
 dsw
 dtD
-dvm
+dfz
 coE
 dfn
 dzW
@@ -169039,8 +169055,8 @@ dBa
 dCB
 dDQ
 dEY
-dcA
-cvI
+doG
+dqc
 dJb
 dCy
 cyE
@@ -169211,7 +169227,7 @@ aSl
 aTZ
 dnJ
 aXr
-aBt
+aLu
 baQ
 bct
 bdW
@@ -169219,7 +169235,7 @@ bfr
 aGa
 aWY
 bjS
-blO
+aYg
 baQ
 aKY
 bip
@@ -169543,11 +169559,11 @@ dlV
 dnr
 cXf
 cjW
-dsz
+cSO
 dtC
 dvp
-dwT
-dyt
+cgx
+dnt
 dzZ
 dBc
 abc
@@ -169737,7 +169753,7 @@ aJw
 aJQ
 aLc
 bip
-aOB
+aZx
 bsW
 bvK
 bvK
@@ -170005,7 +170021,7 @@ blf
 aTu
 bwH
 aPV
-bav
+bso
 aPV
 aPV
 aPV
@@ -170239,7 +170255,7 @@ azy
 aqy
 dov
 azy
-aBx
+aNU
 baQ
 bcx
 bea
@@ -170531,7 +170547,7 @@ aPQ
 bov
 aPQ
 aPQ
-bso
+bWm
 aPQ
 ciz
 buw
@@ -170547,7 +170563,7 @@ aPQ
 cjZ
 aPQ
 aPQ
-bso
+bWm
 aPQ
 bLe
 bNd
@@ -170755,7 +170771,7 @@ dow
 aXt
 aBz
 baQ
-bcy
+aQB
 beb
 bfx
 aGd
@@ -171583,7 +171599,7 @@ bPV
 cNH
 cPB
 cRd
-cSO
+cxp
 bVz
 cAo
 bVz
@@ -172038,7 +172054,7 @@ aSt
 axe
 doD
 azK
-aZc
+aZh
 aQP
 bcC
 bee
@@ -172086,7 +172102,7 @@ bCh
 bNa
 aNW
 cAm
-bEQ
+cgl
 dgm
 bHj
 bIJ
@@ -172639,14 +172655,14 @@ cXI
 cug
 cXI
 cXI
-cwQ
+dnu
 cPy
 cyP
 cGH
 cAR
 cBL
 dPm
-cCm
+dqS
 cLz
 dRZ
 dPq
@@ -172807,7 +172823,7 @@ aad
 aQR
 aSw
 axN
-doG
+aZc
 azO
 aZf
 aQR
@@ -173323,7 +173339,7 @@ aSy
 axU
 doI
 aAc
-aZh
+cbK
 aQT
 aad
 bej
@@ -173659,7 +173675,7 @@ dtN
 dtN
 dby
 dxi
-dyD
+dnW
 dma
 dBo
 cvy
@@ -174155,7 +174171,7 @@ cio
 bTU
 cSW
 cUO
-cWy
+cye
 cRe
 cZK
 dbu
@@ -174198,7 +174214,7 @@ dVz
 cFo
 cPG
 dYa
-dYV
+dsb
 dPq
 aad
 aad
@@ -174398,7 +174414,7 @@ cuw
 bCm
 cxj
 bRG
-bHd
+cfX
 bHE
 bLv
 dgZ
@@ -174684,7 +174700,7 @@ dnG
 dnG
 dfB
 ckU
-dtQ
+cWy
 dcf
 dxl
 dyG
@@ -174704,7 +174720,7 @@ aad
 dPq
 dQi
 cCL
-cDS
+dqY
 cMr
 cEy
 cEH
@@ -175411,7 +175427,7 @@ bhY
 djT
 blt
 cbp
-cdk
+bKE
 cfa
 cgO
 ciy
@@ -175734,7 +175750,7 @@ dQm
 cCW
 cLT
 drd
-dTU
+dri
 dQl
 dVD
 dWx
@@ -175912,7 +175928,7 @@ bnG
 byD
 bAF
 btd
-bDW
+bjM
 bFG
 bHt
 aZr
@@ -175920,7 +175936,7 @@ baT
 bcA
 baT
 baT
-bgq
+bwe
 bid
 djT
 blu
@@ -177192,9 +177208,9 @@ bpi
 aMa
 bpo
 bri
-bwc
+bbh
 bnG
-byI
+beO
 bBX
 aTv
 bEb
@@ -177443,8 +177459,8 @@ aFm
 bgZ
 biy
 aYV
-bmg
-bnG
+bmc
+aJS
 bpj
 aMb
 bpp
@@ -177701,14 +177717,14 @@ aUt
 bdg
 bmR
 aJz
-aJS
+aQv
 aJz
 aJz
 bpq
 aJz
 aJz
-aQv
-aRl
+bmg
+beP
 bHG
 aTw
 bNj
@@ -177724,7 +177740,7 @@ cJs
 dkt
 aJz
 bns
-boE
+bQu
 aYA
 bAo
 bsF
@@ -178205,7 +178221,7 @@ aQY
 aSE
 aFE
 azo
-aAh
+aFn
 aNF
 aCH
 aDB
@@ -178462,7 +178478,7 @@ aFm
 aFm
 aFm
 aFm
-aFm
+aAh
 aNM
 aCH
 aFm
@@ -178733,8 +178749,8 @@ aJT
 bpl
 aMx
 bpv
-buM
-bwe
+bku
+bbZ
 bhd
 bmr
 bIR
@@ -179775,7 +179791,7 @@ bLs
 bNp
 bNp
 bNp
-bTi
+bwA
 bVp
 dky
 bZV
@@ -180057,7 +180073,7 @@ bFs
 bGb
 bHZ
 bEz
-bKd
+cjt
 bVw
 bNH
 bRh
@@ -181302,8 +181318,8 @@ bmt
 bmw
 bcN
 aMW
-bty
-buT
+aMW
+bav
 biP
 aaa
 aaa
@@ -181804,7 +181820,7 @@ aSI
 aUD
 aWl
 aFm
-aQd
+aOa
 aSJ
 bcM
 aad
@@ -182316,7 +182332,7 @@ aMr
 auD
 aFW
 aLG
-dpJ
+aIy
 aFm
 aQu
 aCM
@@ -182636,7 +182652,7 @@ cuM
 aaa
 aad
 aaa
-cOr
+cwQ
 cuM
 dak
 dbL
@@ -183150,7 +183166,7 @@ cFF
 cFF
 cFF
 cuM
-cOr
+cwQ
 cuM
 aad
 aad
@@ -183407,7 +183423,7 @@ cFF
 cFF
 cFF
 cuM
-cOr
+cwQ
 cuM
 aad
 aaa
@@ -183921,7 +183937,7 @@ cFF
 cFF
 cFF
 cuM
-cOr
+cwQ
 cuM
 aad
 ajr
@@ -184178,7 +184194,7 @@ cFF
 cFF
 cFF
 cuM
-cOr
+cwQ
 cuM
 aad
 ajr
@@ -184692,7 +184708,7 @@ cuM
 aaa
 aad
 aaa
-cOr
+cwQ
 cuM
 aad
 aaa

--- a/_maps/yogstation/map_files/YogsPubby/YogsPubby.dmm
+++ b/_maps/yogstation/map_files/YogsPubby/YogsPubby.dmm
@@ -293,15 +293,22 @@
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "aaz" = (
-/obj/structure/table,
-/obj/item/pen,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
-/obj/item/paper_bin,
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/effect/landmark/start/ai/secondary,
+/obj/item/radio/intercom{
+	anyai = 1;
+	freerange = 1;
+	frequency = 1447;
+	name = "Private Channel";
+	pixel_x = -27
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "aaA" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -899,12 +906,15 @@
 /turf/open/floor/wood,
 /area/medical/medbay/central)
 "abT" = (
+/obj/structure/table,
+/obj/item/pen,
+/obj/item/paper_bin,
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 27
+	dir = 8;
+	pixel_x = 26
 	},
-/turf/open/floor/wood,
-/area/medical/medbay/central)
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/turret_protected/aisat_interior)
 "abU" = (
 /obj/machinery/light_switch{
 	pixel_y = 22
@@ -1010,23 +1020,15 @@
 	},
 /area/ai_monitored/turret_protected/ai)
 "acj" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/landmark/start/ai/secondary,
-/obj/item/radio/intercom{
-	anyai = 1;
-	freerange = 1;
-	frequency = 1447;
-	name = "Private Channel";
-	pixel_x = -27
+/obj/machinery/light{
+	dir = 8
 	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 26
+	dir = 4;
+	pixel_x = -26
 	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "ack" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -2035,15 +2037,24 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "aeb" = (
-/obj/machinery/light{
+/obj/structure/table,
+/obj/item/storage/box/bodybags,
+/obj/item/pen,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -27
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "aec" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	icon_state = "vent_map_on-1";
@@ -3409,21 +3420,22 @@
 /turf/open/floor/carpet,
 /area/medical/medbay/central)
 "agV" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun{
+	pixel_x = 3;
+	pixel_y = -3
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -27
+	pixel_x = -26
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "agW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/showroomfloor,
@@ -3955,27 +3967,21 @@
 /turf/open/floor/plasteel,
 /area/clerk)
 "ahT" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/key,
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
-/area/clerk)
+/area/security/main)
 "ahU" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/yellow{
@@ -4453,22 +4459,16 @@
 /area/maintenance/department/security/brig)
 "aiZ" = (
 /obj/structure/table,
-/obj/item/storage/box/bodybags,
-/obj/item/pen,
+/obj/machinery/recharger,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+	dir = 8;
+	pixel_x = 26
 	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "aja" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4845,22 +4845,22 @@
 /turf/closed/wall,
 /area/security/brig)
 "ajN" = (
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun{
-	pixel_x = 3;
-	pixel_y = -3
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -27
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
+/area/crew_quarters/heads/hos)
 "ajO" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
@@ -6617,17 +6617,18 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "amZ" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/obj/machinery/light/small{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
+	pixel_y = 26
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ana" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6705,19 +6706,27 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "anj" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 29
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/key,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/clerk)
 "ank" = (
 /obj/machinery/computer/card/minor/hos{
 	dir = 8
@@ -10845,14 +10854,11 @@
 /area/hallway/primary/central)
 "auX" = (
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 29
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/crew_quarters/dorms)
 "auY" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10968,12 +10974,22 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "avl" = (
-/obj/machinery/firealarm{
+/obj/machinery/light{
 	dir = 8;
-	pixel_x = 28
+	light_color = "#e8eaff"
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "avm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -11889,18 +11905,19 @@
 /area/hallway/primary/central)
 "awY" = (
 /obj/machinery/light{
-	dir = 8;
+	dir = 4;
 	light_color = "#e8eaff"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/computer/rdconsole{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -11951,23 +11968,12 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "axe" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 28
-	},
-/obj/machinery/computer/rdconsole{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/dark,
-/area/bridge)
+/area/crew_quarters/heads/captain)
 "axf" = (
 /obj/machinery/camera{
 	c_tag = "Dormitories Hallway";
@@ -12932,19 +12938,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "azl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/camera{
-	c_tag = "Cargo Mailroom";
-	dir = 8
-	},
+/obj/machinery/computer/cargo/request,
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
+	pixel_y = 26
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hop)
 "azm" = (
 /obj/machinery/button/door{
 	id = "qm_warehouse";
@@ -13029,19 +13028,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "azt" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -28
+	pixel_x = -26
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
 "azu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13520,18 +13514,19 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "aAz" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 29
-	},
-/obj/effect/turf_decal/tile/brown{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/hallway/primary/fore)
 "aAA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	icon_state = "pipe11-3";
@@ -13680,13 +13675,16 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aAU" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 28
+	pixel_x = 26
 	},
-/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/storage/primary)
 "aAV" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -13861,12 +13859,13 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "aBp" = (
+/obj/machinery/photocopier,
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26
+	dir = 4;
+	pixel_x = -26
 	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/captain)
+/turf/open/floor/wood,
+/area/lawoffice)
 "aBq" = (
 /obj/machinery/light{
 	dir = 1
@@ -13987,16 +13986,16 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "aBy" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/structure/sign/departments/evac{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
-/area/hallway/primary/central)
+/area/hallway/secondary/exit/departure_lounge)
 "aBz" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -14014,13 +14013,14 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "aBB" = (
-/obj/machinery/computer/cargo/request,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 29
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/hop)
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aBC" = (
 /obj/structure/closet/secure_closet/hop,
 /obj/machinery/computer/security/telescreen{
@@ -14872,11 +14872,19 @@
 /area/crew_quarters/dorms)
 "aDg" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/white/corner,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/sign/departments/evac{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/primary/central)
 "aDh" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -14906,8 +14914,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/sign/departments/evac{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel/white/corner,
-/area/hallway/primary/central)
+/area/hallway/secondary/exit/departure_lounge)
 "aDk" = (
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
@@ -14939,14 +14950,24 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "aDo" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
+/obj/structure/chair{
+	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/exit/departure_lounge)
 "aDp" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -15061,16 +15082,19 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aDB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/camera{
+	c_tag = "Cargo Mailroom";
+	dir = 8
+	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
-/area/storage/primary)
+/area/quartermaster/sorting)
 "aDC" = (
 /obj/structure/table/wood,
 /obj/item/storage/lockbox/medal,
@@ -15253,15 +15277,13 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aDQ" = (
+/obj/machinery/hydroponics/constructable,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hydroponics)
 "aDR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16833,17 +16855,17 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aGQ" = (
-/obj/structure/disposalpipe/junction/flip{
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "aGR" = (
 /obj/structure/sign/departments/restroom{
 	pixel_y = -32
@@ -17550,6 +17572,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/medical/paramedic)
+"aIe" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "aIf" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/blue,
@@ -17560,11 +17589,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aIh" = (
+/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
+	dir = 8;
+	pixel_x = 26
 	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aIi" = (
@@ -17907,30 +17936,39 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aIT" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"aIU" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/exit/departure_lounge)
+"aIU" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/quartermaster/office)
 "aIV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -18030,6 +18068,11 @@
 	dir = 1;
 	pixel_y = 2
 	},
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
 /turf/open/floor/plating,
 /area/storage/emergency/port)
 "aJf" = (
@@ -18061,13 +18104,16 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "aJi" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26;
-	pixel_y = 28
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "aJj" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -18159,13 +18205,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "aJs" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aJt" = (
 /obj/structure/cable{
@@ -18213,11 +18254,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJz" = (
+/obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
 /turf/open/floor/plating{
-	icon_state = "panelscorched"
+	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/cargo)
 "aJA" = (
@@ -18246,23 +18291,17 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2)
 "aJC" = (
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 28
+	pixel_x = 26
 	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-11"
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1"
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/zone2)
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "aJD" = (
 /obj/structure/chair{
 	dir = 8
@@ -18958,6 +18997,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"aKX" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/cargo)
 "aKY" = (
 /turf/closed/wall/r_wall,
 /area/storage/eva)
@@ -19127,19 +19177,15 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "aLx" = (
-/obj/structure/chair{
-	dir = 8
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/central)
 "aLy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20202,22 +20248,19 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "aNw" = (
-/obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "Xenobiology Central";
-	dir = 1;
-	network = list("ss13","rd")
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -29
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/science/xenobiology)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "aNx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -20241,17 +20284,22 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "aNA" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -29
+/obj/structure/closet/wardrobe/miner,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/dark,
-/area/science/xenobiology)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "aNB" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -20694,9 +20742,15 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "aOs" = (
-/obj/structure/sign/departments/evac,
-/turf/closed/wall,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/sign/departments/evac{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/white/corner,
+/area/hallway/primary/central)
 "aOt" = (
 /obj/structure/table,
 /obj/item/instrument/glockenspiel{
@@ -20771,26 +20825,17 @@
 	},
 /area/maintenance/department/crew_quarters/bar)
 "aOx" = (
-/obj/machinery/power/apc/highcap/ten_k{
-	dir = 1;
-	name = "Research Division APC";
-	pixel_y = 25
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
 	},
-/turf/open/floor/plasteel/dark,
-/area/science/explab)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "aOy" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -22538,9 +22583,13 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "aRH" = (
-/obj/structure/sign/departments/evac,
-/turf/closed/wall,
-/area/hallway/primary/central)
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/robotics/mechbay)
 "aRI" = (
 /obj/machinery/light{
 	dir = 4
@@ -23013,13 +23062,16 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "aSA" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
+/obj/structure/chair,
+/obj/item/clothing/mask/cigarette,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/obj/machinery/hydroponics/constructable,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel,
-/area/hydroponics)
+/area/hallway/primary/central)
 "aSB" = (
 /obj/machinery/airalarm{
 	pixel_y = 22
@@ -24293,19 +24345,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "aUP" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
 /obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aUQ" = (
 /obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/tile/neutral{
@@ -25583,23 +25630,21 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aXd" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -29
-	},
-/obj/machinery/camera{
-	c_tag = "Research Division Entrance";
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 2
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/shower{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "aXe" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-18";
@@ -25876,9 +25921,22 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "aXB" = (
-/obj/structure/sign/departments/evac,
-/turf/closed/wall,
-/area/security/checkpoint/customs)
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "aXC" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plating,
@@ -25910,25 +25968,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "aXF" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "aXG" = (
 /obj/structure/table,
 /obj/effect/holodeck_effect/cards{
@@ -26386,19 +26431,23 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "aYu" = (
-/obj/machinery/light{
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-11"
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1"
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 28
+	pixel_x = 26
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/zone2)
 "aYv" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
@@ -26887,16 +26936,26 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "aZr" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -29
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
+/obj/machinery/rnd/production/circuit_imprinter/department/science,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/robotics/lab)
 "aZs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26912,18 +26971,18 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aZt" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/vending/clothing,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "aZu" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
@@ -27154,19 +27213,31 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "aZR" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/camera{
+	c_tag = "Research Division Lobby";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/light,
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-10"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/aft)
 "aZS" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -27876,6 +27947,9 @@
 	icon_state = "vent_map_on-1";
 	dir = 1
 	},
+/obj/structure/sign/departments/minsky/research/research{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bbk" = (
@@ -28003,21 +28077,28 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "bbz" = (
-/obj/machinery/camera{
-	c_tag = "Gravity Generator";
-	dir = 8;
-	network = list("ss13")
+/obj/structure/rack,
+/obj/item/stack/packageWrap,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/hand_labeler,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 28
+	pixel_x = 26
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
+/turf/open/floor/plasteel/white,
+/area/science/explab)
 "bbA" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Office Maintenance";
@@ -28497,22 +28578,25 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bcD" = (
-/obj/structure/closet/wardrobe/miner,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
+/obj/structure/closet/l3closet,
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "bcE" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -28541,17 +28625,27 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bcH" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Engineering";
-	name = "engineering security door"
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
 	},
-/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
-/obj/structure/sign/departments/minsky/engineering/engineering{
-	pixel_y = -32
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/medical/sleeper)
 "bcI" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29387,27 +29481,19 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ben" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/chem_dispenser{
+	layer = 2.7
 	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 29
+	dir = 8;
+	pixel_x = 26
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "beo" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30003,14 +30089,19 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/mechbay)
 "bfx" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 24
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/science/robotics/mechbay)
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "bfy" = (
 /obj/machinery/mech_bay_recharge_port,
 /obj/structure/cable{
@@ -30487,17 +30578,23 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgx" = (
+/obj/structure/rack,
+/obj/item/crowbar,
+/obj/item/wrench,
+/obj/item/multitool,
+/obj/item/multitool,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 27
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/structure/chair,
-/obj/item/clothing/mask/cigarette,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/plasteel/white,
+/area/science/explab)
 "bgy" = (
 /obj/machinery/light{
 	dir = 1
@@ -32000,22 +32097,23 @@
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
 "bjs" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Research and Development Lab";
+	dir = 8;
+	network = list("ss13","rd")
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/science/explab)
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "bjt" = (
 /obj/structure/table/glass,
 /obj/structure/disposalpipe/segment{
@@ -32120,9 +32218,23 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bjF" = (
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/library/lounge)
+/obj/machinery/light,
+/obj/machinery/camera{
+	c_tag = "Xenobiology Central";
+	dir = 1;
+	network = list("ss13","rd")
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "bjG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	icon_state = "vent_map_on-1";
@@ -32577,17 +32689,18 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "bkA" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/light,
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26;
-	pixel_y = 28
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "bkB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	icon_state = "pipe11-1";
@@ -33115,18 +33228,26 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "blA" = (
+/obj/machinery/power/apc/highcap/ten_k{
+	dir = 1;
+	name = "Research Division APC";
+	pixel_y = 25
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
+/turf/open/floor/plasteel/dark,
+/area/science/explab)
 "blB" = (
 /obj/structure/closet/wardrobe/red,
 /obj/effect/turf_decal/tile/red,
@@ -34243,20 +34364,21 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bnK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 27;
-	pixel_y = -25
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "bnL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	icon_state = "scrub_map_on-3";
@@ -34282,26 +34404,22 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bnO" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
+	dir = 4
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -28
-	},
-/obj/machinery/rnd/production/circuit_imprinter/department/science,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/robotics/lab)
+/area/science/explab)
 "bnP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -34633,19 +34751,16 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "boz" = (
-/obj/machinery/vending/clothing,
+/obj/structure/closet/bombcloset,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 27
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/turf/open/floor/plasteel/dark,
+/area/science/mixing)
 "boA" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -34852,31 +34967,20 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "boU" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -2;
-	pixel_y = -27
-	},
-/obj/machinery/camera{
-	c_tag = "Research Division Lobby";
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-10"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/aft)
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "boV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/freezer,
@@ -37275,27 +37379,21 @@
 /turf/closed/wall,
 /area/medical/sleeper)
 "bsB" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/obj/machinery/computer/robotics{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/medical/sleeper)
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hor)
 "bsC" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /obj/effect/turf_decal/delivery,
@@ -37459,19 +37557,32 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bsN" = (
-/obj/machinery/chem_dispenser{
-	layer = 2.7
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/meter,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/mixing)
 "bsO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -37706,23 +37817,22 @@
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
 "btg" = (
-/obj/structure/rack,
-/obj/item/crowbar,
-/obj/item/wrench,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
+/obj/item/folder/blue,
+/obj/item/stamp/cmo,
+/obj/structure/table,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/item/multitool,
-/obj/item/multitool,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
+	},
 /turf/open/floor/plasteel/white,
-/area/science/explab)
+/area/crew_quarters/heads/cmo)
 "bth" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -38337,6 +38447,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/sign/departments/minsky/research/genetics{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "btZ" = (
@@ -38531,23 +38644,23 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "bus" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Research and Development Lab";
-	dir = 8;
-	network = list("ss13","rd")
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 28
+	pixel_x = 26
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/aft)
 "but" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -39234,28 +39347,22 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bvp" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Telecommunications Transit Tube";
-	req_access_txt = "10; 61"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
+/obj/structure/sign/departments/minsky/research/xenobiology{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "bvq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	icon_state = "scrub_map_on-3";
@@ -40077,7 +40184,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/sign/departments/minsky/engineering/telecommmunications{
+/obj/structure/sign/departments/minsky/engineering/engineering{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
@@ -40379,23 +40486,20 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bxm" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/camera{
+	c_tag = "Toxins Storage";
+	dir = 8;
+	network = list("ss13","rd")
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 28
+	pixel_x = 26
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
+/turf/open/floor/engine,
+/area/science/storage)
 "bxn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
@@ -41965,6 +42069,9 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/structure/sign/departments/minsky/medical/virology/virology2{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2)
 "bzP" = (
@@ -42055,9 +42162,13 @@
 /turf/open/floor/plating,
 /area/chapel/main/monastery)
 "bzY" = (
-/obj/structure/sign/departments/minsky/medical/medical2,
-/turf/closed/wall,
-/area/crew_quarters/heads/cmo)
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/sign/departments/minsky/medical/medical2{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bzZ" = (
 /obj/machinery/suit_storage_unit/cmo,
 /obj/structure/cable{
@@ -42562,9 +42673,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bAY" = (
-/obj/structure/sign/departments/minsky/medical/virology/virology2,
-/turf/closed/wall,
-/area/medical/virology)
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "bAZ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -43024,16 +43140,19 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bBK" = (
-/obj/structure/closet/bombcloset,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+	dir = 8;
+	pixel_x = 26
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/mixing)
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "bBL" = (
 /obj/structure/closet/bombcloset,
 /obj/machinery/airalarm{
@@ -43230,18 +43349,15 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bCc" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/structure/sign/departments/minsky/research/genetics{
+/obj/structure/sign/departments/minsky/supply/hydroponics{
 	pixel_x = -32;
-	pixel_y = -32
+	pixel_y = 32
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bCd" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -43336,24 +43452,30 @@
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bCk" = (
-/obj/structure/sign/departments/minsky/engineering/atmospherics,
+/obj/machinery/door/airlock/engineering{
+	name = "Gravity Generator";
+	req_access_txt = "11"
+	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bCl" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 10
 	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -2;
-	pixel_y = -27
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/sleeper)
+/area/medical/virology)
 "bCm" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -43561,22 +43683,15 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "bCB" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/sign/departments/minsky/engineering/atmospherics{
+	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "bCC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43610,21 +43725,27 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bCE" = (
-/obj/machinery/computer/robotics{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/camera{
+	c_tag = "Research Division Entrance";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/light{
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hor)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "bCF" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -44487,32 +44608,18 @@
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bEd" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel/dark,
-/area/science/mixing)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/surgery)
 "bEe" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -44930,21 +45037,11 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bEG" = (
-/obj/item/folder/blue,
-/obj/item/stamp/cmo,
-/obj/structure/table,
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
+	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/cmo)
+/turf/open/floor/wood,
+/area/medical/medbay/central)
 "bEH" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-16"
@@ -45902,22 +45999,17 @@
 /turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "bGe" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bGf" = (
 /obj/effect/turf_decal/bot,
@@ -45939,20 +46031,26 @@
 /turf/open/floor/engine,
 /area/science/storage)
 "bGi" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 5
 	},
-/obj/machinery/camera{
-	c_tag = "Toxins Storage";
-	dir = 8;
-	network = list("ss13","rd")
+/obj/item/stock_parts/cell/high/plus,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
+	pixel_y = 26
 	},
-/turf/open/floor/engine,
-/area/science/storage)
+/turf/open/floor/plasteel/dark,
+/area/storage/tech)
 "bGj" = (
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/tile/purple{
@@ -46028,20 +46126,29 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bGq" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/door/airlock/engineering{
+	name = "Telecommunications Transit Tube";
+	req_access_txt = "10; 61"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/sign/departments/minsky/research/xenobiology,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "bGr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	icon_state = "pipe11-1";
@@ -48130,6 +48237,20 @@
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
+"bJU" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access_txt = "61"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "bJV" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/security/glass{
@@ -48146,6 +48267,26 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"bJW" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 5
+	},
+/obj/structure/sign/departments/minsky/engineering/engineering{
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "bJX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -48208,6 +48349,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"bKd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "bKe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -48801,6 +48957,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"bLz" = (
+/obj/machinery/camera{
+	c_tag = "Gravity Generator";
+	dir = 8;
+	network = list("ss13")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/gravity_generator)
 "bLA" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -48811,6 +48983,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"bLB" = (
+/obj/machinery/computer/station_alert,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/chief)
 "bLC" = (
 /obj/machinery/air_sensor/atmos/toxin_tank,
 /turf/open/floor/engine/plasma,
@@ -48897,6 +49082,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
+"bLL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "bLM" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/latex,
@@ -48913,6 +49108,47 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"bLN" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/structure/sign/departments/minsky/engineering/engineering{
+	pixel_y = -32
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"bLO" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"bLP" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/chapel/main/monastery)
 "bLQ" = (
 /obj/structure/table,
 /obj/item/surgical_drapes,
@@ -48973,6 +49209,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
+"bLX" = (
+/obj/structure/chair/wood/normal,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/library/lounge)
 "bLY" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest,
@@ -49003,6 +49247,24 @@
 /obj/item/clothing/gloves/color/black,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"bLZ" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/library/lounge)
+"bMa" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/obj/machinery/camera{
+	c_tag = "Monastery Archives Fore";
+	dir = 2;
+	network = list("ss13","monastery")
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/library)
 "bMe" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 4
@@ -49842,13 +50104,6 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"bPM" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "bPN" = (
 /obj/machinery/conveyor_switch{
 	id = "atmosdeliver"
@@ -50008,28 +50263,6 @@
 	},
 /obj/machinery/light{
 	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/storage/tech)
-"bQu" = (
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 5
-	},
-/obj/item/stock_parts/cell/high/plus,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 29
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
@@ -50754,22 +50987,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"bTL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 29
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "bTM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
 /turf/open/floor/plasteel,
@@ -51066,20 +51283,6 @@
 	pixel_y = 22
 	},
 /obj/machinery/computer/apc_control,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
-"bUL" = (
-/obj/machinery/computer/station_alert,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 29
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -51956,11 +52159,6 @@
 /obj/machinery/computer/station_alert,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"bYf" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/electricshock,
-/turf/open/floor/plating,
-/area/engine/engine_smes)
 "bYg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -53476,17 +53674,6 @@
 /obj/structure/transit_tube,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cgs" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_access_txt = "61"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "cgu" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -54104,14 +54291,6 @@
 /obj/item/extinguisher,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel/monastery)
-"ckD" = (
-/obj/structure/chair/wood/normal,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/dark,
-/area/library/lounge)
 "ckH" = (
 /turf/open/floor/plasteel/dark,
 /area/library)
@@ -55641,21 +55820,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
-"cyQ" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
-	},
-/obj/machinery/camera{
-	c_tag = "Monastery Archives Fore";
-	dir = 2;
-	network = list("ss13","monastery")
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 29
-	},
-/turf/open/floor/plasteel/dark,
-/area/library)
 "cyR" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
@@ -56374,15 +56538,6 @@
 /obj/machinery/shieldwallgen/xenobiologyaccess,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"dRF" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/sign/departments/minsky/supply/hydroponics{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "dSr" = (
 /obj/item/chair,
 /turf/open/floor/wood,
@@ -56740,15 +56895,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
-"fUA" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/exit/departure_lounge)
 "fWv" = (
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/plasteel/dark,
@@ -56777,22 +56923,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"gdL" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
@@ -57564,22 +57694,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"jvi" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "jzz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
@@ -57841,26 +57955,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/science)
-"kFD" = (
-/obj/structure/closet/l3closet,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -27
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/xenobiology)
 "kIo" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -57982,10 +58076,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"llI" = (
-/obj/structure/sign/departments/minsky/engineering/atmospherics,
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "lqc" = (
 /obj/item/toy/gun,
 /obj/effect/decal/cleanable/oil,
@@ -58865,10 +58955,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"pcg" = (
-/obj/structure/sign/departments/minsky/engineering/atmospherics,
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
 "pdq" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
@@ -59153,10 +59239,6 @@
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"qmn" = (
-/obj/structure/sign/departments/minsky/engineering/engineering,
-/turf/closed/wall,
-/area/maintenance/department/engine)
 "qnT" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/plating,
@@ -59424,18 +59506,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"rxV" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 27
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "rEh" = (
 /obj/structure/table/glass,
 /obj/item/restraints/handcuffs/cable/zipties,
@@ -59754,29 +59824,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"tdp" = (
-/obj/structure/rack,
-/obj/item/stack/packageWrap,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/item/hand_labeler,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/explab)
 "tdB" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker,
@@ -60459,14 +60506,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
-"wrU" = (
-/obj/machinery/photocopier,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/turf/open/floor/wood,
-/area/lawoffice)
 "wwr" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -60645,26 +60684,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"xaQ" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 29
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/exit/departure_lounge)
 "xbJ" = (
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
@@ -76763,8 +76782,8 @@ cgG
 bWV
 cuX
 bWV
-cgG
-cgG
+bLP
+bLP
 bWV
 bhm
 bFb
@@ -77014,7 +77033,7 @@ bWV
 cfm
 bFN
 bhm
-cgG
+bLP
 chi
 cid
 cuM
@@ -77022,7 +77041,7 @@ chj
 cvb
 ciT
 cvh
-cgG
+bLP
 bhm
 bHW
 cwa
@@ -77271,7 +77290,7 @@ ceK
 cfm
 bFQ
 bhm
-cgG
+bLP
 cid
 cuA
 cib
@@ -77279,7 +77298,7 @@ cgH
 cgH
 ciS
 cid
-cgG
+bLP
 bhm
 bHC
 bwt
@@ -77785,7 +77804,7 @@ bXJ
 bWX
 bFj
 bhm
-cgG
+bLP
 cgk
 cuA
 ciS
@@ -77793,7 +77812,7 @@ chk
 cgH
 cgH
 cvi
-cgG
+bLP
 bhm
 bFb
 cwa
@@ -78042,7 +78061,7 @@ bXJ
 bWX
 bFj
 bhm
-cgG
+bLP
 cuo
 ciV
 cgI
@@ -78050,7 +78069,7 @@ chl
 cib
 cvg
 cid
-cgG
+bLP
 bhm
 bFb
 cwe
@@ -78313,19 +78332,19 @@ bIb
 cwe
 cjP
 ckl
-ckD
+bLX
 ckS
 clg
 clk
 cwe
 cwe
 bjC
-bjF
-bjF
-bjF
+bLZ
+bLZ
+bLZ
 bjC
 cjp
-cyQ
+bMa
 ckH
 ckH
 ckH
@@ -78556,7 +78575,7 @@ ceK
 cfm
 bFQ
 bhm
-cgG
+bLP
 ciV
 cgH
 cgH
@@ -78564,7 +78583,7 @@ cgH
 cic
 ciV
 cjq
-cgG
+bLP
 bhm
 bHW
 biP
@@ -78813,7 +78832,7 @@ bWV
 cfm
 bFY
 bhm
-cgG
+bLP
 cgm
 cuE
 cuO
@@ -78821,7 +78840,7 @@ cgH
 ciE
 ciW
 cjr
-cgG
+bLP
 bhm
 bHY
 bzw
@@ -79071,13 +79090,13 @@ cfm
 bFj
 bhm
 bWV
-cgG
-cgG
+bLP
+bLP
 bWV
 cuY
 bWV
-cgG
-cgG
+bLP
+bLP
 bWV
 bhm
 bFj
@@ -79091,9 +79110,9 @@ ckU
 cwe
 cwe
 bjC
-bjF
-bjF
-bjF
+bLZ
+bLZ
+bLZ
 bjC
 cjp
 cyR
@@ -79479,7 +79498,7 @@ adK
 aeg
 agF
 aix
-aiZ
+aeb
 ajH
 akx
 aky
@@ -79508,7 +79527,7 @@ asH
 asH
 aHK
 aiu
-xaQ
+aDo
 axk
 coN
 kvj
@@ -80274,7 +80293,7 @@ ebD
 sbY
 aES
 pXT
-wrU
+aBp
 mpy
 aiu
 aHY
@@ -81573,11 +81592,11 @@ aHz
 eLt
 aRB
 aRB
-aOs
-fUA
+aHz
+aBy
 aTk
-aDg
-aOs
+aDj
+aHz
 aYG
 aZy
 aVP
@@ -82091,7 +82110,7 @@ aiu
 aML
 aTj
 aWK
-aXF
+aIT
 aYG
 aEq
 aXp
@@ -82585,7 +82604,7 @@ aAK
 axG
 aBd
 aCi
-aDo
+azt
 xjK
 asJ
 ati
@@ -83126,7 +83145,7 @@ baQ
 aXH
 bax
 baE
-aZr
+aOx
 bfZ
 bgU
 bhF
@@ -83335,7 +83354,7 @@ ahL
 aii
 aiL
 ajg
-ajN
+agV
 akL
 alA
 amh
@@ -84367,12 +84386,12 @@ ajT
 akP
 alA
 amj
-amZ
+aiZ
 aid
 aoi
 aoY
 apN
-anj
+amZ
 ark
 amo
 atB
@@ -84400,11 +84419,11 @@ oEA
 aKH
 aLu
 aLu
-aRH
-aBy
+aAN
+aDg
 aTI
-aDj
-aXB
+aOs
+aXK
 aXI
 baC
 aXI
@@ -84641,7 +84660,7 @@ aAK
 axG
 aqn
 aqy
-azt
+aAz
 aqy
 asV
 aGc
@@ -84873,13 +84892,13 @@ agP
 cnJ
 ahq
 ahq
-aeb
+acj
 aez
 aeJ
 aeL
 aeO
 afD
-agV
+ahT
 ahp
 ahH
 aie
@@ -85171,7 +85190,7 @@ aIL
 azu
 axn
 axn
-aAU
+aIh
 aBO
 aCE
 aDl
@@ -85459,7 +85478,7 @@ buW
 bnN
 bwi
 bhZ
-bCc
+bAY
 bDl
 bvc
 aUq
@@ -85963,7 +85982,7 @@ aaQ
 abk
 abc
 aaM
-boz
+aZt
 bzH
 bnp
 aLr
@@ -86712,14 +86731,14 @@ aKP
 aNm
 coW
 aRL
-aSA
+aDQ
 aTQ
 aUS
 aRL
 aWP
 aXQ
 ydZ
-aZR
+aNw
 aYN
 aYN
 ydZ
@@ -86990,7 +87009,7 @@ bjL
 aIK
 aJe
 bjL
-aJC
+aYu
 aJN
 aJY
 brd
@@ -87000,14 +87019,14 @@ bqY
 aUh
 byn
 bzO
-bAY
+bAW
 bCh
 bjx
 aUc
 bEr
 aUO
 aVV
-bxm
+bCl
 bsO
 bxo
 buo
@@ -87028,8 +87047,8 @@ bxx
 bBI
 bxF
 bxF
-bCB
-qmn
+bJW
+bva
 gMO
 kCc
 bva
@@ -87508,7 +87527,7 @@ bld
 bld
 aKa
 biY
-bsB
+bcH
 bub
 brg
 aPl
@@ -87536,7 +87555,7 @@ anZ
 bbq
 bbJ
 bAn
-pcg
+bPB
 bPB
 bPB
 bPB
@@ -87709,7 +87728,7 @@ akW
 alK
 amW
 ani
-jvi
+ajN
 aiR
 apd
 ajM
@@ -87725,7 +87744,7 @@ aBI
 aAs
 aBj
 gkR
-aDB
+aAU
 aEw
 aFv
 ulu
@@ -87756,7 +87775,7 @@ aHx
 bdm
 aDZ
 awN
-aIh
+aUP
 biY
 bmq
 bmq
@@ -88286,7 +88305,7 @@ bfY
 byo
 bzS
 btx
-bCl
+boU
 bsA
 bEy
 buI
@@ -88521,7 +88540,7 @@ aXS
 aXS
 pWT
 bcb
-bdn
+bCc
 bgZ
 bdn
 kEM
@@ -88561,7 +88580,7 @@ aTg
 bPB
 ajw
 bRG
-bbz
+bLz
 bcj
 bzD
 bPB
@@ -88809,7 +88828,7 @@ bkb
 bjc
 bjc
 bjc
-abT
+bEG
 acb
 agU
 bjc
@@ -89035,7 +89054,7 @@ aYQ
 aXS
 bbe
 bcd
-dRF
+bdo
 bhb
 bdo
 bdo
@@ -89345,11 +89364,11 @@ bDP
 bjA
 bjA
 bjR
-bvp
+bGq
 bwr
 bFK
 bps
-cgs
+bJU
 cgQ
 chv
 mKk
@@ -89522,7 +89541,7 @@ awR
 axW
 azc
 aAy
-aBp
+axe
 axA
 aGZ
 aBm
@@ -89575,7 +89594,7 @@ btE
 cqd
 aMP
 cqc
-aUP
+bBK
 blh
 bvJ
 abP
@@ -89826,11 +89845,11 @@ aMP
 brO
 aPr
 byu
-bzY
+byu
 wLo
 btF
 wLo
-bzY
+byu
 bFU
 bFU
 bIj
@@ -89847,7 +89866,7 @@ bva
 bSw
 aoA
 bUH
-bUL
+bLB
 bbU
 bAU
 bgX
@@ -90032,7 +90051,7 @@ asP
 atQ
 auO
 avG
-awY
+avl
 anx
 aof
 apH
@@ -90316,7 +90335,7 @@ aRN
 aRN
 aRN
 aRN
-rxV
+aJi
 baN
 cpn
 aFL
@@ -90814,7 +90833,7 @@ aED
 aAB
 aGn
 axi
-auX
+aBB
 aKD
 awG
 aAN
@@ -90840,8 +90859,8 @@ aRN
 aRN
 aDZ
 awN
-aIf
-bje
+bzY
+bjc
 bke
 biM
 bqd
@@ -90858,7 +90877,7 @@ bAc
 aSz
 bjt
 aTw
-bEG
+btg
 bFU
 bFU
 bFU
@@ -91120,13 +91139,13 @@ bFU
 bFU
 aVZ
 bvT
-blA
+bEd
 bLM
 bMN
 bFU
 bOG
 bPE
-bQu
+bGi
 aki
 bxG
 bai
@@ -91650,7 +91669,7 @@ bUP
 bVL
 bWv
 bXl
-bYf
+bdO
 bei
 bCf
 cdN
@@ -91870,8 +91889,8 @@ aDZ
 awN
 aDZ
 bjg
-aIT
-aJi
+aXd
+bkh
 aJv
 aJH
 boN
@@ -92648,7 +92667,7 @@ cqd
 boO
 bpV
 brm
-bsN
+ben
 bun
 beY
 nnf
@@ -92678,7 +92697,7 @@ bUT
 bVN
 bWz
 bVN
-bYf
+bdO
 bem
 bDC
 bnJ
@@ -92936,7 +92955,7 @@ bUU
 bUU
 bUU
 bUT
-ben
+bLO
 bCf
 cau
 cbj
@@ -93116,7 +93135,7 @@ asU
 atX
 auT
 awb
-axe
+awY
 ayN
 aoL
 apP
@@ -93181,7 +93200,7 @@ aWJ
 aYo
 aYZ
 aWe
-aZt
+bGe
 aZv
 aYo
 byt
@@ -93584,7 +93603,7 @@ abY
 ace
 abO
 abO
-acj
+aaz
 acq
 abO
 abO
@@ -94148,7 +94167,7 @@ axh
 axh
 axh
 aAH
-aBB
+azl
 aCR
 aIV
 aEM
@@ -94364,7 +94383,7 @@ acB
 acM
 abO
 aab
-aaz
+abT
 ads
 adX
 adZ
@@ -94454,7 +94473,7 @@ bsj
 aQO
 bAo
 bBq
-bCE
+bsB
 bkE
 bER
 bBp
@@ -94685,14 +94704,14 @@ aVk
 aWn
 aWg
 aGC
-aGQ
+aJC
 bdp
 bbt
 bcr
 bck
 beF
 aPE
-bgx
+aSA
 aDZ
 awN
 aDZ
@@ -94731,8 +94750,8 @@ bQD
 pps
 baW
 bzt
-bnK
-bcH
+bLL
+bLN
 bXk
 bYm
 cam
@@ -94954,8 +94973,8 @@ aDZ
 awN
 aDZ
 aIE
-aIU
-bkA
+aXB
+aXF
 bkB
 cqi
 boS
@@ -94980,7 +94999,7 @@ bLU
 bMW
 bOe
 bOM
-bPM
+bCB
 bQD
 bQD
 bQD
@@ -95237,7 +95256,7 @@ bLV
 bMX
 bOf
 bON
-llI
+bJN
 bQE
 bQE
 bSa
@@ -95476,7 +95495,7 @@ boT
 bqb
 bru
 bsT
-bus
+bjs
 bvz
 bss
 mdL
@@ -95729,7 +95748,7 @@ bkp
 aJm
 bkK
 aJI
-boU
+aZR
 cCl
 cCl
 cCl
@@ -95981,7 +96000,7 @@ aDZ
 bdF
 bkX
 bbj
-bGa
+bBo
 bkq
 aJn
 bkM
@@ -96227,7 +96246,7 @@ aCh
 aya
 aRR
 aya
-aDQ
+aLx
 aEW
 aya
 aya
@@ -96259,7 +96278,7 @@ bsM
 bsX
 bto
 bty
-aXd
+bCE
 bJN
 bJN
 bNb
@@ -96503,7 +96522,7 @@ aJa
 aJR
 aKn
 aJa
-aLx
+bfx
 aMT
 aJl
 bsy
@@ -96527,7 +96546,7 @@ bQH
 bRv
 bSe
 bPQ
-bTL
+bKd
 bza
 bmP
 bVX
@@ -97013,7 +97032,7 @@ bjm
 bku
 blE
 bmL
-bnO
+aZr
 boX
 bqg
 brw
@@ -97225,7 +97244,7 @@ aac
 aac
 aas
 ahu
-ahT
+anj
 aac
 aaC
 awd
@@ -97798,7 +97817,7 @@ bBB
 bCN
 bDK
 bEZ
-bGe
+bus
 bHt
 bIE
 bJN
@@ -98020,7 +98039,7 @@ aOR
 iKb
 lAs
 lAs
-aAz
+aGQ
 aSr
 aPY
 aWu
@@ -98546,7 +98565,7 @@ aLf
 aFi
 bdC
 beI
-bfx
+aRH
 bgG
 aHQ
 bea
@@ -99075,7 +99094,7 @@ bkt
 bkt
 bkt
 bkt
-aOx
+blA
 bth
 aRo
 bAA
@@ -99559,7 +99578,7 @@ lAs
 aMl
 aNM
 dse
-azl
+aDB
 azM
 aAc
 aAC
@@ -99567,7 +99586,7 @@ aPY
 aVv
 aWw
 aQE
-aYu
+aIU
 aSr
 aPY
 bbD
@@ -99854,7 +99873,7 @@ bBG
 bCR
 buf
 blD
-bGi
+bxm
 bHv
 bIJ
 bHw
@@ -100358,13 +100377,13 @@ bnY
 bpd
 bqo
 brG
-btg
+bgx
 fjs
 aOI
 bti
 aRv
 bAC
-bjs
+bnO
 bCT
 buh
 bCT
@@ -101081,7 +101100,7 @@ aaa
 apX
 apX
 apX
-avl
+auX
 fIu
 dbi
 avk
@@ -101370,7 +101389,7 @@ aXN
 bFI
 aFa
 bbI
-bcD
+aNA
 aaD
 beM
 bfE
@@ -101392,7 +101411,7 @@ bvU
 bxD
 bzc
 bAF
-bBK
+boz
 bCW
 buw
 boB
@@ -103707,7 +103726,7 @@ bzj
 bAF
 bBT
 bDd
-bEd
+bsN
 bFp
 buT
 bDB
@@ -103954,7 +103973,7 @@ bkD
 vxp
 boc
 bnc
-tdp
+bbz
 oDP
 bqf
 buH
@@ -104726,7 +104745,7 @@ bla
 bGg
 bGg
 bGp
-bGq
+bvp
 bqj
 aNn
 aOL
@@ -105243,7 +105262,7 @@ bqC
 aKS
 bqr
 xzp
-gdL
+bnK
 iLl
 bkF
 bwm
@@ -107555,7 +107574,7 @@ bnj
 bnj
 gIG
 bqA
-aNw
+bjF
 bnj
 bnj
 bnj
@@ -108583,7 +108602,7 @@ bnj
 bnj
 aLa
 bqA
-aNA
+bkA
 bnj
 bnj
 bnj
@@ -109858,8 +109877,8 @@ aaa
 aaa
 aEl
 iCe
-bcI
-aFi
+aIe
+aJs
 rxa
 bnl
 bok
@@ -110118,8 +110137,8 @@ wOf
 aHV
 aNR
 aNR
-aJs
 aJz
+aKX
 aNR
 aNR
 aKw
@@ -110636,7 +110655,7 @@ aEj
 aEl
 bkF
 bkF
-kFD
+bcD
 aRr
 bqR
 aNC

--- a/_maps/yogstation/map_files/YogsPubby/YogsPubby.dmm
+++ b/_maps/yogstation/map_files/YogsPubby/YogsPubby.dmm
@@ -49248,7 +49248,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bLZ" = (
-/obj/effect/spawner/structure/window,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/library/lounge)
 "bMa" = (
@@ -53701,10 +53701,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"cgG" = (
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/chapel/main/monastery)
 "cgH" = (
 /turf/open/floor/grass,
 /area/hydroponics/garden/monastery)
@@ -76777,8 +76773,8 @@ cfm
 bFb
 bhm
 bWV
-cgG
-cgG
+bLP
+bLP
 bWV
 cuX
 bWV

--- a/_maps/yogstation/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/yogstation/map_files/Yogsmeta/Yogsmeta.dmm
@@ -1647,16 +1647,16 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	icon_state = "scrub_map_on-3";
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
@@ -2834,14 +2834,24 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "afh" = (
-/obj/machinery/light/small{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 4
+	},
 /obj/machinery/firealarm{
-	pixel_y = 27
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
+/area/security/prison)
 "afi" = (
 /obj/structure/closet/secure_closet/hos,
 /obj/machinery/light{
@@ -3145,23 +3155,29 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "afF" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "afG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -3319,8 +3335,14 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "afS" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/brute,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "afT" = (
@@ -4250,16 +4272,13 @@
 /turf/closed/wall,
 /area/security/warden)
 "ahC" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
+/obj/machinery/disposal/bin,
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = -20
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -4271,8 +4290,12 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
+/area/crew_quarters/heads/hos)
 "ahD" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -4387,30 +4410,18 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ahJ" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = -20
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
 "ahK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4548,15 +4559,11 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "ahV" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/light/small{
+	dir = 1
 	},
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
@@ -5043,14 +5050,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "aiR" = (
-/obj/structure/table,
-/obj/item/clothing/under/sl_suit{
-	desc = "Whoever wears this makes the rules.";
-	name = "referee suit"
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 2
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "aiS" = (
@@ -5191,9 +5195,12 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "aji" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall,
-/area/maintenance/solars/port/fore)
+/obj/structure/closet/firecloset,
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "ajj" = (
 /obj/structure/table,
 /obj/item/stack/medical/ointment{
@@ -5310,10 +5317,6 @@
 /obj/structure/closet{
 	name = "Evidence Closet 5"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -5323,6 +5326,10 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
@@ -5356,14 +5363,13 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "ajw" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/area/security/main)
 "ajx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -5372,24 +5378,21 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "ajy" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/area/security/main)
 "ajz" = (
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
-"ajA" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/machinery/airalarm{
 	pixel_y = 28
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/area/security/main)
+"ajA" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "ajB" = (
 /obj/machinery/computer/secure_data,
 /obj/structure/cable/yellow{
@@ -5445,23 +5448,14 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "ajF" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Gear Room";
-	req_one_access_txt = "1;4"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel,
-/area/security/warden)
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "ajG" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -6372,15 +6366,34 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akY" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
+	},
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/security/range)
 "akZ" = (
 /obj/structure/rack,
 /obj/item/gun/energy/laser/practice{
@@ -6445,12 +6458,18 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "ale" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1{
-	icon_state = "connector_map";
-	dir = 8
+/obj/structure/table,
+/obj/item/clothing/under/sl_suit{
+	desc = "Whoever wears this makes the rules.";
+	name = "referee suit"
 	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
 "alf" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/dark,
@@ -6466,14 +6485,9 @@
 /area/security/main)
 "alh" = (
 /obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
+/obj/item/storage/firstaid/brute,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "ali" = (
@@ -7254,12 +7268,11 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "amx" = (
-/obj/machinery/holopad,
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/area/security/main)
 "amy" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
@@ -7393,33 +7406,22 @@
 /turf/open/floor/plasteel,
 /area/security/range)
 "amJ" = (
+/obj/structure/rack,
+/obj/item/storage/box/chemimp{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/storage/box/trackimp,
+/obj/item/storage/lockbox/loyalty,
+/obj/item/reagent_containers/glass/bottle/morphine,
+/obj/machinery/light/small,
+/obj/effect/turf_decal/bot,
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 4
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
-/area/security/range)
+/area/security/warden)
 "amK" = (
 /obj/machinery/gravity_generator/main/station,
 /obj/effect/turf_decal/bot_white,
@@ -7646,19 +7648,16 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "ani" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1{
+	icon_state = "connector_map";
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 6
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1{
+	icon_state = "connector_map-1";
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "anj" = (
 /obj/structure/window/reinforced,
 /obj/machinery/door/window/eastright{
@@ -7720,22 +7719,13 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "ann" = (
-/obj/structure/rack,
-/obj/item/storage/box/chemimp{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/item/storage/box/trackimp,
-/obj/item/storage/lockbox/loyalty,
-/obj/item/reagent_containers/glass/bottle/morphine,
-/obj/machinery/light/small,
+/obj/machinery/vending/security,
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
+	dir = 8;
+	pixel_x = 26
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/security/warden)
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "ano" = (
 /obj/structure/rack,
 /obj/item/storage/box/handcuffs,
@@ -7774,26 +7764,37 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "ans" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Gear Room";
+	req_one_access_txt = "1;4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
+"ant" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
-"ant" = (
+/area/security/main)
+"anu" = (
 /obj/structure/table,
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
-"anu" = (
-/obj/machinery/vending/security,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/area/security/main)
 "anv" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -7893,12 +7894,15 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "anF" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "anG" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -32
@@ -7912,18 +7916,26 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "anH" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/light{
+	dir = 8
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
+/obj/machinery/power/apc/highcap/five_k{
+	dir = 8;
+	name = "Brig Control APC";
+	areastring = "/area/security/warden";
+	pixel_x = -26
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 6
+	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/area/security/main)
 "anI" = (
 /obj/structure/chair{
 	dir = 1
@@ -8248,6 +8260,10 @@
 	icon_state = "connector_map";
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1{
+	icon_state = "connector_map-1";
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aov" = (
@@ -8282,22 +8298,27 @@
 	},
 /area/maintenance/port/fore)
 "aoy" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
 /obj/structure/closet/secure_closet/warden,
 /obj/item/gun/energy/laser,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aoz" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/bot,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
+	dir = 8
+	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/area/security/main)
 "aoA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -8335,26 +8356,13 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "aoD" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
-/obj/machinery/power/apc/highcap/five_k{
-	dir = 8;
-	name = "Brig Control APC";
-	areastring = "/area/security/warden";
-	pixel_x = -26
-	},
-/obj/structure/cable/yellow,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 6
-	},
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/area/security/main)
 "aoE" = (
 /obj/machinery/holopad,
 /obj/structure/disposalpipe/segment{
@@ -8389,18 +8397,11 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "aoG" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
-	dir = 8
-	},
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/area/security/main)
 "aoH" = (
 /obj/structure/table,
 /obj/item/folder/red,
@@ -9082,16 +9083,11 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "apQ" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/machinery/camera{
-	c_tag = "Security - Gear Room";
-	dir = 8
-	},
-/obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/area/security/main)
 "apR" = (
 /obj/machinery/light{
 	dir = 1
@@ -9143,32 +9139,20 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "apX" = (
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 32
-	},
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/camera{
+	c_tag = "Restrooms";
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
+	dir = 4
 	},
-/obj/item/reagent_containers/spray/cleaner,
-/turf/open/floor/plasteel/dark,
-/area/medical/genetics)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet/restrooms)
 "apY" = (
 /obj/structure/table,
 /obj/item/folder/red,
@@ -9264,14 +9248,22 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "aqh" = (
+/obj/item/phone{
+	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/cigbutt/cigarbutt{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/obj/structure/table/wood,
 /obj/machinery/firealarm{
-	pixel_y = 28
+	dir = 8;
+	pixel_x = 26
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/turf/open/floor/plasteel/grimy,
+/area/security/main)
 "aqi" = (
 /obj/machinery/computer/security/telescreen/interrogation{
 	dir = 8;
@@ -9360,19 +9352,23 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
 "aqn" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/small{
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/chair/office/light,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/engine/gravity_generator)
 "aqo" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -9713,17 +9709,21 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "ard" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32
 	},
+/obj/machinery/camera{
+	c_tag = "Security - Gear Room";
+	dir = 8
+	},
+/obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/area/security/main)
 "are" = (
-/obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/area/security/main)
 "arf" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -9773,14 +9773,16 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "arj" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/bot,
+/obj/machinery/holopad,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/area/security/main)
 "ark" = (
 /obj/machinery/newscaster/security_unit,
 /turf/closed/wall,
-/area/security/warden)
+/area/security/main)
 "arl" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -9866,21 +9868,19 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/main)
 "arx" = (
-/obj/item/phone{
-	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
-	pixel_x = -3;
-	pixel_y = 3
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/item/cigbutt/cigarbutt{
-	pixel_x = 5;
-	pixel_y = -1
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/structure/table/wood,
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/plasteel,
 /area/security/main)
 "ary" = (
 /obj/structure/rack,
@@ -10089,28 +10089,27 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "arQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
-"arR" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/chair/office/light,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
-	dir = 8
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
+"arR" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/area/security/brig)
 "arS" = (
 /obj/machinery/light,
 /obj/structure/cable/yellow{
@@ -10571,7 +10570,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/area/security/main)
 "asA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -10581,7 +10580,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
-/area/security/warden)
+/area/security/main)
 "asB" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -10686,19 +10685,19 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "asJ" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel,
-/area/security/main)
+/area/crew_quarters/dorms)
 "asK" = (
 /obj/structure/chair{
 	dir = 1
@@ -11023,9 +11022,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "atl" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall,
-/area/maintenance/solars/starboard/fore)
+/obj/item/stack/sheet/cardboard,
+/obj/item/flashlight,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "atm" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard)
@@ -11603,12 +11608,18 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "auy" = (
-/obj/item/stack/sheet/cardboard,
-/obj/item/flashlight,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_y = -32
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/port)
 "auz" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
@@ -11674,19 +11685,19 @@
 	},
 /area/maintenance/port/fore)
 "auH" = (
+/obj/structure/filingcabinet,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	pixel_y = 25
+	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
 "auI" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -12893,7 +12904,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/security/warden)
+/area/security/main)
 "awR" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -13400,18 +13411,20 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "axN" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Fore";
+	dir = 4;
+	network = list("ss13","engine")
 	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "axO" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -13722,6 +13735,10 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -14249,6 +14266,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"azw" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
 "azx" = (
 /obj/machinery/nuclearbomb/selfdestruct,
 /obj/effect/turf_decal/tile/neutral{
@@ -14489,19 +14520,27 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "azQ" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/filingcabinet,
 /obj/machinery/light/small{
-	dir = 1
+	dir = 4
 	},
-/obj/machinery/light_switch{
-	pixel_y = 25
+/obj/machinery/camera{
+	c_tag = "Labor Shuttle Dock";
+	dir = 8
 	},
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
+/obj/machinery/flasher{
+	id = "PRelease";
+	pixel_x = 24;
+	pixel_y = 20
+	},
+/obj/machinery/gulag_item_reclaimer{
+	pixel_y = 24
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/fore)
 "azR" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -15181,27 +15220,19 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "aAX" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Labor Shuttle Dock";
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/flasher{
-	id = "PRelease";
-	pixel_x = 24;
-	pixel_y = 20
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/machinery/gulag_item_reclaimer{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/fore)
+/turf/open/floor/plasteel,
+/area/security/brig)
 "aAY" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -15464,16 +15495,19 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aBz" = (
+/obj/structure/rack,
+/obj/item/electronics/apc,
+/obj/item/stock_parts/cell{
+	maxcharge = 2000
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
-/area/storage/primary)
+/area/quartermaster/warehouse)
 "aBA" = (
 /obj/item/radio/intercom{
 	pixel_x = -29
@@ -15484,12 +15518,29 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aBB" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/computer/shuttle/mining{
+	dir = 4;
+	req_access = null;
+	req_one_access = null
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
-/area/security/courtroom)
+/area/quartermaster/miningoffice)
 "aBC" = (
 /turf/open/floor/wood,
 /area/lawoffice)
@@ -15750,19 +15801,19 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aCc" = (
-/obj/structure/rack,
-/obj/item/electronics/apc,
-/obj/item/stock_parts/cell{
-	maxcharge = 2000
+/obj/machinery/door/poddoor/preopen{
+	id = "prison release";
+	name = "prisoner processing blast door"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/button/door{
+	id = "prison release";
+	name = "Labor Camp Shuttle Lockdown";
+	pixel_x = -25;
+	req_access_txt = "2"
 	},
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
+/area/hallway/primary/fore)
 "aCd" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
@@ -16173,20 +16224,12 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aCP" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+	pixel_y = 26
 	},
-/obj/machinery/camera{
-	c_tag = "Restrooms";
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
-	dir = 4
-	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "aCQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -16204,12 +16247,20 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aCS" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"aCT" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
 	},
 /obj/machinery/camera{
 	c_tag = "Storage Wing - Security Access Door";
@@ -16219,28 +16270,12 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
-"aCT" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = -30
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "aCU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	icon_state = "pipe11-3";
@@ -16353,29 +16388,21 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aDh" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/light_switch{
+	pixel_x = -38
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/computer/shuttle/mining{
-	dir = 4;
-	req_access = null;
-	req_one_access = null
-	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/turf/open/floor/plasteel{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningoffice)
+/area/engine/engineering)
 "aDi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16480,17 +16507,17 @@
 /turf/closed/wall,
 /area/hallway/primary/fore)
 "aDv" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "prison release";
-	name = "prisoner processing blast door"
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/machinery/button/door{
-	id = "prison release";
-	name = "Labor Camp Shuttle Lockdown";
-	pixel_x = -25;
-	req_access_txt = "2"
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/effect/turf_decal/delivery,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aDw" = (
@@ -16563,19 +16590,25 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aDD" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_y = -30
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
+	dir = 1
+	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 26
 	},
-/obj/machinery/camera{
-	c_tag = "Fore Primary Hallway Aft";
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "aDE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -16771,12 +16804,14 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
 "aDR" = (
-/obj/machinery/firealarm{
-	pixel_y = 32
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "aDS" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -17523,20 +17558,14 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aFp" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = -26
 	},
-/obj/machinery/light_switch{
-	pixel_x = -38
-	},
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/turf/open/floor/plasteel{
-	dir = 1
-	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aFq" = (
 /obj/effect/turf_decal/stripes/line{
@@ -17593,15 +17622,15 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aFw" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+	dir = 8;
+	pixel_x = 26
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
+/turf/open/floor/wood,
+/area/lawoffice)
 "aFx" = (
 /obj/machinery/light,
 /obj/machinery/newscaster{
@@ -18582,14 +18611,13 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aHh" = (
+/obj/machinery/biogenerator,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/firealarm{
-	pixel_y = 27
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/area/hydroponics/garden)
 "aHi" = (
 /obj/machinery/light_switch{
 	pixel_y = 28
@@ -18947,19 +18975,16 @@
 	},
 /area/maintenance/starboard/fore)
 "aHP" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery,
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "aHQ" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -19043,15 +19068,16 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aHX" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/storage/primary)
 "aHY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19360,13 +19386,11 @@
 /area/hallway/primary/central)
 "aIy" = (
 /obj/machinery/firealarm{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/security/courtroom)
 "aIz" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -20147,15 +20171,18 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "aKj" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
+/obj/structure/table,
+/obj/item/folder,
+/obj/item/storage/firstaid/regular,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+	dir = 4;
+	pixel_x = -26
 	},
-/turf/open/floor/wood,
-/area/lawoffice)
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "aKk" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -20216,13 +20243,19 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aKq" = (
-/obj/machinery/biogenerator,
-/obj/machinery/firealarm{
-	pixel_y = 27
+/obj/machinery/camera{
+	c_tag = "Fore Primary Hallway Aft";
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/red{
+	dir = 2
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
 /turf/open/floor/plasteel,
-/area/hydroponics/garden)
+/area/hallway/primary/fore)
 "aKr" = (
 /obj/structure/table,
 /obj/item/cultivator,
@@ -20372,14 +20405,28 @@
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "aKJ" = (
-/obj/structure/table/wood,
-/obj/item/bikehorn/rubberducky,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/computer/atmos_alert,
+/obj/structure/sign/map/left{
+	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
+	icon_state = "map-left-MS";
+	pixel_y = 32
 	},
-/turf/open/floor/wood,
-/area/clerk)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "aKK" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -20859,18 +20906,16 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aLt" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
+/obj/effect/turf_decal/tile/neutral{
+	dir = 2
 	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
-	dir = 8
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
-/area/science/robotics/mechbay)
+/area/crew_quarters/locker)
 "aLu" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -21128,16 +21173,21 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aLW" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/machinery/light/small{
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	pixel_y = 27
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
+/turf/open/floor/engine,
+/area/engine/engineering)
 "aLX" = (
 /obj/machinery/door/firedoor/border_only/closed{
 	dir = 8;
@@ -21263,15 +21313,19 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "aMn" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 2
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/rnd/production/techfab/department/cargo,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/quartermaster/storage)
 "aMo" = (
 /obj/structure/reflector/box/anchored{
 	dir = 8
@@ -21319,15 +21373,30 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aMx" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_x = 0;
+	pixel_y = -26
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
 "aMy" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
@@ -21339,7 +21408,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/space)
+/area/construction/storage_wing)
 "aMz" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
@@ -22039,25 +22108,15 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "aNO" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 2
+	},
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
+	dir = 8;
+	pixel_x = 26
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "aNP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22429,18 +22488,14 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "aOs" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/table,
-/obj/item/folder,
-/obj/item/storage/firstaid/regular,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/locker)
+/area/hallway/primary/central)
 "aOt" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -22567,29 +22622,17 @@
 /area/vacant_room/commissary)
 "aOG" = (
 /obj/machinery/light_switch{
-	pixel_x = 28;
-	pixel_y = -6
+	pixel_x = -38
 	},
-/obj/structure/table,
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
-/obj/item/stack/sheet/metal/five,
-/obj/item/radio/intercom{
-	pixel_x = 28;
-	pixel_y = 5
-	},
-/obj/item/circuitboard/machine/paystand,
-/obj/item/stack/cable_coil/random/five,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/loading_area{
 	dir = 1
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel,
-/area/vacant_room/commissary)
+/area/quartermaster/storage)
 "aOH" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -23333,28 +23376,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aPU" = (
-/obj/machinery/computer/atmos_alert,
-/obj/structure/sign/map/left{
-	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
-	icon_state = "map-left-MS";
-	pixel_y = 32
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/firealarm{
+	pixel_y = 26
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "aPV" = (
 /obj/machinery/computer/station_alert,
 /obj/structure/sign/map/right{
@@ -24310,21 +24342,16 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aRC" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/effect/turf_decal/tile/neutral{
+	dir = 2
 	},
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/light{
-	dir = 8
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/central)
 "aRD" = (
 /obj/machinery/light{
 	dir = 8
@@ -24914,14 +24941,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "aSF" = (
-/obj/machinery/firealarm{
-	pixel_y = 32
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/hallway/primary/central)
 "aSG" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -25723,19 +25752,23 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "aUi" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/fyellow,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/multitool,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/rnd/production/techfab/department/cargo,
 /turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/area/storage/tools)
 "aUj" = (
 /obj/structure/closet/secure_closet/security/cargo,
 /obj/machinery/light_switch{
@@ -26049,29 +26082,25 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "aUJ" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_x = -3;
-	pixel_y = 5
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/courtroom)
+/area/crew_quarters/heads/chief)
 "aUK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -26083,15 +26112,20 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "aUL" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 26
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
+/turf/open/floor/plasteel/white/corner,
+/area/hallway/secondary/entry)
 "aUM" = (
 /turf/closed/wall,
 /area/crew_quarters/locker)
@@ -26409,16 +26443,22 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aVq" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 2
+/obj/machinery/light_switch{
+	pixel_x = 27
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_y = 30
+	},
+/obj/structure/closet/secure_closet/security,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/security/checkpoint/customs)
 "aVr" = (
 /obj/machinery/porta_turret/ai{
 	dir = 8
@@ -26776,19 +26816,30 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aVZ" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/machinery/light_switch{
+	pixel_x = 28;
+	pixel_y = -6
 	},
-/obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway - Auxiliary Tool Storage";
+/obj/structure/table,
+/obj/item/stack/sheet/metal/five,
+/obj/item/radio/intercom{
+	pixel_x = 28;
+	pixel_y = 5
+	},
+/obj/item/circuitboard/machine/paystand,
+/obj/item/stack/cable_coil/random/five,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/machinery/firealarm{
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/vacant_room/commissary)
 "aWa" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -27174,23 +27225,15 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "aWE" = (
-/obj/machinery/computer/teleporter,
+/obj/structure/table,
+/obj/item/plant_analyzer,
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
+/area/storage/tech)
 "aWF" = (
 /obj/machinery/status_display/ai{
 	pixel_y = 32
@@ -27867,19 +27910,19 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "aXO" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/camera{
-	c_tag = "Arrivals - Station Entrance";
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/quartermaster/office)
 "aXP" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -27904,14 +27947,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aXR" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
 /obj/machinery/firealarm{
-	pixel_y = 32
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "aXS" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -27955,12 +28001,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aXW" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/obj/structure/sign/departments/minsky/supply/cargo{
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "aXX" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
@@ -28264,18 +28312,23 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai)
 "aYA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/structure/closet/secure_closet/security/engine,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/security/checkpoint/engineering)
 "aYB" = (
 /obj/structure/showcase/cyborg/old{
 	dir = 8;
@@ -28371,18 +28424,19 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aYJ" = (
-/obj/machinery/light_switch{
-	pixel_x = -38
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 4
 	},
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 1
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/area/quartermaster/sorting)
 "aYK" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -28792,20 +28846,14 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "aZv" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+	pixel_y = 26
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/white/corner,
-/area/hallway/secondary/entry)
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "aZw" = (
 /turf/closed/wall/r_wall,
 /area/storage/tech)
@@ -28988,15 +29036,20 @@
 	},
 /area/maintenance/starboard/fore)
 "aZI" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/security/checkpoint/customs)
 "aZJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -29579,18 +29632,20 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "baB" = (
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
+/obj/structure/table,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
-	dir = 4
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/area/quartermaster/office)
 "baC" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -30003,21 +30058,16 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bbm" = (
-/obj/structure/window/reinforced,
-/obj/structure/showcase/cyborg/old{
-	dir = 8;
-	pixel_x = 9;
-	pixel_y = 2
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 2
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 26
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bbn" = (
 /obj/machinery/door/window{
 	base_state = "right";
@@ -30322,17 +30372,20 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bbJ" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "Starboard Primary Hallway - Auxiliary Tool Storage";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
 	},
-/obj/effect/turf_decal/tile/blue,
-/mob/living/simple_animal/bot/cleanbot,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "bbK" = (
 /turf/closed/wall,
 /area/security/checkpoint/customs)
@@ -30557,23 +30610,23 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bcn" = (
-/obj/structure/rack,
+/obj/machinery/computer/teleporter,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/item/clothing/gloves/color/fyellow,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/multitool,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/storage/tools)
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "bco" = (
 /obj/machinery/status_display/evac{
 	pixel_y = -32
@@ -30682,15 +30735,19 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bcz" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/machinery/camera{
+	c_tag = "Arrivals - Station Entrance";
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/area/hallway/secondary/entry)
 "bcA" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/neutral{
@@ -30908,20 +30965,14 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "bcT" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 4
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/sorting)
+/area/hallway/primary/port)
 "bcU" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -31007,26 +31058,14 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "bdc" = (
-/obj/machinery/light_switch{
-	pixel_x = 27
-	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = 30
-	},
-/obj/structure/closet/secure_closet/security,
+/obj/item/storage/fancy/donut_box,
+/obj/structure/table/glass,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 26
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/customs)
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "bdd" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -31538,14 +31577,18 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bea" = (
-/obj/structure/table,
-/obj/item/plant_analyzer,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/turf/open/floor/plasteel/dark,
-/area/storage/tech)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "beb" = (
 /obj/structure/table,
 /obj/item/analyzer,
@@ -31703,19 +31746,23 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bem" = (
-/obj/structure/table/glass,
-/obj/item/tank/internals/emergency_oxygen{
-	pixel_x = -8
+/obj/machinery/light,
+/obj/structure/rack,
+/obj/item/storage/secure/briefcase,
+/obj/item/clothing/mask/cigarette/cigar,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/obj/item/clothing/mask/breath{
-	pixel_x = 4
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/break_room)
+/area/bridge)
 "ben" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -31723,23 +31770,14 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
 "beo" = (
-/obj/structure/closet/secure_closet/security/engine,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
+/area/engine/storage_shared)
 "bep" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -32026,19 +32064,21 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "beQ" = (
-/obj/machinery/firealarm{
+/obj/structure/window/reinforced,
+/obj/structure/showcase/cyborg/old{
 	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Bridge - Port Access";
-	dir = 8
+	pixel_x = 9;
+	pixel_y = 2
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 1
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/dark,
-/area/bridge)
+/area/aisat)
 "beR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	icon_state = "scrub_map_on-3";
@@ -32109,18 +32149,17 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "beZ" = (
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 26
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
+/mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/plasteel/dark,
-/area/bridge)
+/area/ai_monitored/turret_protected/aisat_interior)
 "bfa" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -32680,13 +32719,13 @@
 /turf/open/floor/plating,
 /area/engine/break_room)
 "bga" = (
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -32762,17 +32801,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bgh" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/structure/table,
+/obj/item/camera_film,
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
+	dir = 8;
+	pixel_x = 26
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/plasteel,
+/area/storage/art)
 "bgi" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -32895,15 +32931,19 @@
 	},
 /area/maintenance/central)
 "bgt" = (
+/obj/structure/table/glass,
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = -8
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = 4
+	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = -26
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/plasteel/dark,
+/area/engine/break_room)
 "bgu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -33233,12 +33273,19 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bgW" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+/obj/machinery/camera{
+	c_tag = "Bridge - Port Access";
+	dir = 8
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain/private)
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "bgX" = (
 /obj/item/radio/intercom{
 	pixel_y = -26
@@ -34828,14 +34875,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bjH" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/structure/table/wood,
+/obj/item/folder/yellow,
+/obj/machinery/firealarm{
+	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "bjI" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -35272,20 +35318,18 @@
 /turf/open/floor/plasteel/white/corner,
 /area/quartermaster/sorting)
 "bkn" = (
-/obj/structure/table,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "bko" = (
 /obj/machinery/photocopier,
 /obj/effect/turf_decal/tile/brown,
@@ -35366,25 +35410,40 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bku" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Bar"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"bkv" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks,
+/obj/structure/sign/barsign{
+	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"bkv" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/white/corner,
+/area/hallway/secondary/entry)
 "bkw" = (
 /obj/structure/table,
 /obj/item/toner,
@@ -35401,16 +35460,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bkx" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/bar)
+/area/hallway/primary/port)
 "bky" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -36021,18 +36081,12 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "blE" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/corner,
-/area/hallway/primary/starboard)
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "blF" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/light/small{
@@ -37345,16 +37399,12 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "boa" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
-	dir = 1
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
 /obj/effect/landmark/start/yogs/signal_technician,
-/turf/open/floor/plasteel/dark,
-/area/storage/tcom)
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "bob" = (
 /obj/machinery/light/small,
 /obj/machinery/camera{
@@ -37622,14 +37672,24 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "boC" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Telecomms Admin";
+	departmentType = 5;
+	name = "Telecomms RC";
+	pixel_y = -30
+	},
+/obj/item/paper_bin{
+	pixel_x = -1;
+	pixel_y = 6
+	},
+/obj/structure/table/wood,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 26
 	},
-/obj/item/storage/fancy/donut_box,
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/dark,
-/area/bridge)
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "boD" = (
 /obj/structure/displaycase/captain{
 	pixel_y = 5
@@ -37915,14 +37975,14 @@
 	},
 /area/crew_quarters/kitchen)
 "bpm" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/pie/cream,
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
+	dir = 8;
+	pixel_x = 26
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "bpn" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -37963,16 +38023,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bpt" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
-/area/security/checkpoint/customs)
+/area/crew_quarters/toilet/auxiliary)
 "bpu" = (
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
@@ -38059,19 +38116,28 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bpC" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
+/obj/machinery/light,
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1
+	dir = 2
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/secondary/command)
 "bpD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	icon_state = "scrub_map_on-3";
@@ -38259,19 +38325,23 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "bpP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8"
+	icon_state = "1-8"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
-/obj/structure/reagent_dispensers/cooking_oil,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=7.5-Starboard-Aft-Corner";
+	location = "7-Command-Starboard"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bpQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -38834,22 +38904,23 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bqJ" = (
-/obj/machinery/light,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/structure/rack,
-/obj/item/storage/secure/briefcase,
-/obj/item/clothing/mask/cigarette/cigar,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/machinery/door/airlock/public/glass{
+	name = "Bar"
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "bqK" = (
 /obj/structure/rack,
 /obj/item/aicard,
@@ -39058,15 +39129,23 @@
 /turf/open/floor/wood,
 /area/library)
 "brc" = (
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/crew_quarters/bar)
 "brd" = (
 /obj/structure/table,
 /obj/machinery/power/apc{
@@ -39130,14 +39209,24 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "brk" = (
-/obj/machinery/firealarm{
-	pixel_y = 28
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/crew_quarters/bar)
 "brl" = (
 /obj/item/radio/intercom{
 	pixel_y = 21
@@ -40354,14 +40443,33 @@
 /turf/open/floor/plasteel,
 /area/storage/art)
 "btn" = (
-/obj/structure/table,
-/obj/item/camera_film,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/storage/art)
+/obj/machinery/button/door{
+	id = "atmos";
+	name = "Atmospherics Lockdown";
+	pixel_x = 26;
+	pixel_y = -26;
+	req_access_txt = "24"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/engine/atmos)
 "bto" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/wood,
@@ -41092,23 +41200,18 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
 "buR" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
+/obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white/corner,
-/area/hallway/secondary/entry)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/hallway/primary/starboard)
 "buS" = (
 /obj/machinery/disposal/bin{
 	pixel_x = 2;
@@ -41715,20 +41818,16 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bvY" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/cobweb,
 /obj/machinery/firealarm{
-	pixel_y = 29
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/obj/structure/closet/crate/hydroponics,
-/obj/item/shovel/spade,
-/obj/item/wrench,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/cultivator,
-/obj/item/wirecutters,
-/turf/open/floor/plasteel,
-/area/hydroponics)
+/turf/open/floor/wood,
+/area/library)
 "bvZ" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/shaker,
@@ -41951,13 +42050,22 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "bww" = (
-/obj/structure/table/wood,
-/obj/item/folder/yellow,
-/obj/machinery/firealarm{
-	pixel_y = 28
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "bwx" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -42103,21 +42211,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "bwK" = (
-/obj/structure/table,
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
+	dir = 8;
+	pixel_x = 26
 	},
-/obj/machinery/chem_dispenser/drinks,
-/obj/structure/sign/barsign{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
+/turf/open/floor/wood,
+/area/vacant_room/office)
 "bwL" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer,
@@ -42915,23 +43014,23 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "byj" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/shower{
-	dir = 8;
-	name = "emergency shower"
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/eva)
 "byk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -43153,18 +43252,14 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "byH" = (
+/obj/structure/table/wood,
+/obj/item/bikehorn/rubberducky,
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+	dir = 8;
+	pixel_x = 26
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
+/turf/open/floor/wood,
+/area/clerk)
 "byI" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -43532,11 +43627,15 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bzo" = (
-/obj/structure/chair/office/dark{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/storage/tcom)
 "bzp" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -44392,24 +44491,13 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "bBa" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Telecomms Admin";
-	departmentType = 5;
-	name = "Telecomms RC";
-	pixel_y = -30
-	},
+/obj/machinery/teleport/station,
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/item/paper_bin{
-	pixel_x = -1;
-	pixel_y = 6
-	},
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/turf/open/floor/plating,
+/area/teleporter)
 "bBb" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -44965,14 +45053,27 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
 "bCd" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/camera{
+	c_tag = "Arrivals - Aft Arm";
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 9
+	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 26
 	},
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/pie/cream,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/turf/open/floor/plasteel/white/corner,
+/area/hallway/secondary/entry)
 "bCe" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -44983,19 +45084,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bCf" = (
-/obj/machinery/camera{
-	c_tag = "Aft Primary Hallway - Fore";
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 26
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/open/floor/wood,
+/area/library)
 "bCg" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/northleft{
@@ -45291,6 +45385,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 2
 	},
+/obj/structure/sign/departments/minsky/research/research{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bCK" = (
@@ -45369,13 +45466,15 @@
 /turf/open/floor/plating,
 /area/science/research)
 "bCS" = (
+/obj/machinery/vending/dinnerware,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 26
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/crew_quarters/toilet/auxiliary)
+/turf/open/floor/plasteel/cafeteria{
+	dir = 2
+	},
+/area/crew_quarters/kitchen)
 "bCT" = (
 /obj/structure/table/reinforced,
 /obj/item/hand_labeler,
@@ -46521,15 +46620,19 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bEU" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/table,
+/obj/item/stock_parts/subspace/treatment,
+/obj/item/stock_parts/subspace/treatment,
+/obj/item/stock_parts/subspace/treatment,
+/obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/storage/tcom)
 "bEV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46647,27 +46750,19 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "bFh" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/light,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 2
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/command)
+/area/hallway/primary/central)
 "bFi" = (
 /obj/item/radio/intercom{
 	pixel_x = -29
@@ -47025,30 +47120,17 @@
 "bFK" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 8
+	dir = 1
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
 	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+	dir = 8;
+	pixel_x = 26
 	},
-/obj/machinery/button/door{
-	id = "atmos";
-	name = "Atmospherics Lockdown";
-	pixel_x = 26;
-	pixel_y = -26;
-	req_access_txt = "24"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/corner,
-/area/engine/atmos)
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "bFL" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/tile/yellow{
@@ -47248,9 +47330,6 @@
 	},
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
-	},
-/obj/structure/sign/departments/minsky/research/research{
-	pixel_y = 32
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
@@ -47719,26 +47798,32 @@
 /turf/open/floor/plasteel,
 /area/science/storage)
 "bHe" = (
-/obj/machinery/doorButtons/access_button{
-	idDoor = "xeno_airlock_interior";
-	idSelf = "xeno_airlock_control";
-	name = "Access Button";
-	pixel_x = 29;
-	pixel_y = -8;
-	req_access_txt = "55"
+/obj/item/book/manual/wiki/security_space_law{
+	name = "space law";
+	pixel_y = 2
 	},
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
-/obj/machinery/light{
+/obj/item/toy/gun{
+	name = "cap gun"
+	},
+/obj/item/restraints/handcuffs{
+	name = "handcuffs"
+	},
+/obj/structure/table/wood,
+/obj/item/clothing/head/collectable/HoS{
+	name = "novelty HoS hat"
+	},
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/turf/open/floor/carpet,
+/area/bridge/showroom/corporate)
 "bHf" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -48863,29 +48948,19 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
 "bJp" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
+	icon_state = "2-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
+/obj/structure/reagent_dispensers/cooking_oil,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=7.5-Starboard-Aft-Corner";
-	location = "7-Command-Starboard"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	icon_state = "manifold-1";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	icon_state = "manifold-3";
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen)
 "bJq" = (
 /obj/machinery/door/airlock/medical{
 	name = "Paramedic Staging Area";
@@ -48964,21 +49039,25 @@
 /turf/open/floor/carpet,
 /area/vacant_room/office)
 "bJx" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/wood,
-/area/vacant_room/office)
-"bJy" = (
-/obj/machinery/light/small{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = -26
 	},
-/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"bJy" = (
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
+	},
 /turf/open/floor/wood,
 /area/library)
 "bJz" = (
@@ -49031,8 +49110,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/maintenance,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;47"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "bJF" = (
@@ -49066,23 +49147,14 @@
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
 "bJH" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/firealarm{
+	pixel_y = 26
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/eva)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bJI" = (
 /obj/structure/window/reinforced,
 /obj/structure/table,
@@ -49289,17 +49361,13 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "bJX" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1{
+	icon_state = "connector_map-1";
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "bJY" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -50343,16 +50411,15 @@
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "bLV" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway - Middle";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/structure/sign/departments/minsky/research/genetics{
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -50841,13 +50908,16 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "bMW" = (
-/obj/machinery/teleport/station,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+/obj/item/cigbutt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	icon_state = "manifold-1";
+	dir = 8
 	},
 /turf/open/floor/plating,
-/area/teleporter)
+/area/maintenance/port)
 "bMX" = (
 /obj/machinery/bluespace_beacon,
 /obj/effect/turf_decal/stripes/line{
@@ -51151,15 +51221,11 @@
 	},
 /area/crew_quarters/kitchen)
 "bNC" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
 	},
-/obj/machinery/vending/dinnerware,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 2
-	},
-/area/crew_quarters/kitchen)
+/area/maintenance/port)
 "bND" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -51251,19 +51317,20 @@
 	},
 /area/medical/medbay/aft)
 "bNN" = (
-/obj/structure/table,
-/obj/item/stock_parts/subspace/treatment,
-/obj/item/stock_parts/subspace/treatment,
-/obj/item/stock_parts/subspace/treatment,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
 	},
+/obj/structure/closet/crate/hydroponics,
+/obj/item/shovel/spade,
+/obj/item/wrench,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/cultivator,
+/obj/item/wirecutters,
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+	pixel_y = 26
 	},
-/turf/open/floor/plasteel/dark,
-/area/storage/tcom)
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "bNO" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/plating,
@@ -51810,15 +51877,12 @@
 /turf/closed/wall,
 /area/hallway/primary/aft)
 "bOU" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1{
+	icon_state = "connector_map-1";
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/open/floor/plating,
+/area/maintenance/port)
 "bOV" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria{
@@ -53232,32 +53296,18 @@
 /turf/open/floor/carpet,
 /area/bridge/showroom/corporate)
 "bRG" = (
-/obj/item/book/manual/wiki/security_space_law{
-	name = "space law";
-	pixel_y = 2
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-10"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/item/toy/gun{
-	name = "cap gun"
-	},
-/obj/item/restraints/handcuffs{
-	name = "handcuffs"
-	},
-/obj/structure/table/wood,
-/obj/item/clothing/head/collectable/HoS{
-	name = "novelty HoS hat"
+/obj/effect/turf_decal/tile/purple{
+	dir = 2
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 26
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/bridge/showroom/corporate)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bRH" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/cable/yellow{
@@ -53409,17 +53459,35 @@
 	},
 /area/crew_quarters/kitchen)
 "bRU" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 4
 	},
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/obj/item/pen,
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Research Division - Lobby";
+	dir = 2;
+	network = list("ss13","rd")
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/virology)
+/area/science/research)
 "bRV" = (
 /obj/structure/sink{
 	dir = 4;
@@ -53909,11 +53977,17 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "bSP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
 	},
-/turf/closed/wall,
-/area/medical/virology)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bSQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -54024,8 +54098,43 @@
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "bTd" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall,
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/blood/AMinus,
+/obj/item/reagent_containers/blood/BMinus{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/blood/BPlus{
+	pixel_x = 1;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OPlus{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bTe" = (
 /obj/structure/cable/yellow{
@@ -54124,9 +54233,15 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bTp" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall,
-/area/maintenance/solars/port/aft)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1{
+	icon_state = "connector_map-1";
+	dir = 1
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "bTq" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -54168,15 +54283,35 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bTw" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"bTx" = (
+/obj/structure/closet/l3closet,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
+"bTy" = (
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26;
-	pixel_y = 28
 	},
 /obj/machinery/light{
 	dir = 1
@@ -54194,32 +54329,11 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"bTx" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 10
-	},
-/area/science/research)
-"bTy" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/library)
 "bTz" = (
 /obj/structure/table/wood,
 /obj/machinery/light,
@@ -54427,17 +54541,25 @@
 /area/science/research)
 "bTT" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/virology)
 "bTU" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -55196,24 +55318,29 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "bVn" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/virology{
+	name = "Break Room";
+	req_access_txt = "39"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/area/medical/virology)
 "bVo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -55546,9 +55673,25 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "bVU" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/r_wall,
-/area/medical/virology)
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/pen,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/science/research)
 "bVV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating{
@@ -56197,21 +56340,18 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bXc" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "bXd" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -56446,11 +56586,23 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bXx" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/machinery/shower{
+	dir = 8;
+	name = "emergency shower"
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "bXy" = (
 /obj/structure/closet,
 /obj/item/flashlight,
@@ -56598,12 +56750,11 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bXQ" = (
-/obj/machinery/camera{
-	c_tag = "Central Primary Hallway - Aft-Port";
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/structure/sign/departments/minsky/medical/medical2{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -56665,6 +56816,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 2
 	},
+/obj/structure/sign/departments/minsky/research/research{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bXX" = (
@@ -56706,18 +56860,20 @@
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms/room_a)
 "bXZ" = (
-/obj/machinery/firealarm{
+/obj/structure/sink{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = -12;
+	pixel_y = 2
 	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-10"
+/obj/item/cigbutt,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 2
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/science/research)
 "bYa" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -56924,30 +57080,39 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bYu" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28;
-	pixel_y = 5
+/obj/structure/table/glass,
+/obj/item/folder/white{
+	pixel_y = 2
 	},
-/obj/machinery/light{
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/screwdriver{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/item/radio/headset/headset_med,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/item/wrench,
-/obj/item/screwdriver{
-	pixel_y = 10
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/obj/item/multitool{
-	pixel_x = 3
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
 	},
-/obj/item/stack/cable_coil,
-/obj/effect/turf_decal/delivery,
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "bYv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/light{
@@ -57288,9 +57453,18 @@
 /turf/open/floor/plating,
 /area/medical/medbay/central)
 "bZb" = (
-/obj/structure/sign/departments/minsky/medical/medical2,
-/turf/closed/wall,
-/area/medical/medbay/central)
+/obj/machinery/camera{
+	c_tag = "Central Primary Hallway - Aft-Port";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/sign/departments/minsky/medical/medical2{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bZc" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -57381,9 +57555,14 @@
 /turf/open/floor/plating,
 /area/science/research)
 "bZk" = (
-/obj/structure/sign/departments/minsky/research/research,
-/turf/closed/wall,
-/area/science/research)
+/obj/effect/turf_decal/tile/purple{
+	dir = 2
+	},
+/obj/structure/sign/departments/minsky/research/research{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bZl" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -57392,20 +57571,19 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "bZm" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
+/obj/machinery/camera{
+	c_tag = "Aft Primary Hallway - Fore";
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 2
+	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+	dir = 8;
+	pixel_x = 26
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "bZn" = (
 /turf/closed/wall,
 /area/science/research)
@@ -57520,26 +57698,14 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "bZz" = (
-/obj/machinery/camera{
-	c_tag = "Virology - Airlock";
-	dir = 1;
-	network = list("ss13","medbay")
-	},
-/obj/machinery/light,
-/obj/structure/closet/l3closet,
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+	dir = 8;
+	pixel_x = 26
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
+/turf/open/floor/plasteel,
+/area/science/research)
 "bZA" = (
 /obj/machinery/door/airlock/medical{
 	name = "Patient Room A";
@@ -58140,35 +58306,26 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "caB" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 4
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/machinery/newscaster{
+	pixel_y = -32
 	},
-/obj/item/pen,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
+/obj/machinery/camera{
+	c_tag = "Medbay Recovery Room";
+	dir = 1;
+	network = list("ss13","medbay")
 	},
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Research Division - Lobby";
-	dir = 2;
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/white,
-/area/science/research)
+/area/medical/surgery)
 "caC" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -58230,25 +58387,16 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
 "caE" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/obj/item/pen,
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/science/research)
+/turf/open/floor/plasteel/white,
+/area/science/explab)
 "caF" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -58260,17 +58408,27 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "caG" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 2;
+	pixel_y = 3
 	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/science/lab)
 "caH" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -58342,27 +58500,13 @@
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "caM" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
 	},
-/obj/machinery/camera{
-	c_tag = "Arrivals - Aft Arm";
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 9
-	},
-/turf/open/floor/plasteel/white/corner,
-/area/hallway/secondary/entry)
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "caN" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -59440,16 +59584,16 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "ccy" = (
-/obj/machinery/hydroponics/constructable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_x = 0;
+	pixel_y = -26
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "ccz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -59879,17 +60023,28 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "cdq" = (
+/obj/structure/table/reinforced,
+/obj/item/crowbar,
+/obj/machinery/camera{
+	c_tag = "Medbay Cryo";
+	dir = 1;
+	network = list("ss13","medbay")
+	},
+/obj/item/screwdriver{
+	pixel_y = 6
+	},
+/obj/item/clothing/neck/stethoscope,
+/obj/item/wrench/medical,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/closet/l3closet,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+	pixel_x = 0;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/storage)
+/area/medical/cryo)
 "cdr" = (
 /obj/item/storage/box/bodybags{
 	pixel_x = 3;
@@ -60324,6 +60479,20 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
+"cec" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	icon_state = "manifold-3";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	icon_state = "manifold-1";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
 "ced" = (
 /obj/item/storage/box/rxglasses{
 	pixel_x = 3;
@@ -60669,6 +60838,9 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/structure/sign/departments/minsky/medical/chemistry/chemical2{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -61589,9 +61761,14 @@
 /turf/closed/wall,
 /area/medical/chemistry)
 "cfW" = (
-/obj/structure/sign/departments/minsky/medical/chemistry/chemical2,
-/turf/closed/wall,
-/area/medical/chemistry)
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/sign/departments/minsky/medical/medical2{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "cfX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -62944,6 +63121,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"cii" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 2
+	},
+/obj/structure/sign/departments/minsky/research/research{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "cij" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -63072,13 +63258,32 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "ciu" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1{
-	icon_state = "connector_map";
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 32
+	},
+/obj/structure/table/glass,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics)
 "civ" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -63191,13 +63396,15 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "ciE" = (
-/obj/item/cigbutt,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plating,
-/area/maintenance/port)
+/area/medical/surgery)
 "ciF" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12;5;39;25;28"
@@ -64121,6 +64328,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"ckf" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/science/robotics/lab)
 "ckg" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Incinerator Access";
@@ -64172,20 +64383,22 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "ckm" = (
+/obj/structure/table,
+/obj/item/taperecorder{
+	pixel_x = -3
+	},
+/obj/item/paicard{
+	pixel_x = 4
+	},
+/obj/item/storage/secure/briefcase,
 /obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/sink{
 	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+	pixel_x = 26
 	},
-/obj/item/cigbutt,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
-/area/science/research)
+/area/crew_quarters/heads/hor)
 "ckn" = (
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -64967,38 +65180,20 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "clw" = (
-/obj/structure/table/glass,
-/obj/item/folder/white{
-	pixel_y = 2
+/obj/machinery/camera{
+	c_tag = "Medbay Hallway Central";
+	dir = 4;
+	network = list("ss13","medbay")
 	},
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/screwdriver{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/obj/item/radio/headset/headset_med,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/medical/medbay/central)
 "clx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -65117,13 +65312,18 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "clI" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
+	dir = 8
+	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 26
 	},
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "clJ" = (
 /obj/structure/plasticflaps/opaque,
@@ -65222,9 +65422,20 @@
 	},
 /area/science/research)
 "clS" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/science/explab)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "clT" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -65912,6 +66123,23 @@
 	icon_state = "wood-broken"
 	},
 /area/maintenance/port/aft)
+"cnl" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 2
+	},
+/obj/structure/sign/departments/minsky/research/robotics{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "cnm" = (
 /obj/structure/table,
 /obj/item/hemostat,
@@ -66642,16 +66870,15 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cok" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/wrench,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1{
+	icon_state = "connector_map-1";
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/science/explab)
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "col" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -67868,41 +68095,35 @@
 /turf/open/floor/plating/airless,
 /area/medical/virology)
 "cqa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/medical/virology)
-"cqb" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/mechbay)
+"cqb" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	icon_state = "manifold-1";
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	icon_state = "manifold-3";
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "cqc" = (
 /obj/structure/cable/yellow{
@@ -67922,27 +68143,21 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cqd" = (
-/obj/item/trash/popcorn,
-/obj/structure/table/glass,
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 9
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/virology)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "cqe" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -68049,6 +68264,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"cqj" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "xeno_blastdoor";
+	name = "biohazard containment door"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/sign/departments/minsky/research/xenobiology{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "cqk" = (
 /obj/structure/sink{
 	dir = 8;
@@ -68071,6 +68297,16 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"cqm" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/structure/sign/departments/minsky/supply/cargo{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "cqn" = (
 /obj/machinery/shower{
 	dir = 4
@@ -68108,6 +68344,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"cqp" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 2
+	},
+/obj/structure/sign/departments/minsky/supply/hydroponics{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "cqq" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -68234,26 +68479,29 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "cqy" = (
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 2;
-	pixel_y = 3
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
+/obj/structure/table,
+/obj/item/wrench,
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/obj/item/multitool{
+	pixel_x = 3
+	},
+/obj/item/stack/cable_coil,
+/obj/effect/turf_decal/delivery,
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
 	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
-/area/science/lab)
+/area/science/robotics/lab)
 "cqz" = (
 /obj/item/stack/packageWrap,
 /obj/item/stack/packageWrap,
@@ -68309,12 +68557,16 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cqD" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/light/small,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_x = 0;
+	pixel_y = -26
 	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
+/turf/open/floor/plasteel,
+/area/science/storage)
 "cqE" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 4
@@ -68567,6 +68819,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"cqY" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/sign/departments/minsky/supply/mining{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "cqZ" = (
 /obj/machinery/light_switch{
 	pixel_y = -25
@@ -68631,12 +68892,15 @@
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
 "crj" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/science/misc_lab/range)
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "crk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -68759,27 +69023,22 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "crs" = (
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/structure/table/glass,
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/structure/table/reinforced,
-/obj/item/crowbar,
-/obj/machinery/camera{
-	c_tag = "Medbay Cryo";
-	dir = 1;
-	network = list("ss13","medbay")
+/turf/open/floor/plasteel/white/side{
+	dir = 2
 	},
-/obj/item/screwdriver{
-	pixel_y = 6
-	},
-/obj/item/clothing/neck/stethoscope,
-/obj/item/wrench/medical,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/cryo)
+/area/medical/medbay/aft)
 "crt" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
@@ -69032,6 +69291,23 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/lab)
+"crJ" = (
+/obj/structure/chair/stool,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "crK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -69307,12 +69583,11 @@
 "csm" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_x = 0;
+	pixel_y = -26
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
-/area/medical/surgery)
+/turf/open/floor/plasteel/white,
+/area/science/misc_lab/range)
 "csn" = (
 /obj/item/radio/intercom{
 	broadcasting = 1;
@@ -69358,26 +69633,27 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "csq" = (
-/obj/structure/bed,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/item/book/manual/wiki/medical_cloning{
+	pixel_y = 6
 	},
-/obj/item/bedsheet/medical,
-/obj/machinery/newscaster{
-	pixel_y = -32
+/obj/item/paper,
+/obj/structure/table/glass,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Medbay Recovery Room";
-	dir = 1;
-	network = list("ss13","medbay")
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics/cloning)
 "csr" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance";
@@ -69389,20 +69665,18 @@
 /turf/closed/wall,
 /area/medical/cryo)
 "cst" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/camera{
-	c_tag = "Medbay Hallway Central";
-	dir = 4;
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 10
+	},
+/area/science/research)
 "csu" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -70989,15 +71263,15 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cuC" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/wrench,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1{
-	icon_state = "connector_map";
-	dir = 8
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/science/central)
+/turf/open/floor/plasteel/white/corner{
+	dir = 2
+	},
+/area/medical/medbay/aft)
 "cuD" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/item/storage/box/lights/mixed,
@@ -71143,22 +71417,14 @@
 	},
 /area/crew_quarters/heads/hor)
 "cuR" = (
-/obj/structure/table,
-/obj/item/taperecorder{
-	pixel_x = -3
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/item/paicard{
-	pixel_x = 4
-	},
-/obj/item/storage/secure/briefcase,
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+	pixel_y = 26
 	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/heads/hor)
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "cuS" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/light/small{
@@ -71358,23 +71624,15 @@
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
 "cvm" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/dark,
-/area/medical/virology)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "cvn" = (
 /obj/structure/chair{
 	dir = 8
@@ -71583,28 +71841,18 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "cvC" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/virology{
-	name = "Break Room";
-	req_access_txt = "39"
-	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "cvD" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -71764,21 +72012,18 @@
 	},
 /area/maintenance/starboard/aft)
 "cvS" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "0-4"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	icon_state = "manifold-1";
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	icon_state = "manifold-3";
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plating,
 /area/medical/virology)
 "cvT" = (
 /obj/structure/disposalpipe/segment{
@@ -72007,20 +72252,30 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "cwq" = (
-/obj/structure/chair/stool,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "cwr" = (
 /obj/structure/disposalpipe/segment,
@@ -72074,6 +72329,9 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1{
 	icon_state = "connector_map";
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
@@ -72430,15 +72688,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cwY" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
-/obj/machinery/light/small,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/science/storage)
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/aft)
 "cwZ" = (
 /obj/structure/target_stake,
 /obj/item/target/syndicate,
@@ -72707,33 +72968,30 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cxx" = (
+/obj/item/trash/popcorn,
+/obj/structure/table/glass,
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	icon_state = "pipe11-3";
-	dir = 4
+	dir = 9
 	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/virology)
 "cxy" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -72878,6 +73136,34 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"cxN" = (
+/obj/structure/chair/stool,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
+"cxO" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "cxP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	icon_state = "pipe11-1";
@@ -73122,6 +73408,28 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"cyg" = (
+/obj/machinery/camera{
+	c_tag = "Virology - Airlock";
+	dir = 1;
+	network = list("ss13","medbay")
+	},
+/obj/machinery/light,
+/obj/structure/closet/l3closet,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "cyh" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/purple{
@@ -73361,16 +73669,26 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cyB" = (
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/machinery/light,
+/obj/item/hand_labeler,
+/obj/item/pen,
+/obj/item/pen,
+/obj/structure/table/glass,
 /obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
 	},
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/aft)
 "cyC" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -73485,22 +73803,26 @@
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
 "cyN" = (
+/obj/machinery/vending/wardrobe/viro_wardrobe,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = -26
 	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/white/side{
-	dir = 2
-	},
-/area/medical/medbay/aft)
+/turf/open/floor/plasteel/dark,
+/area/medical/virology)
 "cyO" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -73571,6 +73893,33 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"cyU" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/server)
+"cyW" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "cyY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -73588,6 +73937,96 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"cza" = (
+/obj/item/radio/intercom{
+	pixel_y = 25
+	},
+/obj/structure/table/wood,
+/obj/item/clothing/under/burial,
+/obj/item/clothing/under/burial,
+/obj/item/clothing/under/burial,
+/obj/item/clothing/under/burial,
+/obj/item/clothing/under/burial,
+/obj/item/clothing/under/burial,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/grimy,
+/area/chapel/office)
+"czb" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"czc" = (
+/obj/machinery/doorButtons/access_button{
+	idDoor = "xeno_airlock_interior";
+	idSelf = "xeno_airlock_control";
+	name = "Access Button";
+	pixel_x = 29;
+	pixel_y = -8;
+	req_access_txt = "55"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"czd" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"cze" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "czi" = (
 /obj/machinery/button/door{
 	dir = 2;
@@ -73779,28 +74218,6 @@
 	dir = 5
 	},
 /area/medical/medbay/aft)
-"czX" = (
-/obj/item/book/manual/wiki/medical_cloning{
-	pixel_y = 6
-	},
-/obj/item/paper,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/genetics/cloning)
 "czZ" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/airalarm{
@@ -74214,16 +74631,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"cCb" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/closet/secure_closet/personal/patient,
-/turf/open/floor/plasteel/white/corner{
-	dir = 2
-	},
-/area/medical/medbay/aft)
 "cCd" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /turf/open/floor/plasteel/white/corner{
@@ -74239,16 +74646,6 @@
 /area/medical/morgue)
 "cCg" = (
 /obj/effect/landmark/blobstart,
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
-"cCi" = (
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "cCj" = (
@@ -75135,20 +75532,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
-"cFO" = (
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/aft)
 "cFQ" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
@@ -75414,26 +75797,6 @@
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"cHD" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/machinery/light,
-/obj/item/hand_labeler,
-/obj/item/pen,
-/obj/item/pen,
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/aft)
 "cHP" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -75531,63 +75894,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cIt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/obj/machinery/vending/wardrobe/viro_wardrobe,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/virology)
-"cIu" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/blood/AMinus,
-/obj/item/reagent_containers/blood/BMinus{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/blood/BPlus{
-	pixel_x = 1;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/reagent_containers/blood/OPlus{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/virology)
 "cIw" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/effect/turf_decal/tile/neutral{
@@ -75711,13 +76017,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/science/robotics/lab)
-"cIP" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/sign/departments/minsky/research/robotics{
-	pixel_y = -32
-	},
-/turf/open/floor/plating,
 /area/science/robotics/lab)
 "cIQ" = (
 /obj/structure/disposalpipe/segment,
@@ -76009,20 +76308,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"cJO" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 2
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "cJQ" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-10"
@@ -76032,14 +76317,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"cJR" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/plasteel/dark,
-/area/science/server)
 "cJS" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -76096,13 +76373,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cKb" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1{
-	icon_state = "connector_map-1";
-	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -76246,10 +76516,6 @@
 "cKP" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/aft)
-"cKR" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/maintenance/solars/starboard/aft)
 "cKS" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/dropper,
@@ -76364,21 +76630,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"cLS" = (
-/obj/structure/chair/stool,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "cLT" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/bodycontainer/morgue{
@@ -76391,23 +76642,6 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/engine,
 /area/science/explab)
-"cLV" = (
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/obj/structure/table/wood,
-/obj/item/clothing/under/burial,
-/obj/item/clothing/under/burial,
-/obj/item/clothing/under/burial,
-/obj/item/clothing/under/burial,
-/obj/item/clothing/under/burial,
-/obj/item/clothing/under/burial,
-/turf/open/floor/plasteel/grimy,
-/area/chapel/office)
 "cLW" = (
 /obj/machinery/requests_console{
 	department = "Chapel";
@@ -77602,14 +77836,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"cQR" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno_blastdoor";
-	name = "biohazard containment door"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "cQS" = (
 /obj/item/radio/intercom{
 	pixel_x = 29
@@ -78377,19 +78603,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"cSZ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "cTa" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -78708,13 +78921,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
-"cVi" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/wood,
-/area/library)
 "cVx" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -79330,19 +79536,6 @@
 	},
 /turf/open/space,
 /area/solar/starboard/aft)
-"dca" = (
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "dcb" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -79930,21 +80123,6 @@
 /area/engine/atmos)
 "ddO" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"ddS" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Fore";
-	dir = 4;
-	network = list("ss13","engine")
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ddU" = (
@@ -81061,20 +81239,6 @@
 /obj/structure/closet/crate/wooden/toy,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"dis" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = -32
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
 "diu" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/item/storage/box/lights/mixed,
@@ -82073,10 +82237,6 @@
 "ejI" = (
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
-"eoq" = (
-/obj/structure/sign/departments/minsky/research/xenobiology,
-/turf/closed/wall,
-/area/science/xenobiology)
 "eqG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -82580,10 +82740,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"mNI" = (
-/obj/structure/sign/departments/minsky/supply/hydroponics,
-/turf/closed/wall,
-/area/hallway/primary/central)
 "mWg" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -82892,10 +83048,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
-"rpI" = (
-/obj/structure/sign/departments/minsky/research/genetics,
-/turf/closed/wall,
-/area/medical/paramedic)
 "rrB" = (
 /turf/closed/wall,
 /area/vacant_room/commissary)
@@ -82961,10 +83113,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
-"sAy" = (
-/obj/structure/sign/departments/minsky/supply/cargo,
-/turf/closed/wall,
-/area/quartermaster/office)
 "sBu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	icon_state = "vent_map_on-1";
@@ -83132,10 +83280,6 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/starboard/secondary)
-"uZK" = (
-/obj/structure/sign/departments/minsky/supply/mining,
-/turf/closed/wall,
-/area/quartermaster/miningoffice)
 "vgd" = (
 /obj/item/taperecorder,
 /obj/item/camera,
@@ -83176,10 +83320,6 @@
 	dir = 8
 	},
 /area/engine/storage_shared)
-"vEI" = (
-/obj/structure/sign/departments/minsky/supply/cargo,
-/turf/closed/wall,
-/area/quartermaster/warehouse)
 "vKx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -83320,10 +83460,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
-"xuZ" = (
-/obj/structure/sign/departments/minsky/research/research,
-/turf/closed/wall/r_wall,
-/area/science/lab)
 "xwG" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Library Maintenance";
@@ -96650,7 +96786,7 @@ bzq
 bLU
 bVf
 aZo
-caM
+bCd
 bnH
 alK
 boO
@@ -96894,12 +97030,12 @@ aNc
 aTz
 aNc
 aWP
-aXO
+bcz
 bad
 aNc
 bvE
 beE
-buR
+bkv
 alK
 alK
 alK
@@ -97145,7 +97281,7 @@ aTn
 aUV
 aYY
 aZo
-aZv
+aUL
 aZo
 bcE
 bhd
@@ -97426,8 +97562,8 @@ aqK
 aqO
 alC
 aGN
-cie
-bTp
+auy
+bTn
 bUP
 bVS
 bXv
@@ -98184,7 +98320,7 @@ bqf
 bqf
 btV
 beG
-bga
+bkx
 bzx
 bhG
 bBg
@@ -98199,7 +98335,7 @@ bzx
 amZ
 cih
 chH
-ciE
+bMW
 bvQ
 aob
 alK
@@ -98456,9 +98592,9 @@ bzx
 auF
 cie
 alK
-aob
-aoa
-bXx
+cgV
+bNC
+bOU
 alK
 aaa
 aaf
@@ -98944,9 +99080,9 @@ aaa
 aip
 doJ
 bbK
-bdc
+aVq
 aPF
-bpt
+aZI
 bbK
 aUZ
 bkj
@@ -99476,7 +99612,7 @@ bNh
 bNK
 bBg
 dig
-bJx
+bwK
 bLa
 bMD
 bOh
@@ -100210,7 +100346,7 @@ ayj
 azl
 aAE
 azz
-aDh
+aBB
 aEv
 aFF
 ayj
@@ -100226,7 +100362,7 @@ aIg
 aUe
 aVG
 aXe
-aYJ
+aOG
 bal
 dmF
 bdg
@@ -100235,7 +100371,7 @@ bgF
 dmF
 dmF
 dmF
-aXR
+bcT
 bpT
 bce
 baE
@@ -100289,7 +100425,7 @@ csC
 csP
 csT
 ctr
-bRU
+cxO
 cEE
 cEE
 cEE
@@ -100757,7 +100893,7 @@ bvW
 bgj
 bzB
 bBn
-bCS
+bpt
 bBn
 bQN
 dih
@@ -101061,12 +101197,12 @@ cEE
 bQa
 ctu
 bQa
-bSP
-bTd
-bTd
-bTd
-bVU
-cqa
+cEE
+cEE
+cEE
+cEE
+cBR
+cvS
 cBR
 aaf
 aaa
@@ -101241,8 +101377,8 @@ aBX
 aDj
 aEz
 aFJ
-uZK
-aYM
+ayj
+cqY
 bLL
 aMu
 aMv
@@ -101318,12 +101454,12 @@ cEI
 bQc
 ctv
 bRW
-cIt
+cyN
 cEE
 cKi
 bUa
 cwo
-cqb
+cwq
 cBR
 aaf
 aaf
@@ -101516,7 +101652,7 @@ baq
 dmF
 bdj
 dmF
-bcT
+aYJ
 aRa
 bkk
 dmF
@@ -101575,7 +101711,7 @@ cEJ
 bQd
 ctw
 bRX
-cIu
+bTd
 cEE
 cKj
 cpS
@@ -101832,12 +101968,12 @@ bKq
 csU
 ctC
 cuy
-cvm
-cvC
-csT
-cvS
-cwq
-cqd
+bTT
+bVn
+clS
+cqb
+crJ
+cxx
 cBR
 aaa
 aaa
@@ -102350,7 +102486,7 @@ cIx
 cEE
 cKm
 cKZ
-cLS
+cxN
 cMB
 cBR
 aaf
@@ -102507,8 +102643,8 @@ aee
 agD
 aht
 ain
+bbo
 aji
-dnd
 alm
 dnr
 aRG
@@ -102526,7 +102662,7 @@ aCb
 awc
 aED
 ayl
-aHh
+aDR
 azK
 aAq
 aAS
@@ -102546,9 +102682,9 @@ aOp
 aPL
 bdt
 biK
-bkn
-sAy
-aXW
+baB
+bat
+cqm
 bqc
 bcq
 bue
@@ -102560,7 +102696,7 @@ bSx
 bEw
 bzE
 bHR
-bJy
+bvY
 bLh
 bMH
 bue
@@ -102586,7 +102722,7 @@ bCZ
 cpU
 bWc
 cpU
-csm
+ciE
 cia
 cui
 cwj
@@ -102779,7 +102915,7 @@ awT
 aym
 azu
 aAO
-aCc
+aBz
 aAF
 aEE
 ayl
@@ -102793,7 +102929,7 @@ aHB
 aQo
 aRJ
 aSW
-aUi
+aMn
 aRd
 aTu
 aVm
@@ -103032,8 +103168,8 @@ dne
 awb
 auL
 avS
-awU
-vEI
+aXW
+ayl
 ayl
 ayl
 ayl
@@ -103056,7 +103192,7 @@ aSX
 aSX
 bat
 aNp
-aZI
+aXO
 aPN
 bdx
 aPN
@@ -103081,7 +103217,7 @@ boe
 avr
 bRi
 bSz
-bTy
+bJy
 bue
 asa
 dux
@@ -103578,7 +103714,7 @@ bkr
 bat
 aXS
 bpT
-bcz
+bga
 bue
 aze
 bwe
@@ -103871,7 +104007,7 @@ cnt
 bDw
 bWp
 cdh
-csq
+caB
 cia
 dux
 bHk
@@ -104144,7 +104280,7 @@ bOn
 dzK
 bQr
 ctR
-bZz
+cyg
 clK
 bZT
 bTL
@@ -104377,7 +104513,7 @@ dvE
 cev
 cfG
 byc
-byH
+bXc
 cbV
 cld
 cev
@@ -104392,7 +104528,7 @@ cvn
 cwn
 cxd
 cxU
-cyN
+crs
 aJo
 cAS
 cBU
@@ -104406,7 +104542,7 @@ clK
 cJl
 bTM
 cLa
-cLV
+cza
 cME
 cNv
 cxo
@@ -104596,7 +104732,7 @@ arq
 arq
 aIp
 dne
-baB
+aPU
 bbY
 aOD
 bbY
@@ -104641,7 +104777,7 @@ bBW
 bDc
 ccF
 bWs
-crs
+cdq
 css
 dux
 dux
@@ -104875,7 +105011,7 @@ bzE
 cVb
 cVe
 cVf
-cVi
+bCf
 bOm
 ybn
 bPW
@@ -104913,7 +105049,7 @@ diN
 cxU
 bOn
 dux
-cFO
+cwY
 cGJ
 cHz
 bTs
@@ -105404,7 +105540,7 @@ bvd
 cdp
 cev
 cfK
-byj
+bXx
 byM
 con
 bBV
@@ -105650,7 +105786,7 @@ aMw
 aOQ
 aMw
 beP
-bgt
+bJx
 aMw
 aMw
 bsh
@@ -105658,7 +105794,7 @@ bXK
 bYS
 bZZ
 bvi
-cdq
+bTx
 cev
 cev
 cev
@@ -105927,7 +106063,7 @@ cnA
 bSy
 bWx
 crw
-cst
+clw
 bWx
 crw
 bHl
@@ -106144,7 +106280,7 @@ aLR
 aLR
 bfh
 aLR
-aVq
+bbm
 aXg
 aLR
 aLR
@@ -106200,7 +106336,7 @@ csD
 csQ
 csV
 ctX
-cHD
+cyB
 cxU
 bTr
 cKu
@@ -106380,7 +106516,7 @@ aaa
 aaa
 aaa
 azC
-aCS
+aCT
 aCD
 aHA
 aJN
@@ -106393,7 +106529,7 @@ aDg
 aNx
 aUs
 aJR
-aIy
+aOs
 aVC
 aLR
 rrB
@@ -106679,7 +106815,7 @@ bOo
 bJD
 bJD
 bGy
-brc
+bJH
 aVE
 bso
 bXK
@@ -106872,7 +107008,7 @@ adw
 adO
 abe
 adv
-afF
+afh
 abe
 aax
 aiq
@@ -106899,7 +107035,7 @@ aHw
 aIF
 aJN
 aBh
-aBz
+aHX
 aNY
 aPr
 aQy
@@ -106963,9 +107099,9 @@ cwv
 bIL
 cqh
 cea
-czX
+csq
 cvt
-cCb
+cuC
 bNM
 csG
 cER
@@ -107425,7 +107561,7 @@ aIA
 aVE
 aLV
 rrB
-aOG
+aVZ
 aQr
 bfT
 biV
@@ -107458,7 +107594,7 @@ bYY
 bDv
 cbQ
 cdw
-bTw
+bTy
 cnw
 cnQ
 cnV
@@ -107661,9 +107797,9 @@ avk
 ajo
 aaa
 aDu
-aAX
+azQ
 aCj
-aDv
+aCc
 aEI
 axI
 aHy
@@ -107700,7 +107836,7 @@ biq
 bBG
 bGy
 bIc
-bJH
+byj
 bLq
 bId
 bOs
@@ -108216,12 +108352,12 @@ bGC
 bIe
 bJI
 bLr
-bMW
+bBa
 bOt
 bQb
 bRs
 bGC
-brk
+bJH
 aVE
 aMw
 bXM
@@ -108451,7 +108587,7 @@ aGa
 aUx
 aII
 aVE
-aMn
+aRC
 bcg
 bdG
 bfq
@@ -108481,8 +108617,8 @@ bSG
 bre
 aVE
 aJI
-bXN
-bZb
+bXQ
+cdw
 caj
 bEY
 cml
@@ -108679,7 +108815,7 @@ aiH
 akl
 alT
 akx
-akY
+anF
 alW
 aoq
 alW
@@ -108693,7 +108829,7 @@ aAZ
 aCm
 aDw
 aCs
-axN
+aDv
 aHx
 aaa
 aJS
@@ -109001,7 +109137,7 @@ bux
 bvp
 cmn
 ceG
-cfW
+cga
 chb
 bOk
 cjS
@@ -109013,7 +109149,7 @@ cqr
 cga
 bFz
 ctA
-apX
+ciu
 cvB
 cwC
 aIu
@@ -109234,7 +109370,7 @@ bjc
 bos
 bsS
 bjc
-beQ
+bgW
 bgp
 bgU
 bhJ
@@ -109274,11 +109410,11 @@ azi
 azi
 azi
 azi
-rpI
+azi
 cqQ
 ctA
 ctA
-cCi
+cuR
 cCj
 bOM
 bPC
@@ -109745,7 +109881,7 @@ bja
 bjc
 bmz
 bos
-bqJ
+bem
 bsU
 buC
 bws
@@ -109766,8 +109902,8 @@ chw
 aJJ
 aVE
 aJI
-bXQ
 bZb
+cdw
 cao
 cca
 cmm
@@ -110033,7 +110169,7 @@ cfX
 chf
 ciA
 cjW
-clw
+bYu
 cga
 cnL
 coX
@@ -110220,7 +110356,7 @@ aeq
 bgB
 akC
 ajn
-ann
+amJ
 adY
 apM
 arN
@@ -110282,7 +110418,7 @@ ciK
 bsv
 bXR
 bZe
-bZb
+cdw
 ccb
 cmq
 bZa
@@ -110539,7 +110675,7 @@ ciM
 bsw
 bXN
 bud
-buy
+cfW
 buy
 cms
 buy
@@ -110556,7 +110692,7 @@ bFi
 bFB
 bGD
 ayv
-aRC
+cqd
 aHv
 bKu
 bTB
@@ -110565,7 +110701,7 @@ bLV
 bMY
 byt
 byt
-bOU
+cvm
 bPD
 bQw
 bZc
@@ -111013,7 +111149,7 @@ axV
 axV
 axV
 aRS
-aDD
+aKq
 axV
 axV
 axV
@@ -111053,7 +111189,7 @@ ciP
 bsy
 bXV
 bug
-buz
+cii
 clC
 buz
 buz
@@ -111061,7 +111197,7 @@ bxC
 byu
 aHI
 byu
-bCf
+bZm
 bCJ
 bDg
 bDg
@@ -111086,7 +111222,7 @@ aHI
 bHp
 bSY
 bTH
-bTT
+cvC
 bUB
 cMj
 bWi
@@ -111259,7 +111395,7 @@ asx
 asv
 aty
 atR
-auH
+aAX
 avA
 aDw
 ayy
@@ -111310,7 +111446,7 @@ ciQ
 cjz
 cjN
 bZi
-bZk
+bZn
 clF
 ccc
 bZj
@@ -111319,7 +111455,7 @@ cge
 cgd
 cge
 cgd
-xuZ
+cgd
 cpb
 cpb
 cqv
@@ -111502,14 +111638,14 @@ agd
 agU
 ahH
 aeq
-ajy
-arj
 ajw
-anF
-aoD
+ajA
+ajF
+ant
+anH
+aoG
 are
-arQ
-arQ
+are
 awQ
 ayA
 aAL
@@ -111525,7 +111661,7 @@ aHD
 aIL
 aIR
 aLO
-aBB
+aIy
 aRf
 aPB
 aDV
@@ -111547,7 +111683,7 @@ boy
 bqP
 bsU
 bsU
-bww
+bjH
 bqM
 bqM
 bLT
@@ -111605,7 +111741,7 @@ bUQ
 cPb
 bWk
 cNQ
-cxx
+czb
 cPb
 aaf
 aaa
@@ -111759,15 +111895,15 @@ agc
 dBX
 agc
 ajs
-ajz
-ajz
-ard
-ant
-aoG
-ans
+ajy
+ajy
 amx
-anH
-anr
+anu
+aoz
+apQ
+arj
+arQ
+atT
 alW
 arD
 atB
@@ -111823,7 +111959,7 @@ aIA
 aXP
 aJI
 bXW
-bZk
+bZn
 cau
 clG
 ccd
@@ -111840,7 +111976,7 @@ cqx
 cgd
 bFJ
 ctJ
-cuC
+cok
 cvH
 cwH
 cxF
@@ -112013,18 +112149,18 @@ aaf
 aeq
 aeq
 agQ
-ahC
+afF
 ahI
 aeq
+ajz
 ajA
-arj
+amx
+ann
+aoD
 ard
-anu
-aoz
-apQ
-arj
+ajA
 asz
-ahB
+ajD
 aqb
 arE
 asC
@@ -112074,7 +112210,7 @@ bLv
 bNk
 bOF
 dip
-bRG
+bHe
 bSI
 aIA
 aXP
@@ -112093,7 +112229,7 @@ clB
 cmG
 clB
 cpe
-cqy
+caG
 cgd
 bFM
 diL
@@ -112273,15 +112409,15 @@ aeq
 aeq
 aeq
 aeq
-adY
-ajx
-ajF
-ahB
-aoA
-ahB
+aqa
+aiD
+ans
+ajD
+atX
+ajD
 ark
 asA
-ahB
+ajD
 aqe
 asx
 asj
@@ -112361,7 +112497,7 @@ cxG
 cys
 czk
 cAo
-aLt
+cqa
 cCn
 cDd
 bPd
@@ -112539,7 +112675,7 @@ anG
 amz
 asy
 ajD
-aqh
+arR
 asx
 aws
 atA
@@ -112575,7 +112711,7 @@ aYc
 bot
 bsS
 bjc
-beZ
+bkn
 bvL
 bgp
 bhJ
@@ -112805,7 +112941,7 @@ bEr
 awK
 axk
 azZ
-aCT
+aDD
 aHE
 aIQ
 aKb
@@ -112828,7 +112964,7 @@ aaf
 bfv
 bfv
 bfv
-boC
+bdc
 bqU
 bfv
 bcj
@@ -113042,7 +113178,7 @@ adZ
 afi
 agf
 agW
-ahJ
+ahC
 adZ
 ajD
 ajI
@@ -113077,7 +113213,7 @@ aQx
 aRz
 aTy
 aXn
-aMx
+aSF
 bcj
 bcj
 bcj
@@ -113091,7 +113227,7 @@ bcj
 buF
 bwA
 bvR
-bgW
+blE
 bcj
 biA
 bEB
@@ -113107,8 +113243,8 @@ aJr
 brs
 ciV
 bsC
-bXV
 bZk
+bZn
 caz
 clG
 bvX
@@ -113354,7 +113490,7 @@ biA
 bEH
 aNs
 aAy
-aKJ
+byH
 cbC
 aLM
 aMf
@@ -113364,7 +113500,7 @@ aJr
 brt
 aXP
 bsD
-bXZ
+bRG
 bZj
 caA
 clG
@@ -113393,7 +113529,7 @@ cBl
 cDi
 cQD
 cEo
-bYu
+cqy
 cGf
 bRE
 cuI
@@ -113587,7 +113723,7 @@ aPB
 aQJ
 aIT
 aIT
-aUJ
+aMx
 aHD
 aJJ
 aVE
@@ -113608,7 +113744,7 @@ bvS
 bfA
 bcj
 biO
-bFh
+bpC
 aJr
 aJr
 aJr
@@ -113623,7 +113759,7 @@ ciW
 bsE
 bSS
 bZn
-caB
+bRU
 clM
 cmD
 cmZ
@@ -113635,7 +113771,7 @@ bQx
 bQQ
 bRj
 bSJ
-cqD
+caM
 cgo
 bGm
 ctL
@@ -113654,7 +113790,7 @@ cDi
 cDi
 bRH
 cuJ
-cIP
+ckf
 cCq
 cCq
 bVe
@@ -113828,7 +113964,7 @@ auh
 aFf
 awl
 ayF
-azQ
+auH
 aBk
 azD
 aDI
@@ -113912,11 +114048,11 @@ bSZ
 bRI
 cuK
 cIQ
-cJO
+cnl
 cKI
 bVi
-cQR
-eoq
+cqj
+cSd
 cSd
 cRe
 cRe
@@ -114145,7 +114281,7 @@ cnO
 cnT
 coe
 ckh
-clI
+bZz
 bZn
 bDl
 bSN
@@ -114412,7 +114548,7 @@ bEQ
 ccd
 bHc
 cck
-aHP
+clI
 bJu
 ccd
 bLo
@@ -114422,13 +114558,13 @@ bNw
 ccd
 bPf
 bPH
-bTx
+cst
 bHc
 bSw
 bTa
 cJQ
 cgo
-bVn
+cyW
 cQS
 cRb
 cRe
@@ -114593,7 +114729,7 @@ anB
 aoH
 apY
 asK
-asJ
+arx
 ajD
 alW
 aHe
@@ -114619,7 +114755,7 @@ aQB
 aRB
 aTA
 aXH
-aMx
+aSF
 bcj
 bdM
 bfC
@@ -114651,7 +114787,7 @@ aXP
 bsF
 bYa
 bZo
-caE
+bVU
 ccn
 cdS
 ceX
@@ -114872,7 +115008,7 @@ aPG
 aLd
 aOu
 aFn
-aUL
+aNO
 aSe
 aJJ
 aVE
@@ -114940,7 +115076,7 @@ cEq
 cIg
 cIa
 cIU
-cJR
+cyU
 cIg
 bVv
 dwv
@@ -115121,7 +115257,7 @@ ayJ
 axX
 aHH
 aIY
-aKj
+aFw
 aLG
 aMV
 aOr
@@ -115403,7 +115539,7 @@ aVF
 bcR
 bdI
 aOQ
-bgt
+bJx
 aMw
 bgS
 biW
@@ -115415,7 +115551,7 @@ bnx
 bnV
 boi
 bpk
-bpC
+bFh
 aIA
 aIA
 aXP
@@ -115442,7 +115578,7 @@ cuO
 cdI
 cwR
 crQ
-cyB
+crj
 fIp
 crB
 cBt
@@ -115616,7 +115752,7 @@ agn
 aiK
 ajL
 ajM
-amJ
+akY
 aiJ
 aoK
 aqa
@@ -115638,7 +115774,7 @@ aAk
 aAx
 aBo
 aBN
-aOs
+aKj
 aPH
 aLd
 aOu
@@ -115664,7 +115800,7 @@ blX
 bwI
 bxy
 byw
-bJp
+bpP
 aRx
 bWd
 btP
@@ -115679,7 +115815,7 @@ ciX
 bqp
 bYc
 bZq
-caG
+bSP
 ccp
 bSS
 bwV
@@ -115921,7 +116057,7 @@ aJU
 aJU
 aJU
 bjl
-bjH
+bAt
 aLR
 bmg
 aLU
@@ -115930,7 +116066,7 @@ aLR
 aLR
 aLR
 bmg
-bqp
+cqp
 brv
 cjr
 cjA
@@ -115943,7 +116079,7 @@ bwV
 cgo
 chs
 ciN
-ckm
+bXZ
 clN
 bZn
 cog
@@ -115981,7 +116117,7 @@ cRe
 cRe
 cRe
 cRi
-bHe
+czc
 cye
 bXD
 cRi
@@ -116178,7 +116314,7 @@ dhT
 bmP
 bBS
 bDC
-bku
+bqJ
 bBS
 bmP
 dik
@@ -116187,7 +116323,7 @@ bOP
 bOP
 bOP
 bKe
-mNI
+bSS
 bUd
 bVq
 bVq
@@ -116209,7 +116345,7 @@ bET
 crQ
 cte
 ctV
-cuR
+ckm
 cvU
 cwU
 crQ
@@ -116391,7 +116527,7 @@ aey
 aey
 aoP
 ajD
-arx
+aqh
 asO
 ajD
 avk
@@ -116419,7 +116555,7 @@ aRW
 aTR
 aZt
 bbc
-bcn
+aUi
 bdR
 aZt
 aSE
@@ -116430,12 +116566,12 @@ aYf
 brd
 btl
 bmO
-bwK
+bku
 bwO
 bAi
 bBT
 bwO
-bkv
+brc
 bwO
 bIt
 bKe
@@ -116462,7 +116598,7 @@ bCn
 bCR
 bDk
 bTS
-bEU
+ccy
 crR
 crR
 crR
@@ -116659,7 +116795,7 @@ aGE
 avb
 aCz
 awu
-aCP
+apX
 aFd
 aEj
 aFd
@@ -116670,7 +116806,7 @@ aOw
 aPI
 aLm
 aOu
-aFw
+aLt
 aUM
 aUM
 atv
@@ -116692,7 +116828,7 @@ byy
 bAj
 bBT
 bwO
-bkv
+brc
 bwO
 bIu
 bKe
@@ -116752,7 +116888,7 @@ aaa
 aaa
 aaa
 cRi
-dca
+czd
 cZa
 cSt
 cyk
@@ -116942,14 +117078,14 @@ aVK
 bmM
 aYh
 brf
-btn
+bgh
 bmO
 bwM
 bwO
 bAk
 bBT
 bwO
-bkv
+brc
 bwO
 bBT
 bKf
@@ -117206,7 +117342,7 @@ byz
 bAj
 bBU
 bwO
-bkx
+brk
 bll
 bBT
 bna
@@ -117435,7 +117571,7 @@ aGD
 aHK
 aJc
 axC
-aLW
+aHP
 aBY
 aFY
 aOu
@@ -117450,7 +117586,7 @@ bbg
 bcr
 bdV
 aZt
-aSF
+aZv
 bir
 aVK
 bmP
@@ -117488,7 +117624,7 @@ cbM
 chx
 cgq
 cmQ
-cok
+caE
 bUb
 bEX
 cgq
@@ -117496,7 +117632,7 @@ cti
 ctZ
 cuV
 cvX
-cwY
+cqD
 crR
 cyJ
 czB
@@ -117671,7 +117807,7 @@ acP
 dhn
 aiO
 aje
-ale
+ani
 ahS
 agq
 alG
@@ -117743,7 +117879,7 @@ cgq
 bYh
 coh
 coP
-clS
+cgq
 cmR
 ccE
 bUv
@@ -117798,7 +117934,7 @@ dcV
 cTe
 dda
 cSd
-cSZ
+cze
 ddn
 cTz
 ddv
@@ -118439,7 +118575,7 @@ acQ
 aft
 agt
 ahf
-ahV
+ahJ
 aiQ
 afP
 aia
@@ -118496,7 +118632,7 @@ bUy
 bWe
 caH
 cdE
-bNC
+bCS
 bOW
 bQH
 chM
@@ -118540,8 +118676,8 @@ cvb
 cvb
 cvF
 qBQ
-cKb
-cKR
+bTp
+cKP
 cLK
 cMq
 cNo
@@ -118750,7 +118886,7 @@ bhM
 byC
 bkJ
 byC
-bXc
+bww
 bKe
 bKe
 bKe
@@ -118764,7 +118900,7 @@ bWT
 bYj
 bWT
 ckV
-ccy
+bTw
 bST
 bwV
 cgq
@@ -118952,12 +119088,12 @@ aaa
 acQ
 afv
 afn
-ahh
-ahh
-aiR
 afS
+aiR
+ale
 alh
-ani
+azw
+cec
 aok
 aoZ
 dhs
@@ -119478,7 +119614,7 @@ aqg
 arC
 aog
 axl
-aqn
+asJ
 aog
 axl
 ayN
@@ -119747,7 +119883,7 @@ axu
 aAG
 azf
 aJh
-aKq
+aHh
 aBt
 aNi
 aOI
@@ -120000,7 +120136,7 @@ bDM
 bEz
 avz
 bHr
-bJX
+aCS
 bLt
 azh
 aJh
@@ -120022,7 +120158,7 @@ bdY
 aZw
 aTd
 bir
-aVZ
+bbJ
 alq
 boY
 baP
@@ -120041,11 +120177,11 @@ bKe
 bNG
 bNG
 bpo
-bpP
+bJp
 bqu
 brz
 bKe
-bvY
+bNN
 btw
 bCq
 cle
@@ -120069,7 +120205,7 @@ szA
 npM
 yia
 cdZ
-crj
+csm
 vNW
 cQB
 cAO
@@ -120789,7 +120925,7 @@ aYj
 aLn
 aZh
 aNN
-bea
+aWE
 aWv
 aSE
 bir
@@ -121316,7 +121452,7 @@ buV
 byN
 dhW
 dhX
-bCd
+bpm
 dib
 bkQ
 dif
@@ -121325,7 +121461,7 @@ byN
 bLS
 bnZ
 boJ
-dis
+bFK
 byN
 apc
 brE
@@ -122313,7 +122449,7 @@ axY
 aBD
 aCN
 aEh
-aFp
+aDh
 aGQ
 axY
 aJj
@@ -122321,7 +122457,7 @@ aJk
 aMa
 aMa
 axY
-aPU
+aKJ
 aRj
 aSp
 aTD
@@ -122330,7 +122466,7 @@ aWx
 aYo
 aZC
 bbs
-aNO
+aUJ
 bef
 aWw
 aSE
@@ -122608,7 +122744,7 @@ bVc
 bYn
 caK
 ceA
-boa
+bzo
 bPi
 bKr
 bNO
@@ -122851,7 +122987,7 @@ aTp
 aTo
 aWn
 aXr
-aYA
+bea
 baV
 byQ
 byQ
@@ -122861,11 +122997,11 @@ tzq
 nPc
 pNE
 bkV
-blE
+buR
 bmF
 bKr
 bLW
-bNN
+bEU
 bPj
 bKr
 aqr
@@ -123065,7 +123201,7 @@ aaa
 aaf
 aaa
 acP
-afh
+ahV
 aiZ
 ajX
 ajY
@@ -123641,7 +123777,7 @@ boM
 apc
 aqq
 apc
-ciu
+bJX
 alq
 cjG
 apf
@@ -123857,7 +123993,7 @@ aCi
 aFA
 aEi
 aGV
-aHX
+aFp
 aEi
 aKA
 aMc
@@ -124402,7 +124538,7 @@ byV
 bAF
 bhU
 bDT
-bFK
+btn
 bxc
 bxc
 bxc
@@ -125165,7 +125301,7 @@ aXw
 aYG
 bdm
 bgD
-bpm
+beo
 brK
 bAG
 ceM
@@ -125672,7 +125808,7 @@ aYu
 aZN
 bbD
 bcN
-beo
+aYA
 bfX
 bid
 bjL
@@ -126164,7 +126300,7 @@ ats
 axY
 axZ
 avo
-ddS
+axN
 bUw
 avT
 dek
@@ -126195,7 +126331,7 @@ bhT
 bkX
 bhT
 bvo
-bem
+bgt
 bxc
 bjy
 bne
@@ -126414,7 +126550,7 @@ akk
 ajZ
 apl
 aqx
-arR
+aqn
 ati
 ajb
 att
@@ -126436,7 +126572,7 @@ dfk
 dfq
 djt
 cfj
-bZm
+aLW
 axY
 apc
 apc
@@ -127957,8 +128093,8 @@ alv
 app
 aqA
 arV
+apm
 atl
-auy
 dnS
 dqT
 dqT
@@ -128480,7 +128616,7 @@ aaa
 aaa
 aaa
 axY
-aDR
+aCP
 ceU
 aHa
 ddZ
@@ -136216,7 +136352,7 @@ aaa
 bka
 bmb
 bny
-bbm
+beQ
 aOV
 btb
 bun
@@ -136727,7 +136863,7 @@ aRy
 aRy
 aRy
 aRy
-aWE
+bcn
 aXC
 bnL
 bbp
@@ -137495,7 +137631,7 @@ aZR
 bbF
 bcP
 aVl
-bgh
+aXR
 bgx
 bjQ
 bjQ
@@ -137762,7 +137898,7 @@ bbz
 btL
 bAW
 bfH
-bzo
+boa
 bAV
 bCD
 bEh
@@ -138786,7 +138922,7 @@ bjQ
 bse
 aXJ
 bpA
-bbJ
+beZ
 btL
 bvz
 bxr
@@ -139048,7 +139184,7 @@ btL
 bvA
 bxs
 bzt
-bBa
+boC
 bCD
 bEg
 bGd


### PR DESCRIPTION
This is mostly a signs update, but then I corrected various issues (such as unconnected piping) whenever I saw it, and decided to fix the fire alarms too since that wouldn't be an issue.

**All maps**
Most, if not all, of the signs that were on windows have been moved onto walls.
Fixed a lot of positioning with various signs to make sure they could be seen from the appropriate direction(s) only.
Made sure every single fire alarm was facing the correct way, and that they all had the correct x+y positioning.

**Metastation**
Connected the fitness room pipes.
Connected the bar+theater pipes to the rest of the station.
Connected a vent in cargo.
Added some missing connector ports.
Moved the signal technician spawn to actually be in tcomms.
Added in some missing area tags on the Cargo Bay airlocks, just outside the vault.
Changed the Gear Room area to "Security Office" instead of "Warden Office", since it's not the warden's office.
Moved a genetics and a research sign.
Added access requirements to a maintenance airlock that previously had none.
Virology disposals no longer goes through a wall.

**Pubbystation**
Added in some missing maintenance pipes.
Readded the gravity generator airlock after some prankster removed it.
Removed the atmos signs dotted around the gravity generator.
Added airlock cyclelinks between the tcomms transit tube airlock and space airlock.
Added breath masks and emergency oxygen tanks to the Port Emergency Storage.
Added in a missing corner decal.
Replaced a tcomms sign with an engineering sign.
Added some medical signs.
Moved the genetics and hydroponics signs.
Turned some windows into window spawners (window+grille).

**Deltastation**
Added a few different colored pens to the QM's office.
Moved the QM's stamp to the new pens table.
Fixed the monkey pen windoors name.
Added in some missing nearstation area tags near the holodeck.
Added a tcomms and a virology sign.
Removed a botany sign.
Moved a botany sign.
Replace an exam sign with a nanotrasen sign.

**Omegastation**
Moved the high voltage signs by Engineering.
Removed an unconnected cable.
Swapped the chemical storage and the chemistry sign around.
Removed a medical, xenobiology and botany sign.
Moved a research, botany and robotics sign.
Added decals next to the robotics(?) sign, inbetween the firelocks.

**Boxstation**
Swapped the chemical storage and the chemistry sign around.
Removed department signs from maintenance.
Added robotics, evac and restroom signs.
Moved the science security, cargo security and mining signs.

:cl:  
rscadd: Fixes numerous issues across all the main maps.
/:cl: