### PR TITLE
gunpoint bugfix

### DIFF
--- a/code/datums/components/gunpoint.dm
+++ b/code/datums/components/gunpoint.dm
@@ -81,6 +81,10 @@
 		cancel()
 
 /datum/component/gunpoint/proc/trigger_reaction(var/flinch)
+	if(flinch != TRUE && shooter.pulling == target) //target won't get shot if they're being moved by the shooter
+		return
+	if(disrupted)
+		return
 	if(point_of_no_return)
 		return
 	point_of_no_return = TRUE
@@ -92,10 +96,6 @@
 			"<span class='danger'>You fumble [weapon] and fail to fire at [target]!</span>", target)
 		to_chat(target, "<span class='userdanger'>[shooter] fumbles [weapon] and fails to fire at you!</span>")
 		qdel(src)
-		return
-	if(disrupted)
-		return
-	if(flinch != TRUE && shooter.pulling == target) //target won't get shot if they're being moved by the shooter
 		return
 	if(weapon.check_botched(shooter))
 		return

--- a/code/datums/components/gunpoint.dm
+++ b/code/datums/components/gunpoint.dm
@@ -81,6 +81,8 @@
 		cancel()
 
 /datum/component/gunpoint/proc/trigger_reaction(var/flinch)
+	var/mob/living/shooter
+
 	if(flinch != TRUE && shooter.pulling == target) //target won't get shot if they're being moved by the shooter
 		return
 	if(disrupted)
@@ -88,8 +90,6 @@
 	if(point_of_no_return)
 		return
 	point_of_no_return = TRUE
-
-	var/mob/living/shooter = parent
 
 	if(!weapon.can_shoot() || !weapon.can_trigger_gun(shooter) || (weapon.weapon_weight == WEAPON_HEAVY && shooter.get_inactive_held_item()))
 		shooter.visible_message("<span class='danger'>[shooter] fumbles [weapon]!</span>", \


### PR DESCRIPTION
move passive checks above the point of no return check so they don't trigger it

:cl:  
bugfix: holdup doesn't break when pulling the target
/:cl:
