### PR TITLE
Fixes bug where you can accidentally destroy your spacepod instead of fixing it

### DIFF
--- a/yogstation/code/modules/spacepods/spacepod.dm
+++ b/yogstation/code/modules/spacepods/spacepod.dm
@@ -174,7 +174,7 @@ GLOBAL_LIST_INIT(spacepods_list, list())
 					user.visible_message("[user] slices off [src]'s armor.", "<span class='notice'>You slice off [src]'s armor.</span>")
 					construction_state = SPACEPOD_ARMOR_SECURED
 					update_icon()
-				return TRUE
+			return TRUE
 	return ..()
 
 /obj/spacepod/attack_hand(mob/user as mob)


### PR DESCRIPTION
:cl: monster860
fix: Running out of welding fuel while fixing your spacepod will no longer stack a billion hits on your spacepod
/:cl: