### PR TITLE
Replaces security knockout gas canister with a pepper spray smoke machine

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -17669,7 +17669,11 @@
 "aIi" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/bot_white,
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/smoke_machine,
+/obj/item/reagent_containers/glass/beaker/large/silver_sulfadiazine{
+	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin = 100);
+	name = "liquid pepper spray"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aIj" = (
@@ -51015,14 +51019,6 @@
 "cmd" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"cml" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "cmn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -90013,7 +90009,7 @@ aEu
 aeN
 age
 aIV
-cml
+agt
 agV
 cxk
 agt


### PR DESCRIPTION
The knockout gas (N2O) is almost never used because of how uncontrollable it is and how hard it is to clean up, plus I bet you would get bwoinked if you tried to use it in an open space.

The smoke machine comes with a beaker of pepper spray to make controllable smoke clouds to disable groups of people. Security with their masks and such are unaffected. With the smoke machine, you can customize the size of the cloud and it dissipates after a little while, meaning you can safely use it without flooding an entire compartment with gas the scrubbers won't filter by default. Maybe we will actually see security use it as a riot control measure instead of sitting in the armory and never moving like the knockout gas does.

Also obligatory hong kong reference. 

#### Changelog

:cl:  
rscadd: Replaced security knockout gas canisters with a pepper spray smoke machine for better riot control. 
/:cl:
