### PR TITLE
Makes AIs unable to be Cheesed/Launchpadded

### DIFF
--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -150,7 +150,7 @@
 			var/mob/living/silicon/ai/I = ROI
 			if(I.move_resist > 1000)
 				to_chat(user, "<span class='warning'>ERROR: Launchpad overloaded, unable to operate.</span>")
-				return
+				continue
 		// if it's anchored, don't teleport
 		var/on_chair = ""
 		if(ROI.anchored)

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -145,6 +145,12 @@
 	for(var/atom/movable/ROI in source)
 		if(ROI == src)
 			continue
+		// Dont teleport unanchored ais
+		if(isAI(ROI))
+			var/mob/living/silicon/ai/I = ROI
+			if(I.move_resist == 2999)
+				to_chat(user, "<span class='warning'>ERROR: Launchpad overloaded, unable to operate.</span>")
+				return
 		// if it's anchored, don't teleport
 		var/on_chair = ""
 		if(ROI.anchored)

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -148,7 +148,7 @@
 		// Dont teleport unanchored ais
 		if(isAI(ROI))
 			var/mob/living/silicon/ai/I = ROI
-			if(I.move_resist == 2999)
+			if(I.move_resist > 1000)
 				to_chat(user, "<span class='warning'>ERROR: Launchpad overloaded, unable to operate.</span>")
 				return
 		// if it's anchored, don't teleport


### PR DESCRIPTION
Made it so AIs cannot be teleported unless unachored to stop abuse.

#### Changelog

:cl:  
tweak: AIs need to be unanchored to be able to be moved via launchpad 
/:cl:
