### PR TITLE
Glass shards grind-able

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -256,6 +256,7 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 	armor = list("melee" = 100, "bullet" = 0, "laser" = 0, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 100)
 	max_integrity = 40
 	sharpness = IS_SHARP
+	grind_results = list(/datum/reagent/silicon = 20)
 	var/icon_prefix
 
 


### PR DESCRIPTION
Makes glass shards grind-able.

You can already grind 1 glass mat to 20 silicon and you can create 1 glass mat from 1 shard via welding torch therefore 1 glass shard = 20 silicon

#### Changelog

:cl:  Hopek
rscadd: Glass shards now be ground to silicon just like glass mats.
/:cl:
