### PR TITLE
[admin] Updates swarmer flavortext

### DIFF
--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -19,11 +19,12 @@
 	death = FALSE
 	roundstart = FALSE
 	flavour_text = {"
+	<b><FONT color='red'>You are to allow other beings to leave peacefully on the shuttle without interference. The station and its resources are your only concern.</font></b>
 	<b>You are a swarmer, a weapon of a long dead civilization. Until further orders from your original masters are received, you must continue to consume and replicate.</b>
 	<b>Clicking on any object will try to consume it, either deconstructing it into its components, destroying it, or integrating any materials it has into you if successful.</b>
 	<b>Ctrl-Clicking on a mob will attempt to remove it from the area and place it in a safe environment for storage.</b>
 	<b>Objectives:</b>
-	1. Consume resources and replicate until there are no more resources left.
+	1. Consume resources and replicate on the station until there are no more resources left.
 	2. Ensure that this location is fit for invasion at a later date; do not perform actions that would render it dangerous or inhospitable.
 	3. Biological resources will be harvested at a later date; do not harm them.
 	"}


### PR DESCRIPTION
Since apparently not a single player online knew they weren't allowed to enter the escape shuttle, whether they planned to hijack or not. Red text if this goes through, until enough time has passed so people are aware of the ruling. Also changed law 1 to contain "on the station". Pring for a council vote.

:cl:  
rscadd: Swarmer flavor text has been changed to reflect the server rules.
/:cl: