### PR TITLE
Folding folders.

### DIFF
--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -58,7 +58,9 @@
 	onclose(user, "folder")
 	add_fingerprint(usr)
 
-/obj/item/folder/AltClick(mob/living/user)
+/obj/item/folder/AltClick(mob/living/user, proximity)
+	if(!proximity)
+		return
 	if(contents.len)
 		to_chat(user, "<span class='warning'>You can't fold this folder with something still inside!</span>")
 		return

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -58,6 +58,14 @@
 	onclose(user, "folder")
 	add_fingerprint(usr)
 
+/obj/item/folder/AltClick(mob/living/user)
+	if(contents.len)
+		to_chat(user, "<span class='warning'>You can't fold this folder with something still inside!</span>")
+		return
+	to_chat(user, "<span class='notice'>You fold [src] flat.</span>")
+	var/obj/item/I = new /obj/item/stack/sheet/cardboard
+	qdel(src)
+	user.put_in_hands(I)
 
 /obj/item/folder/Topic(href, href_list)
 	..()

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -58,8 +58,8 @@
 	onclose(user, "folder")
 	add_fingerprint(usr)
 
-/obj/item/folder/AltClick(mob/living/user, proximity)
-	if(!proximity)
+/obj/item/folder/AltClick(mob/living/user)
+	if(!user.canUseTopic(src, BE_CLOSE))
 		return
 	if(contents.len)
 		to_chat(user, "<span class='warning'>You can't fold this folder with something still inside!</span>")


### PR DESCRIPTION
### Intent of your Pull Request
You can now fold folders by alt-clicking, since previously you could waste cardboard by making them into folders, and it would be impossible to get the cardboard back.

#### Changelog

:cl:  
rscadd: You may now fold any folder by alt-clicking on it, so long as it's empty.
/:cl:
