### PR TITLE
Changes (probably) all the times that Clock Cult uses watts to joules

### DIFF
--- a/code/__DEFINES/clockcult.dm
+++ b/code/__DEFINES/clockcult.dm
@@ -7,7 +7,7 @@
 
 GLOBAL_VAR_INIT(clockwork_construction_value, 0) //The total value of all structures built by the clockwork cult
 GLOBAL_VAR_INIT(clockwork_vitality, 0) //How much Vitality is stored, total
-GLOBAL_VAR_INIT(clockwork_power, 0) //How many watts of power are globally available to the clockwork cult
+GLOBAL_VAR_INIT(clockwork_power, 0) //How many joules of power are globally available to the clockwork cult
 
 GLOBAL_LIST_EMPTY(all_clockwork_objects) //All clockwork items, structures, and effects in existence
 GLOBAL_LIST_EMPTY(all_clockwork_mobs) //All clockwork SERVANTS (not creatures) in existence
@@ -28,7 +28,7 @@ GLOBAL_LIST_EMPTY(all_scripture) //a list containing scripture instances; not us
 #define SCRIPTURE_APPLICATION "Application"
 
 //Various costs related to power.
-#define MAX_CLOCKWORK_POWER 50000 //The max power in W that the cult can stockpile
+#define MAX_CLOCKWORK_POWER 50000 //The max power in J that the cult can stockpile
 #define SCRIPT_UNLOCK_THRESHOLD 25000 //Scripts will unlock if the total power reaches this amount
 #define APPLICATION_UNLOCK_THRESHOLD 40000 //Applications will unlock if the total powre reaches this amount
 

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -453,7 +453,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 				time_name = "until the Ark finishes summoning"
 			if(time_info)
 				textlist += "<b>[time_info / 60] minutes</b> [time_name].<br>"
-		textlist += "<b>[DisplayPower(get_clockwork_power())] / [DisplayPower(MAX_CLOCKWORK_POWER)]</b> power available for use."
+		textlist += "<b>[DisplayEnergy(get_clockwork_power())] / [DisplayEnergy(MAX_CLOCKWORK_POWER)]</b> power available for use."
 		desc = textlist.Join()
 	..()
 

--- a/code/modules/antagonists/clockcult/clock_effects/clock_sigils.dm
+++ b/code/modules/antagonists/clockcult/clock_effects/clock_sigils.dm
@@ -196,7 +196,7 @@
 		var/structure_number = 0
 		for(var/obj/structure/destructible/clockwork/powered/P in range(SIGIL_ACCESS_RANGE, src))
 			structure_number++
-		. += {"<span class='[get_clockwork_power() ? "brass":"alloy"]'>It is storing <b>[DisplayPower(get_clockwork_power())]</b> of shared power, 
+		. += {"<span class='[get_clockwork_power() ? "brass":"alloy"]'>It is storing <b>[DisplayEnergy(get_clockwork_power())]</b> of shared power,
 		and <b>[structure_number]</b> clockwork structure[structure_number == 1 ? " is":"s are"] in range.</span>"}
 		if(iscyborg(user))
 			. += "<span class='brass'>You can recharge from the [sigil_name] by crossing it.</span>"

--- a/code/modules/antagonists/clockcult/clock_helpers/power_helpers.dm
+++ b/code/modules/antagonists/clockcult/clock_helpers/power_helpers.dm
@@ -24,7 +24,7 @@
 		hierophant_message(unlock_message)
 	return TRUE
 
-/proc/can_access_clockwork_power(atom/movable/access_point, amount) //Returns true if the access point has access to clockwork power (and optionally, a number of watts for it)
+/proc/can_access_clockwork_power(atom/movable/access_point, amount) //Returns true if the access point has access to clockwork power (and optionally, a number of joules for it)
 	if(amount && !get_clockwork_power(amount)) //No point in trying if we don't have the power anyway
 		return
 	var/list/possible_conduits = view(5, access_point)

--- a/code/modules/antagonists/clockcult/clock_items/clockwork_slab.dm
+++ b/code/modules/antagonists/clockcult/clock_items/clockwork_slab.dm
@@ -437,7 +437,7 @@
 			var/list/temp_info = list("name" = "<font color=[scripture_color]><b>[S.name]</b></font>",
 			"descname" = "<font color=[scripture_color]>([S.descname])</font>",
 			"tip" = "[S.desc]\n[S.usage_tip]",
-			"required" = "([DisplayPower(S.power_cost)][S.special_power_text ? "+ [replacetext(S.special_power_text, "POWERCOST", "[DisplayEnergy(S.special_power_cost)]")]" : ""])",
+			"required" = "([DisplayEnergy(S.power_cost)][S.special_power_text ? "+ [replacetext(S.special_power_text, "POWERCOST", "[DisplayEnergy(S.special_power_cost)]")]" : ""])",
 			"type" = "[S.type]",
 			"quickbind" = S.quickbind)
 			if(S.important)

--- a/code/modules/antagonists/clockcult/clock_items/clockwork_slab.dm
+++ b/code/modules/antagonists/clockcult/clock_items/clockwork_slab.dm
@@ -128,7 +128,7 @@
 					continue
 				var/datum/clockwork_scripture/quickbind_slot = quickbound[i]
 				. += "<b>Quickbind</b> button: <span class='[get_component_span(initial(quickbind_slot.primary_component))]'>[initial(quickbind_slot.name)]</span>."
-		. += "<b>Available power:</b> <span class='bold brass'>[DisplayPower(get_clockwork_power())].</span>"
+		. += "<b>Available power:</b> <span class='bold brass'>[DisplayEnergy(get_clockwork_power())].</span>"
 
 //Slab actions; Hierophant, Quickbind
 /obj/item/clockwork/slab/ui_action_click(mob/user, action)
@@ -337,7 +337,7 @@
 			anything but a last resort. Instead, it is recommended that a <b>Sigil of Transmission</b> is created. This sigil serves as both battery  and power generator for nearby clockwork \
 			structures, and those structures will happily draw power from the sigil before they resort to APCs.<br><br>"
 			dat += "Generating power is less easy. The most reliable and efficient way is using brass sheets; attacking a sigil of transmission with brass sheets will convert them \
-			to power, at a rate of <b>[DisplayPower(POWER_FLOOR)]</b> per sheet. (Brass sheets are created from replica fabricators, which are explained more in detail in the <b>Conversion</b> section.) \
+			to power, at a rate of <b>[DisplayEnergy(POWER_FLOOR)]</b> per sheet. (Brass sheets are created from replica fabricators, which are explained more in detail in the <b>Conversion</b> section.) \
 			Activating a sigil of transmission will also cause it to drain power from the nearby area, which, while effective, serves as an obvious tell that there is something wrong.<br><br>"
 			dat += "Without power, many structures will not function, making a base vulnerable to attack. For this reason, it is critical that you keep an eye on your power reserves and \
 			ensure that they remain comfortably high.<br><br>"
@@ -405,7 +405,7 @@
 
 /obj/item/clockwork/slab/ui_data(mob/user) //we display a lot of data via TGUI
 	var/list/data = list()
-	data["power"] = "<b><font color=#B18B25>[DisplayPower(get_clockwork_power())]</b> power is available for scripture and other consumers.</font>"
+	data["power"] = "<b><font color=#B18B25>[DisplayEnergy(get_clockwork_power())]</b> power is available for scripture and other consumers.</font>"
 
 	switch(selected_scripture) //display info based on selected scripture tier
 		if(SCRIPTURE_DRIVER)
@@ -414,12 +414,12 @@
 			if(GLOB.scripture_states[SCRIPTURE_SCRIPT])
 				data["tier_info"] = "<font color=#B18B25><b>These scriptures are permanently unlocked.</b></font>"
 			else
-				data["tier_info"] = "<font color=#B18B25><i>These scriptures will automatically unlock when the Ark is halfway ready or if [DisplayPower(SCRIPT_UNLOCK_THRESHOLD)] of power is reached.</i></font>"
+				data["tier_info"] = "<font color=#B18B25><i>These scriptures will automatically unlock when the Ark is halfway ready or if [DisplayEnergy(SCRIPT_UNLOCK_THRESHOLD)] of power is reached.</i></font>"
 		if(SCRIPTURE_APPLICATION)
 			if(GLOB.scripture_states[SCRIPTURE_APPLICATION])
 				data["tier_info"] = "<font color=#B18B25><b>These scriptures are permanently unlocked.</b></font>"
 			else
-				data["tier_info"] = "<font color=#B18B25><i>Unlock these optional scriptures by converting another servant or if [DisplayPower(APPLICATION_UNLOCK_THRESHOLD)] of power is reached..</i></font>"
+				data["tier_info"] = "<font color=#B18B25><i>Unlock these optional scriptures by converting another servant or if [DisplayEnergy(APPLICATION_UNLOCK_THRESHOLD)] of power is reached..</i></font>"
 
 	data["selected"] = selected_scripture
 	data["scripturecolors"] = "<font color=#DAAA18>Scriptures in <b>yellow</b> are related to construction and building.</font><br>\
@@ -437,7 +437,7 @@
 			var/list/temp_info = list("name" = "<font color=[scripture_color]><b>[S.name]</b></font>",
 			"descname" = "<font color=[scripture_color]>([S.descname])</font>",
 			"tip" = "[S.desc]\n[S.usage_tip]",
-			"required" = "([DisplayPower(S.power_cost)][S.special_power_text ? "+ [replacetext(S.special_power_text, "POWERCOST", "[DisplayPower(S.special_power_cost)]")]" : ""])",
+			"required" = "([DisplayPower(S.power_cost)][S.special_power_text ? "+ [replacetext(S.special_power_text, "POWERCOST", "[DisplayEnergy(S.special_power_cost)]")]" : ""])",
 			"type" = "[S.type]",
 			"quickbind" = S.quickbind)
 			if(S.important)

--- a/code/modules/antagonists/clockcult/clock_items/replica_fabricator.dm
+++ b/code/modules/antagonists/clockcult/clock_items/replica_fabricator.dm
@@ -49,22 +49,22 @@
 		. += {"<span class='brass'>Can be used to replace walls, floors, tables, windows, windoors, and airlocks with Clockwork variants.</span>\n
 			<span class='brass'>Can construct Clockwork Walls on Clockwork Floors and deconstruct Clockwork Walls to Clockwork Floors.</span>"}
 		if(uses_power)
-			. += {"<span class='alloy'>It can consume floor tiles, rods, metal, and plasteel for power at rates of <b>2:[DisplayPower(POWER_ROD)]</b>, <b>1:[DisplayPower(POWER_ROD)]</b>, <b>1:[DisplayPower(POWER_METAL)]</b>, \
-			and <b>1:[DisplayPower(POWER_PLASTEEL)]</b>, respectively.</span>\n
-			<span class='alloy'>It can also consume brass sheets for power at a rate of <b>1:[DisplayPower(POWER_FLOOR)]</b>.</span>\n
-			<span class='alloy'>Use it in-hand to produce <b>5</b> brass sheets at a cost of <b>[DisplayPower(POWER_WALL_TOTAL)]</b> power.</span>\n
-			<span class='alloy'>It has access to <b>[DisplayPower(get_clockwork_power())]</b> of power.</span>"}
+			. += {"<span class='alloy'>It can consume floor tiles, rods, metal, and plasteel for power at rates of <b>2:[DisplayEnergy(POWER_ROD)]</b>, <b>1:[DisplayEnergy(POWER_ROD)]</b>, <b>1:[DisplayEnergy(POWER_METAL)]</b>, \
+			and <b>1:[DisplayEnergy(POWER_PLASTEEL)]</b>, respectively.</span>\n
+			<span class='alloy'>It can also consume brass sheets for power at a rate of <b>1:[DisplayEnergy(POWER_FLOOR)]</b>.</span>\n
+			<span class='alloy'>Use it in-hand to produce <b>5</b> brass sheets at a cost of <b>[DisplayEnergy(POWER_WALL_TOTAL)]</b> power.</span>\n
+			<span class='alloy'>It has access to <b>[DisplayEnergy(get_clockwork_power())]</b> of power.</span>"}
 
 /obj/item/clockwork/replica_fabricator/attack_self(mob/living/user)
 	if(is_servant_of_ratvar(user))
 		if(uses_power)
 			if(!get_clockwork_power(POWER_WALL_TOTAL))
-				to_chat(user, "<span class='warning'>[src] requires <b>[DisplayPower(POWER_WALL_TOTAL)]</b> of power to produce brass sheets!</span>")
+				to_chat(user, "<span class='warning'>[src] requires <b>[DisplayEnergy(POWER_WALL_TOTAL)]</b> of power to produce brass sheets!</span>")
 				return
 			adjust_clockwork_power(-POWER_WALL_TOTAL)
 		playsound(src, 'sound/items/deconstruct.ogg', 50, 1)
 		new/obj/item/stack/tile/brass(user.loc, 5)
-		to_chat(user, "<span class='brass'>You use [get_clockwork_power() ? "some":"all"] of [src]'s power to produce <b>5</b> brass sheets. It now has access to <b>[DisplayPower(get_clockwork_power())]</b> of power.</span>")
+		to_chat(user, "<span class='brass'>You use [get_clockwork_power() ? "some":"all"] of [src]'s power to produce <b>5</b> brass sheets. It now has access to <b>[DisplayEnergy(get_clockwork_power())]</b> of power.</span>")
 
 /obj/item/clockwork/replica_fabricator/pre_attack(atom/target, mob/living/user, params)
 	if(!target || !user || !is_servant_of_ratvar(user) || istype(target, /obj/item/storage))
@@ -177,7 +177,7 @@
 			if(!silent)
 				var/atom/A = fabrication_values["new_obj_type"]
 				if(A)
-					to_chat(user, "<span class='warning'>You need <b>[DisplayPower(fabrication_values["power_cost"])]</b> power to fabricate \a [initial(A.name)] from [target]!</span>")
+					to_chat(user, "<span class='warning'>You need <b>[DisplayEnergy(fabrication_values["power_cost"])]</b> power to fabricate \a [initial(A.name)] from [target]!</span>")
 		return FALSE
 	return TRUE
 
@@ -217,7 +217,7 @@
 	repair_values["power_required"] = round(repair_values["healing_for_cycle"]*MIN_CLOCKCULT_POWER, MIN_CLOCKCULT_POWER) //and get the power cost from that
 	if(!GLOB.ratvar_awakens && !get_clockwork_power(repair_values["power_required"]))
 		if(!silent)
-			to_chat(user, "<span class='warning'>You need at least <b>[DisplayPower(repair_values["power_required"])]</b> power to start repairin[target == user ? "g yourself" : "g [target]"], and at least \
-			<b>[DisplayPower(repair_values["amount_to_heal"]*MIN_CLOCKCULT_POWER, MIN_CLOCKCULT_POWER)]</b> to fully repair [target == user ? "yourself" : "[target.p_them()]"]!</span>")
+			to_chat(user, "<span class='warning'>You need at least <b>[DisplayEnergy(repair_values["power_required"])]</b> power to start repairin[target == user ? "g yourself" : "g [target]"], and at least \
+			<b>[DisplayEnergy(repair_values["amount_to_heal"]*MIN_CLOCKCULT_POWER, MIN_CLOCKCULT_POWER)]</b> to fully repair [target == user ? "yourself" : "[target.p_them()]"]!</span>")
 		return FALSE
 	return TRUE

--- a/code/modules/antagonists/clockcult/clock_scripture.dm
+++ b/code/modules/antagonists/clockcult/clock_scripture.dm
@@ -10,7 +10,7 @@ Applications: 8 servants, 3 caches, and 100 CV
 GLOBAL_LIST_INIT(scripture_states,scripture_states_init_value()) //list of clockcult scripture states for announcements
 
 /proc/scripture_states_init_value()
-	return list(SCRIPTURE_DRIVER = TRUE, SCRIPTURE_SCRIPT = FALSE, SCRIPTURE_APPLICATION = FALSE) 
+	return list(SCRIPTURE_DRIVER = TRUE, SCRIPTURE_SCRIPT = FALSE, SCRIPTURE_APPLICATION = FALSE)
 
 /datum/clockwork_scripture
 	var/descname = "useless" //a simple name for the scripture's effect
@@ -92,7 +92,7 @@ GLOBAL_LIST_INIT(scripture_states,scripture_states_init_value()) //list of clock
 	if(!GLOB.ratvar_awakens && !slab.no_cost)
 		checked_penalty = check_offstation_penalty()
 		if(!get_clockwork_power(power_cost))
-			to_chat(invoker, "<span class='warning'>There isn't enough power to recite this scripture! ([DisplayPower(get_clockwork_power())]/[DisplayPower(power_cost)])</span>")
+			to_chat(invoker, "<span class='warning'>There isn't enough power to recite this scripture! ([DisplayEnergy(get_clockwork_power())]/[DisplayEnergy(power_cost)])</span>")
 			return
 	if(multiple_invokers_used && !multiple_invokers_optional && !GLOB.ratvar_awakens && !slab.no_cost)
 		var/nearby_servants = 0

--- a/code/modules/antagonists/clockcult/clock_structure.dm
+++ b/code/modules/antagonists/clockcult/clock_structure.dm
@@ -160,7 +160,7 @@
 		if(!can_access_clockwork_power(src))
 			. += "<span class='alloy'>It has no access to the power network! Create a sigil of transmission nearby.</span>"
 		else
-			. += "<span class='brass'>It has access to <b>[DisplayPower(get_clockwork_power())]</b> of power.</span>"
+			. += "<span class='brass'>It has access to <b>[DisplayEnergy(get_clockwork_power())]</b> of power.</span>"
 
 /obj/structure/destructible/clockwork/powered/Destroy()
 	SSfastprocess.processing -= src

--- a/code/modules/antagonists/clockcult/clock_structures/clockwork_obelisk.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/clockwork_obelisk.dm
@@ -23,7 +23,7 @@
 /obj/structure/destructible/clockwork/powered/clockwork_obelisk/examine(mob/user)
 	. = ..()
 	if(is_servant_of_ratvar(user) || isobserver(user))
-		. += "<span class='nzcrentr_small'>It requires <b>[DisplayPower(hierophant_cost)]</b> to broadcast over the Hierophant Network, and <b>[DisplayPower(gateway_cost)]</b> to open a Spatial Gateway.</span>"
+		. += "<span class='nzcrentr_small'>It requires <b>[DisplayEnergy(hierophant_cost)]</b> to broadcast over the Hierophant Network, and <b>[DisplayEnergy(gateway_cost)]</b> to open a Spatial Gateway.</span>"
 
 /obj/structure/destructible/clockwork/powered/clockwork_obelisk/can_be_unfasten_wrench(mob/user, silent)
 	if(active)

--- a/code/modules/antagonists/clockcult/clock_structures/mania_motor.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/mania_motor.dm
@@ -19,7 +19,7 @@
 /obj/structure/destructible/clockwork/powered/mania_motor/examine(mob/user)
 	. = ..()
 	if(is_servant_of_ratvar(user) || isobserver(user))
-		. += "<span class='sevtug_small'>It requires <b>[DisplayPower(mania_cost)]</b> to run.</span>"
+		. += "<span class='sevtug_small'>It requires <b>[DisplayEnergy(mania_cost)]</b> to run.</span>"
 
 /obj/structure/destructible/clockwork/powered/mania_motor/forced_disable(bad_effects)
 	if(active)


### PR DESCRIPTION
Changes (probably) all the times Clock Cult uses the term watts to joules

If you do not understand what either joules or watts means lemme give you a quick physics lesson: Watts are a calculation of how much energy is being used in a second and since joules are a way to denote energy you can calculate watts, among other ways, as `W = J / second` e.g. 100 joules per second is 100 watts and 400 joules per two seconds is 200 watts.

Now that that's out of the way, why is this necessary? Well since watts are a calculation of how much energy is being used second by second and Clock Cult uses it's power as one off thing (Clock Cultist uses this much power to do this in this instance) it doesn't really make sense to measure it in watts rather joules.

No recalculations were changed in this PR, just how it describes the numbers. Also since there are a lot places in which the code did the thing to classify it as watts there's a chance I missed a few.

Some Pictures:
![1](https://user-images.githubusercontent.com/5571930/68505496-5d4bea80-0235-11ea-8904-8b191f1e8a50.png)
![2](https://user-images.githubusercontent.com/5571930/68505505-5e7d1780-0235-11ea-97d5-0b6b5aca8bbf.png)


:cl:  
tweak:  The Clock Cult now calculates their power in joules rather than watts 
/:cl:
