### PR TITLE
Minor atmos optimizations

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -3,7 +3,6 @@
 #define MOLES			1
 #define ARCHIVE			2
 #define GAS_META		3
-#define INNER_MOLES		4
 #define META_GAS_SPECIFIC_HEAT	1
 #define META_GAS_NAME			2
 #define META_GAS_MOLES_VISIBLE	3
@@ -285,13 +284,6 @@
 	out_var = 0;\
 	for(var/total_moles_id in cached_gases){\
 		out_var += cached_gases[total_moles_id][MOLES];\
-	}
-
-#define TOTAL_MOLES_INNER(cached_gases, out_var)\
-	out_var = 0;\
-	for(var/total_moles_id in cached_gases){\
-		var/list/total_moles_cached_gas = cached_gases[total_moles_id];\
-		out_var += min(total_moles_cached_gas[INNER_MOLES], total_moles_cached_gas[MOLES]);\
 	}
 
 #ifdef TESTING

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -60,7 +60,7 @@
 
 /turf/open/remove_air(amount)
 	var/datum/gas_mixture/ours = return_air()
-	var/datum/gas_mixture/removed = ours.remove_outer(amount)
+	var/datum/gas_mixture/removed = ours.remove(amount)
 	update_visuals()
 	return removed
 

--- a/code/modules/atmospherics/environmental/monstermos.dm
+++ b/code/modules/atmospherics/environmental/monstermos.dm
@@ -65,7 +65,9 @@
 				finalize_eq_neighbors(transfer_dirs)
 			if(T.eq_transfer_dirs)
 				T.eq_transfer_dirs -= src
-			T.assume_air(remove_air(amount)) // push them gases.
+			air.transfer_to(T.return_air(), amount) // push them gases.
+			update_visuals()
+			T.update_visuals()
 			consider_pressure_difference(T, amount)
 
 /turf/open/proc/finalize_eq_neighbors(list/transfer_dirs)

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -484,3 +484,36 @@ get_true_breath_pressure(pp) --> gas_pp = pp/breath_pp*total_moles()
 10/20*5 = 2.5
 10 = 2.5/5*20
 */
+
+/*
+/mob/verb/profile_atmos()
+	/world{loop_checks = 0;}
+	var/datum/gas_mixture/A = new
+	var/datum/gas_mixture/B = new
+	A.parse_gas_string("o2=200;n2=800;TEMP=50")
+	B.parse_gas_string("co2=500;plasma=500;TEMP=5000")
+	var/pa
+	var/pb
+	pa = world.tick_usage
+	for(var/I in 1 to 100000)
+		B.transfer_to(A, 1)
+		A.transfer_to(B, 1)
+	pb = world.tick_usage
+	var/total_time = (pb-pa) * world.tick_lag
+	to_chat(src, "Total time (gas transfer): [total_time]ms")
+	to_chat(src, "Operations per second: [100000 / (total_time/1000)]")
+	pa = world.tick_usage
+	for(var/I in 1 to 100000)
+		B.total_moles();
+	pb = world.tick_usage
+	total_time = (pb-pa) * world.tick_lag
+	to_chat(src, "Total time (total_moles): [total_time]ms")
+	to_chat(src, "Operations per second: [100000 / (total_time/1000)]")
+	pa = world.tick_usage
+	for(var/I in 1 to 100000)
+		var/datum/gas_mixture/GM = new
+	pb = world.tick_usage
+	total_time = (pb-pa) * world.tick_lag
+	to_chat(src, "Total time (new gas mixture): [total_time]ms")
+	to_chat(src, "Operations per second: [100000 / (total_time/1000)]")
+*/

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -13,14 +13,13 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 /proc/init_gaslist_cache()
 	. = list()
 	for(var/id in GLOB.meta_gas_info)
-		var/list/cached_gas = new(4)
+		var/list/cached_gas = new(3)
 
 		.[id] = cached_gas
 
 		cached_gas[MOLES] = 0
 		cached_gas[ARCHIVE] = 0
 		cached_gas[GAS_META] = GLOB.meta_gas_info[id]
-		cached_gas[INNER_MOLES] = 0
 
 /datum/gas_mixture
 	var/list/gases
@@ -117,7 +116,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	//Update archived versions of variables
 	//Returns: 1 in all cases
 
-/datum/gas_mixture/proc/merge(datum/gas_mixture/giver, inner = TRUE)
+/datum/gas_mixture/proc/merge(datum/gas_mixture/giver)
 	//Merges all air from giver into self. Deletes giver.
 	//Returns: 1 if we are mutable, 0 otherwise
 
@@ -125,20 +124,13 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	//Removes amount of gas from the gas_mixture
 	//Returns: gas_mixture with the gases removed
 
+/datum/gas_mixture/proc/transfer_to(datum/gas_mixture/target, amount)
+	//Transfers amount of gas to target. Equivalent to target.merge(remove(amount)) but faster.
+	//Removes amount of gas from the gas_mixture
+
 /datum/gas_mixture/proc/remove_ratio(ratio)
 	//Proportionally removes amount of gas from the gas_mixture
 	//Returns: gas_mixture with the gases removed
-
-/datum/gas_mixture/proc/remove_outer(amount)
-	//Removes amount of gas from the gas_mixture, while avoiding removing inner gases
-	//Returns: gas_mixture with the gases removed
-
-/datum/gas_mixture/proc/remove_ratio_outer(ratio)
-	//Proportionally removes amount of gas from the gas_mixture, while avoiding removing inner gases
-	//Returns: gas_mixture with the gases removed
-
-/datum/gas_mixture/proc/clear_inner()
-	//sets the INNER_MOLES of all gases to 0
 
 /datum/gas_mixture/proc/copy()
 	//Creates new, identical gas mixture
@@ -181,7 +173,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 	return 1
 
-/datum/gas_mixture/merge(datum/gas_mixture/giver, inner = TRUE)
+/datum/gas_mixture/merge(datum/gas_mixture/giver)
 	if(!giver)
 		return 0
 
@@ -199,10 +191,32 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	for(var/giver_id in giver_gases)
 		ASSERT_GAS(giver_id, src)
 		cached_gases[giver_id][MOLES] += giver_gases[giver_id][MOLES]
-		if(inner)
-			cached_gases[giver_id][INNER_MOLES] += giver_gases[giver_id][MOLES]
 
 	return 1
+
+/datum/gas_mixture/transfer_to(datum/gas_mixture/target, amount) // Transfer gases
+	var/list/cached_gases = gases
+	var/sum
+	TOTAL_MOLES(cached_gases, sum)
+	amount = min(amount, sum) //Can not take more air than tile has!
+	if(amount <= 0)
+		return null
+	var/list/target_gases = target.gases
+	var/heat_capacity_transferred = 0
+	for(var/id in cached_gases)
+		ASSERT_GAS(id, target)
+		var/list/cached_gas = cached_gases[id]
+		var/moles_to_transfer = QUANTIZE((cached_gases[id][MOLES] / sum) * amount)
+		target_gases[id][MOLES] += moles_to_transfer
+		cached_gas[MOLES] -= moles_to_transfer
+		heat_capacity_transferred += cached_gas[GAS_META][META_GAS_SPECIFIC_HEAT] * moles_to_transfer
+
+	if(abs(temperature - target.temperature) > MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER)
+		var/target_heat_capacity = target.heat_capacity()
+		var/target_heat_capacity_before = heat_capacity_transferred
+		target.temperature = (temperature * heat_capacity_transferred + target.temperature * target_heat_capacity_before) / target_heat_capacity
+	
+	garbage_collect()
 
 /datum/gas_mixture/remove(amount)
 	var/sum
@@ -219,35 +233,6 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		ADD_GAS(id, removed_gases)
 		removed_gases[id][MOLES] = QUANTIZE((cached_gases[id][MOLES] / sum) * amount)
 		cached_gases[id][MOLES] -= removed_gases[id][MOLES]
-		cached_gases[id][INNER_MOLES] = max(0, cached_gases[id][INNER_MOLES] - QUANTIZE((cached_gases[id][INNER_MOLES] / sum) * amount))
-	garbage_collect()
-
-	return removed
-
-/datum/gas_mixture/remove_outer(amount)
-	if(amount <= 0)
-		return null
-	var/sum
-	var/inner_sum
-	var/list/cached_gases = gases
-	TOTAL_MOLES(cached_gases, sum)
-	TOTAL_MOLES_INNER(cached_gases, inner_sum)
-	amount = min(amount, sum) // cant' take away more than it has
-	var/datum/gas_mixture/removed = new type
-	var/list/removed_gases = removed.gases
-
-	var/outer_amount = min(sum - inner_sum, amount)
-	var/inner_amount = outer_amount < amount ? (amount - (sum - inner_sum)) : 0
-
-	removed.temperature = temperature
-	for(var/id in cached_gases)
-		ADD_GAS(id, removed_gases)
-		var/removed_outer = sum > inner_sum ? QUANTIZE(max(0, cached_gases[id][MOLES] - cached_gases[id][INNER_MOLES]) / (sum - inner_sum) * outer_amount) : 0
-		var/removed_inner = inner_sum ? QUANTIZE(cached_gases[id][INNER_MOLES] / inner_sum * inner_amount) : 0
-		removed_gases[id][MOLES] = removed_outer + removed_inner
-		cached_gases[id][MOLES] -= removed_outer + removed_inner
-		cached_gases[id][INNER_MOLES] -= removed_inner
-
 	garbage_collect()
 
 	return removed
@@ -266,45 +251,10 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		ADD_GAS(id, removed_gases)
 		removed_gases[id][MOLES] = QUANTIZE(cached_gases[id][MOLES] * ratio)
 		cached_gases[id][MOLES] -= removed_gases[id][MOLES]
-		cached_gases[id][INNER_MOLES] -= QUANTIZE(cached_gases[id][INNER_MOLES] * ratio)
 
 	garbage_collect()
 
 	return removed
-
-/datum/gas_mixture/remove_ratio_outer(ratio)
-	if(ratio <= 0)
-		return null
-	ratio = min(ratio, 1)
-
-	var/sum
-	var/inner_sum
-	var/list/cached_gases = gases
-	var/datum/gas_mixture/removed = new type
-	var/list/removed_gases = removed.gases
-	TOTAL_MOLES(cached_gases, sum)
-	TOTAL_MOLES_INNER(cached_gases, inner_sum)
-	var/outer_ratio = sum > inner_sum ? min(1, ratio * sum / (sum - inner_sum)) : 0
-	var/inner_ratio = (outer_ratio >= 1 && inner_sum) ? (((ratio * sum) - (outer_ratio * (sum - inner_sum))) / inner_sum) : 0
-
-	removed.temperature = temperature
-	for(var/id in cached_gases)
-		ADD_GAS(id, removed_gases)
-		var/removed_outer = QUANTIZE(max(0, cached_gases[id][MOLES] - cached_gases[id][INNER_MOLES]) * outer_ratio)
-		var/removed_inner = QUANTIZE(cached_gases[id][INNER_MOLES] * inner_ratio)
-		removed_gases[id][MOLES] = removed_outer + removed_inner
-		cached_gases[id][MOLES] -= removed_outer + removed_inner
-		cached_gases[id][INNER_MOLES] -= removed_inner
-
-	garbage_collect()
-
-	return removed
-
-
-/datum/gas_mixture/clear_inner()
-	var/list/cached_gases = gases
-	for(var/id in cached_gases)
-		cached_gases[id][INNER_MOLES] = 0
 
 /datum/gas_mixture/copy()
 	var/list/cached_gases = gases
@@ -359,8 +309,6 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	return 1
 
 /datum/gas_mixture/share(datum/gas_mixture/sharer, atmos_adjacent_turfs = 4)
-	clear_inner()
-	sharer.clear_inner()
 	var/list/cached_gases = gases
 	var/list/sharer_gases = sharer.gases
 

--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -21,6 +21,25 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 		gas_info[META_GAS_ID] = initial(gas.id)
 		.[gas_path] = gas_info
 
+/mob/verb/profile_atmos()
+	var/datum/gas_mixture/A = new
+	var/datum/gas_mixture/B = new
+	A.parse_gas_string("o2=200;n2=800;TEMP=50")
+	B.parse_gas_string("co2=500;plasma=500;TEMP=5000")
+	var/pa
+	var/pb
+	pa = world.tick_usage
+	for(var/I in 1 to 100000)
+		B.transfer_to(A, 1);
+		A.transfer_to(B, 1);
+		//A.merge(B.remove(1))
+		//B.merge(A.remove(1))
+	pb = world.tick_usage
+	var/total_time = (pb-pa) * world.tick_lag
+	to_chat(src, "Total time: [total_time]ms")
+	to_chat(src, "Operations per second: [100000 / (total_time/1000)]")
+
+
 /proc/gas_id2path(id)
 	var/list/meta_gas = GLOB.meta_gas_info
 	if(id in meta_gas)

--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -21,25 +21,6 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 		gas_info[META_GAS_ID] = initial(gas.id)
 		.[gas_path] = gas_info
 
-/mob/verb/profile_atmos()
-	var/datum/gas_mixture/A = new
-	var/datum/gas_mixture/B = new
-	A.parse_gas_string("o2=200;n2=800;TEMP=50")
-	B.parse_gas_string("co2=500;plasma=500;TEMP=5000")
-	var/pa
-	var/pb
-	pa = world.tick_usage
-	for(var/I in 1 to 100000)
-		B.transfer_to(A, 1);
-		A.transfer_to(B, 1);
-		//A.merge(B.remove(1))
-		//B.merge(A.remove(1))
-	pb = world.tick_usage
-	var/total_time = (pb-pa) * world.tick_lag
-	to_chat(src, "Total time: [total_time]ms")
-	to_chat(src, "Operations per second: [100000 / (total_time/1000)]")
-
-
 /proc/gas_id2path(id)
 	var/list/meta_gas = GLOB.meta_gas_info
 	if(id in meta_gas)


### PR DESCRIPTION
- Removes inner_moles system that I added with monstermos. It's supposed to make gases spread slower but it never really worked, and it adds performance costs to all aspects of atmos.
- Adds a transfer_to proc for gas mixtures that acts the same as merge(remove()) except that it doesn't create a temporary gas mixture, making it faster.

Here's a look at how gas mixture transfer is affected:

```
gas mixture transfer
                     Ops/sec
before             - 26,824
remove inner_moles - 33,058
transfer_to proc   - 52,910
```

Since gas mixture transfer accounts for approximately 20% of the performance cost of monstermos, this should make monstermos about 10% faster.

Things that could be done in the future include:
- restructuring gas mixtures to not have associative lists. This would require refactoring any code that does anything with gas mixtures.
- Do a basic gas-mixture-averaging algorithm when zones have only a little pressure difference and are mostly homogenous