### PR TITLE
Adds allergic reactions to chems

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -170,6 +170,7 @@
 #define TRAIT_LIGHT_DRINKER		"light_drinker"
 #define TRAIT_EMPATH			"empath"
 #define TRAIT_FRIENDLY			"friendly"
+#define TRAIT_ALLERGIC			"allergic"
 
 // common trait sources
 #define TRAIT_GENERIC "generic"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -586,15 +586,7 @@
 	mob_trait = TRAIT_ALLERGIC
 	gain_text = "<span class='danger'>You remember your allergic reaction to a common medicine.</span>"
 	lose_text = "<span class='notice'>You no longer are allergic to medicine.</span>"
-	medical_record_text = "Patient has a severe allergic reaction to a commong medicine."
-//	var/allergy_list = list(/obj/item/reagent_containers/food/snacks/grown/apple,
-//							/obj/item/reagent_containers/food/snacks/grown/banana
-//							/obj/item/reagent_containers/food/snacks/grown/berries
-//							/obj/item/reagent_containers/food/snacks/grown/cherries
-//							/obj/item/reagent_containers/food/snacks/grown/grapes
-//							/obj/item/reagent_containers/food/snacks/grown/pineapple
-//							/obj/item/reagent_containers/food/snacks/grown/tomato
-							//Was going to make it pick if you allergic to eating a food, or a chem. too much work
+	medical_record_text = "Patient has a severe allergic reaction to a common medicine."
 	var/allergy_chem_list = list(	/datum/reagent/medicine/inacusiate,
 									/datum/reagent/medicine/silver_sulfadiazine,
 									/datum/reagent/medicine/styptic_powder,
@@ -604,26 +596,19 @@
 									/datum/reagent/medicine/bicaridine,
 									/datum/reagent/medicine/kelotane,) //Everything in the list can be healed from another source round-start
 	var/reagent_id
-	var/cooldown_time = 600 //1 minute. Cant act again until the first wears off. Test to make sure this is enough
-	var/cooldown = 0
+	var/cooldown_time = 1 MINUTES //Cant act again until the first wears off
+	var/cooldown = FALSE
 
 /datum/quirk/allergic/on_spawn()
 	reagent_id = pick(allergy_chem_list)
-	announce_allergy()
-
-/datum/quirk/allergic/proc/announce_allergy()
 	var/datum/reagent/allergy = GLOB.chemical_reagents_list[reagent_id]
 	to_chat(quirk_holder, "<span class='danger'>You remember you are allergic to [allergy.name].</span>")
 
 /datum/quirk/allergic/on_process()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/H = quirk_holder
 	var/datum/reagent/allergy = GLOB.chemical_reagents_list[reagent_id]
-	if(cooldown == 0)
-		if(H.reagents.has_reagent(reagent_id))
-			to_chat(quirk_holder, "<span class='danger'>You forgot you were allergic to [allergy.name]!</span>")
-			H.reagents.add_reagent(/datum/reagent/toxin/histamine, 5)
-			cooldown = 1
-			addtimer(CALLBACK(src, .proc/reset_cooldown), cooldown_time)
-
-/datum/quirk/allergic/proc/reset_cooldown()
-	cooldown = 0
+	if(cooldown == FALSE && H.reagents.has_reagent(reagent_id))
+		to_chat(quirk_holder, "<span class='danger'>You forgot you were allergic to [allergy.name]!</span>")
+		H.reagents.add_reagent(/datum/reagent/toxin/histamine, rand(5,10))
+		cooldown = TRUE
+		addtimer(VARSET_CALLBACK(src, cooldown, FALSE), cooldown_time)

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -594,7 +594,7 @@
 									/datum/reagent/medicine/oculine,
 									/datum/reagent/medicine/neurine,
 									/datum/reagent/medicine/bicaridine,
-									/datum/reagent/medicine/kelotane,) //Everything in the list can be healed from another source round-start
+									/datum/reagent/medicine/kelotane) //Everything in the list can be healed from another source round-start
 	var/reagent_id
 	var/cooldown_time = 1 MINUTES //Cant act again until the first wears off
 	var/cooldown = FALSE
@@ -603,6 +603,7 @@
 	reagent_id = pick(allergy_chem_list)
 	var/datum/reagent/allergy = GLOB.chemical_reagents_list[reagent_id]
 	to_chat(quirk_holder, "<span class='danger'>You remember you are allergic to [allergy.name].</span>")
+	quirk_holder.allergies += allergy
 
 /datum/quirk/allergic/on_process()
 	var/mob/living/carbon/H = quirk_holder

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -578,3 +578,47 @@
 	H.remove_language(/datum/language/common)
 	if(!H.can_speak_language(/datum/language/draconic) && !H.can_speak_language(/datum/language/machine))
 		H.grant_language(/datum/language/japanese)
+
+/datum/quirk/allergic
+	name = "Allergic Reaction"
+	desc = "You have had an allergic reaction to this in the past. Better stay away from it!"
+	value = -2
+	mob_trait = TRAIT_ALLERGIC
+	gain_text = "<span class='danger'>You are very allergic to something.</span>"
+	lose_text = "<span class='notice'>You no longer are allergic to something.</span>"
+	medical_record_text = "Patient has a severe allergic reaction to a chemical reagent."
+//	var/allergy_list = list(/obj/item/reagent_containers/food/snacks/grown/apple,
+//							/obj/item/reagent_containers/food/snacks/grown/banana
+//							/obj/item/reagent_containers/food/snacks/grown/berries
+//							/obj/item/reagent_containers/food/snacks/grown/cherries
+//							/obj/item/reagent_containers/food/snacks/grown/grapes
+//							/obj/item/reagent_containers/food/snacks/grown/pineapple
+//							/obj/item/reagent_containers/food/snacks/grown/tomato
+							//Was going to make it pick if you allergic to eating a food, or a chem. too much work
+	var/allergy_chem_list = list(	/datum/reagent/medicine/inacusiate,
+									/datum/reagent/medicine/silver_sulfadiazine,
+									/datum/reagent/medicine/styptic_powder,
+									/datum/reagent/medicine/omnizine,
+									/datum/reagent/medicine/oculine,
+									/datum/reagent/medicine/neurine,
+									/datum/reagent/medicine/bicaridine,
+									/datum/reagent/medicine/kelotane,) //Everything in the list can be healed from another source round-start
+	var/reagent_id
+	var/cooldown_duration = 600 //1 minute. Cant act again until the first wears off. Test to make sure this is enough
+	var/cooldown = 0
+
+/datum/quirk/allergic/on_spawn()
+	reagent_id = pick(allergy_chem_list)
+
+/datum/quirk/allergic/on_process()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(cooldown == 1)
+		if(cooldown_duration >0)
+			cooldown_duration--
+		else
+			cooldown = 0
+	else if(cooldown == 0)
+		if(H.reagents.has_reagent(reagent_id))
+			to_chat(quirk_holder, "<span class='danger'>You just remembered you were allergic to!</span>")
+			H.reagents.add_reagent(/datum/reagent/toxin/histamine, 10)
+			cooldown = 1

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -185,6 +185,8 @@ GENE SCANNER
 			to_chat(user, "\t<span class='alert'>Cerebral traumas detected: subject appears to be suffering from [english_list(trauma_text)].</span>")
 		if(C.roundstart_quirks.len)
 			to_chat(user, "\t<span class='info'>Subject has the following physiological traits: [C.get_trait_string()].</span>")
+		if(C.has_quirk(/datum/quirk/allergic))
+			to_chat(user, "\t<span class='info'>Subject is allergic to the chemical [C.allergies].</span>")
 	if(advanced)
 		to_chat(user, "\t<span class='info'>Brain Activity Level: [(200 - M.getOrganLoss(ORGAN_SLOT_BRAIN))/2]%.</span>")
 

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -114,3 +114,6 @@
 	//List of active diseases
 	var/list/diseases = list() // list of all diseases in a mob
 	var/list/disease_resistances = list()
+
+	//Allergies
+	var/allergies


### PR DESCRIPTION
### Intent of your Pull Request
Adds a fairly benign negative quirk, Allergies. Every chem that you can be allergic to can be replaced with other healing methods round-start, and doesn't actually stop the chem from working in you. Its just a mild annoyance at the moment.

Should I add food allergies as well to the list it can pick?
Should I randomize the amount of histamine it gives?
Maybe add some other effects? Like a "seizure" putting you unconcious or pure toxin





#### Changelog

:cl:  
rscadd: Added a negative quirk that will make you allergic to some chems
/:cl:
