### PR TITLE
Better radio/headset suicide

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -45,7 +45,7 @@
 	use_command = TRUE
 	talk_into(user, pick_list_replacements(BRAIN_DAMAGE_FILE, "brain_damage"))
 	use_command = FALSE
-	return OXYLOSS // you die from oxygen loss from yelling the brain damage line at full volume
+	return OXYLOSS // you die from oxygen loss by yelling the brain damage line at full volume
 
 /obj/item/radio/proc/set_frequency(new_frequency)
 	SEND_SIGNAL(src, COMSIG_RADIO_NEW_FREQUENCY, args)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -45,7 +45,7 @@
 	use_command = TRUE
 	talk_into(user, pick_list_replacements(BRAIN_DAMAGE_FILE, "brain_damage"))
 	use_command = FALSE
-	return OXYLOSS // your die from oxygen loss by yelling the brain damage line at full volume
+	return OXYLOSS // you die from oxygen loss from yelling the brain damage line at full volume
 
 /obj/item/radio/proc/set_frequency(new_frequency)
 	SEND_SIGNAL(src, COMSIG_RADIO_NEW_FREQUENCY, args)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -42,9 +42,7 @@
 	//FREQ_BROADCASTING = 2
 
 /obj/item/radio/suicide_act(mob/living/user)
-	use_command = TRUE
-	talk_into(user, pick_list_replacements(BRAIN_DAMAGE_FILE, "brain_damage"))
-	use_command = FALSE
+	talk_into(user, pick_list_replacements(BRAIN_DAMAGE_FILE, "brain_damage"), null, SPAN_COMMAND)
 	return OXYLOSS // you die from oxygen loss by yelling the brain damage line at full volume
 
 /obj/item/radio/proc/set_frequency(new_frequency)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -43,6 +43,7 @@
 
 /obj/item/radio/suicide_act(mob/living/user)
 	talk_into(user, pick_list_replacements(BRAIN_DAMAGE_FILE, "brain_damage"), null, SPAN_COMMAND)
+	use_command = TRUE // converts the radio in to use LOUD per poll.
 	return OXYLOSS // you die from oxygen loss by yelling the brain damage line at full volume
 
 /obj/item/radio/proc/set_frequency(new_frequency)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -42,8 +42,10 @@
 	//FREQ_BROADCASTING = 2
 
 /obj/item/radio/suicide_act(mob/living/user)
-	user.visible_message("<span class='suicide'>[user] starts bouncing [src] off [user.p_their()] head! It looks like [user.p_theyre()] trying to commit suicide!</span>")
-	return BRUTELOSS
+	use_command = TRUE
+	talk_into(user, pick_list_replacements(BRAIN_DAMAGE_FILE, "brain_damage"))
+	use_command = FALSE
+	return OXYLOSS // your die from oxygen loss by yelling the brain damage line at full volume
 
 /obj/item/radio/proc/set_frequency(new_frequency)
 	SEND_SIGNAL(src, COMSIG_RADIO_NEW_FREQUENCY, args)


### PR DESCRIPTION
Instead of just bouncing the radio off your head to die.. you now:

Yell a brain damage line into the radio/headset and die from oxygen loss.
The message you yell into the radio is LOUD

**Currently the LOUD function after suicide is removed but here is a poll to vote on if it should stay on:**

https://strawpoll.com/bfxyb697

what this means:
If the LOUD stays on you'll be able to convert a radio or headset to LOUD for others by suiciding with it.

#### Changelog

:cl:  Hopek
rscadd: New radio/headset suicide
/:cl:
