### PR TITLE
[map] Omegastation map things

### DIFF
--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -3240,6 +3240,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
 "afe" = (
@@ -4401,7 +4404,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/status_display/evac{
+/obj/item/storage/secure/safe{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/grimy,
@@ -5047,12 +5050,8 @@
 "ahF" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
-/obj/item/storage/secure/safe{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24;
-	pixel_y = -26
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
@@ -6517,11 +6516,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"ajH" = (
-/obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "ajI" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -7033,12 +7027,14 @@
 /obj/structure/cable/white{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/delivery,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	icon_state = "manifold-1";
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13184,11 +13180,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"atf" = (
-/obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/storage/primary)
 "atg" = (
 /turf/open/floor/plating,
 /area/maintenance/port/central)
@@ -15844,6 +15835,10 @@
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "awN" = (
@@ -16201,10 +16196,6 @@
 /area/engine/atmos)
 "axs" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = 24
-	},
 /obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -17579,13 +17570,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"azv" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/loading_area,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "azw" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -18367,7 +18351,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	icon_state = "pipe11-1";
 	dir = 8
@@ -18397,6 +18380,7 @@
 	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aAA" = (
@@ -19165,15 +19149,17 @@
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
 "aBE" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
 "aBF" = (
 /obj/structure/tank_dispenser,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
 "aBG" = (
@@ -19885,16 +19871,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"aCJ" = (
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/door/poddoor/preopen{
-	id = "atmoslock";
-	name = "Atmospherics Lockdown Blast door"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "aCK" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
@@ -20541,6 +20517,7 @@
 /obj/structure/cable/white{
 	icon_state = "0-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "aDy" = (
@@ -21271,6 +21248,10 @@
 	dir = 9
 	},
 /obj/item/clothing/glasses/meson/engine,
+/obj/machinery/airalarm/unlocked{
+	dir = 4;
+	pixel_x = -23
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aEy" = (
@@ -21315,14 +21296,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
-/area/engine/break_room)
-"aED" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
@@ -38761,11 +38734,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/maintenance/starboard)
-"beO" = (
-/obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "beP" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -38930,17 +38898,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	icon_state = "pipe11-3";
 	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
-"bfb" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	icon_state = "pipe11-3";
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -40839,15 +40796,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
-"cWR" = (
-/obj/structure/plasticflaps,
-/obj/machinery/door/poddoor/preopen{
-	id = "atmoslock";
-	name = "Atmospherics Lockdown Blast door"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "ddI" = (
 /obj/machinery/air_sensor/atmos/toxin_tank,
 /turf/open/floor/engine/plasma,
@@ -40902,6 +40850,16 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"ebn" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/loading_area,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ehE" = (
@@ -42171,6 +42129,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"scm" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/engine/break_room)
 "scC" = (
 /turf/open/floor/plating/asteroid/airless,
 /area/space)
@@ -44490,6 +44459,15 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/asteroid/nearstation)
+"vOO" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "vVS" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input{
 	dir = 2
@@ -77223,7 +77201,7 @@ swZ
 agF
 atL
 avK
-cWR
+aqz
 axs
 bdc
 bcw
@@ -78768,11 +78746,11 @@ avP
 sAx
 axw
 ayo
-azu
+ebn
 aAy
 aBE
-aCJ
-aEC
+aqz
+scm
 aFp
 aFH
 aGt
@@ -79025,11 +79003,11 @@ axt
 aqz
 axx
 ayp
-azv
+azu
 aAz
 aBF
 aDx
-aED
+aEC
 aFp
 aFL
 aGF
@@ -83131,7 +83109,7 @@ apJ
 sAz
 apI
 arW
-atf
+apI
 apI
 apI
 awQ
@@ -90573,7 +90551,7 @@ adn
 adn
 swL
 adn
-ajH
+adn
 ado
 adn
 ado
@@ -90830,7 +90808,7 @@ agv
 ahM
 ado
 aiI
-ajI
+vOO
 akL
 alA
 amv
@@ -94712,8 +94690,8 @@ aFk
 beD
 beG
 aJb
-beO
-bfb
+azb
+bdW
 aMA
 aNI
 sDP


### PR DESCRIPTION
Adds an air alarm.
Removed most plastic flaps - they are meant for MULEbots but the map has none.
Moves around some wall items in the detective's office.