### PR TITLE
Makes the fire alert message more new player friendly

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -265,7 +265,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 /obj/screen/alert/fire
 	name = "On Fire"
-	desc = "You're on fire. Stop, drop and roll to put the fire out or move to a vacuum area."
+	desc = "You're on fire. Click to stop, drop and roll to put the fire out or move to a vacuum area."
 	icon_state = "fire"
 
 /obj/screen/alert/fire/Click()


### PR DESCRIPTION
Makes me sad when new players don't know how to put out fire so they have no choice but to die a slow, painful death.

:cl:  
rscadd: The on fire alert message tells you to click on it.
/:cl: