### PR TITLE
Makes miasma production consume oxygen

### DIFF
--- a/code/datums/components/rot.dm
+++ b/code/datums/components/rot.dm
@@ -17,11 +17,23 @@
 	if(!istype(T) || T.return_air().return_pressure() > (WARNING_HIGH_PRESSURE - 10))
 		return
 
-	var/datum/gas_mixture/stank = new
-	ADD_GAS(/datum/gas/miasma, stank.gases)
-	stank.gases[/datum/gas/miasma][MOLES] = amount
-	stank.temperature = BODYTEMP_NORMAL // otherwise we have gas below 2.7K which will break our lag generator
-	T.assume_air(stank)
+	var/datum/gas_mixture/turf_air = T.return_air()
+	var/datum/gas_mixture/stank_breath = T.remove_air(1 / turf_air.volume * turf_air.total_moles())
+	stank_breath.volume = 1
+	var/oxygen_pp = 0
+	if(stank_breath.gases[/datum/gas/oxygen])
+		oxygen_pp = stank_breath.gases[/datum/gas/oxygen][MOLES] * R_IDEAL_GAS_EQUATION * stank_breath.temperature / stank_breath.volume
+	
+	if(oxygen_pp > 18)
+		var/this_amount = min((oxygen_pp - 8) * stank_breath.volume / stank_breath.temperature / R_IDEAL_GAS_EQUATION, amount)
+		stank_breath.gases[/datum/gas/oxygen][MOLES] -= this_amount
+
+		var/datum/gas_mixture/stank = new
+		ADD_GAS(/datum/gas/miasma, stank.gases)
+		stank.gases[/datum/gas/miasma][MOLES] = this_amount
+		stank.temperature = BODYTEMP_NORMAL // otherwise we have gas below 2.7K which will break our lag generator
+		stank_breath.merge(stank)
+	T.assume_air(stank_breath)
 	T.air_update_turf()
 
 /datum/component/rot/corpse


### PR DESCRIPTION
**This will halt miasma production once oxygen reaches a partial pressure of 18 kPa**. This will not make the station unbreathable.

The upshot of this is that miasma production will no longer result in the pressure of the kitchen backroom being really high for no reason, messing up people's kitchen spreads. The other upshot is that bodies in space dont produce miasma anymore.

:cl: monster860
tweak: Miasma production now consumes oxygen
/:cl: