### PR TITLE
increase engiborg stunprod arm cost

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -8,7 +8,7 @@
 /obj/item/borg/stun
 	name = "electrically-charged arm"
 	icon_state = "elecarm"
-	var/charge_cost = 30
+	var/charge_cost = 750
 
 /obj/item/borg/stun/attack(mob/living/M, mob/living/user)
 	if(ishuman(M))


### PR DESCRIPTION
less than a stunbaton at 1000 but more than a peacekeeper borg's stun attack at 500.
:cl:  
tweak: emagged engiborg stun arm cell cost per use 750 from 30 
/:cl:
