### PR TITLE
Fixes tricorder anomaly detection

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -75,7 +75,7 @@
 
 
 /obj/effect/anomaly/attackby(obj/item/I, mob/user, params)
-	if(I.tool_behaviour == TOOL_ANALYZER)
+	if(I.tool_behaviour == TOOL_ANALYZER || istype(I, /obj/item/multitool/tricorder))
 		to_chat(user, "<span class='notice'>Analyzing... [src]'s unstable field is fluctuating along frequency [format_frequency(aSignal.frequency)], code [aSignal.code].</span>")
 
 ///////////////////////


### PR DESCRIPTION
### Intent of your Pull Request

Many CE's have died because their tricorders don't scan anomalies, what gives.

#### Changelog

:cl:  
rscadd: Tricorders now scan anomalies correctly.
/:cl:
