### PR TITLE
reconnecting should no longer runtime if you have an active ticket

### DIFF
--- a/yogstation/code/modules/admin/verbs/adminhelp.dm
+++ b/yogstation/code/modules/admin/verbs/adminhelp.dm
@@ -46,7 +46,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	C.current_ticket = CKey2ActiveTicket(C.ckey)
 	if(C.current_ticket)
 		C.current_ticket.initiator = C
-		C.current_ticket.AddInteraction("Client reconnected.")
+		C.current_ticket.AddInteraction("Client reconnected.", ckey = C.ckey)
 
 //Dissasociate ticket
 /datum/admin_help_tickets/proc/ClientLogout(client/C)
@@ -184,9 +184,9 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		return FALSE
 	return TRUE
 
-/datum/admin_help/proc/AddInteraction(msg, for_admins = FALSE)
+/datum/admin_help/proc/AddInteraction(msg, for_admins = FALSE, ckey = null)
 	_interactions += new /datum/ticket_log(src, usr, msg, for_admins)
-	webhook_send("ticket", list("ticketid" = id, "message" = strip_html_simple(msg), "roundid" = GLOB.round_id, "user" = usr.client.ckey))
+	webhook_send("ticket", list("ticketid" = id, "message" = strip_html_simple(msg), "roundid" = GLOB.round_id, "user" = ckey ? ckey : usr.client.ckey))
 
 //Removes the ahelp verb and returns it after 2 minutes
 /datum/admin_help/proc/TimeoutVerb()


### PR DESCRIPTION

runtime error: Cannot read null.ckey
--
  |   | - proc name: AddInteraction (/datum/admin_help/proc/AddInteraction)
  |   | - source file: adminhelp.dm,189
  |   | - usr: Sophia Mason (/mob/living/carbon/human)
  |   | - src: Hello there. Would you agree t... (/datum/admin_help)
  |   | - usr.loc: the floor (175,111,2) (/turf/open/floor/plasteel/white)
  |   | - call stack:
  |   | - Hello there. Would you agree t... (/datum/admin_help): AddInteraction("Client reconnected.", 0)
  |   | - /datum/admin_help_tickets (/datum/admin_help_tickets): ClientLogin(JohnMcBurger (/client))
  |   | - JohnMcBurger (/client): New(null)
  |   | -

