### PR TITLE
Cyborg disablers now require 500 J per shot 

### DIFF
--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -24,3 +24,6 @@
 
 /obj/item/ammo_casing/energy/disabler/hos
 	e_cost = 60
+
+/obj/item/ammo_casing/energy/disabler/cyborg
+	e_cost = 500

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -44,5 +44,6 @@
 /obj/item/gun/energy/disabler/cyborg
 	name = "cyborg disabler"
 	desc = "An integrated disabler that draws from a cyborg's power cell. This weapon contains a limiter to prevent the cyborg's power cell from overheating."
+	ammo_type = list(/obj/item/ammo_casing/energy/disabler/cyborg)
 	can_charge = FALSE
 	use_cyborg_cell = TRUE


### PR DESCRIPTION
### Intent of your Pull Request

Cyborg disablers now require 500 J per shot they fire. I chose this number because 500 joules per shot still leaves cyborgs with room to maneuver with the disabler but significantly punishes them for spamming it. You can still get 30 shots off using a 15k power cell, so there's that. Obviously it can be tweaked.

Closes #6865 

#### Changelog

:cl:  
tweak: Cyborg disablers now require 500 joules per shot fired.
/:cl:
