### PR TITLE
ports "Fixes an issue with sentient diseases and darkness #50712" from TG

### DIFF
--- a/code/modules/antagonists/disease/disease_mob.dm
+++ b/code/modules/antagonists/disease/disease_mob.dm
@@ -14,6 +14,7 @@ the new instance inside the host to be updated to the template's stats.
 	mouse_opacity = MOUSE_OPACITY_ICON
 	move_on_shuttle = FALSE
 	see_in_dark = 8
+	see_invisible = SEE_INVISIBLE_LIVING
 	invisibility = INVISIBILITY_OBSERVER
 	layer = BELOW_MOB_LAYER
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE


### PR DESCRIPTION
### Intent of your Pull Request

Fixes an apparent bug with sentient disease visibility being slightly darker. All credit to **LemonInTheDark** for the original PR. I just ported it.
"see_invis is used to show/hide the lighting plane"

#### Changelog

:cl:  LemonInTheDark
bugfix: Fixes an issue with sentient diseases and darkness
/:cl:
