### PR TITLE
Deathgasp fix for lings

### DIFF
--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -24,7 +24,6 @@
 	else
 		to_chat(user, "<span class='notice'>We begin our stasis, preparing energy to arise once more.</span>")
 		if(user.stat != DEAD)
-			user.emote("deathgasp")
 			user.tod = station_time_timestamp()
 		user.fakedeath("changeling") //play dead
 		user.update_stat()


### PR DESCRIPTION
Emote deathgasp already done in fake death proc
:cl:  
bugfix: fake death for lings no longer causes you to deathgasp twice
/:cl:
