### PR TITLE
Makes PDA messages use the language system

### DIFF
--- a/code/game/machinery/telecomms/computers/message.dm
+++ b/code/game/machinery/telecomms/computers/message.dm
@@ -425,6 +425,7 @@
 							"name" = "[customsender]",
 							"job" = "[customjob]",
 							"message" = custommessage,
+							"language" = get_default_language(), // PDAs now use the language system!
 							"targets" = list("[customrecepient.owner] ([customrecepient.ownjob])")
 						))
 						// this will log the signal and transmit it to the target

--- a/code/game/machinery/telecomms/machines/message_server.dm
+++ b/code/game/machinery/telecomms/machines/message_server.dm
@@ -121,15 +121,26 @@
 	return copy
 
 // PDA signal datum
+/datum/signal/subspace/messaging/pda
+	var/datum/language/lang // Stores what language the message was written in.
+
+/datum/signal/subspace/messaging/pda/New(init_source,init_data)
+	..()
+	lang = data["language"] || /datum/language/common
+
 /datum/signal/subspace/messaging/pda/proc/format_target()
 	if (length(data["targets"]) > 1)
 		return "Everyone"
 	return data["targets"][1]
 
-/datum/signal/subspace/messaging/pda/proc/format_message()
+/datum/signal/subspace/messaging/pda/proc/format_message(mob/living/listener)
+	var/msg = data["message"]
+	if(istype(listener) && !listener.has_language(lang))
+		var/datum/language/langue = GLOB.language_datum_instances[lang]
+		msg = langue.scramble(msg)
 	if (logged && data["photo"])
-		return "\"[data["message"]]\" (<a href='byond://?src=[REF(logged)];photo=1'>Photo</a>)"
-	return "\"[data["message"]]\""
+		return "\"[msg]\" (<a href='byond://?src=[REF(logged)];photo=1'>Photo</a>)"
+	return "\"[msg]\""
 
 /datum/signal/subspace/messaging/pda/broadcast()
 	if (!logged)  // Can only go through if a message server logs it

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -51,7 +51,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	var/f_lum = 2.3 //Luminosity for the flashlight function
 	var/silent = FALSE //To beep or not to beep, that is the question
 	var/toff = FALSE //If TRUE, messenger disabled
-	var/tnote = null //Current Texts
+	var/list/tnote = list() //Current list of received signals, which are transmuted into messages on-the-spot. Can also be just plain strings, y'know, like, who really gives a shit, y'know
 	var/last_text //No text spamming
 	var/last_everyone //No text for everyone spamming
 	var/last_noise //Also no honk spamming that's bad too
@@ -340,7 +340,13 @@ GLOBAL_LIST_EMPTY(PDAs)
 
 				dat += "<h4>[PDAIMG(mail)] Messages</h4>"
 
-				dat += tnote
+				//Build the message list
+				for(var/x in tnote)
+					if(istext(x)) // If it's literally just text
+						dat += tnote
+					else // It's hopefully a signal
+						var/datum/signal/subspace/messaging/pda/sig = x
+						dat += "<i><b><a href='byond://?src=[REF(src)];choice=Message;target=[REF(sig.source)]'>[sig.data["name"]]</a> ([sig.data["job"]]):</b></i><br>[sig.format_message(user)]<br>"
 				dat += "<br>"
 
 			if (3)
@@ -649,7 +655,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 
 	var/target_text = signal.format_target()
 	// Log it in our logs
-	tnote += "<i><b>&rarr; To [target_text]:</b></i><br>[signal.format_message()]<br>"
+	tnote += signal
 	// Show it to ghosts
 	var/ghost_message = "<span class='name'>[owner] </span><span class='game say'>PDA Message</span> --> <span class='name'>[target_text]</span>: <span class='message'>[signal.format_message()]</span>"
 	for(var/mob/M in GLOB.player_list)
@@ -665,7 +671,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 		last_everyone = world.time
 
 /obj/item/pda/proc/receive_message(datum/signal/subspace/messaging/pda/signal)
-	tnote += "<i><b>&larr; From <a href='byond://?src=[REF(src)];choice=Message;target=[REF(signal.source)]'>[signal.data["name"]]</a> ([signal.data["job"]]):</b></i><br>[signal.format_message()]<br>"
+	tnote += signal
 
 	if (!silent)
 		playsound(src, 'sound/machines/twobeep_high.ogg', 50, 1)


### PR DESCRIPTION
Robert paid me to do this.
![image](https://user-images.githubusercontent.com/29939414/70363551-71900100-184e-11ea-9a70-62bd3e7f3ee6.png)
## Overview
This makes it so that all messages you write via PDA are written in your default language. People who attempt to read your messages but lack knowledge of your language will see a ``scramble()``'d gobbledygook.


### Changelog
:cl:  Altoids
rscadd: Messages you write with PDAs are now written in your default language! Get a load of that one, sheltered folk!
/:cl:
