### PR TITLE
Fixes clock cultists not being able to understand common when declaring war

### DIFF
--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -323,6 +323,12 @@ Key procs
 	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
 							/datum/language/machine = list(LANGUAGE_ATOM),)
 
+/datum/language_holder/clockwork
+	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
+								/datum/language/ratvar = list(LANGUAGE_ATOM),)
+	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
+							/datum/language/ratvar = list(LANGUAGE_ATOM),)
+
 /datum/language_holder/empty
 	understood_languages = list()
 	spoken_languages = list()

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -655,6 +655,7 @@
 	damage_overlay_type = "synth"
 	prefix = "Clockwork"
 	special_names = list("Remnant", "Relic", "Scrap", "Vestige") //RIP Ratvar
+	species_language_holder = /datum/language_holder/clockwork
 	var/has_corpse
 
 /datum/species/golem/clockwork/on_species_gain(mob/living/carbon/human/H)


### PR DESCRIPTION
This adds a language holder to clockwork golems because TGuinext didn't support clockwork golems (because TG doesn't have the Clockwork cult)

This bug only affects you if you have a second language before transforming (such as being a lizard or preternis)

![image](https://user-images.githubusercontent.com/24533979/79174598-c3c6cd00-7dc0-11ea-9765-36083a4c7e3a.png)


#### Changelog

:cl:  Hopek
rscadd: Makes clockwork golems compatible with tgUI's language holder system.
bugfix: fixed clock cult not understanding common after declaring war.
/:cl:
