### PR TITLE
Restores immersion by removing healing holopara's ability to heal mac…

### DIFF
--- a/yogstation/code/modules/guardian/abilities/major/healing.dm
+++ b/yogstation/code/modules/guardian/abilities/major/healing.dm
@@ -28,10 +28,10 @@
 		if(isliving(target))
 			var/mob/living/L = target
 			guardian.do_attack_animation(L)
-			L.adjustBruteLoss(-(master_stats.potential * 1.5), forced = TRUE)
-			L.adjustFireLoss(-(master_stats.potential * 1.5), forced = TRUE)
-			L.adjustOxyLoss(-(master_stats.potential * 1.5), forced = TRUE)
-			L.adjustToxLoss(-(master_stats.potential * 1.5), forced = TRUE)
+			L.adjustBruteLoss(-(master_stats.potential * 1.5))
+			L.adjustFireLoss(-(master_stats.potential * 1.5))
+			L.adjustOxyLoss(-(master_stats.potential * 1.5))
+			L.adjustToxLoss(-(master_stats.potential * 1.5))
 			var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal(get_turf(L))
 			if(guardian.namedatum)
 				H.color = guardian.namedatum.colour


### PR DESCRIPTION
Fixes #8220 by removing a part of #7999

Healing holoparas should not be able to heal machines or silicons, androids, preternis or whatever.
This is immersion-breaking.

#### Changelog

:cl:  
bugfix: Healing holoparas can't heal machines again as intended.
/:cl:
