### PR TITLE
Airlock scanner fixes

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -2,6 +2,15 @@
 //////////Autolathe Designs ///////
 ///////////////////////////////////
 
+/datum/design/airlock_scanner
+	name = "Airlock scanner"
+	id = "airlock_scanner"
+	build_type = AUTOLATHE | PROTOLATHE
+	materials = list(MAT_METAL = 50, MAT_GLASS = 50)
+	build_path = /obj/item/airlock_scanner
+	category = list("initial","Tools","Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
+
 /datum/design/bucket
 	name = "Bucket"
 	id = "bucket"

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2980,7 +2980,7 @@
 #include "yogstation\code\game\objects\effects\decals\turfdecal\markings.dm"
 #include "yogstation\code\game\objects\effects\decals\turfdecal\tilecoloring.dm"
 #include "yogstation\code\game\objects\effects\spawner\structure.dm"
-#include "yogstation\code\game\objects\items\airlock_scaner.dm"
+#include "yogstation\code\game\objects\items\airlock_scanner.dm"
 #include "yogstation\code\game\objects\items\bandage.dm"
 #include "yogstation\code\game\objects\items\brace.dm"
 #include "yogstation\code\game\objects\items\cards_ids.dm"

--- a/yogstation/code/game/objects/items/airlock_scanner.dm
+++ b/yogstation/code/game/objects/items/airlock_scanner.dm
@@ -1,7 +1,7 @@
 /obj/item/airlock_scanner
 	name = "access scanner"
-	desc = "A tool used to idetifying access requiremnts of various machinery. Make sure airlocks id scan routines were activated at least once before the scan"
-	icon = 'icons/obj/objects.dmi'
+	desc = "A tool used to identify the access requirements of various machinery. Only works on airlocks that have previously used their ID scan."
+	icon = 'yogstation/icons/obj/objects.dmi'
 	icon_state = "airlock_scanner"
 
 	w_class = WEIGHT_CLASS_SMALL

--- a/yogstation/code/modules/research/designs/autolathe_designs.dm
+++ b/yogstation/code/modules/research/designs/autolathe_designs.dm
@@ -1,8 +1,0 @@
-/datum/design/airlock_scaner
-	name = "Airlock scanner"
-	id = "airlock_scaner"
-	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(MAT_METAL = 50, MAT_GLASS = 50)
-	build_path = /obj/item/airlock_scaner
-	category = list("initial","Tools","Tool Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING


### PR DESCRIPTION
Sprite, description, file name. Moves code out of the yogstation folder.

Fixes #6977

:cl:   
imageadd: The airlock scanner is no longer invisible.
/:cl:
