### PR TITLE
Detective office gets a photocopier

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -49891,6 +49891,10 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"cLH" = (
+/obj/machinery/photocopier,
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
 "cLZ" = (
 /obj/item/stack/ore/iron,
 /obj/effect/turf_decal/stripes/line{
@@ -52948,10 +52952,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"iRL" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
 "iSS" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -89231,7 +89231,7 @@ anw
 anz
 aov
 bON
-iRL
+cLH
 bLE
 ayZ
 bQG


### PR DESCRIPTION
Created per:
https://forums.yogstation.net/index.php?threads/add-a-photocopier-to-the-detectives-office.21390/

![image](https://user-images.githubusercontent.com/24533979/82008158-8e1c3a80-9631-11ea-863d-e32a90f8a820.png)


#### Changelog

:cl:  Hopek
tweak: Sacrificed the detective's plant to bring a photocopier into existence
/:cl:
