### PR TITLE
Fixes Chlorine Trifluoride deleting reinforced walls

### DIFF
--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -60,6 +60,8 @@
 					new /obj/effect/hotspot(F)
 	if(iswallturf(T))
 		var/turf/closed/wall/W = T
+		if(istype(T, /turf/closed/wall/r_wall))
+			return
 		if(prob(reac_volume))
 			W.ScrapeAway()
 


### PR DESCRIPTION
The code currently just straight up deletes reinforced walls lmao

![image](https://user-images.githubusercontent.com/24533979/79627469-1de7cb00-80fe-11ea-803f-195749d1dae2.png)



#### Changelog

:cl:  
bugfix: clf3 no longer deletes reinforced walls
/:cl:
