### PR TITLE
Adds the bo staff to the uplink and removes its stupid rng stun

### DIFF
--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -217,16 +217,12 @@
 							   "<span class='userdanger'>[pick(fluffmessages)]</span>")
 		playsound(get_turf(user), 'sound/effects/woodhit.ogg', 75, 1, -1)
 		H.adjustStaminaLoss(rand(13,20))
-		if(prob(10))
-			H.visible_message("<span class='warning'>[H] collapses!</span>", \
-								   "<span class='userdanger'>Your legs give out!</span>")
-			H.Paralyze(80)
 		if(H.staminaloss && !H.IsSleeping())
 			var/total_health = (H.health - H.staminaloss)
 			if(total_health <= HEALTH_THRESHOLD_CRIT && !H.stat)
 				H.visible_message("<span class='warning'>[user] delivers a heavy hit to [H]'s head, knocking [H.p_them()] out cold!</span>", \
 									   "<span class='userdanger'>[user] knocks you unconscious!</span>")
-				H.SetSleeping(600)
+				H.SetSleeping(300)
 				H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 15, 150)
 	else
 		return ..()

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -211,7 +211,7 @@
 									  "[user] smacks [H] with the butt of [src]!", \
 									  "[user] broadsides [H] with [src]!", \
 									  "[user] smashes [H]'s head with [src]!", \
-									  "[user] beats [H] with front of [src]!", \
+									  "[user] beats [H] with the front of [src]!", \
 									  "[user] twirls and slams [H] with [src]!")
 		H.visible_message("<span class='warning'>[pick(fluffmessages)]</span>", \
 							   "<span class='userdanger'>[pick(fluffmessages)]</span>")

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -222,7 +222,6 @@
 		H.lastattackerckey = user.ckey
 
 		user.do_attack_animation(H)
-		H.attacked_by(src, user)
 
 		log_combat(user, H, "Bo Staffed", src.name, "((DAMTYPE: STAMINA)")
 		add_fingerprint(user)

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -165,7 +165,7 @@
 	name = "bo staff"
 	desc = "A long, tall staff made of polished wood. Traditionally used in ancient old-Earth martial arts. Can be wielded to both kill and incapacitate."
 	force = 10
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = ITEM_SLOT_BACK
 	force_unwielded = 10
 	force_wielded = 24
@@ -216,7 +216,7 @@
 		H.visible_message("<span class='warning'>[pick(fluffmessages)]</span>", \
 							   "<span class='userdanger'>[pick(fluffmessages)]</span>")
 		playsound(get_turf(user), 'sound/effects/woodhit.ogg', 75, 1, -1)
-		H.adjustStaminaLoss(rand(13,20))
+		H.adjustStaminaLoss(rand(27,35))
 		if(H.staminaloss && !H.IsSleeping())
 			var/total_health = (H.health - H.staminaloss)
 			if(total_health <= HEALTH_THRESHOLD_CRIT && !H.stat)

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -225,7 +225,7 @@
 
 		log_combat(user, H, "Bo Staffed", src.name, "((DAMTYPE: STAMINA)")
 		add_fingerprint(user)
-		H.adjustStaminaLoss(rand(28,33))
+		H.adjustStaminaLoss(rand(28,35))
 		if(H.staminaloss && !H.IsSleeping())
 			var/total_health = (H.health - H.staminaloss)
 			if(total_health <= HEALTH_THRESHOLD_CRIT && !H.stat)

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -216,7 +216,7 @@
 		H.visible_message("<span class='warning'>[pick(fluffmessages)]</span>", \
 							   "<span class='userdanger'>[pick(fluffmessages)]</span>")
 		playsound(get_turf(user), 'sound/effects/woodhit.ogg', 75, 1, -1)
-		H.adjustStaminaLoss(rand(27,35))
+		H.adjustStaminaLoss(rand(28,35))
 		if(H.staminaloss && !H.IsSleeping())
 			var/total_health = (H.health - H.staminaloss)
 			if(total_health <= HEALTH_THRESHOLD_CRIT && !H.stat)

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -216,6 +216,7 @@
 		H.visible_message("<span class='warning'>[pick(fluffmessages)]</span>", \
 							   "<span class='userdanger'>[pick(fluffmessages)]</span>")
 		playsound(get_turf(user), 'sound/effects/woodhit.ogg', 75, 1, -1)
+		playsound(get_turf(user), 'sound/effects/hit_kick.ogg', 75, 1, -1)
 		SEND_SIGNAL(src, COMSIG_ITEM_ATTACK, H, user)
 		SEND_SIGNAL(user, COMSIG_MOB_ITEM_ATTACK, H, user)
 		H.lastattacker = user.real_name

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -216,6 +216,16 @@
 		H.visible_message("<span class='warning'>[pick(fluffmessages)]</span>", \
 							   "<span class='userdanger'>[pick(fluffmessages)]</span>")
 		playsound(get_turf(user), 'sound/effects/woodhit.ogg', 75, 1, -1)
+		SEND_SIGNAL(src, COMSIG_ITEM_ATTACK, H, user)
+		SEND_SIGNAL(user, COMSIG_MOB_ITEM_ATTACK, H, user)
+		H.lastattacker = user.real_name
+		H.lastattackerckey = user.ckey
+
+		user.do_attack_animation(H)
+		H.attacked_by(src, user)
+
+		log_combat(user, H, "Bo Staffed", src.name, "((DAMTYPE: STAMINA)")
+		add_fingerprint(user)
 		H.adjustStaminaLoss(rand(28,35))
 		if(H.staminaloss && !H.IsSleeping())
 			var/total_health = (H.health - H.staminaloss)

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -225,7 +225,7 @@
 
 		log_combat(user, H, "Bo Staffed", src.name, "((DAMTYPE: STAMINA)")
 		add_fingerprint(user)
-		H.adjustStaminaLoss(rand(28,35))
+		H.adjustStaminaLoss(rand(28,33))
 		if(H.staminaloss && !H.IsSleeping())
 			var/total_health = (H.health - H.staminaloss)
 			if(total_health <= HEALTH_THRESHOLD_CRIT && !H.stat)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -405,6 +405,12 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 8
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 
+/datum/uplink_item/dangerous/bostaff
+	name = "Bo Staff"
+	desc = "A wielded wooden staff that can be used to incapacitate opponents if intending to disarm."
+	item = /obj/item/twohanded/bostaff
+	cost = 8
+
 /datum/uplink_item/dangerous/shield
 	name = "Energy Shield"
 	desc = "An incredibly useful personal shield projector, capable of reflecting energy projectiles and defending \


### PR DESCRIPTION
### Intent of your Pull Request

Adds the bo staff to the uplink for 8 tc. Similarly to the now removed katana it is large and difficult to conceal, however the bo staff is capable of dealing moderate stamina damage and will knock someone out if they are stamcrit by it, giving it a position as a nonlethal melee weapon. Currently it is a normal sized iem that can be stored on the back, with 24 wielded damage, 28-33 stamina damage when on disarm intent instead, 20 throwforce and 50% blockchance.
~~Might decrease the size and/or increase the stamina damage to make it more viable~~

#### Changelog

:cl:  
rscadd: Adds the bo staff to the uplink for 8 tc. The bo staff is slightly weaker than the standard esword when attacking lethally but can be wielded on disarm intent to cause large amounts of stamina damage and incapacitate its target
rscdel: bo staff no longer has a chance to randomly 8 second stun, and the knockout duration is 30 seconds instead of a minute
/:cl:
