### PR TITLE
Plasma tank objective now checks for 28 moles across all tanks, not 28 moles in one tank

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -504,6 +504,7 @@ GLOBAL_LIST_EMPTY(possible_items)
 /datum/objective/steal/proc/set_target(datum/objective_item/item)
 	if(item)
 		targetinfo = item
+		targetinfo.objective = src
 		steal_target = targetinfo.targetitem
 		explanation_text = "Steal [targetinfo.name]"
 		give_special_equipment(targetinfo.special_equipment)

--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -7,6 +7,7 @@
 	var/list/excludefromjob = list()				//If you don't want a job to get a certain objective (no captain stealing his own medal, etcetc)
 	var/list/altitems = list()				//Items which can serve as an alternative to the objective (darn you blueprints)
 	var/list/special_equipment = list()
+	var/datum/objective/steal/objective		//The objective datum for our objective
 
 /datum/objective_item/proc/check_special_completion() //for objectives with special checks (is that slime extract unused? does that intellicard have an ai in it? etcetc)
 	return 1
@@ -121,10 +122,10 @@
 	difficulty = 3
 	excludefromjob = list("Chief Engineer","Research Director","Station Engineer","Scientist","Atmospheric Technician")
 
-/datum/objective_item/steal/plasma/check_completion() //So special that not even check_special_completion is good enough for it
+/datum/objective_item/steal/plasma/check_special_completion() //So special that not even check_special_completion is good enough for it
 	var/target_amount = text2num(name)
 	var/found_amount = 0
-	for(var/datum/mind/M in get_owners())
+	for(var/datum/mind/M in objective.get_owners())
 		if(!isliving(M.current))
 			continue
 

--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -122,7 +122,7 @@
 	difficulty = 3
 	excludefromjob = list("Chief Engineer","Research Director","Station Engineer","Scientist","Atmospheric Technician")
 
-/datum/objective_item/steal/plasma/check_special_completion() //So special that not even check_special_completion is good enough for it
+/datum/objective_item/steal/plasma/check_special_completion()
 	var/target_amount = text2num(name)
 	var/found_amount = 0
 	for(var/datum/mind/M in objective.get_owners())

--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -124,7 +124,7 @@
 /datum/objective_item/steal/plasma/check_completion() //So special that not even check_special_completion is good enough for it
 	var/target_amount = text2num(name)
 	var/found_amount = 0
-	for(var/datum/mind/M in owners)
+	for(var/datum/mind/M in get_owners())
 		if(!isliving(M.current))
 			continue
 

--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -121,11 +121,21 @@
 	difficulty = 3
 	excludefromjob = list("Chief Engineer","Research Director","Station Engineer","Scientist","Atmospheric Technician")
 
-/datum/objective_item/steal/plasma/check_special_completion(obj/item/tank/T)
+/datum/objective_item/steal/plasma/check_completion() //So special that not even check_special_completion is good enough for it
 	var/target_amount = text2num(name)
 	var/found_amount = 0
-	found_amount += T.air_contents.gases[/datum/gas/plasma] ? T.air_contents.gases[/datum/gas/plasma][MOLES] : 0
-	return found_amount>=target_amount
+	for(var/datum/mind/M in owners)
+		if(!isliving(M.current))
+			continue
+
+		var/list/all_items = M.current.GetAllContents()
+		for(var/o in all_items)
+			if(!istype(o, /obj/item/tank))
+				continue
+			var/obj/item/tank/T = o
+			found_amount += T.air_contents.gases[/datum/gas/plasma] ? T.air_contents.gases[/datum/gas/plasma][MOLES] : 0
+
+	return found_amount >= target_amount
 
 
 /datum/objective_item/steal/functionalai


### PR DESCRIPTION
This is something that has always come up intermittently, and it honestly surprises me that noone did this sooner.

closes: #6994 
#### Changelog

:cl:  
tweak: the "steal a full plasma tank" objective now checks for the equivalent to a full tank, not necessarily a single full tank.
/:cl:
