### PR TITLE
Adds dragnets to box armory

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -8822,7 +8822,7 @@
 /turf/open/floor/plating,
 /area/medical/sleeper)
 "arc" = (
-/obj/structure/table/reinforced,
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ard" = (
@@ -8842,10 +8842,12 @@
 /turf/closed/wall,
 /area/crew_quarters/dorms)
 "arg" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/item/gun/energy/e_gun/dragnet{
+	pixel_x = -2;
+	pixel_y = 2
 	},
-/obj/structure/table/reinforced,
+/obj/item/gun/energy/e_gun/dragnet,
+/obj/structure/rack,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "arh" = (
@@ -9773,12 +9775,11 @@
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
 "atl" = (
-/obj/structure/rack,
-/obj/item/storage/lockbox/loyalty,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+/obj/structure/window/reinforced{
+	dir = 4
 	},
+/obj/item/storage/lockbox/loyalty,
+/obj/structure/rack,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "atm" = (
@@ -18676,7 +18677,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aKh" = (
-/obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/camera/motion{
 	c_tag = "Armory Motion Sensor";
 	dir = 2
@@ -46853,6 +46853,14 @@
 "bNR" = (
 /turf/closed/wall,
 /area/hallway/primary/fore)
+"bNT" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/closet/secure_closet/brig,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "bOd" = (
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -88709,7 +88717,7 @@ aaa
 aaf
 aaa
 aaZ
-amN
+arc
 atX
 avB
 atX
@@ -88966,7 +88974,7 @@ aaa
 aaf
 aaa
 aaZ
-arc
+arg
 adl
 awX
 adl
@@ -89223,7 +89231,7 @@ aaa
 aaf
 aaa
 aaZ
-arg
+atl
 adl
 axd
 ada
@@ -90508,7 +90516,7 @@ aaa
 aaf
 aaa
 aaZ
-atl
+bNT
 auN
 azP
 aqH


### PR DESCRIPTION
Gets rid of those disgusting empty tables, plus these are on the other maps just not box.

:cl:  
rscadd: DRAGnets have been added to the Yogbox armory.
/:cl: