### PR TITLE
Canisters emit faint light in the dark (Aurora port)

### DIFF
--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -258,18 +258,27 @@
 		return
 
 	cut_overlays()
+	set_light(FALSE)
 	if(update & CANISTER_UPDATE_HOLDING)
 		add_overlay("can-open")
 	if(update & CANISTER_UPDATE_CONNECTED)
 		add_overlay("can-connector")
 	if(update & CANISTER_UPDATE_LOW)
-		add_overlay("can-o0")
+		var/mutable_appearance/indicator_overlay = mutable_appearance(icon, "can-o0", ABOVE_LIGHTING_LAYER)
+		add_overlay(indicator_overlay)
+		set_light(1.4, 1, COLOR_RED_LIGHT)
 	else if(update & CANISTER_UPDATE_MEDIUM)
-		add_overlay("can-o1")
+		var/mutable_appearance/indicator_overlay = mutable_appearance(icon, "can-o1", ABOVE_LIGHTING_LAYER)
+		add_overlay(indicator_overlay)
+		set_light(1.4, 1, COLOR_RED_LIGHT)
 	else if(update & CANISTER_UPDATE_FULL)
-		add_overlay("can-o2")
+		var/mutable_appearance/indicator_overlay = mutable_appearance(icon, "can-o2", ABOVE_LIGHTING_LAYER)
+		add_overlay(indicator_overlay)
+		set_light(1.4, 1, COLOR_YELLOW)
 	else if(update & CANISTER_UPDATE_DANGER)
-		add_overlay("can-o3")
+		var/mutable_appearance/indicator_overlay = mutable_appearance(icon, "can-o3", ABOVE_LIGHTING_LAYER)
+		add_overlay(indicator_overlay)
+		set_light(1.4, 1, COLOR_LIME)
 #undef CANISTER_UPDATE_HOLDING
 #undef CANISTER_UPDATE_CONNECTED
 #undef CANISTER_UPDATE_EMPTY
@@ -327,7 +336,7 @@
 	investigate_log("was destroyed.", INVESTIGATE_ATMOS)
 
 	if(holding)
-		holding.forceMove(T)
+		usr.put_in_hands(holding)
 		holding = null
 
 /obj/machinery/portable_atmospherics/canister/replace_tank(mob/living/user, close_valve)


### PR DESCRIPTION
### Intent of your Pull Request

All credit to **Geevies** for the original coding.
https://github.com/Aurorastation/Aurora.3/pull/8784

Atmos Canisters now emit a faint light in the dark (color depends on the display light's color).

![dreamseeker_ZJMPpISCpY](https://user-images.githubusercontent.com/49619518/81760831-258c5c80-947d-11ea-922b-23ddd525b330.png)

Also canisters now eject tanks into any of your hands, dropping them to your feet if your hands aren't free.

#### Changelog

:cl:  Geevies
rscadd: Canisters emit a faint light depending on the display light's color
tweak: Tank ejection tweak
/:cl:
