### PR TITLE
Adds a Genetics manual to genetics

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -33460,11 +33460,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"bra" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/rxglasses,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "brb" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 8
@@ -34397,14 +34392,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"bsK" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/disks{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "bsL" = (
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -54513,6 +54500,11 @@
 	},
 /turf/open/space/basic,
 /area/maintenance/disposal/incinerator)
+"lvD" = (
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/medical_genetics,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "lxr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -59763,6 +59755,15 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"xXp" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/rxglasses,
+/obj/item/storage/box/disks{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "xYi" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
@@ -101645,8 +101646,8 @@ rZt
 bjK
 bon
 bpH
-bra
-bsK
+xXp
+lvD
 bpE
 bpE
 bpE

--- a/code/game/objects/items/manuals.dm
+++ b/code/game/objects/items/manuals.dm
@@ -373,6 +373,13 @@
 	title = "Cloning techniques of the 26th century"
 	page_link = "Guide_to_genetics#Cloning"
 
+/obj/item/book/manual/wiki/medical_genetics
+	name = "Genetics of the 26th century"
+	icon_state ="bookCloning"
+	author = "Dr. Likes-The-Powers "
+	title = "Genetics of the 26th century"
+	page_link = "Guide_to_genetics"
+
 /obj/item/book/manual/wiki/cooking_to_serve_man
 	name = "To Serve Man"
 	desc = "It's a cookbook!"


### PR DESCRIPTION
Requested by Puremanbird

Adds a new manual pointing to our Guide to Genetics page under:
https://wiki.yogstation.net/wiki/Guide_to_Genetics

![image](https://user-images.githubusercontent.com/24533979/80298301-751a1b00-8750-11ea-9e7d-1e2a556886a6.png)


#### Changelog

:cl:  Hopek
rscadd: Added a new Guide to Genetics book in the genetics department.
/:cl:
