### PR TITLE
Power tools now start in their usual modes again + cleanup

### DIFF
--- a/yogstation/code/game/objects/items/tools.dm
+++ b/yogstation/code/game/objects/items/tools.dm
@@ -17,6 +17,35 @@
 	toolspeed = 0.7
 	tool_behaviour = TOOL_CROWBAR
 
+/obj/item/jawsoflife/proc/transform_crowbar(mob/user)
+	desc = "A set of jaws of life, compressed through the magic of science. It's fitted with a prying head."
+	attack_verb = list("attacked", "bashed", "battered", "bludgeoned", "whacked")
+	usesound = 'sound/items/jaws_pry.ogg'
+	hitsound = 'sound/items/jaws_pry.ogg'
+	tool_behaviour = TOOL_CROWBAR
+	icon_state = "jaws_pry"
+	playsound(get_turf(user), 'sound/items/change_jaws.ogg', 50, 1)
+	if (iscyborg(user))
+		to_chat(user,"<span class='notice'>Your servos whirr as the cutting head reconfigures into a prying head.</span>")
+	else
+		to_chat(user, "<span class='notice'>You attach the pry jaws to [src].</span>")
+	update_icon()
+
+
+/obj/item/jawsoflife/proc/transform_cutters(mob/user)
+	attack_verb = list("pinched", "nipped")
+	icon_state = "jaws_cutter"
+	hitsound = 'sound/items/jaws_cut.ogg'
+	usesound = 'sound/items/jaws_cut.ogg'
+	tool_behaviour = TOOL_WIRECUTTER
+	playsound(get_turf(user), 'sound/items/change_jaws.ogg', 50, 1)
+	desc = "A set of jaws of life, compressed through the magic of science. It's fitted with a cutting head."
+	if (iscyborg(user))
+		to_chat(user,"<span class='notice'>Your servos whirr as the prying head reconfigures into a cutting head.</span>")
+	else
+		to_chat(user, "<span class='notice'>You attach the cutting jaws to [src].</span>")
+	update_icon()
+
 //jaws of life suicide code
 /obj/item/jawsoflife/suicide_act(mob/user)
 	if(TOOL_CROWBAR)
@@ -51,36 +80,6 @@
 	else
 		..()
 
-/obj/item/jawsoflife/proc/transform_crowbar(mob/user)
-	desc = "A set of jaws of life, compressed through the magic of science. It's fitted with a prying head."
-	attack_verb = list("attacked", "bashed", "battered", "bludgeoned", "whacked")
-	usesound = 'sound/items/jaws_pry.ogg'
-	hitsound = 'sound/items/jaws_pry.ogg'
-	tool_behaviour = TOOL_CROWBAR
-	icon_state = "jaws_pry"
-	playsound(get_turf(user), 'sound/items/change_jaws.ogg', 50, 1)
-	if (iscyborg(user))
-		to_chat(user,"<span class='notice'>Your servos whirr as the cutting head reconfigures into a prying head.</span>")
-	else
-		to_chat(user, "<span class='notice'>You attach the pry jaws to [src].</span>")
-	update_icon()
-
-
-/obj/item/jawsoflife/proc/transform_cutters(mob/user)
-	attack_verb = list("pinched", "nipped")
-	icon_state = "jaws_cutter"
-	hitsound = 'sound/items/jaws_cut.ogg'
-	usesound = 'sound/items/jaws_cut.ogg'
-	tool_behaviour = TOOL_WIRECUTTER
-	playsound(get_turf(user), 'sound/items/change_jaws.ogg', 50, 1)
-	desc = "A set of jaws of life, compressed through the magic of science. It's fitted with a cutting head."
-	if (iscyborg(user))
-		to_chat(user,"<span class='notice'>Your servos whirr as the prying head reconfigures into a cutting head.</span>")
-	else
-		to_chat(user, "<span class='notice'>You attach the cutting jaws to [src].</span>")
-	update_icon()
-
-
 //better handdrill
 /obj/item/handdrill
 	name = "hand drill"
@@ -102,15 +101,6 @@
 	toolspeed = 0.7
 	tool_behaviour = TOOL_SCREWDRIVER
 
-/obj/item/handdrill/suicide_act(mob/user)
-	user.visible_message("<span class='suicide'>[user] is putting [src] to [user.p_their()] temple. It looks like [user.p_theyre()] trying to commit suicide!</span>")
-	return(BRUTELOSS)
-
-/obj/item/handdrill/attack_self(mob/user)
-	if (tool_behaviour == TOOL_SCREWDRIVER)
-		transform_wrench(user)
-	else
-		transform_screwdriver(user)
 
 /obj/item/handdrill/proc/transform_wrench(mob/user)
 	desc = "A simple powered hand drill. It's fitted with a bolt bit."
@@ -133,3 +123,13 @@
 	else
 		to_chat(user, "<span class='notice'>You attach the screw driver bit to [src].</span>")
 	update_icon()
+
+/obj/item/handdrill/suicide_act(mob/user)
+	user.visible_message("<span class='suicide'>[user] is putting [src] to [user.p_their()] temple. It looks like [user.p_theyre()] trying to commit suicide!</span>")
+	return(BRUTELOSS)
+
+/obj/item/handdrill/attack_self(mob/user)
+	if (tool_behaviour == TOOL_SCREWDRIVER)
+		transform_wrench(user)
+	else
+		transform_screwdriver(user)

--- a/yogstation/code/game/objects/items/tools.dm
+++ b/yogstation/code/game/objects/items/tools.dm
@@ -45,18 +45,19 @@
 
 //jaws of life suicide code
 /obj/item/jawsoflife/suicide_act(mob/user)
-	if(TOOL_CROWBAR)
-		user.visible_message("<span class='suicide'>[user] is putting [user.p_their()] head in [src], it looks like [user.p_theyre()] trying to commit suicide!</span>")
-		playsound(loc, 'sound/items/jaws_pry.ogg', 50, 1, -1)
-	if(TOOL_WIRECUTTER)
-		user.visible_message("<span class='suicide'>[user] is wrapping \the [src] around [user.p_their()] neck. It looks like [user.p_theyre()] trying to rip [user.p_their()] head off!</span>")
-		playsound(loc, 'sound/items/jaws_cut.ogg', 50, 1, -1)
-		if(iscarbon(user))
-			var/mob/living/carbon/C = user
-			var/obj/item/bodypart/BP = C.get_bodypart(BODY_ZONE_HEAD)
-			if(BP)
-				BP.drop_limb()
-				playsound(loc,pick('sound/misc/desceration-01.ogg','sound/misc/desceration-02.ogg','sound/misc/desceration-01.ogg') ,50, 1, -1)
+	switch(tool_behaviour)
+		if(TOOL_CROWBAR)
+			user.visible_message("<span class='suicide'>[user] is putting [user.p_their()] head in [src], it looks like [user.p_theyre()] trying to commit suicide!</span>")
+			playsound(loc, 'sound/items/jaws_pry.ogg', 50, 1, -1)
+		if(TOOL_WIRECUTTER)
+			user.visible_message("<span class='suicide'>[user] is wrapping \the [src] around [user.p_their()] neck. It looks like [user.p_theyre()] trying to rip [user.p_their()] head off!</span>")
+			playsound(loc, 'sound/items/jaws_cut.ogg', 50, 1, -1)
+			if(iscarbon(user))
+				var/mob/living/carbon/C = user
+				var/obj/item/bodypart/BP = C.get_bodypart(BODY_ZONE_HEAD)
+				if(BP)
+					BP.drop_limb()
+					playsound(loc,pick('sound/misc/desceration-01.ogg','sound/misc/desceration-02.ogg','sound/misc/desceration-01.ogg') ,50, 1, -1)
 	return (BRUTELOSS)
 
 //jaws of life changing jaw code

--- a/yogstation/code/game/objects/items/tools.dm
+++ b/yogstation/code/game/objects/items/tools.dm
@@ -15,7 +15,6 @@
 	toolspeed = 0.7
 	tool_behaviour = TOOL_CROWBAR
 
-
 //jaws of life changing jaw code
 /obj/item/jawsoflife/attack_self(mob/user)
 	if (tool_behaviour == TOOL_CROWBAR)

--- a/yogstation/code/game/objects/items/tools.dm
+++ b/yogstation/code/game/objects/items/tools.dm
@@ -2,16 +2,14 @@
 //the new and improved jaws
 /obj/item/jawsoflife
 	name = "jaws of life"
-	
-	materials = list(MAT_METAL=150,MAT_SILVER=50,MAT_TITANIUM=25)
 	desc = "A set of jaws of life, compressed through the magic of science. It's fitted with a prying head."
+	materials = list(MAT_METAL=150,MAT_SILVER=50,MAT_TITANIUM=25)
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "jaws_pry"
 	item_state = "jawsoflife"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	w_class = WEIGHT_CLASS_SMALL
-
 	usesound = 'sound/items/jaws_pry.ogg'
 	force = 15
 	toolspeed = 0.7
@@ -30,7 +28,6 @@
 	else
 		to_chat(user, "<span class='notice'>You attach the pry jaws to [src].</span>")
 	update_icon()
-
 
 /obj/item/jawsoflife/proc/transform_cutters(mob/user)
 	attack_verb = list("pinched", "nipped")
@@ -100,7 +97,6 @@
 	usesound = 'sound/items/drill_use.ogg'
 	toolspeed = 0.7
 	tool_behaviour = TOOL_SCREWDRIVER
-
 
 /obj/item/handdrill/proc/transform_wrench(mob/user)
 	desc = "A simple powered hand drill. It's fitted with a bolt bit."

--- a/yogstation/code/game/objects/items/tools.dm
+++ b/yogstation/code/game/objects/items/tools.dm
@@ -4,65 +4,42 @@
 	name = "jaws of life"
 	
 	materials = list(MAT_METAL=150,MAT_SILVER=50,MAT_TITANIUM=25)
-	desc = "A set of jaws of life, compressed through the magic of science. It's fitted with a cutting head."
+	desc = "A set of jaws of life, compressed through the magic of science. It's fitted with a prying head."
 	icon = 'icons/obj/tools.dmi'
-	icon_state = "jaws_cutter"
+	icon_state = "jaws_pry"
 	item_state = "jawsoflife"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	w_class = WEIGHT_CLASS_SMALL
 
-	usesound = 'sound/items/jaws_cut.ogg'
+	usesound = 'sound/items/jaws_pry.ogg'
 	force = 15
 	toolspeed = 0.7
-	tool_behaviour = TOOL_WIRECUTTER
+	tool_behaviour = TOOL_CROWBAR
 
 //jaws of life suicide code
 /obj/item/jawsoflife/suicide_act(mob/user)
-	switch(tool_behaviour)
-		if(TOOL_CROWBAR)
-			user.visible_message("<span class='suicide'>[user] is putting [user.p_their()] head in [src], it looks like [user.p_theyre()] trying to commit suicide!</span>")
-			playsound(loc, 'sound/items/jaws_pry.ogg', 50, 1, -1)
-			return (BRUTELOSS)
-		if(TOOL_WIRECUTTER)
-			user.visible_message("<span class='suicide'>[user] is wrapping \the [src] around [user.p_their()] neck. It looks like [user.p_theyre()] trying to rip [user.p_their()] head off!</span>")
-			playsound(loc, 'sound/items/jaws_cut.ogg', 50, 1, -1)
-			if(iscarbon(user))
-				var/mob/living/carbon/C = user
-				var/obj/item/bodypart/BP = C.get_bodypart(BODY_ZONE_HEAD)
-				if(BP)
-					BP.drop_limb()
-					playsound(loc,pick('sound/misc/desceration-01.ogg','sound/misc/desceration-02.ogg','sound/misc/desceration-01.ogg') ,50, 1, -1)
-			return (BRUTELOSS)
+	if(TOOL_CROWBAR)
+		user.visible_message("<span class='suicide'>[user] is putting [user.p_their()] head in [src], it looks like [user.p_theyre()] trying to commit suicide!</span>")
+		playsound(loc, 'sound/items/jaws_pry.ogg', 50, 1, -1)
+	if(TOOL_WIRECUTTER)
+		user.visible_message("<span class='suicide'>[user] is wrapping \the [src] around [user.p_their()] neck. It looks like [user.p_theyre()] trying to rip [user.p_their()] head off!</span>")
+		playsound(loc, 'sound/items/jaws_cut.ogg', 50, 1, -1)
+		if(iscarbon(user))
+			var/mob/living/carbon/C = user
+			var/obj/item/bodypart/BP = C.get_bodypart(BODY_ZONE_HEAD)
+			if(BP)
+				BP.drop_limb()
+				playsound(loc,pick('sound/misc/desceration-01.ogg','sound/misc/desceration-02.ogg','sound/misc/desceration-01.ogg') ,50, 1, -1)
+	return (BRUTELOSS)
 
 //jaws of life changing jaw code
 /obj/item/jawsoflife/attack_self(mob/user)
-	playsound(get_turf(user), 'sound/items/change_jaws.ogg', 50, 1)
 	if (tool_behaviour == TOOL_CROWBAR)
-		desc = "A set of jaws of life, compressed through the magic of science. It's fitted with a cutting head."
-		if (iscyborg(user))
-			to_chat(user,"<span class='notice'>Your servos whirr as the prying head reconfigures into a cutting head.</span>")
-		else
-			to_chat(user, "<span class='notice'>You attach the cutting jaws to [src].</span>")
-		attack_verb = list("pinched", "nipped")
-		icon_state = "jaws_cutter"
-		hitsound = 'sound/items/jaws_cut.ogg'
-		usesound = 'sound/items/jaws_cut.ogg'
-		tool_behaviour = TOOL_WIRECUTTER
-		update_icon()
-	else if (tool_behaviour == TOOL_WIRECUTTER)
-		desc = "A set of jaws of life, compressed through the magic of science. It's fitted with a prying head."
-		if (iscyborg(user))
-			to_chat(user,"<span class='notice'>Your servos whirr as the cutting head reconfigures into a prying head.</span>")
-		else
-			to_chat(user, "<span class='notice'>You attach the pry jaws to [src].</span>")
-		attack_verb = list("attacked", "bashed", "battered", "bludgeoned", "whacked")
-		usesound = 'sound/items/jaws_pry.ogg'
-		hitsound = 'sound/items/jaws_pry.ogg'
-		tool_behaviour = TOOL_CROWBAR
-		icon_state = "jaws_pry"
-		update_icon()
-	
+		transform_cutters(user)
+	else
+		transform_crowbar(user)
+		
 /obj/item/jawsoflife/attack(mob/living/carbon/C, mob/user)
 	if (tool_behaviour == TOOL_WIRECUTTER)
 		if(istype(C) && C.handcuffed)
@@ -74,13 +51,42 @@
 	else
 		..()
 
+/obj/item/jawsoflife/proc/transform_crowbar(mob/user)
+	desc = "A set of jaws of life, compressed through the magic of science. It's fitted with a prying head."
+	attack_verb = list("attacked", "bashed", "battered", "bludgeoned", "whacked")
+	usesound = 'sound/items/jaws_pry.ogg'
+	hitsound = 'sound/items/jaws_pry.ogg'
+	tool_behaviour = TOOL_CROWBAR
+	icon_state = "jaws_pry"
+	playsound(get_turf(user), 'sound/items/change_jaws.ogg', 50, 1)
+	if (iscyborg(user))
+		to_chat(user,"<span class='notice'>Your servos whirr as the cutting head reconfigures into a prying head.</span>")
+	else
+		to_chat(user, "<span class='notice'>You attach the pry jaws to [src].</span>")
+	update_icon()
+
+
+/obj/item/jawsoflife/proc/transform_cutters(mob/user)
+	attack_verb = list("pinched", "nipped")
+	icon_state = "jaws_cutter"
+	hitsound = 'sound/items/jaws_cut.ogg'
+	usesound = 'sound/items/jaws_cut.ogg'
+	tool_behaviour = TOOL_WIRECUTTER
+	playsound(get_turf(user), 'sound/items/change_jaws.ogg', 50, 1)
+	desc = "A set of jaws of life, compressed through the magic of science. It's fitted with a cutting head."
+	if (iscyborg(user))
+		to_chat(user,"<span class='notice'>Your servos whirr as the prying head reconfigures into a cutting head.</span>")
+	else
+		to_chat(user, "<span class='notice'>You attach the cutting jaws to [src].</span>")
+	update_icon()
+
 
 //better handdrill
 /obj/item/handdrill
 	name = "hand drill"
-	desc = "A simple powered hand drill. It's fitted with a bolt bit."
+	desc = "A simple powered hand drill. It's fitted with a screw bit."
 	icon = 'icons/obj/tools.dmi'
-	icon_state = "drill_bolt"
+	icon_state = "drill_screw"
 	item_state = "drill"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
@@ -94,31 +100,36 @@
 	hitsound = 'sound/items/drill_hit.ogg'
 	usesound = 'sound/items/drill_use.ogg'
 	toolspeed = 0.7
-	tool_behaviour = TOOL_WRENCH
+	tool_behaviour = TOOL_SCREWDRIVER
 
 /obj/item/handdrill/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is putting [src] to [user.p_their()] temple. It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return(BRUTELOSS)
 
 /obj/item/handdrill/attack_self(mob/user)
-	playsound(get_turf(user),'sound/items/change_drill.ogg',50,1)
 	if (tool_behaviour == TOOL_SCREWDRIVER)
-		if (iscyborg(user))
-			to_chat(user,"<span class='notice'>Your servos whirr as the drill reconfigures into bolt mode.</span>")
-		else
-			to_chat(user, "<span class='notice'>You attach the bolt driver bit to [src].</span>")
-		desc = "A simple powered hand drill. It's fitted with a bolt bit."
-		icon_state = "drill_bolt"
-		item_state = "drill"
-		tool_behaviour = TOOL_WRENCH
-		update_icon()
-	else if (tool_behaviour == TOOL_WRENCH)
-		if (iscyborg(user))
-			to_chat(user,"<span class='notice'>Your servos whirr as the drill reconfigures into screw mode.</span>")
-		else
-			to_chat(user, "<span class='notice'>You attach the screw driver bit to [src].</span>")
-		desc = "A simple powered hand drill. It's fitted with a screw bit."
-		icon_state = "drill_screw"
-		item_state = "drill"
-		tool_behaviour = TOOL_SCREWDRIVER
-		update_icon()
+		transform_wrench(user)
+	else
+		transform_screwdriver(user)
+
+/obj/item/handdrill/proc/transform_wrench(mob/user)
+	desc = "A simple powered hand drill. It's fitted with a bolt bit."
+	icon_state = "drill_bolt"
+	tool_behaviour = TOOL_WRENCH
+	playsound(get_turf(user),'sound/items/change_drill.ogg',50,1)
+	if (iscyborg(user))
+		to_chat(user,"<span class='notice'>Your servos whirr as the drill reconfigures into bolt mode.</span>")
+	else
+		to_chat(user, "<span class='notice'>You attach the bolt driver bit to [src].</span>")
+	update_icon()
+
+/obj/item/handdrill/proc/transform_screwdriver(mob/user)
+	desc = "A simple powered hand drill. It's fitted with a screw bit."
+	icon_state = "drill_screw"
+	tool_behaviour = TOOL_SCREWDRIVER
+	playsound(get_turf(user),'sound/items/change_drill.ogg',50,1)
+	if (iscyborg(user))
+		to_chat(user,"<span class='notice'>Your servos whirr as the drill reconfigures into screw mode.</span>")
+	else
+		to_chat(user, "<span class='notice'>You attach the screw driver bit to [src].</span>")
+	update_icon()

--- a/yogstation/code/game/objects/items/tools.dm
+++ b/yogstation/code/game/objects/items/tools.dm
@@ -15,6 +15,42 @@
 	toolspeed = 0.7
 	tool_behaviour = TOOL_CROWBAR
 
+
+//jaws of life changing jaw code
+/obj/item/jawsoflife/attack_self(mob/user)
+	if (tool_behaviour == TOOL_CROWBAR)
+		transform_cutters(user)
+	else
+		transform_crowbar(user)
+
+//jaws of life suicide code
+/obj/item/jawsoflife/suicide_act(mob/user)
+	switch(tool_behaviour)
+		if(TOOL_CROWBAR)
+			user.visible_message("<span class='suicide'>[user] is putting [user.p_their()] head in [src], it looks like [user.p_theyre()] trying to commit suicide!</span>")
+			playsound(loc, 'sound/items/jaws_pry.ogg', 50, 1, -1)
+		if(TOOL_WIRECUTTER)
+			user.visible_message("<span class='suicide'>[user] is wrapping \the [src] around [user.p_their()] neck. It looks like [user.p_theyre()] trying to rip [user.p_their()] head off!</span>")
+			playsound(loc, 'sound/items/jaws_cut.ogg', 50, 1, -1)
+			if(iscarbon(user))
+				var/mob/living/carbon/C = user
+				var/obj/item/bodypart/BP = C.get_bodypart(BODY_ZONE_HEAD)
+				if(BP)
+					BP.drop_limb()
+					playsound(loc,pick('sound/misc/desceration-01.ogg','sound/misc/desceration-02.ogg','sound/misc/desceration-01.ogg') ,50, 1, -1)
+	return (BRUTELOSS)
+
+/obj/item/jawsoflife/attack(mob/living/carbon/C, mob/user)
+	if (tool_behaviour == TOOL_WIRECUTTER)
+		if(istype(C) && C.handcuffed)
+			user.visible_message("<span class='notice'>[user] cuts [C]'s restraints with [src]!</span>")
+			qdel(C.handcuffed)
+			return
+		else
+			..()
+	else
+		..()
+		
 /obj/item/jawsoflife/proc/transform_crowbar(mob/user)
 	desc = "A set of jaws of life, compressed through the magic of science. It's fitted with a prying head."
 	attack_verb = list("attacked", "bashed", "battered", "bludgeoned", "whacked")
@@ -43,41 +79,6 @@
 		to_chat(user, "<span class='notice'>You attach the cutting jaws to [src].</span>")
 	update_icon()
 
-//jaws of life suicide code
-/obj/item/jawsoflife/suicide_act(mob/user)
-	switch(tool_behaviour)
-		if(TOOL_CROWBAR)
-			user.visible_message("<span class='suicide'>[user] is putting [user.p_their()] head in [src], it looks like [user.p_theyre()] trying to commit suicide!</span>")
-			playsound(loc, 'sound/items/jaws_pry.ogg', 50, 1, -1)
-		if(TOOL_WIRECUTTER)
-			user.visible_message("<span class='suicide'>[user] is wrapping \the [src] around [user.p_their()] neck. It looks like [user.p_theyre()] trying to rip [user.p_their()] head off!</span>")
-			playsound(loc, 'sound/items/jaws_cut.ogg', 50, 1, -1)
-			if(iscarbon(user))
-				var/mob/living/carbon/C = user
-				var/obj/item/bodypart/BP = C.get_bodypart(BODY_ZONE_HEAD)
-				if(BP)
-					BP.drop_limb()
-					playsound(loc,pick('sound/misc/desceration-01.ogg','sound/misc/desceration-02.ogg','sound/misc/desceration-01.ogg') ,50, 1, -1)
-	return (BRUTELOSS)
-
-//jaws of life changing jaw code
-/obj/item/jawsoflife/attack_self(mob/user)
-	if (tool_behaviour == TOOL_CROWBAR)
-		transform_cutters(user)
-	else
-		transform_crowbar(user)
-		
-/obj/item/jawsoflife/attack(mob/living/carbon/C, mob/user)
-	if (tool_behaviour == TOOL_WIRECUTTER)
-		if(istype(C) && C.handcuffed)
-			user.visible_message("<span class='notice'>[user] cuts [C]'s restraints with [src]!</span>")
-			qdel(C.handcuffed)
-			return
-		else
-			..()
-	else
-		..()
-
 //better handdrill
 /obj/item/handdrill
 	name = "hand drill"
@@ -98,6 +99,16 @@
 	usesound = 'sound/items/drill_use.ogg'
 	toolspeed = 0.7
 	tool_behaviour = TOOL_SCREWDRIVER
+
+/obj/item/handdrill/attack_self(mob/user)
+	if (tool_behaviour == TOOL_SCREWDRIVER)
+		transform_wrench(user)
+	else
+		transform_screwdriver(user)
+
+/obj/item/handdrill/suicide_act(mob/user)
+	user.visible_message("<span class='suicide'>[user] is putting [src] to [user.p_their()] temple. It looks like [user.p_theyre()] trying to commit suicide!</span>")
+	return(BRUTELOSS)
 
 /obj/item/handdrill/proc/transform_wrench(mob/user)
 	desc = "A simple powered hand drill. It's fitted with a bolt bit."
@@ -121,12 +132,3 @@
 		to_chat(user, "<span class='notice'>You attach the screw driver bit to [src].</span>")
 	update_icon()
 
-/obj/item/handdrill/suicide_act(mob/user)
-	user.visible_message("<span class='suicide'>[user] is putting [src] to [user.p_their()] temple. It looks like [user.p_theyre()] trying to commit suicide!</span>")
-	return(BRUTELOSS)
-
-/obj/item/handdrill/attack_self(mob/user)
-	if (tool_behaviour == TOOL_SCREWDRIVER)
-		transform_wrench(user)
-	else
-		transform_screwdriver(user)


### PR DESCRIPTION
For some reason, the power tools PR made the tools start in different modes, and it's bugging me.

Jaws of life now start in crowbar mode and drill now starts in screwdriver mode.

While I was here I also cleaned up this file by splitting the transformations into functions + removing redundant defines.

I was going to redo the flavor text since for some reason it's repeated twice in the code per mode but didn't feel like it.

#### Changelog

:cl:  
tweak: power tools now start in their previous modes again.
/:cl:
