### PR TITLE
Some more map things

### DIFF
--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -13193,9 +13193,6 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/structure/sign/barsign{
-	pixel_y = 32
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
@@ -18234,14 +18231,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aBB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/structure/cable/white{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -25052,9 +25044,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"aLC" = (
-/turf/open/space/basic,
-/area/science/xenobiology)
 "aLD" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/effect/turf_decal/stripes/line{
@@ -25842,6 +25831,11 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"aMQ" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "aMR" = (
 /obj/machinery/camera{
 	c_tag = "Supermatter Chamber";
@@ -25901,6 +25895,12 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"aMY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/airless,
+/area/asteroid/nearstation)
 "aMZ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -25914,6 +25914,12 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"aNa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 9
+	},
+/turf/open/floor/plating/asteroid/airless,
+/area/asteroid/nearstation)
 "aNb" = (
 /obj/machinery/light,
 /obj/structure/extinguisher_cabinet{
@@ -26068,6 +26074,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
+"aNo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"aNp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/tcommsat/server)
 "aNq" = (
 /obj/machinery/hydroponics/constructable,
 /obj/structure/cable/white,
@@ -37110,13 +37135,6 @@
 	},
 /turf/open/floor/plating,
 /area/tcommsat/server)
-"bxt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/tcommsat/server)
 "bxu" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line,
@@ -37598,13 +37616,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"csP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "csX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
@@ -38037,11 +38048,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/hallway/secondary/entry)
-"ezP" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "eCg" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -38431,12 +38437,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port/fore)
-"gNH" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/plating/asteroid/airless,
-/area/asteroid/nearstation)
 "gPY" = (
 /obj/machinery/vr_sleeper,
 /obj/effect/turf_decal/tile/red{
@@ -43738,12 +43738,6 @@
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
-"xPz" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/turf/open/floor/plating/asteroid/airless,
-/area/asteroid/nearstation)
 "xSr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -69917,7 +69911,7 @@ bpn
 xZO
 dMl
 uhz
-gNH
+aMY
 aad
 aad
 aad
@@ -70174,7 +70168,7 @@ pvX
 gSv
 xtL
 uhz
-gNH
+aMY
 aad
 aad
 aad
@@ -70430,8 +70424,8 @@ ueC
 qMr
 kiw
 nUk
-ezP
-xPz
+aMQ
+aNa
 aad
 aad
 aad
@@ -73013,7 +73007,7 @@ aMN
 aMN
 sJD
 aMN
-bxt
+aNp
 bwW
 aMJ
 aMJ
@@ -76596,7 +76590,7 @@ wZa
 dBX
 toF
 jWK
-csP
+aBB
 auC
 aqz
 aEt
@@ -76853,7 +76847,7 @@ scU
 axb
 azr
 aAt
-aBB
+aNo
 vhn
 utN
 aVM
@@ -85889,7 +85883,7 @@ bix
 bgU
 aaa
 aaa
-aLC
+aaa
 aaa
 aaa
 aaa
@@ -86146,7 +86140,7 @@ biw
 bgU
 aaa
 aaa
-aLC
+aaa
 aaa
 aaa
 aaa

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -5016,8 +5016,7 @@
 /turf/open/space,
 /area/solar/port/fore)
 "ajr" = (
-/obj/structure/table,
-/obj/item/restraints/handcuffs,
+/obj/machinery/computer/prisoner,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "ajs" = (
@@ -5033,6 +5032,7 @@
 /obj/machinery/camera{
 	c_tag = "Labor Shuttle Dock North"
 	},
+/obj/item/restraints/handcuffs,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "aju" = (
@@ -5218,15 +5218,15 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajJ" = (
-/obj/structure/chair{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	icon_state = "pipe11-1";
 	dir = 6
+	},
+/obj/structure/chair{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -7079,14 +7079,6 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "anu" = (
-/obj/machinery/button/door{
-	desc = "A remote control switch for the exit.";
-	id = "laborexit";
-	name = "exit button";
-	normaldoorcontrol = 1;
-	pixel_x = 26;
-	pixel_y = -6
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -7255,8 +7247,11 @@
 /area/space)
 "anP" = (
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/unres{
+	icon_state = "airlock_unres_helper";
+	dir = 8
+	},
 /obj/machinery/door/airlock/security{
-	id_tag = "laborexit";
 	name = "Labor Shuttle";
 	req_access_txt = "63"
 	},

--- a/_maps/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/map_files/YogsDelta/YogsDelta.dmm
@@ -39251,14 +39251,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/button/door{
-	desc = "A remote control switch.";
-	id = "gulagdoor";
-	name = "Transfer Door Control";
-	normaldoorcontrol = 1;
-	pixel_x = -24;
-	pixel_y = -8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -54420,16 +54412,19 @@
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "gulagdoor";
-	name = "Security Transferring Center";
-	req_access_txt = "63"
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Transferring Center";
+	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	icon_state = "airlock_unres_helper";
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)

--- a/_maps/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/map_files/YogsDelta/YogsDelta.dmm
@@ -80604,6 +80604,7 @@
 	icon_state = "manifold-1";
 	dir = 4
 	},
+/obj/item/pen,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "ctu" = (
@@ -80619,7 +80620,6 @@
 	pixel_y = 6
 	},
 /obj/item/folder/white,
-/obj/item/pen,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -80630,6 +80630,7 @@
 	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
+/obj/item/stamp/cmo,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "ctv" = (
@@ -89263,7 +89264,6 @@
 /turf/open/floor/plating,
 /area/crew_quarters/toilet/restrooms)
 "cGL" = (
-/obj/machinery/vending/clothing,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -89274,6 +89274,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/locker)
 "cGM" = (
@@ -89305,6 +89306,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/vending/clothing,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/locker)
 "cGO" = (

--- a/_maps/map_files/YogsPubby/YogsPubby.dmm
+++ b/_maps/map_files/YogsPubby/YogsPubby.dmm
@@ -964,8 +964,8 @@
 	base_state = "right";
 	dir = 4;
 	icon_state = "right";
-	name = "Core Modules";
-	req_access_txt = "20"
+	name = "Patient Monitoring Room";
+	req_access_txt = "0"
 	},
 /turf/open/floor/wood,
 /area/medical/medbay/central)
@@ -11033,6 +11033,10 @@
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_target{
+	dirx = 1;
+	diry = -1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "avr" = (
@@ -11045,6 +11049,10 @@
 	},
 /obj/machinery/gulag_item_reclaimer{
 	pixel_y = 24
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -11718,7 +11726,12 @@
 "awH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
-	name = "Labor Camp Shuttle Airlock"
+	name = "Labor Camp Shuttle Airlock";
+	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_target{
+	dirx = -1;
+	diry = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -13393,9 +13406,6 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aAj" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/light/small{
 	brightness = 3;
 	dir = 8
@@ -23822,6 +23832,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aTS" = (
@@ -23834,15 +23847,19 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/meter/atmos/atmos_waste_loop,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -25158,14 +25175,18 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "aWj" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Distro to Waste"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	icon_state = "pipe11-2";
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -25177,15 +25198,19 @@
 	},
 /area/maintenance/department/science)
 "aWl" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/meter/atmos/distro_loop,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Distro to Waste"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -26203,10 +26228,13 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	icon_state = "pipe11-2";
+	dir = 8
 	},
-/obj/machinery/meter/atmos/distro_loop,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aYd" = (
@@ -28197,7 +28225,12 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "bbN" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bbO" = (
@@ -39783,8 +39816,9 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bwd" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	icon_state = "pipe11-2";
+	dir = 8
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
@@ -48604,8 +48638,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bKI" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	icon_state = "intact";
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	icon_state = "pipe11-2";
 	dir = 9
 	},
 /turf/closed/wall,
@@ -49376,6 +49410,13 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
+"bMo" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "bMp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -49406,6 +49447,27 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"bMs" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"bMt" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"bMu" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/white/corner,
+/area/hallway/secondary/exit/departure_lounge)
 "bMy" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -49610,12 +49672,6 @@
 /area/engine/atmos)
 "bNc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"bNd" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -80310,7 +80366,7 @@ aML
 gmO
 aQt
 gpC
-ppQ
+bMu
 aYG
 aZy
 baK
@@ -88785,7 +88841,7 @@ aKQ
 aKQ
 aLL
 aQN
-aRN
+aAj
 aRN
 aTX
 aUX
@@ -89042,7 +89098,7 @@ aNf
 aKT
 aLL
 azx
-aAj
+aPG
 bMb
 aUY
 aPU
@@ -96794,7 +96850,7 @@ bvA
 aXf
 bJN
 aTR
-bNd
+bbN
 bOl
 bQI
 bPR
@@ -97051,7 +97107,7 @@ bvE
 aXg
 bJN
 aTT
-bbN
+bMo
 bxI
 bpO
 bpO
@@ -97307,8 +97363,8 @@ btp
 bvF
 aXi
 bJN
-aWl
-bMf
+aWj
+bMs
 bxW
 bOV
 bPQ
@@ -97564,8 +97620,8 @@ aVD
 aJa
 aXj
 bJN
-aYc
-bbN
+aWl
+bMo
 bxZ
 bOW
 bPQ
@@ -97821,8 +97877,8 @@ bHt
 bIE
 bJN
 bJN
-aWj
-bMf
+aYc
+bMt
 bOk
 bOX
 bPQ

--- a/_maps/map_files/YogsPubby/YogsPubby.dmm
+++ b/_maps/map_files/YogsPubby/YogsPubby.dmm
@@ -11733,6 +11733,10 @@
 	dirx = -1;
 	diry = 1
 	},
+/obj/effect/mapping_helpers/airlock/unres{
+	icon_state = "airlock_unres_helper";
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "awI" = (
@@ -49468,6 +49472,9 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
+"bMv" = (
+/turf/closed/wall,
+/area/hallway/primary/fore)
 "bMy" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -80856,8 +80863,8 @@ apE
 avq
 apE
 ajM
-aiu
-aiu
+bMv
+bMv
 gSH
 xJy
 aEX

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -2518,6 +2518,10 @@
 	dirx = -1;
 	diry = 1
 	},
+/obj/effect/mapping_helpers/airlock/unres{
+	icon_state = "airlock_unres_helper";
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "aeF" = (

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -888,17 +888,7 @@
 	name = "blast door"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/security/execution/education)
 "acb" = (
 /obj/structure/table,
@@ -1874,6 +1864,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"adz" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_target{
+	dirx = 1;
+	diry = -1
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/fore)
 "adA" = (
 /obj/structure/bed,
 /obj/item/clothing/suit/straight_jacket,
@@ -2296,6 +2296,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"aem" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Labor Shuttle Dock";
+	dir = 8
+	},
+/obj/machinery/gulag_item_reclaimer{
+	pixel_y = 24
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/fore)
 "aen" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -2491,6 +2508,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"aeE" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Labor Camp Shuttle Airlock";
+	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_target{
+	dirx = -1;
+	diry = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/fore)
 "aeF" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/structure/lattice/catwalk,
@@ -14325,28 +14354,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"azQ" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Labor Shuttle Dock";
-	dir = 8
-	},
-/obj/machinery/flasher{
-	id = "PRelease";
-	pixel_x = 24;
-	pixel_y = 20
-	},
-/obj/machinery/gulag_item_reclaimer{
-	pixel_y = 24
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/fore)
 "azR" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -15019,12 +15026,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"aAW" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock"
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/fore)
 "aAX" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -15701,13 +15702,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"aCj" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Labor Camp Shuttle Airlock"
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/fore)
 "aCk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -107348,7 +107342,7 @@ avY
 ajo
 aaa
 azC
-aAW
+adz
 azC
 aDu
 aDu
@@ -107605,8 +107599,8 @@ avk
 ajo
 aaa
 aDu
-azQ
-aCj
+aem
+aeE
 aCc
 aEI
 axI


### PR DESCRIPTION
**All Maps**
Replaced the labor camp exit buttons with unrestricted side helpers, as they had no access requirements anyway.

**Omega**
Fixed some coloring and the hidden/visible status of some pipes in atmospherics.
Removed the second barsign.

**Pubby**
Added decals to make the jump between hidden/visible pipes less sudden.
Fixed the hidden/visible status of some pipes in atmospherics.
Added an evac status display to escape.
Removed an unneeded maint wall.
Fixed the psych windoor name and access.
Added airlock cyclelink helpers on the labor camp airlocks.
Fixed greytide being able to access the labor shuttle.
Added a fire alarm between the labor camp airlocks.
Fixed some area tags in Fore Primary Hallway.

**Delta**
Added a cig vendor to the locker room.
Added the CMO's rubber stamp.

**Meta**
Replaced the decals with plating under some windows in the transfer center.
Added airlock cyclelink helpers on the labor camp airlocks.
Fixed greytide being able to access the labor shuttle.
Removed an unneeded wall flash.

**Box**
Added a prisoner management console to the Brig.