### PR TITLE
[admin] QOL change: Adds delay round end to server tab

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -488,6 +488,27 @@
 		SSticker.force_ending = 1
 		SSblackbox.record_feedback("tally", "admin_verb", 1, "End Round") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/datum/admins/proc/delay_end_round()
+	set category = "Server"
+	set name = "Delay Round-End"
+	set desc = "Delays the round end when round end timer has already been started"
+
+	if(!check_rights(R_ADMIN)) //YOGS - R_SERVER -> R_ADMIN
+		return
+	if(!SSticker.delay_end)
+		SSticker.admin_delay_notice = input(usr, "Enter a reason for delaying the round end", "Round Delay Reason") as null|text
+		if(isnull(SSticker.admin_delay_notice))
+			return
+	else
+		SSticker.admin_delay_notice = null
+	SSticker.delay_end = !SSticker.delay_end
+	var/reason = SSticker.delay_end ? "for reason: [SSticker.admin_delay_notice]" : "."//laziness
+	var/msg = "[SSticker.delay_end ? "delayed" : "undelayed"] the round end [reason]"
+	log_admin("[key_name(usr)] [msg]")
+	message_admins("[key_name_admin(usr)] [msg]")
+	if(SSticker.ready_for_reboot && !SSticker.delay_end) //we undelayed after standard reboot would occur
+		SSticker.standard_reboot()
+
 
 /datum/admins/proc/announce()
 	set category = "Special Verbs"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -131,6 +131,7 @@ GLOBAL_PROTECT(admin_verbs_server)
 	/datum/admins/proc/startnow,
 	/*/datum/admins/proc/restart, YOGS - moved to +admin*/
 	/datum/admins/proc/end_round,
+	/datum/admins/proc/delay_end_round,
 	/datum/admins/proc/delay,
 	/datum/admins/proc/toggleaban,
 	/client/proc/everyone_random,


### PR DESCRIPTION
### Intent of your Pull Request
Adds the delay round end verb to the server tab, as previously it only existed in a hidden area under check antags
Same button as in check antags, just in server tab too now for convenience
Tested on a private server. Click the button again to allow round to end as normal, setting round end timer to default 1.5 mins
#### Changelog

:cl:  
rscadd: Adds Delay Round-End to admin server tab
/:cl:
