### PR TITLE
Gulag Processor & The Return of the Beepsky

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -17,6 +17,10 @@
 /obj/effect/landmark/stationroom/box/foreportmaint1,
 /turf/template_noop,
 /area/template_noop)
+"aad" = (
+/obj/machinery/gulag_processor,
+/turf/open/floor/plasteel,
+/area/security/processing)
 "aae" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space,
@@ -629,6 +633,13 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
+"abs" = (
+/obj/machinery/computer/prisoner,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "abt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -947,6 +958,12 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"abX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "abY" = (
 /obj/structure/grille,
 /turf/open/space,
@@ -1462,6 +1479,20 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
+"acU" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
+"acV" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/red,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "acW" = (
 /obj/structure/cable,
 /obj/structure/lattice/catwalk,
@@ -1688,6 +1719,22 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"adr" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
+"ads" = (
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/turf/open/floor/plating,
+/area/security/processing)
 "adt" = (
 /obj/structure/cable,
 /obj/structure/lattice/catwalk,
@@ -2024,6 +2071,9 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/starboard/fore)
+"adZ" = (
+/turf/open/floor/plating,
+/area/security/processing)
 "aea" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -2307,6 +2357,11 @@
 /obj/item/pen,
 /turf/open/floor/plasteel,
 /area/security/main)
+"aeC" = (
+/obj/item/bedsheet/red,
+/mob/living/simple_animal/bot/secbot/beepsky,
+/turf/open/floor/plating,
+/area/security/processing)
 "aeD" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -2331,6 +2386,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/space/basic,
 /area/space/nearstation)
+"aeG" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/potato{
+	name = "\improper Beepsky's emergency battery"
+	},
+/turf/open/floor/plating,
+/area/security/processing)
 "aeH" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -2472,6 +2535,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"aeR" = (
+/obj/item/paper/fluff/jobs/security/beepsky_mom,
+/turf/open/floor/plating,
+/area/security/processing)
 "aeS" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1{
 	dir = 6
@@ -2692,6 +2759,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"afl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel,
+/area/security/processing)
+"afm" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
+"afn" = (
+/obj/structure/sign/warning/securearea{
+	pixel_x = 32
+	},
+/obj/structure/table,
+/obj/item/storage/box/prisoner,
+/obj/machinery/camera{
+	c_tag = "Labor Shuttle Dock North"
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "afo" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Three"
@@ -4758,26 +4852,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port/fore)
-"ajr" = (
-/obj/machinery/computer/prisoner,
-/turf/open/floor/plasteel,
-/area/security/processing)
-"ajs" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel,
-/area/security/processing)
-"ajt" = (
-/obj/structure/sign/warning/securearea{
-	pixel_x = 32
-	},
-/obj/structure/table,
-/obj/item/storage/box/prisoner,
-/obj/machinery/camera{
-	c_tag = "Labor Shuttle Dock North"
-	},
-/obj/item/restraints/handcuffs,
-/turf/open/floor/plasteel,
-/area/security/processing)
 "aju" = (
 /obj/machinery/computer/security{
 	name = "Labor Camp Monitoring";
@@ -4945,18 +5019,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"ajJ" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "ajK" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/hos";
@@ -5129,15 +5191,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"akb" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "akc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -6530,13 +6583,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"amX" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/bot_assembly/secbot,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "amY" = (
 /obj/structure/chair{
 	dir = 1
@@ -6713,10 +6759,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"anu" = (
-/obj/item/paper/fluff/jobs/security/beepsky_mom,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "anv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
@@ -7160,15 +7202,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"aou" = (
-/obj/structure/window/reinforced,
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/potato{
-	name = "\improper Beepsky's emergency battery"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "aov" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -8148,17 +8181,6 @@
 "aqR" = (
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"aqS" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel,
-/area/security/processing)
 "aqT" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -8888,15 +8910,6 @@
 /obj/item/clothing/ears/earmuffs,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"asL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/structure/table,
-/obj/item/hand_labeler,
-/obj/item/paper/guides/jobs/security/labor_lockers,
-/turf/open/floor/plasteel,
-/area/security/processing)
 "asM" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -45546,22 +45559,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"bQP" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/closet/secure_closet/personal/prisoner,
-/turf/open/floor/plasteel,
-/area/security/processing)
 "bQQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -45571,45 +45568,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"bQR" = (
-/obj/machinery/door/window/northright{
-	name = "Labor Camp Storage"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
-"bQS" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/closet/secure_closet/personal/prisoner,
-/turf/open/floor/plasteel,
-/area/security/processing)
-"bQT" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/closet/secure_closet/personal/prisoner,
-/turf/open/floor/plasteel,
-/area/security/processing)
-"bQU" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "bQZ" = (
 /turf/closed/wall/r_wall,
 /area/science/misc_lab)
@@ -85660,18 +85618,18 @@ aaf
 aaa
 aaf
 aiT
-ajs
-akb
+aad
+abX
 akI
 tPc
 amc
 aiT
 ant
 tPc
-asL
-bQP
-bQS
-bQT
+afl
+aiT
+aeR
+aeC
 arP
 asT
 aqR
@@ -85917,8 +85875,8 @@ aaf
 aaa
 aaa
 akG
-ajr
-alq
+abs
+acU
 apn
 lhn
 asp
@@ -85926,9 +85884,9 @@ aiU
 apb
 lhn
 axY
-bQR
-bQU
-alq
+ads
+adZ
+aeG
 arP
 asS
 aqR
@@ -86175,7 +86133,7 @@ aaa
 aaa
 akG
 aju
-ajJ
+afm
 akK
 jCA
 lLO
@@ -86431,13 +86389,13 @@ aai
 aai
 aai
 aai
-ajt
+afn
 ajM
 akJ
 alr
 alq
 aiU
-aqS
+adr
 alq
 anX
 apc
@@ -92326,8 +92284,8 @@ aaa
 aaa
 aaf
 abp
-amX
-aou
+acV
+aqI
 abP
 aco
 acO
@@ -92583,7 +92541,7 @@ aaa
 aaa
 aaa
 afu
-anu
+abO
 aqN
 abO
 abO

--- a/code/game/machinery/gulag_processor.dm
+++ b/code/game/machinery/gulag_processor.dm
@@ -189,7 +189,7 @@ GLOBAL_VAR_INIT(gulag_required_items, typecacheof(list(
 
 /obj/item/circuitboard/machine/gulag_processor
 	name = "labor camp processor (Machine Board)"
-	build_path = /obj/machinery/gulag_processor s
+	build_path = /obj/machinery/gulag_processor
 	req_components = list(
 							/obj/item/stock_parts/scanning_module,
 							/obj/item/stock_parts/manipulator)

--- a/code/game/machinery/gulag_processor.dm
+++ b/code/game/machinery/gulag_processor.dm
@@ -189,9 +189,7 @@ GLOBAL_VAR_INIT(gulag_required_items, typecacheof(list(
 
 /obj/item/circuitboard/machine/gulag_processor
 	name = "labor camp processor (Machine Board)"
-	build_path = /obj/machinery/gulag_teleporter
+	build_path = /obj/machinery/gulag_processor
 	req_components = list(
-							/obj/item/stack/ore/bluespace_crystal = 2,
 							/obj/item/stock_parts/scanning_module,
 							/obj/item/stock_parts/manipulator)
-	def_components = list(/obj/item/stack/ore/bluespace_crystal = /obj/item/stack/ore/bluespace_crystal/artificial)

--- a/code/game/machinery/gulag_processor.dm
+++ b/code/game/machinery/gulag_processor.dm
@@ -1,0 +1,196 @@
+/*
+Gulag processor
+It automatically strips the prisoner and equips a prisoner ID, prisoner jumpsuit and oranges sneakers.
+You can set the amount of points in the regular console
+*/
+
+GLOBAL_VAR_INIT(gulag_required_items, typecacheof(list(
+		/obj/item/implant,
+		/obj/item/clothing/suit/space/eva/plasmaman,
+		/obj/item/clothing/under/plasmaman,
+		/obj/item/clothing/head/helmet/space/plasmaman,
+		/obj/item/tank/internals,
+		/obj/item/clothing/mask/breath,
+		/obj/item/clothing/mask/gas)))
+
+//Gulag processor
+/obj/machinery/gulag_processor
+	name = "labor camp processing machine"
+	desc = "A machine used to process prisoners before they're sent to the labor camp. Alt-Click to remove an inserted ID."
+	icon = 'icons/obj/machines/implantchair.dmi'
+	icon_state = "implantchair"
+	state_open = FALSE
+	density = TRUE
+	use_power = IDLE_POWER_USE
+	idle_power_usage = 200
+	active_power_usage = 5000
+	circuit = /obj/item/circuitboard/machine/gulag_processor
+
+	var/stun_duration = 70 //Half of a stunbaton
+
+	var/obj/item/card/id/prisoner/id = null
+
+	var/jumpsuit_type = /obj/item/clothing/under/rank/prisoner
+
+	var/shoes_type = /obj/item/clothing/shoes/sneakers/orange
+
+	var/obj/machinery/gulag_item_reclaimer/linked_reclaimer
+
+
+/obj/machinery/gulag_processor/Initialize()
+	. = ..()
+	locate_reclaimer()
+
+/obj/machinery/gulag_processor/Destroy()
+	if(linked_reclaimer)
+		linked_reclaimer.linked_teleporter = null
+
+	return ..()
+
+/obj/machinery/gulag_processor/examine(mob/user)
+	. = ..()
+	if(id)
+		. += "<span class='notice'>\The [id] ID has been inserted.</span>"
+	else
+		. += "<span class='warning'>There is no ID inserted.</span>"
+
+/obj/machinery/gulag_processor/AltClick(mob/living/user)
+	if(id)
+		id.forceMove(get_turf(src))
+		id = null
+
+/obj/machinery/gulag_processor/power_change()
+	..()
+	update_icon()
+
+/obj/machinery/gulag_processor/interact(mob/user)
+	. = ..()
+	toggle_open()
+
+/obj/machinery/gulag_processor/updateUsrDialog()
+	return
+
+/obj/machinery/gulag_processor/attackby(obj/item/I, mob/user)
+	if(!occupant && default_deconstruction_screwdriver(user, "[icon_state]", "[icon_state]",I))
+		update_icon()
+		return
+
+	if(default_deconstruction_crowbar(I))
+		return
+
+	if(default_pry_open(I))
+		return
+
+	if(istype(I, /obj/item/card/id/prisoner))
+		if(!id)
+			I.moveToNullspace()
+			id = I
+			to_chat(user, "<span class='notice'>You insert [I].</span>")
+			return
+		else
+			to_chat(user, "<span class='notice'>There's an ID inserted already.</span>")
+
+
+	return ..()
+
+/obj/machinery/gulag_processor/update_icon()
+	icon_state = initial(icon_state) + (state_open ? "_open" : "")
+	//no power or maintenance
+	if(stat & (NOPOWER|BROKEN))
+		icon_state += "_unpowered"
+		if((stat & MAINT) || panel_open)
+			icon_state += "_maintenance"
+		return
+
+	if((stat & MAINT) || panel_open)
+		icon_state += "_maintenance"
+		return
+
+	//running and someone in there
+	if(occupant)
+		icon_state += "_occupied"
+		return
+
+
+/obj/machinery/gulag_processor/proc/locate_reclaimer()
+	linked_reclaimer = locate(/obj/machinery/gulag_item_reclaimer)
+	if(linked_reclaimer)
+		linked_reclaimer.linked_teleporter = src
+
+/obj/machinery/gulag_processor/proc/toggle_open()
+	if(panel_open)
+		to_chat(usr, "<span class='notice'>Close the maintenance panel first.</span>")
+		return
+
+	if(state_open)
+		close_machine()
+		return
+
+	open_machine()
+
+/obj/machinery/gulag_processor/close_machine()
+	..()
+
+	if(occupant)
+		if(id)
+			handle_prisoner(id)
+			id = null
+		else
+			visible_message("<span class='warning'>No ID inserted. Processing aborted..</span>")
+	else
+		open_machine()
+		visible_message("<span class='warning'>No occupant detected. Processing aborted.</span>")
+		return
+
+// strips and stores all occupant's items
+/obj/machinery/gulag_processor/proc/strip_occupant()
+	if(linked_reclaimer)
+		linked_reclaimer.stored_items[occupant] = list()
+
+	var/mob/living/carbon/human/mob_occupant = occupant
+	for(var/obj/item/W in mob_occupant)
+		if(!is_type_in_typecache(W, GLOB.gulag_required_items))
+			if(mob_occupant.temporarilyRemoveItemFromInventory(W))
+				if(istype(W, /obj/item/restraints/handcuffs))
+					W.forceMove(get_turf(src))
+					continue
+				if(linked_reclaimer)
+					linked_reclaimer.stored_items[mob_occupant] += W
+					linked_reclaimer.contents += W
+					W.forceMove(linked_reclaimer)
+				else
+					W.forceMove(src)
+
+/obj/machinery/gulag_processor/proc/handle_prisoner(obj/item/id)
+	if(!ishuman(occupant))
+		return
+	strip_occupant()
+	var/mob/living/carbon/human/prisoner = occupant
+	if(!isplasmaman(prisoner) && jumpsuit_type)
+		prisoner.equip_to_appropriate_slot(new jumpsuit_type)
+	if(shoes_type)
+		prisoner.equip_to_appropriate_slot(new shoes_type)
+	if(id)
+		prisoner.equip_to_appropriate_slot(id)
+
+	if(!isnull(GLOB.data_core.general))
+		for(var/r in GLOB.data_core.security)
+			var/datum/data/record/R = r
+			if(R.fields["name"] == prisoner.real_name)
+				R.fields["criminal"] = "Incarcerated"
+
+	open_machine()
+	prisoner.Paralyze(stun_duration)
+	if(!prisoner.handcuffed)
+		prisoner.handcuffed = new /obj/item/restraints/handcuffs/cable/zipties/used(prisoner)
+		prisoner.update_handcuffed()
+	visible_message("<span class='warning'>Prisoner Processed.</span>")
+
+/obj/item/circuitboard/machine/gulag_processor
+	name = "labor camp processor (Machine Board)"
+	build_path = /obj/machinery/gulag_teleporter
+	req_components = list(
+							/obj/item/stack/ore/bluespace_crystal = 2,
+							/obj/item/stock_parts/scanning_module,
+							/obj/item/stock_parts/manipulator)
+	def_components = list(/obj/item/stack/ore/bluespace_crystal = /obj/item/stack/ore/bluespace_crystal/artificial)

--- a/code/game/machinery/gulag_processor.dm
+++ b/code/game/machinery/gulag_processor.dm
@@ -189,7 +189,7 @@ GLOBAL_VAR_INIT(gulag_required_items, typecacheof(list(
 
 /obj/item/circuitboard/machine/gulag_processor
 	name = "labor camp processor (Machine Board)"
-	build_path = /obj/machinery/gulag_processor
+	build_path = /obj/machinery/gulag_processor s
 	req_components = list(
 							/obj/item/stock_parts/scanning_module,
 							/obj/item/stock_parts/manipulator)

--- a/code/game/machinery/gulag_processor.dm
+++ b/code/game/machinery/gulag_processor.dm
@@ -58,6 +58,7 @@ GLOBAL_VAR_INIT(gulag_required_items, typecacheof(list(
 	if(id)
 		id.forceMove(get_turf(src))
 		id = null
+	..()
 
 /obj/machinery/gulag_processor/power_change()
 	..()

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -649,6 +649,7 @@
 #include "code\game\machinery\firealarm.dm"
 #include "code\game\machinery\flasher.dm"
 #include "code\game\machinery\gulag_item_reclaimer.dm"
+#include "code\game\machinery\gulag_processor.dm"
 #include "code\game\machinery\gulag_teleporter.dm"
 #include "code\game\machinery\harvester.dm"
 #include "code\game\machinery\hologram.dm"


### PR DESCRIPTION
### Intent of your Pull Request
It's the gulag teleporter, but without the teleporter part

Guide:
Take prisoner ID.
Configure the points in the normal console.
Insert ID into gulag processor.
Put prisoner into gulag processor
Prisoner is stripped and given prison clothing.
ID is equipped on prisoner.
Prisoner is set to Incarcerated
Prisoner is ziptied.


All their stuff is moved to the reclaimer, which means the prisoner can easily get their stuff back by using their ID on the Equipment reclaimer

Added the Gulag Processor to Boxstation
Removed the locker storage room that was the replacement
Moved beepsky's room back to its original space.
Beepsky is now assembled roundstart
#### Changelog

:cl:  
rscadd: The process of gulagging has been made easier. Put the prisoner into the new Gulag Processor near the shuttle, and they will automatically be stripped.
rscadd: Beepsky now starts assembled
/:cl:
