### PR TITLE
Removes emag requirement for the meteor shuttle.

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -211,7 +211,6 @@
 	admin_notes = "This shuttle will likely crush escape, killing anyone there."
 	credit_cost = 15000
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
-	emag_buy = TRUE
 
 /datum/map_template/shuttle/emergency/luxury
 	suffix = "luxury"


### PR DESCRIPTION
🆑 
rscadd: Removes the emag requirement for the meteor shuttle.
/🆑
