### PR TITLE
Mech Construction Refactor + QoL (from TG)

### DIFF
--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -137,7 +137,7 @@
 	qdel(src)
 
 /datum/disease/proc/IsSame(datum/disease/D)
-	if(istype(src, D.type))
+	if(istype(D, type))
 		return TRUE
 	return FALSE
 

--- a/code/game/mecha/combat/combat.dm
+++ b/code/game/mecha/combat/combat.dm
@@ -7,6 +7,11 @@
 	destruction_sleep_duration = 40
 	exit_delay = 40
 
+/obj/mecha/combat/restore_equipment()
+	mouse_pointer = 'icons/mecha/mecha_mouse.dmi'
+	. = ..()
+
+
 /obj/mecha/combat/proc/max_ammo() //Max the ammo stored for Nuke Ops mechs, or anyone else that calls this
 	for(var/obj/item/I in equipment)
 		if(istype(I, /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/))

--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -15,6 +15,7 @@
 	var/salvageable = 1
 	var/selectable = 1	// Set to 0 for passive equipment such as mining scanner or armor plates
 	var/harmful = FALSE //Controls if equipment can be used to attack by a pacifist.
+	var/destroy_sound = 'sound/mecha/critdestr.ogg'
 
 /obj/item/mecha_parts/mecha_equipment/proc/update_chassis_page()
 	if(chassis)
@@ -35,9 +36,10 @@
 		if(chassis.selected == src)
 			chassis.selected = null
 		src.update_chassis_page()
-		chassis.occupant_message("<span class='danger'>[src] is destroyed!</span>")
 		log_message("[src] is destroyed.", LOG_MECHA)
-		SEND_SOUND(chassis.occupant, sound(istype(src, /obj/item/mecha_parts/mecha_equipment/weapon) ? 'sound/mecha/weapdestr.ogg' : 'sound/mecha/critdestr.ogg', volume=50))
+		if(chassis.occupant)
+			chassis.occupant_message("<span class='danger'>[src] is destroyed!</span>")
+			chassis.occupant.playsound_local(chassis, destroy_sound, 50)
 		chassis = null
 	return ..()
 

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -513,8 +513,17 @@
 		N.cell = M.cell
 		M.cell.forceMove(N)
 		M.cell = null
-	N.step_energy_drain = M.step_energy_drain //For the scanning module
-	N.armor = N.armor.setRating(energy = M.armor["energy"]) //for the capacitor
+	QDEL_NULL(N.scanmod)
+	if (M.scanmod)
+		N.scanmod = M.scanmod
+		M.scanmod.forceMove(N)
+		M.scanmod = null
+	QDEL_NULL(N.capacitor)
+	if (M.capacitor)
+		N.capacitor = M.capacitor
+		M.capacitor.forceMove(N)
+		M.capacitor = null
+	N.update_part_values()
 	for(var/obj/item/mecha_parts/E in M.contents)
 		if(istype(E, /obj/item/mecha_parts/concealed_weapon_bay)) //why is the bay not just a variable change who did this
 			E.forceMove(N)

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -1,6 +1,7 @@
 /obj/item/mecha_parts/mecha_equipment/weapon
 	name = "mecha weapon"
 	range = RANGED
+	destroy_sound = 'sound/mecha/weapdestr.ogg'
 	var/projectile
 	var/fire_sound
 	var/projectiles_per_shot = 1

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -38,7 +38,9 @@
 	armor = list("melee" = 20, "bullet" = 10, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 100)
 	var/list/facing_modifiers = list(FRONT_ARMOUR = 1.5, SIDE_ARMOUR = 1, BACK_ARMOUR = 0.5)
 	var/equipment_disabled = 0 //disabled due to EMP
-	var/obj/item/stock_parts/cell/cell
+	var/obj/item/stock_parts/cell/cell ///Keeps track of the mech's cell
+	var/obj/item/stock_parts/scanning_module/scanmod ///Keeps track of the mech's scanning module
+	var/obj/item/stock_parts/capacitor/capacitor ///Keeps track of the mech's capacitor
 	var/state = 0
 	var/last_message = 0
 	var/add_req_access = 1
@@ -145,6 +147,8 @@
 	smoke_system.set_up(3, src)
 	smoke_system.attach(src)
 	add_cell()
+	add_scanmod()
+	add_capacitor()
 	START_PROCESSING(SSobj, src)
 	GLOB.poi_list |= src
 	log_message("[src.name] created.", LOG_MECHA)
@@ -175,37 +179,25 @@
 			AI = M //AIs are loaded into the mech computer itself. When the mech dies, so does the AI. They can be recovered with an AI card from the wreck.
 		else
 			M.forceMove(loc)
-	if(wreckage)
-		var/obj/structure/mecha_wreckage/WR = new wreckage(loc, AI)
-		for(var/obj/item/mecha_parts/mecha_equipment/E in equipment)
-			if(E.salvageable && prob(30))
-				WR.crowbar_salvage += E
-				E.detach(WR) //detaches from src into WR
-				E.equip_ready = 1
-			else
-				E.detach(loc)
-				qdel(E)
-		if(cell)
-			WR.crowbar_salvage += cell
-			cell.forceMove(WR)
-			cell.charge = rand(0, cell.charge)
-		if(internal_tank)
-			WR.crowbar_salvage += internal_tank
-			internal_tank.forceMove(WR)
-	else
-		for(var/obj/item/mecha_parts/mecha_equipment/E in equipment)
-			E.detach(loc)
-			qdel(E)
-		if(cell)
-			qdel(cell)
-		if(internal_tank)
-			qdel(internal_tank)
-		if(AI)
-			AI.gib() //No wreck, no AI to recover
+	for(var/obj/item/mecha_parts/mecha_equipment/E in equipment)
+		E.detach(loc)
+		qdel(E)
+	if(cell)
+		qdel(cell)
+	if(scanmod)
+		qdel(scanmod)
+	if(capacitor)
+		qdel(capacitor)
+	if(internal_tank)
+		qdel(internal_tank)
+	if(AI)
+		AI.gib() //No wreck, no AI to recover
 	STOP_PROCESSING(SSobj, src)
 	GLOB.poi_list.Remove(src)
 	equipment.Cut()
 	cell = null
+	scanmod = null
+	capacitor = null
 	internal_tank = null
 	if(loc)
 		loc.assume_air(cabin_air)
@@ -233,15 +225,22 @@
 /obj/mecha/CheckParts(list/parts_list)
 	..()
 	cell = locate(/obj/item/stock_parts/cell) in contents
-	var/obj/item/stock_parts/scanning_module/SM = locate() in contents
-	var/obj/item/stock_parts/capacitor/CP = locate() in contents
-	if(SM)
-		normal_step_energy_drain = 20 - (5 * SM.rating) //10 is normal, so on lowest part its worse, on second its ok and on higher its real good up to 0 on best
+	scanmod = locate(/obj/item/stock_parts/scanning_module) in contents
+	capacitor = locate(/obj/item/stock_parts/capacitor) in contents
+	update_part_values()
+
+/obj/mecha/proc/update_part_values() ///Updates the values given by scanning module and capacitor tier, called when a part is removed or inserted.
+	if(scanmod)
+		normal_step_energy_drain = 20 - (5 * scanmod.rating) //10 is normal, so on lowest part its worse, on second its ok and on higher its real good up to 0 on best
 		step_energy_drain = normal_step_energy_drain
-		qdel(SM)
-	if(CP)
-		armor = armor.modifyRating(energy = (CP.rating * 5)) //Each level of capacitor protects the mech against emp by 5%
-		qdel(CP)
+	else
+		normal_step_energy_drain = 500
+		step_energy_drain = normal_step_energy_drain
+	if(capacitor)
+		armor = armor.modifyRating(energy = (capacitor.rating * 5)) //Each level of capacitor protects the mech against emp by 5%
+	else //because we can still be hit without a cap, even if we can't move
+		armor = armor.setRating(energy = 0)
+
 
 ////////////////////////
 ////// Helpers /////////
@@ -251,12 +250,29 @@
 	internal_tank = new /obj/machinery/portable_atmospherics/canister/air(src)
 	return internal_tank
 
-/obj/mecha/proc/add_cell(var/obj/item/stock_parts/cell/C=null)
+/obj/mecha/proc/add_cell(var/obj/item/stock_parts/cell/C=null) ///Adds a cell, for use in Map-spawned mechs, Nuke Ops mechs, and admin-spawned mechs. Mechs built by hand will replace this.
+	QDEL_NULL(cell)
 	if(C)
 		C.forceMove(src)
 		cell = C
 		return
 	cell = new /obj/item/stock_parts/cell/high/plus(src)
+
+/obj/mecha/proc/add_scanmod(var/obj/item/stock_parts/scanning_module/sm=null) ///Adds a scanning module, for use in Map-spawned mechs, Nuke Ops mechs, and admin-spawned mechs. Mechs built by hand will replace this.
+	QDEL_NULL(scanmod)
+	if(sm)
+		sm.forceMove(src)
+		scanmod = sm
+		return
+	scanmod = new /obj/item/stock_parts/scanning_module(src)
+
+/obj/mecha/proc/add_capacitor(var/obj/item/stock_parts/capacitor/cap=null) ///Adds a capacitor, for use in Map-spawned mechs, Nuke Ops mechs, and admin-spawned mechs. Mechs built by hand will replace this.
+	QDEL_NULL(capacitor)
+	if(cap)
+		cap.forceMove(src)
+		capacitor = cap
+		return
+	capacitor = new /obj/item/stock_parts/capacitor(src)
 
 /obj/mecha/proc/add_cabin()
 	cabin_air = new
@@ -565,7 +581,9 @@
 			last_message = world.time
 		return 0
 	if(state)
-		occupant_message("<span class='danger'>Maintenance protocols in effect.</span>")
+		if(world.time - last_message > 20)
+			occupant_message("<span class='danger'>Maintenance protocols in effect.</span>")
+			last_message = world.time
 		return
 	return domove(direction)
 
@@ -584,6 +602,16 @@
 	if(zoom_mode)
 		if(world.time - last_message > 20)
 			occupant_message("Unable to move while in zoom mode.")
+			last_message = world.time
+		return 0
+	if(!cell)
+		if(world.time - last_message > 20)
+			occupant_message("<span class='warning'>Missing power cell.</span>")
+			last_message = world.time
+		return 0
+	if(!scanmod || !capacitor)
+		if(world.time - last_message > 20)
+			occupant_message("<span class='warning'>Missing [scanmod? "capacitor" : "scanning module"].</span>")
 			last_message = world.time
 		return 0
 
@@ -1004,6 +1032,19 @@
 	if(occupant && occupant == M) // The occupant exited the mech without calling go_out()
 		go_out(TRUE, newloc)
 
+	if(cell && cell == M)
+		cell = null
+		return
+	if(scanmod && scanmod == M)
+		scanmod = null
+		update_part_values()
+		return
+	if(capacitor && capacitor == M)
+		armor = armor.modifyRating(energy = (capacitor.rating * -5)) //lose the energy armor if we lose this cap
+		capacitor = null
+		update_part_values()
+		return
+		
 /obj/mecha/proc/go_out(forced, atom/newloc = loc)
 	if(!occupant)
 		return

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -215,8 +215,6 @@
 
 /obj/mecha/proc/restore_equipment()
 	equipment_disabled = 0
-	if(istype(src, /obj/mecha/combat))
-		mouse_pointer = 'icons/mecha/mecha_mouse.dmi'
 	if(occupant)
 		SEND_SOUND(occupant, sound('sound/items/timer.ogg', volume=50))
 		to_chat(occupant, "<span=notice>Equipment control unit has been rebooted successfuly.</span>")
@@ -1044,7 +1042,7 @@
 		capacitor = null
 		update_part_values()
 		return
-		
+
 /obj/mecha/proc/go_out(forced, atom/newloc = loc)
 	if(!occupant)
 		return

--- a/code/game/mecha/mecha_construction_paths.dm
+++ b/code/game/mecha/mecha_construction_paths.dm
@@ -4,12 +4,34 @@
 /datum/component/construction/mecha
 	var/base_icon
 
+	// Component typepaths.
+	// most must be defined unless
+	// get_steps is overriden.
+
+	// Circuit board typepaths.
+	// circuit_control and circuit_periph must be defined
+	// unless get_circuit_steps is overriden.
+	var/circuit_control
+	var/circuit_periph
+	var/circuit_weapon
+
+	// Armor plating typepaths. both must be defined
+	// unless relevant step procs are overriden. amounts
+	// must be defined if using /obj/item/stack/sheet types
+	var/inner_plating
+	var/inner_plating_amount
+
+	var/outer_plating
+	var/outer_plating_amount
+
 /datum/component/construction/mecha/spawn_result()
 	if(!result)
 		return
 	// Remove default mech power cell, as we replace it with a new one.
 	var/obj/mecha/M = new result(drop_location())
 	QDEL_NULL(M.cell)
+	QDEL_NULL(M.scanmod)
+	QDEL_NULL(M.capacitor)
 
 	var/obj/item/mecha_parts/chassis/parent_chassis = parent
 	M.CheckParts(parent_chassis.contents)
@@ -17,7 +39,14 @@
 	SSblackbox.record_feedback("tally", "mechas_created", 1, M.name)
 	QDEL_NULL(parent)
 
+// Default proc to generate mech steps.
+// Override if the mech needs an entirely custom process (See HONK mech)
+// Otherwise override specific steps as needed (Ripley, firefighter, Phazon)
+/datum/component/construction/mecha/proc/get_steps()
+	return get_frame_steps() + get_circuit_steps() + (circuit_weapon ? get_circuit_weapon_steps() : list()) + get_stockpart_steps() + get_inner_plating_steps() + get_outer_plating_steps()
+
 /datum/component/construction/mecha/update_parent(step_index)
+	steps = get_steps()
 	..()
 	// By default, each step in mech construction has a single icon_state:
 	// "[base_icon][index - 1]"
@@ -41,6 +70,188 @@
 	parent_atom.cut_overlays()
 	..()
 
+// Default proc for the first steps of mech construction.
+/datum/component/construction/mecha/proc/get_frame_steps()
+	return list(
+		list(
+			"key" = TOOL_WRENCH,
+			"desc" = "The hydraulic systems are disconnected."
+		),
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_WRENCH,
+			"desc" = "The hydraulic systems are connected."
+		),
+		list(
+			"key" = /obj/item/stack/cable_coil,
+			"amount" = 5,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The hydraulic systems are active."
+		),
+		list(
+			"key" = TOOL_WIRECUTTER,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The wiring is added."
+		)
+	)
+
+// Default proc for the circuit board steps of a mech.
+// Second set of steps by default.
+/datum/component/construction/mecha/proc/get_circuit_steps()
+	return list(
+		list(
+			"key" = circuit_control,
+			"action" = ITEM_DELETE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "The wiring is adjusted."
+		),
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Central control module is installed."
+		),
+		list(
+			"key" = circuit_periph,
+			"action" = ITEM_DELETE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "Central control module is secured."
+		),
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Peripherals control module is installed."
+		)
+	)
+
+// Default proc for weapon circuitboard steps
+// Used by combat mechs
+/datum/component/construction/mecha/proc/get_circuit_weapon_steps()
+	return list(
+		list(
+			"key" = circuit_weapon,
+			"action" = ITEM_DELETE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "Peripherals control module is secured."
+		),
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Weapons control module is installed."
+		)
+	)
+
+// Default proc for stock part installation
+// Third set of steps by default
+/datum/component/construction/mecha/proc/get_stockpart_steps()
+	var/prevstep_text = circuit_weapon ? "Weapons control module is secured." : "Peripherals control module is secured."
+	return list(
+		list(
+			"key" = /obj/item/stock_parts/scanning_module,
+			"action" = ITEM_MOVE_INSIDE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = prevstep_text
+		),
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Scanner module is installed."
+		),
+		list(
+			"key" = /obj/item/stock_parts/capacitor,
+			"action" = ITEM_MOVE_INSIDE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "Scanner module is secured."
+		),
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Capacitor is installed."
+		),
+		list(
+			"key" = /obj/item/stock_parts/cell,
+			"action" = ITEM_MOVE_INSIDE,
+			"back_key" = TOOL_SCREWDRIVER,
+			"desc" = "Capacitor is secured."
+		),
+		list(
+			"key" = TOOL_SCREWDRIVER,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "The power cell is installed."
+		)
+	)
+
+// Default proc for inner armor plating
+// Fourth set of steps by default
+/datum/component/construction/mecha/proc/get_inner_plating_steps()
+	var/list/first_step
+	if(ispath(inner_plating, /obj/item/stack/sheet))
+		first_step = list(
+			list(
+				"key" = inner_plating,
+				"amount" = inner_plating_amount,
+				"back_key" = TOOL_SCREWDRIVER,
+				"desc" = "The power cell is secured."
+			)
+		)
+	else
+		first_step = list(
+			list(
+				"key" = inner_plating,
+				"action" = ITEM_DELETE,
+				"back_key" = TOOL_SCREWDRIVER,
+				"desc" = "The power cell is secured."
+			)
+		)
+
+	return first_step + list(
+		list(
+			"key" = TOOL_WRENCH,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "Inner plating is installed."
+		),
+		list(
+			"key" = TOOL_WELDER,
+			"back_key" = TOOL_WRENCH,
+			"desc" = "Inner Plating is wrenched."
+		)
+	)
+
+// Default proc for outer armor plating
+// Fifth set of steps by default
+/datum/component/construction/mecha/proc/get_outer_plating_steps()
+	var/list/first_step
+	if(ispath(outer_plating, /obj/item/stack/sheet))
+		first_step = list(
+			list(
+				"key" = outer_plating,
+				"amount" = outer_plating_amount,
+				"back_key" = TOOL_WELDER,
+				"desc" = "Inner plating is welded."
+			)
+		)
+	else
+		first_step = list(
+			list(
+				"key" = outer_plating,
+				"action" = ITEM_DELETE,
+				"back_key" = TOOL_WELDER,
+				"desc" = "Inner plating is welded."
+			)
+		)
+
+	return first_step + list(
+		list(
+			"key" = TOOL_WRENCH,
+			"back_key" = TOOL_CROWBAR,
+			"desc" = "External armor is installed."
+		),
+		list(
+			"key" = TOOL_WELDER,
+			"back_key" = TOOL_WRENCH,
+			"desc" = "External armor is wrenched."
+		)
+	)
+
 
 /datum/component/construction/unordered/mecha_chassis/ripley
 	result = /datum/component/construction/mecha/ripley
@@ -55,141 +266,24 @@
 /datum/component/construction/mecha/ripley
 	result = /obj/mecha/working/ripley
 	base_icon = "ripley"
-	steps = list(
-		//1
-		list(
-			"key" = TOOL_WRENCH,
-			"desc" = "The hydraulic systems are disconnected."
-		),
 
-		//2
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_WRENCH,
-			"desc" = "The hydraulic systems are connected."
-		),
+	circuit_control = /obj/item/circuitboard/mecha/ripley/main
+	circuit_periph = /obj/item/circuitboard/mecha/ripley/peripherals
 
-		//3
-		list(
-			"key" = /obj/item/stack/cable_coil,
-			"amount" = 5,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "The hydraulic systems are active."
-		),
+	inner_plating=/obj/item/stack/sheet/metal
+	inner_plating_amount = 5
 
-		//4
-		list(
-			"key" = TOOL_WIRECUTTER,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "The wiring is added."
-		),
+	outer_plating=/obj/item/stack/rods
+	outer_plating_amount = 10
 
-		//5
-		list(
-			"key" = /obj/item/circuitboard/mecha/ripley/main,
-			"action" = ITEM_DELETE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "The wiring is adjusted."
-		),
-
-		//6
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Central control module is installed."
-		),
-
-		//7
-		list(
-			"key" = /obj/item/circuitboard/mecha/ripley/peripherals,
-			"action" = ITEM_DELETE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Central control module is secured."
-		),
-
-		//8
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Peripherals control module is installed."
-		),
-
-		//9
-		list(
-			"key" = /obj/item/stock_parts/scanning_module,
-			"action" = ITEM_MOVE_INSIDE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Peripherals control module is secured."
-		),
-
-		//10
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Scanner module is installed."
-		),
-
-		//11
-		list(
-			"key" = /obj/item/stock_parts/capacitor,
-			"action" = ITEM_MOVE_INSIDE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Scanner module is secured."
-		),
-
-		//12
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Capacitor is installed."
-		),
-
-		//13
-		list(
-			"key" = /obj/item/stock_parts/cell,
-			"action" = ITEM_MOVE_INSIDE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Capacitor is secured."
-		),
-
-		//14
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "The power cell is installed."
-		),
-
-		//15
-		list(
-			"key" = /obj/item/stack/sheet/metal,
-			"amount" = 5,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "The power cell is secured."
-		),
-
-		//16
-		list(
-			"key" = TOOL_WRENCH,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Outer plating is installed."
-		),
-
-		//17
-		list(
-			"key" = TOOL_WELDER,
-			"back_key" = TOOL_WRENCH,
-			"desc" = "Outer Plating is wrenched."
-		),
-
-		//18
+/datum/component/construction/mecha/ripley/get_outer_plating_steps()
+	return list(
 		list(
 			"key" = /obj/item/stack/rods,
 			"amount" = 10,
 			"back_key" = TOOL_WELDER,
 			"desc" = "Outer Plating is welded."
 		),
-
-		//19
 		list(
 			"key" = TOOL_WELDER,
 			"back_key" = TOOL_WIRECUTTER,
@@ -315,170 +409,16 @@
 /datum/component/construction/mecha/gygax
 	result = /obj/mecha/combat/gygax
 	base_icon = "gygax"
-	steps = list(
-		//1
-		list(
-			"key" = TOOL_WRENCH,
-			"desc" = "The hydraulic systems are disconnected."
-		),
 
-		//2
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_WRENCH,
-			"desc" = "The hydraulic systems are connected."
-		),
+	circuit_control = /obj/item/circuitboard/mecha/gygax/main
+	circuit_periph = /obj/item/circuitboard/mecha/gygax/peripherals
+	circuit_weapon = /obj/item/circuitboard/mecha/gygax/targeting
 
-		//3
-		list(
-			"key" = /obj/item/stack/cable_coil,
-			"amount" = 5,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "The hydraulic systems are active."
-		),
+	inner_plating = /obj/item/stack/sheet/metal
+	inner_plating_amount = 5
 
-		//4
-		list(
-			"key" = TOOL_WIRECUTTER,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "The wiring is added."
-		),
-
-		//5
-		list(
-			"key" = /obj/item/circuitboard/mecha/gygax/main,
-			"action" = ITEM_DELETE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "The wiring is adjusted."
-		),
-
-		//6
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Central control module is installed."
-		),
-
-		//7
-		list(
-			"key" = /obj/item/circuitboard/mecha/gygax/peripherals,
-			"action" = ITEM_DELETE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Central control module is secured."
-		),
-
-		//8
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Peripherals control module is installed."
-		),
-
-		//9
-		list(
-			"key" = /obj/item/circuitboard/mecha/gygax/targeting,
-			"action" = ITEM_DELETE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Peripherals control module is secured."
-		),
-
-		//10
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Weapon control module is installed."
-		),
-
-		//11
-		list(
-			"key" = /obj/item/stock_parts/scanning_module,
-			"action" = ITEM_MOVE_INSIDE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Weapon control module is secured."
-		),
-
-		//12
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Scanner module is installed."
-		),
-
-		//13
-		list(
-			"key" = /obj/item/stock_parts/capacitor,
-			"action" = ITEM_MOVE_INSIDE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Scanner module is secured."
-		),
-
-		//14
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Capacitor is installed."
-		),
-
-		//15
-		list(
-			"key" = /obj/item/stock_parts/cell,
-			"action" = ITEM_MOVE_INSIDE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Capacitor is secured."
-		),
-
-		//16
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "The power cell is installed."
-		),
-
-		//17
-		list(
-			"key" = /obj/item/stack/sheet/metal,
-			"amount" = 5,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "The power cell is secured."
-		),
-
-		//18
-		list(
-			"key" = TOOL_WRENCH,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Internal armor is installed."
-		),
-
-		//19
-		list(
-			"key" = TOOL_WELDER,
-			"back_key" = TOOL_WRENCH,
-			"desc" = "Internal armor is wrenched."
-		),
-
-		//20
-		list(
-			"key" = /obj/item/mecha_parts/part/gygax_armor,
-			"action" = ITEM_DELETE,
-			"back_key" = TOOL_WELDER,
-			"desc" = "Internal armor is welded."
-		),
-
-		//21
-		list(
-			"key" = TOOL_WRENCH,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "External armor is installed."
-		),
-
-		//22
-		list(
-			"key" = TOOL_WELDER,
-			"back_key" = TOOL_WRENCH,
-			"desc" = "External armor is wrenched."
-		),
-
-	)
+	outer_plating=/obj/item/mecha_parts/part/gygax_armor
+	outer_plating_amount=1
 
 /datum/component/construction/mecha/gygax/action(datum/source, atom/used_atom, mob/user)
 	return check_step(used_atom,user)
@@ -611,132 +551,15 @@
 /datum/component/construction/mecha/firefighter
 	result = /obj/mecha/working/ripley/firefighter
 	base_icon = "fireripley"
-	steps = list(
-		//1
-		list(
-			"key" = TOOL_WRENCH,
-			"desc" = "The hydraulic systems are disconnected."
-		),
 
-		//2
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_WRENCH,
-			"desc" = "The hydraulic systems are connected."
-		),
+	circuit_control = /obj/item/circuitboard/mecha/ripley/main
+	circuit_periph = /obj/item/circuitboard/mecha/ripley/peripherals
 
-		//3
-		list(
-			"key" = /obj/item/stack/cable_coil,
-			"amount" = 5,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "The hydraulic systems are active."
-		),
+	inner_plating = /obj/item/stack/sheet/plasteel
+	inner_plating_amount = 5
 
-		//4
-		list(
-			"key" = TOOL_WIRECUTTER,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "The wiring is added."
-		),
-
-		//5
-		list(
-			"key" = /obj/item/circuitboard/mecha/ripley/main,
-			"action" = ITEM_DELETE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "The wiring is adjusted."
-		),
-
-		//6
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Central control module is installed."
-		),
-
-		//7
-		list(
-			"key" = /obj/item/circuitboard/mecha/ripley/peripherals,
-			"action" = ITEM_DELETE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Central control module is secured."
-		),
-
-		//8
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Peripherals control module is installed."
-		),
-		//9
-		list(
-			"key" = /obj/item/stock_parts/scanning_module,
-			"action" = ITEM_MOVE_INSIDE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Peripherals control module is secured."
-		),
-
-		//10
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Scanner module is installed."
-		),
-
-		//11
-		list(
-			"key" = /obj/item/stock_parts/capacitor,
-			"action" = ITEM_MOVE_INSIDE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Scanner module is secured."
-		),
-
-		//12
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Capacitor is installed."
-		),
-
-		//13
-		list(
-			"key" = /obj/item/stock_parts/cell,
-			"action" = ITEM_MOVE_INSIDE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Capacitor is secured."
-		),
-
-		//14
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "The power cell is installed."
-		),
-
-		//15
-		list(
-			"key" = /obj/item/stack/sheet/plasteel,
-			"amount" = 5,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "The power cell is secured."
-		),
-
-		//16
-		list(
-			"key" = TOOL_WRENCH,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Internal armor is installed."
-		),
-
-		//13
-		list(
-			"key" = TOOL_WELDER,
-			"back_key" = TOOL_WRENCH,
-			"desc" = "Internal armor is wrenched."
-		),
-
-		//17
+/datum/component/construction/mecha/firefighter/get_outer_plating_steps()
+	return list(
 		list(
 			"key" = /obj/item/stack/sheet/plasteel,
 			"amount" = 5,
@@ -744,7 +567,6 @@
 			"desc" = "Internal armor is welded."
 		),
 
-		//18
 		list(
 			"key" = /obj/item/stack/sheet/plasteel,
 			"amount" = 5,
@@ -752,20 +574,18 @@
 			"desc" = "External armor is being installed."
 		),
 
-		//19
 		list(
 			"key" = TOOL_WRENCH,
 			"back_key" = TOOL_CROWBAR,
 			"desc" = "External armor is installed."
 		),
 
-		//20
 		list(
 			"key" = TOOL_WELDER,
 			"back_key" = TOOL_WRENCH,
 			"desc" = "External armor is wrenched."
 		),
-	)
+)
 
 /datum/component/construction/mecha/firefighter/custom_action(obj/item/I, mob/living/user, diff)
 	if(!..())
@@ -891,99 +711,68 @@
 /datum/component/construction/mecha/honker
 	result = /obj/mecha/combat/honker
 	steps = list(
-		//1
 		list(
 			"key" = /obj/item/bikehorn
 		),
-
-		//2
 		list(
 			"key" = /obj/item/circuitboard/mecha/honker/main,
 			"action" = ITEM_DELETE
 		),
-
-		//3
 		list(
 			"key" = /obj/item/bikehorn
 		),
-
-		//4
 		list(
 			"key" = /obj/item/circuitboard/mecha/honker/peripherals,
 			"action" = ITEM_DELETE
 		),
-
-		//5
 		list(
 			"key" = /obj/item/bikehorn
 		),
-
-		//6
 		list(
 			"key" = /obj/item/circuitboard/mecha/honker/targeting,
 			"action" = ITEM_DELETE
 		),
-
-		//7
 		list(
 			"key" = /obj/item/bikehorn
 		),
-
-		//6
 		list(
 			"key" = /obj/item/stock_parts/scanning_module,
 			"action" = ITEM_MOVE_INSIDE
 		),
-
-		//8
 		list(
 			"key" = /obj/item/bikehorn
 		),
-
-		//9
 		list(
 			"key" = /obj/item/stock_parts/capacitor,
 			"action" = ITEM_MOVE_INSIDE
 		),
-
-		//10
 		list(
 			"key" = /obj/item/bikehorn
 		),
-
-		//11
 		list(
 			"key" = /obj/item/stock_parts/cell,
 			"action" = ITEM_MOVE_INSIDE
 		),
-
-		//12
 		list(
 			"key" = /obj/item/bikehorn
 		),
-
-		//13
 		list(
 			"key" = /obj/item/clothing/mask/gas/clown_hat,
 			"action" = ITEM_DELETE
 		),
-
-		//14
 		list(
 			"key" = /obj/item/bikehorn
 		),
-
-		//15
 		list(
 			"key" = /obj/item/clothing/shoes/clown_shoes,
 			"action" = ITEM_DELETE
 		),
-
-		//16
 		list(
 			"key" = /obj/item/bikehorn
 		),
 	)
+/datum/component/construction/mecha/honker/get_steps()
+	return steps
 
 // HONK doesn't have any construction step icons, so we just set an icon once.
 /datum/component/construction/mecha/honker/update_parent(step_index)
@@ -1035,170 +824,16 @@
 /datum/component/construction/mecha/durand
 	result = /obj/mecha/combat/durand
 	base_icon = "durand"
-	steps = list(
-		//1
-		list(
-			"key" = TOOL_WRENCH,
-			"desc" = "The hydraulic systems are disconnected."
-		),
 
-		//2
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_WRENCH,
-			"desc" = "The hydraulic systems are connected."
-		),
+	circuit_control = /obj/item/circuitboard/mecha/durand/main
+	circuit_periph = /obj/item/circuitboard/mecha/durand/peripherals
+	circuit_weapon = /obj/item/circuitboard/mecha/durand/targeting
 
-		//3
-		list(
-			"key" = /obj/item/stack/cable_coil,
-			"amount" = 5,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "The hydraulic systems are active."
-		),
+	inner_plating = /obj/item/stack/sheet/metal
+	inner_plating_amount = 5
 
-		//4
-		list(
-			"key" = TOOL_WIRECUTTER,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "The wiring is added."
-		),
-
-		//5
-		list(
-			"key" = /obj/item/circuitboard/mecha/durand/main,
-			"action" = ITEM_DELETE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "The wiring is adjusted."
-		),
-
-		//6
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Central control module is installed."
-		),
-
-		//7
-		list(
-			"key" = /obj/item/circuitboard/mecha/durand/peripherals,
-			"action" = ITEM_DELETE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Central control module is secured."
-		),
-
-		//8
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Peripherals control module is installed."
-		),
-
-		//9
-		list(
-			"key" = /obj/item/circuitboard/mecha/durand/targeting,
-			"action" = ITEM_DELETE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Peripherals control module is secured."
-		),
-
-		//10
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Weapon control module is installed."
-		),
-
-		//11
-		list(
-			"key" = /obj/item/stock_parts/scanning_module,
-			"action" = ITEM_MOVE_INSIDE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Weapon control module is secured."
-		),
-
-		//12
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Scanner module is installed."
-		),
-
-		//13
-		list(
-			"key" = /obj/item/stock_parts/capacitor,
-			"action" = ITEM_MOVE_INSIDE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Scanner module is secured."
-		),
-
-		//14
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Capacitor is installed."
-		),
-
-		//15
-		list(
-			"key" = /obj/item/stock_parts/cell,
-			"action" = ITEM_MOVE_INSIDE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Capacitor is secured."
-		),
-
-		//16
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "The power cell is installed."
-		),
-
-		//17
-		list(
-			"key" = /obj/item/stack/sheet/metal,
-			"amount" = 5,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "The power cell is secured."
-		),
-
-		//18
-		list(
-			"key" = TOOL_WRENCH,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Internal armor is installed."
-		),
-
-		//19
-		list(
-			"key" = TOOL_WELDER,
-			"back_key" = TOOL_WRENCH,
-			"desc" = "Internal armor is wrenched."
-		),
-
-		//20
-		list(
-			"key" = /obj/item/mecha_parts/part/durand_armor,
-			"action" = ITEM_DELETE,
-			"back_key" = TOOL_WELDER,
-			"desc" = "Internal armor is welded."
-		),
-
-		//21
-		list(
-			"key" = TOOL_WRENCH,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "External armor is installed."
-		),
-
-		//22
-		list(
-			"key" = TOOL_WELDER,
-			"back_key" = TOOL_WRENCH,
-			"desc" = "External armor is wrenched."
-		),
-	)
-
+	outer_plating = /obj/item/mecha_parts/part/durand_armor
+	outer_plating_amount = 1
 
 /datum/component/construction/mecha/durand/custom_action(obj/item/I, mob/living/user, diff)
 	if(!..())
@@ -1331,210 +966,94 @@
 /datum/component/construction/mecha/phazon
 	result = /obj/mecha/combat/phazon
 	base_icon = "phazon"
-	steps = list(
-		//1
-		list(
-			"key" = TOOL_WRENCH,
-			"desc" = "The hydraulic systems are disconnected."
-		),
 
-		//2
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_WRENCH,
-			"desc" = "The hydraulic systems are connected."
-		),
+	circuit_control = /obj/item/circuitboard/mecha/phazon/main
+	circuit_periph = /obj/item/circuitboard/mecha/phazon/peripherals
+	circuit_weapon = /obj/item/circuitboard/mecha/phazon/targeting
 
-		//3
-		list(
-			"key" = /obj/item/stack/cable_coil,
-			"amount" = 5,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "The hydraulic systems are active."
-		),
+	inner_plating = /obj/item/stack/sheet/plasteel
+	inner_plating_amount = 5
 
-		//4
-		list(
-			"key" = TOOL_WIRECUTTER,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "The wiring is added."
-		),
+	outer_plating = /obj/item/mecha_parts/part/phazon_armor
+	outer_plating_amount = 1
 
-		//5
-		list(
-			"key" = /obj/item/circuitboard/mecha/phazon/main,
-			"action" = ITEM_DELETE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "The wiring is adjusted."
-		),
-
-		//6
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Central control module is installed."
-		),
-
-		//7
-		list(
-			"key" = /obj/item/circuitboard/mecha/phazon/peripherals,
-			"action" = ITEM_DELETE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Central control module is secured."
-		),
-
-		//8
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Peripherals control module is installed"
-		),
-
-		//9
-		list(
-			"key" = /obj/item/circuitboard/mecha/phazon/targeting,
-			"action" = ITEM_DELETE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Peripherals control module is secured."
-		),
-
-		//10
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Weapon control is installed."
-		),
-
-		//11
-		list(
-			"key" = /obj/item/stock_parts/scanning_module,
-			"action" = ITEM_MOVE_INSIDE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Weapon control module is secured."
-		),
-
-		//12
+/datum/component/construction/mecha/phazon/get_stockpart_steps()
+	return list(
 		list(
 			"key" = TOOL_SCREWDRIVER,
 			"back_key" = TOOL_CROWBAR,
 			"desc" = "Scanner module is installed."
 		),
-
-		//13
 		list(
 			"key" = /obj/item/stock_parts/capacitor,
 			"action" = ITEM_MOVE_INSIDE,
 			"back_key" = TOOL_SCREWDRIVER,
 			"desc" = "Scanner module is secured."
 		),
-
-		//14
 		list(
 			"key" = TOOL_SCREWDRIVER,
 			"back_key" = TOOL_CROWBAR,
 			"desc" = "Capacitor is installed."
 		),
-
-		//15
 		list(
 			"key" = /obj/item/stack/ore/bluespace_crystal,
 			"amount" = 1,
 			"back_key" = TOOL_SCREWDRIVER,
 			"desc" = "Capacitor is secured."
 		),
-
-		//16
 		list(
 			"key" = /obj/item/stack/cable_coil,
 			"amount" = 5,
 			"back_key" = TOOL_CROWBAR,
 			"desc" = "The bluespace crystal is installed."
 		),
-
-		//17
 		list(
 			"key" = TOOL_SCREWDRIVER,
 			"back_key" = TOOL_WIRECUTTER,
 			"desc" = "The bluespace crystal is connected."
 		),
-
-		//18
 		list(
 			"key" = /obj/item/stock_parts/cell,
 			"action" = ITEM_MOVE_INSIDE,
 			"back_key" = TOOL_SCREWDRIVER,
 			"desc" = "The bluespace crystal is engaged."
 		),
-
-		//19
 		list(
 			"key" = TOOL_SCREWDRIVER,
 			"back_key" = TOOL_CROWBAR,
 			"desc" = "The power cell is installed.",
 			"icon_state" = "phazon17"
 			// This is the point where a step icon is skipped, so "icon_state" had to be set manually starting from here.
-		),
+		)
+	)
 
-		//20
+/datum/component/construction/mecha/phazon/get_outer_plating_steps()
+	return list(
 		list(
-			"key" = /obj/item/stack/sheet/plasteel,
-			"amount" = 5,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "The power cell is secured.",
-			"icon_state" = "phazon18"
-		),
-
-		//21
-		list(
-			"key" = TOOL_WRENCH,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Phase armor is installed.",
-			"icon_state" = "phazon19"
-		),
-
-		//22
-		list(
-			"key" = TOOL_WELDER,
-			"back_key" = TOOL_WRENCH,
-			"desc" = "Phase armor is wrenched.",
-			"icon_state" = "phazon20"
-		),
-
-		//23
-		list(
-			"key" = /obj/item/mecha_parts/part/phazon_armor,
+			"key" = outer_plating,
+			"amount" = 1,
 			"action" = ITEM_DELETE,
 			"back_key" = TOOL_WELDER,
-			"desc" = "Phase armor is welded.",
-			"icon_state" = "phazon21"
+			"desc" = "Internal armor is welded."
 		),
-
-		//24
 		list(
 			"key" = TOOL_WRENCH,
 			"back_key" = TOOL_CROWBAR,
-			"desc" = "External armor is installed.",
-			"icon_state" = "phazon22"
+			"desc" = "External armor is installed."
 		),
-
-		//25
 		list(
 			"key" = TOOL_WELDER,
 			"back_key" = TOOL_WRENCH,
-			"desc" = "External armor is wrenched.",
-			"icon_state" = "phazon23"
+			"desc" = "External armor is wrenched."
 		),
-
-		//26
 		list(
 			"key" = /obj/item/assembly/signaler/anomaly,
 			"action" = ITEM_DELETE,
 			"back_key" = TOOL_WELDER,
 			"desc" = "Anomaly core socket is open.",
 			"icon_state" = "phazon24"
-		),
+		)
 	)
-
 
 /datum/component/construction/mecha/phazon/custom_action(obj/item/I, mob/living/user, diff)
 	if(!..())
@@ -1686,153 +1205,15 @@
 /datum/component/construction/mecha/odysseus
 	result = /obj/mecha/medical/odysseus
 	base_icon = "odysseus"
-	steps = list(
-		//1
-		list(
-			"key" = TOOL_WRENCH,
-			"desc" = "The hydraulic systems are disconnected."
-		),
 
-		//2
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_WRENCH,
-			"desc" = "The hydraulic systems are connected."
-		),
+	circuit_control = /obj/item/circuitboard/mecha/odysseus/main
+	circuit_periph = /obj/item/circuitboard/mecha/odysseus/peripherals
 
-		//3
-		list(
-			"key" = /obj/item/stack/cable_coil,
-			"amount" = 5,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "The hydraulic systems are active."
-		),
+	inner_plating = /obj/item/stack/sheet/metal
+	inner_plating_amount = 5
 
-		//4
-		list(
-			"key" = TOOL_WIRECUTTER,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "The wiring is added."
-		),
-
-		//5
-		list(
-			"key" = /obj/item/circuitboard/mecha/odysseus/main,
-			"action" = ITEM_DELETE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "The wiring is adjusted."
-		),
-
-		//6
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Central control module is installed."
-		),
-
-		//7
-		list(
-			"key" = /obj/item/circuitboard/mecha/odysseus/peripherals,
-			"action" = ITEM_DELETE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Central control module is secured."
-		),
-
-		//8
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Peripherals control module is installed."
-		),
-		//9
-		list(
-			"key" = /obj/item/stock_parts/scanning_module,
-			"action" = ITEM_MOVE_INSIDE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Peripherals control module is secured."
-		),
-
-		//10
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Scanner module is installed."
-		),
-
-		//11
-		list(
-			"key" = /obj/item/stock_parts/capacitor,
-			"action" = ITEM_MOVE_INSIDE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Scanner module is secured."
-		),
-
-		//12
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Capacitor is installed."
-		),
-
-		//13
-		list(
-			"key" = /obj/item/stock_parts/cell,
-			"action" = ITEM_MOVE_INSIDE,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Capacitor is secured."
-		),
-
-		//11
-		list(
-			"key" = TOOL_SCREWDRIVER,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "The power cell is installed."
-		),
-
-		//12
-		list(
-			"key" = /obj/item/stack/sheet/metal,
-			"amount" = 5,
-			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "The power cell is secured."
-		),
-
-		//13
-		list(
-			"key" = TOOL_WRENCH,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "Internal armor is installed."
-		),
-
-		//14
-		list(
-			"key" = TOOL_WELDER,
-			"back_key" = TOOL_WRENCH,
-			"desc" = "Internal armor is wrenched."
-		),
-
-		//15
-		list(
-			"key" = /obj/item/stack/sheet/plasteel,
-			"amount" = 5,
-			"back_key" = TOOL_WELDER,
-			"desc" = "Internal armor is welded."
-		),
-
-		//16
-		list(
-			"key" = TOOL_WRENCH,
-			"back_key" = TOOL_CROWBAR,
-			"desc" = "External armor is installed."
-		),
-
-		//17
-		list(
-			"key" = TOOL_WELDER,
-			"back_key" = TOOL_WRENCH,
-			"desc" = "External armor is wrenched."
-		),
-	)
+	outer_plating = /obj/item/stack/sheet/plasteel
+	outer_plating_amount = 5
 
 /datum/component/construction/mecha/odysseus/custom_action(obj/item/I, mob/living/user, diff)
 	if(!..())

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -218,32 +218,47 @@
 			else
 				to_chat(user, "<span class='warning'>You need two lengths of cable to fix this mech!</span>")
 		return
-	else if(W.tool_behaviour == TOOL_SCREWDRIVER && user.a_intent != INTENT_HARM)
-		if(internal_damage & MECHA_INT_TEMP_CONTROL)
-			clearInternalDamage(MECHA_INT_TEMP_CONTROL)
-			to_chat(user, "<span class='notice'>You repair the damaged temperature controller.</span>")
-		else if(state==3 && cell)
-			cell.forceMove(loc)
-			cell = null
-			state = 4
-			to_chat(user, "<span class='notice'>You unscrew and pry out the powercell.</span>")
-			log_message("Powercell removed", LOG_MECHA)
-		else if(state==4 && cell)
-			state=3
-			to_chat(user, "<span class='notice'>You screw the cell in place.</span>")
-		return
 
 	else if(istype(W, /obj/item/stock_parts/cell))
-		if(state==4)
+		if(state==3)
 			if(!cell)
 				if(!user.transferItemToLoc(W, src))
 					return
 				var/obj/item/stock_parts/cell/C = W
-				to_chat(user, "<span class='notice'>You install the powercell.</span>")
+				to_chat(user, "<span class='notice'>You install the power cell.</span>")
+				playsound(src, 'sound/items/screwdriver2.ogg', 50, FALSE)
 				cell = C
 				log_message("Powercell installed", LOG_MECHA)
 			else
-				to_chat(user, "<span class='notice'>There's already a powercell installed.</span>")
+				to_chat(user, "<span class='notice'>There's already a power cell installed.</span>")
+		return
+
+	if(istype(W, /obj/item/stock_parts/scanning_module))
+		if(state == 3)
+			if(!scanmod)
+				if(!user.transferItemToLoc(W, src))
+					return
+				to_chat(user, "<span class='notice'>You install the scanning module.</span>")
+				playsound(src, 'sound/items/screwdriver2.ogg', 50, FALSE)
+				scanmod = W
+				log_message("[W] installed", LOG_MECHA)
+				update_part_values()
+			else
+				to_chat(user, "<span class='notice'>There's already a scanning module installed.</span>")
+		return
+
+	if(istype(W, /obj/item/stock_parts/capacitor))
+		if(state == 3)
+			if(!capacitor)
+				if(!user.transferItemToLoc(W, src))
+					return
+				to_chat(user, "<span class='notice'>You install the capacitor.</span>")
+				playsound(src, 'sound/items/screwdriver2.ogg', 50, FALSE)
+				capacitor = W
+				log_message("[W] installed", LOG_MECHA)
+				update_part_values()
+			else
+				to_chat(user, "<span class='notice'>There's already a capacitor installed.</span>")
 		return
 
 	else if(W.tool_behaviour == TOOL_WELDER && user.a_intent != INTENT_HARM)
@@ -335,3 +350,29 @@
 			else if(damtype == TOX)
 				visual_effect_icon = ATTACK_EFFECT_MECHTOXIN
 	..()
+
+/obj/mecha/obj_destruction()
+	if(wreckage)
+		var/mob/living/silicon/ai/AI
+		if(isAI(occupant))
+			AI = occupant
+			occupant = null
+		var/obj/structure/mecha_wreckage/WR = new wreckage(loc, AI)
+		for(var/obj/item/mecha_parts/mecha_equipment/E in equipment)
+			if(E.salvageable && prob(30))
+				WR.crowbar_salvage += E
+				E.detach(WR) //detaches from src into WR
+				E.equip_ready = 1
+			else
+				E.detach(loc)
+				qdel(E)
+		if(cell)
+			WR.crowbar_salvage += cell
+			cell.forceMove(WR)
+			cell.charge = rand(0, cell.charge)
+			cell = null
+		if(internal_tank)
+			WR.crowbar_salvage += internal_tank
+			internal_tank.forceMove(WR)
+			cell = null
+	. = ..() 

--- a/code/game/mecha/mecha_topic.dm
+++ b/code/game/mecha/mecha_topic.dm
@@ -186,18 +186,23 @@
 	if(!id_card || !user)
 		return
 	. = {"<html>
-						<head>
-						<style>
-						body {color: #00ff00; background: #000000; font-family:"Courier New", Courier, monospace; font-size: 12px;}
-						a {padding:2px 5px; background:#32CD32;color:#000;display:block;margin:2px;text-align:center;text-decoration:none;}
-						</style>
-						</head>
-						<body>
-						[add_req_access?"<a href='?src=[REF(src)];req_access=1;id_card=[REF(id_card)];user=[REF(user)]'>Edit operation keycodes</a>":null]
-						[maint_access?"<a href='?src=[REF(src)];maint_access=1;id_card=[REF(id_card)];user=[REF(user)]'>[(state>0) ? "Terminate" : "Initiate"] maintenance protocol</a>":null]
-						[(state>0) ?"<a href='?src=[REF(src)];set_internal_tank_valve=1;user=[REF(user)]'>Set Cabin Air Pressure</a>":null]
-						</body>
-						</html>"}
+			<head>
+				<style>
+					body {color: #00ff00; background: #000000; font-family:"Courier New", Courier, monospace; font-size: 12px;}
+					a {padding:2px 5px; background:#32CD32;color:#000;display:block;margin:2px;text-align:center;text-decoration:none;}
+				</style>
+			</head>
+			<body>
+				[add_req_access?"<a href='?src=[REF(src)];req_access=1;id_card=[REF(id_card)];user=[REF(user)]'>Edit operation keycodes</a>":null]
+				[maint_access?"<a href='?src=[REF(src)];maint_access=1;id_card=[REF(id_card)];user=[REF(user)]'>[(state > 0) ? "Terminate" : "Initiate"] maintenance protocol</a>":null]
+				[(state == 3) ?"--------------------</br>":null]
+				[(state == 3) ?"[cell?"<a href='?src=[REF(src)];drop_cell=1;id_card=[REF(id_card)];user=[REF(user)]'>Drop power cell</a>":"No cell installed</br>"]":null]
+				[(state == 3) ?"[scanmod?"<a href='?src=[REF(src)];drop_scanmod=1;id_card=[REF(id_card)];user=[REF(user)]'>Drop scanning module</a>":"No scanning module installed</br>"]":null]
+				[(state == 3) ?"[capacitor?"<a href='?src=[REF(src)];drop_cap=1;id_card=[REF(id_card)];user=[REF(user)]'>Drop capacitor</a>":"No capacitor installed</br>"]":null]
+				[(state == 3) ?"--------------------</br>":null]
+				[(state>0) ?"<a href='?src=[REF(src)];set_internal_tank_valve=1;user=[REF(user)]'>Set Cabin Air Pressure</a>":null]
+			</body>
+		</html>"}
 	user << browse(., "window=exosuit_maint_console")
 	onclose(user, "exosuit_maint_console")
 
@@ -233,7 +238,31 @@
 			else if(state==1)
 				state = 0
 				to_chat(usr, "The securing bolts are now hidden.")
+			else if(state==2) //user feedback YOGGERZ
+				visible_message("<span class='warning'>You need to tighten the securing bolts first!</span>")
+			else if(state==3)
+				visible_message("<span class='warning'>You need to close the hatch to the power unit first!</span>")	
 			output_maintenance_dialog(id_card,usr)
+			return
+
+		if(href_list["drop_cell"])
+			if(state == 3)
+				cell.forceMove(get_turf(src))
+				cell = null
+			output_maintenance_dialog(id_card,usr)
+			return
+		if(href_list["drop_scanmod"])
+			if(state == 3)
+				scanmod.forceMove(get_turf(src))
+				scanmod = null
+			output_maintenance_dialog(id_card,usr)
+			return
+		if(href_list["drop_cap"])
+			if(state == 3)
+				capacitor.forceMove(get_turf(src))
+				capacitor = null
+			output_maintenance_dialog(id_card,usr)
+			return
 
 		if(href_list["set_internal_tank_valve"] && state >=1)
 			var/new_pressure = input(usr,"Input new output pressure","Pressure setting",internal_tank_valve) as num
@@ -299,7 +328,8 @@
 			occupant_message("<span class='danger'>Maintenance protocols in effect</span>")
 			return
 		maint_access = !maint_access
-		send_byjax(usr,"exosuit.browser","t_maint_access","[maint_access?"Forbid":"Permit"] maintenance protocols")
+		send_byjax(usr,"exosuit.browser","t_maint_access","[maint_access?"Forbid":"Permit"] maintenance protocols")	
+
 
 	if (href_list["toggle_port_connection"])
 		if(internal_tank.connected_port)

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -73,6 +73,10 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	else if(AIuser)
 		return ..(freq, level)
 	return FALSE
+	
+/obj/item/radio/headset/ui_data(mob/user)
+	. = ..()
+	.["headset"] = TRUE
 
 /obj/item/radio/headset/syndicate //disguised to look like a normal headset for stealth ops
 

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -137,6 +137,12 @@
 
 /obj/item/radio/intercom/add_blood_DNA(list/blood_dna)
 	return FALSE
+	
+/obj/item/radio/intercom/end_emp_effect(curremp)
+	. = ..()
+	if(!.)
+		return
+	on = FALSE
 
 //Created through the autolathe or through deconstructing intercoms. Can be applied to wall to make a new intercom on it!
 /obj/item/wallframe/intercom

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -137,7 +137,7 @@
 	data["useCommand"] = use_command
 	data["subspace"] = subspace_transmission
 	data["subspaceSwitchable"] = subspace_switchable
-	data["headset"] = istype(src, /obj/item/radio/headset)
+	data["headset"] = FALSE
 
 	return data
 
@@ -357,11 +357,14 @@
 	for (var/ch_name in channels)
 		channels[ch_name] = 0
 	on = FALSE
-	spawn(200)
-		if(emped == curremp) //Don't fix it if it's been EMP'd again
-			emped = 0
-			if (!istype(src, /obj/item/radio/intercom)) // intercoms will turn back on on their own
-				on = TRUE
+	addtimer(CALLBACK(src, .proc/end_emp_effect, curremp), 200)
+
+/obj/item/radio/proc/end_emp_effect(curremp)
+	if(emped != curremp) //Don't fix it if it's been EMP'd again
+		return FALSE
+	emped = FALSE
+	on = TRUE
+	return TRUE
 
 ///////////////////////////////
 //////////Borg Radios//////////

--- a/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
@@ -111,7 +111,7 @@
 	return 0 //multiplier for whatever head armor you wear as a drone
 
 /mob/living/simple_animal/drone/proc/update_drone_hack(hack, clockwork)
-	if(!istype(src) || !mind)
+	if(!mind)
 		return
 	if(hack)
 		if(hacked)


### PR DESCRIPTION
### Intent of your Pull Request

This PR combines 4 PR's from TG into one. All credit to their respective owners. Only code I did was a little user feedback (thanks Hopek!).

What this PR does:
"Refactors mech construction to dynamically generate the construction step list. Now just specify the circuit board types and plating types to use the standard build process, or specific phases can be customized by overriding the different steps procs or by overriding get_steps entirely. (HONK does this)."

"Adds in the ability to remove and insert scanning modules and capacitors to mechs after they've been built. This is done by starting maintenance (via ID/PDA), using a wrench and then a crowbar to open the panel, and finally using the ID/PDA again to open the gui and drop the part you want to remove. A new part can be added afterwards while the panel is still open."
"Removes the need for a screwdriver when replacing a power cell, and instead moves cells to the system that scanners and caps use."

UI:
![image](https://user-images.githubusercontent.com/49619518/80447178-8c324780-88cd-11ea-9d1a-63e7dc000145.png)

"Makes mechs removed from the game via means other than damage no longer leave a wreckage."

"Removes some istype(src) stuff."

PRs used:
https://github.com/tgstation/tgstation/pull/49299 **jdawg1290**
https://github.com/tgstation/tgstation/pull/46579 **zxaber**
https://github.com/tgstation/tgstation/pull/46376 **zxaber**
https://github.com/tgstation/tgstation/pull/45534 **nemvar**

#### Changelog

:cl:  
rscadd: You can now replace the scanning modules and capacitors on a mech. Just use your ID on the mech after opening the panel during maintenance procedures to remove the part you want to replace, and then insert the new part afterwards.
bugfix: Mechs removed from the game via means other than damage no longer leave a wreckage.
tweak: Refactors Mech construction
tweak: Replacing a power cell on a mech no longer uses a screwdriver, and functions the same as the replacement steps for scanning modules and capacitors.
/:cl:
