### PR TITLE
fuck it,blitz sec

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -974,8 +974,8 @@
 /datum/design/wallframe/flasher
 	name = "Mounted Flash Frame" 
 	id =  "wallframe/flasher" 
-	build_type = AUTOLATHE | PROTOLATHE
+	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 10000, MAT_GLASS = 4000)
 	build_path = /obj/item/wallframe/flasher
-	category = list("hacked","Security","Misc. Machinery")
+	category = list("Misc. Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -973,7 +973,7 @@
 
 /datum/design/wallframe/flasher
 	name = "Mounted Flash Frame" 
-	id =  "flasher" 
+	id =  "wallframe/flasher" 
 	build_type = AUTOLATHE | PROTOLATHE
 	materials = list(MAT_METAL = 10000, MAT_GLASS = 4000)
 	build_path = /obj/item/wallframe/flasher

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -971,8 +971,8 @@
 	category = list("initial", "Medical", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
-/datum/design/flasher
-	name = "Mounted Flash" 
+/datum/design/wallframe/flasher
+	name = "Mounted Flash Frame" 
 	id =  "flasher" 
 	build_type = AUTOLATHE | PROTOLATHE
 	materials = list(MAT_METAL = 10000, MAT_GLASS = 4000)

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -976,6 +976,6 @@
 	id =  "flasher" 
 	build_type = AUTOLATHE | PROTOLATHE
 	materials = list(MAT_METAL = 10000, MAT_GLASS = 4000)
-	build_path = /obj/machinery/flasher 
+	build_path = /obj/item/wallframe/flasher
 	category = list("hacked","Security","Misc. Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -970,3 +970,12 @@
 	build_path = /obj/item/flashlight/pen
 	category = list("initial", "Medical", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+
+/datum/design/flasher
+	name = "Mounted Flash" 
+	id =  "flasher" 
+	build_type = AUTOLATHE | PROTOLATHE
+	materials = list(MAT_METAL = 10000, MAT_GLASS = 4000)
+	build_path = /obj/machinery/flasher 
+	category = list("hacked","Security","Misc. Machinery")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -10,7 +10,7 @@
 	design_ids = list("basic_matter_bin", "basic_cell", "basic_scanning", "basic_capacitor", "basic_micro_laser", "micro_mani", "desttagger", "handlabel", "packagewrap",
 	"destructive_analyzer", "circuit_imprinter", "experimentor", "rdconsole", "design_disk", "tech_disk", "rdserver", "rdservercontrol", "mechfab", "paystand",
 	"space_heater", "beaker", "large_beaker", "bucket", "xlarge_beaker", "sec_rshot", "sec_beanbag_slug", "sec_bshot", "sec_slug", "sec_Islug", "sec_dart", "sec_38",
-	"rglass","plasteel","plastitanium","plasmaglass","plasmareinforcedglass","titaniumglass","plastitaniumglass")
+	"rglass","plasteel","plastitanium","plasmaglass","plasmareinforcedglass","titaniumglass","plastitaniumglass","wallframe/flasher")
 
 /datum/techweb_node/mmi
 	id = "mmi"


### PR DESCRIPTION
### Intent of your Pull Request
Do you know what really grinds my gears?
Underused mechanics.
Especially ones that are meant for sec, and that the fact that mounted flashes are literally unmakeable, so you have to rip your department up for one

(nonmeme)
You can print Mounted flash frames in the sec protolathe and autolathe,wew
Auto lathe change was for ordered riot shields, may be subject to change(but I mean come to the fuck on its literally 1 door you have to hack to get a mounted flash)
Honestly, I would want to rig this up but holy shit I literally cannot think of a way of making these linkable that would not literally annihilate every other map-spawned flash


Suggest any changes as you see fit,I'm not a balance god just a retard with a keyboard.

#### Changelog

:cl:  
rscadd: You can now print mounted flashes in the sec protolathe and autolathe for all your strobe shields/blitz cosplays
/:cl:
