### PR TITLE
Port grab numbers change from tg

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -711,7 +711,7 @@
 		if(resting && pulledby.grab_state < GRAB_KILL) //If resting, resisting out of a grab is equivalent to 1 grab state higher. wont make the grab state exceed the normal max, however
 			altered_grab_state++
 		var/resist_chance = BASE_GRAB_RESIST_CHANCE // see defines/combat.dm
-		resist_chance = max(resist_chance/altered_grab_state-sqrt((getStaminaLoss()+getBruteLoss()/2)*(3-altered_grab_state)), 0) // https://i.imgur.com/6yAT90T.png for sample output values
+		resist_chance = max((resist_chance/altered_grab_state)-sqrt((getBruteLoss()+getFireLoss()+getOxyLoss()+getToxLoss()+getCloneLoss())*0.5+getStaminaLoss()), 0) //stamina loss is weighted twice as heavily as the other damage types in this calculation
 		if(prob(resist_chance))
 			visible_message("<span class='danger'>[src] has broken free of [pulledby]'s grip!</span>")
 			log_combat(pulledby, src, "broke grab")


### PR DESCRIPTION
Ports tgstation/tgstation#49544
Grab resisting now accounts for all damage instead of just brute and stamina, non-stamina damage types are weighted at half
Aggressive grab level now has 20% breakout chance from 15% at 100 damage for grab calculations
Neck grab breakout chance minimum hasn't changed
Kill grab now has a 0% breakout chance from 10% at 100 damage for grab calculations
Alternatively, chart: https://user-images.githubusercontent.com/42606352/75658908-b6012200-5c2e-11ea-9dd9-e4fbd475c7a5.PNG

:cl:  ATHATH
tweak: The chances to break out of aggressive, neck, and kill grabs have been modified slightly, and having large amounts of damage should actually affect how hard it is to break out of a kill grab now.
tweak: All types of damage now affect how hard it is to break out of a grab, not just brute and stamina damage. Stamina damage is, as before, weighted twice as much as the other damage types in the grab escape chance calculation(s).
/:cl:
