### PR TITLE
Synthflesh only works on corpses

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -389,9 +389,7 @@
 	color = "#FFEBEB"
 
 /datum/reagent/medicine/synthflesh/reaction_mob(mob/living/M, method=TOUCH, reac_volume,show_message = 1)
-	if(iscarbon(M))
-		if (M.stat == DEAD)
-			show_message = 0
+	if(iscarbon(M) && M.stat == DEAD)
 		if(method in list(PATCH, TOUCH))
 			M.adjustBruteLoss(-1.25 * reac_volume)
 			M.adjustFireLoss(-1.25 * reac_volume)


### PR DESCRIPTION
Synthflesh right now works like a ranged pre-nerf legion cores except you can make infinite amounts of them and load them with beakers to splash people.

This at the moment functions like an instant aheal.

Synthflesh's purpose is to fix dead bodies to be able to do other things to them with other chems.

With this change, other chems have a chance to be useful instead of just using synthflesh in healing.

#### Changelog

:cl:  
tweak: Snythflesh now only works on corpses per its original intent instead of being a ranged instant heal.
/:cl:
