### PR TITLE
[admin] Increases number of Response team spawners from 9 to 18

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -18483,6 +18483,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
+"NH" = (
+/obj/effect/landmark/ert_spawn,
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "NI" = (
 /obj/structure/closet/lasertag/red,
 /turf/open/floor/wood,
@@ -20968,6 +20972,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/two)
+"Vl" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/landmark/ert_spawn,
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "Vm" = (
 /obj/machinery/gibber,
 /obj/machinery/light{
@@ -60273,11 +60291,11 @@ ws
 wB
 yr
 sw
-sw
+Vl
 Ad
 AL
 Bx
-sw
+Vl
 Cv
 mD
 aa
@@ -61301,11 +61319,11 @@ ws
 ts
 mD
 uV
-sw
+Vl
 Ah
 AP
 Ah
-sw
+Vl
 Cz
 mD
 aa
@@ -61558,11 +61576,11 @@ ws
 ts
 qR
 pH
-zA
-sw
-zA
-sw
-zA
+NH
+Vl
+NH
+Vl
+NH
 CA
 mD
 aa


### PR DESCRIPTION
There is a hard cap to ERT/response team spawners because there just weren't enough spawners.
So if you created an ERT larger than 9 people the rest would not spawn.

Encountered this cap when bussing in huge ERT's which forced me to create 2 identical ERT's to spawn them in 2 waves instead.

The ERT selection menu lets you put in a number as to how many people you want so it is assumed you can go higher than 9.

#### Changelog

:cl:  
bugfix: Added more spawners so admins can now spawn more than 9 ERT/response team members at once (now 18)
/:cl:
