### PR TITLE
Stimulants stamina damage heal buff (5->30)

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -935,7 +935,7 @@
 		M.adjustBruteLoss(-1*REM, 0)
 		M.adjustFireLoss(-1*REM, 0)
 	M.AdjustAllImmobility(-60, FALSE)
-	M.adjustStaminaLoss(-5*REM, 0)
+	M.adjustStaminaLoss(-30*REM, 0)
 	..()
 	. = 1
 


### PR DESCRIPTION
### Intent of your Pull Request

#### Changelog

:cl:  
tweak: Stimulants now erase stamina damage as effectively as they reduce stun times
/:cl:
