### PR TITLE
Adds two missing surgeries for the augmented among us.

### DIFF
--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -4,6 +4,13 @@
 	target_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_CHEST)
 
+/datum/surgery/cavity_implant/mechanical
+	name = "Prosthesis cavity implant"
+	steps = list(/datum/surgery_step/mechanic_open, /datum/surgery_step/open_hatch, /datum/surgery_step/prepare_electronics, /datum/surgery_step/handle_cavity, /datum/surgery_step/mechanic_close)
+	possible_locs = list(BODY_ZONE_CHEST)
+	requires_bodypart_type = BODYPART_ROBOTIC
+	lying_required = FALSE
+	self_operable = TRUE
 
 //handle cavity
 /datum/surgery_step/handle_cavity

--- a/code/modules/surgery/implant_removal.dm
+++ b/code/modules/surgery/implant_removal.dm
@@ -4,6 +4,13 @@
 	target_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_CHEST)
 
+/datum/surgery/implant_removal/mechanical
+	name = "Prosthesis implant removal"
+	steps = list(/datum/surgery_step/mechanic_open, /datum/surgery_step/open_hatch, /datum/surgery_step/prepare_electronics, /datum/surgery_step/extract_implant, /datum/surgery_step/mechanic_close)
+	possible_locs = list(BODY_ZONE_CHEST)
+	requires_bodypart_type = BODYPART_ROBOTIC
+	lying_required = FALSE
+	self_operable = TRUE
 
 //extract implant
 /datum/surgery_step/extract_implant


### PR DESCRIPTION
### Intent of your Pull Request
Adds a prosthetic cavity implant, and prosthetic implant removal.

Because if there's any implants or cavity items in someone when they get their torso augmented, there's no chance to remove them past gouging the organs out, and even then I don't actually know if that can be done to people who have an augmented torso.

If desired, I can at least make this require laying down and remove the capability to do it yourself.

#### Changelog

:cl:  
rscadd: Adds cavity implants and implant removal surgeries for preternis and those with augmented torsos.
/:cl: