### PR TITLE
boring map things

### DIFF
--- a/_maps/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/map_files/YogsDelta/YogsDelta.dmm
@@ -698,9 +698,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"abu" = (
-/turf/closed/wall/r_wall,
-/area/clerk)
 "abv" = (
 /obj/item/stack/cable_coil,
 /obj/structure/lattice/catwalk,
@@ -44035,36 +44032,26 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bpA" = (
-/obj/item/grenade/barrier{
-	pixel_x = -3;
-	pixel_y = 1
-	},
-/obj/item/grenade/barrier,
-/obj/item/grenade/barrier{
-	pixel_x = 3;
-	pixel_y = -1
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 6;
-	pixel_y = -2
-	},
-/obj/structure/table/reinforced,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/cable/white,
+/obj/machinery/camera{
+	c_tag = "Armory - Interior";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/security/armory";
+	dir = 2;
+	name = "Armoury APC";
+	pixel_y = -26
 	},
-/obj/item/gun/energy/e_gun/dragnet,
-/obj/item/gun/energy/e_gun/dragnet,
-/turf/open/floor/plasteel/dark,
+/obj/item/storage/box/breacherslug,
+/obj/item/storage/box/breacherslug,
+/obj/item/gun/ballistic/shotgun/automatic/breaching,
+/obj/item/gun/ballistic/shotgun/automatic/breaching,
+/turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "bpB" = (
 /obj/machinery/door/airlock/public/glass{
@@ -59291,9 +59278,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bLd" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bLe" = (
@@ -59946,10 +59930,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
-"bLV" = (
-/obj/structure/window/reinforced,
-/turf/open/space,
-/area/space)
 "bLW" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -60965,26 +60945,36 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "bNq" = (
-/obj/structure/cable/white,
-/obj/machinery/camera{
-	c_tag = "Armory - Interior";
-	dir = 1
+/obj/item/grenade/barrier{
+	pixel_x = -3;
+	pixel_y = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/item/grenade/barrier,
+/obj/item/grenade/barrier{
+	pixel_x = 3;
+	pixel_y = -1
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 6;
+	pixel_y = -2
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/security/armory";
-	dir = 2;
-	name = "Armoury APC";
-	pixel_y = -26
+/obj/item/radio/intercom{
+	pixel_y = 26
 	},
-/obj/item/storage/box/breacherslug,
-/obj/item/storage/box/breacherslug,
-/obj/item/gun/ballistic/shotgun/automatic/breaching,
-/obj/item/gun/ballistic/shotgun/automatic/breaching,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/gun/energy/e_gun/dragnet,
+/obj/item/gun/energy/e_gun/dragnet,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "bNr" = (
 /obj/item/storage/box/chemimp{
@@ -64048,7 +64038,7 @@
 "bRP" = (
 /obj/structure/sign/warning/vacuum,
 /turf/closed/wall,
-/area/space/nearstation)
+/area/aisat)
 "bRQ" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/curved/flipped{
@@ -83825,7 +83815,7 @@
 /obj/structure/sign/directions/command{
 	dir = 1
 	},
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/hallway/secondary/command)
 "cvA" = (
 /obj/structure/cable/white{
@@ -83893,7 +83883,7 @@
 	icon_state = "doors";
 	name = "WARNING: BLAST DOORS"
 	},
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/clerk)
 "cvG" = (
 /obj/effect/landmark/start/medical_doctor,
@@ -123678,13 +123668,16 @@
 /turf/open/floor/plating,
 /area/crew_quarters/theatre/abandoned)
 "dLw" = (
-/obj/structure/frame/computer,
 /obj/item/circuitboard/computer/secure_data,
 /obj/machinery/light/small{
 	dir = 8
 	},
 /obj/machinery/status_display/evac{
 	pixel_x = -32
+	},
+/obj/structure/frame/computer{
+	icon_state = "0";
+	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office/private_investigators_office)
@@ -123981,8 +123974,11 @@
 /turf/open/floor/plating,
 /area/crew_quarters/theatre/abandoned)
 "dNi" = (
-/obj/structure/frame/computer,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/frame/computer{
+	icon_state = "0";
+	dir = 4
+	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office/private_investigators_office)
 "dNj" = (
@@ -129702,6 +129698,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"pKo" = (
+/turf/closed/wall,
+/area/aisat)
 "pQm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
@@ -135577,7 +135576,7 @@ aaa
 ajr
 ajr
 aad
-bLV
+bkE
 bsD
 bmj
 bVN
@@ -143038,7 +143037,7 @@ bRP
 bgI
 dje
 bYk
-aJD
+pKo
 aad
 aad
 aad
@@ -172615,7 +172614,7 @@ ach
 dgz
 dhJ
 aaZ
-bKm
+bLd
 bZp
 bPE
 cNA
@@ -172872,7 +172871,7 @@ abL
 dgA
 abL
 aaZ
-bKm
+bLd
 bZp
 bPE
 cNz
@@ -173121,15 +173120,15 @@ cjJ
 bzq
 bMc
 abk
-abu
+aaZ
 abM
 abL
 aci
 acm
 dgB
 acZ
-abu
-bKm
+aaZ
+bLd
 bZp
 bPE
 cNz
@@ -173378,7 +173377,7 @@ crg
 byW
 bMt
 cvz
-abu
+aaZ
 aaZ
 aaZ
 aaZ
@@ -183637,7 +183636,7 @@ bFQ
 bHJ
 bJD
 bLs
-bpA
+bNq
 bPx
 bRt
 bRt
@@ -184158,7 +184157,7 @@ bRv
 bRv
 bXQ
 bZX
-bNq
+bpA
 bLs
 cfq
 chf

--- a/_maps/map_files/YogsPubby/YogsPubby.dmm
+++ b/_maps/map_files/YogsPubby/YogsPubby.dmm
@@ -29462,7 +29462,6 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "bch" = (
-/obj/structure/closet/wardrobe/red,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -32703,7 +32702,6 @@
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
-/obj/structure/closet/wardrobe/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -33610,7 +33608,6 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "bjX" = (
-/obj/structure/filingcabinet,
 /obj/machinery/requests_console{
 	department = "Security";
 	departmentType = 5;
@@ -33629,6 +33626,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/security/med,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bjY" = (
@@ -34480,7 +34478,6 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "blB" = (
-/obj/structure/closet/wardrobe/red,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -34941,7 +34938,6 @@
 	dir = 4;
 	network = list("ss13","medbay")
 	},
-/obj/structure/closet/secure_closet/security/med,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -34949,6 +34945,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bmt" = (
@@ -46963,7 +46960,6 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -32
 	},
-/obj/structure/filingcabinet/security,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -46971,6 +46967,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bEX" = (
@@ -53221,7 +53218,6 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bUk" = (
-/obj/machinery/computer/secure_data,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -53229,6 +53225,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/computer/security,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bUl" = (
@@ -53870,7 +53867,6 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bWA" = (
-/obj/structure/filingcabinet,
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the engine containment area.";
 	dir = 4;
@@ -53885,13 +53881,13 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bWC" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 32
 	},
-/obj/structure/closet/secure_closet/security/engine,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -53899,6 +53895,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/security/engine,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bWD" = (

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -61120,7 +61120,6 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "cbR" = (
-/obj/structure/chair/office/dark,
 /obj/machinery/button/door{
 	desc = "A remote control switch for the medbay foyer.";
 	id = "MedbayFoyer";
@@ -61135,6 +61134,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -62091,7 +62093,6 @@
 /turf/closed/wall,
 /area/medical/medbay/central)
 "cdx" = (
-/obj/machinery/computer/crew,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -62102,7 +62103,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/closed/wall,
 /area/medical/medbay/central)
 "cdy" = (
 /obj/effect/turf_decal/tile/blue,

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -818,6 +818,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "checkpoint_aux"
 
 /area/security/checkpoint/escape
+	name = "Security Post - Escape"
 	icon_state = "checkpoint_esc"
 
 /area/security/checkpoint/supply


### PR DESCRIPTION
**delta** - Removed some reinforced walls and decals leftover from gateway removal.
Rotated some consoles in maint.
Corrected some areas near the AI sat.
mapmerge cleaned up some unused things i cant remember what but seems to be caused by nickvr's pr due to all the armory shit, doesn't seem to be an issue
**meta**  - Made the sec checkpoint and medbay desk two seperate rooms. I'll see about redesigning this part completely some time.
**pubby**  - Replaced some wardrobes with vendors.
Replaced a duplicated security records console with a security camera console.

Renames /area/security/checkpoint/escape from "Security Post" to "Security Post - Escape" since some maps had arrivals and escape checkpoints named the same due to this.