### PR TITLE
Enables CTF at round end

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -230,6 +230,8 @@
 	//stop collecting feedback during grifftime
 	SSblackbox.Seal()
 
+	toggle_all_ctf()
+
 	sleep(50)
 	ready_for_reboot = TRUE
 	standard_reboot()


### PR DESCRIPTION
It doesn't _appear_ to break anything. Also prebase feature.

:cl:  
rscadd: CTF is enabled at round end.
/:cl: