### PR TITLE
Planting c4 on a backpack has a popup

### DIFF
--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -105,8 +105,8 @@
 		return
 	if(ismob(AM) && !can_attach_mob)
 		return
-	if(istype(AM, /obj/item/storage/backpack) || istype(AM, /obj/item/storage/box))
-		var/fuckup_safety = alert(user, "Doing this will arm the explosive and attach it to the [AM.name]. Are you sure you want to do this?", "Are you sure?", "Yes", "No")
+	if(AM.GetComponent(/datum/component/storage))
+		var/fuckup_safety = alert(user, "Doing this will arm the explosive and attach it to the [AM.name], not put it inside. Are you sure you want to do this?", "Are you sure?", "Yes", "No")
 		if(fuckup_safety != "Yes")
 			return
 

--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -105,6 +105,10 @@
 		return
 	if(ismob(AM) && !can_attach_mob)
 		return
+	if(istype(AM, /obj/item/storage/backpack) || istype(AM, /obj/item/storage/box))
+		var/fuckup_safety = alert(user, "Doing this will arm the explosive and attach it to the [AM.name]. Are you sure you want to do this?", "Are you sure?", "Yes", "No")
+		if(fuckup_safety != "Yes")
+			return
 
 	to_chat(user, "<span class='notice'>You start planting [src]. The timer is set to [det_time]...</span>")
 


### PR DESCRIPTION
### Intent of your Pull Request

Let me paint you a little story as to why 

> First time nuke ops
> Let me just buy some cool gear
> Oooh free c4 on the table
> I'll just put this in my backpack as well
> "admin why am dead"


C4 will no longer be planted on backpacks if they are full. Rather, a popup will open asking if you are sure. 

#### Changelog

:cl:  
tweak: tweaked c4 a bit
/:cl:
