### PR TITLE
ports Researchable Smartmines + Exploding Rubber Duck traitor item from Beestation

### DIFF
--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -33,7 +33,7 @@
 
 /obj/item/deployablemine/honk
 	name = "deployable honkblaster 1000"
-	desc = "An advanced pranking landmine for clowns, honk! Delivers an extra loud HONK to the head when triggered. It can be planted to arm it, or have its sound customised with a sound synthesiser."	
+	desc = "An advanced pranking landmine for clowns, honk! Delivers an extra loud HONK to the head when triggered. It can be planted to arm it, or have its sound customised with a sound synthesiser."
 	mine_type = /obj/effect/mine/sound
 
 /obj/item/deployablemine/traitor

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -1,3 +1,90 @@
+/obj/item/deployablemine
+	name = "deployable mine"
+	desc = "An unarmed landmine. It can be planted to arm it."
+	icon_state = "uglymine"
+	var/mine_type = /obj/effect/mine
+	var/arming_time = 30
+
+/obj/item/deployablemine/stun
+	desc = "An unarmed stun mine. It can be planted to arm it."
+	mine_type = /obj/effect/mine/stun
+
+/obj/item/deployablemine/smartstun
+	name = "deployable smart mine"
+	desc = "An unarmed smart stun mine. It can be planted to arm it."
+	mine_type = /obj/effect/mine/stun/smart
+
+/obj/item/deployablemine/rapid
+	name = "deployable rapid smart mine"
+	desc = "An unarmed smart stun mine designed to be rapidly placeable."
+	mine_type = /obj/effect/mine/stun/smart/adv
+	arming_time = 10
+	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/deployablemine/heavy
+	name = "deployable sledgehammer smart mine"
+	desc = "An unarmed smart heavy stun mine designed to be hard to disarm."
+	mine_type = /obj/effect/mine/stun/smart/heavy
+	arming_time = 50
+	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/deployablemine/explosive
+	mine_type = /obj/effect/mine/explosive
+
+/obj/item/deployablemine/honk
+	name = "deployable honkblaster 1000"
+	desc = "An advanced pranking landmine for clowns, honk! Delivers an extra loud HONK to the head when triggered. It can be planted to arm it, or have its sound customised with a sound synthesiser."	
+	mine_type = /obj/effect/mine/sound
+
+/obj/item/deployablemine/traitor
+	name = "exploding rubber duck"
+	desc = "A pressure activated explosive disguised as a rubber duck. Plant it to arm."
+	icon = 'icons/obj/watercloset.dmi'
+	icon_state = "rubberducky"
+	mine_type = /obj/effect/mine/explosive/traitor
+
+/obj/item/deployablemine/traitor/bigboom
+	name = "high yield exploding rubber duck"
+	desc = "A pressure activated explosive disguised as a rubber duck. Plant it to arm. This version is fitted with high yield X4 for a larger blast."
+	mine_type = /obj/effect/mine/explosive/traitor/bigboom
+
+/obj/item/deployablemine/gas
+	name = "oxygen gas mine"
+	desc = "An unarmed mine that releases oxygen into the air when triggered. Pretty pointless huh."
+	mine_type = /obj/effect/mine/gas
+
+/obj/item/deployablemine/plasma
+	name = "incendiary mine"
+	desc = "An unarmed mine that releases plasma into the air when triggered, then ignites it."
+	mine_type = /obj/effect/mine/gas/plasma
+
+/obj/item/deployablemine/sleepy
+	name = "knockout mine"
+	desc = "An unarmed mine that releases N2O into the air when triggered. Nighty Night!"
+	mine_type = /obj/effect/mine/gas/n2o
+
+/obj/item/deployablemine/afterattack(atom/plantspot, mob/user, proximity)
+	if(!proximity)
+		return
+
+	if(!istype(plantspot,/turf/open)) // you can't plant a mine inside a wall or on a mob
+		return
+
+	if(isspaceturf(plantspot))
+		to_chat(user, "<span class='warning'>you cannot plant a mine in space!</span>")
+		return
+
+	if((istype(plantspot,/turf/open/lava)) || (istype(plantspot,/turf/open/chasm)))
+		to_chat(user, "<span class='warning'>You can't plant the mine here!</span>")
+		return
+
+	to_chat(user, "<span class='notice'>You start arming the [src]...</span>")
+	if(do_after(user, arming_time, target = src))
+		new mine_type(plantspot)
+		to_chat(user, "<span class='notice'>You plant and arm the [src].</span>")
+		log_combat(user, src, "planted and armed")
+		qdel(src)
+
 /obj/effect/mine
 	name = "dummy mine"
 	desc = "Better stay away from that thing."
@@ -6,6 +93,17 @@
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "uglymine"
 	var/triggered = 0
+	var/smartmine = 0
+	var/disarm_time = 200
+	var/disarm_product = /obj/item/deployablemine // ie what drops when the mine is disarmed
+
+/obj/effect/mine/attackby(obj/I, mob/user, params)
+	if(istype(I, /obj/item/multitool))
+		to_chat(user, "<span class='notice'>You begin to disarm the [src]...</span>")
+		if(do_after(user, disarm_time, target = src))
+			to_chat(user, "<span class='notice'>You disarm the [src].</span>")
+			new disarm_product(src.loc)
+			qdel(src)
 
 /obj/effect/mine/proc/mineEffect(mob/victim)
 	to_chat(victim, "<span class='danger'>*click*</span>")
@@ -15,9 +113,16 @@
 		if(ismob(AM))
 			var/mob/MM = AM
 			if(!(MM.movement_type & FLYING))
-				triggermine(AM)
+				checksmartmine(AM)
 		else
 			triggermine(AM)
+
+/obj/effect/mine/proc/checksmartmine(mob/target)
+	if(target)
+		if(!(target && HAS_TRAIT(target, TRAIT_MINDSHIELD)))
+			triggermine(target)
+		if(smartmine == 0)
+			triggermine(target)
 
 /obj/effect/mine/proc/triggermine(mob/victim)
 	if(triggered)
@@ -37,18 +142,64 @@
 	var/range_heavy = 1
 	var/range_light = 2
 	var/range_flash = 3
+	disarm_product = /obj/item/deployablemine/explosive
+
+/obj/effect/mine/explosive/traitor
+	name = "rubber ducky"
+	desc = "Rubber ducky you're so fine, you make bathtime lots of fuuun. Rubber ducky I'm awfully fooooond of yooooouuuu~"
+	icon = 'icons/obj/watercloset.dmi'
+	icon_state = "rubberducky"
+	var/sound = 'sound/items/bikehorn.ogg'
+	range_heavy = 2
+	range_light = 3
+	range_flash = 4
+	disarm_time = 400
+	disarm_product = /obj/item/deployablemine/traitor
+
+/obj/effect/mine/explosive/traitor/bigboom
+	range_devastation = 2
+	range_heavy = 4
+	range_light = 8
+	range_flash = 6
+	disarm_product = /obj/item/deployablemine/traitor/bigboom
 
 /obj/effect/mine/explosive/mineEffect(mob/victim)
 	explosion(loc, range_devastation, range_heavy, range_light, range_flash)
 
+/obj/effect/mine/explosive/traitor/mineEffect(mob/victim)
+	playsound(loc, sound, 100, 1)
+	explosion(loc, range_devastation, range_heavy, range_light, range_flash)
 
 /obj/effect/mine/stun
 	name = "stun mine"
-	var/stun_time = 80
+	var/stun_time = 150
+	var/damage = 0
+	disarm_product = /obj/item/deployablemine/stun
+
+/obj/effect/mine/stun/smart
+	name = "smart stun mine"
+	desc = "An advanced mine with IFF features, capable of ignoring people with mindshield implants."
+	smartmine = 1
+	disarm_time = 250
+	disarm_product = /obj/item/deployablemine/smartstun
+
+/obj/effect/mine/stun/smart/adv
+	name = "rapid smart mine"
+	disarm_time = 120
+	disarm_product = /obj/item/deployablemine/rapid
+
+/obj/effect/mine/stun/smart/heavy
+	name = "sledgehammer smart mine"
+	disarm_time = 350
+	stun_time = 230
+	damage = 40
+	disarm_product = /obj/item/deployablemine/heavy
+
 
 /obj/effect/mine/stun/mineEffect(mob/living/victim)
 	if(isliving(victim))
-		victim.Paralyze(stun_time)
+		victim.adjustStaminaLoss(stun_time)
+		victim.adjustBruteLoss(damage)
 
 /obj/effect/mine/kickmine
 	name = "kick mine"
@@ -63,27 +214,37 @@
 	name = "oxygen mine"
 	var/gas_amount = 360
 	var/gas_type = "o2"
+	disarm_product = /obj/item/deployablemine/gas
 
 /obj/effect/mine/gas/mineEffect(mob/victim)
 	atmos_spawn_air("[gas_type]=[gas_amount]")
 
 
 /obj/effect/mine/gas/plasma
-	name = "plasma mine"
+	name = "incendiary mine"
 	gas_type = "plasma"
+	disarm_product = /obj/item/deployablemine/plasma
 
 
 /obj/effect/mine/gas/n2o
-	name = "\improper N2O mine"
+	name = "knockout mine"
 	gas_type = "n2o"
-
+	disarm_product = /obj/item/deployablemine/sleepy
 
 /obj/effect/mine/sound
 	name = "honkblaster 1000"
 	var/sound = 'sound/items/bikehorn.ogg'
+	var/volume = 100
+	disarm_time = 1200 // very long disarm time to expand the annoying factor
+	disarm_product = /obj/item/deployablemine/honk
 
 /obj/effect/mine/sound/mineEffect(mob/victim)
-	playsound(loc, sound, 100, 1)
+	playsound(loc, sound, volume, 1)
+
+/obj/effect/mine/sound/attackby(obj/item/soundsynth/J, mob/user, params)
+	if(istype(J, /obj/item/soundsynth))
+		to_chat(user, "<span class='notice'>You change the sound settings of the [src].</span>")
+		sound = J.selected_sound
 
 
 /obj/effect/mine/sound/bwoink

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -242,7 +242,7 @@
 	playsound(loc, sound, volume, 1)
 
 
-/obj/effect/mine/sound/bwoink 
+/obj/effect/mine/sound/bwoink
 	name = "bwoink mine"
 	sound = 'sound/effects/adminhelp.ogg'
 

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -192,8 +192,7 @@
 
 /obj/effect/mine/stun/mineEffect(mob/living/victim)
 	if(isliving(victim))
-		victim.adjustStaminaLoss(damage)
-		victim.adjustBruteLoss(damage)
+		victim.Paralyze(stun_time)
 
 /obj/effect/mine/kickmine
 	name = "kick mine"
@@ -232,7 +231,7 @@
 	disarm_product = /obj/item/deployablemine/honk
 
 /obj/effect/mine/sound/mineEffect(mob/victim)
-	playsound(loc, sound, 1)
+	playsound(loc, sound, 100, 1)
 
 
 /obj/effect/mine/sound/bwoink

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -66,11 +66,9 @@
 /obj/item/deployablemine/afterattack(atom/plantspot, mob/user, proximity)
 	if(!proximity)
 		return
-
 	if(!istype(plantspot,/turf/open/floor))
 		to_chat(user, "<span class='warning'>You can't plant the mine here!</span>")
 		return
-
 	to_chat(user, "<span class='notice'>You start arming the [src]...</span>")
 	if(do_after(user, arming_time, target = src))
 		new mine_type(plantspot)

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -3,7 +3,7 @@
 	desc = "An unarmed landmine. It can be planted to arm it."
 	icon_state = "uglymine"
 	var/mine_type = /obj/effect/mine
-	var/arming_time = 30
+	var/arming_time = 3 SECONDS
 
 /obj/item/deployablemine/stun
 	desc = "An unarmed stun mine. It can be planted to arm it."
@@ -18,14 +18,14 @@
 	name = "deployable rapid smart mine"
 	desc = "An unarmed smart stun mine designed to be rapidly placeable."
 	mine_type = /obj/effect/mine/stun/smart/adv
-	arming_time = 10
+	arming_time = 1 SECONDS
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/deployablemine/heavy
 	name = "deployable sledgehammer smart mine"
 	desc = "An unarmed smart heavy stun mine designed to be hard to disarm."
 	mine_type = /obj/effect/mine/stun/smart/heavy
-	arming_time = 50
+	arming_time = 10 SECONDS
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/deployablemine/explosive
@@ -67,14 +67,7 @@
 	if(!proximity)
 		return
 
-	if(!istype(plantspot,/turf/open)) // you can't plant a mine inside a wall or on a mob
-		return
-
-	if(isspaceturf(plantspot))
-		to_chat(user, "<span class='warning'>you cannot plant a mine in space!</span>")
-		return
-
-	if((istype(plantspot,/turf/open/lava)) || (istype(plantspot,/turf/open/chasm)))
+	if(!istype(plantspot,/turf/open/floor))
 		to_chat(user, "<span class='warning'>You can't plant the mine here!</span>")
 		return
 
@@ -93,8 +86,8 @@
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "uglymine"
 	var/triggered = 0
-	var/smartmine = 0
-	var/disarm_time = 120
+	var/smartmine = FALSE
+	var/disarm_time = 12 SECONDS
 	var/disarm_product = /obj/item/deployablemine // ie what drops when the mine is disarmed
 
 /obj/effect/mine/attackby(obj/I, mob/user, params)
@@ -104,6 +97,8 @@
 			to_chat(user, "<span class='notice'>You disarm the [src].</span>")
 			new disarm_product(src.loc)
 			qdel(src)
+		return
+	return ..()
 
 /obj/effect/mine/proc/mineEffect(mob/victim)
 	to_chat(victim, "<span class='danger'>*click*</span>")
@@ -118,11 +113,10 @@
 			triggermine(AM)
 
 /obj/effect/mine/proc/checksmartmine(mob/target)
-	if(target)
-		if(!(target && HAS_TRAIT(target, TRAIT_MINDSHIELD)))
-			triggermine(target)
-		if(smartmine == 0)
-			triggermine(target)
+	if(smartmine && target && HAS_TRAIT(target, TRAIT_MINDSHIELD))
+		triggermine(target)
+	else if(!smartmine)
+		triggermine(target)
 
 /obj/effect/mine/proc/triggermine(mob/victim)
 	if(triggered)
@@ -153,7 +147,7 @@
 	range_heavy = 2
 	range_light = 3
 	range_flash = 4
-	disarm_time = 250
+	disarm_time = 25 SECONDS
 	disarm_product = /obj/item/deployablemine/traitor
 
 /obj/effect/mine/explosive/traitor/bigboom
@@ -179,26 +173,26 @@
 /obj/effect/mine/stun/smart
 	name = "smart stun mine"
 	desc = "An advanced mine with IFF features, capable of ignoring people with mindshield implants."
-	smartmine = 1
-	disarm_time = 150
+	smartmine = TRUE
+	disarm_time = 15 SECONDS
 	disarm_product = /obj/item/deployablemine/smartstun
 
 /obj/effect/mine/stun/smart/adv
 	name = "rapid smart mine"
-	disarm_time = 80
+	disarm_time = 8 SECONDS
 	disarm_product = /obj/item/deployablemine/rapid
 
 /obj/effect/mine/stun/smart/heavy
 	name = "sledgehammer smart mine"
-	disarm_time = 170
-	stun_time = 230
+	disarm_time = 17 SECONDS
+	stun_time = 23 SECONDS
 	damage = 40
 	disarm_product = /obj/item/deployablemine/heavy
 
 
 /obj/effect/mine/stun/mineEffect(mob/living/victim)
 	if(isliving(victim))
-		victim.adjustStaminaLoss(stun_time)
+		victim.adjustStaminaLoss(damage)
 		victim.adjustBruteLoss(damage)
 
 /obj/effect/mine/kickmine
@@ -234,12 +228,11 @@
 /obj/effect/mine/sound
 	name = "honkblaster 1000"
 	var/sound = 'sound/items/bikehorn.ogg'
-	var/volume = 100
-	disarm_time = 600 // very long disarm time to expand the annoying factor
+	disarm_time = 60 SECONDS // very long disarm time to expand the annoying factor
 	disarm_product = /obj/item/deployablemine/honk
 
 /obj/effect/mine/sound/mineEffect(mob/victim)
-	playsound(loc, sound, volume, 1)
+	playsound(loc, sound, 1)
 
 
 /obj/effect/mine/sound/bwoink

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -242,7 +242,7 @@
 	playsound(loc, sound, volume, 1)
 
 
-/obj/effect/mine/sound/bwoink
+/obj/effect/mine/sound/bwoink 
 	name = "bwoink mine"
 	sound = 'sound/effects/adminhelp.ogg'
 

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -94,7 +94,7 @@
 	icon_state = "uglymine"
 	var/triggered = 0
 	var/smartmine = 0
-	var/disarm_time = 200
+	var/disarm_time = 120
 	var/disarm_product = /obj/item/deployablemine // ie what drops when the mine is disarmed
 
 /obj/effect/mine/attackby(obj/I, mob/user, params)
@@ -153,7 +153,7 @@
 	range_heavy = 2
 	range_light = 3
 	range_flash = 4
-	disarm_time = 400
+	disarm_time = 250
 	disarm_product = /obj/item/deployablemine/traitor
 
 /obj/effect/mine/explosive/traitor/bigboom
@@ -172,7 +172,7 @@
 
 /obj/effect/mine/stun
 	name = "stun mine"
-	var/stun_time = 150
+	var/stun_time = 80
 	var/damage = 0
 	disarm_product = /obj/item/deployablemine/stun
 
@@ -180,17 +180,17 @@
 	name = "smart stun mine"
 	desc = "An advanced mine with IFF features, capable of ignoring people with mindshield implants."
 	smartmine = 1
-	disarm_time = 250
+	disarm_time = 150
 	disarm_product = /obj/item/deployablemine/smartstun
 
 /obj/effect/mine/stun/smart/adv
 	name = "rapid smart mine"
-	disarm_time = 120
+	disarm_time = 80
 	disarm_product = /obj/item/deployablemine/rapid
 
 /obj/effect/mine/stun/smart/heavy
 	name = "sledgehammer smart mine"
-	disarm_time = 350
+	disarm_time = 170
 	stun_time = 230
 	damage = 40
 	disarm_product = /obj/item/deployablemine/heavy
@@ -235,7 +235,7 @@
 	name = "honkblaster 1000"
 	var/sound = 'sound/items/bikehorn.ogg'
 	var/volume = 100
-	disarm_time = 1200 // very long disarm time to expand the annoying factor
+	disarm_time = 600 // very long disarm time to expand the annoying factor
 	disarm_product = /obj/item/deployablemine/honk
 
 /obj/effect/mine/sound/mineEffect(mob/victim)

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -241,11 +241,6 @@
 /obj/effect/mine/sound/mineEffect(mob/victim)
 	playsound(loc, sound, volume, 1)
 
-/obj/effect/mine/sound/attackby(obj/item/soundsynth/J, mob/user, params)
-	if(istype(J, /obj/item/soundsynth))
-		to_chat(user, "<span class='notice'>You change the sound settings of the [src].</span>")
-		sound = J.selected_sound
-
 
 /obj/effect/mine/sound/bwoink
 	name = "bwoink mine"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -616,6 +616,26 @@
 		var/item = pick(contains)
 		new item(C)
 
+/datum/supply_pack/security/armory/smartmine
+	name = "Smart Mine Crate"
+	desc = "Contains three nonlethal pressure activated stun mines capable of ignoring mindshieled personnel. Requires Armory access to open."
+	cost = 4000
+	contains = list(/obj/item/deployablemine/smartstun,					
+					/obj/item/deployablemine/smartstun,
+					/obj/item/deployablemine/smartstun)
+	crate_name = "stun mine create"
+
+/datum/supply_pack/security/armory/stunmine
+	name = "Stun Mine Crate"
+	desc = "Contains five nonlethal pressure activated stun mines. Requires Armory access to open."
+	cost = 2500
+	contains = list(/obj/item/deployablemine/stun,
+					/obj/item/deployablemine/stun,
+					/obj/item/deployablemine/stun,
+					/obj/item/deployablemine/stun,
+					/obj/item/deployablemine/stun)
+	crate_name = "stun mine create"
+
 /datum/supply_pack/security/armory/swat
 	name = "SWAT Crate"
 	desc = "Contains two fullbody sets of tough, fireproof, pressurized suits designed in a joint effort by IS-ERI and Nanotrasen. Each set contains a suit, helmet, mask, combat belt, and combat gloves. Requires Armory access to open."

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -106,7 +106,7 @@
 
 /datum/design/stunmine/sec //mines ported from BeeStation
 	name = "Stun Mine"
-	desc = "A basic nonlethal stunning mine. Does very heavy stamina damage to anyone who walks over it."
+	desc = "A basic nonlethal stunning mine. Stuns anyone who walks over it."
 	id = "stunmine"
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 4000, MAT_GLASS = 1000)

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -104,6 +104,56 @@
 	category = list("Firing Pins")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
+/datum/design/stunmine/sec/ //mines ported from BeeStation
+	name = "Stun Mine"
+	desc = "A basic nonlethal stunning mine. Does very heavy stamina damage to anyone who walks over it."
+	id = "stunmine"
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 4000, MAT_GLASS = 1000)
+	build_path = /obj/item/deployablemine/stun
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/adv_stunmine/sec
+	name = "Smart Stun Mine"
+	desc = "A advanced nonlethal stunning mine. Uses advanced detection software to only trigger when activated by someone without a mindshield implant."
+	id = "stunmine_adv"
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 8000, MAT_GLASS = 3000, MAT_SILVER = 200)
+	build_path = /obj/item/deployablemine/smartstun
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/lm6_stunmine/sec
+	name = "Rapid Deployment Smartmine"
+	desc = "A advanced nonlethal stunning mine. Uses advanced detection software to only trigger when activated by someone without a mindshield implant. Can be rapidly placed and disarmed."
+	id = "stunmine_rapid"
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 10000, MAT_GLASS = 4000, MAT_SILVER = 500, MAT_URANIUM = 200)
+	build_path = /obj/item/deployablemine/rapid
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/lm12_stunmine/sec
+	name = "Sledgehammer Smartmine"
+	desc = "A advanced nonlethal stunning mine. Uses advanced detection software to only trigger when activated by someone without a mindshield implant. Very powerful and hard to disarm."
+	id = "stunmine_heavy"
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 10000, MAT_GLASS = 4000, MAT_SILVER = 500, MAT_URANIUM = 200)
+	build_path = /obj/item/deployablemine/heavy
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/honkmine
+	name = "Honkblaster 1000"
+	desc = "An advanced pressure activated pranking mine, honk!"
+	id = "clown_mine"
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 4000, MAT_GLASS = 1000, MAT_BANANIUM = 500)
+	build_path = /obj/item/deployablemine/honk
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
+
 /datum/design/stunrevolver
 	name = "Tesla Revolver"
 	desc = "A high-tech revolver that fires internal, reusable shock cartridges in a revolving cylinder. The cartridges can be recharged using conventional rechargers."

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -104,7 +104,7 @@
 	category = list("Firing Pins")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
-/datum/design/stunmine/sec/ //mines ported from BeeStation
+/datum/design/stunmine/sec //mines ported from BeeStation
 	name = "Stun Mine"
 	desc = "A basic nonlethal stunning mine. Does very heavy stamina damage to anyone who walks over it."
 	id = "stunmine"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -357,7 +357,7 @@
 	description = "Honk?!"
 	prereq_ids = list("base")
 	design_ids = list("air_horn", "honker_main", "honker_peri", "honker_targ", "honk_chassis", "honk_head", "honk_torso", "honk_left_arm", "honk_right_arm",
-	"honk_left_leg", "honk_right_leg", "mech_banana_mortar", "mech_mousetrap_mortar", "mech_honker", "mech_punching_face", "implant_trombone", "borg_transform_clown")
+	"honk_left_leg", "honk_right_leg", "mech_banana_mortar", "mech_mousetrap_mortar", "mech_honker", "mech_punching_face", "implant_trombone", "borg_transform_clown", "clown_mine")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
@@ -567,6 +567,16 @@
 	export_price = 5000
 
 /////////////////////////weaponry tech/////////////////////////
+
+/datum/techweb_node/landmine
+	id = "nonlethal_mines"
+	display_name = "Nonlethal Landmine Technology"
+	description = "Our weapons technicians could perhaps work out methods for the creation of nonlethal landmines for security teams."
+	prereq_ids = list("sec_basic")
+	design_ids = list("stunmine")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
+	export_price = 5000
+
 /datum/techweb_node/weaponry
 	id = "weaponry"
 	display_name = "Weapon Development Technology"
@@ -576,6 +586,15 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	export_price = 5000
 
+/datum/techweb_node/smartmine
+	id = "smart_mines"
+	display_name = "Smart Landmine Technology"
+	description = "Using IFF technology, we could develop smartmines that do not trigger for those who are mindshielded."
+	prereq_ids = list("weaponry", "nonlethal_mines", "engineering")
+	design_ids = list("stunmine_adv")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	export_price = 5000
+
 /datum/techweb_node/adv_weaponry
 	id = "adv_weaponry"
 	display_name = "Advanced Weapon Development Technology"
@@ -583,6 +602,15 @@
 	prereq_ids = list("adv_engi", "weaponry")
 	design_ids = list("pin_loyalty", "borg_transform_security")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
+	export_price = 5000
+
+/datum/techweb_node/advmine
+	id = "adv_mines"
+	display_name = "Advanced Landmine Technology"
+	description = "We can further develop our smartmines to build some extremely capable designs."
+	prereq_ids = list("weaponry", "smart_mines", "adv_engi")
+	design_ids = list("stunmine_rapid", "stunmine_heavy")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
 /datum/techweb_node/electric_weapons

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -955,6 +955,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndie_kit/emp
 	cost = 2
 
+/datum/uplink_item/explosives/ducky
+	name = "Exploding Rubber Duck"
+	desc = "A seemingly innocent rubber duck. When placed, it arms, and will violently explode when stepped on."
+	item = /obj/item/deployablemine/traitor
+	cost = 4
+	include_modes = list(/datum/game_mode/nuclear/clown_ops)
+
 /datum/uplink_item/explosives/virus_grenade
 	name = "Fungal Tuberculosis Grenade"
 	desc = "A primed bio-grenade packed into a compact box. Comes with five Bio Virus Antidote Kit (BVAK) \
@@ -973,6 +980,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	include_modes = list(/datum/game_mode/nuclear)
 	cost = 22
 	surplus = 0
+
+/datum/uplink_item/explosives/bigducky
+	name = "High Yield Exploding Rubber Duck"
+	desc = "A seemingly innocent rubber duck. When placed, it arms, and will violently explode when stepped on. \
+			This variant has been fitted with high yield X4 charges for a larger explosion."
+	item = /obj/item/deployablemine/traitor/bigboom
+	cost = 10
+	include_modes = list(/datum/game_mode/nuclear/clown_ops)
 
 /datum/uplink_item/explosives/pizza_bomb
 	name = "Pizza Bomb"


### PR DESCRIPTION
### Intent of your Pull Request

All credit to the original coder **WhyIsCaeciliusTaken** for doing the original work.
https://github.com/BeeStation/BeeStation-Hornet/pull/1735

**NOTE: A part of the original PR relied on something called "sound synth" which can make a custom sound based on user choice out of a pile of options. I have removed the call for sound synth because Yogs currently doesn't have it. I won't be adding this feature because it's basically all memes and I don't feel it fits well in this PR.**

"This PR significantly changes how landmines work in game, and can be summarised in three parts:

1: Landmines can now be planted, moved and disarmed.
Adds disarmed versions of most mines, which can be safely picked up and carried around, and walking over one does nothing. Using a disarmed mine on a valid (ie not space, a wall or lava/chasms) turf will plant and arm the mine after a short windup (3 seconds for most mines), after which it functions normally. Mines can be disarmed with a multitool, which takes 12 seconds by default, and drops the appropriate disarmed mine (or the base dummy mine if it's a mine type you shouldn't have like a bwoink mine). Clown mines take 5 times as long to disarm to make them more annoying, and are now louder when set off. Stun mines now do stamina damage instead of hardstunning.

2: New mines and mine tech.
Adds three new tech nodes, three new mines for security, and allows you to build both the new mines as well as stun and clown mines. Nonlethal Landmine Technology allows sec to build stun mines, and requires basic security equipment as a prerequisite, as well as costing 1000 points.

Once you have researched industrial engineering, weapons development and nonlethal mines, you can research Smart Landmine Technology for 2500 points, which allows you to build smart stun mines. These mines are more expensive but are harder to disarm (15s) and do not trigger if the person walking over them is mindshielded, opening up interesting tactical possibilities for security.

Once you have smartmines you can research Advanced Landmine Technology for 2500, which gives you two more advanced smartmines, the rapid deployment and the Sledgehammer. The RD is easier to disarm (8s) but has a very short arm time (1s), allowing for mid combat placement if you play it right, allowing sec to, say, enter through a door and deploy one behind them to block escape via that route. It also fits in pockets and boxes, unlike the other mines.

The sledgehammer is slower to arm (5s) but is hard to disarm (17s), does extra stamina damage as well as 40 brute, making it more suited to defensive use such as blocking off the armoury.

The lower tier mines can be ordered from cargo at a reasonably high cost.

3: Exploding Rubber Duck:
Adds two further new mine types, the regular and high yield exploding rubber duck. Both are explosive, take a long time to disarm (25s) and look like a rubber duck when armed. The high yield version is far more powerful but costs more (10TC vs 4TC). Both make the same sound effect as a rubber duck before detonation, d'aww!"

#### Changelog

:cl:  WhyIsCaeciliusTaken
rscadd: Added ability to move and plant mines, as well as disarm them with a multitool
rscadd: Added ability for mines to be "smart" and detect mindshield implants if a particular mine type
rscadd: Clown and stun mines can now be printed in the service and security protolathes respectively
rscadd: three new mine related tech nodes, and three new printable smart mine types for security
rscadd: Added the exploding rubber duck as a 4TC traitor and clownops item, with a more powerful version available for 10TC.
rscadd: Some mines can be ordered from cargo
tweak: stun mines now do stamina damage instead of a hardstun
/:cl:
