### PR TITLE
[admin] Expands the functionality of the AFK verb, makes the Suicide verb warn important roles

### DIFF
--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -253,18 +253,18 @@
 	switch(stat)
 		if(SOFT_CRIT)
 			to_chat(src, "<span class='warning'>You can't commit suicide while in a critical condition!</span>")
-			return
+			return FALSE
 		if(UNCONSCIOUS)
 			to_chat(src, "<span class='warning'>You need to be conscious to commit suicide!</span>")
-			return
+			return FALSE
 		if(DEAD)
 			to_chat(src, "<span class='warning'>You're already dead!</span>")
-			return
+			return FALSE
 	//We're assuming they're CONSCIOUS
 	if(is_important()) // If they are someone critical to the round, for some reason
 		var/result = (alert("WARNING: You seem to be serving a critical role. Suiciding now may be against the rules. Consider using the AFK verb instead. Continue regardless?","Suicide Warning","Yes","No") == "Yes")
 		if(!result)
-			return
+			return FALSE
 		message_admins("[key_name(src)] may be committing suicide as an important role!")
 	return TRUE
 

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -236,17 +236,37 @@
 /mob/living/carbon/human/suicide_log()
 	log_game("[key_name(src)] (job: [src.job ? "[src.job]" : "None"]) committed suicide at [AREACOORD(src)].")
 
+//IS_IMPORTANT()
+// Returns whether this player can be programmatically deemed to be important to the game. As of 5 Apr 2020, only used for canSuicide().
+// Split into several type-specific implementations because I wanted to pretend that this programming language was Julia for dozen lines or so.
+/mob/living/proc/is_important() 
+	return (mind && mind.special_role)
+
+/mob/living/carbon/alien/is_important() 
+	return TRUE // :clap: all :clap: aliens :clap: are :clap: valid (and ergo shouldn't be fucking suiciding you pieces of shit)
+
+/mob/living/carbon/human/is_important()
+	return (..() || (job in GLOB.command_positions) || mind?.has_antag_datum(/datum/antagonist/ert))
+//end IS_IMPORTANT()
+
 /mob/living/proc/canSuicide()
 	switch(stat)
-		if(CONSCIOUS)
-			return TRUE
 		if(SOFT_CRIT)
 			to_chat(src, "<span class='warning'>You can't commit suicide while in a critical condition!</span>")
+			return
 		if(UNCONSCIOUS)
 			to_chat(src, "<span class='warning'>You need to be conscious to commit suicide!</span>")
+			return
 		if(DEAD)
-	return
 			to_chat(src, "<span class='warning'>You're already dead!</span>")
+			return
+	//We're assuming they're CONSCIOUS
+	if(is_important()) // If they are someone critical to the round, for some reason
+		var/result = (alert("WARNING: You seem to be serving a critical role. Suiciding now may be against the rules. Consider using the AFK verb instead. Continue regardless?","Suicide Warning","Yes","No") == "Yes")
+		if(!result)
+			return
+		message_admins("[key_name(src)] may be committing suicide as an important role!")
+	return TRUE
 
 /mob/living/carbon/canSuicide()
 	if(!..())

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -241,12 +241,12 @@
 		if(CONSCIOUS)
 			return TRUE
 		if(SOFT_CRIT)
-			to_chat(src, "You can't commit suicide while in a critical condition!")
+			to_chat(src, "<span class='warning'>You can't commit suicide while in a critical condition!</span>")
 		if(UNCONSCIOUS)
-			to_chat(src, "You need to be conscious to commit suicide!")
+			to_chat(src, "<span class='warning'>You need to be conscious to commit suicide!</span>")
 		if(DEAD)
-			to_chat(src, "You're already dead!")
 	return
+			to_chat(src, "<span class='warning'>You're already dead!</span>")
 
 /mob/living/carbon/canSuicide()
 	if(!..())

--- a/yogstation/code/modules/client/verbs/afk.dm
+++ b/yogstation/code/modules/client/verbs/afk.dm
@@ -84,6 +84,6 @@
 			var/important_role = special_role || M.job || initial(M.name) || "something important"
 			adminhelp("I need to go AFK as '[important_role]' for duration of '[time]' [reason ? " with the reason: '[reason]'" : ""]")
 		else
-			to_chat(src, "<span class='danger'>Admins will not be specifically alerted, because you are not in a critical station role.</span>")
+			to_chat(src, "<span class='danger'>Admins will not be automatically alerted, because you are not in a critical station role.</span>")
 	else
 		to_chat(src, "<span class='boldnotice'>It is not necessary to report being AFK if you are not in the game.</span>")

--- a/yogstation/code/modules/client/verbs/afk.dm
+++ b/yogstation/code/modules/client/verbs/afk.dm
@@ -56,7 +56,7 @@
 				if(H.job in GLOB.command_positions)
 					alert_admins = TRUE
 					channels += ".c"
-				else if(job in GLOB.security_positions)
+				else if(H.job in GLOB.security_positions)
 					alert_admins = TRUE
 					//Already implicitly sending an IC message on sec channels via the .h above
 			if(H.mind)

--- a/yogstation/code/modules/client/verbs/afk.dm
+++ b/yogstation/code/modules/client/verbs/afk.dm
@@ -67,6 +67,7 @@
 						if("Nuclear Operative","Clown Operative","Syndicate Cyborg","Lone Operative") // Le nukie bois
 							channels = list(".t") // Broadcast their AFK-hood on syndicate channels
 				if(H.mind.has_antag_datum(/datum/antagonist/ert)) // A bit awkward, but they lack a special_role (nor a consistently unique assigned_role) and it would break some things to make them have one
+					alert_admins = TRUE
 					special_role = H.mind.assigned_role // This normally works.
 					channels = list(".y",".c") // Y for.... Centcom, of course!
 		else if(isalien(M))
@@ -86,7 +87,8 @@
 			var/reason = stripped_input(src, "Do you have time to give a reason? If so, please give it:")
 			var/important_role = special_role || M.job || initial(M.name) || "something important"
 			adminhelp("I need to go AFK as '[important_role]' for duration of '[time]' [reason ? " with the reason: '[reason]'" : ""]")
+			log_message("is now AFK for [time] [reason ? " with the reason: '[reason]'" : ""]", LOG_OWNERSHIP)
 		else
-			to_chat(src, "<span class='danger'>Admins will not be automatically alerted, because you are not in a critical station role.</span>")
+			to_chat(src, "<span class='danger'>Admins will not be automatically alerted, because you do not seem to be in a critical station role.</span>")
 	else
 		to_chat(src, "<span class='boldnotice'>It is not necessary to report being AFK if you are not in the game.</span>")

--- a/yogstation/code/modules/client/verbs/afk.dm
+++ b/yogstation/code/modules/client/verbs/afk.dm
@@ -19,6 +19,15 @@
 		"30 minutes" = "I need to shut my eyes for quite a while. Please keep an eye on me while I am resting.",
 		"Whole round" = "I need to shut my eyes for a long time... Someone please take over my station responsibilities."
 	)
+	
+	var/static/list/alientext = list(
+		"Unknown" = "My broodmembers, I must go quiet for a time. Please watch over me.",
+		"5 minutes" = "My broodmembers, I must go quiet for a time. I will awaken very soon.",
+		"10 minutes" = "My broodmembers, I must go quiet for a time. I will awaken soon.",
+		"15 minutes" = "My broodmembers, I must go quiet for a time. I will awaken in time.",
+		"30 minutes" = "My broodmembers, I must go quiet for a time. It will be some time before I awaken.",
+		"Whole round" = "My broodmembers, I must go quiet. I may never awaken during this cycle.",
+	)
 	if(mob && !isdead(mob))
 		var/mob/M = mob
 		
@@ -57,6 +66,10 @@
 				if(H.mind.has_antag_datum(/datum/antagonist/ert)) // A bit awkward, but they lack a special_role and it would break some things to make them have one
 					special_role = H.mind.assigned_job // This normally works.
 					channels = list(".y",".c") // Y for.... Centcom, of course!
+		else if(isalien(M))
+			alert_admins = TRUE
+			text = alientext[time]
+			channels = list(".a")
 		else // This guy is some strange sorta mob
 			alert_admins = (alert("Should admins know about you going AFK?","AFK Verb Notice","Yes","No") == "Yes")
 		

--- a/yogstation/code/modules/client/verbs/afk.dm
+++ b/yogstation/code/modules/client/verbs/afk.dm
@@ -64,7 +64,7 @@
 						if("Nuclear Operative","Clown Operative","Syndicate Cyborg","Lone Operative") // Le nukie bois
 							channels = list(".t") // Broadcast their AFK-hood on syndicate channels
 				if(H.mind.has_antag_datum(/datum/antagonist/ert)) // A bit awkward, but they lack a special_role and it would break some things to make them have one
-					special_role = H.mind.assigned_job // This normally works.
+					special_role = H.mind.assigned_role // This normally works.
 					channels = list(".y",".c") // Y for.... Centcom, of course!
 		else if(isalien(M))
 			alert_admins = TRUE

--- a/yogstation/code/modules/client/verbs/afk.dm
+++ b/yogstation/code/modules/client/verbs/afk.dm
@@ -46,7 +46,7 @@
 		else if(issilicon(M))
 			alert_admins = TRUE
 			text = borgtext[time]
-			channels = list(".o",".c")
+			channels = list(".o",".c",".b") // AI Private, Command, and Binary.
 		else if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			text = humantext[time]

--- a/yogstation/code/modules/client/verbs/afk.dm
+++ b/yogstation/code/modules/client/verbs/afk.dm
@@ -56,6 +56,9 @@
 				if(H.job in GLOB.command_positions)
 					alert_admins = TRUE
 					channels += ".c"
+				else if(job in GLOB.security_positions)
+					alert_admins = TRUE
+					//Already implicitly sending an IC message on sec channels via the .h above
 			if(H.mind)
 				if(H.mind.special_role) // This catches if they are a typical variety of antag (clockwork, traitor, zombie, wizard, etc)
 					alert_admins = TRUE
@@ -63,7 +66,7 @@
 					switch(special_role)
 						if("Nuclear Operative","Clown Operative","Syndicate Cyborg","Lone Operative") // Le nukie bois
 							channels = list(".t") // Broadcast their AFK-hood on syndicate channels
-				if(H.mind.has_antag_datum(/datum/antagonist/ert)) // A bit awkward, but they lack a special_role and it would break some things to make them have one
+				if(H.mind.has_antag_datum(/datum/antagonist/ert)) // A bit awkward, but they lack a special_role (nor a consistently unique assigned_role) and it would break some things to make them have one
 					special_role = H.mind.assigned_role // This normally works.
 					channels = list(".y",".c") // Y for.... Centcom, of course!
 		else if(isalien(M))

--- a/yogstation/code/modules/client/verbs/afk.dm
+++ b/yogstation/code/modules/client/verbs/afk.dm
@@ -87,7 +87,7 @@
 			var/reason = stripped_input(src, "Do you have time to give a reason? If so, please give it:")
 			var/important_role = special_role || M.job || initial(M.name) || "something important"
 			adminhelp("I need to go AFK as '[important_role]' for duration of '[time]' [reason ? " with the reason: '[reason]'" : ""]")
-			log_message("is now AFK for [time] [reason ? " with the reason: '[reason]'" : ""]", LOG_OWNERSHIP)
+			mob.log_message("is now AFK for [time] [reason ? " with the reason: '[reason]'" : ""]", LOG_OWNERSHIP)
 		else
 			to_chat(src, "<span class='danger'>Admins will not be automatically alerted, because you do not seem to be in a critical station role.</span>")
 	else


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/29939414/78508582-94bfb400-774d-11ea-9339-a01b52b1aeb7.png)

This is a response to this bounty: https://forums.yogstation.net/index.php?threads/5-antags-and-additional-limited-job-slots-using-the-afk-command-will-report-to-ahelp-ss13-server.21024/

## Overview

So I've tried to go a little bit above & beyond what the bounty request required, here.

The baseline would've been just to make Security and Antags do a bwoink when going AFK. I bothered to go a bit further, and add some extra functionality for some antag roles. Xenos get their own special IC message they shoot into the hivemind when going AFK, and Nukies/ERT/Deathsquad correctly shoot their messages to their correct, esoteric radio channels.

Also, attempting to suicide as an important role now gives a warning that doing so may be against the rules and that using the AFK verb is preferable. This should act as, at the very least, a soft barrier to the Captain suiciding. Regardless, there's also an entry in the admin log when the important role guy kills himself anyways, which should make noticing and responding to it easier.

## Coder Warnings

I've added a new proc, ``/mob/living/is_important()``, which returns TRUE if the player can be deemed "important to the game" programmatically. Right now it's only used by ``canSuicide()``, but I guess it could be used by something else, or expanded and complicated, as the need arises.

I want to note that *just* using ``special_role`` to determine whether someone is important (or even antag) is not sufficient; ERT and Xenos do not have a ``special_role`` AFAIK yet clearly should bwoink when going AFK. However, #8122 does indeed only use special_role, and so does not fully meet the criteria of this bounty request, per se.

## Changelog

:cl:  Altoids
rscadd: The AFK verb will now automatically ahelp if you go AFK as a Xeno, ERT, or most antagonists.
rscadd: The Suicide verb now warns people with important roles against suiciding.
/:cl:
