### PR TITLE
Remove lag compensation from smooth movement

### DIFF
--- a/code/controllers/subsystem/time_track.dm
+++ b/code/controllers/subsystem/time_track.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(time_track)
 	name = "Time Tracking"
-	wait = 100
+	wait = 600
 	flags = SS_NO_INIT|SS_NO_TICK_CHECK
 	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT
 
@@ -31,7 +31,6 @@ SUBSYSTEM_DEF(time_track)
 		time_dilation_avg = MC_AVERAGE(time_dilation_avg, time_dilation_avg_fast)
 		time_dilation_avg_slow = MC_AVERAGE_SLOW(time_dilation_avg_slow, time_dilation_avg)
 		// okay it's kind of bothering me: byond_time vs byondtime. WTF tg?
-		GLOB.glide_size_multiplier = (current_byondtime - last_tick_byond_time) / (current_realtime - last_tick_realtime)
 	else
 		first_run = FALSE
 	last_tick_realtime = current_realtime


### PR DESCRIPTION
Wasn't sure about this lag compensation but it's definitely causing skipping, because most lag is lag spikes (like caused by BSQL and such), not continuous lag. Would rather have the occasional stepping than the occasional skipping