### PR TITLE
Preternis QoL Update(STOP FUCKING INJECTING ME MEDIBOT)

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -141,6 +141,7 @@
 #define TRAIT_SHELTERED			"sheltered"
 #define TRAIT_ONEWAYROAD		"one-way road"
 #define TRAIT_RANDOM_ACCENT		"random_accent"
+#define TRAIT_MEDICALIGNORE     "medical_ignore"
 
 //non-mob traits
 #define TRAIT_PARALYSIS			"paralysis" //Used for limb-based paralysis, where replacing the limb will fix it

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -355,6 +355,9 @@
 	if(emagged == 2) //Everyone needs our medicine. (Our medicine is toxins)
 		return TRUE
 
+	if(HAS_TRAIT(C,TRAIT_MEDICALIGNORE))
+		return FALSE
+
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C
 		if (H.wear_suit && H.head && istype(H.wear_suit, /obj/item/clothing) && istype(H.head, /obj/item/clothing))
@@ -362,6 +365,7 @@
 			var/obj/item/clothing/CH = H.head
 			if (CS.clothing_flags & CH.clothing_flags & THICKMATERIAL)
 				return FALSE // Skip over them if they have no exposed flesh.
+
 
 	if(declare_crit && C.health <= 0) //Critical condition! Call for help!
 		declare(C)

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -10,7 +10,7 @@ adjust_charge - take a positive or negative value to adjust the charge level
 	id = "preternis"
 	default_color = "FFFFFF"
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
-	inherent_traits = list(TRAIT_NOHUNGER,TRAIT_RADIMMUNE,TRAIT_MEDICALIGNORE) //Medical Ignore doesn't prevent basic treatment,only things that cannot help preternis,such as cryo and medbots
+	inherent_traits = list(TRAIT_NOHUNGER, TRAIT_RADIMMUNE, TRAIT_MEDICALIGNORE) //Medical Ignore doesn't prevent basic treatment,only things that cannot help preternis,such as cryo and medbots
 	species_traits = list(EYECOLOR,HAIR,LIPS)
 	say_mod = "intones"
 	attack_verb = "assault"

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -10,7 +10,7 @@ adjust_charge - take a positive or negative value to adjust the charge level
 	id = "preternis"
 	default_color = "FFFFFF"
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
-	inherent_traits = list(TRAIT_NOHUNGER,TRAIT_RADIMMUNE)
+	inherent_traits = list(TRAIT_NOHUNGER,TRAIT_RADIMMUNE,TRAIT_MEDICALIGNORE) //Medical Ignore doesn't prevent basic treatment,only things that cannot help preternis,such as cryo and medbots
 	species_traits = list(EYECOLOR,HAIR,LIPS)
 	say_mod = "intones"
 	attack_verb = "assault"


### PR DESCRIPTION
### Intent of your Pull Request
The last PR was a bit of a fuck-up but I took some feedback
Basically this PR aims at medibot trying to heal preternis which most of the time just od`s the preternis or forces you to move and it's honestly just really annoying.
Medibot doesn't try to heal you anymore as preternis and won't follow you around and OD you and generally spam chat and godamn I fucking hate medibots as preternis so much.
If medibot is emagged he will, of course, chase you to the ends of the earth.
Tested and seems to work.
Next PR will be probably preventing preternis from going into cryo(because its perma-stasis)
#### Changelog

:cl:  
tweak: Medibot does not try to actively pursue preternis unless emagged, goodbye OD`s and chat spam.
/:cl:
