### PR TITLE
Replaces the travis badge with the turdis one in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Yogstation codebase
 
-[![Build Status](https://travis-ci.org/yogstation13/Yogstation.png)](https://travis-ci.org/yogstation13/Yogstation)  
+[![Build Status](https://github.com/yogstation13/Yogstation/workflows/Turdis/badge.svg?branch=master)](https://github.com/yogstation13/Yogstation/actions?query=workflow%3ATurdis+branch%3Amaster)
 [![forinfinityandbyond](https://user-images.githubusercontent.com/5211576/29499758-4efff304-85e6-11e7-8267-62919c3688a9.gif)](https://www.reddit.com/r/SS13/comments/5oplxp/what_is_the_main_problem_with_byond_as_an_engine/dclbu1a)
 
 [**Website**](https://yogstation.net)


### PR DESCRIPTION
See title, looks like:

[![Build Status](https://github.com/yogstation13/Yogstation/workflows/Turdis/badge.svg?branch=master)](https://github.com/yogstation13/Yogstation/actions?query=workflow%3ATurdis+branch%3Amaster)