### PR TITLE
Goat plushie no longer runtimes if there's no target for it to ram

### DIFF
--- a/yogstation/code/game/objects/items/plushes.dm
+++ b/yogstation/code/game/objects/items/plushes.dm
@@ -31,7 +31,7 @@
 			return
 		target = pick(targets_to_pick_from)
 		visible_message("<span class='notice'>[src] stares at [target].</span>")
-	if (world.time > cooldown)
+	if (world.time > cooldown && target)
 		ram()
 
 /obj/item/toy/plush/goatplushie/angry/proc/ram()


### PR DESCRIPTION

runtime error: Cannot read null.mind
--
  |   | - proc name: ram (/obj/item/toy/plush/goatplushie/angry/proc/ram)
  |   | - source file: plushes.dm,38
  |   | - usr: null
  |   | - src: King Goat Plushie (/obj/item/toy/plush/goatplushie/angry/kinggoat)
  |   | - src.loc: the floor (100,157,2) (/turf/open/floor/plasteel)
  |   | - call stack:
  |   | - King Goat Plushie (/obj/item/toy/plush/goatplushie/angry/kinggoat): ram()
  |   | - King Goat Plushie (/obj/item/toy/plush/goatplushie/angry/kinggoat): process(10)
  |   | - Processing (/datum/controller/subsystem/processing): fire(0)
  |   | - Processing (/datum/controller/subsystem/processing): ignite(0)
  |   | - Master (/datum/controller/master): RunQueue()
  |   | - Master (/datum/controller/master): Loop()
  |   | - Master (/datum/controller/master): StartProcessing(0)
  |   | -

