### PR TITLE
changelings will now gain their victims accent on transformation

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -102,6 +102,8 @@ GLOBAL_VAR(changeling_team_objective_type) //If this is not null, we hand our th
 	user.underwear = chosen_prof.underwear
 	user.undershirt = chosen_prof.undershirt
 	user.socks = chosen_prof.socks
+	user.mind.accent_name = chosen_prof.accent
+	user.mind.RegisterSignal(user, COMSIG_MOB_SAY, /datum/mind/.proc/handle_speech)
 
 	chosen_dna.transfer_identity(user, 1)
 	user.updateappearance(mutcolor_update=1)

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -285,6 +285,7 @@
 	prof.underwear = H.underwear
 	prof.undershirt = H.undershirt
 	prof.socks = H.socks
+	prof.accent = H.mind.accent_name
 
 	var/list/slots = list("head", "wear_mask", "back", "wear_suit", "w_uniform", "shoes", "belt", "gloves", "glasses", "ears", "wear_id", "s_store")
 	for(var/slot in slots)
@@ -400,7 +401,7 @@
 		if(CL != src)
 			other_changelings_exist = TRUE
 			break
-	
+
 	var/changeling_objective = other_changelings_exist ? pick(1,3) : 1 //yogs - fuck absorb most
 	switch(changeling_objective) //yogs - see above
 		if(1)
@@ -523,6 +524,7 @@
 	var/underwear
 	var/undershirt
 	var/socks
+	var/accent
 
 /datum/changelingprofile/Destroy()
 	qdel(dna)
@@ -542,6 +544,7 @@
 	newprofile.underwear = underwear
 	newprofile.undershirt = undershirt
 	newprofile.socks = socks
+	newprofile.accent = accent
 
 
 /datum/antagonist/changeling/xenobio


### PR DESCRIPTION
see summary. tested by creating 2 characters with different accents then: absorbed one, transformed, spoke, transformed back to default and spoke again. accent appropriately updated on each transformation.

Fixes #7804 

:cl:  
tweak: updated user accent when transforming as changeling
/:cl:
