### PR TITLE
Makes felinids enjoy raw food

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -11,6 +11,9 @@
 	mutanttail = /obj/item/organ/tail/cat
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 
+	disliked_food = JUNKFOOD | VEGETABLES | FRUIT
+	liked_food = GROSS | MEAT | RAW
+	
 /datum/species/human/felinid/qualifies_for_rank(rank, list/features)
 	return TRUE
 


### PR DESCRIPTION
### Intent of your Pull Request
It's in the title, it never made much sense to me that literal catpeople are disgusted by eating mice and raw meat. Balanced it out by making them hate vegetables, fruits and junkfood.

#### Changelog
:cl:  
tweak: Felinids now enjoy raw food and dislike veggies
/:cl:
