### PR TITLE
Fixes bug where antags can get other antags as objective (yes this is actually a bug)

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -112,7 +112,7 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 		if(!(possible_target in owners) && ishuman(possible_target.current) && (possible_target.current.stat != DEAD) && is_unique_objective(possible_target,dupe_search_range))
 			//yogs start -- Quiet Rounds
 			var/mob/living/carbon/human/guy = possible_target.current
-			if(possible_target.antag_datums || !(guy.client && (guy.client.prefs.yogtoggles & QUIET_ROUND)))
+			if(possible_target.special_role || !(guy.client && (guy.client.prefs.yogtoggles & QUIET_ROUND)))
 				if (!(possible_target in blacklist))
 					possible_targets += possible_target//yogs indent
 			//yogs end


### PR DESCRIPTION
There is a clause in the code supposed to prevent this from happening, but it doesnt work correctly, because antags get antag datums at the same time they get objectives, so an antag can get an objective that hasn't been made a traitor yet, then they get made a traitor.

Oh yeah, this bug means that latejoin > ready up because if you get latejoin antag then you physically cannot be someone's objective. Yall always complaint about how people don't ready up and this is one bug that could prevent people from readying up.

You could still get potentially cucked if you're a antag token receiver, or get antagged by an admin, but meh.