### PR TITLE
makes a capital letter to a lower case letter in cargo crates (this wont affect anything ingame)

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -289,7 +289,7 @@
 					/obj/item/clothing/head/stormer,
 					/obj/item/clothing/head/stormer,
 					/obj/item/clothing/head/stormer)
-	crate_name = "Stormtrooper crate"
+	crate_name = "stormtrooper crate"
 
 /datum/supply_pack/security/disabler
 	name = "Disabler Crate"


### PR DESCRIPTION
### Intent of your Pull Request
originally this pr was a attempted bugfix but since i was dumb and forgot about test merges this pr was unneeeded. but this pr is still useful to bring my new crate to standards with other modern ones
### Changelog

:cl:  
bugfix: made a capital a non capital
:cl:
