### PR TITLE
Boxstation brig changes

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -9455,6 +9455,7 @@
 	},
 /obj/structure/table,
 /obj/item/hand_labeler,
+/obj/item/paper/guides/jobs/security/labor_lockers,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "asM" = (
@@ -47403,7 +47404,6 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "bQP" = (
-/obj/structure/closet,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -47416,6 +47416,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/structure/closet/secure_closet/personal/prisoner,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "bQQ" = (
@@ -47440,17 +47441,16 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "bQS" = (
-/obj/structure/closet,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/structure/closet/secure_closet/personal/prisoner,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "bQT" = (
-/obj/structure/closet,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
@@ -47458,6 +47458,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/structure/closet/secure_closet/personal/prisoner,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "bQU" = (

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -6812,22 +6812,12 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "amX" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
+/obj/item/bot_assembly/secbot,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "amY" = (
 /obj/structure/chair{
 	dir = 1
@@ -7031,15 +7021,9 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "anu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
+/obj/item/paper/fluff/jobs/security/beepsky_mom,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "anv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
@@ -7523,12 +7507,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aos" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
+/obj/structure/bed,
+/obj/item/bedsheet/red,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "aot" = (
 /obj/machinery/camera{
 	c_tag = "Fore Primary Hallway West";
@@ -7546,23 +7528,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aou" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/window/reinforced,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/potato{
+	name = "\improper Beepsky's emergency battery"
 	},
-/obj/machinery/camera{
-	c_tag = "Labor Shuttle Dock South";
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/security/processing)
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "aov" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -7795,8 +7768,16 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "apb" = (
-/obj/structure/plasticflaps,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/processing)
 "apc" = (
 /obj/machinery/door/airlock/maintenance{
@@ -8171,8 +8152,20 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "apR" = (
-/obj/item/paper/fluff/jobs/security/beepsky_mom,
-/turf/open/floor/plating,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
 /area/security/processing)
 "apS" = (
 /obj/structure/cable{
@@ -8625,15 +8618,15 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aqS" = (
-/obj/machinery/light/small{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/potato{
-	name = "\improper Beepsky's emergency battery"
-	},
-/turf/open/floor/plating,
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel,
 /area/security/processing)
 "aqT" = (
 /obj/structure/disposalpipe/segment,
@@ -9457,16 +9450,11 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "asL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
+/obj/structure/table,
+/obj/item/hand_labeler,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "asM" = (
@@ -12150,9 +12138,6 @@
 /area/maintenance/fore/secondary)
 "axY" = (
 /obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
@@ -36597,6 +36582,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"bui" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/camera{
+	c_tag = "Labor Shuttle Dock South";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/security/processing)
 "buj" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "robotics2";
@@ -47402,6 +47402,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"bQP" = (
+/obj/structure/closet,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "bQQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -47411,6 +47427,45 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"bQR" = (
+/obj/machinery/door/window/northright{
+	name = "Labor Camp Storage"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
+"bQS" = (
+/obj/structure/closet,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
+"bQT" = (
+/obj/structure/closet,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
+"bQU" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "bQZ" = (
 /turf/closed/wall/r_wall,
 /area/science/misc_lab)
@@ -52339,13 +52394,6 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
-"cCh" = (
-/obj/item/bedsheet/red,
-/mob/living/simple_animal/bot/secbot/beepsky{
-	name = "Officer Beepsky"
-	},
-/turf/open/floor/plating,
-/area/security/processing)
 "cCi" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -84223,7 +84271,7 @@ aaa
 aaa
 aiT
 aiT
-aiV
+aiT
 alO
 cxJ
 akG
@@ -84231,7 +84279,7 @@ amK
 akG
 cxP
 aAD
-aiV
+aiT
 aiT
 aiT
 arP
@@ -84487,10 +84535,10 @@ amc
 aiT
 ant
 akI
-aos
-aiT
-apR
-cCh
+asL
+bQP
+bQS
+bQT
 arP
 asT
 aqR
@@ -84742,12 +84790,12 @@ apn
 alq
 asp
 aiU
-asL
+apb
 alq
 axY
-apb
-alp
-aqS
+bQR
+bQU
+alq
 arP
 asS
 aqR
@@ -84999,9 +85047,9 @@ akK
 als
 ana
 amM
-amX
+apR
 mLv
-aou
+bui
 aiT
 aiT
 aiT
@@ -85256,7 +85304,7 @@ akJ
 alr
 alq
 aiU
-anu
+aqS
 alq
 anX
 apc
@@ -91145,8 +91193,8 @@ aaa
 aaa
 aaf
 abp
-abO
-aqI
+amX
+aou
 abP
 aco
 acO
@@ -91402,7 +91450,7 @@ aaa
 aaa
 aaa
 afu
-abO
+anu
 aqN
 abO
 abO
@@ -91659,7 +91707,7 @@ aaa
 aaa
 aaa
 abp
-abO
+aos
 aqI
 abO
 acq

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -31,6 +31,12 @@
 	new /obj/item/instrument/piano_synth(src)
 	new /obj/item/radio/headset( src )
 
+/obj/structure/closet/secure_closet/personal/prisoner
+	desc = "It's a secure locker for prisoners. The first card swiped gains control."
+	name = "prisoner closet"
+
+/obj/structure/closet/secure_closet/personal/prisoner/PopulateContents() //empty intentionally
+
 /obj/structure/closet/secure_closet/personal/attackby(obj/item/W, mob/user, params)
 	var/obj/item/card/id/I = W.GetID()
 	if(istype(I))

--- a/code/modules/paperwork/paper_premade.dm
+++ b/code/modules/paperwork/paper_premade.dm
@@ -33,17 +33,20 @@
 	info = "<b>Labor Camp Facility Operation Guide</b><br><br>Hello there, proud operator of an NT-Sec Prisoner Rehabilitation Center.  A solution to rising crime rates and falling productivity, these facilities are specifically designed for the safe, productive imprisonment of your most dangerous criminals.  <br><br>To press a long-term prisoner into the service of the station, replace his equipment with prisoners' garb at one of the prison lockers, as per normal operating procedure.  Before assigning a prisoner his ID, insert the ID into a prisoner management console and assign the prisoner a quota, based on the severity of his crime.  <br>A single sheet of most materials produces five points for the prisoner, and points can be expected to be produced at a rate of about 100 per minute, though punishments as severe as forced labor should be reserved for serious crimes of sentences not less than five minutes long.<br>Once you have prepared the prisoner, place him in the secure northern half of the labor shuttle, and send him to the station.  Once he meets his quota by feeding sheets to the stacker, he will be allowed to return to the station, and will be able to open the secure door to the prisoner release area.<br><br>In the case of dangerous prisoners, surveillance may be needed. To that end, there is a prisoner monitoring room on the mining station, equipped with a remote flasher and a lockdown button.  The mine itself is patrolled by a securibot, so the nearby security records console can also be used to secure hostile prisoners on the mine."
 	infolang = /datum/language/common
 
+/obj/item/paper/guides/jobs/security/labor_lockers
+	name = "Labor Camp Storage"
+	info = "<b>Labor Camp Storage Guide</b><br><br>Hello there, proud operator of an NT-Sec Prisoner Rehabilitation Center.  <br><br>Before you correctly process the prisoner, use these lockers to store any of their personal items.  After assigning a prisoner his ID, use it to lock the locker."
+	infolang = /datum/language/common
+
 /obj/item/paper/guides/jobs/security/range
 	name = "paper- Firing Range Instructions"
 	info = "Directions:<br><i>First you'll want to make sure there is a target stake in the center of the magnetic platform. Next, take an aluminium target from the crates back there and slip it into the stake. Make sure it clicks! Next, there should be a control console mounted on the wall somewhere in the room.<br><br> This control console dictates the behaviors of the magnetic platform, which can move your firing target around to simulate real-world combat situations. From here, you can turn off the magnets or adjust their electromagnetic levels and magnetic fields. The electricity level dictates the strength of the pull - you will usually want this to be the same value as the speed. The magnetic field level dictates how far the magnetic pull reaches.<br><br>Speed and path are the next two settings. Speed is associated with how fast the machine loops through the designated path. Paths dictate where the magnetic field will be centered at what times. There should be a pre-fabricated path input already. You can enable moving to observe how the path affects the way the stake moves. To script your own path, look at the following key:</i><br><br>N: North<br>S: South<br>E: East<br>W: West<br>C: Center<br>R: Random (results may vary)<br>; or &: separators. They are not necessary but can make the path string better visible."
 	infolang = /datum/language/common
 
-//YOGS start
 /obj/item/paper/guides/jobs/security/paystand_setup
 	name = "Setting up your Paystand Correctly"
 	info = "<b><u>Setting up your paystand</u><br>Step 1</b><br>Locate your department budget card.<br><b>Step 2</b><br>Scan your department budget card onto the paystand."
 	infolang = /datum/language/common
-//YOGS end
 
 /obj/item/paper/fluff/jobs/jobs
 	name = "paper- 'Job Information'"


### PR DESCRIPTION
Fixes #7517 , if this isn't liked I can try something else.

Moved beepsky's mom room to the top of the equipment room (currently completely empty), added a bed and turned the secbot into an assembly. May add shutters to the windows in the future, pretty sure we used to have them.
![image](https://user-images.githubusercontent.com/59522545/73069997-2043db80-3ea7-11ea-9601-9a500439b832.png)

Replaced the old (unused) beepsky's mom room with a small locker room to store labor camp prisoners' equipment.
![image](https://user-images.githubusercontent.com/59522545/73070044-40739a80-3ea7-11ea-9581-398819a5f6ab.png)

A label maker has been added in order to label the lockers if desired.
![image](https://user-images.githubusercontent.com/59522545/73070078-55502e00-3ea7-11ea-9c15-bb66db3c76b0.png)

:cl:  ktlwjec
rscadd: Boxstation has a prisoner locker room, located south of the labor camp shuttle dock.
/:cl:
