### PR TITLE
Pepper spray now contains red dye to mark fleeing suspects

### DIFF
--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -212,16 +212,16 @@
 //pepperspray
 /obj/item/reagent_containers/spray/pepper
 	name = "pepperspray"
-	desc = "Manufactured by UhangInc, used to blind and down an opponent quickly."
+	desc = "Manufactured by UhangInc, used to blind and down an opponent quickly. Now contains red dye to mark fleeing suspects!"
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "pepperspray"
 	item_state = "pepperspray"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
-	volume = 40
+	volume = 60
 	stream_range = 4
 	amount_per_transfer_from_this = 5
-	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin = 40)
+	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin = 40, /datum/reagent/colorful_reagent/crayonpowder/red = 20) //red dye)
 
 /obj/item/reagent_containers/spray/pepper/empty //for protolathe printing
 	list_reagents = null


### PR DESCRIPTION
Apparently real life pepper spray contains colored dye so officers can tell who has been sprayed, this would make a good feature. If you spray a suspect and they flee, they better get to the showers or soap to clean off the red dye or they will stick out like a sore thumb. This will alert other officers to suspects that were subdued and then fled and make running away from security harder. 

![image](https://user-images.githubusercontent.com/20388263/71563241-2c7c7a80-2a5a-11ea-9bb6-a57c4f09690c.png)

Only the standard pepper spray canisters have the dye, the wall dispensers do not because adding several hundred units of colored dye to every wall mount would be asking for trouble. Near-infinite red paint would not be good. Once you run out of the dye mix you can get chemistry to make more or just use normal pepper spray.

:cl:
rscadd: Pepper spray now contains a marking dye to help catch fleeing suspects.
/:cl: