### PR TITLE
Derelict additions

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -606,6 +606,10 @@
 	pixel_x = -5;
 	pixel_y = -3
 	},
+/obj/item/areaeditor/blueprints{
+	desc = "Use to build new structures in the wastes.";
+	name = "land claim"
+	},
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/bridge/ai_upload)
 "bV" = (
@@ -4484,12 +4488,29 @@
 "Sv" = (
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
+"SH" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/obj/item/stack/sheet/bluespace_crystal{
+	amount = 5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/derelict/bridge)
 "Tm" = (
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/hallway/primary/port)
 "Uz" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"UZ" = (
+/obj/item/card/id/away/derelict/robo,
+/turf/open/floor/plasteel/airless{
+	icon_state = "damaged4"
+	},
+/area/ruin/space/derelict/bridge/ai_upload)
 "Vz" = (
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/hallway/primary/port)
@@ -11081,7 +11102,7 @@ ax
 bz
 bM
 bL
-bE
+UZ
 bO
 cf
 aa
@@ -12677,7 +12698,7 @@ cX
 cF
 dq
 cs
-dI
+SH
 ea
 eb
 ea

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -488,6 +488,12 @@ update_label("John Doe", "Clowny")
 	desc = "A perfectly generic identification card. Looks like it could use some flavor."
 	access = list(ACCESS_AWAY_GENERAL)
 
+/obj/item/card/id/away/derelict/robo
+	name = "Outdated Roboticist ID"
+	desc = "An old Roboticit's ID. Surely it has some use?"
+	access = list(ACCESS_ROBOTICS)
+	icon_state = "centcom"
+
 /obj/item/card/id/away/hotel
 	name = "Staff ID"
 	desc = "A staff ID used to access the hotel's doors."


### PR DESCRIPTION
Added some stuff to Derelict in hopes of making it more feasible for drones to actually repair. Additions are: Old roboticist ID (for unlocking bots), Free Golem's blueprints (although they aren't called that), and 5 bluespace mesh so they can get a functional teleporter up and running.

I posted this in a comment below, but I'm going to put it here too. In case you don't feel like scrolling down and reading it.

"The point of the bluespace crystals is mainly to go resource gathering. Without them its either, salvage the base for scrap metal, which can only get you so far, or float around in space looking for an asteroid or the station which takes ages. Drone's laws do not bind them to the derelict either, technically they can improve whatever station they want. Be it the Derelict, the main station, or the free miners ship. In regards to the Free Golem's blueprints, they are mainly for creating new rooms, so creating new APCs and other stuff works. You can definitely make the station habitable for humans without this stuff, but why stop there? Make the Derelict be the best it can be; fuck make it better than the main station, if you want. I just want to give drones the ability to get to that stage, before the main station calls the shuttle and the round is over.

:cl:  
tweak: Added some stuff to the Derelict in hopes of making it more feasible for the drones to repair.
/:cl:
