### PR TITLE
War ops less people

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -1,6 +1,6 @@
 #define CHALLENGE_TELECRYSTALS 280
 #define CHALLENGE_TIME_LIMIT 3000
-#define CHALLENGE_MIN_PLAYERS 50
+#define CHALLENGE_MIN_PLAYERS 40
 #define CHALLENGE_SHUTTLE_DELAY 15000 // 25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
 
 GLOBAL_LIST_EMPTY(jam_on_wardec)

--- a/code/modules/holiday/halloween.dm
+++ b/code/modules/holiday/halloween.dm
@@ -46,7 +46,7 @@
 /obj/structure/closet/proc/set_spooky_trap()
 	if(prob(0.1))
 		trapped = INSANE_CLOWN
-		returncode/modules/holiday/halloween.dm
+		return
 	if(prob(1))
 		trapped = ANGRY_FAITHLESS
 		return

--- a/code/modules/holiday/halloween.dm
+++ b/code/modules/holiday/halloween.dm
@@ -46,7 +46,7 @@
 /obj/structure/closet/proc/set_spooky_trap()
 	if(prob(0.1))
 		trapped = INSANE_CLOWN
-		return
+		returncode/modules/holiday/halloween.dm
 	if(prob(1))
 		trapped = ANGRY_FAITHLESS
 		return


### PR DESCRIPTION
### Intent of your Pull Request
allows nuke ops to declare war at 40 people. as for the past month or two its been impossible to do war ops and war ops is the best part of nuclear operatives
#### Changelog

:cl:  
tweak: tweaked the number of players required for nuke ops to declare war
/:cl:
