### PR TITLE
Race Sensor Nanites from tg

### DIFF
--- a/code/modules/research/designs/nanite_designs.dm
+++ b/code/modules/research/designs/nanite_designs.dm
@@ -474,4 +474,11 @@
 	desc = "The nanites receive a signal when the nanite supply is above/below a certain percentage."
 	id = "sensor_nanite_volume"
 	program_type = /datum/nanite_program/sensor/nanite_volume
-	category = list("Sensor Nanites")
+	category = list("Sensor Nanites") 
+	
+/datum/design/nanites/sensor_race
+	name = "Race Sensor"
+	desc = "When triggered, the nanites scan the host to determine their race and output a signal depending on the conditions set in the settings."
+	id = "sensor_race_nanites"
+	program_type = /datum/nanite_program/sensor/race
+	category = list("Sensor Nanites") 

--- a/code/modules/research/nanites/nanite_programs/sensor.dm
+++ b/code/modules/research/nanites/nanite_programs/sensor.dm
@@ -397,3 +397,81 @@
 	else
 		if(low_message == low_sentence)
 			send_code()
+/datum/nanite_program/sensor/race
+	name = "Race Sensor"
+	desc = "When triggered, the nanites scan the host to determine their race and output a signal depending on the conditions set in the settings."
+	can_trigger = TRUE
+	trigger_cost = 0
+	trigger_cooldown = 5
+
+	extra_settings = list("Sent Code","Race","Mode")
+	var/race_type = "Human"
+	var/mode = "Is"
+	var/list/static/allowed_species = list(
+    	"Human" = /datum/species/human,
+    	"Lizard" = /datum/species/lizard,
+		"Moth" = /datum/species/moth,
+		"Ethereal" = /datum/species/ethereal,
+		"Pod" = /datum/species/pod,
+		"Fly" = /datum/species/fly,
+		"Felinid" = /datum/species/human/felinid,
+		"Jelly" = /datum/species/jelly
+	)
+
+/datum/nanite_program/sensor/race/set_extra_setting(user, setting)
+	if(setting == "Sent Code")
+		var/new_code = input(user, "Set the sent code (1-9999):", name, null) as null|num
+		if(isnull(new_code))
+			return
+		sent_code = CLAMP(round(new_code, 1), 1, 9999)
+	if(setting == "Race")
+		var/list/race_types = list()
+		for(var/name in allowed_species)
+			race_types += name
+		race_types += "Other"
+		var/new_race_type = input("Choose the race", name) as null|anything in sortList(race_types)
+		if(!new_race_type)
+			return
+		race_type = new_race_type
+	if(setting == "Mode")
+		mode = mode == "Is" ? "Is Not" : "Is"
+
+
+/datum/nanite_program/sensor/race/get_extra_setting(setting)
+	if(setting == "Sent Code")
+		return sent_code
+	if(setting == "Race")
+		return race_type
+	if(setting == "Mode")
+		return mode
+
+/datum/nanite_program/sensor/race/copy_extra_settings_to(datum/nanite_program/sensor/race/target)
+	target.sent_code = sent_code
+	target.race_type = race_type
+	target.mode = mode
+
+/datum/nanite_program/sensor/race/trigger()
+	if(!..())
+		return
+
+	var/species = allowed_species[race_type]
+	var/race_match = FALSE
+
+	if(species)
+		if(is_species(host_mob, species))
+			race_match = TRUE
+	else	//this is the check for the "Other" option
+		race_match = TRUE
+		for(var/name in allowed_species)
+			var/species_other = allowed_species[name]
+			if(is_species(host_mob, species_other))
+				race_match = FALSE
+				break
+
+	switch(mode)
+		if("Is")
+			if(race_match)
+				send_code()
+		if("Is Not")
+			if(!race_match)
+				send_code()

--- a/code/modules/research/nanites/nanite_programs/sensor.dm
+++ b/code/modules/research/nanites/nanite_programs/sensor.dm
@@ -415,7 +415,8 @@
 		"Pod" = /datum/species/pod,
 		"Fly" = /datum/species/fly,
 		"Felinid" = /datum/species/human/felinid,
-		"Jelly" = /datum/species/jelly
+		"Jelly" = /datum/species/jelly,
+		"Preternis" = /datum/species/preternis
 	)
 
 /datum/nanite_program/sensor/race/set_extra_setting(user, setting)

--- a/code/modules/research/nanites/nanite_programs/sensor.dm
+++ b/code/modules/research/nanites/nanite_programs/sensor.dm
@@ -418,7 +418,7 @@
 		"Jelly" = /datum/species/jelly,
 		"Preternis" = /datum/species/preternis
 	)
-
+//preternis is yog only baybe
 /datum/nanite_program/sensor/race/set_extra_setting(user, setting)
 	if(setting == "Sent Code")
 		var/new_code = input(user, "Set the sent code (1-9999):", name, null) as null|num

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -915,7 +915,7 @@
 	description = "Nanite programs that require complex biological interaction."
 	prereq_ids = list("nanite_base","biotech")
 	design_ids = list("regenerative_nanites", "bloodheal_nanites", "coagulating_nanites","poison_nanites","flesheating_nanites",\
-					"sensor_crit_nanites","sensor_death_nanites", "sensor_health_nanites", "sensor_damage_nanites")
+					"sensor_crit_nanites","sensor_death_nanites", "sensor_health_nanites", "sensor_damage_nanites", "sensor_race_nanites")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 


### PR DESCRIPTION
### Intent of your Pull Request

Race sensor nanites allow for custom tuned nanites to a race without having to have multiple cloud ID
It is not for "haha racism funny gimmick x3", since each race has their quirks which can influence nanite performance"

Slime People Don't have blood, why keep rapid coagulation on?
Preternis? more like cringeternis, shit can't use healing programs except for a couple of mechanical ones
Clockwork Golems trying to take your nanites? Fuck em, they don't need it you do.
Lizards trying to revolt in sec again?Its called CIVIL rights, not CIVILIZARD rights,bye-bye ashwalkers.

#### Changelog

:cl:  
rscadd: Ports Race Sensor Nanites from /tg/  

/:cl:
(Please Excuse me If I have any formatting wrong since I had to take a small break from coding and ss13 in general due to burnout.)
