### PR TITLE
ports "Cardboard cutouts now use a radial menu to choose their skins #50617" from tg

### DIFF
--- a/code/game/objects/items/cardboard_cutouts.dm
+++ b/code/game/objects/items/cardboard_cutouts.dm
@@ -6,17 +6,36 @@
 	icon_state = "cutout_basic"
 	w_class = WEIGHT_CLASS_BULKY
 	resistance_flags = FLAMMABLE
-	// Possible restyles for the cutout;
-	// add an entry in change_appearance() if you add to here
-	var/list/possible_appearances = list("Assistant", "Clown", "Mime",
-		"Traitor", "Nuke Op", "Cultist", "Clockwork Cultist",
-		"Revolutionary", "Wizard", "Shadowling", "Xenomorph", "Xenomorph Maid", "Swarmer",
-		"Ash Walker", "Deathsquad Officer", "Ian", "Slaughter Demon",
-		"Laughter Demon", "Private Security Officer")
-	var/pushed_over = FALSE //If the cutout is pushed over and has to be righted
-	var/deceptive = FALSE //If the cutout actually appears as what it portray and not a discolored version
+	/// Possible restyles for the cutout, add an entry in change_appearance() if you add to here
+	var/list/possible_appearances = list()
+	/// If the cutout is pushed over and has to be righted
+	var/pushed_over = FALSE
+	/// If the cutout actually appears as what it portray and not a discolored version
+	var/deceptive = FALSE
 
-	var/lastattacker = null
+/obj/item/cardboard_cutout/Initialize()
+	. = ..()
+	possible_appearances = sortList(list(
+		"Assistant" = image(icon = src.icon, icon_state = "cutout_greytide"),
+		"Clown" = image(icon = src.icon, icon_state = "cutout_clown"),
+		"Mime" = image(icon = src.icon, icon_state = "cutout_mime"),
+		"Traitor" = image(icon = src.icon, icon_state = "cutout_traitor"),
+		"Nuke Op" = image(icon = src.icon, icon_state = "cutout_fluke"),
+		"Cultist" = image(icon = src.icon, icon_state = "cutout_cultist"),
+		"Clockwork Cultist" = image(icon = src.icon, icon_state = "cutout_servant"),
+		"Revolutionary" = image(icon = src.icon, icon_state = "cutout_viva"),
+		"Wizard" = image(icon = src.icon, icon_state = "cutout_wizard"),
+		"Shadowling" = image(icon = src.icon, icon_state = "cutout_shadowling"),
+		"Xenomorph" = image(icon = src.icon, icon_state = "cutout_fukken_xeno"),
+		"Xenomorph Maid" = image(icon = src.icon, icon_state = "cutout_lusty"),
+		"Swarmer" = image(icon = src.icon, icon_state = "cutout_swarmer"),
+		"Ash Walker" = image(icon = src.icon, icon_state = "cutout_free_antag"),
+		"Deathsquad Officer" = image(icon = src.icon, icon_state = "cutout_deathsquad"),
+		"Ian" = image(icon = src.icon, icon_state = "cutout_ian"),
+		"Slaughter Demon" = image(icon = 'icons/mob/mob.dmi', icon_state = "daemon"),
+		"Laughter Demon" = image(icon = 'icons/mob/mob.dmi', icon_state = "bowmon"),
+		"Private Security Officer" = image(icon = src.icon, icon_state = "cutout_ntsec")
+	))
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/item/cardboard_cutout/attack_hand(mob/living/user)
@@ -76,22 +95,22 @@
 		push_over()
 	return BULLET_ACT_HIT
 
+/**
+  * change_appearance: Changes a skin of the cardboard cutout based on a user's choice
+  *
+  * Arguments:
+  * * crayon The crayon used to change and recolor the cardboard cutout
+  * * user The mob choosing a skin of the cardboard cutout
+  */
+
 /obj/item/cardboard_cutout/proc/change_appearance(obj/item/toy/crayon/crayon, mob/living/user)
-	if(!crayon || !user)
-		return
-	if(pushed_over)
-		to_chat(user, "<span class='warning'>Right [src] first!</span>")
-		return
-	if(crayon.check_empty(user))
-		return
-	if(crayon.is_capped)
-		to_chat(user, "<span class='warning'>Take the cap off first!</span>")
-		return
-	var/new_appearance = input(user, "Choose a new appearance for [src].", "26th Century Deception") as null|anything in possible_appearances
-	if(!new_appearance || !crayon || !user.canUseTopic(src, BE_CLOSE))
-		return
+	var/new_appearance = show_radial_menu(user, src, possible_appearances, custom_check = CALLBACK(src, .proc/check_menu, user, crayon), radius = 36, require_near = TRUE)
+	if(!new_appearance)
+		return FALSE
 	if(!do_after(user, 10, FALSE, src, TRUE))
-		return
+		return FALSE
+	if(!check_menu(user, crayon))
+		return FALSE
 	user.visible_message("<span class='notice'>[user] gives [src] a new look.</span>", "<span class='notice'>Voila! You give [src] a new look.</span>")
 	crayon.use_charges(1)
 	crayon.check_empty(user)
@@ -180,7 +199,33 @@
 			name = "Private Security Officer"
 			desc = "A cardboard cutout of a private security officer."
 			icon_state = "cutout_ntsec"
-	return 1
+		else
+			return FALSE
+	return TRUE
+
+/**
+  * check_menu: Checks if we are allowed to interact with a radial menu
+  *
+  * Arguments:
+  * * user The mob interacting with a menu
+  * * crayon The crayon used to interact with a menu
+  */
+/obj/item/cardboard_cutout/proc/check_menu(mob/living/user, obj/item/toy/crayon/crayon)
+	if(!istype(user))
+		return FALSE
+	if(user.incapacitated())
+		return FALSE
+	if(pushed_over)
+		to_chat(user, "<span class='warning'>Right [src] first!</span>")
+		return FALSE
+	if(!crayon || !user.is_holding(crayon))
+		return FALSE
+	if(crayon.check_empty(user))
+		return FALSE
+	if(crayon.is_capped)
+		to_chat(user, "<span class='warning'>Take the cap off first!</span>")
+		return FALSE
+	return TRUE
 
 /obj/item/cardboard_cutout/setDir(newdir)
 	dir = SOUTH

--- a/code/game/objects/items/cardboard_cutouts.dm
+++ b/code/game/objects/items/cardboard_cutouts.dm
@@ -6,12 +6,9 @@
 	icon_state = "cutout_basic"
 	w_class = WEIGHT_CLASS_BULKY
 	resistance_flags = FLAMMABLE
-	/// Possible restyles for the cutout, add an entry in change_appearance() if you add to here
-	var/list/possible_appearances = list()
-	/// If the cutout is pushed over and has to be righted
-	var/pushed_over = FALSE
-	/// If the cutout actually appears as what it portray and not a discolored version
-	var/deceptive = FALSE
+	var/list/possible_appearances = list() // Possible restyles for the cutout, add an entry in change_appearance() if you add to here
+	var/pushed_over = FALSE // If the cutout is pushed over and has to be righted
+	var/deceptive = FALSE // If the cutout actually appears as what it portray and not a discolored version
 
 /obj/item/cardboard_cutout/Initialize()
 	. = ..()
@@ -95,12 +92,12 @@
 		push_over()
 	return BULLET_ACT_HIT
 
-/**
-  * change_appearance: Changes a skin of the cardboard cutout based on a user's choice
-  *
-  * Arguments:
-  * * crayon The crayon used to change and recolor the cardboard cutout
-  * * user The mob choosing a skin of the cardboard cutout
+  /*
+  change_appearance: Changes a skin of the cardboard cutout based on a user's choice
+  
+  Arguments:
+  crayon : The crayon used to change and recolor the cardboard cutout
+  user : The mob choosing a skin of the cardboard cutout
   */
 
 /obj/item/cardboard_cutout/proc/change_appearance(obj/item/toy/crayon/crayon, mob/living/user)
@@ -203,12 +200,12 @@
 			return FALSE
 	return TRUE
 
-/**
-  * check_menu: Checks if we are allowed to interact with a radial menu
-  *
-  * Arguments:
-  * * user The mob interacting with a menu
-  * * crayon The crayon used to interact with a menu
+  /*
+  check_menu: Checks if we are allowed to interact with a radial menu
+  
+  Arguments:
+  user : The mob interacting with a menu
+  crayon : The crayon used to interact with a menu
   */
 /obj/item/cardboard_cutout/proc/check_menu(mob/living/user, obj/item/toy/crayon/crayon)
 	if(!istype(user))


### PR DESCRIPTION
### About The Pull Request

Switches the "adaptive" cardboard cutouts from a list selection menu to a radial selection menu, similar to that of a borg or RCD (doors).

All credit to Arkatos1, they did the original work, I'm just porting it to here.

Example GIF:
![tglWKdAJeA](https://user-images.githubusercontent.com/49619518/80229347-2318ae80-8605-11ea-8322-028d75064036.gif)


#### Changelog

:cl:  Arkatos
rscadd: Cardboard cutouts now use a radial menu to choose their skins.
/:cl:
