### PR TITLE
literally the easiest code job I've ever done on yogs, period (gives engiborgs light replacers with only one use before requiring more lights)

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -37,7 +37,6 @@
 #define LIGHT_BROKEN 2
 #define LIGHT_BURNED 3
 
-
 /obj/item/lightreplacer
 
 	name = "light replacer"
@@ -65,6 +64,15 @@
 	var/bulb_shards = 0
 	// when we get this many shards, we get a free bulb.
 	var/shards_required = 4
+
+
+//redds engiborg light replace because fuck you
+/obj/item/lightreplacer/cyborg/engineer
+	name = "engineering cyborg light replacer"
+	desc = "A device to automatically replace a single light. Refill with a broken or working light bulb, or a sheet of glass."
+	max_uses = 1
+	uses = 1
+	increment = 1
 
 /obj/item/lightreplacer/examine(mob/user)
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -314,7 +314,8 @@
 		/obj/item/stack/sheet/rglass/cyborg,
 		/obj/item/stack/rods/cyborg,
 		/obj/item/stack/tile/plasteel/cyborg,
-		/obj/item/stack/cable_coil/cyborg)
+		/obj/item/stack/cable_coil/cyborg,
+		/obj/item/lightreplacer/cyborg/engineer)
 	emag_modules = list(/obj/item/borg/stun)
 	ratvar_modules = list(
 		/obj/item/clockwork/slab/cyborg/engineer,


### PR DESCRIPTION
Gives engiborgs light replacers with one use before needing a refill.
See: https://github.com/yogstation13/Yogstation/pull/7986

#### Changelog

:cl:  
rscadd: engiborgs now have a light replacer with one use before needing refilled
/:cl:
