### PR TITLE
[admin] Adds a confirmation to nuke ops creation

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -128,6 +128,8 @@
 					message_admins("[key_name_admin(usr)] tried to create a wizard. Unfortunately, there were no candidates available.")
 					log_admin("[key_name(usr)] failed to create a wizard.")
 			if("nukeops")
+				if(alert(usr, "Create a nuke team?", "Confirm", "Yes", "No") != "Yes")
+					return
 				message_admins("[key_name(usr)] is creating a nuke team...")
 				if(src.makeNukeTeam())
 					message_admins("[key_name(usr)] created a nuke team.")


### PR DESCRIPTION
Please shame the below admin for creating a nuke ops team due to there being no confirmation option.

FatalEYES/(Damien Shaffer)BOTToday at 19:41
I HATE THAT BUTTON
It doesn't have a confirm button.