### PR TITLE
Locks medical holodeck behind red or delta seclevel

### DIFF
--- a/code/game/area/areas/holodeck.dm
+++ b/code/game/area/areas/holodeck.dm
@@ -7,6 +7,7 @@
 
 	var/obj/machinery/computer/holodeck/linked
 	var/restricted = 0 // if true, program goes on emag list
+	var/minimum_sec_level = SEC_LEVEL_GREEN //override this var if you want the program to be locked to a different alert-level (eg. SEC_LEVEL_BLUE, SEC_LEVEL_RED, SEC_LEVEL_DELTA)
 
 /*
 	Power tracking: Use the holodeck computer's power grid
@@ -77,6 +78,7 @@
 
 /area/holodeck/rec_center/medical
 	name = "Holodeck - Emergency Medical"
+	minimum_sec_level = SEC_LEVEL_RED
 
 /area/holodeck/rec_center/pet_lounge
 	name = "Holodeck - Pet Park"

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -231,11 +231,13 @@
 		var/obj/effect/holodeck_effect/HE = e
 		HE.safety(active)
 
-/obj/machinery/computer/holodeck/proc/load_program(area/A, force = FALSE, add_delay = TRUE)
+/obj/machinery/computer/holodeck/proc/load_program(area/holodeck/A, force = FALSE, add_delay = TRUE)
 	if(!is_operational())
 		A = offline_program
 		force = TRUE
-
+	if(A.minimum_sec_level > GLOB.security_level && !force && !(obj_flags & EMAGGED))
+		say("ERROR. Program currently unavailiable, the security level is not high enough.")
+		return
 	if(program == A)
 		return
 	if(current_cd > world.time && !force)


### PR DESCRIPTION
### Intent of your Pull Request
Basically adds support for locking future holodecks behind security levels. Also locks the medical holodeck away.

I was initially going to remove the medical holodeck as I think it's a bit powercreepy but I decided to do this instead. Hopefully it's still got some uses.

Using an emag will override it.

#### Changelog

:cl:  
tweak: The medical holodeck template is now only available during red or delta security alert.   
/:cl:
