### PR TITLE
renames broodmothers back to midwives

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -131,9 +131,9 @@
 	QDEL_NULL(set_directive)
 	return ..()
 
-//broodmothers are the queen of the spiders, can send messages to all them and web faster. That rare round where you get a queen spider and turn your 'for honor' players into 'r6siege' players will be a fun one.
+//midwives are the queen of the spiders, can send messages to all them and web faster. That rare round where you get a queen spider and turn your 'for honor' players into 'r6siege' players will be a fun one.
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse/midwife
-	name = "broodmother"
+	name = "midwife"
 	desc = "Furry and black, it makes you shudder to look at it. This one has scintillating green eyes. Might also be hiding a real knife somewhere."
 	icon_state = "midwife"
 	icon_living = "midwife"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1746,7 +1746,7 @@
 
 /datum/reagent/spider_extract
 	name = "Spider Extract"
-	description = "A highly specialized extract coming from the Australicus sector, used to create broodmother spiders."
+	description = "A highly specialized extract coming from the Australicus sector, used to create midwife spiders."
 	color = "#ED2939"
 	taste_description = "upside down"
 	can_synth = FALSE


### PR DESCRIPTION
there was no reason to name them broodmothers, and i think midwife sounds better.

theres also a spider in hollow knight called midwife so
#### Changelog

:cl:  Identification
spellcheck: Broodmothers are called midwifes again.
/:cl:
