### PR TITLE
Probably fixes malf not going blue alert

### DIFF
--- a/code/game/gamemodes/malfunction/malf.dm
+++ b/code/game/gamemodes/malfunction/malf.dm
@@ -32,7 +32,7 @@
 		AI.mind.add_antag_datum(/datum/antagonist/traitor/malf)
 
 	gamemode_ready = TRUE
-	return TRUE
+	. = ..()
 
 /datum/game_mode/malf/make_antag_chance()
 	return FALSE //no latejoins for you


### PR DESCRIPTION
Fixes #8503

:cl:  
bugfix: malf will now actually send a command report and set the security level to blue like every other roundtype does
/:cl:
