### PR TITLE
Adds two more chem bags to the Chemdrobe

### DIFF
--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -433,7 +433,7 @@
 					/obj/item/clothing/suit/toggle/labcoat/chemist = 2,
 					/obj/item/storage/backpack/chemistry = 2,
 					/obj/item/storage/backpack/satchel/chem = 2,
-					/obj/item/storage/bag/chemistry = 2)
+					/obj/item/storage/bag/chemistry = 4)
 	refill_canister = /obj/item/vending_refill/wardrobe/chem_wardrobe
 	payment_department = ACCOUNT_MED
 /obj/item/vending_refill/wardrobe/chem_wardrobe


### PR DESCRIPTION
Right now there isn't any efficient way for doctors or paramedics to make use of the chemicals put in Chem Storage in a way that makes it more efficient then just throwing someone in a sleeper. If Doctors or Paramedics could get access to chem bags, they could organize and carry healing chemicals for use during the round. This doesn't really buff chemistry in any way, but it allows for competent players to benefit from competent chemists in a way that's more rewarding then just throwing someone in cryo/sleeper.
More medbay/paramedic/chemistry interaction is good.
