### PR TITLE
Obsessed people may no longer have the objective to have a picture with their target

### DIFF
--- a/code/modules/antagonists/creep/creep.dm
+++ b/code/modules/antagonists/creep/creep.dm
@@ -70,10 +70,14 @@
 				spendtime.target = obsessionmind
 				objectives += spendtime
 			if("polaroid")
+				/*
+				 * This is currently commented out like this so that there still is a chance for a third objective if applicable
+				 * but this won't add the objective if it tries to select the picture one
 				var/datum/objective/polaroid/polaroid = new
 				polaroid.owner = owner
 				polaroid.target = obsessionmind
 				objectives += polaroid
+				*/
 			if("hug")
 				var/datum/objective/hug/hug = new
 				hug.owner = owner


### PR DESCRIPTION
Obsessed people may no longer have the objective to have a picture with their target.
They will now get 2-3 objectives instead of the hard 3 as the polaroid objective will not get added no matter what.

Yes I know, im a big fan of improve dont remove myself but in this case, I can't figure out why it does this so it might be better to leave it out.

#### Changelog

:cl:  
rscdel: Obsessed people may no longer get the objective to take a picture with their target as it was bugged out.
/:cl:
