### PR TITLE
Space Heater buff (cit port)

### DIFF
--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -114,8 +114,8 @@
 		return PROCESS_KILL
 
 /obj/machinery/space_heater/RefreshParts()
-	var/laser = 0
-	var/cap = 0
+	var/laser = 2
+	var/cap = 1
 	for(var/obj/item/stock_parts/micro_laser/M in component_parts)
 		laser += M.rating
 	for(var/obj/item/stock_parts/capacitor/M in component_parts)
@@ -162,6 +162,11 @@
 		return
 	else
 		return ..()
+
+/obj/machinery/space_heater/wrench_act(mob/living/user, obj/item/I)
+	..()
+	default_unfasten_wrench(user, I, 5)
+	return TRUE
 
 /obj/machinery/space_heater/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, \
 										datum/tgui/master_ui = null, datum/ui_state/state = GLOB.physical_state)

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -53,7 +53,7 @@
 	else
 		. += "There is no power cell installed."
 	if(in_range(user, src) || isobserver(user))
-		. += "<span class='notice'>The status display reads: Temperature range at <b>[settableTemperatureRange]°C</b>.<br>Heating power at <b>[heatingPower*0.001]kJ</b>.<br>Power consumption at <b>[(efficiency*-0.0025)+150]%</b>.<span>" //100%, 75%, 50%, 25%
+		. += "<span class='notice'>The status display reads: Temperature range at <b>[settableTemperatureRange]°C</b>.<br>Heating power at <b>[heatingPower*0.001]kJ</b>.<br>Power consumption at <b>[(efficiency*-0.0025)+150]%</b>.<span>" //100%, 75%, 50%, 25% 
 
 /obj/machinery/space_heater/update_icon()
 	if(on)


### PR DESCRIPTION
### Intent of your Pull Request

All credit to the original coder **Trilbyspaceclone**.
https://github.com/Citadel-Station-13/Citadel-Station-13/pull/12241

"space heaters can now be wrenched and unwrenched to remove bolts
space heaters now have 300% more laser powering and 200% more capacitor power"

Obviously the wrench ability is a given, why they aren't able to be wrenched up until now is unknown to me. I also feel like the buff to their temp change ability is warranted given how horribly slow they are.

#### Changelog

:cl:  Trilbyspaceclone
rscadd: Space heaters can now be wrenched and unwrenched
tweak: Space heaters drain less and can reach even hotter/colder temps faster!
/:cl:
