### PR TITLE
rolling pins are not contraband

### DIFF
--- a/code/modules/vending/drinnerware.dm
+++ b/code/modules/vending/drinnerware.dm
@@ -15,8 +15,7 @@
 					/obj/item/clothing/suit/apron/chef = 2,
 					/obj/item/kitchen/rollingpin = 2,
 					/obj/item/kitchen/knife = 2)
-	contraband = list(/obj/item/kitchen/rollingpin = 2,
-					  /obj/item/kitchen/knife/butcher = 2, // Yogs -- Pan
+	contraband = list(/obj/item/kitchen/knife/butcher = 2, // Yogs -- Pan
 					  /obj/item/melee/fryingpan = 2) // Yogs -- Pan
 	refill_canister = /obj/item/vending_refill/dinnerware
 	default_price = 5


### PR DESCRIPTION
They were duplicated in the vendor so I took it off contraband.

:cl:  
rscdel: Rolling pins are gone from the contraband section of the dinnerware vendor.
/:cl: