### PR TITLE
Military is no longer a gender

### DIFF
--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -100,7 +100,7 @@
 
 	last_announcement = message
 
-	var/voxType = input(src, "Male, female, or military VOX?", "VOX-gender") in list("male", "female", "military") //yogs - male vox
+	var/voxType = input(src, "Which voice?", "VOX") in list("Victor", "Verity", "Oscar") //Victor is vox_sounds_male, Verity is vox_sounds, Oscar is vox_sounds_military
 
 	if(!message || announcing_vox > world.time)
 		return
@@ -123,11 +123,11 @@
 		if(!word)
 			words -= word
 			continue
-		if(!GLOB.vox_sounds[word] && voxType == "female") //yogs start - male vox
+		if(!GLOB.vox_sounds[word] && voxType == "Verity") //yogs start - male vox
 			incorrect_words += word
-		if(!GLOB.vox_sounds_male[word] && voxType == "male")
+		if(!GLOB.vox_sounds_male[word] && voxType == "Victor")
 			incorrect_words += word  //yogs end- male vox
-		if(!GLOB.vox_sounds_military[word] && voxType == "military")
+		if(!GLOB.vox_sounds_military[word] && voxType == "Oscar")
 			incorrect_words += word
 
 	if(incorrect_words.len)
@@ -142,17 +142,17 @@
 		play_vox_word(word, src.z, null, voxType) //yogs - male vox
 
 
-/proc/play_vox_word(word, z_level, mob/only_listener, voxType = "female", pitch = 0) // Yogs -- Pitch variation
+/proc/play_vox_word(word, z_level, mob/only_listener, voxType = "Verity", pitch = 0) // Yogs -- Pitch variation
 
 	word = lowertext(word)
 
-	if( (GLOB.vox_sounds[word] && voxType == "female") || (GLOB.vox_sounds_male[word] &&voxType == "male") || (GLOB.vox_sounds_military[word] &&voxType == "military") ) //yogs - male vox
+	if( (GLOB.vox_sounds[word] && voxType == "Verity") || (GLOB.vox_sounds_male[word] &&voxType == "Victor") || (GLOB.vox_sounds_military[word] &&voxType == "Oscar") ) //yogs - male vox
 
 		var/sound_file //yogs start - male vox
 
-		if(voxType == "female")
+		if(voxType == "Verity")
 			sound_file = GLOB.vox_sounds[word]
-		else if(voxType == "male")
+		else if(voxType == "Victor")
 			sound_file = GLOB.vox_sounds_male[word] //yogs end - male vox
 		else
 			sound_file = GLOB.vox_sounds_military[word]

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -100,7 +100,7 @@
 
 	last_announcement = message
 
-	var/voxType = input(src, "Which voice?", "VOX") in list("Victor", "Verity", "Oscar") //Victor is vox_sounds_male, Verity is vox_sounds, Oscar is vox_sounds_military
+	var/voxType = input(src, "Which voice?", "VOX") in list("Victor (male)", "Verity (female)", "Oscar (military)") //Victor is vox_sounds_male, Verity is vox_sounds, Oscar is vox_sounds_military
 
 	if(!message || announcing_vox > world.time)
 		return
@@ -123,11 +123,11 @@
 		if(!word)
 			words -= word
 			continue
-		if(!GLOB.vox_sounds[word] && voxType == "Verity") //yogs start - male vox
+		if(!GLOB.vox_sounds[word] && voxType == "Verity (female)") //yogs start - male vox
 			incorrect_words += word
-		if(!GLOB.vox_sounds_male[word] && voxType == "Victor")
+		if(!GLOB.vox_sounds_male[word] && voxType == "Victor (male)")
 			incorrect_words += word  //yogs end- male vox
-		if(!GLOB.vox_sounds_military[word] && voxType == "Oscar")
+		if(!GLOB.vox_sounds_military[word] && voxType == "Oscar (military)")
 			incorrect_words += word
 
 	if(incorrect_words.len)
@@ -142,17 +142,17 @@
 		play_vox_word(word, src.z, null, voxType) //yogs - male vox
 
 
-/proc/play_vox_word(word, z_level, mob/only_listener, voxType = "Verity", pitch = 0) // Yogs -- Pitch variation
+/proc/play_vox_word(word, z_level, mob/only_listener, voxType = "Verity (female)", pitch = 0) // Yogs -- Pitch variation
 
 	word = lowertext(word)
 
-	if( (GLOB.vox_sounds[word] && voxType == "Verity") || (GLOB.vox_sounds_male[word] &&voxType == "Victor") || (GLOB.vox_sounds_military[word] &&voxType == "Oscar") ) //yogs - male vox
+	if( (GLOB.vox_sounds[word] && voxType == "Verity (female)") || (GLOB.vox_sounds_male[word] &&voxType == "Victor (male)") || (GLOB.vox_sounds_military[word] &&voxType == "Oscar (military)") ) //yogs - male vox
 
 		var/sound_file //yogs start - male vox
 
-		if(voxType == "Verity")
+		if(voxType == "Verity (female)")
 			sound_file = GLOB.vox_sounds[word]
-		else if(voxType == "Victor")
+		else if(voxType == "Victor (male)")
 			sound_file = GLOB.vox_sounds_male[word] //yogs end - male vox
 		else
 			sound_file = GLOB.vox_sounds_military[word]

--- a/yogstation/code/modules/admin/verbs/adminvox.dm
+++ b/yogstation/code/modules/admin/verbs/adminvox.dm
@@ -14,7 +14,7 @@
 	if(!message)
 		return
 
-	var/voxType = input(src, "Which voice?", "VOX") in list("Victor", "Verity", "Oscar")
+	var/voxType = input(src, "Which voice?", "VOX") in list("Victor (male)", "Verity (female)", "Oscar (military)")
 
 
 	var/list/words = splittext(trim(message), " ")//Turns the received text into an array of words
@@ -26,13 +26,13 @@
 		words.len = 30
 
 	var/list/voxlist
-	if(voxType == "Verity") // The if for this is OUTSIDE the for-loop, for optimization.
+	if(voxType == "Verity (female)") // The if for this is OUTSIDE the for-loop, for optimization.
 		//Putting it inside makes it check for it every single damned time it parses a word,
 		//Which might be super shitty if someone removes the length limit above at some point.
 		voxlist = GLOB.vox_sounds
-	else if(voxType == "Victor") // If we're doing the yog-ly male AI vox voice
+	else if(voxType == "Victor (male)") // If we're doing the yog-ly male AI vox voice
 		voxlist = GLOB.vox_sounds_male
-	else if(voxType == "Oscar") // If we're doing the also yog-ly male AI vox voice but from Black Mesa
+	else if(voxType == "Oscar (military)") // If we're doing the also yog-ly male AI vox voice but from Black Mesa
 		voxlist = GLOB.vox_sounds_military
 	else
 		to_chat(src,"<span class='notice'>Unknown or unsupported vox type. Yell at a coder about this.</span>", confidential=TRUE)

--- a/yogstation/code/modules/admin/verbs/adminvox.dm
+++ b/yogstation/code/modules/admin/verbs/adminvox.dm
@@ -14,7 +14,7 @@
 	if(!message)
 		return
 
-	var/voxType = input(src, "Male, female, or military VOX?", "VOX-gender") in list("male", "female", "military")
+	var/voxType = input(src, "Which voice?", "VOX") in list("Victor", "Verity", "Oscar")
 
 
 	var/list/words = splittext(trim(message), " ")//Turns the received text into an array of words
@@ -26,13 +26,13 @@
 		words.len = 30
 
 	var/list/voxlist
-	if(voxType == "female") // The if for this is OUTSIDE the for-loop, for optimization.
+	if(voxType == "Verity") // The if for this is OUTSIDE the for-loop, for optimization.
 		//Putting it inside makes it check for it every single damned time it parses a word,
 		//Which might be super shitty if someone removes the length limit above at some point.
 		voxlist = GLOB.vox_sounds
-	else if(voxType == "male") // If we're doing the yog-ly male AI vox voice
+	else if(voxType == "Victor") // If we're doing the yog-ly male AI vox voice
 		voxlist = GLOB.vox_sounds_male
-	else if(voxType == "military") // If we're doing the also yog-ly male AI vox voice but from Black Mesa
+	else if(voxType == "Oscar") // If we're doing the also yog-ly male AI vox voice but from Black Mesa
 		voxlist = GLOB.vox_sounds_military
 	else
 		to_chat(src,"<span class='notice'>Unknown or unsupported vox type. Yell at a coder about this.</span>", confidential=TRUE)


### PR DESCRIPTION
Currently whenever VOX is pulled up a prompt asks the user which gender VOX they want: male, female, or military. Since this is an issue I thought I might as well give them actual names instead of making this only get weirder if even more voices get added.

NAME CHANGES:

**male** is now **Victor**
**female** is now **Verity**
**military** is now **Oscar**

The previous name will remain in parenthesizes for the time being and I'll eventually remove them entirely so that people aren't confused.

For an explanation of the names, Verity and Victor are both names of AI cockpit assistants you choose for your ship in _Elite Dangerous_, Verity being the default and once only assistant, Victor becoming the first free one added, while Oscar is the letter "O" in the NATO alphabet and sounded more fitting than Mike.

I'm not too attached to the names (minus Oscar) so feel free to suggest better ones if you want to.


:cl:  
tweak: VOX voices now have names. Male is Victor, Female is Verity, Military is Oscar
/:cl:
