### PR TITLE
Fixes pipe dispenser recycling bug

### DIFF
--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -102,7 +102,7 @@
 
 //Allow you to drag-drop disposal pipes and transit tubes into it
 /obj/machinery/pipedispenser/disposal/MouseDrop_T(obj/structure/pipe, mob/usr)
-	if(!usr.incapacitated())
+	if(usr.incapacitated())
 		return
 
 	if (!istype(pipe, /obj/structure/disposalconstruct) && !istype(pipe, /obj/structure/c_transit_tube) && !istype(pipe, /obj/structure/c_transit_tube_pod))


### PR DESCRIPTION
fix #3046

this is a bug. This PR fixes it. Has this PR ever affected anyone? Heck no, no one uses the big ass stationary pipe dispenser anyways, because the portable ones can do the same shizz. However, this PR fixes a bug with them anyways.