### PR TITLE
Fixes typo and an indenting error that caused ERT leaders to very technically be able to murder

### DIFF
--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -144,7 +144,7 @@
 	else
 		missiondesc += " Follow orders given to you by your squad leader."
 
-		missiondesc += "Avoid civilian casualites when possible."
+	missiondesc += "Avoid civilian casualites when possible."
 
 	missiondesc += "<BR><B>Your Mission</B> : [ert_team.mission.explanation_text]"
 	to_chat(owner,missiondesc)

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -144,7 +144,7 @@
 	else
 		missiondesc += " Follow orders given to you by your squad leader."
 
-	missiondesc += "Avoid civilian casualites when possible."
+	missiondesc += "Avoid civilian casualties when possible."
 
 	missiondesc += "<BR><B>Your Mission</B> : [ert_team.mission.explanation_text]"
 	to_chat(owner,missiondesc)


### PR DESCRIPTION
Leaders don't get the "Avoid civilian casualties when possible." objective because someone messed up and forgot to remove a tab.

Also; "casualties" was misspelled.

#### Changelog

:cl:  
bugfix: ERT leaders now get told to avoid civilian casualties when possible. Also fixed a typo
/:cl:
