### PR TITLE
ports a bunch of mutations from tgstation

### DIFF
--- a/code/datums/mutations/_combined.dm
+++ b/code/datums/mutations/_combined.dm
@@ -32,3 +32,11 @@
 /datum/generecipe/antiglow
 	required = "/datum/mutation/human/glow; /datum/mutation/human/void"
 	result = ANTIGLOWY
+
+/datum/generecipe/tonguechem
+	required = "/datum/mutation/human/tongue_spike; /datum/mutation/human/stimmed"
+	result = TONGUESPIKECHEM
+
+/datum/generecipe/martyrdom
+	required = "/datum/mutation/human/strong; /datum/mutation/human/stimmed"
+	result = MARTYRDOM

--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -189,3 +189,185 @@
 /obj/effect/proc_holder/spell/self/void/cast(mob/user = usr)
 	. = ..()
 	new /obj/effect/immortality_talisman/void(get_turf(user), user)
+	
+/datum/mutation/human/tongue_spike
+	name = "Tongue Spike"
+	desc = "Allows a creature to voluntary shoot their tongue out as a deadly weapon."
+	quality = POSITIVE
+	text_gain_indication = "<span class='notice'>Your feel like you can throw your voice.</span>"
+	instability = 15
+	power = /obj/effect/proc_holder/spell/self/tongue_spike
+
+	energy_coeff = 1
+	synchronizer_coeff = 1
+
+/obj/effect/proc_holder/spell/self/tongue_spike
+	name = "Launch spike"
+	desc = "Shoot your tongue out in the direction you're facing, embedding it and dealing damage until they remove it."
+	clothes_req = FALSE
+	human_req = TRUE
+	charge_max = 100
+	action_icon = 'icons/mob/actions/actions_genetic.dmi'
+	action_icon_state = "spike"
+	var/spike_path = /obj/item/hardened_spike
+
+/obj/effect/proc_holder/spell/self/tongue_spike/cast(list/targets, mob/user = usr)
+	if(!iscarbon(user))
+		return
+
+	var/mob/living/carbon/C = user
+	if(HAS_TRAIT(C, TRAIT_NODISMEMBER))
+		return
+	var/obj/item/organ/tongue/tongue
+	for(var/org in C.internal_organs)
+		if(istype(org, /obj/item/organ/tongue))
+			tongue = org
+			break
+
+	if(!tongue)
+		to_chat(C, "<span class='notice'>You don't have a tongue to shoot!</span>")
+		return
+
+	tongue.Remove(C, special = TRUE)
+	var/obj/item/hardened_spike/spike = new spike_path(get_turf(C), C)
+	tongue.forceMove(spike)
+	spike.throw_at(get_edge_target_turf(C,C.dir), 14, 4, C)
+
+/obj/item/hardened_spike
+	name = "biomass spike"
+	desc = "Hardened biomass, shaped into a spike. Very pointy!"
+	icon_state = "tonguespike"
+	force = 2
+	throwforce = 15 //15 + 2 (WEIGHT_CLASS_SMALL) * 4 (EMBEDDED_IMPACT_PAIN_MULTIPLIER) = i didnt do the math
+	throw_speed = 4
+	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 100, "embedded_fall_chance" = 0, "embedded_ignore_throwspeed_threshold" = TRUE)
+	w_class = WEIGHT_CLASS_SMALL
+	sharpness = IS_SHARP
+	custom_materials = list(/datum/material/biomass = 500)
+	var/mob/living/carbon/human/fired_by
+	/// if we missed our target
+	var/missed = TRUE
+
+/obj/item/hardened_spike/Initialize(mapload, firedby)
+	. = ..()
+	fired_by = firedby
+	addtimer(CALLBACK(src, .proc/checkembedded), 5 SECONDS)
+
+/obj/item/hardened_spike/proc/checkembedded()
+	if(missed)
+		unembedded()
+
+/obj/item/hardened_spike/embedded(atom/target)
+	if(isbodypart(target))
+		missed = FALSE
+
+/obj/item/hardened_spike/unembedded()
+	var/turf/T = get_turf(src)
+	visible_message("<span class='warning'>[src] cracks and twists, changing shape!</span>")
+	for(var/i in contents)
+		var/obj/o = i
+		o.forceMove(T)
+	qdel(src)
+
+/datum/mutation/human/tongue_spike/chem
+	name = "Chem Spike"
+	desc = "Allows a creature to voluntary shoot their tongue out as biomass, allowing a long range transfer of chemicals."
+	quality = POSITIVE
+	text_gain_indication = "<span class='notice'>Your feel like you can really connect with people by throwing your voice.</span>"
+	instability = 15
+	locked = TRUE
+	power = /obj/effect/proc_holder/spell/self/tongue_spike/chem
+	energy_coeff = 1
+	synchronizer_coeff = 1
+
+/obj/effect/proc_holder/spell/self/tongue_spike/chem
+	name = "Launch chem spike"
+	desc = "Shoot your tongue out in the direction you're facing, embedding it for a very small amount of damage. While the other person has the spike embedded, you can transfer your chemicals to them."
+	action_icon_state = "spikechem"
+	spike_path = /obj/item/hardened_spike/chem
+
+/obj/item/hardened_spike/chem
+	name = "chem spike"
+	desc = "Hardened biomass, shaped into... something."
+	icon_state = "tonguespikechem"
+	throwforce = 2 //2 + 2 (WEIGHT_CLASS_SMALL) * 0 (EMBEDDED_IMPACT_PAIN_MULTIPLIER) = i didnt do the math again but very low or smthin
+	embedding = list("embedded_pain_multiplier" = 0, "embed_chance" = 100, "embedded_fall_chance" = 0, "embedded_pain_chance" = 0, "embedded_ignore_throwspeed_threshold" = TRUE) //never hurts once it's in you
+	var/been_places = FALSE
+	var/datum/action/innate/send_chems/chems
+
+/obj/item/hardened_spike/chem/embedded(mob/living/carbon/human/embedded_mob)
+	if(been_places)
+		return
+	been_places = TRUE
+	chems = new
+	chems.transfered = embedded_mob
+	chems.spikey = src
+	to_chat(fired_by, "<span class='notice'>Link established! Use the \"Transfer Chemicals\" ability to send your chemicals to the linked target!</span>")
+	chems.Grant(fired_by)
+
+/obj/item/hardened_spike/chem/unembedded()
+	to_chat(fired_by, "<span class='warning'>Link lost!</span>")
+	QDEL_NULL(chems)
+	..()
+
+/datum/action/innate/send_chems
+	icon_icon = 'icons/mob/actions/actions_genetic.dmi'
+	background_icon_state = "bg_spell"
+	check_flags = AB_CHECK_CONSCIOUS
+	button_icon_state = "spikechemswap"
+	name = "Transfer Chemicals"
+	desc = "Send all of your reagents into whomever the chem spike is embedded in. One use."
+	var/obj/item/hardened_spike/chem/spikey
+	var/mob/living/carbon/human/transfered
+
+/datum/action/innate/send_chems/Activate()
+	if(!ishuman(transfered) || !ishuman(owner))
+		return
+	var/mob/living/carbon/human/transferer = owner
+
+	to_chat(transfered, "<span class='warning'>You feel a tiny prick!</span>")
+	transferer.reagents.trans_to(transfered, transferer.reagents.total_volume, 1, 1, 0, transfered_by = transferer)
+
+	var/obj/item/bodypart/L = spikey.checkembedded()
+
+	//this is where it would deal damage, if it transfers chems it removes itself so no damage
+	spikey.forceMove(get_turf(L))
+	transfered.visible_message("<span class='notice'>[spikey] falls out of [transfered]!</span>")
+
+/datum/mutation/human/webbing
+	name = "Webbing Production"
+	desc = "Allows the user to lay webbing, and travel through it."
+	quality = POSITIVE
+	text_gain_indication = "<span class='notice'>Your skin feels webby.</span>"
+	instability = 15
+	power = /obj/effect/proc_holder/spell/self/lay_genetic_web
+
+/obj/effect/proc_holder/spell/self/lay_genetic_web
+	name = "Lay Web"
+	desc = "Drops a web. Only you will be able to traverse your web easily, making it pretty good for keeping you safe."
+	clothes_req = FALSE
+	human_req = FALSE
+	charge_max = 4 SECONDS //the same time to lay a web
+	action_icon = 'icons/mob/actions/actions_genetic.dmi'
+	action_icon_state = "lay_web"
+
+/obj/effect/proc_holder/spell/self/lay_genetic_web/cast(list/targets, mob/user = usr)
+	var/failed = FALSE
+	if(!isturf(user.loc))
+		to_chat(user, "<span class='warning'>You can't lay webs here!</span>")
+		failed = TRUE
+	var/turf/T = get_turf(user)
+	var/obj/structure/spider/stickyweb/genetic/W = locate() in T
+	if(W)
+		to_chat(user, "<span class='warning'>There's already a web here!</span>")
+		failed = TRUE
+	if(failed)
+		revert_cast(user)
+		return FALSE
+
+	user.visible_message("<span class='notice'>[user] begins to secrete a sticky substance.</span>","<span class='notice'>You begin to lay a web.</span>")
+	if(!do_after(user, 4 SECONDS, target = T))
+		to_chat(user, "<span class='warning'>Your web spinning was interrupted!</span>")
+		return
+	else
+		new /obj/structure/spider/stickyweb/genetic(T, user)

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -375,3 +375,99 @@
 			owner.SetStun(owner.AmountStun()*2)
 			owner.visible_message("<span class='danger'>[owner] tries to stand up, but trips!</span>", "<span class='userdanger'>You trip over your own feet!</span>")
 			stun_cooldown = world.time + 300
+
+/datum/mutation/human/stimmed
+	name = "Stimmed"
+	desc = "The user's chemical balance is more robust."
+	quality = POSITIVE
+	text_gain_indication = "<span class='notice'>You feel stimmed.</span>"
+	difficulty = 16
+	
+/datum/mutation/human/martyrdom
+	name = "Internal Martyrdom"
+	desc = "A mutation that makes the body destruct when near death. Not damaging, but very, VERY disorienting."
+	locked = TRUE
+	quality = POSITIVE //not that cloning will be an option a lot but generally lets keep this around i guess?
+	text_gain_indication = "<span class='warning'>You get an intense feeling of heartburn.</span>"
+	text_lose_indication = "<span class'notice'>Your internal organs feel at ease.</span>"
+
+/datum/mutation/human/martyrdom/on_acquiring()
+	. = ..()
+	if(.)
+		return TRUE
+	RegisterSignal(owner, COMSIG_MOB_STATCHANGE, .proc/bloody_shower)
+
+/datum/mutation/human/martyrdom/on_losing()
+	. = ..()
+	if(.)
+		return TRUE
+	UnregisterSignal(owner, COMSIG_MOB_STATCHANGE)
+
+/datum/mutation/human/martyrdom/proc/bloody_shower(new_stat)
+	if(new_stat != UNCONSCIOUS)
+		return
+	var/list/organs = owner.getorganszone(BODY_ZONE_HEAD, 1)
+
+	for(var/obj/item/organ/I in organs)
+		I.Remove(owner, TRUE)
+
+	explosion(get_turf(owner), 0, 0, 2, 0, TRUE)
+	for(var/mob/living/carbon/human/H in view(2,owner))
+		var/obj/item/organ/eyes/eyes = H.getorganslot(ORGAN_SLOT_EYES)
+		if(eyes)
+			to_chat(H, "<span class='userdanger'>You are blinded by a shower of blood!</span>")
+		else
+			to_chat(H, "<span class='userdanger'>You are knocked down by a wave of... blood?!</span>")
+		H.Stun(20)
+		H.blur_eyes(20)
+		eyes?.applyOrganDamage(5)
+		H.confused += 3
+	for(var/mob/living/silicon/S in view(2,owner))
+		to_chat(S, "<span class='userdanger'>Your sensors are disabled by a shower of blood!</span>")
+		S.Paralyze(60)
+	owner.gib()
+
+/datum/mutation/human/headless
+	name = "H.A.R.S."
+	desc = "A mutation that makes the body reject the head. Stands for Head Allergic Rejection Syndrome. Warning: Removing this mutation is very dangerous, though it will regenerate head organs."
+	difficulty = 12 //pretty good for traitors
+	quality = NEGATIVE //holy shit no eyes or tongue or ears
+	text_gain_indication = "<span class='warning'>Something feels off.</span>"
+
+/datum/mutation/human/headless/on_acquiring()
+	. = ..()
+	if(.)//cant add
+		return TRUE
+	var/obj/item/organ/brain/brain = owner.getorganslot(ORGAN_SLOT_BRAIN)
+	if(brain) //so this doesn't instantly kill you
+		brain.organ_flags &= ~ORGAN_VITAL
+		qdel(brain)
+
+	var/obj/item/bodypart/head/head = owner.get_bodypart(BODY_ZONE_HEAD)
+	if(head)
+		owner.visible_message("<span class='warning'>[owner]'s head splatters with a sickening crunch!</span>", ignored_mobs = list(owner))
+		new /obj/effect/gibspawner/generic(get_turf(owner), owner)
+		head.dismember(BRUTE)
+		head.drop_organs()
+		qdel(head)
+		owner.regenerate_icons()
+	RegisterSignal(owner, COMSIG_LIVING_ATTACH_LIMB, .proc/abortattachment)
+
+/datum/mutation/human/headless/on_losing()
+	. = ..()
+	if(.)
+		return TRUE
+	UnregisterSignal(owner, COMSIG_LIVING_ATTACH_LIMB)
+	var/successful = owner.regenerate_limb(BODY_ZONE_HEAD, noheal = TRUE) //noheal needs to be TRUE to prevent weird adding and removing mutation healing
+	if(!successful)
+		stack_trace("HARS mutation head regeneration failed! (usually caused by headless syndrome having a head)")
+		return TRUE
+	owner.dna.species.regenerate_organs(owner, excluded_zones = list(BODY_ZONE_CHEST)) //only regenerate head
+	owner.apply_damage(damage = 50, damagetype = BRUTE, def_zone = BODY_ZONE_HEAD) //and this to DISCOURAGE organ farming, or at least not make it free.
+	owner.visible_message("<span class='warning'>[owner]'s head returns with a sickening crunch!</span>", "<span class='warning'>Your head regrows with a sickening crack! Ouch.</span>")
+	new /obj/effect/gibspawner/generic(get_turf(owner), owner)
+
+
+/datum/mutation/human/headless/proc/abortattachment(datum/source, obj/item/bodypart/new_limb, special) //you aren't getting your head back
+	if(istype(new_limb, /obj/item/bodypart/head))
+		return COMPONENT_NO_ATTACH


### PR DESCRIPTION
ports a bunch of mutations from tg station
"tongue spike: removes tongue to shoot it outwards, embedding for a decent amount of damage.
stimmed: generic mutation, doesn't do anything
tongue spike + stimmed = chem spike: the tongue spike no longer deals a lot of damage and does not hurt to keep in. the person who fired it can activate it remotely to transfer all of his chemicals into the spike'd person
"martyrdom: deep crit makes you go goosh into a shower of blood, no damage but good stun

HADS: removes your head with a splat. pretty awful experience without a head, so negative.

chem spike can only be made with crafting"
lay web: lay a "genetic" web that only lets you pass through without resistance. neato"
https://github.com/tgstation/tgstation/pull/48665 
https://github.com/tgstation/tgstation/pull/49062
from these tg pr 

#### Changelog

:cl:  
rscadd: Adds a bunch of mutations
/:cl:
