### PR TITLE
override analyzer action for tricorder for tcomms

### DIFF
--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -27,6 +27,13 @@
 	else
 		return ..()
 
+/obj/machinery/telecomms/analyzer_act(mob/living/user, obj/item/T)
+	//Prevent the tricorder's air analysis when trying to configure tcomms
+	if (istype(T, /obj/item/multitool/tricorder))
+		return 
+	else
+		return ..()
+
 /obj/machinery/telecomms/ui_interact(mob/user)
 	. = ..()
 	// You need a multitool to use this, or be silicon


### PR DESCRIPTION
### Intent of your Pull Request

Sorry, I was trying out the pr plugin for vscode, and apparently I need to do something else to get a prompt for the body.

The actual change is [this forum code request](https://forums.yogstation.net/index.php?threads/make-the-tricoder-stop-giving-atmos-read-outs-every-fucking-time-you-use-it-on-something.20944/), which is also #7590. Simply overrides analyzer behavior for tricorders on tcomms machines.

#### Changelog

:cl:  
tweak: tricorders no longer analyze atmos of tcomms machines 
/:cl:
