### PR TITLE
darkspawn season pass part 1: progenitors actually do stuff

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -131,6 +131,8 @@
 
 #define STATUS_EFFECT_TAGALONG /datum/status_effect/tagalong //allows darkspawn to accompany people's shadows //Yogs
 
+#define STATUS_EFFECT_PROGENITORCURSE /datum/status_effect/progenitor_curse
+
 /////////////
 //  SLIME  //
 /////////////

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -555,7 +555,7 @@
 	. = ..()
 	deltimer(timerid)
 
-/datum/status_effect/progenitor_curse/
+/datum/status_effect/progenitor_curse
 	duration = 200
 	tick_interval = 5
 

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -544,9 +544,8 @@
 	set waitfor = FALSE
 	new/obj/effect/temp_visual/dir_setting/curse/grasp_portal(spawn_turf, owner.dir)
 	playsound(spawn_turf, 'sound/effects/curse2.ogg', 80, 1, -1)
-	var/turf/ownerloc = get_turf(owner)
 	var/obj/item/projectile/curse_hand/C = new (spawn_turf)
-	C.preparePixelProjectile(ownerloc, spawn_turf)
+	C.preparePixelProjectile(owner, spawn_turf)
 	C.fire()
 
 /obj/effect/temp_visual/curse
@@ -556,6 +555,25 @@
 	. = ..()
 	deltimer(timerid)
 
+/datum/status_effect/progenitor_curse/
+	duration = 200
+	tick_interval = 5
+
+/datum/status_effect/progenitor_curse/tick()
+	if(owner.stat == DEAD)
+		return
+	var/grab_dir = turn(owner.dir, rand(-180, 180)) //grab them from a random direction
+	var/turf/spawn_turf = get_ranged_target_turf(owner, grab_dir, 5)
+	if(spawn_turf)
+		grasp(spawn_turf)
+
+/datum/status_effect/progenitor_curse/proc/grasp(turf/spawn_turf)
+	set waitfor = FALSE
+	new/obj/effect/temp_visual/dir_setting/curse/grasp_portal(spawn_turf, owner.dir)
+	playsound(spawn_turf, 'sound/effects/curse2.ogg', 80, 1, -1)
+	var/obj/item/projectile/curse_hand/progenitor/C = new (spawn_turf)
+	C.preparePixelProjectile(owner, spawn_turf)
+	C.fire()
 
 //Kindle: Used by servants of Ratvar. 10-second knockdown, reduced by 1 second per 5 damage taken while the effect is active.
 /datum/status_effect/kindle

--- a/code/modules/projectiles/projectile/special/curse.dm
+++ b/code/modules/projectiles/projectile/special/curse.dm
@@ -50,3 +50,8 @@
 		animate(B, alpha = 0, time = 32)
 	return ..()
 
+/obj/item/projectile/curse_hand/progenitor
+	name = "psionic barrage"
+	damage_type = BRAIN
+	paralyze = 0
+

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn.dm
@@ -348,6 +348,7 @@
 	var/mob/living/simple_animal/hostile/darkspawn_progenitor/progenitor = new(get_turf(user))
 	user.status_flags |= GODMODE
 	user.mind.transfer_to(progenitor)
+	progenitor.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/progenitor_curse(null))
 	if(!SSticker.mode.sacrament_done)
 		addtimer(CALLBACK(src, .proc/sacrament_shuttle_call), 50)
 	for(var/V in abilities)

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/pass.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/pass.dm
@@ -8,7 +8,7 @@
 	blacklisted = TRUE //baseline
 
 /datum/action/innate/darkspawn/pass/IsAvailable()
-	if(istype(owner, /mob/living/simple_animal/hostile/crawling_shadows) || !owner.get_empty_held_indexes() && !active)
+	if(istype(owner, /mob/living/simple_animal/hostile/crawling_shadows) || istype(owner, /mob/living/simple_animal/hostile/darkspawn_progenitor) || !owner.get_empty_held_indexes() && !active)
 		return
 	return ..()
 

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_progenitor.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_progenitor.dm
@@ -80,6 +80,29 @@
 				L.Stun(20)
 	time_since_last_roar = world.time + 400
 
+/obj/effect/proc_holder/spell/targeted/progenitor_curse
+	name = "Viscerate Mind"
+	desc = "Unleash a powerful psionic barrage into the mind of the target."
+	charge_max = 50
+	clothes_req = FALSE
+	action_icon = 'yogstation/icons/mob/actions/actions_darkspawn.dmi'
+	action_icon_state = "veil_mind"
+	action_background_icon_state = "bg_alien"
+
+/obj/effect/proc_holder/spell/aimed/update_icon()
+	return
+
+/obj/effect/proc_holder/spell/targeted/progenitor_curse/cast(list/targets, mob/user = usr)
+	if(!targets.len)
+		to_chat(user, "<span class='notice'>You can't reach anyone's minds.</span>")
+		return
+	var/mob/living/target = targets[1]
+	var/mob/living/M = target
+	var/zoinks = pick(0.1, 0.5, 1)//like, this isn't even my final form!
+	usr.visible_message("<span class='warning'>[usr]'s sigils flare as it glances at [M]!</span>", \
+						"<span class='velvet'>You direct [zoinks]% of your psionic power into [M]'s mind!.</span>")
+	M.apply_status_effect(STATUS_EFFECT_PROGENITORCURSE)
+
 /mob/living/simple_animal/hostile/darkspawn_progenitor/narsie_act()
 	return
 


### PR DESCRIPTION
adds an ability to progenitors that spawns a bunch of curse hands that deal brain damage
#### Changelog

:cl:  
rscadd: Progenitors have a new spell that gives them more offensive capability
bugfix: curse hands now actually hit people instead of passing them ineffectively 
/:cl:
