### PR TITLE
More map things

### DIFF
--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -1421,11 +1421,11 @@
 /turf/open/floor/plasteel/grimy,
 /area/bridge)
 "ach" = (
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/bridge)
 "aci" = (
 /obj/item/beacon,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/bridge)
 "acj" = (
 /obj/structure/cable/white{
@@ -1883,7 +1883,7 @@
 	icon_state = "pipe11-3";
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/bridge)
 "acZ" = (
 /obj/structure/table/wood,
@@ -1907,7 +1907,7 @@
 	icon_state = "pipe11-3";
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/bridge)
 "ada" = (
 /obj/structure/chair/comfy/black{
@@ -1921,7 +1921,7 @@
 	icon_state = "pipe11-3";
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/bridge)
 "adb" = (
 /obj/structure/cable/white{
@@ -3910,17 +3910,17 @@
 	dir = 2;
 	name = "command camera"
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain/private)
 "afZ" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain/private)
 "aga" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
 /obj/item/toy/figure/captain,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain/private)
 "agb" = (
 /obj/structure/cable/white{
@@ -4453,7 +4453,7 @@
 	icon_state = "vent_map_on-1";
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain/private)
 "agQ" = (
 /obj/structure/chair/comfy/brown{
@@ -4467,7 +4467,7 @@
 	icon_state = "pipe11-1";
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain/private)
 "agR" = (
 /obj/structure/table/wood,
@@ -4482,7 +4482,7 @@
 	icon_state = "pipe11-1";
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain/private)
 "agS" = (
 /obj/structure/chair/comfy/brown{
@@ -5094,7 +5094,7 @@
 	pixel_x = -24;
 	pixel_y = -24
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain/private)
 "ahJ" = (
 /obj/machinery/computer/card{
@@ -5103,7 +5103,7 @@
 /obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain/private)
 "ahK" = (
 /obj/machinery/computer/security/wooden_tv,
@@ -5114,7 +5114,7 @@
 	pixel_y = -24;
 	req_access_txt = "20"
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain/private)
 "ahL" = (
 /obj/structure/chair/comfy/brown{
@@ -21779,6 +21779,10 @@
 	dir = 4;
 	light_color = "#e8eaff"
 	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aFk" = (
@@ -23803,6 +23807,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"aHW" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/black{
+	icon_state = "tile_corner";
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/black{
+	icon_state = "tile_corner";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "aHX" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light,
@@ -24397,6 +24416,101 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
+"aIS" = (
+/obj/structure/cable/white{
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/black{
+	icon_state = "tile_corner";
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/black{
+	icon_state = "tile_corner";
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"aIT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"aIU" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 10
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/black{
+	icon_state = "tile_corner";
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"aIV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/black{
+	icon_state = "tile_corner";
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"aIW" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "aIX" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=6.2-DeparturesN";
@@ -25113,6 +25227,21 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"aJW" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	icon_state = "manifold-3";
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "aJX" = (
 /obj/machinery/vending/cola/random,
 /obj/effect/turf_decal/tile/neutral{
@@ -37604,80 +37733,12 @@
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint)
-"bdi" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"bdj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/structure/cable/white{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "bdk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/white{
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
-/area/engine/atmos)
-"bdl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 10
-	},
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"bdm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	icon_state = "manifold-3";
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"bdn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bdo" = (
 /obj/machinery/light{
@@ -37689,26 +37750,6 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/science/robotics/mechbay)
-"bdq" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "bdr" = (
 /obj/machinery/status_display/evac{
 	pixel_y = -32
@@ -44478,12 +44519,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
 /area/hallway/secondary/entry)
-"wZa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "xej" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxin_output{
 	dir = 2
@@ -77428,8 +77463,8 @@ agF
 auE
 avL
 aqz
-wZa
-bdi
+aHW
+aIT
 bcx
 aAt
 aBb
@@ -77685,11 +77720,11 @@ agF
 auF
 avK
 aqz
-bdj
-bdl
-bdn
-bdq
-bdm
+aIS
+aIU
+aIV
+aIW
+aJW
 aCF
 aDy
 bbO

--- a/_maps/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/map_files/YogsDelta/YogsDelta.dmm
@@ -27523,7 +27523,6 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "aSL" = (
-/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
@@ -27533,6 +27532,12 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/engine/storage_shared";
+	dir = 4;
+	name = "Shared Engineering Storage";
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
@@ -35651,7 +35656,11 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc{
+	areastring = "/area/hydroponics";
+	name = "Hydroponics APC";
+	pixel_y = -24
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "beS" = (
@@ -38640,9 +38649,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bjc" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
@@ -38663,6 +38669,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	icon_state = "pipe11-1";
 	dir = 8
+	},
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -47976,7 +47985,7 @@
 /obj/structure/table/glass,
 /obj/item/reagent_containers/spray/plantbgone,
 /obj/item/reagent_containers/spray/plantbgone{
-	pixel_x = 16
+	pixel_x = 12
 	},
 /obj/item/watertank,
 /obj/item/grenade/chem_grenade/antiweed,
@@ -64793,17 +64802,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bVh" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
+	icon_state = "pipe11-3";
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
 "bVi" = (
@@ -65146,14 +65150,10 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "bVB" = (
-/obj/machinery/meter,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	icon_state = "manifold-1";
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
 	},
@@ -66638,11 +66638,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
-	dir = 9
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1{
+	icon_state = "pipe11-1";
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
@@ -66877,13 +66877,12 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "bXT" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	icon_state = "manifold-3";
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
+/obj/machinery/meter{
+	target_layer = 1
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
@@ -66955,14 +66954,12 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bYa" = (
-/obj/machinery/meter,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1{
+	icon_state = "manifold-1";
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
@@ -72227,8 +72224,13 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/white,
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/department/science";
+	dir = 8;
+	name = "Science Maintenance APC";
+	pixel_x = -24
+	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/science)
 "cfL" = (
@@ -72973,11 +72975,16 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cgR" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	icon_state = "pipe11-3";
-	dir = 5
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
@@ -74095,7 +74102,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -26
 	},
-/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/white,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
@@ -74110,6 +74116,12 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/science/explab";
+	dir = 8;
+	name = "Experimentation Lab APC";
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
@@ -76255,13 +76267,18 @@
 /turf/closed/wall,
 /area/medical/chemistry)
 "cmk" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/dark/corner{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible/layer3{
+	icon_state = "manifold-3";
 	dir = 1
 	},
+/obj/machinery/meter{
+	target_layer = 3
+	},
+/turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
 "cml" = (
 /obj/structure/cable/white{
@@ -76879,11 +76896,17 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "cni" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
+	icon_state = "pipe11-3";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
 /area/maintenance/department/electrical)
 "cnj" = (
 /obj/structure/cable/white{
@@ -85334,8 +85357,13 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/white,
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/department/medical";
+	dir = 8;
+	name = "Medbay Maintenance APC";
+	pixel_x = -24
+	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
 "cAS" = (
@@ -97654,17 +97682,17 @@
 "cSI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	icon_state = "pipe11-3";
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
 "cSJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	icon_state = "pipe11-3";
 	dir = 9
 	},
@@ -111267,7 +111295,6 @@
 /area/maintenance/port)
 "dlt" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/white{
 	icon_state = "0-4"
 	},
@@ -111280,6 +111307,12 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/science/nanite";
+	dir = 8;
+	name = "Nanite Lab";
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
@@ -116020,6 +116053,27 @@
 /mob/living/simple_animal/pet/fox/fennec/Autumn,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"dsy" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/science/misc_lab";
+	dir = 4;
+	name = "Testing Lab APC";
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
 "dsC" = (
 /obj/structure/table/glass,
 /obj/item/folder/white,
@@ -119600,22 +119654,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/misc_lab)
-"dHd" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable/white{
-	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
@@ -147468,9 +147506,9 @@ cbl
 cMO
 ciw
 clN
-bVh
-cTm
 bXA
+cTm
+cgR
 cRB
 cSG
 cMO
@@ -147725,9 +147763,9 @@ cbr
 cMP
 ciB
 cmh
-cni
-cTn
 bXT
+cTn
+cmk
 cRC
 cSH
 cMO
@@ -147980,12 +148018,12 @@ car
 ceb
 cbt
 cgI
-cgR
-cmk
+bVh
 bVB
-cxa
 bYa
-cmk
+cxa
+cni
+bVB
 cSI
 cgI
 cUm
@@ -156490,7 +156528,7 @@ caE
 aad
 gSi
 dFE
-dHd
+dsy
 cCl
 dqe
 dKC

--- a/_maps/map_files/YogsPubby/YogsPubby.dmm
+++ b/_maps/map_files/YogsPubby/YogsPubby.dmm
@@ -16643,12 +16643,12 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "aGn" = (
-/obj/item/twohanded/required/kirbyplants/photosynthetic{
-	layer = 3.1
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3{
+	icon_state = "inje_map-3";
+	dir = 8
 	},
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/hallway/primary/central)
+/turf/open/floor/plating/airless,
+/area/tcommsat/computer)
 "aGo" = (
 /obj/structure/lattice,
 /obj/structure/sign/logo{
@@ -29610,9 +29610,10 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "bes" = (
-/obj/machinery/meter,
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/manifold/general/hidden/layer1,
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 2;
+	piping_layer = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bet" = (
@@ -29633,10 +29634,16 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bev" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "bew" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/dark,
@@ -32559,7 +32566,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bkg" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "bkh" = (
@@ -32624,10 +32631,11 @@
 /turf/closed/wall,
 /area/tcommsat/computer)
 "bkm" = (
-/obj/item/wrench,
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
+/obj/item/wrench,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "bkn" = (
@@ -32642,6 +32650,19 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "bko" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 9
+	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "bkp" = (
@@ -39788,7 +39809,6 @@
 /area/engine/atmos)
 "bvX" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -39811,10 +39831,12 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bwb" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	icon_state = "pipe11-2";
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	icon_state = "pipe11-2";
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
@@ -40261,8 +40283,14 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bwO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/item/stack/cable_coil,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 9
+	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "bwP" = (
@@ -42633,7 +42661,9 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "bAR" = (
-/obj/machinery/meter,
+/obj/machinery/meter{
+	target_layer = 3
+	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	icon_state = "manifold-3";
 	dir = 8
@@ -42836,6 +42866,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	icon_state = "vent_map_on-1";
 	dir = 4
+	},
+/obj/machinery/status_display/evac{
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
@@ -44054,9 +44087,11 @@
 /turf/open/space,
 /area/space/nearstation)
 "bDg" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 2
+/obj/machinery/meter{
+	target_layer = 1
 	},
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/manifold/general/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bDh" = (
@@ -44364,7 +44399,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bDJ" = (
-/obj/machinery/meter,
+/obj/machinery/meter{
+	target_layer = 1
+	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	icon_state = "manifold-1";
 	dir = 8
@@ -47935,35 +47972,22 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bJq" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
+/obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 8
-	},
+/obj/structure/cable/yellow,
+/obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "bJr" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "testlab";
+	name = "test chamber blast door"
 	},
-/obj/item/stack/cable_coil,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/tcommsat/computer)
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/engine,
+/area/science/explab)
 "bJs" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -48158,6 +48182,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"bJJ" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/tcomms,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/pen,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/tcommsat/computer)
 "bJK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -48173,6 +48211,20 @@
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
+"bJL" = (
+/obj/machinery/meter,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal/incinerator)
 "bJM" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red,
@@ -48849,12 +48901,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "bLj" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3{
-	icon_state = "inje_map-2";
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/tcommsat/computer)
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "bLk" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -49433,6 +49482,13 @@
 /obj/machinery/vending/wardrobe/sig_wardrobe,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"bMx" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	icon_state = "pipe11-2";
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "bMy" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -49441,6 +49497,12 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
+"bMz" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "bMA" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
@@ -49470,6 +49532,15 @@
 "bME" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
+/area/maintenance/department/engine)
+"bMF" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 1;
+	piping_layer = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/maintenance/department/engine)
 "bMH" = (
 /obj/structure/table,
@@ -51256,16 +51327,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"bUy" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "bUz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -51518,14 +51579,6 @@
 /obj/structure/mopbucket,
 /obj/item/mop,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
-"bVw" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 1
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
 /area/maintenance/department/engine)
 "bVy" = (
 /obj/structure/table,
@@ -52455,18 +52508,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
-"bZR" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
-"bZT" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "bZU" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
 	dir = 8
@@ -53148,18 +53189,6 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/disposal/incinerator)
-"cdi" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/obj/machinery/meter,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -54597,23 +54626,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
-/turf/open/floor/plasteel,
-/area/tcommsat/computer)
-"cmw" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/obj/structure/table,
-/obj/item/book/manual/wiki/tcomms,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/item/pen,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cmx" = (
@@ -57848,10 +57860,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"jLW" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "jOB" = (
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
@@ -58459,13 +58467,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"mxy" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable/yellow,
-/turf/open/floor/plating,
-/area/tcommsat/computer)
 "mzl" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -82312,7 +82313,7 @@ bxY
 bzz
 bAK
 bBX
-bDg
+bes
 blm
 bFF
 bva
@@ -82569,8 +82570,8 @@ btq
 bhK
 bAK
 bBX
-bDg
 bes
+bDg
 bva
 bva
 bHQ
@@ -85673,7 +85674,7 @@ bSw
 bxA
 byV
 bAj
-bVw
+bMF
 bva
 iEQ
 bBz
@@ -89824,7 +89825,7 @@ aaa
 aaa
 aaa
 aaa
-emV
+bBW
 bJw
 clB
 hQz
@@ -89835,7 +89836,7 @@ brV
 fGz
 bJx
 bkw
-cmw
+bJJ
 clG
 cmK
 qYS
@@ -90082,7 +90083,7 @@ aaa
 aaa
 aaa
 aaa
-bLj
+aGn
 clw
 clw
 clw
@@ -90339,13 +90340,13 @@ aaa
 aaa
 aaa
 aaa
-mVM
+aht
+aht
 clw
 bkg
-bko
 bkm
+bko
 bJq
-mxy
 clw
 bJC
 bJY
@@ -90596,12 +90597,12 @@ aaa
 aaa
 aaa
 aaa
-abI
+aaa
+aht
 clw
 clN
 bwK
 bwO
-bJr
 mDW
 clw
 cml
@@ -90853,8 +90854,8 @@ aaa
 aaa
 aaa
 aaa
-abI
-clw
+aht
+aht
 clw
 clw
 clw
@@ -91005,13 +91006,13 @@ aCG
 aDK
 aED
 aAB
-aGn
+aht
 axi
 aBB
 aKD
 awG
 aAN
-aGn
+abI
 aKT
 ayK
 aPE
@@ -91110,7 +91111,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aht
 aaa
 aaa
 aaa
@@ -91624,7 +91625,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aht
 aaa
 aaa
 aaa
@@ -92547,13 +92548,13 @@ aqS
 aDN
 aEI
 aAB
-aGn
+aht
 axi
 aDd
 awN
 awG
 aAN
-aGn
+abI
 aKT
 coW
 azj
@@ -99805,7 +99806,7 @@ bRB
 bSh
 bLA
 bNl
-bUy
+bev
 bVk
 bWb
 bNl
@@ -99816,7 +99817,7 @@ bZQ
 bCv
 cbC
 ccr
-cdi
+bJL
 bKy
 ceA
 aaa
@@ -100067,11 +100068,11 @@ bVl
 bWc
 bWR
 bwb
-jLW
-bev
-bZR
+bLj
+bLj
+bMx
 bCw
-bZT
+bMz
 bYw
 bgc
 bYw
@@ -100547,7 +100548,7 @@ bjw
 bky
 blP
 bmV
-bnY
+bJr
 bpd
 bqo
 brG
@@ -100583,9 +100584,9 @@ bLb
 bJP
 aaa
 bYw
-bZT
+bMz
 caN
-bZT
+bMz
 bYw
 cdl
 bYw

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -3568,11 +3568,41 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"agh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "detective_shutters";
+	name = "detective's office shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/security/detectives_office)
 "agi" = (
 /obj/structure/table/wood,
 /obj/item/stamp/hos,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"agj" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security{
+	name = "Detective's Office";
+	req_access_txt = "4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/security/detectives_office)
 "agk" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -3763,6 +3793,26 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/solars/port/fore)
+"agE" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "detective_shutters";
+	name = "detective's office shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/detectives_office)
+"agF" = (
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
+"agG" = (
+/obj/structure/table/wood,
+/obj/item/storage/fancy/cigarettes,
+/obj/item/clothing/glasses/sunglasses,
+/turf/open/floor/carpet,
+/area/security/detectives_office)
 "agH" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/effect/turf_decal/tile/neutral{
@@ -3832,6 +3882,29 @@
 	},
 /turf/closed/wall,
 /area/security/prison)
+"agO" = (
+/obj/machinery/turretid{
+	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
+	enabled = 1;
+	icon_state = "control_standby";
+	name = "Antechamber Turret Control";
+	pixel_x = 30;
+	req_access_txt = "61;65"
+	},
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
+"agP" = (
+/obj/machinery/light_switch{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "agQ" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/bulletproof,
@@ -6175,6 +6248,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"akO" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
+	dir = 8
+	},
+/obj/machinery/turretid{
+	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
+	name = "Antechamber Turret Control";
+	pixel_y = 30;
+	req_one_access_txt = "61;65"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
+"akP" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/maintenance/starboard/secondary";
+	dir = 1;
+	name = "Starboard Maintenance APC";
+	pixel_y = 25
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/secondary)
 "akQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	icon_state = "pipe11-1";
@@ -6183,6 +6284,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/range)
+"akR" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/power/apc{
+	areastring = "/area/science/misc_lab/range";
+	dir = 8;
+	name = "Testing Range APC";
+	pixel_x = -25
+	},
+/turf/open/floor/plasteel/white,
+/area/science/misc_lab/range)
 "akS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7102,6 +7216,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"amr" = (
+/obj/structure/chair/comfy,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/maintenance/department/science";
+	dir = 1;
+	name = "Science Maintenance APC";
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/department/science)
 "ams" = (
 /obj/item/target,
 /obj/item/target,
@@ -7501,6 +7628,19 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"anb" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/aft";
+	dir = 1;
+	name = "Aft Maintenance APC";
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "anc" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "N2O Storage";
@@ -8170,6 +8310,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"aou" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/department/medical/central";
+	dir = 1;
+	name = "Medbay Maintenance APC";
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical/central)
 "aov" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -31
@@ -8193,6 +8348,24 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"aox" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/department/science/central";
+	dir = 1;
+	name = "Science Maintenance APC";
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "aoy" = (
 /obj/structure/closet/secure_closet/warden,
 /obj/item/gun/energy/laser,
@@ -8851,6 +9024,18 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port/fore)
+"apD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc{
+	areastring = "/area/engine/break_room";
+	name = "Engineering Foyer APC";
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "apE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -9528,6 +9713,29 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"aqV" = (
+/obj/structure/cable/yellow,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/maintenance/aft/secondary";
+	name = "Aft Maintenance";
+	pixel_y = -24
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft/secondary)
+"aqW" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/power/apc{
+	areastring = "/area/science/nanite";
+	dir = 8;
+	name = "Nanite Lab APC";
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "aqX" = (
 /obj/structure/chair,
 /obj/item/restraints/handcuffs,
@@ -11276,14 +11484,24 @@
 /turf/open/floor/plating,
 /area/security/main)
 "aua" = (
-/obj/structure/table/wood,
-/obj/item/storage/fancy/cigarettes,
-/obj/item/clothing/glasses/sunglasses,
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/floor/carpet,
-/area/security/detectives_office)
+/obj/structure/cable/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/engine/storage_shared";
+	dir = 8;
+	name = "Shared Engineering Storage APC";
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/engine/storage_shared)
 "aub" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
@@ -13700,16 +13918,20 @@
 /turf/closed/wall/r_wall,
 /area/security/detectives_office)
 "ayG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "detective_shutters";
-	name = "detective's office shutters"
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/security/detectives_office)
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	icon_state = "pipe11-2";
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/engine/atmos)
 "ayH" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -13971,6 +14193,19 @@
 "azi" = (
 /turf/closed/wall,
 /area/medical/paramedic)
+"azj" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	icon_state = "pipe11-2";
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "azk" = (
 /obj/structure/closet/crate,
 /obj/machinery/light/small{
@@ -14386,12 +14621,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"azR" = (
+"azQ" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/visible,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"azR" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	icon_state = "pipe11-2";
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/hallway/primary/starboard)
 "azS" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -14913,6 +15162,34 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"aAI" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	icon_state = "left";
+	name = "Atmospherics Desk";
+	req_access_txt = "24"
+	},
+/obj/item/folder/yellow,
+/obj/item/folder/yellow,
+/obj/item/pen,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Blast Door"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "aAJ" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "qm_mine_warehouse";
@@ -15044,6 +15321,24 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"aAW" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/landmark/start/atmospheric_technician,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/engine/atmos)
 "aAX" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -15720,6 +16015,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"aCj" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "aCk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -27502,15 +27810,19 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "aXv" = (
-/obj/machinery/power/apc/auto_name/south{
-	pixel_y = -26
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 10
 	},
-/obj/structure/cable/yellow,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/atmos)
 "aXw" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -27607,22 +27919,17 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "aXE" = (
-/obj/machinery/turretid{
-	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
-	enabled = 1;
-	icon_state = "control_standby";
-	name = "Antechamber Turret Control";
-	pixel_x = 30;
-	req_access_txt = "65"
+/obj/machinery/computer/atmos_control{
+	dir = 8
 	},
-/obj/machinery/ai_slipper{
-	uses = 10
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
+/turf/open/floor/plasteel/dark/corner,
+/area/engine/atmos)
 "aXF" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -31597,20 +31904,12 @@
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
 "bep" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/structure/cable/yellow,
-/obj/machinery/power/apc/auto_name/west{
-	pixel_x = -26
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
-/area/engine/storage_shared)
+/turf/open/floor/plating,
+/area/engine/atmos)
 "beq" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/r_wall,
@@ -31638,12 +31937,25 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
 "bet" = (
-/obj/structure/showcase/cyborg/old{
-	dir = 2;
-	pixel_y = 20
+/obj/structure/table,
+/obj/item/book/manual/wiki/atmospherics,
+/obj/item/storage/belt/utility,
+/obj/item/t_scanner,
+/obj/item/t_scanner,
+/obj/item/t_scanner,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/engine/atmos)
 "beu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31686,19 +31998,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bex" = (
-/obj/machinery/light_switch{
-	pixel_y = 28
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Blast Door"
 	},
-/obj/structure/showcase/cyborg/old{
-	dir = 2;
-	pixel_y = 20
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
-	dir = 8
-	},
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/obj/structure/cable/yellow,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "bey" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -33563,14 +33870,12 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
 "bhR" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/structure/tank_dispenser{
+	pixel_x = -1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
-	dir = 4
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bhS" = (
 /obj/structure/table,
@@ -33605,13 +33910,8 @@
 /turf/closed/wall/r_wall,
 /area/engine/break_room)
 "bhU" = (
-/obj/machinery/computer/atmos_control{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/corner,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bhV" = (
 /obj/item/book/manual/wiki/engineering_hacking{
@@ -43281,14 +43581,18 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "byX" = (
+/obj/machinery/holopad,
 /obj/structure/cable/yellow{
-	icon_state = "2-8"
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	icon_state = "pipe11-1";
-	dir = 10
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "byY" = (
@@ -43297,18 +43601,18 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "byZ" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bza" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -43339,21 +43643,21 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bzd" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/atmospherics,
-/obj/item/storage/belt/utility,
-/obj/item/t_scanner,
-/obj/item/t_scanner,
-/obj/item/t_scanner,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
+/turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
 "bze" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
@@ -44914,41 +45218,42 @@
 /turf/open/floor/wood,
 /area/library)
 "bCg" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	icon_state = "left";
-	name = "Atmospherics Desk";
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics Monitoring";
 	req_access_txt = "24"
 	},
-/obj/item/folder/yellow,
-/obj/item/folder/yellow,
-/obj/item/pen,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
-	},
-/obj/effect/turf_decal/delivery,
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bCh" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/landmark/start/atmospheric_technician,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	icon_state = "pipe11-1";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	icon_state = "pipe11-3";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible,
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
 	},
@@ -45516,18 +45821,12 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bDj" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/dark/hidden{
+	icon_state = "pipe11-2";
+	dir = 8
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
-	name = "Detective's Office";
-	req_access_txt = "4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/security/detectives_office)
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "bDk" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -45801,20 +46100,6 @@
 /obj/item/clothing/mask/cigarette/cigar,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"bDK" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/carpet,
-/area/security/detectives_office)
 "bDL" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/item/bikehorn/rubberducky,
@@ -45843,17 +46128,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"bDO" = (
-/obj/structure/tank_dispenser{
-	pixel_x = -1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
-/area/engine/atmos)
 "bDP" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -45862,41 +46136,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
-"bDQ" = (
-/obj/machinery/holopad,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"bDR" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "bDS" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -45904,26 +46143,6 @@
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
 	},
-/area/engine/atmos)
-"bDT" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
 "bDU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -45955,27 +46174,6 @@
 /area/engine/atmos)
 "bDY" = (
 /obj/machinery/atmospherics/pipe/manifold/purple/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"bDZ" = (
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Atmospherics Monitoring";
-	req_access_txt = "24"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -46927,19 +47125,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
-"bFJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/science/central)
 "bFK" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -47021,31 +47206,6 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
-"bFT" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	icon_state = "pipe11-1";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
 /area/engine/atmos)
 "bFU" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -59582,12 +59742,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"ccL" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "ccM" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
@@ -62130,18 +62284,6 @@
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
-/area/hallway/primary/starboard)
-"cgN" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "cgO" = (
 /obj/machinery/portable_atmospherics/pump,
@@ -71732,14 +71874,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
-"cvJ" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/auto_name/west,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/science/nanite)
 "cvK" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -75933,14 +76067,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space/nearstation)
-"cJl" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "cJm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
@@ -76555,12 +76681,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"cMk" = (
-/obj/structure/cable/yellow,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/power/apc/auto_name/south,
-/turf/open/floor/plating,
-/area/maintenance/aft/secondary)
 "cMl" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty{
@@ -81761,18 +81881,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
-"dBK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
-	},
-/obj/structure/cable/yellow,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
 "dBN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -81883,13 +81991,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/library)
-"dCY" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "dDe" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/cafeteria{
@@ -82307,16 +82408,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"joY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical/central)
 "jwW" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/crew_quarters/fitness/recreation)
@@ -82398,16 +82489,6 @@
 "kwT" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
-"kxk" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/auto_name/west{
-	pixel_x = -25
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/white,
-/area/science/misc_lab/range)
 "kzn" = (
 /obj/machinery/door/airlock/external{
 	name = "Departure Lounge Airlock"
@@ -82621,16 +82702,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
-"nPc" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	icon_state = "manifold-2";
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/corner,
-/area/hallway/primary/starboard)
 "nPk" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -82762,28 +82833,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"pNE" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark/corner,
-/area/hallway/primary/starboard)
-"pPn" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/secondary)
 "pSG" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
 	icon_state = "manifold-2";
@@ -82977,15 +83026,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/mixing/chamber)
-"tzq" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark/corner,
-/area/hallway/primary/starboard)
 "tDM" = (
 /obj/machinery/door/airlock/engineering/glass/critical{
 	heat_proof = 1;
@@ -83307,14 +83347,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"xAp" = (
-/obj/structure/chair/comfy,
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/department/science)
 "xBE" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -104363,7 +104395,7 @@ bQs
 bWm
 cHy
 cBR
-cJl
+anb
 bTM
 cLa
 cza
@@ -108714,7 +108746,7 @@ cga
 cga
 cga
 cga
-joY
+aou
 ctA
 cuu
 cvA
@@ -111798,7 +111830,7 @@ bDh
 cpd
 cqx
 cgd
-bFJ
+aox
 ctJ
 cok
 cvH
@@ -112829,7 +112861,7 @@ cJm
 bGi
 ctL
 cuF
-cvJ
+aqW
 cwK
 cdV
 cyt
@@ -113105,7 +113137,7 @@ cFh
 cKH
 bVb
 wFH
-cMk
+aqV
 lvi
 lvi
 lvi
@@ -114044,8 +114076,8 @@ atW
 alW
 aFe
 asg
-ayG
-azR
+agh
+agF
 aBl
 azF
 aBu
@@ -114301,8 +114333,8 @@ atX
 alW
 aFQ
 bzw
-bDj
-bDK
+agj
+bEt
 bEt
 bFw
 aBP
@@ -114558,8 +114590,8 @@ ajD
 alW
 aHe
 asg
-ayG
-aua
+agE
+agG
 aBn
 aCv
 awo
@@ -117972,7 +118004,7 @@ dwL
 dwL
 dwL
 dwL
-xAp
+amr
 vhG
 cAI
 crT
@@ -118481,7 +118513,7 @@ cpr
 bFa
 crV
 dwL
-pPn
+akP
 cuY
 cwa
 dzQ
@@ -120024,7 +120056,7 @@ cqX
 cuZ
 bGs
 cud
-kxk
+akR
 szA
 npM
 yia
@@ -122560,8 +122592,8 @@ blY
 blY
 bsX
 blY
-cgN
-cgN
+azj
+azQ
 gLo
 cgR
 bVc
@@ -122817,9 +122849,9 @@ byQ
 byQ
 bfE
 byQ
-tzq
-nPc
-pNE
+byQ
+azR
+byQ
 bkV
 buR
 bmF
@@ -123075,8 +123107,8 @@ bhT
 bxc
 bxc
 bAA
-bCg
-dBK
+aAI
+bex
 bFF
 bxc
 bxc
@@ -123327,13 +123359,13 @@ aWs
 aXt
 hfn
 wPB
-bep
+aua
 vzO
 bxd
 byR
 bAB
-bCh
-bDO
+aAW
+bhR
 bFG
 blF
 aaO
@@ -123589,8 +123621,8 @@ bve
 bxd
 byS
 bCi
-bhR
-dCY
+aCj
+bhU
 bFH
 aiN
 aiN
@@ -123846,8 +123878,8 @@ qdT
 bxd
 byT
 bhD
+aXv
 byX
-bDQ
 bFH
 bBt
 bBt
@@ -123864,7 +123896,7 @@ cjH
 bxc
 bxc
 bxc
-ccL
+bDj
 bxc
 bxp
 cgz
@@ -124103,8 +124135,8 @@ bvg
 bxd
 byU
 bAE
-bCi
-bDR
+bib
+byZ
 bkW
 blG
 cVD
@@ -124352,7 +124384,7 @@ cfR
 cfT
 cfU
 ecs
-aXv
+apD
 bpi
 sao
 bdl
@@ -124360,8 +124392,8 @@ bvh
 bxd
 byV
 bAF
-bhU
-bDT
+aXE
+bzd
 btn
 bxc
 bxc
@@ -124617,8 +124649,8 @@ bfF
 bxc
 bxc
 bxc
-bza
-bDZ
+bep
+bCg
 nPS
 bxc
 bmG
@@ -124874,8 +124906,8 @@ owR
 bxc
 bhS
 bjA
-bzd
-bFT
+bet
+bCh
 bFL
 bHt
 bIO
@@ -126414,7 +126446,7 @@ baZ
 bdo
 ben
 bxc
-byZ
+ayG
 bAL
 ddF
 bDX
@@ -137202,7 +137234,7 @@ aTV
 aTV
 bjP
 blD
-aXE
+agO
 bof
 bby
 btL
@@ -137977,7 +138009,7 @@ aXG
 boS
 bbA
 btL
-bet
+agP
 bxq
 bxq
 bJh
@@ -138491,7 +138523,7 @@ aXI
 dFq
 bbI
 btL
-bex
+akO
 bxq
 bgM
 bAY


### PR DESCRIPTION
**Pubby**
Removed the plants that were inside windows under the AI upload.
Tweaked tcomms maintenance slightly, didn't like the freezer placement before.
Adds missing pipe under experimentor window.
Moves the status display off the window in tcomms.
Changed a 4-way manifold to a 3-way manifold in the incinerator room.
Fixed a pipe being invisible to mappers.
Changed the visible/hidden status of some pipes in atmos.
Fixed some unconnected meters and pressure tanks in maint.

**Meta**
Detective's office windows wiring looks neater.
Grants sig tech's access to the exterior turret control and adds a control to their room.
Replaced lazy-mapper auto_name APCs with actual ones.
Changed the visible/hidden status of some pipes in and around atmos.

**Delta**
Moved plant-b-gone bottle out of the wall.
Replaced lazy-mapper auto_name APCs with actual ones.
Made pipes visible in electrical maint.
Rotates a brig chair.

**Omega**
Replaced the bridge and captain office carpets with blue carpets.
Atmos is prettier near the entrance.
Adds an air alarm to perma.