### PR TITLE
Cleans up the limited amount of powershell we use

### DIFF
--- a/tools/SQLAlertEmail/email_script.ps1
+++ b/tools/SQLAlertEmail/email_script.ps1
@@ -12,10 +12,10 @@ $Matches = Get-ChildItem "$Path$Date" -recurse -include *.log | Select-String "$
 
 $email = New-Object System.Net.Mail.MailMessage
 $email.From = $From
-foreach($i in $To) {$email.To.Add($i)}
+foreach ($i in $To) { $email.To.Add($i) }
 $email.Subject = $Subject
-$MatchList = foreach($m in $Matches) {"`t$m`n"}
-$email.Body = $Body+"`n"+$MatchList
+$MatchList = foreach ($m in $Matches) { "`t$m`n" }
+$email.Body = $Body + "`n" + $MatchList
 
 $smtp = New-Object System.Net.Mail.SmtpClient($SMTPServer, $SMTPPort);
 $smtp.Credentials = New-Object System.Net.NetworkCredential($Account, $Password);

--- a/tools/appveyor/build.ps1
+++ b/tools/appveyor/build.ps1
@@ -1,7 +1,7 @@
-if(!(Test-Path -Path "C:/byond")){
-    bash tools/appveyor/download_byond.sh
-    [System.IO.Compression.ZipFile]::ExtractToDirectory("C:/byond.zip", "C:/")
-    Remove-Item C:/byond.zip
+if (!(Test-Path -Path "C:/byond")) {
+	bash tools/appveyor/download_byond.sh
+	[System.IO.Compression.ZipFile]::ExtractToDirectory("C:/byond.zip", "C:/")
+	Remove-Item C:/byond.zip
 }
 
 Set-Location $env:APPVEYOR_BUILD_FOLDER

--- a/tools/tgs4_scripts/PreSynchronize.ps1
+++ b/tools/tgs4_scripts/PreSynchronize.ps1
@@ -1,29 +1,29 @@
 param(
-    $game_path
+	$game_path
 )
 
-cd $game_path
+Set-Location $game_path
 
 Write-Host "Installing pip dependencies..."
 pip3 install PyYaml beautifulsoup4
-if(!$?){
-    Write-Host "pip3 returned non-zero!"
-    exit $LASTEXITCODE
+if (!$?) {
+	Write-Host "pip3 returned non-zero!"
+	exit $LASTEXITCODE
 }
 
 Write-Host "Running changelog script..."
 python3 tools/ss13_genchangelog.py html/changelog.html html/changelogs
-if(!$?){
-    Write-Host "python3 returned non-zero!"
-    exit $LASTEXITCODE
+if (!$?) {
+	Write-Host "python3 returned non-zero!"
+	exit $LASTEXITCODE
 }
 
 Write-Host "Committing changes..."
 git add html
 
-if(!$?){
-    Write-Host "`git add` returned non-zero!"
-    exit $LASTEXITCODE
+if (!$?) {
+	Write-Host "`git add` returned non-zero!"
+	exit $LASTEXITCODE
 }
 
 #we now don't care about failures


### PR DESCRIPTION
Now it is actually formatted + changed the cd alias as using aliases is not best practice.
Mostly indenting and spacing besides the "Set-Location" alias expansion.

#### Changelog

:cl:  Hopek
tweak: Reformatted the small amount of PowerShell that we use.
/:cl:
