### PR TITLE
Locks security module to an upgrade

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -663,3 +663,15 @@
 	desc = "Allows you to to turn a cyborg into a clown, honk."
 	icon_state = "cyborg_upgrade3"
 	new_module = /obj/item/robot_module/clown
+
+/obj/item/borg/upgrade/transform/security
+	name = "borg module picker (Security)"
+	desc = "Allows you to to turn a cyborg into a validhunter, HALT!"
+	icon_state = "cyborg_upgrade3"
+	new_module = /obj/item/robot_module/security
+
+/obj/item/borg/upgrade/transform/security/action()
+	if(CONFIG_GET(flag/disable_secborg))
+		to_chat(user, "<span class='warning'>Nanotrasen policy disallows the use of weapons of mass destruction.</span>")
+		return FALSE
+	return ..()

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -666,7 +666,7 @@
 
 /obj/item/borg/upgrade/transform/security
 	name = "borg module picker (Security)"
-	desc = "Allows you to turn a cyborg into a validhunter, HALT!"
+	desc = "Allows you to turn a cyborg into a hunter, HALT!"
 	icon_state = "cyborg_upgrade3"
 	new_module = /obj/item/robot_module/security
 

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -670,7 +670,7 @@
 	icon_state = "cyborg_upgrade3"
 	new_module = /obj/item/robot_module/security
 
-/obj/item/borg/upgrade/transform/security/action()
+/obj/item/borg/upgrade/transform/security/action(mob/living/silicon/robot/R, user = usr)
 	if(CONFIG_GET(flag/disable_secborg))
 		to_chat(user, "<span class='warning'>Nanotrasen policy disallows the use of weapons of mass destruction.</span>")
 		return FALSE

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -649,7 +649,7 @@
 
 /obj/item/borg/upgrade/transform
 	name = "borg module picker (Standard)"
-	desc = "Allows you to to turn a cyborg into a standard cyborg."
+	desc = "Allows you to turn a cyborg into a standard cyborg."
 	icon_state = "cyborg_upgrade3"
 	var/obj/item/robot_module/new_module = /obj/item/robot_module/standard
 
@@ -660,13 +660,13 @@
 
 /obj/item/borg/upgrade/transform/clown
 	name = "borg module picker (Clown)"
-	desc = "Allows you to to turn a cyborg into a clown, honk."
+	desc = "Allows you to turn a cyborg into a clown, honk."
 	icon_state = "cyborg_upgrade3"
 	new_module = /obj/item/robot_module/clown
 
 /obj/item/borg/upgrade/transform/security
 	name = "borg module picker (Security)"
-	desc = "Allows you to to turn a cyborg into a validhunter, HALT!"
+	desc = "Allows you to turn a cyborg into a validhunter, HALT!"
 	icon_state = "cyborg_upgrade3"
 	new_module = /obj/item/robot_module/security
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -211,8 +211,6 @@
 	"Service" = /obj/item/robot_module/butler)
 	if(!CONFIG_GET(flag/disable_peaceborg))
 		modulelist["Peacekeeper"] = /obj/item/robot_module/peacekeeper
-	if(!CONFIG_GET(flag/disable_secborg))
-		modulelist["Security"] = /obj/item/robot_module/security
 
 	var/list/moduleicons = list() //yogs start
 	for(var/option in modulelist)

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -668,6 +668,16 @@
 	materials = list(MAT_METAL = 15000, MAT_GLASS = 15000, MAT_BANANIUM = 1000)
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
+	
+
+/datum/design/borg_transform_security
+	name = "Cyborg Upgrade (Security Module)"
+	id = "borg_transform_security"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/transform/security
+	materials = list(MAT_METAL = 15000, MAT_GLASS = 15000, MAT_DIAMOND = 2500)
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
 
 /datum/design/borg_upgrade_selfrepair
 	name = "Cyborg Upgrade (Self-repair)"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -675,7 +675,7 @@
 	id = "borg_transform_security"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/transform/security
-	materials = list(MAT_METAL = 15000, MAT_GLASS = 15000, MAT_DIAMOND = 2500)
+	materials = list(MAT_METAL = 15000, MAT_GLASS = 15000, MAT_DIAMOND = 3000)
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -580,7 +580,7 @@
 	id = "adv_weaponry"
 	display_name = "Advanced Weapon Development Technology"
 	description = "Our weapons are breaking the rules of reality by now."
-	prereq_ids = list("adv_engi", "weaponry")
+	prereq_ids = list("adv_engi", "weaponry", "borg_transform_security")
 	design_ids = list("pin_loyalty")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	export_price = 5000


### PR DESCRIPTION
This PR does many things:

Security Cyborg Module is no longer available at round start
Adds an upgrade buildable at roboticts to transform a borg into a sec borg, it costs 7.5 metal sheets, 7.5 glass sheets and 1.5 diamond sheets in unupgraded exofabs
Said upgrade is locked behind the Advanced Weaponry Tech node which is about 25 000 points in total.

This PR is here to give antags some needed breathing room at round start to prepare their equipment without a valid borg on their ass, which is why secborgs are locked at a fairly "hard" to get node in order to timegate them until antags get a better position.

Now this PR also does another thing, by making them cost diamonds, it limits the maximal amount of sec borgs which should prevent having 10 secborgs patrolling the station.

:cl: 
rscdel: Removed the ability to chose the security module on borgs by default.
rscadd: Added an upgrade to allow a borg to switch to the security module. It is locked behing the Advanced Weaponry tech node
/:cl: