### PR TITLE
Secborgs now have an autocharging disabler instead of an infinite one

### DIFF
--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -32,6 +32,11 @@
 	variance = 15
 	harmful = FALSE
 
+/obj/item/ammo_casing/energy/laser/cyborg
+	projectile_type = /obj/item/projectile/beam/laser
+	select_name = "kill"
+	e_cost = 125
+
 /obj/item/ammo_casing/energy/laser/heavy
 	projectile_type = /obj/item/projectile/beam/laser/heavylaser
 	select_name = "anti-vehicle"

--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -24,3 +24,6 @@
 
 /obj/item/ammo_casing/energy/disabler/hos
 	e_cost = 60
+
+/obj/item/ammo_casing/energy/disabler/cyborg
+	e_cost = 100

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -18,6 +18,7 @@
 	var/selfcharge = 0
 	var/charge_tick = 0
 	var/charge_delay = 4
+	var/charge_amount = 1
 	var/use_cyborg_cell = FALSE //whether the gun's cell drains the cyborg user's cell to recharge
 	var/dead_cell = FALSE //set to true so the gun is given an empty cell
 
@@ -68,7 +69,7 @@
 		if(charge_tick < charge_delay)
 			return
 		charge_tick = 0
-		cell.give(100)
+		cell.give(100*charge_amount)
 		if(!chambered) //if empty chamber we try to charge a new shot
 			recharge_newshot(TRUE)
 		update_icon()

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -48,8 +48,9 @@
 
 /obj/item/gun/energy/laser/cyborg
 	can_charge = FALSE
-	desc = "An energy-based laser gun that draws power from the cyborg's internal energy cell directly. So this is what freedom looks like?"
-	use_cyborg_cell = TRUE
+	desc = "An energy-based laser gun that self charges. So this is what freedom looks like?"
+	charge_delay = 5
+	selfcharge = 1
 
 /obj/item/gun/energy/laser/cyborg/emp_act()
 	return

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -50,7 +50,7 @@
 	can_charge = FALSE
 	desc = "An energy-based laser gun that self charges. So this is what freedom looks like?"
 	charge_delay = 5
-	selfcharge = 1
+	selfcharge = TRUE
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/cyborg)
 
 /obj/item/gun/energy/laser/cyborg/emp_act()

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -51,6 +51,7 @@
 	desc = "An energy-based laser gun that self charges. So this is what freedom looks like?"
 	charge_delay = 5
 	selfcharge = 1
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/cyborg)
 
 /obj/item/gun/energy/laser/cyborg/emp_act()
 	return

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -47,4 +47,5 @@
 	charge_delay = 5
 	can_charge = FALSE
 	selfcharge = 1
+	charge_amount = 3
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler/cyborg)

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -43,6 +43,7 @@
 
 /obj/item/gun/energy/disabler/cyborg
 	name = "cyborg disabler"
-	desc = "An integrated disabler that draws from a cyborg's power cell. This weapon contains a limiter to prevent the cyborg's power cell from overheating."
+	desc = "A cyborg-integrated disabler that self charges."
+	charge_delay = 5
 	can_charge = FALSE
-	use_cyborg_cell = TRUE
+	selfcharge = 1

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -46,6 +46,6 @@
 	desc = "A cyborg-integrated disabler that self charges."
 	charge_delay = 5
 	can_charge = FALSE
-	selfcharge = 1
+	selfcharge = TRUE
 	charge_amount = 3
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler/cyborg)

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -47,3 +47,4 @@
 	charge_delay = 5
 	can_charge = FALSE
 	selfcharge = 1
+	ammo_type = list(/obj/item/ammo_casing/energy/disabler/cyborg)


### PR DESCRIPTION
### Intent of your Pull Request

cyborg disabler has 10 shots
laser has 8 shots
recharges like adv egun

#### Changelog

:cl:  
tweak: Security module cyborgs now have an auto-charging disabler instead of one that draws from their cell
/:cl: