### PR TITLE
Allow firelocks to be opened without crowbar in more situations

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -337,9 +337,7 @@
 
 /obj/machinery/door/firedoor/border_only/allow_hand_open(mob/user)
 	var/area/A = get_area(src)
-	if(A && A.fire)
-		return FALSE
-	if(!is_holding_pressure())
+	if((!A || !A.fire) && !is_holding_pressure())
 		return TRUE
 	whack_a_mole(TRUE) // WOOP WOOP SIDE EFFECTS
 	var/turf/T = loc
@@ -405,6 +403,9 @@
 	max_integrity = 50
 	resistance_flags = 0 // not fireproof
 	heat_proof = FALSE
+
+/obj/machinery/door/firedoor/window/allow_hand_open()
+	return TRUE
 
 /obj/item/electronics/firelock
 	name = "firelock circuitry"


### PR DESCRIPTION
:cl: monster860
tweak: Window shutters can now *always* be opened without a crowbar no matter what
tweak: Fire alarms now longer prevent hand-opening of thin firelocks
/:cl: