### PR TITLE
Fixes some Quirks not working

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -371,6 +371,8 @@ SUBSYSTEM_DEF(ticker)
 				captainless=0
 			if(player.mind.assigned_role != player.mind.special_role)
 				SSjob.EquipRank(N, player.mind.assigned_role, 0)
+				if(CONFIG_GET(flag/roundstart_traits) && ishuman(N.new_character))
+					SSquirks.AssignQuirks(N.new_character, N.client, TRUE)
 		CHECK_TICK
 	if(captainless)
 		for(var/mob/dead/new_player/N in GLOB.player_list)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -408,6 +408,9 @@
 					if(SSshuttle.emergency.timeLeft(1) > initial(SSshuttle.emergencyCallTime)*0.5)
 						SSticker.mode.make_antag_chance(humanc)
 
+	if(humanc && CONFIG_GET(flag/roundstart_traits))
+		SSquirks.AssignQuirks(humanc, humanc.client, TRUE)
+
 	log_manifest(character.mind.key,character.mind,character,latejoin = TRUE)
 
 /mob/dead/new_player/proc/AddEmploymentContract(mob/living/carbon/human/employee)
@@ -477,8 +480,6 @@
 		client.prefs.real_name = client.prefs.pref_species.random_name(gender,1)
 	client.prefs.copy_to(H)
 	H.dna.update_dna_identity()
-	if(CONFIG_GET(flag/roundstart_traits))
-		SSquirks.AssignQuirks(H, client, TRUE)
 	if(mind)
 		if(transfer_after)
 			mind.late_joiner = TRUE


### PR DESCRIPTION
A part of #7715 involved altering at what point in the character creation process Quirks were assigned and set-up. This caused some bizarre errors that were best fixed by just reverting back to the original boot order.

#### Changelog

:cl:  Altoids
bugfix: Fixes several quirks working improperly.
/:cl:
