### PR TITLE
Adds safety flares

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -258,13 +258,15 @@
 	var/fuel = 0
 	var/on_damage = 7
 	var/produce_heat = 1500
+	var/frng_min = 800
+	var/frng_max = 1000
 	heat = 1000
 	light_color = LIGHT_COLOR_FLARE
 	grind_results = list(/datum/reagent/sulfur = 15)
 
 /obj/item/flashlight/flare/Initialize()
 	. = ..()
-	fuel = rand(800, 1000) // Sorry for changing this so much but I keep under-estimating how long X number of ticks last in seconds.
+	fuel = rand(frng_min, frng_max)
 
 /obj/item/flashlight/flare/process()
 	open_flame(heat)
@@ -319,6 +321,15 @@
 
 /obj/item/flashlight/flare/is_hot()
 	return on * heat
+
+/obj/item/flashlight/flare/emergency
+	name = "safety flare"
+	desc = "A flare issued to nanotrasen employees for emergencies. There are instructions on the side, it reads 'pull cord, make light, obey nanotrasen'."
+	brightness_on = 3
+	icon_state = "flare"
+	item_state = "flare"
+	frng_min = 40
+	frng_max = 70
 
 /obj/item/flashlight/flare/torch
 	name = "torch"

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -326,8 +326,6 @@
 	name = "safety flare"
 	desc = "A flare issued to nanotrasen employees for emergencies. There are instructions on the side, it reads 'pull cord, make light, obey nanotrasen'."
 	brightness_on = 3
-	icon_state = "flare"
-	item_state = "flare"
 	frng_min = 40
 	frng_max = 70
 

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -126,8 +126,8 @@
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/tank/internals/emergency_oxygen(src)
 	new /obj/item/reagent_containers/hypospray/medipen(src)
-	new /obj/item/map/station(src)
 	new /obj/item/flashlight/flare/emergency(src)
+	new /obj/item/map/station(src)
 
 /obj/item/storage/box/survival/radio/PopulateContents()
 	..() // we want the survival stuff too.
@@ -138,16 +138,16 @@
 	new /obj/item/tank/internals/emergency_oxygen(src)
 	new /obj/item/crowbar/red(src)
 	new /obj/item/reagent_containers/hypospray/medipen(src)
-	new /obj/item/map/station(src)
 	new /obj/item/flashlight/flare/emergency(src)
+	new /obj/item/map/station(src)
 
 // Engineer survival box
 /obj/item/storage/box/engineer/PopulateContents()
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/tank/internals/emergency_oxygen/engi(src)
 	new /obj/item/reagent_containers/hypospray/medipen(src)
-	new /obj/item/map/station(src)
 	new /obj/item/flashlight/flare/emergency(src)
+	new /obj/item/map/station(src)
 
 /obj/item/storage/box/engineer/radio/PopulateContents()
 	..() // we want the regular items too.
@@ -163,8 +163,8 @@
 	new /obj/item/clothing/mask/gas/sechailer(src)
 	new /obj/item/tank/internals/emergency_oxygen(src)
 	new /obj/item/reagent_containers/hypospray/medipen(src)
-	new /obj/item/map/station(src)
 	new /obj/item/flashlight/flare/emergency(src)
+	new /obj/item/map/station(src)
 
 /obj/item/storage/box/security/radio/PopulateContents()
 	..() // we want the regular stuff too

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -127,6 +127,7 @@
 	new /obj/item/tank/internals/emergency_oxygen(src)
 	new /obj/item/reagent_containers/hypospray/medipen(src)
 	new /obj/item/map/station(src)
+	new /obj/item/flashlight/flare/emergency(src)
 
 /obj/item/storage/box/survival/radio/PopulateContents()
 	..() // we want the survival stuff too.
@@ -138,7 +139,7 @@
 	new /obj/item/crowbar/red(src)
 	new /obj/item/reagent_containers/hypospray/medipen(src)
 	new /obj/item/map/station(src)
-
+	new /obj/item/flashlight/flare/emergency(src)
 
 // Engineer survival box
 /obj/item/storage/box/engineer/PopulateContents()
@@ -146,6 +147,7 @@
 	new /obj/item/tank/internals/emergency_oxygen/engi(src)
 	new /obj/item/reagent_containers/hypospray/medipen(src)
 	new /obj/item/map/station(src)
+	new /obj/item/flashlight/flare/emergency(src)
 
 /obj/item/storage/box/engineer/radio/PopulateContents()
 	..() // we want the regular items too.
@@ -162,6 +164,7 @@
 	new /obj/item/tank/internals/emergency_oxygen(src)
 	new /obj/item/reagent_containers/hypospray/medipen(src)
 	new /obj/item/map/station(src)
+	new /obj/item/flashlight/flare/emergency(src)
 
 /obj/item/storage/box/security/radio/PopulateContents()
 	..() // we want the regular stuff too


### PR DESCRIPTION
From old yogs but nerfed by like 1/4 of the time it lasted prebase, since it's for emergencies. And added them to the starting boxes, like prebase.

:cl:  
rscadd: Safety flares added to player boxes. They give off less light and last for less time than normal flares.
/:cl:
