### PR TITLE
Moves mining medic locker to lavaland base

### DIFF
--- a/_maps/RandomRuins/LavaRuins/miningbase.dmm
+++ b/_maps/RandomRuins/LavaRuins/miningbase.dmm
@@ -256,6 +256,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
+/obj/vehicle/ridden/atv,
 /turf/open/floor/plasteel/white,
 /area/mine/living_quarters)
 "aG" = (
@@ -533,7 +534,7 @@
 /turf/open/floor/plasteel/white,
 /area/mine/living_quarters)
 "bh" = (
-/obj/vehicle/ridden/atv,
+/obj/structure/closet/secure_closet/mmedical,
 /turf/open/floor/plasteel/white,
 /area/mine/living_quarters)
 "bi" = (

--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -11063,8 +11063,6 @@
 	c_tag = "Mining Dock";
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/secure_closet/mmedical,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "aqr" = (

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -44437,7 +44437,6 @@
 /area/quartermaster/miningdock)
 "bKo" = (
 /obj/machinery/light,
-/obj/structure/closet/secure_closet/mmedical,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bKp" = (
@@ -53640,27 +53639,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"fPW" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "fRC" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -54247,6 +54225,27 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"hQO" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "hQT" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -102441,7 +102440,7 @@ aty
 auF
 apC
 alP
-fPW
+hQO
 alP
 alP
 alP

--- a/_maps/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/map_files/YogsDelta/YogsDelta.dmm
@@ -118440,11 +118440,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/science/mixing)
-"drS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/mmedical,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningoffice)
 "drT" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/r_wall,
@@ -174625,7 +174620,7 @@ aFu
 bfD
 aXj
 bjX
-drS
+aJw
 baQ
 aLA
 aig

--- a/_maps/map_files/YogsPubby/YogsPubby.dmm
+++ b/_maps/map_files/YogsPubby/YogsPubby.dmm
@@ -375,7 +375,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/structure/closet/secure_closet/mmedical,
+/obj/machinery/mineral/equipment_vendor,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "aaE" = (
@@ -30877,9 +30877,19 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "beM" = (
-/obj/machinery/mineral/equipment_vendor,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
+	},
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/pickaxe{
+	pixel_x = 5
+	},
+/obj/item/shovel{
+	pixel_x = -5
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -31318,17 +31328,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bfE" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/pickaxe{
-	pixel_x = 5
-	},
-/obj/item/shovel{
-	pixel_x = -5
-	},
 /obj/machinery/camera{
 	c_tag = "Cargo Mining Dock";
 	dir = 4

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -14704,7 +14704,6 @@
 /obj/machinery/light_switch{
 	pixel_y = 38
 	},
-/obj/structure/closet/wardrobe/miner,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -14727,7 +14726,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/structure/closet/secure_closet/mmedical,
+/obj/structure/closet/wardrobe/miner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "azq" = (


### PR DESCRIPTION
Moves it off the station maps and to the mining medic office.

:cl:  
tweak: Mining medic locker spawns in their room on lavaland.
/:cl: