### PR TITLE
Might fix a runtime in mood.dm

### DIFF
--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -170,6 +170,9 @@
 
 /datum/component/mood/process() //Called on SSmood process
 	var/mob/living/owner = parent
+	if(!owner)
+		qdel(src)
+		return
 
 	switch(mood_level)
 		if(1)


### PR DESCRIPTION
### Intent of your Pull Request
Somehow the parent of the mood component is set to null without the component being destroyed.
This might be a hacky fix depending on how components work. Should fix a few runtimes
![image](https://user-images.githubusercontent.com/5618080/80833628-3e7c4e80-8bef-11ea-8b10-4cf0afba2b6f.png)

#### Changelog

:cl:  
bugfix: fixed a few mood runtimes
/:cl:
