### PR TITLE
[admin] Updates to select_equipment for plasmamen

### DIFF
--- a/code/modules/clothing/outfits/plasmaman.dm
+++ b/code/modules/clothing/outfits/plasmaman.dm
@@ -1,122 +1,235 @@
-/datum/outfit/plasmaman/bar
-	name = "Bartender Plasmaman"
+/datum/outfit/plasmaman/bartender
+	name = "Plasmaman Bartender"
 
 	uniform = /obj/item/clothing/under/plasmaman/enviroslacks
+	back = /obj/item/storage/backpack
+	suit = /obj/item/clothing/suit/armor/vest
+	ears = /obj/item/radio/headset/headset_srv
+	shoes = /obj/item/clothing/shoes/laceup
+	glasses = /obj/item/clothing/glasses/sunglasses/reagent
 
-/datum/outfit/plasmaman/chef
-	name = "Chef Plasmaman"
+/datum/outfit/plasmaman/cook
+	name = "Plasmaman Cook"
 
 	uniform = /obj/item/clothing/under/plasmaman/chef
+	back = /obj/item/storage/backpack
+	suit = /obj/item/clothing/suit/toggle/chef
+	ears = /obj/item/radio/headset/headset_srv
 
-/datum/outfit/plasmaman/botany
-	name = "Botany Plasmaman"
+/datum/outfit/plasmaman/botanist
+	name = "Plasmaman Botanist"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/blue
 	uniform = /obj/item/clothing/under/plasmaman/botany
+	ears = /obj/item/radio/headset/headset_srv
+	suit = /obj/item/clothing/suit/apron
+	gloves  =/obj/item/clothing/gloves/botanic_leather
+	suit_store = /obj/item/plant_analyzer
+	back = /obj/item/storage/backpack/botany
 
 /datum/outfit/plasmaman/curator
-	name = "Curator Plasmaman"
+	name = "Plasmaman Curator"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/curator
 	uniform = /obj/item/clothing/under/plasmaman/curator
+	ears = /obj/item/radio/headset/headset_srv
+	l_hand = /obj/item/storage/bag/books
+	r_pocket = /obj/item/key/displaycase
+	l_pocket = /obj/item/laser_pointer
+	accessory = /obj/item/clothing/accessory/pocketprotector/full
 
 /datum/outfit/plasmaman/chaplain
-	name = "Chaplain Plasmaman"
+	name = "Plasmaman Chaplain"
 
 	uniform = /obj/item/clothing/under/plasmaman/chaplain
+	ears = /obj/item/radio/headset/headset_srv
+	back = /obj/item/storage/backpack/cultpack
+
 
 /datum/outfit/plasmaman/janitor
-	name = "Janitor Plasmaman"
+	name = "Plasmaman Janitor"
 
 	uniform = /obj/item/clothing/under/plasmaman/janitor
+	ears = /obj/item/radio/headset/headset_srv
 
 /datum/outfit/plasmaman/security
-	name = "Security Plasmaman"
+	name = "Plasmaman Security Officer"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/security
 	uniform = /obj/item/clothing/under/plasmaman/security
+	ears = /obj/item/radio/headset/headset_sec/alt
+	gloves = /obj/item/clothing/gloves/color/black
+	suit = /obj/item/clothing/suit/armor/vest/alt
+	shoes = /obj/item/clothing/shoes/jackboots
+	l_pocket = /obj/item/restraints/handcuffs
+	r_pocket = /obj/item/assembly/flash/handheld
+	suit_store = /obj/item/gun/energy/disabler
+	back = /obj/item/storage/backpack/security
 
 /datum/outfit/plasmaman/detective
-	name = "Detective Plasmaman"
+	name = "Plasmaman Detective"
 
 	uniform = /obj/item/clothing/under/plasmaman/enviroslacks
-	ears = /obj/item/radio/headset/headset_sec
+	ears = /obj/item/radio/headset/headset_sec/alt
+	neck = /obj/item/clothing/neck/tie/detective
+	shoes = /obj/item/clothing/shoes/sneakers/brown
+	suit = /obj/item/clothing/suit/det_suit
+	gloves = /obj/item/clothing/gloves/color/black
+	l_pocket = /obj/item/toy/crayon/white
 
 /datum/outfit/plasmaman/warden
-	name = "Warden Plasmaman"
+	name = "Plasmaman Warden"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/security
 	uniform = /obj/item/clothing/under/plasmaman/security/warden
+	ears = /obj/item/radio/headset/headset_sec/alt
+	shoes = /obj/item/clothing/shoes/jackboots
+	suit = /obj/item/clothing/suit/armor/vest/warden/alt
+	gloves = /obj/item/clothing/gloves/color/black
+	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
+	r_pocket = /obj/item/assembly/flash/handheld
+	l_pocket = /obj/item/restraints/handcuffs
+	suit_store = /obj/item/gun/energy/disabler
+	back = /obj/item/storage/backpack/security
 
-/datum/outfit/plasmaman/cargo
-	name = "Cargo Plasmaman"
+/datum/outfit/plasmaman/cargo_tech
+	name = "Plasmaman Cargo Technician"
 
 	uniform = /obj/item/clothing/under/plasmaman/cargo
+	ears = /obj/item/radio/headset/headset_cargo
+	l_hand = /obj/item/export_scanner
 
-/datum/outfit/plasmaman/qm
-	name = "Quartermaster Plasmaman"
+/datum/outfit/plasmaman/quartermaster
+	name = "Plasmaman Quartermaster"
 
 	uniform = /obj/item/clothing/under/plasmaman/qm
+	ears = /obj/item/radio/headset/headset_cargo
+	shoes = /obj/item/clothing/shoes/sneakers/brown
+	glasses = /obj/item/clothing/glasses/sunglasses
+	l_hand = /obj/item/clipboard
 
-/datum/outfit/plasmaman/mining
-	name = "Mining Plasmaman"
+/datum/outfit/plasmaman/miner
+	name = "Plasmaman Shaft Miner"
 
 	uniform = /obj/item/clothing/under/plasmaman/mining
+	ears = /obj/item/radio/headset/headset_cargo/mining
+	shoes = /obj/item/clothing/shoes/workboots/mining
+	gloves = /obj/item/clothing/gloves/color/black
+	l_pocket = /obj/item/reagent_containers/hypospray/medipen/survival
+	r_pocket = /obj/item/flashlight/seclite
+	back = /obj/item/storage/backpack/explorer
 
-/datum/outfit/plasmaman/medical
-	name = "Medical Plasmaman"
+/datum/outfit/plasmaman/lawyer
+	name = "Plasmaman Laywer"
+
+	uniform = /obj/item/clothing/under/plasmaman/enviroslacks
+	shoes = /obj/item/clothing/shoes/laceup
+	ears = /obj/item/radio/headset/headset_srvsec
+	suit = /obj/item/clothing/suit/toggle/lawyer
+	l_hand = /obj/item/storage/briefcase/lawyer
+	l_pocket = /obj/item/laser_pointer
+	r_pocket = /obj/item/clothing/accessory/lawyers_badge
+
+/datum/outfit/plasmaman/doctor
+	name = "Plasmaman Medical Doctor"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/blue
 	uniform = /obj/item/clothing/under/plasmaman/medical
+	ears = /obj/item/radio/headset/headset_med
+	suit =  /obj/item/clothing/suit/toggle/labcoat
+	l_hand = /obj/item/storage/firstaid/regular
+	suit_store = /obj/item/flashlight/pen
+	back = /obj/item/storage/backpack/medic
 
-/datum/outfit/plasmaman/viro
-	name = "Virology Plasmaman"
+/datum/outfit/plasmaman/virologist
+	name = "Plasmaman Virologist"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/viro
 	uniform = /obj/item/clothing/under/plasmaman/viro
+	ears = /obj/item/radio/headset/headset_med
+	shoes = /obj/item/clothing/shoes/sneakers/white
+	suit =  /obj/item/clothing/suit/toggle/labcoat/virologist
+	suit_store =  /obj/item/flashlight/pen
+	back = /obj/item/storage/backpack/virology
 
 /datum/outfit/plasmaman/chemist
-	name = "Chemist Plasmaman"
+	name = "Plasmaman Chemist"
 
 	uniform = /obj/item/clothing/under/plasmaman/chemist
+	glasses = /obj/item/clothing/glasses/science
+	ears = /obj/item/radio/headset/headset_med
+	shoes = /obj/item/clothing/shoes/sneakers/white
+	suit =  /obj/item/clothing/suit/toggle/labcoat/chemist
+	back = /obj/item/storage/backpack/chemistry
 
-/datum/outfit/plasmaman/genetics
-	name = "Genetics Plasmaman"
+/datum/outfit/plasmaman/geneticist
+	name = "Plasmaman Geneticist"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/blue
 	uniform = /obj/item/clothing/under/plasmaman/genetics
+	ears = /obj/item/radio/headset/headset_medsci
+	shoes = /obj/item/clothing/shoes/sneakers/white
+	suit =  /obj/item/clothing/suit/toggle/labcoat/genetics
+	suit_store =  /obj/item/flashlight/pen
+	l_pocket = /obj/item/sequence_scanner
+	back = /obj/item/storage/backpack/genetics
 
-/datum/outfit/plasmaman/science
-	name = "Science Plasmaman"
+/datum/outfit/plasmaman/scientist
+	name = "Plasmaman Scientist"
 
 	uniform = /obj/item/clothing/under/plasmaman/science
+	ears = /obj/item/radio/headset/headset_sci
+	shoes = /obj/item/clothing/shoes/sneakers/white
+	suit = /obj/item/clothing/suit/toggle/labcoat/science
+	back = /obj/item/storage/backpack/science
 
-/datum/outfit/plasmaman/robotics
-	name = "Robotics Plasmaman"
+/datum/outfit/plasmaman/roboticist
+	name = "Plasmaman Roboticist"
 
 	uniform = /obj/item/clothing/under/plasmaman/robotics
+	belt = /obj/item/storage/belt/utility/full
+	ears = /obj/item/radio/headset/headset_sci
+	suit = /obj/item/clothing/suit/toggle/labcoat
+	back = /obj/item/storage/backpack/science
 
-/datum/outfit/plasmaman/engineering
-	name = "Engineering Plasmaman"
+/datum/outfit/plasmaman/engineer
+	name = "Plasmaman Station Engineer"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/engineering
 	uniform = /obj/item/clothing/under/plasmaman/engineering
+	belt = /obj/item/storage/belt/utility/full/engi
+	ears = /obj/item/radio/headset/headset_eng
+	shoes = /obj/item/clothing/shoes/workboots
+	r_pocket = /obj/item/t_scanner
+	back = /obj/item/storage/backpack/industrial
 
-/datum/outfit/plasmaman/atmospherics
-	name = "Atmospherics Plasmaman"
+/datum/outfit/plasmaman/atmos
+	name = "Plasmaman Atmospheric Technician"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/engineering
 	uniform = /obj/item/clothing/under/plasmaman/atmospherics
+	belt = /obj/item/storage/belt/utility/atmostech
+	ears = /obj/item/radio/headset/headset_eng
+	r_pocket = /obj/item/analyzer
+	back = /obj/item/storage/backpack/industrial
 
 /datum/outfit/plasmaman/mime
-	name = "Plasmamime"
+	name = "Plasmaman Mime"
 	head = /obj/item/clothing/head/helmet/space/plasmaman/mime
 	uniform = /obj/item/clothing/under/plasmaman/mime
 	mask = /obj/item/clothing/mask/gas/mime
+	ears = /obj/item/radio/headset/headset_srv
+	gloves = /obj/item/clothing/gloves/color/white
+	suit = /obj/item/clothing/suit/suspenders
+	back = /obj/item/storage/backpack/mime
 
 /datum/outfit/plasmaman/clown
-	name = "Plasmaclown"
+	name = "Plasmaman Clown"
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/clown
 	uniform = /obj/item/clothing/under/plasmaman/clown
 	mask = /obj/item/clothing/mask/gas/clown_hat
+	ears = /obj/item/radio/headset/headset_srv
+	shoes = /obj/item/clothing/shoes/clown_shoes
+	l_pocket = /obj/item/bikehorn
+	back = /obj/item/storage/backpack/clown

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -363,10 +363,13 @@
 /datum/outfit/plasmaman
 	name = "Plasmaman"
 
-	head = /obj/item/clothing/head/helmet/space/plasmaman
 	uniform = /obj/item/clothing/under/plasmaman
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
 	mask = /obj/item/clothing/mask/breath
+	back = /obj/item/storage/backpack
+	ears = /obj/item/radio/headset
+	head = /obj/item/clothing/head/helmet/space/plasmaman
+	shoes = /obj/item/clothing/shoes/sneakers/black
 
 /datum/outfit/death_commando
 	name = "Death Commando"

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -57,23 +57,23 @@
 	var/current_job = J.title
 	var/datum/outfit/plasmaman/O = new /datum/outfit/plasmaman
 	switch(current_job)
-		if("Chaplain")
-			O = new /datum/outfit/plasmaman/chaplain
+		if("Bartender", "Lawyer")
+			O = new /datum/outfit/plasmaman/bartender
+
+		if("Cook")
+			O = new /datum/outfit/plasmaman/cook
+
+		if("Botanist")
+			O = new /datum/outfit/plasmaman/botanist
 
 		if("Curator")
 			O = new /datum/outfit/plasmaman/curator
 
+		if("Chaplain")
+			O = new /datum/outfit/plasmaman/chaplain
+
 		if("Janitor")
 			O = new /datum/outfit/plasmaman/janitor
-
-		if("Botanist")
-			O = new /datum/outfit/plasmaman/botany
-
-		if("Bartender", "Lawyer")
-			O = new /datum/outfit/plasmaman/bar
-
-		if("Cook")
-			O = new /datum/outfit/plasmaman/chef
 
 		if("Security Officer")
 			O = new /datum/outfit/plasmaman/security
@@ -85,37 +85,40 @@
 			O = new /datum/outfit/plasmaman/warden
 
 		if("Cargo Technician")
-			O = new /datum/outfit/plasmaman/cargo
+			O = new /datum/outfit/plasmaman/cargo_tech
 
 		if("Quartermaster")
-			O = new /datum/outfit/plasmaman/qm
+			O = new /datum/outfit/plasmaman/quartermaster
 
 		if("Shaft Miner")
-			O = new /datum/outfit/plasmaman/mining
+			O = new /datum/outfit/plasmaman/miner
+
+		if("Lawyer")
+			O = new /datum/outfit/plasmaman/lawyer
 
 		if("Medical Doctor")
-			O = new /datum/outfit/plasmaman/medical
+			O = new /datum/outfit/plasmaman/doctor
+
+		if("Virologist")
+			O = new /datum/outfit/plasmaman/virologist
 
 		if("Chemist")
 			O = new /datum/outfit/plasmaman/chemist
 
 		if("Geneticist")
-			O = new /datum/outfit/plasmaman/genetics
-
-		if("Roboticist")
-			O = new /datum/outfit/plasmaman/robotics
-
-		if("Virologist")
-			O = new /datum/outfit/plasmaman/viro
+			O = new /datum/outfit/plasmaman/geneticist
 
 		if("Scientist")
-			O = new /datum/outfit/plasmaman/science
+			O = new /datum/outfit/plasmaman/scientist
+
+		if("Roboticist")
+			O = new /datum/outfit/plasmaman/roboticist
 
 		if("Station Engineer")
-			O = new /datum/outfit/plasmaman/engineering
+			O = new /datum/outfit/plasmaman/engineer
 
 		if("Atmospheric Technician")
-			O = new /datum/outfit/plasmaman/atmospherics
+			O = new /datum/outfit/plasmaman/atmos
 
 		if("Mime")
 			O = new /datum/outfit/plasmaman/mime

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -57,7 +57,7 @@
 	var/current_job = J.title
 	var/datum/outfit/plasmaman/O = new /datum/outfit/plasmaman
 	switch(current_job)
-		if("Bartender", "Lawyer")
+		if("Bartender")
 			O = new /datum/outfit/plasmaman/bartender
 
 		if("Cook")


### PR DESCRIPTION
Consider this the first part of me fixing #6886 , I don't plan on working on it again anytime soon so I'm pring the parts I changed to merge hopefully. Changes the layout so every outfit for plasmamen is labelled as "Plasmamen Job", to make it easier to find. Added all the equipment (besides IDs, PDAs and bag contents) to each listed job.

:cl:  
rscadd: Added more equipment to select equipment for plasmamen.
/:cl:
