### PR TITLE
You can only vote for a map once per round

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -138,6 +138,7 @@ SUBSYSTEM_DEF(vote)
 			if("map")
 				SSmapping.changemap(global.config.maplist[.])
 				SSmapping.map_voted = TRUE
+				CONFIG_SET(flag/allow_vote_map, FALSE)
 	if(restart)
 		var/active_admins = 0
 		for(var/client/C in GLOB.admins)


### PR DESCRIPTION
Once the vote is passed, the option is disabled and cannot be used until next round or until an admin reenables it via the vote panel