### PR TITLE
Fixes several bugs with Paper, buffs/nerfs photocopiers

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -32,6 +32,7 @@
 	dog_fashion = /datum/dog_fashion/head
 
 	var/info = "" // What's prewritten on the paper. Appears first and is a special snowflake callback to how paper used to work.
+	var/coloroverride // A hexadecimal as a string that, if set, overrides the font color of the whole document. Used by photocopiers
 	var/datum/language/infolang // The language info is written in. If left NULL, info will default to being omnilingual and readable by all.
 	var/list/written//What's written on the paper by people. Stores /datum/langtext values, plus plaintext values that mark where fields are.
 	var/stamps		//The (text for the) stamps on the paper.
@@ -138,7 +139,10 @@
 		onclose(usr, "[name]")
 
 /obj/item/paper/proc/render_body(mob/user,links = FALSE)
-	var/text = info // The actual text displayed. Starts with & defaults to $info.
+	var/text = ""// The actual text displayed. Starts with & defaults to $info.
+	if(coloroverride)
+		text = "<font color='#[coloroverride]'>"
+	text += info
 	if(istype(infolang) && !user.has_language(infolang))
 		var/datum/language/paperlang = GLOB.language_datum_instances[infolang]
 		text = paperlang.scramble_HTML(text)
@@ -156,6 +160,8 @@
 			text += "<span class=\"paper_field\">" + "<font face=\"[PEN_FONT]\"><A href='?src=[REF(src)];write=[i]'>write</A></font>" + "</span>"
 	if(links)
 		text += "<span class=\"paper_field\">" + "<font face=\"[PEN_FONT]\"><A href='?src=[REF(src)];write=end'>write</A></font>" + "</span>"
+	if(coloroverride)
+		text += "</font>"
 	return text
 
 /obj/item/paper/proc/clearpaper()

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -66,7 +66,7 @@
 	if(resistance_flags & ON_FIRE)
 		icon_state = "paper_onfire"
 		return
-	if(info)
+	if(info || length(written))
 		icon_state = "paper_words"
 		return
 	icon_state = "paper"

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -253,7 +253,7 @@
 			if(id == "end")
 				written += templist
 			else
-				written.Insert(id,templist)
+				written.Insert(text2num(id),templist) // text2num, otherwise it writes to the hashtable index instead of into the array
 			usr << browse("<HTML><HEAD><TITLE>[name]</TITLE></HEAD><BODY>[render_body(usr,TRUE)]<HR>[stamps]</BODY><div align='right'style='position:fixed;bottom:0;font-style:bold;'><A href='?src=[REF(src)];help=1'>\[?\]</A></div></HTML>", "window=[name]") // Update the window
 			update_icon()
 

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -66,16 +66,23 @@
 							copy_as_paper = 0
 					if(copy_as_paper)
 						var/obj/item/paper/c = new /obj/item/paper (loc)
-						if(length(copy.info) > 0)	//Only print and add content if the copied doc has words on it
+						if(length(copy.info) || length(copy.written))	//Only print and add content if the copied doc has words on it
 							if(toner > 10)	//lots of toner, make it dark
 								c.info = "<font color = #101010>"
 							else			//no toner? shitty copies for you!
 								c.info = "<font color = #808080>"
-							var/copied = copy.info
-							copied = replacetext(copied, "<font face=\"[PEN_FONT]\" color=", "<font face=\"[PEN_FONT]\" nocolor=")	//state of the art techniques in action
-							copied = replacetext(copied, "<font face=\"[CRAYON_FONT]\" color=", "<font face=\"[CRAYON_FONT]\" nocolor=")	//This basically just breaks the existing color tag, which we need to do because the innermost tag takes priority.
-							c.info += copied
-							c.info += "</font>"
+							var/copyinfo = copy.info
+							copyinfo = replacetext(copyinfo, "<font face=\"[PEN_FONT]\" color=", "<font face=\"[PEN_FONT]\" nocolor=")	//state of the art techniques in action
+							copyinfo = replacetext(copyinfo, "<font face=\"[CRAYON_FONT]\" color=", "<font face=\"[CRAYON_FONT]\" nocolor=")	//This basically just breaks the existing color tag, which we need to do because the innermost tag takes priority.
+							c.info += copyinfo + "</font>"
+							//Now for copying the new $written var
+							for(var/L in copy.written)
+								if(istype(L,/datum/langtext))
+									var/datum/langtext/oldL = L
+									var/datum/langtext/newL = new(oldL.text,oldL.lang)
+									c.written += newL
+								else
+									c.written += L
 							c.name = copy.name
 							c.fields = copy.fields
 							c.update_icon()

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -7,6 +7,9 @@
 /*
  * Photocopier
  */
+
+#define MAX_TONER 40 // The maximum amount of toner in the photocopier, as well as the amount of toner given by toner cartridges.
+
 /obj/machinery/photocopier
 	name = "photocopier"
 	desc = "Used to copy important documents and anatomy studies."
@@ -23,7 +26,7 @@
 	var/obj/item/photo/photocopy = null
 	var/obj/item/documents/doccopy = null
 	var/copies = 1	//how many copies to print!
-	var/toner = 40 //how much toner is left! woooooo~
+	var/toner = MAX_TONER //how much toner is left! woooooo~
 	var/maxcopies = 10	//how many copies can be copied at once- idea shamelessly stolen from bs12's copier!
 	var/greytoggle = "Greyscale"
 	var/mob/living/ass //i can't believe i didn't write a stupid-ass comment about this var when i first coded asscopy.
@@ -246,7 +249,7 @@
 			if(!user.temporarilyRemoveItemFromInventory(O))
 				return
 			qdel(O)
-			toner = 40
+			toner = MAX_TONER
 			to_chat(user, "<span class='notice'>You insert [O] into [src].</span>")
 			updateUsrDialog()
 		else
@@ -339,3 +342,6 @@
 	grind_results = list(/datum/reagent/iodine = 40, /datum/reagent/iron = 10)
 	var/charges = 5
 	var/max_charges = 5
+
+
+#undef MAX_TONER

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -54,6 +54,10 @@
 	user << browse(dat, "window=copier")
 	onclose(user, "copier")
 
+/obj/machinery/photocopier/proc/clearcolor(text) // Breaks all font color spans in the HTML text.
+	return replacetext(replacetext(text, "<font face=\"[CRAYON_FONT]\" color=", "<font face=\"[CRAYON_FONT]\" nocolor="), "<font face=\"[PEN_FONT]\" color=", "<font face=\"[PEN_FONT]\" nocolor=") //This basically just breaks the existing color tag, which we need to do because the innermost tag takes priority.
+
+
 /obj/machinery/photocopier/Topic(href, href_list)
 	if(..())
 		return
@@ -75,14 +79,13 @@
 							else			//no toner? shitty copies for you!
 								c.coloroverride = "808080"
 							var/copyinfo = copy.info
-							copyinfo = replacetext(copyinfo, "<font face=\"[PEN_FONT]\" color=", "<font face=\"[PEN_FONT]\" nocolor=")	//state of the art techniques in action
-							copyinfo = replacetext(copyinfo, "<font face=\"[CRAYON_FONT]\" color=", "<font face=\"[CRAYON_FONT]\" nocolor=")	//This basically just breaks the existing color tag, which we need to do because the innermost tag takes priority.
+							copyinfo = clearcolor(copyinfo)
 							c.info += copyinfo + "</font>"
 							//Now for copying the new $written var
 							for(var/L in copy.written)
 								if(istype(L,/datum/langtext))
 									var/datum/langtext/oldL = L
-									var/datum/langtext/newL = new(oldL.text,oldL.lang)
+									var/datum/langtext/newL = new(clearcolor(oldL.text),oldL.lang)
 									c.written += newL
 								else
 									c.written += L
@@ -124,7 +127,7 @@
 			for(var/i = 0, i < copies, i++)
 				var/icon/temp_img
 				if(ishuman(ass) && (ass.get_item_by_slot(SLOT_W_UNIFORM) || ass.get_item_by_slot(SLOT_WEAR_SUIT)))
-					to_chat(usr, "<span class='notice'>You feel kind of silly, copying [ass == usr ? "your" : ass][ass == usr ? "" : "\'s"] ass with [ass == usr ? "your" : "[ass.p_their()]"] clothes on.</span>" )
+					to_chat(usr, "<span class='notice'>You feel kind of silly, copying [ass == usr ? "your" : ass][ass == usr ? "" : "\'s"] ass with [ass == usr ? "your" : "[ass.p_their()]"] clothes on.</span>" ) // '
 					break
 				else if(toner >= 5 && !busy && check_ass()) //You have to be sitting on the copier and either be a xeno or a human without clothes on.
 					if(isalienadult(ass) || istype(ass, /mob/living/simple_animal/hostile/alien)) //Xenos have their own asses, thanks to Pybro.

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -71,9 +71,9 @@
 						var/obj/item/paper/c = new /obj/item/paper (loc)
 						if(length(copy.info) || length(copy.written))	//Only print and add content if the copied doc has words on it
 							if(toner > 10)	//lots of toner, make it dark
-								c.info = "<font color = #101010>"
+								c.coloroverride = "101010"
 							else			//no toner? shitty copies for you!
-								c.info = "<font color = #808080>"
+								c.coloroverride = "808080"
 							var/copyinfo = copy.info
 							copyinfo = replacetext(copyinfo, "<font face=\"[PEN_FONT]\" color=", "<font face=\"[PEN_FONT]\" nocolor=")	//state of the art techniques in action
 							copyinfo = replacetext(copyinfo, "<font face=\"[CRAYON_FONT]\" color=", "<font face=\"[CRAYON_FONT]\" nocolor=")	//This basically just breaks the existing color tag, which we need to do because the innermost tag takes priority.

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -344,5 +344,3 @@
 	var/charges = 5
 	var/max_charges = 5
 
-
-#undef MAX_TONER

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -8,8 +8,6 @@
  * Photocopier
  */
 
-#define MAX_TONER 40 // The maximum amount of toner in the photocopier, as well as the amount of toner given by toner cartridges.
-
 /obj/machinery/photocopier
 	name = "photocopier"
 	desc = "Used to copy important documents and anatomy studies."
@@ -26,7 +24,7 @@
 	var/obj/item/photo/photocopy = null
 	var/obj/item/documents/doccopy = null
 	var/copies = 1	//how many copies to print!
-	var/toner = MAX_TONER //how much toner is left! woooooo~
+	var/toner = 40 //how much toner is left! woooooo~
 	var/maxcopies = 10	//how many copies can be copied at once- idea shamelessly stolen from bs12's copier!
 	var/greytoggle = "Greyscale"
 	var/mob/living/ass //i can't believe i didn't write a stupid-ass comment about this var when i first coded asscopy.
@@ -252,7 +250,7 @@
 			if(!user.temporarilyRemoveItemFromInventory(O))
 				return
 			qdel(O)
-			toner = MAX_TONER
+			toner = initial(toner)
 			to_chat(user, "<span class='notice'>You insert [O] into [src].</span>")
 			updateUsrDialog()
 		else


### PR DESCRIPTION
# Altoids releases Paperwork: 2!

![image](https://user-images.githubusercontent.com/29939414/71554129-d0294480-29e0-11ea-963a-99e78ab25fce.png)

## Overview
This fixes a bunch of bugs created by the recent language overhaul with paper (https://github.com/yogstation13/Yogstation/pull/7268), especially with how it interacts with photocopiers.

## Coder Warnings
While I was in there I made the maximum toner amount in photocopiers a #define called ``MAX_TONER``, so, there's that.

This also involved the creation of a new var in all paper called ``color_override`` which lathers a new font color over the whole paper (provided all font color spans within have been already neutered), so that's a thing too. It doesn't automatically kill all fontcolor'd things on the paper to allow for clowns to write in crayon on copied pieces of paper.

### Changelog
:cl:  Altoids
bugfix: The paper icon should now update when it's written onto.
bugfix: Fixes photocopiers failing to copy paper with only player-written text.
bugfix: Fixes bug with handwritten paperfields always writing to bottom.
bugfix: Copies of copies of copies of copies of paper should now be capable of being faded out.
bugfix: Player-written text will now actually be printed black in photocopiers.
/:cl:
