### PR TITLE
[admin] quick Mulligan in the equipment screen

### DIFF
--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -239,3 +239,12 @@
 			implants += imptype
 	accessory = text2path(outfit_data["accessory"])
 	return TRUE
+
+
+/datum/outfit/mulligan
+	name = "a Mulligan"
+
+/datum/outfit/mulligan/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	var/mob/living/carbon/human/M = H
+	randomize_human(M)

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -242,7 +242,7 @@
 
 
 /datum/outfit/mulligan
-	name = "a Mulligan"
+	name = "a Mulligan (Naked)"
 
 /datum/outfit/mulligan/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24533979/79807803-98e4f780-8331-11ea-82ca-827d0b3a5bd8.png)

The new "a Mulligan" option to quickly spawn yourself or others in as a randomized individual.

I have thought of needing an easy tool like this for a while so we can spawn as a generic centcom individual, quickly bus someone in as a random character instead of their IC etc.

#### Changelog

:cl:  Hopek
rscadd: Added the ability to quickly spawn as a randomized character via the "Select Equipment" right-click menu.
/:cl:
