### PR TITLE
station room landmarks now only log to world if testing is enabled

### DIFF
--- a/yogstation/code/game/objects/effects/landmarks.dm
+++ b/yogstation/code/game/objects/effects/landmarks.dm
@@ -55,7 +55,7 @@
 	var/datum/map_template/template = SSmapping.station_room_templates[template_name]
 	if(!template)
 		return FALSE
-	log_world("Ruin \"[template_name]\" placed at ([T.x], [T.y], [T.z])")
+	testing("Ruin \"[template_name]\" placed at ([T.x], [T.y], [T.z])")
 	template.load(T, centered = FALSE)
 	template.loaded++
 	GLOB.stationroom_landmarks -= src


### PR DESCRIPTION
Instead of
00:00:16.75 |   | Ruin loader finished with 0 left to spend.
00:00:19.18 |   | Ruin loader finished with 0 left to spend.
00:00:19.18 |   | Ruin "Maintenance Surgery" placed at (61, 162, 2)
00:00:19.19 |   | Ruin "Engine SM" placed at (103, 59, 2)
00:00:19.28 |   | Ruin "Bar Diner" placed at (138, 141, 2)
00:00:19.87 |   | Initialized Mapping subsystem within 14.9 seconds!

We'll have

00:00:16.75 |   | Ruin loader finished with 0 left to spend.
00:00:19.18 |   | Ruin loader finished with 0 left to spend.
00:00:19.87 |   | Initialized Mapping subsystem within 14.9 seconds!

Unless you enable the testing debug messages, in which case station room placement will be logged like the other landmarks
