### PR TITLE
Rebalances BoH bombings (take 2, new PR)

### DIFF
--- a/code/datums/components/storage/concrete/bag_of_holding.dm
+++ b/code/datums/components/storage/concrete/bag_of_holding.dm
@@ -27,7 +27,7 @@
 				continue
 			for(var/atom/AT in T)
 				AT.emp_act(EMP_HEAVY)
-				if(istype(AT, /obj)
+				if(istype(AT, /obj))
 					var/obj/O = AT
 					O.obj_break()
 				if(istype(AT, /mob/living))

--- a/code/datums/components/storage/concrete/bag_of_holding.dm
+++ b/code/datums/components/storage/concrete/bag_of_holding.dm
@@ -23,11 +23,20 @@
 		log_game("[key_name(user)] detonated a bag of holding at [loc_name(loccheck)].")
 
 		user.gib(TRUE, TRUE, TRUE)
-		for(var/turf/T in range(1,loccheck))
+		for(var/turf/T in range(2,loccheck))
 			if(istype(T, /turf/open/space/transit))
 				continue
 			for(var/atom/AT in T)
-				A.ex_act(EXPLODE_DEVASTATE)
+				AT.emp_act(EMP_HEAVY)
+				if(istype(AT, /obj)
+					var/obj/O = AT
+					O.obj_break()
+				if(istype(AT, /mob/living))
+					var/mob/living/M = AT
+					M.take_overall_damage(85)
+					if(M.movement_type & FLYING)
+						M.visible_message("<span class='danger'>The bluespace collapse crushes the air towards it, pulling [M] towards the ground...</span>")
+						M.Paralyze(5, TRUE, TRUE)		//Overrides stun absorbs.
 			T.TerraformTurf(/turf/open/chasm/magic, /turf/open/chasm/magic)
 		for(var/fabricarea in get_areas(/area/fabric_of_reality))
 			var/area/fabric_of_reality/R = fabricarea

--- a/code/datums/components/storage/concrete/bag_of_holding.dm
+++ b/code/datums/components/storage/concrete/bag_of_holding.dm
@@ -26,7 +26,7 @@
 		for(var/turf/T in range(1,loccheck))
 			if(istype(T, /turf/open/space/transit))
 				continue
-			for(var/atom/A in T)
+			for(var/atom/AT in T)
 				A.ex_act(EXPLODE_DEVASTATE)
 			T.TerraformTurf(/turf/open/chasm/magic, /turf/open/chasm/magic)
 		for(var/fabricarea in get_areas(/area/fabric_of_reality))

--- a/code/datums/components/storage/concrete/bag_of_holding.dm
+++ b/code/datums/components/storage/concrete/bag_of_holding.dm
@@ -1,4 +1,4 @@
-/datum/component/storage/concrete/bluespace/bag_of_holding/handle_item_insertion(obj/item/W, prevent_warning = FALSE, mob/living/user)
+/datum/component/storage/bluespace/bag_of_holding/handle_item_insertion(obj/item/W, prevent_warning = FALSE, mob/living/user)
 	var/atom/A = parent
 	if(A == W)		//don't put yourself into yourself.
 		return
@@ -18,18 +18,16 @@
 		to_chat(user, "<span class='danger'>The Bluespace interfaces of the two devices catastrophically malfunction!</span>")
 		qdel(W)
 		playsound(loccheck,'sound/effects/supermatter.ogg', 200, 1)
-		
+
 		message_admins("[ADMIN_LOOKUPFLW(user)] detonated a bag of holding at [ADMIN_VERBOSEJMP(loccheck)].")
 		log_game("[key_name(user)] detonated a bag of holding at [loc_name(loccheck)].")
-		
+
 		user.gib(TRUE, TRUE, TRUE)
-		for(var/turf/T in range(6,loccheck))
+		for(var/turf/T in range(1,loccheck))
 			if(istype(T, /turf/open/space/transit))
 				continue
-			for(var/mob/living/M in T)
-				if(M.movement_type & FLYING)
-					M.visible_message("<span class='danger'>The bluespace collapse crushes the air towards it, pulling [M] towards the ground...</span>")
-					M.Paralyze(5, TRUE, TRUE)		//Overrides stun absorbs.
+			for(var/atom/A in T)
+				A.ex_act(EXPLODE_DEVASTATE)
 			T.TerraformTurf(/turf/open/chasm/magic, /turf/open/chasm/magic)
 		for(var/fabricarea in get_areas(/area/fabric_of_reality))
 			var/area/fabric_of_reality/R = fabricarea

--- a/code/datums/components/storage/concrete/bag_of_holding.dm
+++ b/code/datums/components/storage/concrete/bag_of_holding.dm
@@ -1,4 +1,4 @@
-/datum/component/storage/bluespace/bag_of_holding/handle_item_insertion(obj/item/W, prevent_warning = FALSE, mob/living/user)
+/datum/component/storage/concrete/bluespace/bag_of_holding/handle_item_insertion(obj/item/W, prevent_warning = FALSE, mob/living/user)
 	var/atom/A = parent
 	if(A == W)		//don't put yourself into yourself.
 		return

--- a/code/datums/components/storage/concrete/bag_of_holding.dm
+++ b/code/datums/components/storage/concrete/bag_of_holding.dm
@@ -22,7 +22,6 @@
 		message_admins("[ADMIN_LOOKUPFLW(user)] detonated a bag of holding at [ADMIN_VERBOSEJMP(loccheck)].")
 		log_game("[key_name(user)] detonated a bag of holding at [loc_name(loccheck)].")
 
-		user.gib(TRUE, TRUE, TRUE)
 		for(var/turf/T in range(2,loccheck))
 			if(istype(T, /turf/open/space/transit))
 				continue

--- a/yogstation/code/datums/components/storage/storage.dm
+++ b/yogstation/code/datums/components/storage/storage.dm
@@ -92,7 +92,7 @@
 		for(var/turf/T in range(1,loccheck))
 			if(istype(T, /turf/open/space/transit))
 				continue
-			for(var/atom/A in T)
+			for(var/atom/AT in T)
 				A.ex_act(EXPLODE_DEVASTATE)
 			T.TerraformTurf(/turf/open/chasm/magic, /turf/open/chasm/magic)
 		for(var/fabricarea in get_areas(/area/fabric_of_reality))

--- a/yogstation/code/datums/components/storage/storage.dm
+++ b/yogstation/code/datums/components/storage/storage.dm
@@ -87,13 +87,21 @@
 
 		message_admins("[ADMIN_LOOKUPFLW(user)] detonated a bag of holding at [ADMIN_VERBOSEJMP(loccheck)].")
 		log_game("[key_name(user)] detonated a bag of holding at [loc_name(loccheck)].")
-
-		user.gib(TRUE, TRUE, TRUE)
-		for(var/turf/T in range(1,loccheck))
+		
+		for(var/turf/T in range(2,loccheck))
 			if(istype(T, /turf/open/space/transit))
 				continue
 			for(var/atom/AT in T)
-				A.ex_act(EXPLODE_DEVASTATE)
+				AT.emp_act(EMP_HEAVY)
+				if(istype(AT, /obj)
+					var/obj/O = AT
+					O.obj_break()
+				if(istype(AT, /mob/living))
+					var/mob/living/M = AT
+					M.take_overall_damage(85)
+					if(M.movement_type & FLYING)
+						M.visible_message("<span class='danger'>The bluespace collapse crushes the air towards it, pulling [M] towards the ground...</span>")
+						M.Paralyze(5, TRUE, TRUE)		//Overrides stun absorbs.
 			T.TerraformTurf(/turf/open/chasm/magic, /turf/open/chasm/magic)
 		for(var/fabricarea in get_areas(/area/fabric_of_reality))
 			var/area/fabric_of_reality/R = fabricarea

--- a/yogstation/code/datums/components/storage/storage.dm
+++ b/yogstation/code/datums/components/storage/storage.dm
@@ -93,7 +93,7 @@
 				continue
 			for(var/atom/AT in T)
 				AT.emp_act(EMP_HEAVY)
-				if(istype(AT, /obj)
+				if(istype(AT, /obj))
 					var/obj/O = AT
 					O.obj_break()
 				if(istype(AT, /mob/living))

--- a/yogstation/code/datums/components/storage/storage.dm
+++ b/yogstation/code/datums/components/storage/storage.dm
@@ -89,13 +89,11 @@
 		log_game("[key_name(user)] detonated a bag of holding at [loc_name(loccheck)].")
 
 		user.gib(TRUE, TRUE, TRUE)
-		for(var/turf/T in range(6,loccheck))
+		for(var/turf/T in range(1,loccheck))
 			if(istype(T, /turf/open/space/transit))
 				continue
-			for(var/mob/living/M in T)
-				if(M.movement_type & FLYING)
-					M.visible_message("<span class='danger'>The bluespace collapse crushes the air towards it, pulling [M] towards the ground...</span>")
-					M.Paralyze(5, TRUE, TRUE)		//Overrides stun absorbs.
+			for(var/atom/A in T)
+				A.ex_act(EXPLODE_DEVASTATE)
 			T.TerraformTurf(/turf/open/chasm/magic, /turf/open/chasm/magic)
 		for(var/fabricarea in get_areas(/area/fabric_of_reality))
 			var/area/fabric_of_reality/R = fabricarea
@@ -105,7 +103,7 @@
 		qdel(A)
 		return
 	. = ..()
-
+	
 /datum/component/storage/concrete/trashbag/handle_item_insertion(obj/item/I, prevent_warning = FALSE, mob/M, datum/component/storage/remote)
 	..() // Actually sets the default return value
 	var/atom/real_location = real_location()


### PR DESCRIPTION
This rebalances BoH bombings by both nerfing and buffing them

Made a new PR for polishing the PR body and because this is very different from the old one in terms of changes

Buffs:

- Everything in range are emp'd
- All objects in range are marked as being broken
- The user is no longer gibbed
- All mobs in range get 85 brute damage applied to them

Nerfs:

- Its only a 5x5 instead of a 13x13

This PR has several goals:

- Make BoH bombs valid for people that don't have hijacks
- Restrict the amount of instant this department hasn't been found 404 grief
- Make it a viable method of assasination
- Prevent moving machinery that shouldn't be moved
- Remove the instant you are no longer part of this round because i clicked two buttons behind a wall 10 tiles away

# I DONT KNOW WHERE YOU GOT THIS IDEA BUT THIS DOESNT REMOVE THE TEAR