### PR TITLE
Allows you to add circuitboards to machine- and computerframes by drag&dropping

### DIFF
--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -141,3 +141,9 @@
 		return
 
 	setDir(turn(dir, -90))
+
+/obj/structure/frame/computer/MouseDrop_T(atom/dropping, mob/user)
+	if(istype(dropping, /obj/item/circuitboard))
+		attackby(dropping, user)
+	else
+		return ..()

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -146,4 +146,4 @@
 	if(istype(dropping, /obj/item/circuitboard))
 		attackby(dropping, user)
 	else
-		return ..()
+		..()

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -277,7 +277,7 @@
 			I.forceMove(loc)
 	..()
 
-/obj/structure/frame/machine/mouseDrop_T(atom/dropping, mob/user)
+/obj/structure/frame/machine/MouseDrop_T(atom/dropping, mob/user)
 	if(istype(dropping, /obj/item/circuitboard))
 		attackby(dropping, user)
 	else

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -281,4 +281,4 @@
 	if(istype(dropping, /obj/item/circuitboard))
 		attackby(dropping, user)
 	else
-		return ..()
+		..()

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -276,3 +276,9 @@
 			var/obj/item/I = X
 			I.forceMove(loc)
 	..()
+
+/obj/structure/frame/machine/mouseDrop_T(atom/dropping, mob/user)
+	if(istype(dropping, /obj/item/circuitboard))
+		attackby(dropping, user)
+	else
+		return ..()


### PR DESCRIPTION
### Intent of your Pull Request

Which allows borgs to create normal machines and computers, instead of only APCs/firealarms/firelocks

#### Changelog

:cl:  
tweak: You can now drag&drop circuits into machines/computers
tweak: The above can also be used by borgs to create machines
/:cl:
