### PR TITLE
fix air alarm electronics not being constructable

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -195,7 +195,7 @@
 	category = list("initial", "Electronics")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
-/datum/design/airalarm_electronics
+/datum/design/acc_electronics
 	name = "Airlock Controller Electronics"
 	id = "aac_electronics"
 	build_type = AUTOLATHE | PROTOLATHE


### PR DESCRIPTION


:cl:  
bugfix: air alarm electronics are constructable again
/:cl:
