### PR TITLE
This is up for debate (Ash-walker Update)

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -575,7 +575,7 @@
 	if(istype(head, /obj/item/clothing/head/wizard) || istype(head, /obj/item/clothing/head/helmet/space/hardsuit/wizard))
 		threatcount += 2
 
-	//Check for nonhuman scum
+	//Check if nonhuman
 	if(dna && dna.species.id && dna.species.id != "human")
 		threatcount += 1
 
@@ -995,7 +995,7 @@
 
 /mob/living/carbon/human/species/golem/durathread
 	race = /datum/species/golem/durathread
-	
+
 /mob/living/carbon/human/species/golem/snow
 	race = /datum/species/golem/snow
 

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -45,7 +45,7 @@
 	name = "Ash Walker"
 	id = "ashlizard"
 	limbs_id = "lizard"
-	species_traits = list(MUTCOLORS,EYECOLOR,LIPS,DIGITIGRADE)
+	species_traits = list(MUTCOLORS,EYECOLOR,LIPS)
 	inherent_traits = list(TRAIT_NOGUNS) //yogs start - ashwalkers have special lungs and actually breathe
 	mutantlungs = /obj/item/organ/lungs/ashwalker
 	breathid = "n2" // yogs end


### PR DESCRIPTION
Ashwalkers can put on shoes because they cant craft the tribal shoes but cant put it on. I think thats dumb.

Oh and there was a unnecessary comment in the file i wad looking into that "may or may not oppress lizard people" so i fixed it

:cl:   
tweak: Allows ash walkers to put on the shoes they craft
spellcheck: Also fixed a bad comment
/:cl:
