### PR TITLE
removes map and gamemode from the hub entry, puts back in taglines and 99% lag free

### DIFF
--- a/yogstation/code/game/world.dm
+++ b/yogstation/code/game/world.dm
@@ -42,7 +42,7 @@ GLOBAL_LIST_EMPTY(donators)
 	if (server_name)
 		s += "<b>[server_name]</b> &#8212; "
 	
-	s += "<b>[station_name()]</b>] 99% lag free<br>"; // The station & server name line
+	s += "<b>[station_name()]</b>] 99% LAG FREE<br>"; // The station & server name line
 	s += "(<a href=\"https://forums.yogstation.net/index.php\">Forums</a>|<a href=\"https://discord.gg/8hphvMe\">Discord</a>)<br>" // The Forum & Discord links line
 	s += "<br><i>[pick(world.file2list("yogstation/strings/taglines.txt"))]</i><br>"
 	

--- a/yogstation/code/game/world.dm
+++ b/yogstation/code/game/world.dm
@@ -42,23 +42,9 @@ GLOBAL_LIST_EMPTY(donators)
 	if (server_name)
 		s += "<b>[server_name]</b> &#8212; "
 	
-	s += "<b>[station_name()]</b>]<br>"; // The station & server name line
+	s += "<b>[station_name()]</b>] 99% lag free<br>"; // The station & server name line
 	s += "(<a href=\"https://forums.yogstation.net/index.php\">Forums</a>|<a href=\"https://discord.gg/8hphvMe\">Discord</a>)<br>" // The Forum & Discord links line
-	
-	//TAGLINE
-	//s += "<br><i>[pick(world.file2list("yogstation/strings/taglines.txt"))]</i><br>"
-	
-	//MAP AND GAMEMODE
-	s += "Mode: <b>[GLOB.master_mode]</b><br>" // The Gamemode line
-	s += "Map: <b>[SSmapping.config?.map_name || "Loading..."]</b><br>" // The map line
-	
-	//FEATURES
-	var/list/features = list()
-	if(!CONFIG_GET(flag/norespawn)) 
-		features += "<b>Respawn Enabled</b>" // Bold it since it will be an amazing(ly questionable) event
-	
-	if(features.len)
-		s += "[jointext(features,", ")]<br>" // The features line
+	s += "<br><i>[pick(world.file2list("yogstation/strings/taglines.txt"))]</i><br>"
 	
 	
 	


### PR DESCRIPTION


### Intent of your Pull Request

Latter part requested by council, former part personal preference. Gamemode is stupid since it's almost always secret anyways and I doubt anyone joins a server just because it says secret.

Map is pretty much also irrelevant IMO.

#### Changelog

:cl:  
tweak: The hub entry now features a tagline and doesn't feature the map and gamemode
/:cl:
