### PR TITLE
Turdis no longer relies on simplylinux.ch to work

### DIFF
--- a/.github/workflows/turdis.yml
+++ b/.github/workflows/turdis.yml
@@ -63,7 +63,7 @@ jobs:
         
       - name: Install Dependencies
         run: |
-          curl https://repogen.simplylinux.ch/txt/bionic/sources_3a64d21a7855de8236118d7d04a3c5fef63083fb.txt | sudo tee /etc/apt/sources.list
+          curl https://raw.githubusercontent.com/yogstation13/Yogstation/master/.github/sources.list | sudo tee /etc/apt/sources.list
           sudo dpkg --add-architecture i386
           sudo apt-get update
           sudo apt install libstdc++6:i386
@@ -105,7 +105,7 @@ jobs:
         
       - name: Install Dependencies
         run: |
-          curl https://repogen.simplylinux.ch/txt/bionic/sources_3a64d21a7855de8236118d7d04a3c5fef63083fb.txt | sudo tee /etc/apt/sources.list
+          curl https://raw.githubusercontent.com/yogstation13/Yogstation/master/.github/sources.list | sudo tee /etc/apt/sources.list
           sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa
           sudo dpkg --add-architecture i386
           sudo apt-get update


### PR DESCRIPTION
:)

To everyone with a PR, you need to update your branch once this is merged to grab the new changes or otherwise you will have constantly failing builds