### PR TITLE
cheese always heals mice instead of not healing them if they are already supercheese mode

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -191,10 +191,10 @@ GLOBAL_VAR_INIT(mouse_killed, 0)
 	SSminor_mapping.trigger_migration(mice)
 
 /mob/living/simple_animal/mouse/proc/cheese_up()
+	regen_health(15)
 	if(cheesed)
 		return
 	cheesed = TRUE
-	regen_health(15)
 	resize = 2
 	update_transform()
 	add_movespeed_modifier(MOVESPEED_ID_MOUSE_CHEESE, TRUE, 100, multiplicative_slowdown = -1)


### PR DESCRIPTION


:cl:  
tweak: cheese will now always heal mice when they eat it
/:cl:
