### PR TITLE
Peach can tweak

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_other.dm
+++ b/code/modules/food_and_drinks/food/snacks_other.dm
@@ -549,7 +549,7 @@
 
 /obj/item/reagent_containers/food/snacks/cannedpeaches
 	name = "Canned Peaches"
-	desc = "Just a nice can of ripe peaches swimming in their own juices."
+	desc = "A nice can of ripe peaches swimming in their own juices, somehow left untouched."
 	icon_state = "peachcan"
 	grind_results = null
 	juice_results = list(/datum/reagent/consumable/peachjuice = 20, /datum/reagent/consumable/sugar = 8, /datum/reagent/consumable/nutriment = 2)
@@ -560,7 +560,7 @@
 
 /obj/item/reagent_containers/food/snacks/cannedpeaches/maint
 	name = "Maintenance Peaches"
-	desc = "I have a mouth and I must eat."
+	desc = "A can of peaches, perhaps stashed here long ago to hide them from the wizards."
 	icon_state = "peachcanmaint"
 	tastes = list("peaches" = 1, "tin" = 7)
 

--- a/code/modules/food_and_drinks/food/snacks_other.dm
+++ b/code/modules/food_and_drinks/food/snacks_other.dm
@@ -551,7 +551,8 @@
 	name = "Canned Peaches"
 	desc = "Just a nice can of ripe peaches swimming in their own juices."
 	icon_state = "peachcan"
-	list_reagents = list(/datum/reagent/consumable/peachjuice = 20, /datum/reagent/consumable/sugar = 8, /datum/reagent/consumable/nutriment = 2)
+	grind_results = null
+	juice_results = list(/datum/reagent/consumable/peachjuice = 20, /datum/reagent/consumable/sugar = 8, /datum/reagent/consumable/nutriment = 2)
 	filling_color = "#ffdf26"
 	w_class = WEIGHT_CLASS_NORMAL
 	tastes = list("peaches" = 7, "tin" = 1)


### PR DESCRIPTION
### Intent of your Pull Request

Tweak canned peaches to be juiced instead of ground. Also make some flavor text changes to hint at some rarity of peaches due to wizards.

The secret, true purpose of this PR is for me to get my feet wet. Based on [this forum post](https://forums.yogstation.net/index.php?threads/helpfulherbert-adjust-peach-handling-in-context-of-drinkmixing.21017/). The post recommends accompanying wiki changes, for which I have begun the registration process.

The wiki changes **would be** to the [guide to drinks entry on peach juice](https://wiki.yogstation.net/wiki/Guide_to_drinks#peach_juice), specifically changing "To acquire" from "Grind a can of Maintenance Peaches" to "Juice a can of Maintenance Peaches".

Maybe the peach juice description should be changed as well, but I'm not so sure about that as it would theoretically only come up after already finding a can of peaches. On the other hand, a little more information on rarity is requested in the forum post, and the description of peach juice would be the place to put that on the wiki.

#### Changelog

:cl:Negative_robustness  
tweak: canned peaches and maint peaches now need to be juiced, not ground, to get peach juice  
/:cl:
