### PR TITLE
Replace stimpacks in the lavaland cafe thing with a suit of power armor so people can stop putting "stimpacks" on the list of OP lavaland loot

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_cafe_of_broken_dreams.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_cafe_of_broken_dreams.dmm
@@ -14,11 +14,6 @@
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion,
 /turf/open/floor/plasteel,
 /area/lavaland/surface/outdoors)
-"ae" = (
-/obj/item/reagent_containers/syringe/stimulants,
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/lavaland/surface/outdoors)
 "af" = (
 /turf/closed/wall/r_wall/rust,
 /area/lavaland/surface/outdoors)
@@ -114,11 +109,6 @@
 /obj/structure/table/wood/bar,
 /turf/open/floor/wood,
 /area/ruin/powered)
-"ax" = (
-/obj/structure/table/wood/bar,
-/obj/item/reagent_containers/syringe/stimulants,
-/turf/open/floor/wood,
-/area/ruin/powered)
 "ay" = (
 /obj/machinery/door/airlock,
 /obj/structure/fans/tiny/invisible,
@@ -205,7 +195,6 @@
 "aN" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
-/obj/item/reagent_containers/syringe/stimulants,
 /obj/item/clothing/under/scratch,
 /turf/open/floor/wood,
 /area/ruin/powered)
@@ -495,6 +484,10 @@
 /mob/living/simple_animal/hostile/asteroid/marrowweaver,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"xf" = (
+/obj/item/clothing/suit/space/hardsuit/powerarmor_t45b,
+/turf/open/floor/wood,
+/area/ruin/powered)
 "zW" = (
 /obj/machinery/light{
 	icon_state = "tube";
@@ -1266,7 +1259,7 @@ aW
 ai
 ai
 aW
-ai
+xf
 aY
 aW
 ac
@@ -1679,7 +1672,7 @@ aW
 ai
 ao
 ar
-ax
+aw
 ai
 ai
 at
@@ -1722,7 +1715,7 @@ aa
 aa
 ab
 ab
-ae
+ac
 aW
 ai
 ai
@@ -2704,7 +2697,7 @@ ai
 ai
 ai
 ai
-ax
+aw
 ai
 bE
 bP


### PR DESCRIPTION


:cl:  
rscadd: Power armor in the lavaland loot
rscdel: No more stimpacks in the lavaland loot
/:cl:
