### PR TITLE
Borg security module now takes uranium instead of diamonds

### DIFF
--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -675,7 +675,7 @@
 	id = "borg_transform_security"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/transform/security
-	materials = list(MAT_METAL = 15000, MAT_GLASS = 15000, MAT_DIAMOND = 3000)
+	materials = list(MAT_METAL = 15000, MAT_GLASS = 15000, MAT_URANIUM = 3000)
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 


### PR DESCRIPTION
Its quite rare to see them and the main purpose of giving them a high material cost was to make it only viable late game. Thing is that the advanced weaponry tech node is quite hard to research and takes alot of time. This PR makes it still take time so its only a lategame thing while making the cost low enough so its actually used.