### PR TITLE
Makes holotool a small item

### DIFF
--- a/yogstation/code/game/objects/items/holotool/holotool.dm
+++ b/yogstation/code/game/objects/items/holotool/holotool.dm
@@ -4,6 +4,7 @@
 	icon = 'yogstation/icons/obj/holotool.dmi'
 	icon_state = "holotool"
 	slot_flags = ITEM_SLOT_BELT
+	w_class = WEIGHT_CLASS_SMALL
 	usesound = 'sound/items/pshoom.ogg'
 	lefthand_file = 'yogstation/icons/mob/inhands/lefthand.dmi'
 	righthand_file = 'yogstation/icons/mob/inhands/righthand.dmi'


### PR DESCRIPTION
### Intent of your Pull Request

how is this any more useful than a toolbelt in its current state
shit fucking sucks just give it to the traitor theres no reason to have it
some of its functions dont even fully work so it's **worse** than just having a toolbelt
smh

anyways yeah this PR makes the holotool fit in your pocket just like the other tools, makes sense right?

#### Changelog

:cl:  
tweak: The experimental holotool is now a small item.
/:cl: