### PR TITLE
Adds welsh accent

### DIFF
--- a/strings/accents/accent_welsh.json
+++ b/strings/accents/accent_welsh.json
@@ -1,0 +1,22 @@
+{
+	"Welsh": {
+		"l": "ll",
+		"\bwhere\b": "whereby",
+		"\bnow\b": "now in a minute",
+		"\bnice\b": "tidy",
+		"\bbuddy\b": "butt",
+		"\bhere\b": "year",
+		"\bhear\b": "year",
+		"\bear\b": "year",
+		"\bears\b": "years",
+		"\bhey\b": "oh",
+		"\bgreat\b": "bangin",
+		"\bhello\b": "aight",
+		"\bboy\b": "boyo",
+		"\bheard\b": "yeared",
+		"\bbye\b": "tra",
+		"\bshoes\b": "daps",
+		"\bcuddle\b": "cwtch",
+		"\bhug\b": "cwtch"
+	}
+}

--- a/strings/accents/accents.json
+++ b/strings/accents/accents.json
@@ -21,6 +21,7 @@
 	"Heavy Shakespearean": "accent_shakespearean.json",
 	"Muppet": "accent_chef_muppet.json",
 	"Valley": "accent_valspeak.json",
+	"Welsh": "accent_welsh.json",
 	"Skaven": "accent_skaven.json"
 
 		}


### PR DESCRIPTION
### Intent of your Pull Request

Adds Welsh accent. Change has not been tested beyond being selectable in chargen (due to issues getting yogstation running locally), but JSON validates fine.  
All single l's become double l's, along with a few substitutions (e.g. here/ear/year = year, among others)  
Reasoning: We have scottish, I don't see any harm in having welsh.  

#### Changelog

:cl:  
rscadd: Added Welsh accent to character creation
/:cl:
