### PR TITLE
Fixes eggpeople not being able to understand and speak common

### DIFF
--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -340,3 +340,9 @@ Key procs
 /datum/language_holder/mouse
 	understood_languages = list(/datum/language/mouse = list(LANGUAGE_ATOM))
 	spoken_languages = list(/datum/language/mouse = list(LANGUAGE_ATOM))
+
+/datum/language_holder/egg
+	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
+								/datum/language/egg = list(LANGUAGE_ATOM),)
+	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
+							/datum/language/egg = list(LANGUAGE_ATOM),)

--- a/code/modules/mob/living/carbon/human/species_types/eggpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/eggpeople.dm
@@ -24,7 +24,7 @@
 	disliked_food = GROSS | DAIRY | EGG
 	liked_food = MEAT // Eggpeople are carnivores.
 	screamsound = 'yogstation/sound/voice/eggperson/egg_scream.ogg' // (Hopefully) the sound of an egg cracking
-	species_language_holder = /datum/language/egg
+	species_language_holder = /datum/language_holder/egg
 
 /datum/species/egg/apply_damage(damage, damagetype = BRUTE, def_zone = null, blocked, mob/living/carbon/human/H)
 	if(damagetype == BRUTE) // Dynamic brute resist based on burn damage. The more fried the egg, the harder the shell!!


### PR DESCRIPTION
Adds a language holder for egg people because for some reason there was only a single language where the holder should be and the holder didn't exist.

Nice.

#### Changelog

:cl:  Hopek
rscadd: Added a language holder for Eggpeople meaning that they can now understand common instead of only Ovarian
/:cl:
