### PR TITLE
Shuttle now takes 20 minutes instead of 2 minutes to arrive to Central Command

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -20,7 +20,7 @@ SUBSYSTEM_DEF(shuttle)
 	var/obj/docking_port/mobile/emergency/backup/backup_shuttle
 	var/emergencyCallTime = 6000	//time taken for emergency shuttle to reach the station when called (in deciseconds)
 	var/emergencyDockTime = 1800	//time taken for emergency shuttle to leave again once it has docked (in deciseconds)
-	var/emergencyEscapeTime = 1200	//time taken for emergency shuttle to reach a safe distance after leaving station (in deciseconds)
+	var/emergencyEscapeTime = 12000	//time taken for emergency shuttle to reach a safe distance after leaving station (in deciseconds)
 	var/area/emergencyLastCallLoc
 	var/emergencyCallAmount = 0		//how many times the escape shuttle was called
 	var/emergencyNoEscape


### PR DESCRIPTION
### Intent of your Pull Request

appeasing yogurt, our lord
![XwO59mp](https://user-images.githubusercontent.com/28408322/76557703-68788680-6472-11ea-9270-ce7c3a857171.png)

#### Changelog

:cl:  
tweak: Shuttle now takes 20 minutes instead of 2 minutes to arrive to Central Command
/:cl:
