### PR TITLE
heal_bodypart no longer heals roboticts limb by default

### DIFF
--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -168,11 +168,11 @@
 //It automatically updates damage overlays if necessary
 //It automatically updates health status
 /mob/living/carbon/heal_bodypart_damage(brute = 0, burn = 0, stamina = 0, updating_health = TRUE, required_status)
-	var/list/obj/item/bodypart/parts = get_damaged_bodyparts(brute,burn,stamina,required_status)
+	var/list/obj/item/bodypart/parts = get_damaged_bodyparts(brute,burn,stamina,required_status ? required_status : BODYPART_ORGANIC)
 	if(!parts.len)
 		return
 	var/obj/item/bodypart/picked = pick(parts)
-	if(picked.heal_damage(brute, burn, stamina, required_status))
+	if(picked.heal_damage(brute, burn, stamina, required_status ? required_status : BODYPART_ORGANIC))
 		update_damage_overlays()
 
 //Damages ONE bodypart randomly selected from damagable ones.


### PR DESCRIPTION
:cl:  alexkar598
bugfix: Many unintended ways of healing preternis and robotic limbs have been fixed
/:cl:

Fixes #7392 
