### PR TITLE
Replaces the engi holofan in ce's locker with the atmos holofan

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -21,7 +21,7 @@
 	new /obj/item/megaphone/command(src)
 	new /obj/item/areaeditor/blueprints(src)
 	new /obj/item/airlock_painter(src)
-	new /obj/item/holosign_creator/engineering(src)
+	new /obj/item/holosign_creator/atmos(src)
 	new /obj/item/clothing/mask/gas(src)
 	new /obj/item/multitool(src)
 	new /obj/item/assembly/flash/handheld(src)


### PR DESCRIPTION
### Intent of your Pull Request

![Discord_V68WyMLNyk](https://user-images.githubusercontent.com/48154165/78465806-6c5a9a00-76fa-11ea-8284-0c0954998cac.png)

![Discord_94I1eOBl0Z](https://user-images.githubusercontent.com/48154165/78465807-79778900-76fa-11ea-8126-7d9373964bc6.png)

The CE main has spoken

#### Changelog

:cl:  
tweak: replaces the engi holofan in ce's locker with the atmos holofan
/:cl:
