### PR TITLE
Fixes swedish speech mutation having æ & ø in it

### DIFF
--- a/code/datums/mutations/speech.dm
+++ b/code/datums/mutations/speech.dm
@@ -158,9 +158,9 @@
 	if(message)
 		message = replacetext(message,"w","v")
 		message = replacetext(message,"j","y")
-		message = replacetext(message,"a",pick("å","ä","æ","a"))
+		message = replacetext(message,"a",pick("å","ä","a"))
 		message = replacetext(message,"bo","bjo")
-		message = replacetext(message,"o",pick("ö","ø","o"))
+		message = replacetext(message,"o",pick("ö","o"))
 		if(prob(30))
 			message += " Bork[pick("",", bork",", bork, bork")]!"
 		speech_args[SPEECH_MESSAGE] = trim(message)


### PR DESCRIPTION
Swedish language doesn't have æ/ø, and use äöå instead of æøå

:cl:
tweak: Swedish mutation no longer uses characters that aren't in the swedish alphabet
/:cl: