### PR TITLE
Adds spare bowman headset to HOS locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -63,6 +63,7 @@
 	..()
 	new /obj/item/clothing/neck/cloak/hos(src)
 	new /obj/item/cartridge/hos(src)
+	new /obj/item/radio/headset/heads/hos/alt(src)
 	new /obj/item/radio/headset/heads/hos(src)
 	new /obj/item/clothing/under/hosparadefem(src)
 	new /obj/item/clothing/under/hosparademale(src)


### PR DESCRIPTION
for meep

Meeeeep7 (Sir Lagsalot)Today at 22:09
What you _should_ add
Is a spare bowman to the HoS locker
I'd say make it like the cap locker
with one spare headset and one spare bowman

:cl:  
rscadd: Spare bowman headset in the Head of Security's locker.
/:cl: