### PR TITLE
Removes katana from uplink

### DIFF
--- a/yogstation/code/game/objects/items/weaponry.dm
+++ b/yogstation/code/game/objects/items/weaponry.dm
@@ -23,6 +23,3 @@
 	else
 		user.visible_message("[user] is left hanging by [target].", "<span class='notice'>[target] leaves you hanging.</span>")
 		playsound(src, 'sound/weapons/punchmiss.ogg', 50, 0)
-
-/obj/item/katana/faketoy
-	name = "replica katana"

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -52,13 +52,6 @@
 /////////New Items////////
 //////////////////////////
 
-/datum/uplink_item/dangerous/katana
-	name = "Katana"
-	desc = "The katana is an edged weapon with a blade of pure degeneracy. While more robust than an energy sword, it cannot be as easily sheathed and hidden. At a glance, it looks like a fake katana; you can tell from the pixels."
-	item = /obj/item/katana/faketoy
-	cost = 10
-	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
-
 /datum/uplink_item/stealthy_weapons/door_charge
 	name = "Explosive Airlock Charge"
 	desc = "A small, easily concealable device. It can be applied to an open airlock panel, booby-trapping it. \


### PR DESCRIPTION
It is ridiculously OP, along with a riot shield(which basically anyone can get by breaking into sec), you are invul to any melee attacks including stun batons.
It takes a single hit to delimb/decapitate someone
It takes three hits to kill someone
It is impossible to "know" its fake as it is metashielded and by the time you can get into range to get told its fake by the impaling of your body. Its too late to use ranged stuns and melee stuns are ineffective.

Now about the people who will say improve dont remove, the katana is simply trying to fit in with the other traitor weapons despite other actually balanced weapons being able to do this:
Dual Esword: Main Weapon (What katana is, does massive damage)
Esword: Side Weapon (What katana is, can be held in a single hand)
Edagger: Stealth Weapon (What katana is, is metashielded)

#### Changelog

:cl:  
rscdel: The fake toy katana is no longer available for traitors to buy  
/:cl:

Also no I wasn't killed by it recently and no it taking up the belt slot is not a valid argument.