### PR TITLE
Limit non-space monstermos to 75 tiles at a time

### DIFF
--- a/code/modules/atmospherics/environmental/monstermos.dm
+++ b/code/modules/atmospherics/environmental/monstermos.dm
@@ -1,3 +1,5 @@
+#define MONSTERMOS_TURF_LIMIT 75
+
 /turf/open
 	var/last_eq_cycle
 	var/eq_mole_delta = 0
@@ -119,15 +121,16 @@
 		T.eq_mole_delta = 0
 		T.eq_transfer_dirs = list()
 		T.eq_distance_score = i
-		var/turf_moles
-		var/list/cached_gases = T.air.gases
-		TOTAL_MOLES(cached_gases, turf_moles)
-		T.eq_mole_delta = turf_moles
-		T.eq_fast_done = FALSE
-		if(T.planetary_atmos)
-			planet_turfs += T
-			continue
-		total_moles += turf_moles
+		if(i < MONSTERMOS_TURF_LIMIT)
+			var/turf_moles
+			var/list/cached_gases = T.air.gases
+			TOTAL_MOLES(cached_gases, turf_moles)
+			T.eq_mole_delta = turf_moles
+			T.eq_fast_done = FALSE
+			if(T.planetary_atmos)
+				planet_turfs += T
+				continue
+			total_moles += turf_moles
 		for(var/t2 in T.atmos_adjacent_turfs)
 			var/turf/open/T2 = t2
 			turfs[T2] = 1
@@ -137,6 +140,8 @@
 				// (I just made explosions less laggy, you're welcome)
 				explosively_depressurize(T, cyclenum)
 				return
+	if(turfs.len >= MONSTERMOS_TURF_LIMIT)
+		turfs.Cut(MONSTERMOS_TURF_LIMIT)
 	var/average_moles = total_moles / (turfs.len - planet_turfs.len)
 	var/list/giver_turfs = list()
 	var/list/taker_turfs = list()


### PR DESCRIPTION
This makes it less laggy, while still effectively acting the same
:cl: monster860
tweak: Limit non-space monstermos to 75 tiles at a time
/:cl: