### PR TITLE
disguisable prosthetics

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -400,6 +400,31 @@
 			SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "painful_medicine", /datum/mood_event/painful_medicine)
 	..()
 
+/datum/reagent/medicine/synthflesh/reaction_obj(obj/O, reac_volume)
+	if(O.type == /obj/item/bodypart/l_arm/robot/surplus)
+		var/t_loc = get_turf(O)
+		qdel(O)
+		new /obj/item/bodypart/l_arm/robot/surplus/disguised(t_loc)
+		
+/datum/reagent/medicine/synthflesh/reaction_obj(obj/O, reac_volume)
+	if(O.type == /obj/item/bodypart/r_arm/robot/surplus)
+		var/t_loc = get_turf(O)
+		qdel(O)
+		new /obj/item/bodypart/r_arm/robot/surplus/disguised(t_loc)
+
+/datum/reagent/medicine/synthflesh/reaction_obj(obj/O, reac_volume)
+	if(O.type == /obj/item/bodypart/r_leg/robot/surplus)
+		var/t_loc = get_turf(O)
+		qdel(O)
+		new /obj/item/bodypart/r_leg/robot/surplus/disguised(t_loc)
+
+/datum/reagent/medicine/synthflesh/reaction_obj(obj/O, reac_volume)
+	if(O.type == /obj/item/bodypart/l_leg/robot/surplus)
+		var/t_loc = get_turf(O)
+		qdel(O)
+		new //obj/item/bodypart/l_leg/robot/surplus/disguised(t_loc)
+
+
 /datum/reagent/medicine/charcoal
 	name = "Charcoal"
 	description = "Heals toxin damage as well as slowly removing any other chemicals the patient has in their bloodstream."

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -422,7 +422,7 @@
 	if(O.type == /obj/item/bodypart/l_leg/robot/surplus)
 		var/t_loc = get_turf(O)
 		qdel(O)
-		new //obj/item/bodypart/l_leg/robot/surplus/disguised(t_loc)
+		new /obj/item/bodypart/l_leg/robot/surplus/disguised(t_loc)
 
 
 /datum/reagent/medicine/charcoal

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -323,6 +323,38 @@
 	burn_reduction = 0
 	max_damage = 20
 
+/obj/item/bodypart/r_leg/robot/surplus/disguised
+	name = "disguised surplus prosthetic right leg"
+	desc = "A skeletal, robotic limb. Outdated and fragile, but it's still better than nothing."
+	icon_state = "default_human_l_leg"
+	brute_reduction = 0
+	burn_reduction = 0
+	max_damage = 20
+
+/obj/item/bodypart/l_leg/robot/surplus/disguised
+	name = "surplus prosthetic left leg"
+	desc = "A disguised skeletal, robotic limb. Outdated and fragile, but it's still better than nothing."
+	icon_state = "default_human_l_leg"
+	brute_reduction = 0
+	burn_reduction = 0
+	max_damage = 20
+	
+/obj/item/bodypart/r_arm/robot/surplus
+	name = "surplus prosthetic right arm"
+	desc = "A disguised skeletal, robotic limb. Outdated and fragile, but it's still better than nothing."
+	icon_state = "default_human_r_arm"
+	brute_reduction = 0
+	burn_reduction = 0
+	max_damage = 20
+	
+/obj/item/bodypart/l_arm/robot/surplus
+	name = "surplus prosthetic left arm"
+	desc = "A disguised skeletal, robotic limb. Outdated and fragile, but it's still better than nothing."
+	icon_state = "default_human_l_arm"
+	brute_reduction = 0
+	burn_reduction = 0
+	max_damage = 20
+	
 
 #undef ROBOTIC_LIGHT_BRUTE_MSG
 #undef ROBOTIC_MEDIUM_BRUTE_MSG

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -339,7 +339,7 @@
 	burn_reduction = 0
 	max_damage = 20
 	
-/obj/item/bodypart/r_arm/robot/surplus
+/obj/item/bodypart/r_arm/robot/surplus/disguised
 	name = "surplus prosthetic right arm"
 	desc = "A disguised skeletal, robotic limb. Outdated and fragile, but it's still better than nothing."
 	icon_state = "default_human_r_arm"
@@ -347,7 +347,7 @@
 	burn_reduction = 0
 	max_damage = 20
 	
-/obj/item/bodypart/l_arm/robot/surplus
+/obj/item/bodypart/l_arm/robot/surplus/disguised
 	name = "surplus prosthetic left arm"
 	desc = "A disguised skeletal, robotic limb. Outdated and fragile, but it's still better than nothing."
 	icon_state = "default_human_l_arm"


### PR DESCRIPTION
allows you to disguise prosthetic limbs as normal limbs (appearance only they have the same name) by pouring synth flesh on them this doesnt work for cyborg limbs and they are still repaired like normal prosthetics
#### Changelog

:cl:  
rscadd: Added new synthflesh reaction and a way to disguise prosthetics 
/:cl:
