### PR TITLE
Added an RCD to the Chief Engineer's locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -26,6 +26,7 @@
 	new /obj/item/multitool(src)
 	new /obj/item/assembly/flash/handheld(src)
 	new /obj/item/clothing/glasses/meson/engine(src)
+	new /obj/item/construction/rcd/loaded(src)
 	new /obj/item/door_remote/chief_engineer(src)
 	new /obj/item/pipe_dispenser(src)
 	new /obj/item/inducer(src)


### PR DESCRIPTION
Tested before commit. it works.

I have no clue why this wasn't a thing before. 
I always thought the CE should have his own RCD in his locker. 
Sometimes he arrives late and isn't able to get one from the vending machine.

#### Changelog

:cl:  
rscadd: CE's locker now contains an RCD because sometimes he arrives late
/:cl:
