### PR TITLE
Allows the Rapid Piping Device(RPD) to construct TINY fans.

### DIFF
--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -34,7 +34,7 @@ GLOBAL_LIST_INIT(atmos_pipe_recipes, list(
 		new /datum/pipe_info/meter("Meter"),
 		new /datum/pipe_info/pipe("Gas Filter",			/obj/machinery/atmospherics/components/trinary/filter),
 		new /datum/pipe_info/pipe("Gas Mixer",			/obj/machinery/atmospherics/components/trinary/mixer),
-		new /datum/pipe_info/pipe("Tiny Fan",		/obj/structure/fans/tiny),
+		new /datum/pipe_info/pipe("Tiny Fan",			/obj/structure/fans/tiny),
 	),
 	"Heat Exchange" = list(
 		new /datum/pipe_info/pipe("Pipe",				/obj/machinery/atmospherics/pipe/heat_exchanging/simple),

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -34,6 +34,7 @@ GLOBAL_LIST_INIT(atmos_pipe_recipes, list(
 		new /datum/pipe_info/meter("Meter"),
 		new /datum/pipe_info/pipe("Gas Filter",			/obj/machinery/atmospherics/components/trinary/filter),
 		new /datum/pipe_info/pipe("Gas Mixer",			/obj/machinery/atmospherics/components/trinary/mixer),
+		new /datum/pipe_info/pipe("Tiny Fan",		/obj/structure/fans/tiny),
 	),
 	"Heat Exchange" = list(
 		new /datum/pipe_info/pipe("Pipe",				/obj/machinery/atmospherics/pipe/heat_exchanging/simple),


### PR DESCRIPTION
### Intent of your Pull Request
Tiny fans are neato and underused,may make this a crafting recipe later on if "too op" but atmospheric resistance is really not the biggest of deals in all honesty and at worst it could be used to what, block a plasma flood when a firesuit, strong blobs, atmos holo fans and more can do it.
(also atmos holo fans leak heat so this would be preferable for fusion opposed to a x-k class end of world scenario heat leak)
I think this gives a good spot for atmos holo fans as a mostly "repair" tool, because if you fucking spam the shit out of mini fans you might have problems later on with pressurization.

Anyhow,I'm open to changes if this is "op" 
#### Changelog

:cl:  
rscadd: RPDs can now make holo fans, don't spam them because you won't be able to repressurize the environment.
/:cl:
