### PR TITLE
Pick up this bayonet and stab that man NICKVR to death.

### DIFF
--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -76,7 +76,7 @@
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	sharpness = IS_SHARP_ACCURATE
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
-	var/bayonet = FALSE	//Can this be attached to a gun?
+	var/bayonet = TRUE	//Can this be attached to a gun?
 	custom_price = 30
 
 /obj/item/kitchen/knife/Initialize()
@@ -118,6 +118,7 @@
 	attack_verb = list("cleaved", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	w_class = WEIGHT_CLASS_NORMAL
 	custom_price = 60
+	bayonet = TRUE
 
 /obj/item/kitchen/knife/combat
 	name = "combat knife"
@@ -149,6 +150,7 @@
 	force = 15
 	throwforce = 15
 	materials = list()
+	bayonet = TRUE
 
 /obj/item/kitchen/knife/combat/cyborg
 	name = "cyborg knife"

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -177,6 +177,7 @@
 	sawn_desc = "I'm just here for the gasoline."
 	unique_reskin = null
 	var/slung = FALSE
+	can_bayonet = TRUE //STOP WATCHING THIS FILTH MY FELLOW CARGONIAN,WE MUST DEFEND OURSELVES
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/improvised/attackby(obj/item/A, mob/user, params)
 	..()
@@ -210,3 +211,5 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	sawn_off = TRUE
 	slot_flags = ITEM_SLOT_BELT
+	can_bayonet = FALSE
+


### PR DESCRIPTION
### Intent of your Pull Request

Bayonets are cool,I like them and then I saw only the combat knife was bayonnetable, thus this just spreads the bayonets out a little, with adding a bayonet to the improvised shotgun(but not when its sawn-off, for a trade of stealth VS bayonet)
In all honesty,I don't think bayonets should be locked behind cargo,instead I think they should offer weaker options but they are more avaliable.
Note that you **Cannot Bayonet a sawn-off shotgun,as in you are trading stealth and storability for bayonets**
Improvised shotgun I felt would make sense,it being ghetto and all,why not a ghetto combat knife bayonet,but if it is hated I'll chop it.

#### Changelog

:cl:  
rscadd: More Knives can be bayoneted now
rscadd: The Improvised Shotgun can now be bayoneted,glory to graytide.
🆑 
