### PR TITLE
disables pheromone receptors

### DIFF
--- a/code/modules/antagonists/changeling/powers/pheromone_receptors.dm
+++ b/code/modules/antagonists/changeling/powers/pheromone_receptors.dm
@@ -2,7 +2,7 @@
 #define CHANGELING_PHEROMONE_MAX_DISTANCE 25 //They can smell your fear a mile away.  Well, 50 meters.
 #define CHANGELING_PHEROMONE_PING_TIME 20 //2s update time.
 
-
+/*
 /datum/action/changeling/pheromone_receptors
 	name = "Pheromone Receptors"
 	desc = "We attune our senses to track other changelings by scent.  The closer they are, the easier we can find them."
@@ -56,3 +56,4 @@
 /obj/screen/alert/status_effect/agent_pinpointer/changeling
 	name = "Pheromone Scent"
 	desc = "The nose always knows."
+*/


### PR DESCRIPTION
### Intent of your Pull Request

in my [last attempt](https://github.com/yogstation13/Yogstation/pull/7056) people seemed to really like the absorb ling objective which i didnt really care about so im remaking it with just this bit

**how does this benefit the game?**
lings that want to get mega uber will now have to manipulate or deceive other lings or keep a keen eye out for other lings and capitalize on their low chemicals/being lynched

**lings will be hesitant to work together now because they could be deceived into being succed while before they could just be easily hunted from the shadows unless they themselves wasted 2 points on pheromones which was pretty much the meta if you didnt want to get bumfucked by mr. powerling**

this will not encourage ling metagangs, if anything it will massively discourage it for reason(s) listed above

as a side note ive had ling disabled for quite a long time

input welcome

#### Changelog

:cl:    
experimental: Pheremone Receptors have been disabled
/:cl: