### PR TITLE
Increase minimum pop for blob

### DIFF
--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -4,7 +4,7 @@
 	weight = 10
 	max_occurrences = 1
 
-	min_players = 30
+	min_players = 25
 
 	gamemode_blacklist = list("blob") //Just in case a blob survives that long
 

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -4,7 +4,7 @@
 	weight = 10
 	max_occurrences = 1
 
-	min_players = 20
+	min_players = 30
 
 	gamemode_blacklist = list("blob") //Just in case a blob survives that long
 


### PR DESCRIPTION
On low pop rounds its a landslide and unfair to the crew.

:cl:  JamieD12
tweak: Changed blob from 20 to 25 players
/:cl:
