### PR TITLE
Random Role Option (Late Game Joining)

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -78,8 +78,9 @@ SUBSYSTEM_DEF(job)
 		SetupOccupations()
 	return type_occupations[jobtype]
 
-// Checks for if player is Assignable to Role
-/datum/controller/subsystem/job/proc/CanAssignRole(mob/dead/new_player/player, rank)
+// Attempts to Assign player to Role
+/datum/controller/subsystem/job/proc/AssignRole(mob/dead/new_player/player, rank, latejoin = FALSE)
+	JobDebug("Running AR, Player: [player], Rank: [rank], LJ: [latejoin]")
 	if(player && player.mind && rank)
 		var/datum/job/job = GetJob(rank)
 		if(!job)
@@ -90,14 +91,6 @@ SUBSYSTEM_DEF(job)
 			return FALSE
 		if(job.required_playtime_remaining(player.client))
 			return FALSE
-		return TRUE
-	return FALSE
-
-// Attempts to Assign player to Role
-/datum/controller/subsystem/job/proc/AssignRole(mob/dead/new_player/player, rank, latejoin = FALSE)
-	JobDebug("Running AR, Player: [player], Rank: [rank], LJ: [latejoin]")
-	if(CanAssignRole(player, rank))
-		var/datum/job/job = GetJob(rank)
 		var/position_limit = job.total_positions
 		if(!latejoin)
 			position_limit = job.spawn_positions
@@ -173,8 +166,7 @@ SUBSYSTEM_DEF(job)
 
 		if((job.current_positions < job.spawn_positions) || job.spawn_positions == -1)
 			JobDebug("GRJ Random job can give, Player: [player], Job: [job]")
-			if(CanAssignRole(player, job.title))
-				return job
+			return job
 
 // Assign a random job to a specific player
 /datum/controller/subsystem/job/proc/GiveRandomJob(mob/dead/new_player/player)

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -96,7 +96,7 @@ SUBSYSTEM_DEF(job)
 // Attempts to Assign player to Role
 /datum/controller/subsystem/job/proc/AssignRole(mob/dead/new_player/player, rank, latejoin = FALSE)
 	JobDebug("Running AR, Player: [player], Rank: [rank], LJ: [latejoin]")
-	if(CanAssignRole(player, rank)
+	if(CanAssignRole(player, rank))
 		var/datum/job/job = GetJob(rank)
 		var/position_limit = job.total_positions
 		if(!latejoin)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -165,8 +165,10 @@
 		// Check if random role is requested
 		if(href_list["SelectedJob"] == "Random")
 			var/datum/job/job = SSjob.GetRandomJob(src)
-			if(job != FALSE)
-				href_list["SelectedJob"] = job.title
+			if(!job)
+				to_chat(usr, "<span class='warning'>There is no randomly assignable Job at this time. Please manually choose one of the other possible options.</span>")
+				return
+			href_list["SelectedJob"] = job.title
 
 		AttemptLateSpawn(href_list["SelectedJob"])
 		return

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -77,6 +77,7 @@
 	popup.set_content(output)
 	popup.open(FALSE)
 
+// List of possible actions user has chosen on the New Players menus
 /mob/dead/new_player/Topic(href, href_list[])
 	if(src != usr)
 		return 0
@@ -160,6 +161,12 @@
 			if((living_player_count() >= relevant_cap) || (src != SSticker.queued_players[1]))
 				to_chat(usr, "<span class='warning'>Server is full.</span>")
 				return
+
+		// Check if random role is requested
+		if(href_list["SelectedJob"] == "Random")
+			var/datum/job/job = SSjob.GetRandomJob(src)
+			if(job != FALSE)
+				href_list["SelectedJob"] = job.title
 
 		AttemptLateSpawn(href_list["SelectedJob"])
 		return
@@ -457,6 +464,15 @@
 		column_counter++
 		if(column_counter > 0 && (column_counter % 3 == 0))
 			dat += "</td><td valign='top'>"
+
+	// Random Job Section
+	dat += "<fieldset style='width: 185px; border: 2px solid #f0ebe2; display: inline'>"
+	dat += "<legend align='center' style='color: #f0ebe2'>Random</legend>"
+	dat += "<a class='job' href='byond://?src=[REF(src)];SelectedJob=Random'>Random Job</a>"
+	// TODO could add random job selection to be based on player preferences too
+	dat += "</fieldset><br>"
+
+	// Table end
 	dat += "</td></tr></table></center>"
 	dat += "</div></div>"
 	var/datum/browser/popup = new(src, "latechoices", "Choose Profession", 680, 580)


### PR DESCRIPTION
### Intent of your Pull Request

This adds a option to the Job Selection page when entering Late/Mid-Round.
A new job category 'Random' with a job title 'Random Job' added to give a random role to those that missed out on that random chance happening at Game Start.

### Reasons:

This is a quality of life recommendation for those that miss that 5 minute joining window between 2 hour long matches. Half time I enter the server and just sit there waiting for 1-120 minutes so I can get a random job when a new game starts.

Desired TODO for future: An option to use the Job Preferences as well

------

Added 'GetRandomJob' functions and moved the functionality from 'GiveRandomJob' into them for reuse elsewhere.


#### Changelog

:cl:  
rscadd: Adds 'Random Job' to Late Join Job Selection 
rscadd: Added 'GetRandomJob' proc to Job def
tweak: Moved around Job Functions to avoid duplication (all existing intact) 
/:cl:
