### PR TITLE
Captains can now unlock their own display case on RED or DELTA alert

### DIFF
--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -227,8 +227,17 @@
 /obj/structure/displaycase/captain
 	alert = TRUE
 	start_showpiece_type = /obj/item/gun/energy/laser/captain
-	req_access = list(ACCESS_CAPTAIN)
+	req_access = list(ACCESS_CENT_SPECOPS)
 
+/obj/structure/displaycase/attackby(obj/item/W, mob/user, params)
+	if(seclevel2num(get_security_level()) >= SEC_LEVEL_RED)
+		req_access = list(ACCESS_CAPTAIN)
+	else
+		to_chat(user, "ID scanning with this display will not work until RED or DELTA security levels")
+		req_access = list(ACCESS_CENT_SPECOPS)
+		return
+	. = ..()
+	
 /obj/structure/displaycase/labcage
 	name = "lab cage"
 	desc = "A glass lab container for storing interesting creatures."

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -223,12 +223,11 @@
 	else
 		return ..()
 
-//The captains display case requiring specops ID access is intentional.
-//The lab cage and captains display case do not spawn with electronics, which is why req_access is needed.
+// Not being able to unlock your own gun in emergency situations is weird
 /obj/structure/displaycase/captain
 	alert = TRUE
 	start_showpiece_type = /obj/item/gun/energy/laser/captain
-	req_access = list(ACCESS_CENT_SPECOPS)
+	req_access = list(ACCESS_CAPTAIN)
 
 /obj/structure/displaycase/labcage
 	name = "lab cage"


### PR DESCRIPTION
I always thought it was really weird that captains are unable to unlock their own case in emergencies.
They always have to break their own glass while every other head (even the RD) are able to just open their case with their ID

EDIT:
-----

**Captains can now only open their display case during RED alert or higher.**

![image](https://user-images.githubusercontent.com/24533979/81511337-3fdc0400-92de-11ea-9e26-97581a3080c4.png)


#### Changelog

:cl:  Hopek
tweak: Captains can now unlock their own display case
/:cl:
