### PR TITLE
Fixes some buttons defaulting to darkmode colors

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1,21 +1,22 @@
 macro "default"
 
+
 menu "menu"
-	elem
+	elem 
 		name = "&File"
 		command = ""
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Quick screenshot\tF2"
 		command = ".screenshot auto"
 		category = "&File"
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Save screenshot as...\tShift+F2"
 		command = ".screenshot"
 		category = "&File"
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = ""
 		command = ""
 		category = "&File"
@@ -25,21 +26,21 @@ menu "menu"
 		command = ".reconnect"
 		category = "&File"
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Quit\tAlt-F4"
 		command = ".quit"
 		category = "&File"
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Help"
 		command = ""
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Admin Help\tF1"
 		command = "adminhelp"
 		category = "&Help"
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Hotkeys"
 		command = "hotkeys-help"
 		category = "&Help"
@@ -149,10 +150,11 @@ window "mapwindow"
 window "infowindow"
 	elem "infowindow"
 		type = MAIN
-		pos = 0,0
+		pos = 281,0
 		size = 640x480
 		anchor1 = none
 		anchor2 = none
+		background-color = none
 		saved-params = "pos;size;is-minimized;is-maximized"
 		is-pane = true
 	elem "info"
@@ -161,6 +163,7 @@ window "infowindow"
 		size = 640x445
 		anchor1 = 0,0
 		anchor2 = 100,100
+		background-color = none
 		saved-params = "splitter"
 		left = "statwindow"
 		right = "outputwindow"
@@ -171,8 +174,7 @@ window "infowindow"
 		size = 80x20
 		anchor1 = 3,0
 		anchor2 = 19,0
-		text-color = #99aab5
-		background-color = #494949
+		background-color = none
 		saved-params = "is-checked"
 		text = "Changelog"
 		command = "changelog"
@@ -182,8 +184,7 @@ window "infowindow"
 		size = 80x20
 		anchor1 = 19,0
 		anchor2 = 34,0
-		text-color = #99aab5
-		background-color = #494949
+		background-color = none
 		saved-params = "is-checked"
 		text = "Rules"
 		command = "rules"
@@ -193,6 +194,7 @@ window "infowindow"
 		size = 80x20
 		anchor1 = 34,0
 		anchor2 = 50,0
+		background-color = none
 		saved-params = "is-checked"
 		text = "Wiki"
 		command = "wiki"
@@ -202,6 +204,7 @@ window "infowindow"
 		size = 80x20
 		anchor1 = 50,0
 		anchor2 = 66,0
+		background-color = none
 		saved-params = "is-checked"
 		text = "Forum"
 		command = "forum"
@@ -211,6 +214,7 @@ window "infowindow"
 		size = 80x20
 		anchor1 = 66,0
 		anchor2 = 81,0
+		background-color = none
 		saved-params = "is-checked"
 		text = "Github"
 		command = "github"
@@ -220,36 +224,20 @@ window "infowindow"
 		size = 80x20
 		anchor1 = 81,0
 		anchor2 = 97,0
+		background-color = none
 		saved-params = "is-checked"
 		text = "Report Issue"
 		command = "report-issue"
 	elem "tickets"
 		type = BUTTON
-		button-type = pushbutton
 		pos = 520,5
 		size = 80x20
 		anchor1 = 97,0
 		anchor2 = 113,0
-		font-family = ""
-		font-size = 0
-		font-style = ""
-		text-color = #000000
 		background-color = none
-		is-visible = true
-		is-disabled = false
-		is-transparent = false
-		is-default = false
-		border = none
-		drop-zone = false
-		right-click = false
 		saved-params = "is-checked"
-		on-size = ""
 		text = "Tickets"
-		image = ""
 		command = "tickets"
-		is-flat = false
-		stretch = false
-		is-checked = false
 
 window "outputwindow"
 	elem "outputwindow"
@@ -287,7 +275,6 @@ window "preferences_window"
 		size = 1280x1000
 		anchor1 = none
 		anchor2 = none
-		background-color = none
 		is-visible = false
 		saved-params = "pos;size;is-minimized;is-maximized"
 		statusbar = false
@@ -297,7 +284,6 @@ window "preferences_window"
 		size = 960x1008
 		anchor1 = 0,0
 		anchor2 = 75,100
-		background-color = none
 		saved-params = ""
 	elem "character_preview_map"
 		type = MAP
@@ -307,7 +293,7 @@ window "preferences_window"
 		anchor2 = 75,100
 		right-click = true
 		saved-params = "zoom;letterbox;zoom-mode"
-		
+
 window "statwindow"
 	elem "statwindow"
 		type = MAIN
@@ -333,8 +319,8 @@ window "Telecomms IDE"
 		size = 569x582
 		anchor1 = none
 		anchor2 = none
-		background-color = #222222
 		text-color = #eeeeee
+		background-color = #222222
 		is-visible = false
 		saved-params = "pos;size;is-minimized;is-maximized"
 		title = "TCS IDE"
@@ -346,8 +332,8 @@ window "Telecomms IDE"
 		size = 70x20
 		anchor1 = 37,80
 		anchor2 = 49,83
-		background-color = #555555
 		text-color = #eeeeee
+		background-color = #555555
 		saved-params = "is-checked"
 		text = "Clear Memory"
 		command = "tcsclearmem"
@@ -357,8 +343,8 @@ window "Telecomms IDE"
 		size = 52x20
 		anchor1 = 28,80
 		anchor2 = 37,83
-		background-color = #555555
 		text-color = #eeeeee
+		background-color = #555555
 		saved-params = "is-checked"
 		text = "Revert"
 		command = "tcsrevert"
@@ -368,8 +354,8 @@ window "Telecomms IDE"
 		size = 52x20
 		anchor1 = 18,80
 		anchor2 = 28,83
-		background-color = #555555
 		text-color = #eeeeee
+		background-color = #555555
 		saved-params = "is-checked"
 		text = "Execute"
 		command = "tcsrun"
@@ -379,10 +365,10 @@ window "Telecomms IDE"
 		size = 566x94
 		anchor1 = 0,84
 		anchor2 = 99,100
-		background-color = #333334
-		text-color = #eeeeee
 		font-family = "sans-serif"
 		font-size = 9
+		text-color = #eeeeee
+		background-color = #333334
 		saved-params = "max-lines"
 	elem "button2"
 		type = BUTTON
@@ -390,8 +376,8 @@ window "Telecomms IDE"
 		size = 52x20
 		anchor1 = 9,80
 		anchor2 = 18,83
-		background-color = #555555
 		text-color = #eeeeee
+		background-color = #555555
 		saved-params = "is-checked"
 		text = "Compile"
 		command = "tcscompile"
@@ -401,8 +387,8 @@ window "Telecomms IDE"
 		size = 53x20
 		anchor1 = 0,80
 		anchor2 = 9,83
-		background-color = #555555
 		text-color = #eeeeee
+		background-color = #555555
 		saved-params = "is-checked"
 		text = "Save"
 		command = "tcssave"
@@ -412,11 +398,12 @@ window "Telecomms IDE"
 		size = 569x464
 		anchor1 = 0,0
 		anchor2 = 100,80
-		background-color = #333334
-		text-color = #eeeeee
 		font-family = "Courier"
 		font-size = 10
+		text-color = #eeeeee
+		background-color = #333334
 		saved-params = ""
 		command = "cancel"
 		multi-line = true
 		no-command = true
+


### PR DESCRIPTION
changelog + rules buttons were in darkmode colors by default

I just used dreammaker to edit, if there's anything else I should be using then tell me please since there's so many changes apparently.

:cl:  
bugfix: Changelog and rules buttons are not in darkmode by default.
/:cl: