### PR TITLE
Adds a second locker to hydroponics

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -18522,14 +18522,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"aMG" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/shovel/spade,
-/obj/item/wrench,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/wirecutters,
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "aMH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -18540,11 +18532,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"aMI" = (
-/obj/machinery/light/small,
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "aMJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -57345,6 +57332,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"skk" = (
+/obj/structure/closet/secure_closet/hydroponics,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "slk" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -58534,6 +58525,15 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"uRs" = (
+/obj/machinery/light/small,
+/obj/structure/closet/crate/hydroponics,
+/obj/item/shovel/spade,
+/obj/item/wrench,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/wirecutters,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "uVA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -101302,7 +101302,7 @@ aIp
 aIj
 aIp
 aKW
-aMG
+aKK
 aIp
 aIp
 aMl
@@ -101559,7 +101559,7 @@ aIp
 aLb
 aIp
 aKH
-aMI
+uRs
 aIp
 aOV
 aOX
@@ -102072,7 +102072,7 @@ aGE
 aIp
 aIo
 aIp
-aKK
+skk
 aUh
 aIp
 aOX


### PR DESCRIPTION

### Intent of your Pull Request
Fulfills this request : https://forums.yogstation.net/index.php?threads/add-a-second-botanist-locker-to-yogstation-map.20951/
 
Picture:
![vivaldi_jcY2E7R14j](https://user-images.githubusercontent.com/48154165/78202022-7464d080-7493-11ea-96db-596199c384f0.png)

#### Changelog

:cl:  
rscadd: second locker  
rscdel: plant has been annihilated   
tweak: moved the vendor and crate around
/:cl:
