### PR TITLE
Makes wheelchairs not obscenely shitty by default

### DIFF
--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -44,7 +44,7 @@
 		var/datum/component/riding/D = GetComponent(/datum/component/riding)
 		//1.5 (movespeed as of this change) multiplied by 6.7 gets ABOUT 10 (rounded), the old constant for the wheelchair that gets divided by how many arms they have
 		//if that made no sense this simply makes the wheelchair speed change along with movement speed delay
-		D.vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * 4.1) / min(user.get_num_arms(), 2)
+		D.vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * 4) / min(user.get_num_arms(), 2)
 	return ..()
 
 /obj/vehicle/ridden/wheelchair/Moved()

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -42,7 +42,8 @@
 			addtimer(VARSET_CALLBACK(src, canmove, TRUE), 20)
 			return FALSE
 		var/datum/component/riding/D = GetComponent(/datum/component/riding)
-		//1.5 (movespeed as of this change) multiplied by 6.7 gets ABOUT 10 (rounded), the old constant for the wheelchair that gets divided by how many arms they have
+		//1.5 (movespeed as of this change) multiplied by 4 gets 6, which gives you a delay of 3 assuming the user has two arms,
+		//getting the speed of the wheelchair roughly equal to the speed of a scooter based on testing.
 		//if that made no sense this simply makes the wheelchair speed change along with movement speed delay
 		D.vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * 4) / min(user.get_num_arms(), 2)
 	return ..()

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -44,7 +44,7 @@
 		var/datum/component/riding/D = GetComponent(/datum/component/riding)
 		//1.5 (movespeed as of this change) multiplied by 6.7 gets ABOUT 10 (rounded), the old constant for the wheelchair that gets divided by how many arms they have
 		//if that made no sense this simply makes the wheelchair speed change along with movement speed delay
-		D.vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * 6.7) / min(user.get_num_arms(), 2)
+		D.vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * 4.1) / min(user.get_num_arms(), 2)
 	return ..()
 
 /obj/vehicle/ridden/wheelchair/Moved()


### PR DESCRIPTION
After discussing with mongoose and some other staff last night, we thought the default move speed for wheelchairs made them unbearably shitty and I have attempted to fix that and only make them somewhat shitty. Makes wheelchair move speed roughly the same as scooter move speed.

Also thought about modifying the trait bonus from -3 to -2 to reflect the newly lowered shittiness of wheelchairs, but decided not to since not having legs and being bound to a chair for your entire life is still a decent debuff.

:cl:  
tweak: Made wheelchairs less obscenely shitty by default
/:cl:
