### PR TITLE
Conveyor recycling.

### DIFF
--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -373,6 +373,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	max_amount = 30
 	singular_name = "conveyor belt"
 	w_class = WEIGHT_CLASS_BULKY
+	materials = list(MAT_METAL = 3000)
 	///id for linking
 	var/id = ""
 


### PR DESCRIPTION
### Intent of your Pull Request

Makes it so that conveyors can be recycled, in the event you only needed 26 conveyors but made 30 to get the job done faster.

Switches unfortunately cannot be recycled yet, since if you upgrade an autolathe the cost of it changes. But if you pry the switch back up the materials in the switch would reset back to the default amount of mats.

#### Changelog

:cl:  
rscadd: Conveyors may be recycled now.
/:cl:
