### PR TITLE
Removes engi borg flashes

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -292,7 +292,6 @@
 /obj/item/robot_module/engineering
 	name = "Engineering"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
 		/obj/item/borg/sight/meson,
 		/obj/item/construction/rcd/borg,
 		/obj/item/pipe_dispenser,


### PR DESCRIPTION
again

There was a PR to give engineering borgs a light replacer and there was a council vote that said to not merge that PR because it would make it too powerful. It has been deemed that giving an engineering borg the ability to change a light is far too powerful. So yeah I think this nerf fits quite nicely, and maybe we can get a light replacer now.

Anyway I don't really care if this thing gets merged or not, I think of this as a place to let the people speak.

:cl:   
rscdel: Removed engi borg flashes
/:cl:
