### PR TITLE
[admin] Add spiderizing as a smiting option

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -64,6 +64,7 @@
 #define ADMIN_INDIVIDUALLOG(user) "(<a href='?_src_=holder;[HrefToken(TRUE)];individuallog=[REF(user)]'>LOGS</a>)"
 
 #define ADMIN_PUNISHMENT_LIGHTNING "Lightning bolt"
+#define ADMIN_PUNISHMENT_SPIDERIZE "Spiderize"
 #define ADMIN_PUNISHMENT_BRAINDAMAGE "Brain damage"
 #define ADMIN_PUNISHMENT_GIB "Gib"
 #define ADMIN_PUNISHMENT_BSA "Bluespace Artillery Device"

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1102,6 +1102,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 			for (var/i in 1 to rand(2,4))
 				var/obj/structure/spider/spiderling/S = new(target.drop_location())
 				S.directive = "Erase the legacy of [target.name]."
+				addtimer(CALLBACK(S, .Destroy), 50) //just enough time for them to skitter around a little
 			target.gib(TRUE)
 		if(ADMIN_PUNISHMENT_BRAINDAMAGE)
 			target.adjustOrganLoss(ORGAN_SLOT_BRAIN, 199, 199)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1081,7 +1081,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!check_rights(R_ADMIN) || !check_rights(R_FUN))
 		return
 
-	var/list/punishment_list = list(ADMIN_PUNISHMENT_LIGHTNING, ADMIN_PUNISHMENT_BRAINDAMAGE, ADMIN_PUNISHMENT_GIB, ADMIN_PUNISHMENT_BSA, ADMIN_PUNISHMENT_FIREBALL, ADMIN_PUNISHMENT_ROD, ADMIN_PUNISHMENT_SUPPLYPOD_QUICK, ADMIN_PUNISHMENT_SUPPLYPOD, ADMIN_PUNISHMENT_MAZING)
+	var/list/punishment_list = list(ADMIN_PUNISHMENT_LIGHTNING, ADMIN_PUNISHMENT_SPIDERIZE, ADMIN_PUNISHMENT_BRAINDAMAGE, ADMIN_PUNISHMENT_GIB, ADMIN_PUNISHMENT_BSA, ADMIN_PUNISHMENT_FIREBALL, ADMIN_PUNISHMENT_ROD, ADMIN_PUNISHMENT_SUPPLYPOD_QUICK, ADMIN_PUNISHMENT_SUPPLYPOD, ADMIN_PUNISHMENT_MAZING)
 
 	var/punishment = input("Choose a punishment", "DIVINE SMITING") as null|anything in punishment_list
 
@@ -1097,6 +1097,12 @@ Traitors and the like can also be revived with the previous role mostly intact.
 				var/mob/living/carbon/human/H = target
 				H.electrocution_animation(40)
 			to_chat(target, "<span class='userdanger'>The gods have punished you for your sins!</span>")
+		if(ADMIN_PUNISHMENT_SPIDERIZE)
+			target.visible_message("<span class='danger'>[target.name] explodes into spiders!</span>", "<span class='userdanger'>The gods have rended your form!</span>", "<span class='italics'>You hear chittering and a horrible wet sound!</span>")
+			for (var/i in 1 to rand(2,4))
+				var/obj/structure/spider/spiderling/S = new(target.drop_location())
+				S.directive = "Erase the legacy of [target.name]."
+			target.gib(TRUE)
 		if(ADMIN_PUNISHMENT_BRAINDAMAGE)
 			target.adjustOrganLoss(ORGAN_SLOT_BRAIN, 199, 199)
 		if(ADMIN_PUNISHMENT_GIB)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1075,6 +1075,20 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggled Hub Visibility", "[GLOB.hub_visibility ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/client/proc/spiderize_more(mob/living/target as mob, progress = 1)
+	target.SetAllImmobility(500)
+	target.do_jitter_animation(progress * 200)
+	target.visible_message("<span class='danger'>Spiders emerge from [target.name]!</span>", "<span class='userdanger'>They crawl within you.</span>")
+	for (var/i in 1 to rand(progress * 9, progress * 11))
+		var/obj/structure/spider/spiderling/S = new(target.drop_location())
+		S.directive = "Erase the legacy of [target.name]."
+		QDEL_IN(S, rand(50, 300)) //just enough time for them to skitter around a little
+	if (progress < 5)
+		addtimer(CALLBACK(src, /client/proc/spiderize_more, target, progress + 1), 75)
+	else
+		target.visible_message("<span class='danger'>[target.name] explodes into a chittering mass!</span>", "<span class='userdanger'>The gods have rended your form.</span>")
+		target.gib(TRUE)
+
 /client/proc/smite(mob/living/target as mob)
 	set name = "Smite"
 	set category = "Fun"
@@ -1098,12 +1112,9 @@ Traitors and the like can also be revived with the previous role mostly intact.
 				H.electrocution_animation(40)
 			to_chat(target, "<span class='userdanger'>The gods have punished you for your sins!</span>")
 		if(ADMIN_PUNISHMENT_SPIDERIZE)
-			target.visible_message("<span class='danger'>[target.name] explodes into spiders!</span>", "<span class='userdanger'>The gods have rended your form!</span>", "<span class='italics'>You hear chittering and a horrible wet sound!</span>")
-			for (var/i in 1 to rand(2,4))
-				var/obj/structure/spider/spiderling/S = new(target.drop_location())
-				S.directive = "Erase the legacy of [target.name]."
-				addtimer(CALLBACK(S, .Destroy), 50) //just enough time for them to skitter around a little
-			target.gib(TRUE)
+			target.visible_message("<span class='danger'>[target.name] freezes!</span>", "<span class='userdanger'>You feel the weight of your actions.</span>")
+			target.SetAllImmobility(500)
+			addtimer(CALLBACK(src, /client/proc/spiderize_more, target, 1), 25)
 		if(ADMIN_PUNISHMENT_BRAINDAMAGE)
 			target.adjustOrganLoss(ORGAN_SLOT_BRAIN, 199, 199)
 		if(ADMIN_PUNISHMENT_GIB)


### PR DESCRIPTION
### Intent of your Pull Request

[Implements this coding request.](https://forums.yogstation.net/index.php?threads/but-she-was-already-pouring-you-a-brimming-glass-of-spiders.20398/)

Adds a new entry under the admin smiting menu ("Spiderize") to explode a mob into spiders.  Specifically, the mob will be gibbed, and 2-4 spiderlings will spawn at its location. As the intent in the forum post is to deal with the body of a griefer, the brain is destroyed in the gibbing.

why did I write spidirizing to begin with?

#### Changelog

:cl:  
rscadd: Adds a spiderizing smite that destroys the brain and spawns spiderlings!
/:cl:
