### PR TITLE
Engineering borgs can no longer destroy reinforced walls with their RCD

### DIFF
--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -544,7 +544,6 @@ RLD
 /obj/item/construction/rcd/borg
 	no_ammo_message = "<span class='warning'>Insufficient charge.</span>"
 	desc = "A device used to rapidly build walls and floors."
-	canRturf = TRUE
 	var/energyfactor = 72
 
 


### PR DESCRIPTION
:cl:  
tweak: Engineering borgs can no longer destroy reinforced walls with their RCD.
/:cl:
