### PR TITLE
Nerfs katana

### DIFF
--- a/yogstation/code/game/objects/items/weaponry.dm
+++ b/yogstation/code/game/objects/items/weaponry.dm
@@ -26,7 +26,6 @@
 
 /obj/item/katana/faketoy
 	name = "replica katana"
-	force = 20
+	force = 30
 	throwforce = 13
-	sharpness = IS_BLUNT
-	block_chance = 25
+	block_chance = 35

--- a/yogstation/code/game/objects/items/weaponry.dm
+++ b/yogstation/code/game/objects/items/weaponry.dm
@@ -29,3 +29,4 @@
 	force = 20
 	throwforce = 13
 	sharpness = IS_BLUNT
+	block_chance = 25

--- a/yogstation/code/game/objects/items/weaponry.dm
+++ b/yogstation/code/game/objects/items/weaponry.dm
@@ -26,3 +26,6 @@
 
 /obj/item/katana/faketoy
 	name = "replica katana"
+	force = 20
+	throwforce = 13
+	sharpness = IS_BLUNT

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -56,7 +56,7 @@
 	name = "Katana"
 	desc = "The katana is an edged weapon with a blade of pure degeneracy. While more robust than an energy sword, it cannot be as easily sheathed and hidden. At a glance, it looks like a fake katana; you can tell from the pixels."
 	item = /obj/item/katana/faketoy
-	cost = 10
+	cost = 14
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 
 /datum/uplink_item/stealthy_weapons/door_charge


### PR DESCRIPTION
Let's be honest, katanas are way too OP. Ive been on both sides, being killed by daniel burnwood with a katana and killing him with other tools to after use a katana to kill people.

Dmg: 40 -> 30
Blocc: 50% -> 35%
TC: 10 -> 14
Keep in mind this is a dual esword you can keep in one hand,put on your belt,is metashieleded,doesn't make the iconic esword sound and is cheaper than a. Dual esword(although my change will bring it close)

#### Changelog

:cl:  
tweak: Katana has been heavily nerfed. 
/:cl:
