### PR TITLE
Pixel shifting fix

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -669,6 +669,8 @@
 
 /mob/verb/eastshift()
 	set hidden = TRUE
+	if (istype(src,/mob/living/silicon/ai) || istype(src,/mob/camera))
+		return FALSE
 	if(!canface())
 		return FALSE
 	if(pixel_x <= 16)
@@ -676,6 +678,8 @@
 
 /mob/verb/westshift()
 	set hidden = TRUE
+	if (istype(src,/mob/living/silicon/ai) || istype(src,/mob/camera))
+		return FALSE
 	if(!canface())
 		return FALSE
 	if(pixel_x >= -16)
@@ -683,6 +687,8 @@
 
 /mob/verb/northshift()
 	set hidden = TRUE
+	if (istype(src,/mob/living/silicon/ai) || istype(src,/mob/camera))
+		return FALSE
 	if(!canface())
 		return FALSE
 	if(pixel_y <= 16)
@@ -690,6 +696,8 @@
 
 /mob/verb/southshift()
 	set hidden = TRUE
+	if (istype(src,/mob/living/silicon/ai) || istype(src,/mob/camera))
+		return FALSE
 	if(!canface())
 		return FALSE
 	if(pixel_y >= -16)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -75,7 +75,11 @@
 
 	if(!mob.Process_Spacemove(direct))
 		return FALSE
-
+	if (!src.prefs.bindings.isheld_key("Ctrl"))
+		if (mob.pixel_x > 0 || mob.pixel_x < 0)
+			mob.pixel_x = 0
+		if (mob.pixel_y > 0 || mob.pixel_y < 0)
+			mob.pixel_y = 0
 	var/handled = SEND_SIGNAL(L, COMSIG_PROCESS_MOVE, direct) //yogs start - movement components
 	if(handled)
 		return FALSE//yogs end


### PR DESCRIPTION
AIs could pixel shift. Blob camera could pixel shift. No more, though. Through a generous application of spaghetti code, I have fixed monster's buggy pixel shifting. **It Just Works™**

Oh, and it also makes pixel shifting reset on player move.

:cl:  
rscadd: Added pixel shifting auto reset on player mob movement
rscdel: Removed AI pixel shifting
/:cl:
