### PR TITLE
Simplemobs now get rid of slur damage

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -148,6 +148,8 @@
 	..()
 	if(stuttering)
 		stuttering = 0
+	if(slurring)
+		slurring = max(slurring-1,0)
 
 /mob/living/simple_animal/proc/handle_automated_action()
 	set waitfor = FALSE


### PR DESCRIPTION
For some reason, simplemobs never got rid of slur damage, so whenever they got any slur damage theyd be permanently slurring.

I guess no-one expected slimes to get drunk??

Also fixes issue 7710