### PR TITLE
Xeno queen can now disable their hostile environment

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -17,7 +17,7 @@
 	. = ..()
 
 /obj/machinery/computer/emergency_shuttle/attack_alien(mob/living/carbon/alien/humanoid/user)
-	if(istype(user, /mob/living/carbon/alien/humanoid/royal/queen)
+	if(istype(user, /mob/living/carbon/alien/humanoid/royal/queen) 
 		SSshuttle.clearHostileEnvironment(user)
 
 /obj/machinery/computer/emergency_shuttle/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.human_adjacent_state)

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -17,7 +17,7 @@
 	. = ..()
 
 /obj/machinery/computer/emergency_shuttle/attack_alien(mob/living/carbon/alien/humanoid/user)
-	if(istype(user, /mob/living/carbon/alien/humanoid/royal/queen) 
+	if(istype(user, /mob/living/carbon/alien/humanoid/royal/queen))
 		SSshuttle.clearHostileEnvironment(user)
 
 /obj/machinery/computer/emergency_shuttle/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.human_adjacent_state)

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -17,7 +17,8 @@
 	. = ..()
 
 /obj/machinery/computer/emergency_shuttle/attack_alien(mob/living/carbon/alien/humanoid/user)
-	SSshuttle.clearHostileEnvironment(user)
+	if(istype(user, /mob/living/carbon/alien/humanoid/royal/queen)
+		SSshuttle.clearHostileEnvironment(user)
 
 /obj/machinery/computer/emergency_shuttle/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.human_adjacent_state)
 

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -16,6 +16,9 @@
 		say("Please equip your ID card into your ID slot to authenticate.")
 	. = ..()
 
+/obj/machinery/computer/emergency_shuttle/attack_alien(mob/living/carbon/alien/humanoid/user)
+	SSshuttle.clearHostileEnvironment(user)
+
 /obj/machinery/computer/emergency_shuttle/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.human_adjacent_state)
 
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)


### PR DESCRIPTION
attacking the emergency shuttle console as the xeno queen will clear the hostile environment warning caused by the queen early

:cl:   
tweak: xeno queens can smack the emergency shuttle console to clear the xeno hostile environment rather than waiting it out
/:cl:
