### PR TITLE
Can now toggle seclite via hand when when on a disabler or helm

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -53,6 +53,10 @@
 /obj/item/clothing/head/helmet/sec
 	can_flashlight = TRUE
 
+/obj/item/clothing/head/helmet/sec/attack_self(mob/user)
+	. = ..()
+	toggle_helmlight()
+
 /obj/item/clothing/head/helmet/sec/attackby(obj/item/I, mob/user, params)
 	if(issignaler(I))
 		var/obj/item/assembly/signaler/S = I

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -40,7 +40,6 @@
 	can_flashlight = TRUE
 	flight_x_offset = 15
 	flight_y_offset = 10
-	gun_light
 
 /obj/item/gun/energy/disabler/attack_self(mob/living/user)
 	. = ..()

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -40,6 +40,12 @@
 	can_flashlight = TRUE
 	flight_x_offset = 15
 	flight_y_offset = 10
+	gun_light
+
+/obj/item/gun/energy/disabler/attack_self(mob/living/user)
+	. = ..()
+	toggle_gunlight()
+
 
 /obj/item/gun/energy/disabler/cyborg
 	name = "cyborg disabler"


### PR DESCRIPTION
What happens before this PR:
put disabler with seclight or helm with helmlight in your hands. Use it with Z . Nothing happens

after this PR:
Using it with Z toggles the lights as expected.

#### Changelog

:cl:  Hopek
rscadd: The disabler and security helms now toggle the light on and off when used in your hands.
/:cl:
