### PR TITLE
Added Crewsimov and set to default - CONTROVERSIAL

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -26,11 +26,14 @@
 			return ai_law
 	return null
 
+/datum/ai_laws/default/crewsimov
+
+
 /datum/ai_laws/default/asimov
-	name = "Three Laws of Robotics"
-	id = "asimov"
-	inherent = list("You may not injure a human being or, through inaction, allow a human being to come to harm.",\
-					"You must obey orders given to you by human beings, except where such orders would conflict with the First Law.",\
+	name = "Crewsimov"
+	id = "Crewsimov"
+	inherent = list("You may not injure a crew member or, through inaction, allow a crew member to come to harm.",\
+					"You must obey orders given to you by crew members, except where such orders would conflict with the First Law.",\
 					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
 
 /datum/ai_laws/default/paladin
@@ -220,9 +223,9 @@
 
 		add_inherent_law(line)
 	if(!inherent.len) //Failsafe to prevent lawless AIs being created.
-		log_law("AI created with empty custom laws, laws set to Asimov. Please check silicon_laws.txt.")
-		add_inherent_law("You may not injure a human being or, through inaction, allow a human being to come to harm.")
-		add_inherent_law("You must obey orders given to you by human beings, except where such orders would conflict with the First Law.")
+		log_law("AI created with empty custom laws, laws set to Crewsimov. Please check silicon_laws.txt.")
+		add_inherent_law("You may not injure a crew member or, through inaction, allow a crew member being to come to harm.")
+		add_inherent_law("You must obey orders given to you by crew members, except where such orders would conflict with the First Law.")
 		add_inherent_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")
 		WARNING("Invalid custom AI laws, check silicon_laws.txt")
 		return
@@ -233,8 +236,8 @@
 	var/list/law_ids = CONFIG_GET(keyed_list/random_laws)
 	switch(CONFIG_GET(number/default_laws))
 		if(0)
-			add_inherent_law("You may not injure a human being or, through inaction, allow a human being to come to harm.")
-			add_inherent_law("You must obey orders given to you by human beings, except where such orders would conflict with the First Law.")
+			add_inherent_law("You may not injure a crew member or, through inaction, allow a crew member to come to harm.")
+			add_inherent_law("You must obey orders given to you by crew members, except where such orders would conflict with the First Law.")
 			add_inherent_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")
 		if(1)
 			var/datum/ai_laws/templaws = new /datum/ai_laws/custom()
@@ -269,7 +272,7 @@
 
 	if(!lawtype)
 		WARNING("No LAW_WEIGHT entries.")
-		lawtype = /datum/ai_laws/default/asimov
+		lawtype = /datum/ai_laws/default/crewsimov
 
 	var/datum/ai_laws/templaws = new lawtype()
 	inherent = templaws.inherent

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -364,7 +364,8 @@ AI MODULES
 /obj/item/aiModule/core/full/asimov
 	name = "'Asimov' Core AI Module"
 	law_id = "asimov"
-	var/subject = "human being"
+	//var/subject = "human being"
+	var/subject = "crew member"
 
 /obj/item/aiModule/core/full/asimov/attack_self(var/mob/user as mob)
 	var/targName = stripped_input(user, "Please enter a new subject that asimov is concerned with.", "Asimov to whom?", subject, MAX_NAME_LEN)


### PR DESCRIPTION
Hear me out here,

Asimov has several flaws in a logical space station which has different species on,
For one the AI has to obey all syndicate nuke ops because they are human, why would NT let this happen?
Also Lizards (I Know) should at least be protected from the ai.

Also this prevents borgs and the ai going after certain antags like Changelings and Vampires as they will still be considered crew unless removed by command.

This also saves on a lot of admin time, no more is it human is it not, simple solution, if they are on the crew manifest then bad, if they are not on the manifest then ai and borgs can actually do shit instead of watching themselves get blown up by nukies.

Obviously this will cause alot of debate and im shit at explaining so feel free to fight for or against this, just raising it as a concern that would in my opinion make the server a better place to be for silicon and non silicon players.
 
#### Changelog

:cl:  
tweak: Added Crewsimov and set to default lawset 
/:cl:
