### PR TITLE
Makes syndicate listening posts not overheat

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -5303,6 +5303,7 @@
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "nh" = (
 /obj/machinery/telecomms/relay/preset/ruskie{
+	generates_heat = 0;
 	use_power = 0
 	},
 /obj/machinery/light/small{

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -93,6 +93,7 @@
 /area/ruin/space/has_grav/listeningstation)
 "ak" = (
 /obj/machinery/telecomms/relay/preset/ruskie{
+	generates_heat = 0;
 	use_power = 0
 	},
 /obj/effect/decal/cleanable/dirt,


### PR DESCRIPTION
### Intent of your Pull Request

Fixes #7852 
Comm relays in syndicate secret bases no longer make the user boil alive in the room

#### Changelog

:cl:  
tweak: Added a var to the two syndicate comm relays that makes them not heat up
/:cl:
