### PR TITLE
adds support for hiding achievement descriptions untill they've been achieved

### DIFF
--- a/code/datums/achievements/achievements.dm
+++ b/code/datums/achievements/achievements.dm
@@ -2,6 +2,7 @@
 	var/name = "achievement"
 	var/desc = "Please make an issue on github, including this achievement's name and how you got it."
 	var/id = 0 //Should be incremented so every achievement has a unique ID
+	var/hidden = FALSE // Whether or not this achievement's description is hidden untill you accomplish this (doesn't apply to the online viewer)
 
 /datum/achievement/bubblegum
 	name = "Kick Ass and Chew Bubblegum."
@@ -22,6 +23,7 @@
 	name = "Catastrophe"
 	desc = "Emag a Particle Accelerator"
 	id = 4
+	hidden = TRUE
   
 /datum/achievement/flukeops
 	name = "Reverse Card"
@@ -37,3 +39,4 @@
 	name = "Honorary Nukie"
 	desc = "Kill yourself using the nuclear authentication disk"
 	id = 7
+	hidden = TRUE

--- a/code/datums/achievements/viewer.dm
+++ b/code/datums/achievements/viewer.dm
@@ -25,8 +25,8 @@
 		var/datum/achievement/achievement = B
 		var/list/A = list(
 			"name" = achievement.name,
-			"desc" = achievement.desc,
-			"unlocked" = achievements[achievement]
+			"unlocked" = achievements[achievement],
+			"desc" = (!achievement.hidden || achievements[achievement]) ? achievement.desc : "???"
 		)
 		data["achievements"] += list(A)
 	


### PR DESCRIPTION
Untill then, the description'll show up as "???". The description will not be hidden on the website or on github, so anyone could just go on there and check 