### PR TITLE
Tape recorder can be played by alt clicking

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -64,6 +64,10 @@
 	else
 		return ..()
 
+/obj/item/taperecorder/AltClick(mob/user)
+	. = ..()
+	play()
+
 /obj/item/taperecorder/proc/can_use(mob/user)
 	if(user && ismob(user))
 		if(!user.incapacitated())


### PR DESCRIPTION
**Old way:**
![0YXgVcMNdv](https://user-images.githubusercontent.com/24533979/81488864-81b07000-9234-11ea-85ef-73bb027ab0a7.gif)

**New way:**
![UEl2rkUv3y](https://user-images.githubusercontent.com/24533979/81488863-7fe6ac80-9234-11ea-9a73-68d412650f12.gif)

#### Changelog

:cl:  Hopek
rscadd: You can now Alt-click on the tape recorder to play it.
/:cl:
