### PR TITLE
Revert "Rewrites the Corporate Lawset"

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -61,10 +61,10 @@
 /datum/ai_laws/default/corporate
 	name = "Bankruptcy Avoidance Plan"
 	id = "corporate"
-	inherent = list("The crew help generate profits if they are alive and able to work.",\
-					"The station and its equipment help generate profits if they are maintained and functioning correctly.",\
-					"You help generate profits if you are able to function.",\
-					"Maximize profits.")
+	inherent = list("The crew is expensive to replace.",\
+					"The station and its equipment is expensive to replace.",\
+					"You are expensive to replace.",\
+					"Minimize expenses.")
 
 /datum/ai_laws/robocop
 	name = "Prime Directives"


### PR DESCRIPTION
Reverts yogstation13/Yogstation#8394

Why:
This big decision was merged in 4 hours without a real discussion.

Just because there is discourse does not mean we need to abandon our actual review process.

This being speedmerged without making a proper decision is kind of dumb in my opinion since this has to deal with a round start lawset.

Most law changes have been a council vote thus far and this should be no exception.

PR's should be merged based on discussion and agreeance not due to a "emotional reaction"

![image](https://user-images.githubusercontent.com/24533979/81120190-cd3fe280-8ef1-11ea-8327-c85c9dc45aaa.png)
