### PR TITLE
Dangerous shuttles can only be bought using emagged comms consoles

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -384,7 +384,7 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 
 		var/datum/map_template/shuttle/S = new shuttle_type()
 		if(unbuyable.Find(S.mappath))
-			S.can_be_bought = FALSE
+			S.credit_cost = INFINITY
 
 		shuttle_templates[S.shuttle_id] = S
 		map_templates[S.shuttle_id] = S

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -47,6 +47,7 @@ SUBSYSTEM_DEF(shuttle)
 	var/datum/round_event/shuttle_loan/shuttle_loan
 
 	var/shuttle_purchased = FALSE //If the station has purchased a replacement escape shuttle this round
+	var/emag_shuttle_purchased = FALSE //If the traitors have purchased a replacement escape shuttle this round
 	var/list/shuttle_purchase_requirements_met = list() //For keeping track of ingame events that would unlock new shuttles, such as defeating a boss or discovering a secret item
 
 	var/lockdown = FALSE	//disallow transit after nuke goes off

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -10,7 +10,7 @@
 	var/admin_notes
 
 	var/credit_cost = INFINITY
-	var/can_be_bought = TRUE
+	var/emag_buy = FALSE
 
 	var/list/movement_force // If set, overrides default movement_force on shuttle
 
@@ -118,58 +118,45 @@
 
 /datum/map_template/shuttle/labour
 	port_id = "labour"
-	can_be_bought = FALSE
 
 /datum/map_template/shuttle/mining
 	port_id = "mining"
-	can_be_bought = FALSE
 
 /datum/map_template/shuttle/cargo
 	port_id = "cargo"
-	can_be_bought = FALSE
 
 /datum/map_template/shuttle/arrival
 	port_id = "arrival"
-	can_be_bought = FALSE
 
 /datum/map_template/shuttle/infiltrator
 	port_id = "infiltrator"
-	can_be_bought = FALSE
 
 /datum/map_template/shuttle/aux_base
 	port_id = "aux_base"
-	can_be_bought = FALSE
 
 /datum/map_template/shuttle/escape_pod
 	port_id = "escape_pod"
-	can_be_bought = FALSE
 
 /datum/map_template/shuttle/assault_pod
 	port_id = "assault_pod"
-	can_be_bought = FALSE
 
 /datum/map_template/shuttle/pirate
 	port_id = "pirate"
-	can_be_bought = FALSE
 
 /datum/map_template/shuttle/hunter
 	port_id = "hunter"
-	can_be_bought = FALSE
 
 /datum/map_template/shuttle/ruin //For random shuttles in ruins
 	port_id = "ruin"
-	can_be_bought = FALSE
 
 /datum/map_template/shuttle/snowdin
 	port_id = "snowdin"
-	can_be_bought = FALSE
 
 // Shuttles start here:
 
 /datum/map_template/shuttle/emergency/backup
 	suffix = "backup"
 	name = "Backup Shuttle"
-	can_be_bought = FALSE
 
 /datum/map_template/shuttle/emergency/construction
 	suffix = "construction"
@@ -208,7 +195,6 @@
 	name = "Emergency Pods"
 	description = "We did not expect an evacuation this quickly. All we have available is two escape pods."
 	admin_notes = "For player punishment."
-	can_be_bought = FALSE
 
 /datum/map_template/shuttle/emergency/russiafightpit
 	suffix = "russiafightpit"
@@ -216,6 +202,7 @@
 	description = "Dis is a high-quality shuttle, da. Many seats, lots of space, all equipment! Even includes entertainment! Such as lots to drink, and a fighting arena for drunk crew to have fun! If arena not fun enough, simply press button of releasing bears. Do not worry, bears trained not to break out of fighting pit, so totally safe so long as nobody stupid or drunk enough to leave door open. Try not to let asimov babycons ruin fun!"
 	admin_notes = "Includes a small variety of weapons. And bears. Only captain-access can release the bears. Bears won't smash the windows themselves, but they can escape if someone lets them."
 	credit_cost = 5000 // While the shuttle is rusted and poorly maintained, trained bears are costly.
+	emag_buy = TRUE
 
 /datum/map_template/shuttle/emergency/meteor
 	suffix = "meteor"
@@ -224,6 +211,7 @@
 	admin_notes = "This shuttle will likely crush escape, killing anyone there."
 	credit_cost = 15000
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
+	emag_buy = TRUE
 
 /datum/map_template/shuttle/emergency/luxury
 	suffix = "luxury"
@@ -238,6 +226,7 @@
 	description = "The glorious results of centuries of plasma research done by Nanotrasen employees. This is the reason why you are here. Get on and dance like you're on fire, burn baby burn!"
 	admin_notes = "Flaming hot. The main area has a dance machine as well as plasma floor tiles that will be ignited by players every single time."
 	credit_cost = 10000
+	emag_buy = TRUE
 
 /datum/map_template/shuttle/emergency/arena
 	suffix = "arena"
@@ -245,6 +234,7 @@
 	description = "The crew must pass through an otherworldy arena to board this shuttle. Expect massive casualties. The source of the Bloody Signal must be tracked down and eliminated to unlock this shuttle."
 	admin_notes = "RIP AND TEAR."
 	credit_cost = 10000
+	emag_buy = TRUE
 
 /datum/map_template/shuttle/emergency/arena/prerequisites_met()
 	if("bubblegum" in SSshuttle.shuttle_purchase_requirements_met)
@@ -309,6 +299,7 @@
 	description = "Due to a lack of functional emergency shuttles, we bought this second hand from a scrapyard and pressed it into service. Please do not lean too heavily on the exterior windows, they are fragile."
 	admin_notes = "An abomination with no functional medbay, sections missing, and some very fragile windows. Surprisingly airtight."
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
+	emag_buy = TRUE
 
 /datum/map_template/shuttle/emergency/narnar
 	suffix = "narnar"
@@ -344,6 +335,7 @@
 	It does, however, still dust anything on contact, emits high levels of radiation, and induce hallucinations in anyone looking at it without protective goggles. \
 	Emitters spawn powered on, expect admin notices, they are harmless."
 	credit_cost = 100000
+	emag_buy = TRUE
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
 
 /datum/map_template/shuttle/emergency/imfedupwiththisworld
@@ -352,7 +344,8 @@
 	description = "How was space work today? Oh, pretty good. We got a new space station and the company will make a lot of money. What space station? I cannot tell you; it's space confidential. \
 	Aw, come space on. Why not? No, I can't. Anyway, how is your space roleplay life?"
 	admin_notes = "Tiny, with a single airlock and wooden walls. What could go wrong?"
-	can_be_bought = FALSE
+	credit_cost = 7500
+	emag_buy = TRUE
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
 
 /datum/map_template/shuttle/emergency/goon
@@ -369,6 +362,7 @@
 	Needless to say, no engineering team wanted to go near the thing, and it's only being used as an Emergency Escape Shuttle because there is literally nothing else available."
 	admin_notes = "If the crew can solve the puzzle, they will wake the wabbajack statue. It will likely not end well. There's a reason it's boarded up. Maybe they should have just left it alone."
 	credit_cost = 15000
+	emag_buy = TRUE
 
 /datum/map_template/shuttle/emergency/omega
 	suffix = "omega"

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -154,10 +154,12 @@
 					if(SSshuttle.emergency.mode != SHUTTLE_RECALL && SSshuttle.emergency.mode != SHUTTLE_IDLE)
 						to_chat(usr, "It's a bit late to buy a new shuttle, don't you think?")
 						return
-					if(SSshuttle.shuttle_purchased)
+					if(SSshuttle.shuttle_purchased && (SSshuttle.emag_shuttle_purchased || !(obj_flags & EMAGGED)))
 						to_chat(usr, "A replacement shuttle has already been purchased.")
 					else if(!S.prerequisites_met())
 						to_chat(usr, "You have not met the requirements for purchasing this shuttle.")
+					else if(S.emag_buy && !(obj_flags & EMAGGED))
+						return //return silently, only way this could happen is an attempted href exploit
 					else
 						var/points_to_check
 						var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
@@ -165,6 +167,8 @@
 							points_to_check = D.account_balance
 						if(points_to_check >= S.credit_cost)
 							SSshuttle.shuttle_purchased = TRUE
+							if(obj_flags & EMAGGED)
+								SSshuttle.emag_shuttle_purchased = TRUE
 							SSshuttle.unload_preview()
 							SSshuttle.load_template(S)
 							SSshuttle.existing_shuttle = SSshuttle.emergency
@@ -559,7 +563,11 @@
 			dat += "<BR>"
 			for(var/shuttle_id in SSmapping.shuttle_templates)
 				var/datum/map_template/shuttle/S = SSmapping.shuttle_templates[shuttle_id]
-				if(S.can_be_bought && S.credit_cost < INFINITY)
+				if(S.credit_cost < INFINITY)
+					if(S.emag_buy)
+						if(!(obj_flags & EMAGGED))
+							continue
+						dat += "<font color=red>Warning: unverified shuttle!</font><BR>"
 					dat += "[S.name] | [S.credit_cost] Credits<BR>"
 					dat += "[S.description]<BR>"
 					if(S.prerequisites)


### PR DESCRIPTION
see: https://github.com/yogstation13/yogstation-2017-/pull/2728

Also removed an uncessary "can-be-bought" variable since the credit cost can do it just fine.

We shouldn't allow non-antags to buy hyper-fractal gigashuttles, or russian arena shuttles.

:cl:
tweak: you now need an emag to buy dangerous shuttles
/:cl:

(also it's entirely untested as per usual)