### PR TITLE
Ash walkers can no longer use machinery

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -241,6 +241,8 @@ Class Procs:
 	else
 		if(interaction_flags_machine & INTERACT_MACHINE_REQUIRES_SILICON)
 			return FALSE
+		if(is_species(user, /datum/species/lizard/ashwalker))
+			return FALSE
 		if(!Adjacent(user))
 			var/mob/living/carbon/H = user
 			if(!(istype(H) && H.has_dna() && H.dna.check_mutation(TK)))


### PR DESCRIPTION
ash walkers can no longer use machinery including hacking doors,extracting shit out of an ORM,using shuttle console,etc.. Putting the ghost role that hunts careless miners back where it belongs killing careless miners and NOT hunting down the whole station sabotaging it.

:cl:  alexkar598
tweak: Ash walkers can no longer interact with machinery and consoles.
/:cl:
