### PR TITLE
completely changes Rev meta

### DIFF
--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -233,7 +233,7 @@
 		H.dna.remove_mutation(CLOWNMUT)
 
 	if(give_flash)
-		var/obj/item/assembly/flash/T = new(H)
+		var/obj/item/assembly/flash/handheld/T = new(H)
 		var/list/slots = list (
 			"backpack" = SLOT_IN_BACKPACK,
 			"left pocket" = SLOT_L_STORE,
@@ -338,7 +338,7 @@
 			SSachievements.unlock_achievement(/datum/achievement/greentext/revolution,M.current.client)
 			if(M.has_antag_datum(/datum/antagonist/rev/head))
 				SSachievements.unlock_achievement(/datum/achievement/greentext/revolution/head,M.current.client)
-	
+
 	if(headrevs.len)
 		var/list/headrev_part = list()
 		headrev_part += "<span class='header'>The head revolutionaries were:</span>"


### PR DESCRIPTION
### Intent of your Pull Request

Fixes being able to test for revs by trying to put a rev-spawned flash into a security belt. Revs spawn with a version of a flash that is completely identical to every other flash but for some reason didn't fit in belts.

#### Changelog

:cl:  
tweak: makes head rev flashes the same as every other flash
/:cl:
