### PR TITLE
Several changes to vampire (mostly buffs)

### DIFF
--- a/yogstation/code/datums/antagonists/vampire.dm
+++ b/yogstation/code/datums/antagonists/vampire.dm
@@ -25,16 +25,16 @@
 		/datum/vampire_passive/vision = 75,
 		/obj/effect/proc_holder/spell/self/shapeshift = 75,
 		/obj/effect/proc_holder/spell/self/cloak = 100,
-		/obj/effect/proc_holder/spell/targeted/disease = 175,
-		/obj/effect/proc_holder/spell/bats = 250,
+		/obj/effect/proc_holder/spell/self/revive = 100,
+		/obj/effect/proc_holder/spell/targeted/disease = 200,//why is spell-that-kills-people unlocked so early what the fuck
 		/obj/effect/proc_holder/spell/self/batform = 200,
 		/obj/effect/proc_holder/spell/self/screech = 215,
+		/obj/effect/proc_holder/spell/bats = 250,
 		/datum/vampire_passive/regen = 255,
 		/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/mistform = 300,
 		/datum/vampire_passive/full = 420,
 		/obj/effect/proc_holder/spell/self/summon_coat = 420,
-		/obj/effect/proc_holder/spell/targeted/vampirize = 450,
-		/obj/effect/proc_holder/spell/self/revive = 0)
+		/obj/effect/proc_holder/spell/targeted/vampirize = 450)
 
 /datum/antagonist/vampire/get_admin_commands()
 	. = ..()
@@ -202,6 +202,7 @@
 		C.adjustFireLoss(-4)
 		C.adjustToxLoss(-4)
 		C.adjustOxyLoss(-4)
+		C.adjustCloneLoss(-4)
 		return
 	if(!get_ability(/datum/vampire_passive/full) && istype(get_area(C.loc), /area/chapel))
 		vamp_burn()
@@ -232,9 +233,9 @@
 			to_chat(O, "<span class='warning'>They've got no blood left to give.</span>")
 			break
 		if(H.stat != DEAD)
-			blood = min(20, H.blood_volume)// if they have less than 20 blood, give them the remnant else they get 20 blood
-			total_blood += blood / 2	//divide by 2 to counted the double suction since removing cloneloss -Melandor0
-			usable_blood += blood / 2
+			blood = min(20, H.blood_volume)	// if they have less than 20 blood, give them the remnant else they get 20 blood
+			total_blood += blood			//get total blood 100% efficiency because fuck waiting out 5 fucking minutes and 1500 actual blood to get your 600 blood for the objective
+			usable_blood += blood * 0.75	//75% usable blood since it's actually used for stuff
 		else
 			blood = min(5, H.blood_volume)	// The dead only give 5 blood
 			total_blood += blood
@@ -244,7 +245,7 @@
 		H.blood_volume = max(H.blood_volume - 25, 0)
 		if(ishuman(O))
 			O.nutrition = min(O.nutrition + (blood / 2), NUTRITION_LEVEL_WELL_FED)
-		playsound(O.loc, 'sound/items/eatfood.ogg', 40, 1)
+		playsound(O.loc, 'sound/items/eatfood.ogg', 40, 1, extrarange = -4)//have to be within 3 tiles to hear the sucking
 
 	draining = null
 	to_chat(owner, "<span class='notice'>You stop draining [H.name] of blood.</span>")

--- a/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -112,16 +112,17 @@
 	vamp_req = TRUE
 
 /obj/effect/proc_holder/spell/targeted/hypnotise/cast(list/targets, mob/user = usr)
-	for(var/mob/living/target in targets)
+	for(var/mob/living/carbon/target in targets)
 		user.visible_message("<span class='warning'>[user]'s eyes flash briefly as he stares into [target]'s eyes</span>")
 		if(do_mob(user, target, 30))
 			to_chat(user, "<span class='warning'>Your piercing gaze knocks out [target].</span>")
-			to_chat(target, "<span class='warning'>You find yourself unable to move and barely able to speak.</span>")
+			to_chat(target, "<span class='warning'>You find yourself unable to move or speak.</span>")
 			target.Paralyze(150)
-			target.stuttering = 10
+			target.silent = 10 //finally makes this stupid spell USEFUL
 		else
 			revert_cast(usr)
 			to_chat(usr, "<span class='warning'>You broke your gaze.</span>")
+
 
 /obj/effect/proc_holder/spell/self/shapeshift
 	name = "Shapeshift (50)"
@@ -139,6 +140,7 @@
 		user.visible_message("<span class='warning'>[H] transforms!</span>")
 		randomize_human(H)
 	user.regenerate_icons()
+
 
 /obj/effect/proc_holder/spell/self/cloak
 	name = "Cloak of Darkness"
@@ -169,6 +171,49 @@
 	update_name()
 	to_chat(user, "<span class='notice'>You will now be [V.iscloaking ? "hidden" : "seen"] in darkness.</span>")
 
+
+/obj/effect/proc_holder/spell/self/revive
+	name = "Revive"
+	gain_desc = "You have gained the ability to revive after death... However you can still be cremated/gibbed, and you will disintergrate if you're in the chapel!"
+	desc = "Revives you, provided you are not in the chapel!"
+	blood_used = 0
+	stat_allowed = TRUE
+	charge_max = 1000
+	action_icon = 'yogstation/icons/mob/vampire.dmi'
+	action_icon_state = "coffin"
+	action_background_icon_state = "bg_demon"
+	vamp_req = TRUE
+
+/obj/effect/proc_holder/spell/self/revive/cast(list/targets, mob/user = usr)
+	if(!is_vampire(user) || !isliving(user))
+		revert_cast()
+		return
+	if(user.stat != DEAD)
+		to_chat(user, "<span class='notice'>We aren't dead enough to do that yet!</span>")
+		revert_cast()
+		return
+	if(user.reagents.has_reagent("holywater"))
+		to_chat(user, "<span class='danger'>We cannot revive, holy water is in our system!</span>")
+		return
+	var/mob/living/L = user
+	if(istype(get_area(L.loc), /area/chapel))
+		L.visible_message("<span class='warning'>[L] disintergrates into dust!</span>", "<span class='userdanger'>Holy energy seeps into our very being, disintergrating us instantly!</span>", "You hear sizzling.")
+		new /obj/effect/decal/remains/human(L.loc)
+		L.dust()
+	to_chat(L, "<span class='notice'>We begin to reanimate... this will take 1 minute.</span>")
+	addtimer(CALLBACK(src, /obj/effect/proc_holder/spell/self/revive.proc/revive, L), 600)
+
+/obj/effect/proc_holder/spell/self/revive/proc/revive(mob/living/user)
+	user.revive(full_heal = TRUE)
+	user.visible_message("<span class='warning'>[user] reanimates from death!</span>", "<span class='notice'>We get back up.</span>")
+	var/list/missing = user.get_missing_limbs()
+	if(missing.len)
+		playsound(user, 'sound/magic/demon_consume.ogg', 50, 1)
+		user.visible_message("<span class='warning'>Shadowy matter takes the place of [user]'s missing limbs as they reform!</span>")
+		user.regenerate_limbs(0, list(BODY_ZONE_HEAD))
+		user.regenerate_organs()
+
+
 /obj/effect/proc_holder/spell/targeted/disease
 	name = "Diseased Touch (50)"
 	desc = "Touches your victim with infected blood giving them Grave Fever, which will, left untreated, causes toxic building and frequent collapsing."
@@ -188,6 +233,7 @@
 			continue
 		var/datum/disease/D = new /datum/disease/vampire
 		target.ForceContractDisease(D)
+
 
 /obj/effect/proc_holder/spell/self/screech
 	name = "Chiropteran Screech (20)"
@@ -213,6 +259,7 @@
 	for(var/obj/structure/window/W in view(4))
 		W.take_damage(75)
 	playsound(user.loc, 'sound/effects/screech.ogg', 100, 1)
+
 
 /obj/effect/proc_holder/spell/bats
 	name = "Summon Bats (30)"
@@ -257,6 +304,7 @@
 	. = ..()
 	range = -1
 	addtimer(VARSET_CALLBACK(src, range, -1), 10) //Avoid fuckery
+
 
 /obj/effect/proc_holder/spell/targeted/vampirize
 	name = "Lilith's Pact (400)"
@@ -304,47 +352,6 @@
 			target.mind.store_memory("<B>[user] showed you the glory of Lilith. <I>You are not required to respect or obey [user] in any way</I></B>")
 			add_vampire(target)
 
-
-/obj/effect/proc_holder/spell/self/revive
-	name = "Revive"
-	gain_desc = "You have gained the ability to revive after death... However you can still be cremated/gibbed, and you will disintergrate if you're in the chapel!"
-	desc = "Revives you, provided you are not in the chapel!"
-	blood_used = 0
-	stat_allowed = TRUE
-	charge_max = 1000
-	action_icon = 'yogstation/icons/mob/vampire.dmi'
-	action_icon_state = "coffin"
-	action_background_icon_state = "bg_demon"
-	vamp_req = TRUE
-
-/obj/effect/proc_holder/spell/self/revive/cast(list/targets, mob/user = usr)
-	if(!is_vampire(user) || !isliving(user))
-		revert_cast()
-		return
-	if(user.stat != DEAD)
-		to_chat(user, "<span class='notice'>We aren't dead enough to do that yet!</span>")
-		revert_cast()
-		return
-	if(user.reagents.has_reagent("holywater"))
-		to_chat(user, "<span class='danger'>We cannot revive, holy water is in our system!</span>")
-		return
-	var/mob/living/L = user
-	if(istype(get_area(L.loc), /area/chapel))
-		L.visible_message("<span class='warning'>[L] disintergrates into dust!</span>", "<span class='userdanger'>Holy energy seeps into our very being, disintergrating us instantly!</span>", "You hear sizzling.")
-		new /obj/effect/decal/remains/human(L.loc)
-		L.dust()
-	to_chat(L, "<span class='notice'>We begin to reanimate... this will take a minute.</span>")
-	addtimer(CALLBACK(src, /obj/effect/proc_holder/spell/self/revive.proc/revive, L), 600)
-
-/obj/effect/proc_holder/spell/self/revive/proc/revive(mob/living/user)
-	user.revive(full_heal = TRUE)
-	user.visible_message("<span class='warning'>[user] reanimates from death!</span>", "<span class='notice'>We get back up.</span>")
-	var/list/missing = user.get_missing_limbs()
-	if(missing.len)
-		playsound(user, 'sound/magic/demon_consume.ogg', 50, 1)
-		user.visible_message("<span class='warning'>Shadowy matter takes the place of [user]'s missing limbs as they reform!</span>")
-		user.regenerate_limbs(0, list(BODY_ZONE_HEAD))
-		user.regenerate_organs()
 
 /obj/effect/proc_holder/spell/self/summon_coat
 	name = "Summon Dracula Coat (100)"


### PR DESCRIPTION
LIST
revive now requires 100 total blood instead of 0 which used to be like 300 or 400 or something
grave fever now requires 200 total blood instead of 175 because it's still just a shitty murder ability that is good at killing people who don't know what a doctor is
organized the ability list based off total blood requirement instead of some abilities randomly being placed at stupid spots
total blood is now not halved from succ because you'd end up needing an average of 1500 blood which would be fine if vampires weren't terrible at defending themselves and sucked fast but are terrible at defending themselves and suck slow
usable blood is now 75% instead of 50% of a succ
succ noise is now only hearable from 3 tiles away instead of WHAT A BEAUTIFUL DUWANG **C H E W**
hypnotize has a mute attached so it's no longer terrible
consequentially, hypnotize only works on carbons instead of being able to be ineffectually used to stun simplemobs (doesn't do anything) or borgs (who you'd probably need a flash to set up the hypnotize stun and why not just kill them with that)
ability spacing is now better
a very half-assed attempt to reorganize spells by cost was made
oh also coffins now heal clone damage because they heal every other kind of damage and are still unused

:cl:  
tweak: vampires suck quieter
tweak: vampire revive requires 100 total blood up from 0
tweak: grave fever requires 200 total blood up from 175
tweak: vampires are way more efficient as sucking blood
tweak: hypnotize now has a mute attached due to how terrible it is
tweak: hypnotize can no longer be used on borgs
tweak: vampires can heal clone damage from sleeping in a coffin
/:cl:
