### PR TITLE
Achievement Get Part 1 - Greentext Achievements

### DIFF
--- a/code/controllers/subsystem/achievements.dm
+++ b/code/controllers/subsystem/achievements.dm
@@ -52,6 +52,8 @@ SUBSYSTEM_DEF(achievements)
 	if(!achievement)
 		log_sql("Achievement [achievementPath] not found in list of achievements when trying to unlock for [C.ckey]")
 		return FALSE
+	if(istype(achievement,/datum/achievement/greentext) && achievementPath != /datum/achievement/greentext)
+		unlock_achievement(/datum/achievement/greentext,C) // Oooh, a little bit recursive!
 	if(!has_achievement(achievementPath, C))
 		var/datum/DBQuery/medalQuery = SSdbcore.NewQuery("INSERT INTO [format_table_name("earned_achievements")] (ckey, id) VALUES ('[C.ckey]', '[achievement.id]')")
 		medalQuery.Execute()

--- a/code/controllers/subsystem/achievements.dm
+++ b/code/controllers/subsystem/achievements.dm
@@ -92,6 +92,6 @@ SUBSYSTEM_DEF(achievements)
 
 /datum/controller/subsystem/achievements/proc/get_achievement(achievementPath)
 	for(var/datum/achievement/i in achievements)
-		if(istype(i, achievementPath))
+		if(i.type == achievementPath) // Can't use istype() here since it needs to be the EXACT correct type.
 			return i
 	return FALSE

--- a/code/datums/achievements/achievements.dm
+++ b/code/datums/achievements/achievements.dm
@@ -208,17 +208,28 @@
 	name = "Yaaaahr!"
 	desc = "As member of the Pirate crew, collect sufficient bounty from the crew"
 	id = 37
+
+/datum/achievement/greentext/vampire
+	name = "Count de Ville"
+	desc = "As a Vampire, complete your objectives"
+	id = 38
+
+/datum/achievement/greentext/revenant
+	name = "From The Shadows"
+	desc = "As a Revenant, complete your objectives"
+	id = 39
+
 //end-greentext
 
 //start-redtext
 /datum/achievement/redtext
 	name = "Mission Failed, We'll Get'em Next Time"
 	desc = "As an antagonist, fail your objectives."
-	id = 38
+	id = 40
 
 /datum/achievement/redtext/winlost
 	name = "Arcane Failure"
 	desc = "As a Wizard, fail your objectives."
-	id = 39
+	id = 41
 	hidden = TRUE
 //end-redtext

--- a/code/datums/achievements/achievements.dm
+++ b/code/datums/achievements/achievements.dm
@@ -201,10 +201,14 @@
 //end-greentext
 
 //start-redtext
+/datum/achievement/redtext
+	name = "Mission Failed, We'll Get'em Next Time"
+	desc = "As an antagonist, fail your objectives."
+	id = 36
 
 /datum/achievement/redtext/winlost
 	name = "Arcane Failure"
 	desc = "As a Wizard, fail your objectives."
-	id = 36
+	id = 37
 	hidden = TRUE
 //end-redtext

--- a/code/datums/achievements/achievements.dm
+++ b/code/datums/achievements/achievements.dm
@@ -203,17 +203,22 @@
 	name = "Space Aids"
 	desc = "As Sentient Disease, survive and complete your objectives"
 	id = 36
+
+/datum/achievement/greentext/pirate
+	name = "Yaaaahr!"
+	desc = "As member of the Pirate crew, collect sufficient bounty from the crew"
+	id = 37
 //end-greentext
 
 //start-redtext
 /datum/achievement/redtext
 	name = "Mission Failed, We'll Get'em Next Time"
 	desc = "As an antagonist, fail your objectives."
-	id = 37
+	id = 38
 
 /datum/achievement/redtext/winlost
 	name = "Arcane Failure"
 	desc = "As a Wizard, fail your objectives."
-	id = 38
+	id = 39
 	hidden = TRUE
 //end-redtext

--- a/code/datums/achievements/achievements.dm
+++ b/code/datums/achievements/achievements.dm
@@ -1,6 +1,8 @@
 //OFFSETS - Used so that each general like "group" of achievements can be added to w/o fucking up the whole incremental pattern we got going on.
 //DO NOT MAKE OFFSET VALUES THAT ARE GREATER THAN 2^15 OR LESS THAN 128.
+//TO BE HONEST THIS OFFSET DOESN'T EVEN NEED TO BE POWER OF TWO, THOUGH.
 #define GREENTEXT 256 // An offset for new greentext-related achievements, to keep the incremental pattern.
+#define REDTEXT 512 // Offset for redtexts.
 
 /datum/achievement
 	var/name = "achievement"
@@ -136,19 +138,6 @@
 	desc = "As the QM, have a million cargo credits by the end of the round" //Cargoking-junior
 	id = 22
 
-//start-redtext
-/datum/achievement/redtext
-	name = "Mission Failed, We'll Get'em Next Time"
-	desc = "As an antagonist, fail your objectives."
-	id = 23
-
-/datum/achievement/redtext/winlost
-	name = "Arcane Failure"
-	desc = "As a Wizard, fail your objectives."
-	id = 24
-	hidden = TRUE
-//end-redtext
-
 // The achievements that are basically just "greentext as this sort of antag"
 
 /datum/achievement/greentext
@@ -237,5 +226,18 @@
 	id = GREENTEXT + 17
 
 //end-greentext
+
+//start-redtext
+/datum/achievement/redtext
+	name = "Mission Failed, We'll Get'em Next Time"
+	desc = "As an antagonist, fail your objectives."
+	id = REDTEXT + 1
+
+/datum/achievement/redtext/winlost
+	name = "Arcane Failure"
+	desc = "As a Wizard, fail your objectives."
+	id = REDTEXT + 2
+	hidden = TRUE
+//end-redtext
 
 #undef GREENTEXT

--- a/code/datums/achievements/achievements.dm
+++ b/code/datums/achievements/achievements.dm
@@ -206,5 +206,5 @@
 	name = "Arcane Failure"
 	desc = "As a Wizard, fail your objectives."
 	id = 36
-
+	hidden = TRUE
 //end-redtext

--- a/code/datums/achievements/achievements.dm
+++ b/code/datums/achievements/achievements.dm
@@ -189,3 +189,12 @@
 	desc = "As an External Affairs Agent, complete your objectives"
 	id = 35
 //end-greentext
+
+//start-redtext
+
+/datum/achievement/redtext/winlost
+	name = "Arcane Failure"
+	desc = "As a Wizard, fail your objectives."
+	id = 36
+
+//end-redtext

--- a/code/datums/achievements/achievements.dm
+++ b/code/datums/achievements/achievements.dm
@@ -198,17 +198,22 @@
 	name = "Quadruple Cross"
 	desc = "As an External Affairs Agent, complete your objectives"
 	id = 35
+
+/datum/achievement/greentext/disease
+	name = "Space Aids"
+	desc = "As Sentient Disease, survive and complete your objectives"
+	id = 36
 //end-greentext
 
 //start-redtext
 /datum/achievement/redtext
 	name = "Mission Failed, We'll Get'em Next Time"
 	desc = "As an antagonist, fail your objectives."
-	id = 36
+	id = 37
 
 /datum/achievement/redtext/winlost
 	name = "Arcane Failure"
 	desc = "As a Wizard, fail your objectives."
-	id = 37
+	id = 38
 	hidden = TRUE
 //end-redtext

--- a/code/datums/achievements/achievements.dm
+++ b/code/datums/achievements/achievements.dm
@@ -169,6 +169,16 @@
 	desc = "As a Head Revolutionary, complete your objectives"
 	id = 29
 
+/datum/achievement/greentext/gang
+	name = "Turf War"
+	desc = "As a Gang Member, take over the station"
+	id = 30
+
+/datum/achievement/greentext/gang/leader
+	name = "\"I have built my organization upon fear.\""
+	desc = "As a Gang Leader, take over the station"
+	id = 31
+
 /datum/achievement/greentext/blob
 	name = "Grey Goo"
 	desc = "As a Blob complete your objectives"

--- a/code/datums/achievements/achievements.dm
+++ b/code/datums/achievements/achievements.dm
@@ -1,3 +1,7 @@
+//OFFSETS - Used so that each general like "group" of achievements can be added to w/o fucking up the whole incremental pattern we got going on.
+//DO NOT MAKE OFFSET VALUES THAT ARE GREATER THAN 2^15 OR LESS THAN 128.
+#define GREENTEXT 256 // An offset for new greentext-related achievements, to keep the incremental pattern.
+
 /datum/achievement
 	var/name = "achievement"
 	var/desc = "Please make an issue on github, including this achievement's name and how you got it."
@@ -132,104 +136,106 @@
 	desc = "As the QM, have a million cargo credits by the end of the round" //Cargoking-junior
 	id = 22
 
+//start-redtext
+/datum/achievement/redtext
+	name = "Mission Failed, We'll Get'em Next Time"
+	desc = "As an antagonist, fail your objectives."
+	id = 23
+
+/datum/achievement/redtext/winlost
+	name = "Arcane Failure"
+	desc = "As a Wizard, fail your objectives."
+	id = 24
+	hidden = TRUE
+//end-redtext
+
 // The achievements that are basically just "greentext as this sort of antag"
 
 /datum/achievement/greentext
 	name = "Green Text"
 	desc = "As an Antagonist achieve your first green text"
-	id = 23
+	id = GREENTEXT + 1
 
 /datum/achievement/greentext/ratvar
 	name = "Clock Work"
 	desc = "As a Servant of Ratvar summon Ratvar"
-	id = 24
+	id = GREENTEXT + 2
 
 /datum/achievement/greentext/ratvar/eminence
 	name = "Clock Work"
 	desc = "As the Eminence, summon Ratvar"
-	id = 25
+	id = GREENTEXT + 3
 
 /datum/achievement/greentext/narsie
 	name = "Blood Rites"
 	desc = "As a member of Blood Cult summon Nar-Sie"
-	id = 26
+	id = GREENTEXT + 4
 
 /datum/achievement/greentext/narsie/master
 	name = "Master of Blood"
 	desc = "As a Cult Master, summon Nar-Sie"
-	id = 27
+	id = GREENTEXT + 5
 
 /datum/achievement/greentext/revolution
 	name = "Down with Nanotrasen"
 	desc = "As a Revolutionary, complete your objectives"
-	id = 28
+	id = GREENTEXT + 6
 
 /datum/achievement/greentext/revolution/head
 	name = "Viva la Revolution!"
 	desc = "As a Head Revolutionary, complete your objectives"
-	id = 29
+	id = GREENTEXT + 7
 
 /datum/achievement/greentext/gang
 	name = "Turf War"
 	desc = "As a Gang Member, take over the station"
-	id = 30
+	id = GREENTEXT + 8
 
 /datum/achievement/greentext/gangleader
 	name = "\"I have built my organization upon fear.\""
 	desc = "As a Gang Leader, take over the station"
-	id = 31
+	id = GREENTEXT + 9
 
 /datum/achievement/greentext/blob
 	name = "Grey Goo"
 	desc = "As a Blob complete your objectives"
-	id = 32
+	id = GREENTEXT + 10
 
 /datum/achievement/greentext/clownop
 	name = "\"You wouldn't get it\""
 	desc = "As a Clown Operative score a Major or Minor Victory"
-	id = 33
+	id = GREENTEXT + 11
 
 /datum/achievement/greentext/internal
 	name = "Triple Cross"
 	desc = "As an Internal Affairs Agent, complete your objectives"
-	id = 34
+	id = GREENTEXT + 12
 
 /datum/achievement/greentext/external
 	name = "Quadruple Cross"
 	desc = "As an External Affairs Agent, complete your objectives"
-	id = 35
+	id = GREENTEXT + 13
 
 /datum/achievement/greentext/disease
 	name = "Space Aids"
 	desc = "As Sentient Disease, survive and complete your objectives"
-	id = 36
+	id = GREENTEXT + 14
 
 /datum/achievement/greentext/pirate
 	name = "Yaaaahr!"
 	desc = "As member of the Pirate crew, collect sufficient bounty from the crew"
-	id = 37
+	id = GREENTEXT + 15
 
 /datum/achievement/greentext/vampire
 	name = "Count de Ville"
 	desc = "As a Vampire, complete your objectives"
-	id = 38
+	id = GREENTEXT + 16
 
 /datum/achievement/greentext/revenant
 	name = "From The Shadows"
 	desc = "As a Revenant, complete your objectives"
-	id = 39
+	id = GREENTEXT + 17
 
 //end-greentext
 
-//start-redtext
-/datum/achievement/redtext
-	name = "Mission Failed, We'll Get'em Next Time"
-	desc = "As an antagonist, fail your objectives."
-	id = 40
-
-/datum/achievement/redtext/winlost
-	name = "Arcane Failure"
-	desc = "As a Wizard, fail your objectives."
-	id = 41
-	hidden = TRUE
-//end-redtext
+#undef GREENTEXT

--- a/code/datums/achievements/achievements.dm
+++ b/code/datums/achievements/achievements.dm
@@ -52,7 +52,7 @@
 	id = 9
 	hidden = TRUE
 
-/datum/achievement/wizwin
+/datum/achievement/greentext/wizwin
 	name = "Scholars of the Arcane"
 	desc = "As a wizard, complete your objectives"
 	id = 10
@@ -68,12 +68,12 @@
 	id = 12
 	hidden = TRUE
 
-/datum/achievement/changelingwin
+/datum/achievement/greentext/changelingwin
 	name = "The Thing"
 	desc = "As a changeling, complete your objectives"
 	id = 13
 
-/datum/achievement/slingascend
+/datum/achievement/greentext/slingascend
 	name = "The Dark Shadow"
 	desc = "As a shadowling, ascend successfully"
 	id = 14

--- a/code/datums/achievements/achievements.dm
+++ b/code/datums/achievements/achievements.dm
@@ -159,3 +159,12 @@
 	desc = "As a Cult Master, summon Nar-Sie"
 	id = 27
 
+/datum/achievement/greentext/revolution
+	name = "Down with Nanotrasen"
+	desc = "As a Revolutionary, complete your objectives"
+	id = 28
+
+/datum/achievement/greentext/revolution/head
+	name = "Viva la Revolution!"
+	desc = "As a Head Revolutionary, complete your objectives"
+	id = 29

--- a/code/datums/achievements/achievements.dm
+++ b/code/datums/achievements/achievements.dm
@@ -174,7 +174,7 @@
 	desc = "As a Gang Member, take over the station"
 	id = 30
 
-/datum/achievement/greentext/gang/leader
+/datum/achievement/greentext/gangleader
 	name = "\"I have built my organization upon fear.\""
 	desc = "As a Gang Leader, take over the station"
 	id = 31

--- a/code/datums/achievements/achievements.dm
+++ b/code/datums/achievements/achievements.dm
@@ -241,3 +241,4 @@
 //end-redtext
 
 #undef GREENTEXT
+#undef REDTEXT

--- a/code/datums/achievements/achievements.dm
+++ b/code/datums/achievements/achievements.dm
@@ -149,3 +149,13 @@
 	desc = "As the Eminence, summon Ratvar"
 	id = 25
 
+/datum/achievement/greentext/narsie
+	name = "Blood Rites"
+	desc = "As a member of Blood Cult summon Nar-Sie"
+	id = 26
+
+/datum/achievement/greentext/narsie/master
+	name = "Master of Blood"
+	desc = "As a Cult Master, summon Nar-Sie"
+	id = 27
+

--- a/code/datums/achievements/achievements.dm
+++ b/code/datums/achievements/achievements.dm
@@ -30,7 +30,7 @@
 	desc = "As a member of the Crew, deal a Humiliating defeat to Nuclear Team"
 	id = 5
 
-/datum/achievement/nukewin
+/datum/achievement/greentext/nukewin
 	name = "Delta Alert"
 	desc = "As a Nuclear Operative, score a Major or Minor Victory"
 	id = 6
@@ -173,3 +173,9 @@
 	name = "Grey Goo"
 	desc = "As a Blob complete your objectives"
 	id = 32
+
+/datum/achievement/greentext/clownop
+	name = "\"You wouldn't get it\""
+	desc = "As a Clown Operative score a Major or Minor Victory"
+	id = 33
+//end-greentext

--- a/code/datums/achievements/achievements.dm
+++ b/code/datums/achievements/achievements.dm
@@ -168,3 +168,8 @@
 	name = "Viva la Revolution!"
 	desc = "As a Head Revolutionary, complete your objectives"
 	id = 29
+
+/datum/achievement/greentext/blob
+	name = "Grey Goo"
+	desc = "As a Blob complete your objectives"
+	id = 32

--- a/code/datums/achievements/achievements.dm
+++ b/code/datums/achievements/achievements.dm
@@ -178,4 +178,14 @@
 	name = "\"You wouldn't get it\""
 	desc = "As a Clown Operative score a Major or Minor Victory"
 	id = 33
+
+/datum/achievement/greentext/internal
+	name = "Triple Cross"
+	desc = "As an Internal Affairs Agent, complete your objectives"
+	id = 34
+
+/datum/achievement/greentext/external
+	name = "Quadruple Cross"
+	desc = "As an External Affairs Agent, complete your objectives"
+	id = 35
 //end-greentext

--- a/code/datums/achievements/achievements.dm
+++ b/code/datums/achievements/achievements.dm
@@ -131,3 +131,11 @@
 	name = "Duke of Ducats"
 	desc = "As the QM, have a million cargo credits by the end of the round" //Cargoking-junior
 	id = 22
+
+// The achievements that are basically just "greentext as this sort of antag"
+
+/datum/achievement/greentext
+	name = "Green Text"
+	desc = "As an Antagonist achieve your first green text"
+	id = 23
+

--- a/code/datums/achievements/achievements.dm
+++ b/code/datums/achievements/achievements.dm
@@ -139,3 +139,13 @@
 	desc = "As an Antagonist achieve your first green text"
 	id = 23
 
+/datum/achievement/greentext/ratvar
+	name = "Clock Work"
+	desc = "As a Servant of Ratvar summon Ratvar"
+	id = 24
+
+/datum/achievement/greentext/ratvar/eminence
+	name = "Clock Work"
+	desc = "As the Eminence, summon Ratvar"
+	id = 25
+

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -20,6 +20,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 	var/show_in_antagpanel = TRUE	//This will hide adding this antag type in antag panel, use only for internal subtypes that shouldn't be added directly but still show if possessed by mind
 	var/antagpanel_category = "Uncategorized"	//Antagpanel will display these together, REQUIRED
 	var/show_name_in_check_antagonists = FALSE //Will append antagonist name in admin listings - use for categories that share more than one antag type
+	var/datum/achievement/greentext/greentext_achieve // The achievement received for greentexting as this antag type. Not all antag types use this to distribute their achievements.
 
 /datum/antagonist/New()
 	GLOB.antagonists += src
@@ -143,6 +144,8 @@ GLOBAL_LIST_EMPTY(antagonists)
 	if(objectives.len == 0 || objectives_complete)
 		report += "<span class='greentext big'>The [name] was successful!</span>"
 		unlock_achievement(datum/achievement/greentext,owner.current)
+		if(istype(greentext_achieve))
+			unlock_achievement(greentext_achieve,owner.current)
 	else
 		report += "<span class='redtext big'>The [name] has failed!</span>"
 

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -143,9 +143,10 @@ GLOBAL_LIST_EMPTY(antagonists)
 
 	if(objectives.len == 0 || objectives_complete)
 		report += "<span class='greentext big'>The [name] was successful!</span>"
-		SSachievements.unlock_achievement(/datum/achievement/greentext,owner.current)
 		if(istype(greentext_achieve))
 			SSachievements.unlock_achievement(greentext_achieve,owner.current)
+		else // The above still does award the generic greentext achievement, just implicitly.
+			SSachievements.unlock_achievement(/datum/achievement/greentext,owner.current.client) 
 	else
 		report += "<span class='redtext big'>The [name] has failed!</span>"
 

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -143,9 +143,9 @@ GLOBAL_LIST_EMPTY(antagonists)
 
 	if(objectives.len == 0 || objectives_complete)
 		report += "<span class='greentext big'>The [name] was successful!</span>"
-		unlock_achievement(datum/achievement/greentext,owner.current)
+		SSachievements.unlock_achievement(/datum/achievement/greentext,owner.current)
 		if(istype(greentext_achieve))
-			unlock_achievement(greentext_achieve,owner.current)
+			SSachievements.unlock_achievement(greentext_achieve,owner.current)
 	else
 		report += "<span class='redtext big'>The [name] has failed!</span>"
 

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -142,6 +142,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 
 	if(objectives.len == 0 || objectives_complete)
 		report += "<span class='greentext big'>The [name] was successful!</span>"
+		unlock_achievement(datum/achievement/greentext,owner.current)
 	else
 		report += "<span class='redtext big'>The [name] has failed!</span>"
 

--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -146,6 +146,7 @@
 	for(var/datum/objective/O in objectives)
 		if(!O.check_completion())
 			won = FALSE
+			break
 	if(won)
 		result += "<span class='greentext big'>[name] team fulfilled its mission!</span>"
 	else

--- a/code/modules/antagonists/blob/blob.dm
+++ b/code/modules/antagonists/blob/blob.dm
@@ -17,7 +17,7 @@
 			var/point_report = "<br><b>[owner.name]</b> took over [overmind.max_count] tiles at the height of its growth."
 			return basic_report+point_report
 		else
-			unlock_achievement(/datum/achievement/greentext/blob,overmind.client)
+			SSachievements.unlock_achievement(/datum/achievement/greentext/blob,overmind.client)
 	return basic_report
 
 /datum/antagonist/blob/greet()

--- a/code/modules/antagonists/blob/blob.dm
+++ b/code/modules/antagonists/blob/blob.dm
@@ -16,6 +16,8 @@
 		if(!overmind.victory_in_progress) //if it won this doesn't really matter
 			var/point_report = "<br><b>[owner.name]</b> took over [overmind.max_count] tiles at the height of its growth."
 			return basic_report+point_report
+		else
+			unlock_achievement(/datum/achievement/greentext/blob,overmind.client)
 	return basic_report
 
 /datum/antagonist/blob/greet()

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -575,7 +575,7 @@
 
 	if(changelingwin)
 		parts += "<span class='greentext'>The changeling was successful!</span>"
-		SSachievements.unlock_achievement(/datum/achievement/changelingwin, owner.current.client) //changeling wins, give achivement
+		SSachievements.unlock_achievement(/datum/achievement/greentext/changelingwin, owner.current.client) //changeling wins, give achivement
 	else
 		parts += "<span class='redtext'>The changeling has failed.</span>"
 

--- a/code/modules/antagonists/clockcult/clockcult.dm
+++ b/code/modules/antagonists/clockcult/clockcult.dm
@@ -215,8 +215,8 @@
 		parts += "<span class='greentext big'>Ratvar's servants defended the Ark until its activation!</span>"
 		for(var/mind in SSticker.mode.servants_of_ratvar)
 			var/datum/mind/M = mind
-			SSachievements.unlock_achievement(/datum/achievement/greentext/ratvar,M.current)
-		SSachievements.unlock_achievement(/datum/achievement/greentext/ratvar/eminence,eminence.current)
+			SSachievements.unlock_achievement(/datum/achievement/greentext/ratvar,M.current.client)
+		SSachievements.unlock_achievement(/datum/achievement/greentext/ratvar/eminence,eminence.current.client)
 	else
 		parts += "<span class='redtext big'>The Ark was destroyed! Ratvar will rust away for all eternity!</span>"
 	parts += " "

--- a/code/modules/antagonists/clockcult/clockcult.dm
+++ b/code/modules/antagonists/clockcult/clockcult.dm
@@ -213,6 +213,10 @@
 
 	if(check_clockwork_victory())
 		parts += "<span class='greentext big'>Ratvar's servants defended the Ark until its activation!</span>"
+		for(var/mind in SSticker.mode.servants_of_ratvar)
+			var/datum/mind/M = mind
+			unlock_achievement(datum/achievement/greentext/ratvar,M.current)
+		unlock_achievement(datum/achievement/greentext/ratvar/eminence,eminence.current)
 	else
 		parts += "<span class='redtext big'>The Ark was destroyed! Ratvar will rust away for all eternity!</span>"
 	parts += " "

--- a/code/modules/antagonists/clockcult/clockcult.dm
+++ b/code/modules/antagonists/clockcult/clockcult.dm
@@ -215,8 +215,8 @@
 		parts += "<span class='greentext big'>Ratvar's servants defended the Ark until its activation!</span>"
 		for(var/mind in SSticker.mode.servants_of_ratvar)
 			var/datum/mind/M = mind
-			unlock_achievement(datum/achievement/greentext/ratvar,M.current)
-		unlock_achievement(datum/achievement/greentext/ratvar/eminence,eminence.current)
+			SSachievements.unlock_achievement(/datum/achievement/greentext/ratvar,M.current)
+		SSachievements.unlock_achievement(/datum/achievement/greentext/ratvar/eminence,eminence.current)
 	else
 		parts += "<span class='redtext big'>The Ark was destroyed! Ratvar will rust away for all eternity!</span>"
 	parts += " "

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -382,9 +382,9 @@
 		parts += "<span class='greentext big'>The cult has succeeded! Nar-sie has snuffed out another torch in the void!</span>"
 		for(var/mind in members)
 			var/datum/mind/M = mind
-			unlock_achievement(datum/achievement/greentext/narsie,M.current)
-			if(M.has_antag_datum(datum/antagonist/cult/master))
-				unlock_achievement(datum/achievement/greentext/narsie/master,M.current)
+			SSachievements.unlock_achievement(/datum/achievement/greentext/narsie,M.current)
+			if(M.has_antag_datum(/datum/antagonist/cult/master))
+				SSachievements.unlock_achievement(/datum/achievement/greentext/narsie/master,M.current)
 	else
 		parts += "<span class='redtext big'>The staff managed to stop the cult! Dark words and heresy are no match for Nanotrasen's finest!</span>"
 

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -380,6 +380,11 @@
 
 	if(check_cult_victory())
 		parts += "<span class='greentext big'>The cult has succeeded! Nar-sie has snuffed out another torch in the void!</span>"
+		for(var/mind in members)
+			var/datum/mind/M = mind
+			unlock_achievement(datum/achievement/greentext/narsie,M.current)
+			if(M.has_antag_datum(datum/antagonist/cult/master))
+				unlock_achievement(datum/achievement/greentext/narsie/master,M.current)
 	else
 		parts += "<span class='redtext big'>The staff managed to stop the cult! Dark words and heresy are no match for Nanotrasen's finest!</span>"
 

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -382,9 +382,9 @@
 		parts += "<span class='greentext big'>The cult has succeeded! Nar-sie has snuffed out another torch in the void!</span>"
 		for(var/mind in members)
 			var/datum/mind/M = mind
-			SSachievements.unlock_achievement(/datum/achievement/greentext/narsie,M.current)
+			SSachievements.unlock_achievement(/datum/achievement/greentext/narsie,M.current.client)
 			if(M.has_antag_datum(/datum/antagonist/cult/master))
-				SSachievements.unlock_achievement(/datum/achievement/greentext/narsie/master,M.current)
+				SSachievements.unlock_achievement(/datum/achievement/greentext/narsie/master,M.current.client)
 	else
 		parts += "<span class='redtext big'>The staff managed to stop the cult! Dark words and heresy are no match for Nanotrasen's finest!</span>"
 

--- a/code/modules/antagonists/disease/disease_datum.dm
+++ b/code/modules/antagonists/disease/disease_datum.dm
@@ -57,6 +57,8 @@
 
 	if(win)
 		result += "<span class='greentext'>The [special_role_text] was successful!</span>"
+		if(istype(owner.current, /mob/camera/disease))
+			SSachievements.unlock_achievement(/datum/achievement/greentext/disease,owner.current.client)
 	else
 		result += "<span class='redtext'>The [special_role_text] has failed!</span>"
 

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -380,8 +380,12 @@
 					SSachievements.unlock_achievement(/datum/achievement/flukeops, H.client)
 		if(NUKE_RESULT_NUKE_WIN, NUKE_RESULT_DISK_LOST)
 			for(var/mob/living/carbon/human/H in GLOB.player_list)
-				if(is_nuclear_operative(H))
-					SSachievements.unlock_achievement(/datum/achievement/nukewin, H.client)
+				var/datum/mind/M = H.mind
+				if(M && M.has_antag_datum(/datum/antagonist/nukeop))
+					if(M.has_antag_datum(/datum/antagonist/nukeop/clownop) || M.has_antag_datum(/datum/antagonist/nukeop/leader/clownop))
+						SSachievements.unlock_achievement(/datum/achievement/greentext/clownop, H.client)
+					else
+						SSachievements.unlock_achievement(/datum/achievement/greentext/nukewin, H.client)
 
 
 /datum/team/nuclear/antag_listing_name()

--- a/code/modules/antagonists/pirate/pirate.dm
+++ b/code/modules/antagonists/pirate/pirate.dm
@@ -101,6 +101,8 @@
 
 	if(L.check_completion() && !all_dead)
 		parts += "<span class='greentext big'>The pirate crew was successful!</span>"
+		for(var/datum/mind/M in members)
+			SSachievements.unlock_achievement(/datum/achievement/greentext/pirate,M.current.client)
 	else
 		parts += "<span class='redtext big'>The pirate crew has failed.</span>"
 

--- a/code/modules/antagonists/revenant/revenant_antag.dm
+++ b/code/modules/antagonists/revenant/revenant_antag.dm
@@ -2,6 +2,7 @@
 	name = "Revenant"
 	show_in_antagpanel = FALSE
 	show_name_in_check_antagonists = TRUE
+	greentext_achieve = /datum/achievement/greentext/revenant
 
 /datum/antagonist/revenant/greet()
 	owner.announce_objectives()

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -303,6 +303,12 @@
 	addtimer(CALLBACK(src,.proc/update_heads),HEAD_UPDATE_PERIOD,TIMER_UNIQUE)
 
 
+/datum/team/revolution/proc/check_victory()
+	for(var/datum/objective/O in objectives)
+		if(!O.check_completion())
+			return FALSE
+	return TRUE
+
 /datum/team/revolution/roundend_report()
 	if(!members.len)
 		return
@@ -326,6 +332,13 @@
 	var/list/targets = list()
 	var/list/datum/mind/headrevs = get_antag_minds(/datum/antagonist/rev/head)
 	var/list/datum/mind/revs = get_antag_minds(/datum/antagonist/rev,TRUE)
+	if(check_victory())
+		for(var/H in revs)
+			var/datum/mind/M = H
+			unlock_achievement(/datum/achievement/greentext/revolution,M.current)
+			if(M.has_antag_datum(/datum/antagonist/rev/head))
+				unlock_achievement(/datum/achievement/greentext/revolution/head,M.current)
+	
 	if(headrevs.len)
 		var/list/headrev_part = list()
 		headrev_part += "<span class='header'>The head revolutionaries were:</span>"

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -335,9 +335,9 @@
 	if(check_victory())
 		for(var/H in revs)
 			var/datum/mind/M = H
-			SSachievements.unlock_achievement(/datum/achievement/greentext/revolution,M.current)
+			SSachievements.unlock_achievement(/datum/achievement/greentext/revolution,M.current.client)
 			if(M.has_antag_datum(/datum/antagonist/rev/head))
-				SSachievements.unlock_achievement(/datum/achievement/greentext/revolution/head,M.current)
+				SSachievements.unlock_achievement(/datum/achievement/greentext/revolution/head,M.current.client)
 	
 	if(headrevs.len)
 		var/list/headrev_part = list()

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -335,9 +335,9 @@
 	if(check_victory())
 		for(var/H in revs)
 			var/datum/mind/M = H
-			unlock_achievement(/datum/achievement/greentext/revolution,M.current)
+			SSachievements.unlock_achievement(/datum/achievement/greentext/revolution,M.current)
 			if(M.has_antag_datum(/datum/antagonist/rev/head))
-				unlock_achievement(/datum/achievement/greentext/revolution/head,M.current)
+				SSachievements.unlock_achievement(/datum/achievement/greentext/revolution/head,M.current)
 	
 	if(headrevs.len)
 		var/list/headrev_part = list()

--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -12,7 +12,7 @@
 	var/syndicate = FALSE
 	var/last_man_standing = FALSE
 	var/list/datum/mind/targets_stolen
-
+	greentext_achieve = /datum/achievement/greentext/internal
 
 /datum/antagonist/traitor/internal_affairs/proc/give_pinpointer()
 	if(owner && owner.current)
@@ -234,6 +234,7 @@
 			special_role = TRAITOR_AGENT_ROLE
 			syndicate = TRUE
 			forge_single_objective()
+			greentext_achieve = /datum/achievement/greentext/external
 
 /datum/antagonist/traitor/internal_affairs/forge_traitor_objectives()
 	forge_iaa_objectives()

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -421,6 +421,9 @@
 
 	if(traitorwin)
 		result += "<span class='greentext'>The [special_role_text] was successful!</span>"
+		SSachievements.unlock_achievement(/datum/achievement/greentext,owner.current)
+		if(istype(greentext_achieve))
+			SSachievements.unlock_achievement(greentext_achieve,owner.current)
 	else
 		result += "<span class='redtext'>The [special_role_text] has failed!</span>"
 		SEND_SOUND(owner.current, 'sound/ambience/ambifailure.ogg')

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -421,7 +421,7 @@
 
 	if(traitorwin)
 		result += "<span class='greentext'>The [special_role_text] was successful!</span>"
-		SSachievements.unlock_achievement(/datum/achievement/greentext,owner.current)
+		SSachievements.unlock_achievement(/datum/achievement/greentext,owner.current.client)
 		if(istype(greentext_achieve))
 			SSachievements.unlock_achievement(greentext_achieve,owner.current)
 	else

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -304,7 +304,7 @@
 
 	if(wizardwin)
 		parts += "<span class='greentext'>The wizard was successful!</span>"
-		SSachievements.unlock_achievement(/datum/achievement/wizwin, owner.current.client) //wizard wins, give achievement
+		SSachievements.unlock_achievement(/datum/achievement/greentext/wizwin, owner.current.client) //wizard wins, give achievement
 	else
 		parts += "<span class='redtext'>The wizard has failed!</span>"
 

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -307,7 +307,7 @@
 		SSachievements.unlock_achievement(/datum/achievement/greentext/wizwin, owner.current.client) //wizard wins, give achievement
 	else
 		parts += "<span class='redtext'>The wizard has failed!</span>"
-
+		SSachievements.unlock_achievement(/datum/achievement/redtext/winlost, owner.current.client) //wizard loses, still give achievement lol
 	if(owner.spell_list.len>0)
 		parts += "<B>[owner.name] used the following spells: </B>"
 		var/list/spell_names = list()

--- a/yogstation/code/datums/antagonists/vampire.dm
+++ b/yogstation/code/datums/antagonists/vampire.dm
@@ -341,6 +341,7 @@
 
 	if(vampwin)
 		result += "<span class='greentext'>The vampire was successful!</span>"
+		SSachievements.unlock_achievement(/datum/achievement/greentext/vampire, owner.current.client)
 	else
 		result += "<span class='redtext'>The vampire has failed!</span>"
 		SEND_SOUND(owner.current, 'sound/ambience/ambifailure.ogg')

--- a/yogstation/code/modules/antagonists/gang/gang.dm
+++ b/yogstation/code/modules/antagonists/gang/gang.dm
@@ -331,6 +331,10 @@
 	report += "<span class='header'>[name]:</span>"
 	if(winner)
 		report += "<span class='greentext'>The [name] gang was successful!</span>"
+		for(var/datum/mind/M in leaders)
+			unlock_achievement(/datum/achievement/greentext/gangleader,M.current)
+		for(var/datum/mind/M in members) // Leaders are included in this too
+			unlock_achievement(/datum/achievement/greentext/gang,M.current) // and so get the lower achievement, too
 	else
 		report += "<span class='redtext'>The [name] gang has failed!</span>"
 

--- a/yogstation/code/modules/antagonists/gang/gang.dm
+++ b/yogstation/code/modules/antagonists/gang/gang.dm
@@ -332,9 +332,9 @@
 	if(winner)
 		report += "<span class='greentext'>The [name] gang was successful!</span>"
 		for(var/datum/mind/M in leaders)
-			unlock_achievement(/datum/achievement/greentext/gangleader,M.current)
+			SSachievements.unlock_achievement(/datum/achievement/greentext/gangleader,M.current)
 		for(var/datum/mind/M in members) // Leaders are included in this too
-			unlock_achievement(/datum/achievement/greentext/gang,M.current) // and so get the lower achievement, too
+			SSachievements.unlock_achievement(/datum/achievement/greentext/gang,M.current) // and so get the lower achievement, too
 	else
 		report += "<span class='redtext'>The [name] gang has failed!</span>"
 

--- a/yogstation/code/modules/antagonists/shadowling/special_shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/special_shadowling_abilities.dm
@@ -164,7 +164,7 @@
 				SEND_SOUND(M, sound('sound/hallucinations/veryfar_noise.ogg'))
 			for(var/obj/machinery/power/apc/A in GLOB.apcs_list)
 				A.overload_lighting()
-			SSachievements.unlock_achievement(/datum/achievement/slingascend, H.client)
+			SSachievements.unlock_achievement(/datum/achievement/greentext/slingascend, H.client)
 			var/mob/A = new /mob/living/simple_animal/ascendant_shadowling(H.loc)
 			for(var/X in H.mind.spell_list)
 				var/obj/effect/proc_holder/spell/S = X


### PR DESCRIPTION
Hopek and Readystorm are paying me for this.
![image](https://user-images.githubusercontent.com/29939414/72580424-a5286700-38a1-11ea-81a4-011c7916e6a5.png)

## Overview

Included are 18 of the 88 achievements I'm being paid to add to the game, all of them having to do with greentexting.

There are also unique achievements for the leaders of team antag groups winning, too. Like Eminences get both the default "win as clockie" achievement as well as the "win as Eminence" one.

## Coder Warning

Doing this involved the creation of a new achievement type, ``/datum/achievement/greentext``. All achievements related to greentexting should be put under this type so that the user can also get the generic "get a greentext" achievement, too.

Additionally, ``/datum/antagonist`` got a new var: ``greentext_achieve``, which is the type of an achievement the antag will receive if they greentext as that antag type.

Not all antag types have been converted to the new ``greentext_achieve`` method, due to the excessive copypaste and lack of inheritence when it comes to determining win condition and objective accomplishment.


## Changelog
:cl:  Altoids
rscadd: Gangs, Clownops, Generic antags, EAAs, IAAs, Culties, Clockies, Revs, Sentient Diseases, Revenants, Vampires, Pirates and Blobs now all have unique achievements for greentexting!
/:cl:
