### PR TITLE
Removes the gold necklace contraband item from the clothing vendor

### DIFF
--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -181,7 +181,6 @@
 		           /obj/item/clothing/suit/jacket/leather = 1,
 		           /obj/item/clothing/suit/jacket/leather/overcoat = 1,
 		           /obj/item/clothing/under/pants/mustangjeans = 1,
-		           /obj/item/clothing/neck/necklace/dope = 3,
 		           /obj/item/clothing/suit/jacket/letterman_nanotrasen = 1, //yogs added a ,
 		           /obj/item/clothing/head/yogs/formalhat = 1, //yogs start
 		           /obj/item/clothing/suit/yogs/trainman = 1,


### PR DESCRIPTION
**Edit: Updated description with from my comment explaining "why?"**

**Why:**
-----
Golden chains are a contraband item and it is inconsistent to have NT sell contraband items in the open.
I don't care which way we go to make this consistent we can either remove it from the clothing vendor keeping it a contraband item (now only spawnable via contraband floor satchel drops and gangs) or we can just make this item a non-contraband item by removing them from the contraband satchels.

This inconsistency is just a minor thing that will lead to immersion-breaking so we must fix any inconsistencies in our codebase.

This was probably simply overlooked as the person that added them in the clothing vendor probably thought it didn't spawn at all.

Also; secret option nr.3 would be to now make all clothing contraband items sold by NT so we can add for example the pimp hat, golden shoes, cape etc. But I'd really prefer not to do this one as its the most out of the way solution.

Do I care about golden necklaces? No, I never even use them.
I care about the inconsistency it brings we need to be consistent by either removing it here or as contraband.

Also: 
-----
If you remove this from the clothing vendor you add value to it as it is no longer a common item that is easily obtainable (only through gang spawns + contraband stashes)

**To clear up confusion this item is not sold in a hacked vendor. Just out in the open.**

#### Changelog

:cl:  Hopek
rscdel: Removed gold necklace contraband from the clothing vendor. NT no longer sells contraband.
/:cl:
