### PR TITLE
Removes the reinforced chromazone from the game

### DIFF
--- a/code/game/objects/items/chromosome.dm
+++ b/code/game/objects/items/chromosome.dm
@@ -75,18 +75,3 @@
 	desc = "A chromosome that reduces cooldown on action based mutations by 50%."
 	icon_state = "energy"
 	energy_coeff = 0.5
-
-/obj/item/chromosome/reinforcer
-	name = "reinforcement chromosome"
-	desc = "Renders the mutation immune to mutadone."
-	icon_state = "reinforcer"
-	weight = 3
-
-/obj/item/chromosome/reinforcer/can_apply(datum/mutation/human/HM)
-	if(!HM || !(HM.can_chromosome == CHROMOSOME_NONE))
-		return FALSE
-	return !HM.mutadone_proof
-
-/obj/item/chromosome/reinforcer/apply(datum/mutation/human/HM)
-	HM.mutadone_proof = TRUE
-	..()


### PR DESCRIPTION
Really experienced gene mains are telling me this is the only real OP part of Gene that is abused.

"90% of people dont know how to remove reinforced genes causing a select few to be able to abuse them. if genetics console is destroyed it becomes unremovable. mutadone does not cure a reinforced gene" - puremanbird (one of those gene mains)

#### Changelog
:cl:  Hopek
rscdel: Sent reinforced chromazone to the shadow realm
/:cl:
