### PR TITLE
Escape Podbay now starts with a basic space pod

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -56884,6 +56884,10 @@
 /obj/item/clipboard,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"quO" = (
+/obj/spacepod/prebuilt,
+/turf/open/floor/engine,
+/area/escapepodbay)
 "quT" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -111842,7 +111846,7 @@ aaa
 ptH
 aNZ
 sHo
-sHo
+quO
 sHo
 aMZ
 aOc


### PR DESCRIPTION
Why:
----

I see space pods used recreationally more than for their actual use.

I think the issue is that they get introduced into the shift kind of late in for the utility they provide. 
It's like introducing advanced mining tech mid to late-round instead of having it be 10 minutes in.
I'd be fine with having a basic bitch pod in podbay waiting for someone

**EDIT: (adding more reasoning)**

Basic space pods provide space travel and don't even let you interact with anything outside of the pod itself.
Space pods aren't even used to explore space anymore because it is much easier to just get an EVA suit and jetpack + air tank as opposed to getting through the full research requirements + build requirements to make a pod.
This just lets whoever wants to explore space to do it in a more "fun" way.

At the end of the day, space pods are just visual flavor to doing the same thing (space-traveling) except they're less optimal than just having an EVA suit because you can interact with things with your EVA suit.

![Capture2](https://user-images.githubusercontent.com/24533979/76134711-194fd300-5fe6-11ea-845d-0f185f8ad08e.PNG)
![dreamseeker_6yHdduagVH](https://user-images.githubusercontent.com/24533979/76134712-1bb22d00-5fe6-11ea-8598-7ae14b8e42d1.png)


#### Changelog

:cl:  Hopek
rscadd: Escape Podbay now starts with a basic space pod
/:cl:
