### PR TITLE
The Energy Harvesting Module(zap into dosh)

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -32,6 +32,7 @@
 	new /obj/item/circuitboard/machine/techfab/department/engineering(src)
 	new /obj/item/extinguisher/advanced(src)
 	new /obj/item/storage/photo_album/CE(src)
+	new /obj/item/energy_harvester(src)
 
 /obj/structure/closet/secure_closet/engineering_electrical
 	name = "electrical supplies locker"

--- a/code/modules/power/energyharvester.dm
+++ b/code/modules/power/energyharvester.dm
@@ -12,7 +12,7 @@
 	throw_speed = 1
 	throw_range = 1
 	materials = list(MAT_METAL=750)
-	var/drain_rate = 1000000
+	var/drain_rate = 100000000
 	var/power_drained = 0
 
 	var/obj/structure/cable/attached
@@ -59,4 +59,4 @@
 		attached.add_delayedload(power_avaliable)
 		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_ENG)
 		if(D)
-			D.adjust_money(power_avaliable * 0.0001)
+			D.adjust_money(power_avaliable * 0.000005)

--- a/code/modules/power/energyharvester.dm
+++ b/code/modules/power/energyharvester.dm
@@ -1,0 +1,62 @@
+/obj/item/energy_harvester
+	desc = "A Device which upon connection to a node, will harvest the energy and send it to engineerless stations in return for credits, derived from a syndicate powersink model."
+	name = "Energy Harvesting Module"
+	icon_state = "powersink0"
+	icon = 'icons/obj/device.dmi'
+	item_state = "electronic"
+	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
+	w_class= WEIGHT_CLASS_BULKY
+	flags_1 = CONDUCT_1
+	throwforce = 1
+	throw_speed = 1
+	throw_range = 1
+	materials = list(MAT_METAL=750)
+	var/drain_rate = 1000000
+	var/power_drained = 0
+
+	var/obj/structure/cable/attached
+
+
+/obj/item/energy_harvester/attackby(obj/item/I, mob/user, params)
+	if(I.tool_behaviour == TOOL_SCREWDRIVER)
+		if(!anchored)
+			var/turf/T = loc
+			if(isturf(T) && !T.intact)
+				attached = locate() in T
+				if(!attached)
+					to_chat(user, "<span class='warning'>This device must be placed over an exposed, powered cable node!</span>")
+				else
+					START_PROCESSING(SSobj, src)
+					anchored = 1
+					density = 1
+					user.visible_message( \
+						"[user] attaches \the [src] to the cable.", \
+						"<span class='notice'>You attach \the [src] to the cable.</span>",
+						"<span class='italics'>You hear some wires being connected to something.</span>")
+			else
+				to_chat(user, "<span class='warning'>This device must be placed over an exposed, powered cable node!</span>")
+		else
+			STOP_PROCESSING(SSobj, src)
+			anchored = 0
+			density = 0
+			user.visible_message( \
+				"[user] detaches \the [src] from the cable.", \
+				"<span class='notice'>You detach \the [src] from the cable.</span>",
+				"<span class='italics'>You hear some wires being disconnected from something.</span>")
+
+/obj/item/energy_harvester/process()
+	if(!attached || !anchored)
+		return PROCESS_KILL
+
+	var/datum/powernet/PN = attached.powernet
+	if(PN)
+		set_light(5)
+		var/power_avaliable =  PN.netexcess
+		if(power_avaliable <= 0)
+			return
+		power_avaliable = min(power_avaliable, drain_rate)
+		attached.add_delayedload(power_avaliable)
+		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_ENG)
+		if(D)
+			D.adjust_money(power_avaliable * 0.0001)

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2353,6 +2353,7 @@
 #include "code\modules\power\apc.dm"
 #include "code\modules\power\cable.dm"
 #include "code\modules\power\cell.dm"
+#include "code\modules\power\energyharvester.dm"
 #include "code\modules\power\floodlight.dm"
 #include "code\modules\power\generator.dm"
 #include "code\modules\power\gravitygenerator.dm"


### PR DESCRIPTION
### Intent of your Pull Request

Please note, that things in this PR will be most likely subject to change, based on community feedback, and this is my first "original pr" with some help since I'm rusty(fuck you goon you have done everything good ok not my fault i have to take _"inspiration"_ from you fuck you and your fart comedy)

The Energy Harvesting Module is a Module derived from the powersink that uses a process of static bluespace teleportation to help engineerless stations in return for cash money
Basically, it chews up the excess power in the power network(don't want this being a literal power sink)
and spits out some CASH MONAY with the more you put in, the more you get out, with a current cap of about 3,000 per minute(which ain't that bad nor that good) requiring a **thicc ass load of 1MW**

My intent with this is a couple of things
1-Reward engineers for experimenting with setups for power, promoting a more educated engineering player base and not bots doing the same fucking sm setup 20 times in a row with no volume pumps or optimization 
2-Allow engineers to fund their own autism projects through learning how those projects work.

The Energy Harvesting Module spawns in the CE Locker,and is attached with a screwdriver on an open wire node, looking like a traditional syndicate power sink.
If you need any clarification just ask,edits can be made.

To clear any suspicion that I am being held hostage by the engineer mains,I am not,I love the engineers from team defense station 2.
Halo
Echo
Lima
Plant
#### Changelog

:cl:  
rscadd: Adds the Energy harvesting module,Turn excess power into cash!
/:cl:
