### PR TITLE
Beepsky can no longer become sentient via sentient animals event

### DIFF
--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -13,7 +13,6 @@ GLOBAL_LIST_INIT(high_priority_sentience, typecacheof(list(
 	/mob/living/simple_animal/hostile/retaliate/poison/snake,
 	/mob/living/simple_animal/hostile/retaliate/goose/vomit,
 	/mob/living/simple_animal/bot/mulebot,
-	/mob/living/simple_animal/bot/secbot/beepsky
 )))
 
 /datum/round_event_control/sentience


### PR DESCRIPTION
### Intent of your Pull Request

idk why anyone thought to give beepsky 400 hp and sentience was a good idea

#### Changelog

:cl:  
rscdel: sentient beepsky qdel'd
/:cl:
