### PR TITLE
Attempts to fix the lavaland monstermos airlock problem that causes miners to die in a vaccum

### DIFF
--- a/_maps/RandomRuins/LavaRuins/miningbase.dmm
+++ b/_maps/RandomRuins/LavaRuins/miningbase.dmm
@@ -1833,14 +1833,6 @@
 	},
 /turf/open/floor/carpet,
 /area/mine/living_quarters)
-"eF" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 8;
-	level = 2;
-	piping_layer = 1
-	},
-/turf/open/floor/plating,
-/area/mine/living_quarters)
 "eI" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -2243,6 +2235,15 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/mine/production)
+"xb" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 8;
+	level = 2;
+	piping_layer = 1;
+	volume = 50000
+	},
+/turf/open/floor/plating,
+/area/mine/living_quarters)
 "xH" = (
 /obj/item/radio/intercom{
 	dir = 8;
@@ -3357,8 +3358,8 @@ ac
 ak
 bQ
 bZ
-eF
-eF
+xb
+xb
 bQ
 cF
 de


### PR DESCRIPTION
### Intent of your Pull Request

Recently there has been a huge spike of miners dying in the airlock due to the inside becoming a close vaccum. The issue is that the stationary air tanks on lavaland can only hold so much gas inside them, the gas gets cycled when a miner uses the airlock, then thrown into the disposals loop which just injects all the waste gas outside without any recycling. Thus if miners walk in and out too often, the gas eventually runs out and  the vents cant refill the airlock, only drain it.

The ideal solution would be implementing a way to recycle the gas that gets cycled in and out the airlock so it never gets wasted. I don't know enough about piping or atmos to do that properly in a compact and neat way.
So this PR tries to fix that problem with a lazy temporary solution, adding waay more gas to the tanks so it never runs out. 

#### Changelog

:cl:  
tweak: stationary lavaland air tanks get more air  
/:cl:
