### PR TITLE
Removes OD risk on cigars

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -400,7 +400,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_off = "cigar2off"
 	smoketime = 600 // 20 minutes
 	chem_volume = 80
-	list_reagents =list(/datum/reagent/drug/nicotine = 40)
+	list_reagents =list(/datum/reagent/drug/nicotine = 35)
 
 /obj/item/clothing/mask/cigarette/cigar/havana
 	name = "premium Havanian cigar"


### PR DESCRIPTION
### Intent of your Pull Request
Before : Cohiba Robusto cigar would overdose you 100% of the time if smoked from start to finish

Now : doesn't.

#### Changelog

:cl:  
tweak: Cigars no longer OD
/:cl:
