### PR TITLE
Fix parmesan reagents

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_cheese.dm
+++ b/code/modules/food_and_drinks/food/snacks_cheese.dm
@@ -230,7 +230,7 @@
 	desc = "A big wheel of parmesan cheese."
 	icon_state = "parmesan_wheel"
 	slice_path = /obj/item/reagent_containers/food/snacks/cheesewedge/parmesan
-	list_reagents = list(/datum/reagent/consumable/nutriment = 200, /datum/reagent/consumable/nutriment/vitamin = 50, /datum/reagent/consumable/parmesan_delight = 20)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 20, /datum/reagent/consumable/nutriment/vitamin = 20, /datum/reagent/consumable/parmesan_delight = 10)
 	tastes = list("salt" = 1)
 
 /obj/item/reagent_containers/food/snacks/cheesewheel/preparmesan
@@ -261,7 +261,7 @@
 	desc = "A wedge of parmesan cheese. You feel incredibly artisnal holding this."
 	icon_state = "parmesan_wedge"
 	filling_color = "#F0DF9C"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 40, /datum/reagent/consumable/nutriment/vitamin = 10, /datum/reagent/consumable/parmesan_delight = 4)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/consumable/nutriment/vitamin = 4, /datum/reagent/consumable/parmesan_delight = 2)
 	tastes = list("salt" = 1)
 
 //swiss


### PR DESCRIPTION
I failed to notice when making the original PR that all snacks have a max volume of 50.
I have nerfed permesan amounts to fit in with this, it still is more than other cheese but not as much anymore.
#### Changelog

:cl:  
bugfix: fixed parmesan
/:cl:
