### PR TITLE
removes Idinuum from code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,12 +25,6 @@
 /code/controllers/subsystem/timer.dm @AsV9
 /code/datums/achievements/achievements.dm @AsV9
 
-
-#Identification
-
-/icons/ @Idinuum
-/yogstation/icons/ @Idinuum
-
 #Ktlwjec
 /_maps/ @Ktlwjec1
 


### PR DESCRIPTION
stop emailing me

#### Changelog

:cl:  Identification
rscdel: I no longer get emails when someone touches a folder or two.
/:cl:
