### PR TITLE
adds a 10% chance of getting a bluespace emag if you emag an emag

### DIFF
--- a/yogstation/code/game/objects/items/cards_ids.dm
+++ b/yogstation/code/game/objects/items/cards_ids.dm
@@ -76,6 +76,7 @@
 		qdel(otherEmag)
 		color = rgb(40, 130, 255)
 		prox_check = FALSE
+		return
 	to_chat(user, "<span class='notice'>The cyptographic sequencers attempt to override each other before destroying themselves.</span>")
 	playsound(src.loc, "sparks", 50, 1)
 	qdel(otherEmag)

--- a/yogstation/code/game/objects/items/cards_ids.dm
+++ b/yogstation/code/game/objects/items/cards_ids.dm
@@ -70,6 +70,12 @@
 	var/otherEmag = user.get_active_held_item()
 	if(!otherEmag)
 		return
+	if(prob(10))
+		to_chat(user, "<span class='notice'>By some ungodly miracle, the emag gains new functionality instead of being destroyed.</span>")
+		playsound(src.loc, "sparks", 50, 1)
+		qdel(otherEmag)
+		color = rgb(40, 130, 255)
+		prox_check = FALSE
 	to_chat(user, "<span class='notice'>The cyptographic sequencers attempt to override each other before destroying themselves.</span>")
 	playsound(src.loc, "sparks", 50, 1)
 	qdel(otherEmag)


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/3681297/70021586-31373700-155f-11ea-8d08-934f7f205e3e.png)

it turned out not to be true, so this PR makes it true.


the other 90% of the time, both emags are destroyed (as normally happens)

10% of the time you get a slightly more powerful emag, the other 90% you just wasted 16 TC.

:cl: monster860
add: Adds a 10% chance of getting a bluespace emag if you emag an emag
/:cl: