### PR TITLE
Energy snare now legcuffs on being picked up

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -272,6 +272,8 @@
 	playsound(src, 'sound/effects/snap.ogg', 50, TRUE)
 
 /obj/item/restraints/legcuffs/beartrap/Crossed(AM as mob|obj)
+	if(QDELETED(src))
+		return
 	if(armed && isturf(loc))
 		if(isliving(AM))
 			var/mob/living/L = AM

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -272,8 +272,6 @@
 	playsound(src, 'sound/effects/snap.ogg', 50, TRUE)
 
 /obj/item/restraints/legcuffs/beartrap/Crossed(AM as mob|obj)
-	if(QDELETED(src))
-		return
 	if(armed && isturf(loc))
 		if(isliving(AM))
 			var/mob/living/L = AM
@@ -329,7 +327,6 @@
 
 /obj/item/restraints/legcuffs/beartrap/energy/attack_hand(mob/user)
 	Crossed(user) //honk
-	return ..()
 
 /obj/item/restraints/legcuffs/beartrap/energy/cyborg
 	breakouttime = 20 // Cyborgs shouldn't have a strong restraint


### PR DESCRIPTION
fixes energy snares being deleted while being picked up, which would cause them to become invisible but still be able to trigger
:cl:  
bugfix: energy snare will legcuff on being picked up
/:cl:
