### PR TITLE
Talks-to-Tators, Implement #6848

### DIFF
--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -2344,7 +2344,8 @@
 	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/closet/crate/bin,
+/obj/structure/table/wood,
+/obj/item/phone/real,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
 "adM" = (

--- a/_maps/yogstation/map_files/YogStation/YogStation.dmm
+++ b/_maps/yogstation/map_files/YogStation/YogStation.dmm
@@ -14324,10 +14324,17 @@
 /area/ai_monitored/storage/eva)
 "aCd" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 5;
+	pixel_y = 8
+	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	icon_state = "vent_map_on-1";
 	dir = 8
+	},
+/obj/item/phone/real{
+	pixel_x = -2;
+	pixel_y = -4
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)

--- a/_maps/yogstation/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/yogstation/map_files/YogsDelta/YogsDelta.dmm
@@ -41818,9 +41818,15 @@
 /area/crew_quarters/heads/captain/private)
 "bnY" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -5;
+	pixel_y = 10
+	},
 /obj/structure/window/reinforced{
 	dir = 8
+	},
+/obj/item/phone/real{
+	pixel_x = 4
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/captain/private)

--- a/_maps/yogstation/map_files/YogsPubby/YogsPubby.dmm
+++ b/_maps/yogstation/map_files/YogsPubby/YogsPubby.dmm
@@ -12330,7 +12330,6 @@
 /area/crew_quarters/heads/captain)
 "axT" = (
 /obj/structure/table/wood,
-/obj/machinery/recharger,
 /obj/machinery/requests_console{
 	announcementConsole = 1;
 	department = "Captain's Desk";
@@ -12338,6 +12337,7 @@
 	name = "Captain RC";
 	pixel_y = 30
 	},
+/obj/item/phone/real,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "axU" = (
@@ -13501,6 +13501,7 @@
 /area/crew_quarters/heads/captain)
 "aAx" = (
 /obj/structure/table/wood,
+/obj/machinery/recharger,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "aAy" = (

--- a/_maps/yogstation/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/yogstation/map_files/Yogsmeta/Yogsmeta.dmm
@@ -32456,6 +32456,7 @@
 	pixel_x = -30;
 	pixel_y = 1
 	},
+/obj/item/phone/real,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "bfz" = (


### PR DESCRIPTION
### Installs Syndie-NT hotline red-phones in captain's offices.

Nanotrasen Bureau of Diplomacy, Syndicate Desk has reached an agreement with the powers that be in the Syndicate and has agreed to install a diplomatic hotline for emergency use in standard NT Stations.

Will it be enough?

#### Changelog

:cl:  
rscadd: Syndicate-Nanotrasen Hotline red-phones on: YogBox, YogsMeta, YogsPubby, YogsDelta, Omega.
/:cl:
