### PR TITLE
Nicotine addiction no longer drops items

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -67,35 +67,23 @@
 /datum/reagent/drug/nicotine/addiction_act_stage1(mob/living/M)
 	if(prob(5) && iscarbon(M))
 		M.Jitter(10)
-		var/obj/item/I = M.get_active_held_item()
-		if(I && M.dropItemToGround(I))
-			to_chat(M, "<span class ='notice'>Your hands spaz out and you drop what you were holding!</span>")
 	..()
 
 /datum/reagent/drug/nicotine/addiction_act_stage2(mob/living/M)
 	if(prob(20) && iscarbon(M))
 		M.Jitter(10)
-		var/obj/item/I = M.get_active_held_item()
-		if(I && M.dropItemToGround(I))
-			to_chat(M, "<span class ='notice'>Your hands spaz out and you drop what you were holding!</span>")
 	..()
 	. = 1
 
 /datum/reagent/drug/nicotine/addiction_act_stage3(mob/living/M)
 	if(prob(20) && iscarbon(M))
 		M.Jitter(10)
-		var/obj/item/I = M.get_active_held_item()
-		if(I && M.dropItemToGround(I))
-			to_chat(M, "<span class ='notice'>Your hands spaz out and you drop what you were holding!</span>")
 	..()
 	. = 1
 
 /datum/reagent/drug/nicotine/addiction_act_stage4(mob/living/M)
 	if(prob(40) && iscarbon(M))
 		M.Jitter(10)
-		var/obj/item/I = M.get_active_held_item()
-		if(I && M.dropItemToGround(I))
-			to_chat(M, "<span class ='notice'>Your hands spaz out and you drop what you were holding!</span>")
 	..()
 	. = 1
 


### PR DESCRIPTION
Removes a part of #7666
Smoking still damages your lungs but you no longer drop items like OD'ing on methamphetamine or bath salts

**I think the idea of this PR was good** but in practice, after playing with this for about 2 months dropping items from a nicotine addiction really is just an annoyance. 

Its a really powerful debuff only given by methamphetamine or bath salts. 
I don't think using Nicotine should give you the same level of debuff (dropping things) as methamphetamine or bath salts.

The lung damage is fine and the jitters are "cool" so only reverting the drop part of #7666

#### Changelog

:cl:  Hopek
rscdel: Nicotine addiction no longer drops items
/:cl:
