### PR TITLE
Buff vampire early game by making Hypnotize free to use

### DIFF
--- a/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -103,10 +103,11 @@
 
 
 /obj/effect/proc_holder/spell/targeted/hypnotise
-	name = "Hypnotize (20)"
+	name = "Hypnotize"
 	desc= "A piercing stare that incapacitates your victim for a good length of time."
 	action_icon_state = "hypnotize"
-	blood_used = 20
+	blood_used = 0
+	charge_max = 1500
 	action_icon = 'yogstation/icons/mob/vampire.dmi'
 	action_background_icon_state = "bg_demon"
 	vamp_req = TRUE


### PR DESCRIPTION
### Intent of your Pull Request

Intent is to buff vampire early game by making hypnotize accessible before attacking people to gain blood, making a stealthier tactic more viable. 
Balanced with a long cooldown on each use. 
Tested it locally on a private server, noticed no issues

**Maintainer edit: // TL;DR : Makes the Hypnotize stun spell free to use with no blood requirements //**

#### Changelog

:cl:  
tweak: tweaks a vamp core ability to buff early game and make stealth more viable
rscdel: Removed blood cost of vampire hypnotize
rscadd: Added a long cooldown on each usage of hypnotize
/:cl:
