### PR TITLE
Hierophant club station fix

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1151,6 +1151,9 @@
 	var/turf/T = get_turf(target)
 	if(!T || timer > world.time)
 		return
+	if(!SSmapping.level_trait(T.z, ZTRAIT_MINING))
+		to_chat(user, "<span class='warning'>The club fizzles wekaly, it seem his power does not reach to this realm.</span>" )
+		return
 	calculate_anger_mod(user)
 	timer = world.time + CLICK_CD_MELEE //by default, melee attacks only cause melee blasts, and have an accordingly short cooldown
 	if(proximity_flag)
@@ -1203,6 +1206,10 @@
 	update_icon()
 
 /obj/item/hierophant_club/ui_action_click(mob/user, action)
+	var/turf/user_turf = get_turf(user)
+	if(!SSmapping.level_trait(user_turf, ZTRAIT_MINING))
+		to_chat(user, "<span class='warning'>The club fizzles wekaly, it seem his power does not reach to this realm.</span>")
+		return
 	if(istype(action, /datum/action/item_action/toggle_unfriendly_fire)) //toggle friendly fire...
 		friendly_fire_check = !friendly_fire_check
 		to_chat(user, "<span class='warning'>You toggle friendly fire [friendly_fire_check ? "off":"on"]!</span>")

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1206,10 +1206,6 @@
 	update_icon()
 
 /obj/item/hierophant_club/ui_action_click(mob/user, action)
-	var/turf/user_turf = get_turf(user)
-	if(!SSmapping.level_trait(user_turf, ZTRAIT_MINING))
-		to_chat(user, "<span class='warning'>The club fizzles wekaly, it seem his power does not reach to this realm.</span>")
-		return
 	if(istype(action, /datum/action/item_action/toggle_unfriendly_fire)) //toggle friendly fire...
 		friendly_fire_check = !friendly_fire_check
 		to_chat(user, "<span class='warning'>You toggle friendly fire [friendly_fire_check ? "off":"on"]!</span>")

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1151,8 +1151,8 @@
 	var/turf/T = get_turf(target)
 	if(!T || timer > world.time)
 		return
-	if(!SSmapping.level_trait(T.z, ZTRAIT_MINING))
-		to_chat(user, "<span class='warning'>The club fizzles wekaly, it seem his power does not reach to this realm.</span>" )
+	if(!is_mining_level(T.z))
+		to_chat(user, "<span class='warning'>The club fizzles weakly, it seem its power doesn't reach this area.</span>" )
 		return
 	calculate_anger_mod(user)
 	timer = world.time + CLICK_CD_MELEE //by default, melee attacks only cause melee blasts, and have an accordingly short cooldown


### PR DESCRIPTION
### Intent of your Pull Request

The hierophant club has received complaints and rightfully so.
It is OP when on station due it´s functionality even when compared to a lot of traitor gear, as it can kill people standing behind Rwalls even. 

At the same time miners complained it is good for mining purposes.

Simple fix, it does not work on the station as it is beyond unbalanced there, while it keeps it´s full functionality on lavaland.

Code is tested and works.



#### Changelog

:cl:  

tweak: the hierophant club does not work on the station

/:cl:
