### PR TITLE
Photocopier no longer able to eat secret documents

### DIFF
--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -317,7 +317,7 @@
 	return 0
 
 /obj/machinery/photocopier/proc/copier_empty()
-	if(copy || photocopy || check_ass())
+	if(copy || photocopy || doccopy || check_ass())
 		return 0
 	else
 		return 1


### PR DESCRIPTION
#### Changelog

:cl:  
bugfix: phoyocopier will check ig secret documents are present instead of being able to eat them if something else is placed on the copier
/:cl:
