### PR TITLE
fix runtime in headcrab.dm

### DIFF
--- a/code/modules/antagonists/changeling/powers/headcrab.dm
+++ b/code/modules/antagonists/changeling/powers/headcrab.dm
@@ -22,11 +22,12 @@
 	explosion(get_turf(user), 0, 0, 2, 0, TRUE)
 	for(var/mob/living/carbon/human/H in range(2,user))
 		var/obj/item/organ/eyes/eyes = H.getorganslot(ORGAN_SLOT_EYES)
-		to_chat(H, "<span class='userdanger'>You are blinded by a shower of blood!</span>")
-		H.Stun(20)
-		H.blur_eyes(20)
-		eyes.applyOrganDamage(5)
-		H.confused += 3
+		if(eyes)
+			to_chat(H, "<span class='userdanger'>You are blinded by a shower of blood!</span>")
+			H.Stun(20)
+			H.blur_eyes(20)
+			eyes.applyOrganDamage(5)
+			H.confused += 3
 	for(var/mob/living/silicon/S in range(2,user))
 		to_chat(S, "<span class='userdanger'>Your sensors are disabled by a shower of blood!</span>")
 		S.Paralyze(60)


### PR DESCRIPTION
fixes #7046
fixes #6995
fixes #6708
fixes #6498 

for some stupid reason the proc deletes the ling's head organs including the eyes, then assumes everyone in range (which would include the ling) have eyes. Now it doesn't