### PR TITLE
Prevents the Arc from being able to be laser'd from the outside

### DIFF
--- a/_maps/map_files/generic/City_of_Cogs.dmm
+++ b/_maps/map_files/generic/City_of_Cogs.dmm
@@ -3737,7 +3737,7 @@ aj
 aj
 ai
 aj
-aj
+ah
 aj
 ai
 aj
@@ -3918,9 +3918,9 @@ aj
 aB
 az
 ah
-ai
+ah
 ag
-ai
+ah
 an
 au
 ao
@@ -4188,7 +4188,7 @@ aj
 aj
 aj
 aj
-ai
+ah
 aH
 aj
 aj
@@ -4196,7 +4196,7 @@ aj
 aj
 aj
 aH
-ai
+ah
 aj
 aj
 aj
@@ -4277,7 +4277,7 @@ aj
 ae
 aj
 aj
-aj
+ah
 aj
 ag
 aH
@@ -4289,7 +4289,7 @@ aj
 aH
 ag
 aj
-aj
+ah
 aj
 aj
 ae
@@ -4370,7 +4370,7 @@ aj
 aj
 aj
 aj
-ai
+ah
 aH
 aj
 aj
@@ -4378,7 +4378,7 @@ aj
 aj
 aj
 aH
-ai
+ah
 aj
 aj
 aj
@@ -4646,9 +4646,9 @@ aj
 aj
 aC
 ah
-ai
+ah
 ag
-ai
+ah
 ah
 ay
 aj
@@ -4829,7 +4829,7 @@ aj
 aj
 ai
 aj
-aj
+ah
 aj
 ai
 aj


### PR DESCRIPTION
Red lines and the attacks from the outside prevented.
You can literally stand on the outside and just laser the Arc dead

![image](https://user-images.githubusercontent.com/24533979/80847653-103e4500-8bd6-11ea-99d4-dc4a270fa93b.png)

![68747470733a2f2f6d64622e616666656374656461726330372e636f2e756b2f46696c65732f3132303936363333362f3633373738353730362f302f646966662e706e67](https://user-images.githubusercontent.com/24533979/80852077-34585100-8beb-11ea-8fa3-606ddf9f4f42.png)



#### Changelog

:cl:  Hopek
tweak: Made the clock cult's arc not be able to be lasered from outside of the whole base
/:cl:
