### PR TITLE
ports "Radial menu tweaks #50561" from TG

### DIFF
--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -255,6 +255,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	current_user = M.client
 	//Blank
 	menu_holder = image(icon='icons/effects/effects.dmi',loc=anchor,icon_state="nothing",layer = ABOVE_HUD_LAYER)
+	menu_holder.plane = ABOVE_HUD_PLANE
 	menu_holder.appearance_flags |= KEEP_APART
 	menu_holder.vis_contents += elements + close_button
 	current_user.images += menu_holder
@@ -308,4 +309,9 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	var/answer = menu.selected_choice
 	qdel(menu)
 	GLOB.radial_menus -= uniqueid
+	if(require_near && !in_range(anchor, user))
+		return
+	if(menu.custom_check_callback)
+		if(!menu.custom_check_callback.Invoke())
+			return
 	return answer


### PR DESCRIPTION
### About The Pull Request

Ports some boring radial fixing from TG. All credit to the original coder **Arkatos1**, all I did was port it.

To quote the original PR:

"This PR fixes two issues regarding radial menus:

1. Firstly, radial menus are affected by the lighting, which means options they offer may not be always clearly visible to the user, and may sometimes even be cut in half if the turf the option is on is not visible to the user.

Solved by setting plane of the radial menu holder to ABOVE_HUD_PLANE (which is also the same plane as radial screen objects themselves are on!).

2. Secondly, radials have two types of additional checks - optional require_near check, and custom check callback. These checks are, to save performance, called in intervals. If the checks are not met (for example, if user goes too far from the anchor of the radial menu), the menu automatically closes. Problem is, if the user is faster than the check interval, he is able to bypass these checks completely. For example, user goes away from the anchor of the radial menu, and clicks on some option before regular interval, the menu does not close fast enough and option goes through. This causes teleporting items, pseudo telekinesis and more.

Solved by doing one last check after the option is chosen."

#### Changelog

:cl:  Arkatos
tweak: Radial menu options will now always be clearly visible to the user.
/:cl:
