### PR TITLE
[admin] removes the ability for players to tell if an event is random

### DIFF
--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -97,7 +97,7 @@
 	if(random)
 		log_game("Random Event triggering: [name] ([typepath])")
 	if (alert_observers)
-		deadchat_broadcast(" has just been triggered!", "<b>[name]</b>") //STOP ASSUMING IT'S BADMINS!
+		deadchat_broadcast(" has just been triggered!", "<b>[name]</b>")
 	return E
 
 //Special admins setup

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -97,7 +97,7 @@
 	if(random)
 		log_game("Random Event triggering: [name] ([typepath])")
 	if (alert_observers)
-		deadchat_broadcast(" has just been randomly triggered!", "<b>[name]</b>") //STOP ASSUMING IT'S BADMINS!
+		deadchat_broadcast(" has just been triggered!", "<b>[name]</b>") //STOP ASSUMING IT'S BADMINS!
 	return E
 
 //Special admins setup

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -97,7 +97,7 @@
 	if(random)
 		log_game("Random Event triggering: [name] ([typepath])")
 	if (alert_observers)
-		deadchat_broadcast(" has just been[random ? " randomly" : ""] triggered!", "<b>[name]</b>") //STOP ASSUMING IT'S BADMINS!
+		deadchat_broadcast(" has just been randomly triggered!", "<b>[name]</b>") //STOP ASSUMING IT'S BADMINS!
 	return E
 
 //Special admins setup


### PR DESCRIPTION
### Intent of your Pull Request

makes it so players in deadchat cant tell if an event is random or not

#### Changelog

:cl:  
tweak: removes players ability to see if events random
/:cl:
