### PR TITLE
slimes dont feed on megafauna since it causes offset issues

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -59,6 +59,9 @@
 	if(issilicon(M))
 		return FALSE
 
+	if(ismegafauna(M))
+		return FALSE
+
 	if(isanimal(M))
 		var/mob/living/simple_animal/S = M
 		if(S.damage_coeff[TOX] <= 0 && S.damage_coeff[CLONE] <= 0) //The creature wouldn't take any damage, it must be too weird even for us.


### PR DESCRIPTION


:cl:  
bugfix: megafauna will no longer get buckled by slimes, causing their pixel offset to be reset to 0 or something and moving their icon.
/:cl:
