### PR TITLE
Borgs can now unbuckle users by resist/help intent click

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1187,6 +1187,14 @@
 			riding_datum.restore_position(user)
 	. = ..(user)
 
+/mob/living/silicon/robot/resist()
+	. = ..()
+	if(!buckled_mobs.len)
+		return
+	for(var/i in buckled_mobs)
+		var/mob/unbuckle_me_now = i
+		unbuckle_mob(unbuckle_me_now, FALSE)
+
 /mob/living/silicon/robot/proc/TryConnectToAI()
 	connected_ai = select_active_ai_with_fewest_borgs()
 	if(connected_ai)

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -10,6 +10,13 @@
 		spark_system.start()
 	return ..()
 
+/mob/living/silicon/robot/attack_robot(mob/user)
+	. = ..()
+	if(user == src && buckled_mobs.len && user.a_intent == INTENT_HELP)
+		for(var/i in buckled_mobs)
+			var/mob/buckmob = i
+			unbuckle_mob(buckmob)
+
 /mob/living/silicon/robot/attack_alien(mob/living/carbon/alien/humanoid/M)
 	if (M.a_intent == INTENT_DISARM)
 		if(mobility_flags & MOBILITY_STAND)


### PR DESCRIPTION
### Intent of your Pull Request

"Clicking with Help Intent + No Module OR resisting on yourself will now allow you to safely put a player down" 

No more spinning, no more harm. Farewell

-ExcessiveUseOfCobblestone

#### Changelog

:cl:  
rscadd: Borgs can now unbuckle users without use of spin
/:cl:
