### PR TITLE
Reagent viscosity framework

### DIFF
--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -40,7 +40,6 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	var/self_consuming = FALSE
 	var/reagent_weight = 1 //affects how far it travels when sprayed
 	var/metabolizing = FALSE
-	var/viscosity = 1 // affects how rapidly it can be injected via syringe (lower = faster; formula is viscosity * 30 deciseconds
 
 /datum/reagent/Destroy() // This should only be called by the holder, so it's already handled clearing its references
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -40,6 +40,7 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	var/self_consuming = FALSE
 	var/reagent_weight = 1 //affects how far it travels when sprayed
 	var/metabolizing = FALSE
+	var/viscosity = 1 // affects how rapidly it can be injected via syringe (lower = faster; formula is viscosity * 30 deciseconds
 
 /datum/reagent/Destroy() // This should only be called by the holder, so it's already handled clearing its references
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -116,6 +116,7 @@
 	glass_name = "glass of water"
 	glass_desc = "The father of all refreshments."
 	shot_glass_icon_state = "shotglassclear"
+	viscosity = 0.25
 
 /*
  *	Water reaction to turf

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -116,7 +116,6 @@
 	glass_name = "glass of water"
 	glass_desc = "The father of all refreshments."
 	shot_glass_icon_state = "shotglassclear"
-	viscosity = 0.25
 
 /*
  *	Water reaction to turf

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -129,9 +129,14 @@
 				if(!L.can_inject(user, TRUE))
 					return
 				if(L != user)
+					var/viscosity_highest = 0
+					for(var/datum/reagent/R in reagents.reagent_list) // takes the highest viscosity of all reagents in syringe - Hopek
+						if(R.viscosity > viscosity_highest)
+							viscosity_highest = R.viscosity
+
 					L.visible_message("<span class='danger'>[user] is trying to inject [L]!</span>", \
 											"<span class='userdanger'>[user] is trying to inject [L]!</span>")
-					if(!do_mob(user, L, extra_checks=CALLBACK(L, /mob/living/proc/can_inject, user, TRUE)))
+					if(!do_mob(user, L,time = (30 * viscosity_highest), extra_checks=CALLBACK(L, /mob/living/proc/can_inject, user, TRUE)))
 						return
 					if(!reagents.total_volume)
 						return

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -129,9 +129,14 @@
 				if(!L.can_inject(user, TRUE))
 					return
 				if(L != user)
+					var/viscosity_highest = 0
+					for(var/datum/reagent/R in reagents.reagent_list)
+						if(R.viscosity > viscosity_highest) // takes the highest viscosity of all reagents in syringe - Hopek
+							viscosity_highest = R.viscosity
+
 					L.visible_message("<span class='danger'>[user] is trying to inject [L]!</span>", \
 											"<span class='userdanger'>[user] is trying to inject [L]!</span>")
-					if(!do_mob(user, L, extra_checks=CALLBACK(L, /mob/living/proc/can_inject, user, TRUE)))
+					if(!do_mob(user, L, time = (30 * viscosity_highest), extra_checks=CALLBACK(L, /mob/living/proc/can_inject, user, TRUE)))
 						return
 					if(!reagents.total_volume)
 						return

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -129,14 +129,9 @@
 				if(!L.can_inject(user, TRUE))
 					return
 				if(L != user)
-					var/viscosity_highest = 0
-					for(var/datum/reagent/R in reagents.reagent_list)
-						if(R.viscosity > viscosity_highest) // takes the highest viscosity of all reagents in syringe - Hopek
-							viscosity_highest = R.viscosity
-
 					L.visible_message("<span class='danger'>[user] is trying to inject [L]!</span>", \
 											"<span class='userdanger'>[user] is trying to inject [L]!</span>")
-					if(!do_mob(user, L, time = (30 * viscosity_highest), extra_checks=CALLBACK(L, /mob/living/proc/can_inject, user, TRUE)))
+					if(!do_mob(user, L, extra_checks=CALLBACK(L, /mob/living/proc/can_inject, user, TRUE)))
 						return
 					if(!reagents.total_volume)
 						return


### PR DESCRIPTION
**What this does:**
------
Reagents now have viscosity which affects the speed at which reagents are injected via syringes.

As proof of concept, water is affected by this as I have given it a very low viscosity so you can inject people with water quicker.
**(currently all reagents besides water inject at normal speeds)**

At the moment I am only changing the viscosity on the water as other changes will be done in separate PR's because in my opinion injecting certain reagents quicker or slower should be discussed separately.

**At the moment the viscosity of injection is determined by the highest viscosity in the syringe**. (meaning that you can't do something like mix water and potassium to quickly inject water + potassium)

Originally this took the average viscosity of all reagents in the syringe but I had to take that portion out for the time being as it made injecting lethal reagents OP when mixed with water because at the moment harmful reagents do not have a higher viscosity.

In the future after this framework is merged I plan to make all the reagents in the syringe "average" out so that you can mix and match viscosities. For example, you would be able to mix water with kelotane to make your kelotane syringe inject quicker just using the water as a medium.

why:
-----
Non-harmful "less viscous" reagents can be injected quicker and we can keep the other more harmful reagents more "vicious" meaning they inject slower (currently all reagents besides water inject at normal speeds)

This framework allows reagents to be balanced by their injection speed and in the future will allow more chemistry gameplay in terms of mixing and matching reagents if you want to inject your reagents at an optimal speed.

#### Changelog

:cl:  
rscadd: Reagents now have viscosity which affects the speed at which reagents are injected via syringes.
rscadd: Water was a low viscosity so it injects rapidly.
/:cl:
