### PR TITLE
Fixes some potential fatal errors in how paper handles language scrambling

### DIFF
--- a/code/modules/language/language.dm
+++ b/code/modules/language/language.dm
@@ -111,16 +111,17 @@
 
 /datum/language/proc/scramble_HTML(intext) // Calls scramble() on HTML text, making sure to not disturb the HTML.
 	var/text = ""
-	var/regex/plaintext = regex(@"(?:<\/?[\w\s\d=\x22]+>|^)((?:[\w\s\d!@#$%^&*\(\)\-+?:\x22'}{\[\]~`|;,.\\])+)") // Finds plaintext within the HTML.
+	var/regex/plaintext = regex(@"(<\/?[\w\s\d=\x22]+>|^)((?:[\w\s\d!@#$%^&*\(\)\-+?:\x22'}{\[\]~`|;,.\\])+)") // Finds plaintext within the HTML.
 	var/newtext = intext
 	var/startpos = 1
 	while(startpos < 8192 && startpos > -1)
-		var/f = plaintext.Find(newtext,startpos)
-		if(!f)
+		var/regexstart = plaintext.Find(newtext,startpos) // Where the *regex* first matches
+		if(!regexstart)
 			break
-		var/sentence = plaintext.group[1]
+		var/capturestart = regexstart + length(plantext.group[1]) // Where the *capture* first matches, the actual plaintext of this section
+		var/sentence = plaintext.group[2]
 		var/scramb = scramble(sentence) // The scrambled version of the sentence.
-		newtext = replacetext(newtext, sentence, scramb, f, length(sentence)+1)
+		newtext = replacetext(newtext, sentence, scramb, capturestart, capturestart + length(sentence)+1)
 		startpos = plaintext.next + (length(scramb) - length(sentence))
 	text += newtext
 	return text

--- a/code/modules/language/language.dm
+++ b/code/modules/language/language.dm
@@ -118,7 +118,7 @@
 		var/regexstart = plaintext.Find(newtext,startpos) // Where the *regex* first matches
 		if(!regexstart)
 			break
-		var/capturestart = regexstart + length(plantext.group[1]) // Where the *capture* first matches, the actual plaintext of this section
+		var/capturestart = regexstart + length(plaintext.group[1]) // Where the *capture* first matches, the actual plaintext of this section
 		var/sentence = plaintext.group[2]
 		var/scramb = scramble(sentence) // The scrambled version of the sentence.
 		newtext = replacetext(newtext, sentence, scramb, capturestart, capturestart + length(sentence)+1)

--- a/code/modules/language/language.dm
+++ b/code/modules/language/language.dm
@@ -111,7 +111,7 @@
 
 /datum/language/proc/scramble_HTML(intext) // Calls scramble() on HTML text, making sure to not disturb the HTML.
 	var/text = ""
-	var/regex/plaintext = regex(@"((>|^)([^<>]+)<|$") // Finds plaintext within the HTML.
+	var/regex/plaintext = regex(@"((>|^)([^<>]+)(?:<|$)") // Finds plaintext within the HTML.
 	var/newtext = intext
 	var/startpos = 1
 	while(startpos < 8192 && startpos > -1)

--- a/code/modules/language/language.dm
+++ b/code/modules/language/language.dm
@@ -111,7 +111,7 @@
 
 /datum/language/proc/scramble_HTML(intext) // Calls scramble() on HTML text, making sure to not disturb the HTML.
 	var/text = ""
-	var/regex/plaintext = regex(@"(<\/?[\w\s\d=\x22]+>|^)((?:[\w\s\d!@#$%^&*\(\)\-+?:\x22'}{\[\]~`|;,.\\])+)") // Finds plaintext within the HTML.
+	var/regex/plaintext = regex(@"((>|^)([^<>]+)<|$") // Finds plaintext within the HTML.
 	var/newtext = intext
 	var/startpos = 1
 	while(startpos < 8192 && startpos > -1)


### PR DESCRIPTION
## Overview

Apparently the current implementation misuses ``replacetext``, assuming that the text pointer received points to the capture group and not the matched text, potentially causing infinite loops and ergo crashes.

## Coder Warning
The original regex was made with the assumption that there may be real ``<`` and ``>`` characters in the plaintext of the message, which had to be evaded when the text is parsed.

This actually isn't true; the text (since it's in some html code) actually has those characters escaped, meaning that a far simpler regex is needed instead. This ought to make the purpose of that regex more obvious and legible.

#### Changelog

:cl:  Altoids
bugfix: Fixes paper potentially crashing the server when attempting to scramble language-holding text.
bugfix: Fixed a rare, esoteric bug with paper that could result in broken HTML for people viewing scrambled paper.
/:cl:
