### PR TITLE
Prevents xenos evolving in pipes

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/caste/drone.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/drone.dm
@@ -30,7 +30,9 @@
 	if(node.recent_queen_death)
 		to_chat(user, "<span class='danger'>Your thoughts are still too scattered to take up the position of leadership.</span>")
 		return 0
-
+	if(user.movement_type & (VENTCRAWLING))
+		to_chat(user, "<span class='danger'>You cannot evolve in a pipe.</span>")
+		return 0
 	if(!isturf(user.loc))
 		to_chat(user, "<span class='notice'>You can't evolve here!</span>")
 		return 0

--- a/code/modules/mob/living/carbon/alien/larva/powers.dm
+++ b/code/modules/mob/living/carbon/alien/larva/powers.dm
@@ -36,6 +36,10 @@
 		to_chat(user, "<span class='danger'>You cannot evolve when you are cuffed.</span>")
 		return
 
+	if(L.movement_type & (VENTCRAWLING))
+		to_chat(user, "<span class='danger'>You cannot evolve in a pipe.</span>")
+		return
+
 	if(L.amount_grown >= L.max_grown)	//TODO ~Carn
 		to_chat(L, "<span class='name'>You are growing into a beautiful alien! It is time to choose a caste.</span>")
 		to_chat(L, "<span class='info'>There are three to choose from:</span>")
@@ -45,6 +49,10 @@
 		var/alien_caste = alert(L, "Please choose which alien caste you shall belong to.",,"Hunter","Sentinel","Drone")
 
 		if(user.incapacitated()) //something happened to us while we were choosing.
+			return
+
+		if(L.movement_type & (VENTCRAWLING))
+			to_chat(user, "<span class='danger'>You cannot evolve in a pipe.</span>")
 			return
 
 		var/mob/living/carbon/alien/humanoid/new_xeno


### PR DESCRIPTION
A sort of fix for #7071 

Prevents xenos evolving in pipes, and prevents them opening the evolving menu then entering pipes and trying to evolve.

So they can't get stuck anymore and do nothing without admin intervention.

I did as many tests as I could think of and nothing seems broken.

:cl:  
tweak: Xenos cannot evolve whilst vent-crawling.
/:cl:
