### PR TITLE
Remoes puss translation from cowboy accents

### DIFF
--- a/strings/accents/accent_cowboy.json
+++ b/strings/accents/accent_cowboy.json
@@ -90,6 +90,7 @@
 	"friend": "partner",
 	"horse": "hoss",
 	"color": "cuhlor",
+	"face": "mug",
 	"plain": "puh-lain",
 	"girl": "gal",
 	"red": "ree-ehd",

--- a/strings/accents/accent_cowboy.json
+++ b/strings/accents/accent_cowboy.json
@@ -90,7 +90,6 @@
 	"friend": "partner",
 	"horse": "hoss",
 	"color": "cuhlor",
-	"face": "puss",
 	"plain": "puh-lain",
 	"girl": "gal",
 	"red": "ree-ehd",

--- a/strings/accents/accent_cowboylight.json
+++ b/strings/accents/accent_cowboylight.json
@@ -23,7 +23,6 @@
 	"eat": "chew",
 	"friend": "partner",
 	"horse": "hoss",
-	"face": "puss",
 	"girl": "gal",
 	"soon": "directly",
 	"leave": "cut a path",

--- a/strings/accents/accent_cowboylight.json
+++ b/strings/accents/accent_cowboylight.json
@@ -23,6 +23,7 @@
 	"eat": "chew",
 	"friend": "partner",
 	"horse": "hoss",
+	"face": "mug",
 	"girl": "gal",
 	"soon": "directly",
 	"leave": "cut a path",


### PR DESCRIPTION
Even though this is a legitimate translation I am removing it because it may cause confusion.
Removed "face" being translated to "puss" in both the cowboy accents.

Now "face" translates to "mug" instead.

![image](https://user-images.githubusercontent.com/24533979/74598499-50127900-5038-11ea-8684-e46ac53dfa2d.png)


Now it won't surprise people when they say something like:
"I need to wash my face"


#### Changelog

:cl:  
tweak: Removed cowboy puss. It's now a mug.
/:cl:
