### PR TITLE
fix mechs being able to get negative health from repair droid

### DIFF
--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -251,7 +251,10 @@
 				chassis.clearInternalDamage(int_dam_flag)
 				repaired = 1
 				break
-	if(h_boost<0 || chassis.obj_integrity < chassis.max_integrity)
+	if(h_boost < 0)
+		chassis.take_damage(-h_boost)
+		repaired = 1
+	if(chassis.obj_integrity < chassis.max_integrity && h_boost > 0)
 		chassis.obj_integrity += min(h_boost, chassis.max_integrity-chassis.obj_integrity)
 		repaired = 1
 	if(repaired)


### PR DESCRIPTION


:cl:  
bugfix: mechs can no longer attain negative integrity and become immune to all damage
/:cl:
