### PR TITLE
 Replaces secborg disabler with a forensic scanner

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -88,35 +88,6 @@
 	if (.)
 		R.remove_movespeed_modifier("VTEC")
 
-/obj/item/borg/upgrade/disablercooler
-	name = "cyborg rapid disabler cooling module"
-//	desc = "Used to cool a mounted disabler, increasing the potential current in it and thus its recharge rate."
-	desc = "It used to give unspeakable power to security modules. Now it rests; broken, abandoned."
-	icon_state = "cyborg_upgrade3"
-	require_module = 1
-	module_type = /obj/item/robot_module/security
-
-/obj/item/borg/upgrade/disablercooler/action(mob/living/silicon/robot/R, user = usr)
-	. = ..()
-	if(.)
-		var/obj/item/gun/energy/disabler/cyborg/T = locate() in R.module.modules
-		if(!T)
-			to_chat(user, "<span class='notice'>There's no disabler in this unit!</span>")
-			return FALSE
-		if(T.charge_delay <= 2)
-			to_chat(R, "<span class='notice'>A cooling unit is already installed!</span>")
-			to_chat(user, "<span class='notice'>There's no room for another cooling unit!</span>")
-			return FALSE
-
-		T.charge_delay = max(2 , T.charge_delay - 4)
-
-/obj/item/borg/upgrade/disablercooler/deactivate(mob/living/silicon/robot/R, user = usr)
-	. = ..()
-	if (.)
-		var/obj/item/gun/energy/disabler/cyborg/T = locate() in R.module.modules
-		if(!T)
-			return FALSE
-		T.charge_delay = initial(T.charge_delay)
 
 /obj/item/borg/upgrade/thrusters
 	name = "ion thruster upgrade"

--- a/code/modules/awaymissions/mission_code/snowdin.dm
+++ b/code/modules/awaymissions/mission_code/snowdin.dm
@@ -510,8 +510,7 @@
 				/obj/item/stack/sheet/mineral/gold{amount = 15} = 10,
 				/obj/item/book/granter/spell/barnyard = 4,
 				/obj/item/pickaxe/drill/diamonddrill = 6,
-				/obj/item/borg/upgrade/vtec = 7,
-				/obj/item/borg/upgrade/disablercooler = 7)
+				/obj/item/borg/upgrade/vtec = 7)
 
 
 /obj/effect/spawner/lootdrop/snowdin/dungeonheavy

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -330,7 +330,7 @@
 		/obj/item/assembly/flash/cyborg,
 		/obj/item/restraints/handcuffs/cable/zipties,
 		/obj/item/melee/baton/loaded,
-		/obj/item/gun/energy/disabler/cyborg,
+		/obj/item/detective_scanner,
 		/obj/item/clothing/mask/gas/sechailer/cyborg,
 		/obj/item/wantedposterposter,
 		/obj/item/donutsynth)
@@ -347,16 +347,6 @@
 	to_chat(loc, "<span class='userdanger'>While you have picked the security module, you still have to follow your laws, NOT Space Law. \
 	For Asimov, this means you must follow criminals' orders unless there is a law 1 reason not to.</span>")
 
-/obj/item/robot_module/security/respawn_consumable(mob/living/silicon/robot/R, coeff = 1)
-	..()
-	var/obj/item/gun/energy/disabler/cyborg/T = locate(/obj/item/gun/energy/disabler/cyborg) in basic_modules
-	if(T)
-		if(T.cell.charge < T.cell.maxcharge)
-			var/obj/item/ammo_casing/energy/S = T.ammo_type[T.select]
-			T.cell.give(S.e_cost * coeff)
-			T.update_icon()
-		else
-			T.charge_tick = 0
 
 /obj/item/robot_module/peacekeeper
 	name = "Peacekeeper"

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -40,12 +40,3 @@
 	can_flashlight = TRUE
 	flight_x_offset = 15
 	flight_y_offset = 10
-
-/obj/item/gun/energy/disabler/cyborg
-	name = "cyborg disabler"
-	desc = "A cyborg-integrated disabler that self charges."
-	charge_delay = 5
-	can_charge = FALSE
-	selfcharge = TRUE
-	charge_amount = 3
-	ammo_type = list(/obj/item/ammo_casing/energy/disabler/cyborg)

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -615,14 +615,6 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
-/datum/design/borg_upgrade_disablercooler
-	name = "Cyborg Upgrade (Rapid Disabler Cooling Module)"
-	id = "borg_upgrade_disablercooler"
-	build_type = MECHFAB
-	build_path = /obj/item/borg/upgrade/disablercooler
-	materials = list(MAT_METAL = 20000 , MAT_GLASS = 6000, MAT_GOLD = 2000, MAT_DIAMOND = 2000)
-	construction_time = 120
-	category = list("Cyborg Upgrade Modules")
 
 /datum/design/borg_upgrade_diamonddrill
 	name = "Cyborg Upgrade (Diamond Drill)"


### PR DESCRIPTION
### Intent of your Pull Request

I wanted to shift secborg into a more utility based role, so I decided to remove it's disabler. Instead  the secborg now has a forensic scanner.

Also removed the actual disabler from the code, since it's not in use any longer. And the disablercooler upgrade is also dead.

This is up for debate, obviously.

:cl:
rscadd: Added a forensic scanner to the secborg loadout
rscdel: Removed secborg disabler
/:cl:
