### PR TITLE
Removes the draft

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -214,7 +214,11 @@ SUBSYSTEM_DEF(ticker)
 		if(GLOB.master_mode == "secret")
 			hide_mode = 1
 			if(GLOB.secret_force_mode != "secret")
-				var/datum/game_mode/smode = config.pick_mode(GLOB.secret_force_mode)
+				var/datum/game_mode/smode 
+				if(runnable_modes.len)
+					smode = config.pick_mode(GLOB.secret_force_mode)
+				else 
+					smode = new /datum/game_mode/extended()
 				if(!smode.can_start())
 					message_admins("<span class='notice'>Unable to force secret [GLOB.secret_force_mode]. [smode.required_players] players and [smode.required_enemies] eligible antagonists needed.</span>")
 				else

--- a/yogstation/code/game/gamemodes/game_mode.dm
+++ b/yogstation/code/game/gamemodes/game_mode.dm
@@ -28,14 +28,5 @@
 				if(!player.quiet_round) //and must not want a quiet round
 					filtered_candidates |= player
 
-	var/diff = recommended_enemies - filtered_candidates.len // The difference between how many we need and how many we have
-	if(diff <= 0) // If the filtered candidates is bigger or just as big as what is required by the gamemode
-		return shuffle(filtered_candidates)
-
-	//DRAFTING
-	var/list/drafted = shuffle(candidates - filtered_candidates) // Takes all the candidates who were filtered out, shuffles'em, and prepares them for drafting
-	if(drafted.len > diff)
-		drafted.len = diff
-
-	return shuffle(filtered_candidates + drafted)
+	return shuffle(filtered_candidates) // No more drafting
 

--- a/yogstation/code/game/gamemodes/game_mode.dm
+++ b/yogstation/code/game/gamemodes/game_mode.dm
@@ -28,5 +28,5 @@
 				if(!player.quiet_round) //and must not want a quiet round
 					filtered_candidates |= player
 
-	return shuffle(filtered_candidates) // No more drafting
+	return shuffle(filtered_candidates)
 


### PR DESCRIPTION
### Intent of your Pull Request

Instead of forcing players to be antags that they don't want to be, we now don't run gamemodes without enough antags. If there's somehow a round where noone wants to be any available antag, it forces extended instead.

#### Changelog

:cl:  
tweak: You will no longer be drafted into an antag position that you don't want to be
tweak: The game will now run extended if it cannot run any other modes
/:cl:
