### PR TITLE
makes tcomms storage belong into single area

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -17588,7 +17588,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/tcommsat/entrance)
+/area/tcommsat/computer)
 "aIb" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -54738,7 +54738,7 @@
 /obj/item/circuitboard/machine/telecomms/server,
 /obj/item/circuitboard/machine/telecomms/server,
 /turf/open/floor/plasteel/dark,
-/area/tcommsat/entrance)
+/area/tcommsat/computer)
 "iUt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,


### PR DESCRIPTION
makes tcomms storage on yogs belong to one are as it was split in two with air alarm and vent in the entrance area and scruber in control area
