### PR TITLE
better captain annoncement

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -703,7 +703,7 @@
 	if(!SScommunications.can_announce(user, is_silicon))
 		to_chat(user, "Intercomms recharging. Please stand by.")
 		return
-	var/input = input(user, "Please choose a message to announce to the station crew.", "What?")as message|null
+	var/input = stripped_multiline_input(user, "Please choose a message to announce to the station crew.", "What?")
 	if(!input || !user.canUseTopic(src, !issilicon(usr)))
 		return
 	SScommunications.make_announcement(user, is_silicon, input)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -703,7 +703,7 @@
 	if(!SScommunications.can_announce(user, is_silicon))
 		to_chat(user, "Intercomms recharging. Please stand by.")
 		return
-	var/input = stripped_input(user, "Please choose a message to announce to the station crew.", "What?")
+	var/input = input(user, "Please choose a message to announce to the station crew.", "What?")as message|null
 	if(!input || !user.canUseTopic(src, !issilicon(usr)))
 		return
 	SScommunications.make_announcement(user, is_silicon, input)


### PR DESCRIPTION
makes the captain annoncement able to have multiple lines and spaces. Like a centcom annoncement


changelog:
/🆑 
tweak: changed the stripped format of the Captain's announcement to a full format that allows more creativity and possibilities.
/:cl:
