### PR TITLE
Glowshrooms No Longer Absolutely Murder Server Performance

### DIFF
--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -119,7 +119,8 @@
 			if(locate(/obj/structure/glowshroom in view(1,newloc))) // and there's a glowshroom nearby our target loc
 				continue // then we ain't moving here
 			// We know that there's no glowshroom here so we can just go ahead and plant
-			var/obj/structure/glowshroom/child = new type(newLoc, myseed, TRUE, generation + 1)
+			var/obj/structure/glowshroom/child = new type(newloc, myseed, TRUE, generation + 1)
+			child.generation = generation + 1 // I have to do this to stop the "variable defined but not used" warning
 			--seeds_to_spread
 		else // if we're willing to overgrowth
 			var/obj/structure/glowshroom/glowyboi = locate(/obj/structure/glowshroom) in newloc
@@ -135,10 +136,11 @@
 				glowyboi.Overgrowth(our_dir) // Does not actually create a new glowshroom object on the tile, just updates the sprite of the one already there!
 				--seeds_to_spread
 			else // If there's nobody in this tile we can just go ahead and plant
-				var/obj/structure/glowshroom/child = new type(newLoc, myseed, TRUE, generation + 1)
+				var/obj/structure/glowshroom/child = new type(newloc, myseed, TRUE, generation + 1)
+				child.generation = generation + 1 // I have to do this to stop the "variable defined but not used" warning
 				--seeds_to_spread
 	if(seeds_to_spread)
-		delay *= 1.1
+		delay *= 1.1 // If we keep having seeds left over, it's likely that we will pretty much never have a chance to fully breed, so keep extending the delay
 		addtimer(CALLBACK(src, .proc/Spread), delay)
 
 /obj/structure/glowshroom/proc/Overgrowth(newdir) // Adds a new sprite on top of the current one, of some more glowshroomage.

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -116,7 +116,7 @@
 			continue
 		var/turf/newloc = pick(openlocs)
 		if(!prob(OVERGROWTH_CHANCE)) // If we're refusing to overgrowth
-			if(locate(/obj/structure/glowshroom in view(1,newloc))) // and there's a glowshroom nearby our target loc
+			if(locate(/obj/structure/glowshroom) in view(1,newloc)) // and there's a glowshroom nearby our target loc
 				continue // then we ain't moving here
 			// We know that there's no glowshroom here so we can just go ahead and plant
 			var/obj/structure/glowshroom/child = new type(newloc, myseed, TRUE, generation + 1)

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -1,5 +1,12 @@
 //separate dm since hydro is getting bloated already
 
+#define MAX_GENERATION 6 // The maximum number of generations before glowshroom stop reproducing.
+#define MAX_GLOWSHROOM 1024 // Maximum number of glowshrooms that can exist in-game at the same time
+// There are about ~11,000 open floor tiles on Boxstation, so having 1024 means 10% of the station is covered in the crap.
+#define OVERGROWTH_CHANCE 60 // Probability (out of 100) that this glowshroom can attempt to reproduce into a tile which already has (or is adjacent to) a glowshroom, per reproduction attempt.
+
+#define FLOOR_DIR 16 // Used as a 5th direction when determining what directions have/haven't been planted here
+
 /obj/structure/glowshroom
 	name = "glowshroom"
 	desc = "Mycena Bregprox, a species of mushroom that glows in the dark."
@@ -13,7 +20,9 @@
 	var/delay = 1200
 	var/floor = 0
 	var/generation = 1
-	var/spreadIntoAdjacentChance = 60
+	var/static/glowshroom_count = 0 // The current amount of glowshrooms known to exist. Used to help cap their population.
+	var/seeds_to_spread = 0 // Marks how many times more we can reproduce.
+	var/list/dirs_planted = list() // The directional areas that've already been planted on on this tile by this glowshroom colony, including perhaps FLOOR_DIR.
 	var/obj/item/seeds/myseed = /obj/item/seeds/glowshroom
 	var/static/list/blacklisted_glowshroom_turfs = typecacheof(list(
 	/turf/open/lava,
@@ -41,10 +50,12 @@
 /obj/structure/glowshroom/Destroy()
 	if(myseed)
 		QDEL_NULL(myseed)
+	--glowshroom_count
 	return ..()
 
-/obj/structure/glowshroom/New(loc, obj/item/seeds/newseed, mutate_stats)
+/obj/structure/glowshroom/New(loc, obj/item/seeds/newseed, mutate_stats, ourgen)
 	..()
+	++glowshroom_count
 	if(newseed)
 		myseed = newseed.Copy()
 		myseed.forceMove(src)
@@ -52,114 +63,90 @@
 		myseed = new myseed(src)
 	if(mutate_stats) //baby mushrooms have different stats :3
 		myseed.adjust_potency(rand(-3,6))
-		myseed.adjust_yield(rand(-1,2))
+		myseed.adjust_yield(rand(-2,1)) // The yield naturally decreases as it spreads, on average
 		myseed.adjust_production(rand(-3,6))
 		myseed.adjust_endurance(rand(-3,6))
 	delay = delay - myseed.production * 100 //So the delay goes DOWN with better stats instead of up. :I
 	obj_integrity = myseed.endurance
 	max_integrity = myseed.endurance
+	seeds_to_spread = myseed.yield // It used to be that Glowshrooms would use their seed's yield var on-the-fly for marking how many seeds they had left. I want you to sit back and appreciate how stupid that was.
 	var/datum/plant_gene/trait/glow/G = myseed.get_gene(/datum/plant_gene/trait/glow)
 	if(ispath(G)) // Seeds were ported to initialize so their genes are still typepaths here, luckily their initializer is smart enough to handle us doing this
 		myseed.genes -= G
 		G = new G
 		myseed.genes += G
 	set_light(G.glow_range(myseed), G.glow_power(myseed), G.glow_color)
-	setDir(CalcDir())
-	var/base_icon_state = initial(icon_state)
-	if(!floor)
-		switch(dir) //offset to make it be on the wall rather than on the floor
-			if(NORTH)
-				pixel_y = 32
-			if(SOUTH)
-				pixel_y = -32
-			if(EAST)
-				pixel_x = 32
-			if(WEST)
-				pixel_x = -32
-		icon_state = "[base_icon_state][rand(1,3)]"
-	else //if on the floor, glowshroom on-floor sprite
-		icon_state = base_icon_state
-
-	addtimer(CALLBACK(src, .proc/Spread), delay)
+	//We happen to know with some certainty that we are the only glowshroom object on the tile, so we can handle our directionality however.
+	var/our_dir = pick(list(NORTH, SOUTH, EAST, WEST, FLOOR_DIR))
+	dirs_planted += our_dir
+	switch(our_dir) //offset to make it be on the wall rather than on the floor
+		if(NORTH)
+			pixel_y = 32
+			icon_state = "[initial(icon_state)][rand(1,3)]"
+		if(SOUTH)
+			pixel_y = -32
+			icon_state = "[initial(icon_state)][rand(1,3)]"
+		if(EAST)
+			pixel_x = 32
+			icon_state = "[initial(icon_state)][rand(1,3)]"
+		if(WEST)
+			pixel_x = -32
+			icon_state = "[initial(icon_state)][rand(1,3)]"
+		if(FLOOR_DIR)
+			icon_state = initial(icon_state)
+	if(ourgen)
+		generation = ourgen
+	if(generation < MAX_GENERATION && glowshroom_count < MAX_GLOWSHROOM && seeds_to_spread > 0)
+		addtimer(CALLBACK(src, .proc/Spread), delay)
 
 /obj/structure/glowshroom/proc/Spread()
 	var/turf/ownturf = get_turf(src)
-	var/shrooms_planted = 0
-	for(var/i in 1 to myseed.yield)
-		if(prob(1/(generation * generation) * 100))//This formula gives you diminishing returns based on generation. 100% with 1st gen, decreasing to 25%, 11%, 6, 4, 2...
-			var/list/possibleLocs = list()
-			var/spreadsIntoAdjacent = FALSE
-
-			if(prob(spreadIntoAdjacentChance))
-				spreadsIntoAdjacent = TRUE
-
-			for(var/turf/open/floor/earth in view(3,src))
-				if(is_type_in_typecache(earth, blacklisted_glowshroom_turfs))
-					continue
-				if(!ownturf.CanAtmosPass(earth))
-					continue
-				if(spreadsIntoAdjacent || !locate(/obj/structure/glowshroom) in view(1,earth))
-					possibleLocs += earth
-				CHECK_TICK
-
-			if(!possibleLocs.len)
-				break
-
-			var/turf/newLoc = pick(possibleLocs)
-
-			var/shroomCount = 0 //hacky
-			var/placeCount = 1
-			for(var/obj/structure/glowshroom/shroom in newLoc)
-				shroomCount++
-			for(var/wallDir in GLOB.cardinals)
-				var/turf/isWall = get_step(newLoc,wallDir)
-				if(isWall.density)
-					placeCount++
-			if(shroomCount >= placeCount)
-				continue
-
-			var/obj/structure/glowshroom/child = new type(newLoc, myseed, TRUE)
-			child.generation = generation + 1
-			shrooms_planted++
-
-			CHECK_TICK
-		else
-			shrooms_planted++ //if we failed due to generation, don't try to plant one later
-	if(shrooms_planted < myseed.yield) //if we didn't get all possible shrooms planted, try again later
-		myseed.yield -= shrooms_planted
+	//First lets build the list of turfs we could expand into.
+	//We can do this w/o any defensive if's because we know there is at least *one* seed we can spread.
+	var/list/openlocs = list()
+	for(var/turf/open/floor/earth in oview(3,src)) // Using oview instead of view makes the spread a bit more distributed and makes this run a bit faster, hopefully.
+		if(is_type_in_typecache(earth, blacklisted_glowshroom_turfs))
+			continue
+		if(!ownturf.CanAtmosPass(earth))
+			continue
+		openlocs += earth
+	for(var/i in 1 to seeds_to_spread)
+		if(rand() > 1/(generation * generation))//This formula gives you diminishing returns based on generation. 100% with 1st gen, decreasing to 25%, 11%, 6, 4, 2...
+			--seeds_to_spread // Well, not actually *diminishing* returns. The result is a population that grows (worst-case) in accordance to a logistic curve: https://www.desmos.com/calculator/x9uws7zv98
+			continue
+		var/turf/newloc = pick(openlocs)
+		if(!prob(OVERGROWTH_CHANCE)) // If we're refusing to overgrowth
+			if(locate(/obj/structure/glowshroom in view(1,newloc))) // and there's a glowshroom nearby our target loc
+				continue // then we ain't moving here
+			// We know that there's no glowshroom here so we can just go ahead and plant
+			var/obj/structure/glowshroom/child = new type(newLoc, myseed, TRUE, generation + 1)
+			--seeds_to_spread
+		else // if we're willing to overgrowth
+			var/obj/structure/glowshroom/glowyboi = locate(/obj/structure/glowshroom) in newloc
+			if(glowyboi) // If there's a glowyboi here
+				var/list/possible_dirs = list(NORTH,SOUTH,EAST,WEST,FLOOR_DIR) - glowyboi.dirs_planted
+				for(var/dir in possible_dirs)
+					if(dir == FLOOR_DIR)
+						continue
+					var/turf/isWall = get_step(newloc,dir)
+					if(!isWall.density)
+						possible_dirs -= dir
+				var/our_dir = pick(possible_dirs)
+				glowyboi.Overgrowth(our_dir) // Does not actually create a new glowshroom object on the tile, just updates the sprite of the one already there!
+				--seeds_to_spread
+			else // If there's nobody in this tile we can just go ahead and plant
+				var/obj/structure/glowshroom/child = new type(newLoc, myseed, TRUE, generation + 1)
+				--seeds_to_spread
+	if(seeds_to_spread)
+		delay *= 1.1
 		addtimer(CALLBACK(src, .proc/Spread), delay)
 
-/obj/structure/glowshroom/proc/CalcDir(turf/location = loc)
-	var/direction = 16
-
-	for(var/wallDir in GLOB.cardinals)
-		var/turf/newTurf = get_step(location,wallDir)
-		if(newTurf.density)
-			direction |= wallDir
-
-	for(var/obj/structure/glowshroom/shroom in location)
-		if(shroom == src)
-			continue
-		if(shroom.floor) //special
-			direction &= ~16
-		else
-			direction &= ~shroom.dir
-
-	var/list/dirList = list()
-
-	for(var/i=1,i<=16,i <<= 1)
-		if(direction & i)
-			dirList += i
-
-	if(dirList.len)
-		var/newDir = pick(dirList)
-		if(newDir == 16)
-			floor = 1
-			newDir = 1
-		return newDir
-
-	floor = 1
-	return 1
+/obj/structure/glowshroom/proc/Overgrowth(newdir) // Adds a new sprite on top of the current one, of some more glowshroomage.
+	dirs_planted += newdir
+	if(newdir == FLOOR_DIR)
+		underlays += image(icon, initial(icon_state))
+	else
+		overlays += image(icon, "[initial(icon_state)][rand(1,3)]", newdir)
 
 /obj/structure/glowshroom/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
 	if(damage_type == BURN && damage_amount)
@@ -175,3 +162,8 @@
 	var/obj/effect/decal/cleanable/molten_object/I = new (get_turf(src))
 	I.desc = "Looks like this was \an [src] some time ago."
 	qdel(src)
+
+#undef MAX_GENERATION
+#undef MAX_GLOWSHROOM
+#undef OVERGROWTH_CHANCE
+#undef FLOOR_DIR


### PR DESCRIPTION
Someone should pay me for having done this.

# Overview

Glowshrooms now just straight-up stop attempting to reproduce past the 6th generation.

There also can *never* be more than 1024 glowshrooms at once in the video game.

Further, when a glowshroom still has seeds it can use to spread itself, but it can't find a tile to spread to, instead of checking every 2 seconds, it checks progressively less often the more times it tries, which should reduce the lag from practically-idle glowshrooms.

I've also done a *ton* of code cleanup, which removed a bunch of unnecessary lag caused by these fucking things.

# Coder Warnings
So there were a couple things wrong with glowshroom code.

1. It called ``view(3,src)`` tons of times per seed when it only needed to do so once
2. It called ``locate()`` on dozens of tiles per seed when it only needed to do so once
3. Whoever wrote this has a poor understanding of how exponentials work.

To elaborate on No. 3, look at this code that determines whether a glowshroom can plant with a seed:
```dm
if(prob(1/(generation * generation) * 100))//This formula gives you diminishing returns based on generation. 100% with 1st gen, decreasing to 25%, 11%, 6, 4, 2...
```
The *foolish* among you may think that this should make it pretty difficult for glowshrooms to overspread. However, even with this, the population can still soar in worst-case scenarios:
![image](https://user-images.githubusercontent.com/29939414/76227513-6baf1080-61ed-11ea-9f47-49b2f510e052.png)
*On this graph, black represents the total population of glowshrooms, while purple represents the number born per generation.*

Given maximum yield and mildly poor luck, the population can reach **22,000**, which is about a third of the area of the station Z-level and double the number of floor tiles on Boxstation. Ridiculous.

## Lightsources are a thing.

The other problem is that this results in straight-up 22,000 lightsources being emitted. This is utterly cancer, especially since a lot of this is from multiple glowshroom entities existing on the same turf.

### Wait, what?

Yes, that's right. Instead of just blending sprites together sensibly, it used to be that glowshrooms just fucking had several objects stacked up on the same tile. The logic to determine how they stacked up and how to stop them from growing on the same walls was also very arcane and bizarre.

Now, when some glowshroom tries to grow onto the wall of a tile that already has a glowshroom, the wallshroom's sprite is just blended onto the already-existing glowshroom as an overlay, easy-peasy.

## Changelog
:cl:  Altoids
bugfix: Glowshrooms no longer absolutely murder server performance.
/:cl:
