### PR TITLE
[admin] Semi-Automatic Antag Token System

### DIFF
--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -1,12 +1,29 @@
 Any time you make a change to the schema files, remember to increment the database schema version. Generally increment the minor number, major should be reserved for significant changes to the schema. Both values go up to 255.
 
-The latest database version is 5.3; The query to update the schema revision table is:
+The latest database version is 5.4; The query to update the schema revision table is:
 
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 3);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 4);
 or
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 3);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 4);
 
 In any query remember to add a prefix to the table names if you use one.
+
+version 5.4 18 May 2020, by TheGamer01
+
+Adds table for antag tokens
+
+CREATE TABLE `antag_tokens` (
+	`id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+	`ckey` VARCHAR(32) NULL NOT NULL,
+	`reason` VARCHAR(2048) NOT NULL,
+	`denial_reason` VARCHAR(2048) DEFAULT NULL,
+	`applying_admin` VARCHAR(32) NOT NULL,
+	`denying_admin` VARCHAR(32) DEFAULT NULL,
+	`granted_time` DATETIME NOT NULL,
+	`redeemed` tinyint(1) unsigned NOT NULL DEFAULT '0',
+	`round_id` int(11) unsigned NOT NULL,
+	PRIMARY KEY (`id`)
+) ENGINE=InnoDB;
 
 ----------------------------------------------------
 

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -544,6 +544,23 @@ CREATE TABLE `misc` (
 	PRIMARY KEY (`key`)
 ) ENGINE=InnoDB;
 
+--
+-- Table structure for table `antag_tokens`
+--
+DROP TABLE IF EXISTS `antag_tokens`;
+CREATE TABLE `antag_tokens` (
+	`id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+	`ckey` VARCHAR(32) NULL NOT NULL,
+	`reason` VARCHAR(2048) NOT NULL,
+	`denial_reason` VARCHAR(2048) DEFAULT NULL,
+	`applying_admin` VARCHAR(32) NOT NULL,
+	`denying_admin` VARCHAR(32) DEFAULT NULL,
+	`granted_time` DATETIME NOT NULL,
+	`redeemed` tinyint(1) unsigned NOT NULL DEFAULT '0',
+	`round_id` int(11) unsigned NOT NULL,
+	PRIMARY KEY (`id`)
+) ENGINE=InnoDB;
+
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
 /*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -544,6 +544,23 @@ CREATE TABLE `SS13_misc` (
 	PRIMARY KEY (`key`)
 ) ENGINE=InnoDB;
 
+--
+-- Table structure for table `antag_tokens`
+--
+DROP TABLE IF EXISTS `SS13_antag_tokens`;
+CREATE TABLE `SS13_antag_tokens` (
+	`id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+	`ckey` VARCHAR(32) NULL DEFAULT NULL,
+	`reason` VARCHAR(2048) NOT NULL,
+	`denial_reason` VARCHAR(2048) NOT NULL,
+	`applying_admin` VARCHAR(32) NOT NULL,
+	`denying_admin` VARCHAR(32) NOT NULL,
+	`granted_time` DATETIME NOT NULL,
+	`redeemed` tinyint(1) unsigned NOT NULL DEFAULT '0',
+	`round_id` int(11) unsigned NOT NULL,
+	PRIMARY KEY (`id`)
+) ENGINE=InnoDB;
+
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
 /*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -1,7 +1,7 @@
 //Update this whenever the db schema changes
 //make sure you add an update to the schema_version stable in the db changelog
 #define DB_MAJOR_VERSION 5
-#define DB_MINOR_VERSION 3
+#define DB_MINOR_VERSION 4
 
 
 //Timing subsystem

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -51,6 +51,7 @@
 	var/gamemode_ready = FALSE //Is the gamemode all set up and ready to start checking for ending conditions.
 	var/setup_error		//What stopepd setting up the mode.
 
+
 /datum/game_mode/proc/announce() //Shows the gamemode's name and a fast description.
 	to_chat(world, "<b>The gamemode is: <span class='[announce_span]'>[name]</span>!</b>")
 	to_chat(world, "<b>[announce_text]</b>")
@@ -310,6 +311,18 @@
 //     Player A: 150 / 250 = 0.6 = 60%
 //     Player B: 100 / 250 = 0.4 = 40%
 /datum/game_mode/proc/antag_pick(list/datum/candidates)
+	if(GLOB.antag_token_users.len >= 1) //Antag token users get first priority, no matter their preferences
+		var/client/C = pick_n_take(GLOB.antag_token_users)
+		var/mob/M = C.mob
+		if(C && istype(M, /mob/dead/new_player))
+			var/mob/dead/new_player/player = M
+			if(player.ready == PLAYER_READY_TO_PLAY)
+				if(!is_banned_from(player.ckey, list(antag_flag, ROLE_SYNDICATE)) && !QDELETED(player))
+					addtimer(CALLBACK(GLOBAL_PROC, .proc/antag_token_used, C.ckey, C), 0.5 MINUTES)
+					return player.mind
+
+		GLOB.antag_token_users += C
+
 	if(!CONFIG_GET(flag/use_antag_rep)) // || candidates.len <= 1)
 		return pick(candidates)
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -320,8 +320,6 @@
 					addtimer(CALLBACK(GLOBAL_PROC, .proc/antag_token_used, C.ckey, C), 30 SECONDS)
 					return player.mind
 
-		GLOB.antag_token_users += C
-
 	if(!CONFIG_GET(flag/use_antag_rep)) // || candidates.len <= 1)
 		return pick(candidates)
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -317,7 +317,7 @@
 			var/mob/dead/new_player/player = M
 			if(player.ready == PLAYER_READY_TO_PLAY)
 				if(!is_banned_from(player.ckey, list(antag_flag, ROLE_SYNDICATE)) && !QDELETED(player))
-					addtimer(CALLBACK(GLOBAL_PROC, .proc/antag_token_used, C.ckey, C), 0.5 MINUTES)
+					addtimer(CALLBACK(GLOBAL_PROC, .proc/antag_token_used, C.ckey, C), 30 SECONDS)
 					return player.mind
 
 		GLOB.antag_token_users += C

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -51,7 +51,6 @@
 	var/gamemode_ready = FALSE //Is the gamemode all set up and ready to start checking for ending conditions.
 	var/setup_error		//What stopepd setting up the mode.
 
-
 /datum/game_mode/proc/announce() //Shows the gamemode's name and a fast description.
 	to_chat(world, "<b>The gamemode is: <span class='[announce_span]'>[name]</span>!</b>")
 	to_chat(world, "<b>[announce_text]</b>")

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -115,6 +115,11 @@
 	body += "<A href='?_src_=holder;[HrefToken()];subtlemessage=[REF(M)]'>Subtle message</A> | "
 	body += "<A href='?_src_=holder;[HrefToken()];languagemenu=[REF(M)]'>Language Menu</A>"
 
+	body += "<br><br>"
+	body += "<A href='?_src_=holder;[HrefToken()];antag_token_give=[M.ckey]'>Give Antag Token</A> | "
+	body += "<A href='?_src_=holder;[HrefToken()];antag_token_redeem=[M.ckey]'>Redeem Antag Token</A> | "
+	body += "<A href='?_src_=holder;[HrefToken()];searchAntagTokenByKey=[M.ckey]'>See Antag Tokens</A>"
+
 	if (M.client)
 		if(!isnewplayer(M))
 			body += "<br><br>"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -88,7 +88,10 @@ GLOBAL_PROTECT(admin_verbs_admin)
 	/client/proc/nerf_or_nothing, // yogs -- Groudon's meme nerf verb
 	/client/proc/delay_shuttle, // yogs -- Allows admins to delay the shuttle from launching
 	/client/proc/queue_check, // Yogs -- Some queue manipulation/debuggin kinda verbs
-	/client/proc/cmd_view_polls
+	/client/proc/cmd_view_polls,
+	/client/proc/antag_token_panel, //Yogs -- Access Antag Token Panel
+	/client/proc/give_antag_token,
+	/client/proc/show_redeemable_antag_tokens
 	)
 GLOBAL_LIST_INIT(admin_verbs_ban, list(/client/proc/unban_panel, /client/proc/ban_panel, /client/proc/stickybanpanel))
 GLOBAL_PROTECT(admin_verbs_ban)
@@ -423,6 +426,31 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	holder.unban_panel()
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Unbanning Panel") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/client/proc/antag_token_panel()
+	set name = "Antag Token Panel"
+	set category = "Admin"
+	if(!check_rights(R_ADMIN))
+		return
+	holder.antag_token_panel()
+	SSblackbox.record_feedback("tally", "admin_verb", 1, "Antag Token Panel") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+/client/proc/show_redeemable_antag_tokens()
+	set name = "Redeemable Antag Tokens"
+	set category = "Admin"
+	if(!check_rights(R_ADMIN))
+		return
+	holder.show_redeemable_antag_tokens()
+	SSblackbox.record_feedback("tally", "admin_verb", 1, "Antag Token Redeemable Panel") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+/client/proc/give_antag_token()
+	set name = "Give Antag Token"
+	set category = "Admin"
+	if(!check_rights(R_ADMIN))
+		return
+	holder.give_antag_token()
+	SSblackbox.record_feedback("tally", "admin_verb", 1, "Give Antag Token") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+
 /client/proc/game_panel()
 	set name = "Game Panel"
 	set category = "Admin"
@@ -676,7 +704,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 
 	if(!holder)
 		return
-	
+
 	holder.legacy_mc = !holder.legacy_mc
 
 /client/proc/readmin()

--- a/code/modules/admin/antag_token.dm
+++ b/code/modules/admin/antag_token.dm
@@ -134,7 +134,8 @@
 
 	while(query_antag_token.NextRow())
 		var/id = query_antag_token.item[1]
-		var/datum/DBQuery/query_antag_token_redeem = SSdbcore.NewQuery({"UPDATE [format_table_name("antag_tokens")] SET redeemed = 1, denying_admin = '[sanitizeSQL(ckey(owner.ckey))]'
+		var/datum/DBQuery/query_antag_token_redeem = SSdbcore.NewQuery({"UPDATE [format_table_name("antag_tokens")] 
+		SET redeemed = 1, denying_admin = '[sanitizeSQL(ckey(owner.ckey))]'
 		WHERE id = [id]"})
 		if(!query_antag_token_redeem.warn_execute())
 			alert("Failed to redeem token!")

--- a/code/modules/admin/antag_token.dm
+++ b/code/modules/admin/antag_token.dm
@@ -38,7 +38,7 @@
 			var/round_id = query_antag_token.item[7]
 			var/id = query_antag_token.item[8]
 
-			data += {"<div class='banbox'><div class='header [redeemed ? "banned" : "unbanned"]'>Antag Token for:<b>[ckey]</b> granted by <b>[applying_admin]</b> on
+			data += {"<div class='banbox'><div class='header [redeemed ? "banned" : "unbanned"]'>Antag Token for:<b> [ckey]</b> granted by <b>[applying_admin]</b> on
 			<b>[time]</b> during round<b> #[round_id]</b>
 			</div>"}
 			data += "<br>Token Reason: <br>[reason]"

--- a/code/modules/admin/antag_token.dm
+++ b/code/modules/admin/antag_token.dm
@@ -41,7 +41,7 @@
 			data += {"<div class='banbox'><div class='header [redeemed ? "banned" : "unbanned"]'>Antag Token for:<b> [ckey]</b> granted by <b>[applying_admin]</b> on
 			<b>[time]</b> during round<b> #[round_id]</b>
 			</div>"}
-			data += "<br>Token Reason: <br>[reason]"
+			data += "<br><b>Token Reason:</b> <br>[reason]"
 
 			if(denial_reason)
 				data += "<br>Denied by <b>[denying_admin]</b> for '[denial_reason]'"

--- a/code/modules/admin/antag_token.dm
+++ b/code/modules/admin/antag_token.dm
@@ -1,0 +1,289 @@
+/datum/admins/proc/antag_token_panel(ckey)
+	if(!check_rights(R_ADMIN))
+		return
+
+	if(!SSdbcore.Connect())
+		to_chat(usr, "<span class='danger'>Failed to establish database connection.</span>", confidential=TRUE)
+		return
+
+	var/datum/browser/token_panel = new(usr, "tokenpanel", "Antag Token Panel", 850, 600)
+	token_panel.add_stylesheet("unbanpanelcss", 'html/admin/unbanpanel.css') //CSS thief!
+
+	var/list/data = list("<div class='searchbar'>")
+
+	data += {"<form method='get' action='?src=[REF(src)]'>[HrefTokenFormField()]
+	<input type='hidden' name='src' value='[REF(src)]'>
+	Key: <input type='text' name='searchAntagTokenByKey' size='18' value='[ckey]'>
+	<input type='submit' value='Search'>
+	</form>
+	</div>
+	<div class='main'>
+	"}
+
+	if(ckey)
+		var/datum/DBQuery/query_antag_token = SSdbcore.NewQuery({"SELECT reason, denial_reason, applying_admin, denying_admin, granted_time, redeemed, round_id, id
+		FROM [format_table_name("antag_tokens")] WHERE ckey = '[sanitizeSQL(ckey(ckey))]'
+		ORDER BY granted_time DESC"})
+		if(!query_antag_token.warn_execute())
+			qdel(query_antag_token)
+			return
+
+		while(query_antag_token.NextRow())
+			var/reason = query_antag_token.item[1]
+			var/denial_reason = query_antag_token.item[2]
+			var/applying_admin = query_antag_token.item[3]
+			var/denying_admin = query_antag_token.item[4]
+			var/time = query_antag_token.item[5]
+			var/redeemed = text2num(query_antag_token.item[6])
+			var/round_id = query_antag_token.item[7]
+			var/id = query_antag_token.item[8]
+
+			data += {"<div class='banbox'><div class='header [redeemed ? "banned" : "unbanned"]'>Antag Token for:<b>[ckey]</b> granted by <b>[applying_admin]</b> on
+			<b>[time]</b> during round<b> #[round_id]</b>
+			</div>"}
+			data += "<br>Token Reason: <br>[reason]"
+
+			if(denial_reason)
+				data += "<br>Denied by <b>[denying_admin]</b> for '[denial_reason]'"
+			if(redeemed && !denial_reason)
+				data += "<br>Redeemed by <b>[denying_admin]</b>"
+
+			if(!redeemed)
+				data += "<br><a href='?_src_=holder;[HrefToken()];redeem_token_id=[id]'>Redeem</a>"
+				data += "<a href='?_src_=holder;[HrefToken()];deny_token_id=[id]'>Deny</a>"
+			data += "</div>"
+		qdel(query_antag_token)
+
+	data += "</div>"
+
+	token_panel.set_content(jointext(data, ""))
+	token_panel.open()
+
+/datum/admins/proc/give_antag_token(ckey)
+	if(!check_rights(R_ADMIN))
+		return
+
+	if(!SSdbcore.Connect())
+		to_chat(usr, "<span class='danger'>Failed to establish database connection.</span>", confidential=TRUE)
+		return
+
+	if(!ckey)
+		ckey = input("Please input a ckey", "Antag Token - Ckey") as text|null
+
+	if(!ckey)
+		alert("Antag Token not applied. No valid CKEY specified")
+		return
+
+	if(has_antag_token(ckey))
+		alert("The user '[ckey]' already has an antag token!")
+		return
+
+
+	var/roundid = input("Please input the roundID where the incident happened.", "Antag Token - RoundID") as num|null
+	if(!roundid)
+		alert("Antag Token not applied. No valid roundID specified")
+		return
+
+	var/reason = input("Please input the reason for this antag token.", "Antag Token - Reason") as text|null
+	if(!reason)
+		alert("Antag Token not applied. No valid reason specified")
+		return
+
+	var/admin_key = key_name_admin(usr)
+	reason = sanitizeSQL(reason)
+	var/token = list(
+	list("granted_time" = "NOW()",
+	"ckey" = "'[sanitizeSQL(ckey(ckey))]'",
+	"round_id" = sanitizeSQL(roundid),
+	"reason" = "'[reason]'",
+	"applying_admin" = "'[sanitizeSQL(ckey(owner.ckey))]'",
+	))
+
+	if(!SSdbcore.MassInsert(format_table_name("antag_tokens"), token, warn = 1))
+		alert("Failed to give token!")
+		return
+
+	log_admin_private("[admin_key] has applied an antag token for [ckey] with the reason '[reason]' for round #[roundid]")
+	message_admins("[admin_key] has applied an antag token for [ckey] with the reason '[reason]' for round #[roundid]")
+
+
+/datum/admins/proc/redeem_antag_token(ckey)
+	if(!check_rights(R_ADMIN))
+		return
+
+	if(!SSdbcore.Connect())
+		to_chat(usr, "<span class='danger'>Failed to establish database connection.</span>", confidential=TRUE)
+		return
+	if(!ckey)
+		return
+	if(alert("Are you sure you want to redeem a token?",, "Yes", "No") != "Yes")
+		return
+
+	if(!has_antag_token(ckey))
+		alert("The user '[ckey]' does not have an antag token!")
+		return
+
+	var/datum/DBQuery/query_antag_token = SSdbcore.NewQuery({"SELECT id
+		FROM [format_table_name("antag_tokens")] WHERE ckey = '[sanitizeSQL(ckey(ckey))]' AND redeemed = 0
+		ORDER BY granted_time DESC"})
+
+	if(!query_antag_token.warn_execute())
+		qdel(query_antag_token)
+		return
+
+
+	while(query_antag_token.NextRow())
+		var/id = query_antag_token.item[1]
+		var/datum/DBQuery/query_antag_token_redeem = SSdbcore.NewQuery({"UPDATE [format_table_name("antag_tokens")] SET redeemed = 1, denying_admin = '[sanitizeSQL(ckey(owner.ckey))]'
+		WHERE id = [id]"})
+		if(!query_antag_token_redeem.warn_execute())
+			alert("Failed to redeem token!")
+			qdel(query_antag_token_redeem)
+			return
+
+		to_chat(usr, "<span class='notice'>Token Redeemed</span>")
+		qdel(query_antag_token_redeem)
+
+		var/admin_key = key_name_admin(usr)
+		log_admin_private("[admin_key] has redeemed an antag token for [ckey]")
+		message_admins("[admin_key] has redeemed an antag token for [ckey]")
+		break
+
+	qdel(query_antag_token)
+
+
+/datum/admins/proc/has_antag_token(ckey)
+	var/datum/DBQuery/query_antag_token_existing = SSdbcore.NewQuery({"SELECT ckey FROM [format_table_name("antag_tokens")] WHERE ckey = '[sanitizeSQL(ckey(ckey))]' AND redeemed = 0"})
+
+	if(!query_antag_token_existing.warn_execute())
+		qdel(query_antag_token_existing)
+		return
+
+	if(query_antag_token_existing.NextRow())
+		. = TRUE
+	qdel(query_antag_token_existing)
+
+
+/datum/admins/proc/redeem_specific_antag_token(id)
+	if(!check_rights(R_ADMIN))
+		return
+
+	if(!SSdbcore.Connect())
+		to_chat(usr, "<span class='danger'>Failed to establish database connection.</span>", confidential=TRUE)
+		return
+	if(!id)
+		return
+	if(alert("Are you sure you want to redeem this token?",, "Yes", "No") != "Yes")
+		return
+
+	var/number_id = text2num(id)
+
+	var/ckey
+	var/datum/DBQuery/query_antag_token_exists = SSdbcore.NewQuery({"SELECT ckey FROM [format_table_name("antag_tokens")] WHERE id = [number_id]"})
+	if(!query_antag_token_exists.warn_execute())
+		qdel(query_antag_token_exists)
+		alert("Token not redeemed!")
+		return
+
+	if(query_antag_token_exists.NextRow())
+		ckey = query_antag_token_exists.item[1]
+
+	if(!ckey)
+		qdel(query_antag_token_exists)
+		alert("Token not redeemed!")
+		return
+
+	qdel(query_antag_token_exists)
+
+	var/datum/DBQuery/query_antag_token_deny = SSdbcore.NewQuery({"UPDATE [format_table_name("antag_tokens")] SET redeemed = 1, denying_admin = '[sanitizeSQL(ckey(owner.ckey))]' WHERE id = [number_id]"})
+
+	if(!query_antag_token_deny.warn_execute())
+		qdel(query_antag_token_deny)
+		alert("Token not redeemed!")
+		return
+
+	antag_token_panel(ckey)
+
+	var/admin_key = key_name_admin(usr)
+	log_admin_private("[admin_key] has redeemed antag token ID [number_id]")
+	message_admins("[admin_key] has redeemed antag token ID [number_id]")
+
+/datum/admins/proc/deny_antag_token(id)
+	if(!check_rights(R_ADMIN))
+		return
+
+	if(!SSdbcore.Connect())
+		to_chat(usr, "<span class='danger'>Failed to establish database connection.</span>", confidential=TRUE)
+		return
+
+	if(!id)
+		return
+
+	if(alert("Are you sure you want to deny this token?",, "Yes", "No") != "Yes")
+		return
+
+	var/reason = input("Please input a reason", "Denial Reason") as text|null
+	if(!reason)
+		return
+	var/number_id = text2num(id)
+
+	var/ckey
+
+	var/datum/DBQuery/query_antag_token_exists = SSdbcore.NewQuery({"SELECT ckey FROM [format_table_name("antag_tokens")] WHERE id = [number_id]"})
+	if(!query_antag_token_exists.warn_execute())
+		qdel(query_antag_token_exists)
+		alert("Token not redeemed!")
+		return
+	if(query_antag_token_exists.NextRow())
+		ckey = query_antag_token_exists.item[1]
+
+	if(!ckey)
+		qdel(query_antag_token_exists)
+		alert("Token not redeemed!")
+		return
+
+	qdel(query_antag_token_exists)
+
+
+	var/datum/DBQuery/query_antag_token_deny = SSdbcore.NewQuery({"UPDATE [format_table_name("antag_tokens")] SET denying_admin = '[sanitizeSQL(ckey(owner.ckey))]',
+	denial_reason = '[sanitizeSQL(reason)]', redeemed = 1 WHERE id = [number_id]"})
+	if(!query_antag_token_deny.warn_execute())
+		qdel(query_antag_token_deny)
+		return
+	qdel(query_antag_token_deny)
+
+	antag_token_panel(ckey)
+
+	var/admin_key = key_name_admin(usr)
+	log_admin_private("[admin_key] has denied an antag token. Reason: [reason], ID:[id] [number_id]")
+	message_admins("[admin_key] has denied an antag token. Reason: [reason], ID:[id] [number_id]")
+
+
+/datum/admins/proc/show_redeemable_antag_tokens()
+	if(!check_rights(R_ADMIN))
+		return
+
+	if(!SSdbcore.Connect())
+		to_chat(usr, "<span class='danger'>Failed to establish database connection.</span>", confidential=TRUE)
+		return
+
+	var/datum/browser/token_panel = new(usr, "redeemabletokenpanel", "Antag Token Panel", 850, 600)
+
+	var/list/data = list()
+
+
+	var/datum/DBQuery/query_antag_token = SSdbcore.NewQuery({"SELECT DISTINCT ckey FROM [format_table_name("antag_tokens")] WHERE redeemed = 0"})
+
+	if(!query_antag_token.warn_execute())
+		qdel(query_antag_token)
+		return
+
+	while(query_antag_token.NextRow())
+		var/ckey = query_antag_token.item[1]
+		data += "<a href='?_src_=holder;[HrefToken()];searchAntagTokenByKey=[ckey]'>[ckey]</a>"
+		data += "<br>"
+	qdel(query_antag_token)
+
+
+	token_panel.set_content(jointext(data, ""))
+	token_panel.open()

--- a/code/modules/admin/antag_token.dm
+++ b/code/modules/admin/antag_token.dm
@@ -106,7 +106,6 @@
 	log_admin_private("[admin_key] has applied an antag token for [ckey] with the reason '[reason]' for round #[roundid]")
 	message_admins("[admin_key] has applied an antag token for [ckey] with the reason '[reason]' for round #[roundid]")
 
-
 /datum/admins/proc/redeem_antag_token(ckey)
 	if(!check_rights(R_ADMIN))
 		return
@@ -131,8 +130,7 @@
 		qdel(query_antag_token)
 		return
 
-
-	while(query_antag_token.NextRow())
+	if(query_antag_token.NextRow())
 		var/id = query_antag_token.item[1]
 		var/datum/DBQuery/query_antag_token_redeem = SSdbcore.NewQuery({"UPDATE [format_table_name("antag_tokens")] 
 		SET redeemed = 1, denying_admin = '[sanitizeSQL(ckey(owner.ckey))]'
@@ -148,8 +146,8 @@
 		var/admin_key = key_name_admin(usr)
 		log_admin_private("[admin_key] has redeemed an antag token for [ckey]")
 		message_admins("[admin_key] has redeemed an antag token for [ckey]")
-		break
-
+	else
+		alert("Failed to redeem token!")
 	qdel(query_antag_token)
 
 
@@ -229,7 +227,6 @@
 	var/number_id = text2num(id)
 
 	var/ckey
-
 	var/datum/DBQuery/query_antag_token_exists = SSdbcore.NewQuery({"SELECT ckey FROM [format_table_name("antag_tokens")] WHERE id = [number_id]"})
 	if(!query_antag_token_exists.warn_execute())
 		qdel(query_antag_token_exists)
@@ -245,14 +242,12 @@
 
 	qdel(query_antag_token_exists)
 
-
 	var/datum/DBQuery/query_antag_token_deny = SSdbcore.NewQuery({"UPDATE [format_table_name("antag_tokens")] SET denying_admin = '[sanitizeSQL(ckey(owner.ckey))]',
 	denial_reason = '[sanitizeSQL(reason)]', redeemed = 1 WHERE id = [number_id]"})
 	if(!query_antag_token_deny.warn_execute())
 		qdel(query_antag_token_deny)
 		return
 	qdel(query_antag_token_deny)
-
 	antag_token_panel(ckey)
 
 	var/admin_key = key_name_admin(usr)
@@ -270,21 +265,20 @@
 
 	var/datum/browser/token_panel = new(usr, "redeemabletokenpanel", "Antag Token Panel", 850, 600)
 
-	var/list/data = list()
-
+	
 
 	var/datum/DBQuery/query_antag_token = SSdbcore.NewQuery({"SELECT DISTINCT ckey FROM [format_table_name("antag_tokens")] WHERE redeemed = 0"})
 
 	if(!query_antag_token.warn_execute())
 		qdel(query_antag_token)
 		return
-
+		
+	var/list/data = list()
 	while(query_antag_token.NextRow())
 		var/ckey = query_antag_token.item[1]
 		data += "<a href='?_src_=holder;[HrefToken()];searchAntagTokenByKey=[ckey]'>[ckey]</a>"
 		data += "<br>"
 	qdel(query_antag_token)
-
 
 	token_panel.set_content(jointext(data, ""))
 	token_panel.open()

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1919,6 +1919,13 @@
 
 	else if(href_list["deny_token_id"])
 		deny_antag_token(href_list["deny_token_id"])
+
+	else if(href_list["approve_antag_token"])
+		if(!check_rights(R_ADMIN))
+			return
+		var/client/user_client = locate(href_list["approve_antag_token"])
+		accept_antag_token_usage(user_client)
+
 	//antag tokens end
 
 	else if(href_list["newbankey"])

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1901,6 +1901,26 @@
 		removeMentor(href_list["removementor"])
 	// yogs end
 
+	//antag tokens
+	else if(href_list["searchAntagTokenByKey"])
+		var/player_ckey = href_list["searchAntagTokenByKey"]
+		antag_token_panel(player_ckey)
+
+	else if(href_list["antag_token_give"])
+		var/player_ckey = href_list["antag_token_give"]
+		give_antag_token(player_ckey)
+
+	else if(href_list["antag_token_redeem"])
+		var/player_ckey = href_list["antag_token_redeem"]
+		redeem_antag_token(player_ckey)
+
+	else if(href_list["redeem_token_id"])
+		redeem_specific_antag_token(href_list["redeem_token_id"])
+
+	else if(href_list["deny_token_id"])
+		deny_antag_token(href_list["deny_token_id"])
+	//antag tokens end
+
 	else if(href_list["newbankey"])
 		var/player_key = href_list["newbankey"]
 		var/player_ip = href_list["newbanip"]

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1921,8 +1921,6 @@
 		deny_antag_token(href_list["deny_token_id"])
 
 	else if(href_list["approve_antag_token"])
-		if(!check_rights(R_ADMIN))
-			return
 		var/client/user_client = locate(href_list["approve_antag_token"])
 		accept_antag_token_usage(user_client)
 

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -1176,6 +1176,7 @@
 #include "code\modules\admin\admin_verbs.dm"
 #include "code\modules\admin\adminmenu.dm"
 #include "code\modules\admin\antag_panel.dm"
+#include "code\modules\admin\antag_token.dm"
 #include "code\modules\admin\chat_commands.dm"
 #include "code\modules\admin\check_antagonists.dm"
 #include "code\modules\admin\create_mob.dm"

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3167,6 +3167,7 @@
 #include "yogstation\code\modules\client\preferences_savefile.dm"
 #include "yogstation\code\modules\client\preferences_toggles.dm"
 #include "yogstation\code\modules\client\verbs\afk.dm"
+#include "yogstation\code\modules\client\verbs\antag_token.dm"
 #include "yogstation\code\modules\client\verbs\looc.dm"
 #include "yogstation\code\modules\client\verbs\ooc.dm"
 #include "yogstation\code\modules\clothing\chameleon.dm"

--- a/yogstation/code/modules/client/client_defines.dm
+++ b/yogstation/code/modules/client/client_defines.dm
@@ -1,5 +1,8 @@
 /client
 	var/connection_number = 0
 	var/last_ping_time = 0 // Stores the last time this cilent pinged someone in OOC, to protect against spamming pings
-	
+
 	var/list/afreeze_stored_verbs = list()
+
+	var/last_antag_token_check
+	var/antag_token_timer

--- a/yogstation/code/modules/client/verbs/antag_token.dm
+++ b/yogstation/code/modules/client/verbs/antag_token.dm
@@ -72,7 +72,7 @@ GLOBAL_LIST_EMPTY(antag_token_users)
 		ORDER BY granted_time DESC"})
 
 	if(!query_antag_token.warn_execute())
-		message_admins("Failed to detract antag token from player '[ckey]', please do this manually!")
+		message_admins("Failed to use antag token for player '[ckey]'! Please do this manually!")
 		qdel(query_antag_token)
 		return
 

--- a/yogstation/code/modules/client/verbs/antag_token.dm
+++ b/yogstation/code/modules/client/verbs/antag_token.dm
@@ -4,7 +4,6 @@
 //List of all people using antag tokens this round
 GLOBAL_LIST_EMPTY(antag_token_users)
 
-
 /client/verb/antag_token_check()
 	set name = "Check/Use Antag Token"
 	set category = "OOC"

--- a/yogstation/code/modules/client/verbs/antag_token.dm
+++ b/yogstation/code/modules/client/verbs/antag_token.dm
@@ -50,7 +50,7 @@ GLOBAL_LIST_EMPTY(antag_token_users)
 		return
 
 	if(!check_rights(R_ADMIN))
-			return
+		return
 			
 	if(!istype(C))
 		return
@@ -63,7 +63,7 @@ GLOBAL_LIST_EMPTY(antag_token_users)
 /proc/antag_token_used(ckey, client/C)
 	var/mob/player = C.mob
 	if(!is_special_character(player))
-		message_admins("Failed to detract make player [ckey] an antag. Their token has NOT been used!")
+		message_admins("Failed to make player [ckey] an antag. Their token has NOT been used!")
 		return
 
 	to_chat(C, "<span class='userdanger'>Your antag token has been used!</span>")
@@ -76,16 +76,17 @@ GLOBAL_LIST_EMPTY(antag_token_users)
 		qdel(query_antag_token)
 		return
 
-	while(query_antag_token.NextRow())
+	if(query_antag_token.NextRow())
 		var/id = query_antag_token.item[1]
 		var/datum/DBQuery/query_antag_token_redeem = SSdbcore.NewQuery({"UPDATE [format_table_name("antag_tokens")] SET redeemed = 1, denying_admin = 'AUTOMATICALLY REDEEMED'
 		WHERE id = [id]"})
 		if(!query_antag_token_redeem.warn_execute())
-			message_admins("Failed to detract antag token from player '[ckey]', please do this manually!")
+			message_admins("Failed to use antag token for player '[ckey]'! Please do this manually!")
 			qdel(query_antag_token_redeem)
 			return
 		qdel(query_antag_token_redeem)
 		log_admin_private("Antag token automatically redeemed for [ckey]")
 		message_admins("Antag token automatically redeemed for [ckey]")
-		break
+	else
+		message_admins("Failed to use antag token for player '[ckey]'! Please do this manually!")
 	qdel(query_antag_token)

--- a/yogstation/code/modules/client/verbs/antag_token.dm
+++ b/yogstation/code/modules/client/verbs/antag_token.dm
@@ -1,0 +1,91 @@
+//2.5 minutes, gotta prevent DDoSing using SQL
+#define AntagTokenCooldown 1500
+
+//List of all people using antag tokens this round
+GLOBAL_LIST_EMPTY(antag_token_users)
+
+
+/client/verb/antag_token_check()
+	set name = "Check/Use Antag Token"
+	set category = "OOC"
+	set desc = "Check if you have an antag token, and if you do, use it."
+	var/client/C = usr.client
+
+	if(SSticker.current_state > GAME_STATE_PREGAME)
+		return to_chat(usr, "<span class='userdanger'>You must use this in the lobby!</span>")
+
+	if(world.time < C.last_antag_token_check)
+		to_chat(usr, "<span class='userdanger'>You cannot use this verb yet! Please wait.</span>")
+		return
+	var/datum/DBQuery/query_antag_token_existing = SSdbcore.NewQuery({"SELECT ckey FROM [format_table_name("antag_tokens")] WHERE ckey = '[sanitizeSQL(ckey(ckey))]' AND redeemed = 0"})
+
+	if(!query_antag_token_existing.warn_execute())
+		qdel(query_antag_token_existing)
+		return
+
+	C.last_antag_token_check = world.time + AntagTokenCooldown
+
+	if(query_antag_token_existing.NextRow())
+		if(alert("You have an antag token! Do you want to use it? YOU CAN GET ANTAG'S THAT YOU HAVE DISABLED IN YOUR PREFERENCES",, "Yes", "No") != "Yes")
+			qdel(query_antag_token_existing)
+			return
+		to_chat(src, "<span class='userdanger'>You will be notified if your antag token is used</span>")
+		C.antag_token_timer = addtimer(CALLBACK(src, .proc/deny_antag_token_request), 45 SECONDS, TIMER_STOPPABLE)
+		to_chat(GLOB.admins, "<span class='adminnotice'><b><font color=orange>ANTAG TOKEN REQUEST:</font></b>[ADMIN_LOOKUPFLW(usr)] wants to use their antag token! (will auto-DENY in [DisplayTimeText(45 SECONDS)]). (<A HREF='?_src_=holder;[HrefToken(TRUE)];approve_antag_token=[REF(C)]'>APPROVE</A>)</span>")
+		for(var/client/A in GLOB.admins)
+			if(check_rights_for(A, R_ADMIN) && (A.prefs.toggles & SOUND_ADMINHELP)) // Can't use check_rights here since it's dependent on $usr
+				SEND_SOUND(A, sound('sound/effects/adminhelp.ogg'))
+
+	else
+		alert("You do not have an antag token.")
+	qdel(query_antag_token_existing)
+
+/client/proc/deny_antag_token_request()
+	if(usr in GLOB.antag_token_users)
+		return
+	to_chat(usr, "<span class='userdanger'>Your request has been denied! Your antag token has NOT been used.</span>")
+
+
+/datum/admins/proc/accept_antag_token_usage(client/C)
+	if(SSticker.current_state > GAME_STATE_PREGAME)
+		return
+	if(!istype(C))
+		return
+	GLOB.antag_token_users += C
+	to_chat(C.mob, "<span class='userdanger'>An admin has approved your antag token request! Ready up!</span>")
+	message_admins("[C.ckey]'s antag token request has been approved by [usr.ckey]")
+	deltimer(C.antag_token_timer)
+
+/proc/antag_token_used(ckey, client/C)
+	var/mob/player = C.mob
+	if(!is_special_character(player))
+		message_admins("Failed to detract make player [ckey] an antag. Their token has NOT been used!")
+		return
+
+	to_chat(C, "<span class='userdanger'>Your antag token has been used!</span>")
+	var/datum/DBQuery/query_antag_token = SSdbcore.NewQuery({"SELECT id
+		FROM [format_table_name("antag_tokens")] WHERE ckey = '[sanitizeSQL(ckey(ckey))]' AND redeemed = 0
+		ORDER BY granted_time DESC"})
+
+	if(!query_antag_token.warn_execute())
+		message_admins("Failed to detract antag token from player '[ckey]', please do this manually!")
+		qdel(query_antag_token)
+		return
+
+
+	while(query_antag_token.NextRow())
+		var/id = query_antag_token.item[1]
+		var/datum/DBQuery/query_antag_token_redeem = SSdbcore.NewQuery({"UPDATE [format_table_name("antag_tokens")] SET redeemed = 1, denying_admin = 'AUTOMATICALLY REDEEMED'
+		WHERE id = [id]"})
+		if(!query_antag_token_redeem.warn_execute())
+			message_admins("Failed to detract antag token from player '[ckey]', please do this manually!")
+			qdel(query_antag_token_redeem)
+			return
+
+		qdel(query_antag_token_redeem)
+
+		log_admin_private("Antag token automatically redeemed for [ckey]")
+		message_admins("Antag token automatically redeemed for [ckey]")
+		break
+
+	qdel(query_antag_token)

--- a/yogstation/code/modules/client/verbs/antag_token.dm
+++ b/yogstation/code/modules/client/verbs/antag_token.dm
@@ -11,7 +11,8 @@ GLOBAL_LIST_EMPTY(antag_token_users)
 	var/client/C = usr.client
 
 	if(SSticker.current_state > GAME_STATE_PREGAME)
-		return to_chat(usr, "<span class='userdanger'>You must use this in the lobby!</span>")
+		to_chat(usr, "<span class='userdanger'>You must use this in the lobby!</span>")
+		return
 
 	if(world.time < C.last_antag_token_check)
 		to_chat(usr, "<span class='userdanger'>You cannot use this verb yet! Please wait.</span>")


### PR DESCRIPTION
### Intent of your Pull Request
FOR PLAYERS:
You can now check if you have antag tokens!
You can also request to use your antag token. This will send a request to the admins that they have to approve. 
You need to be readied up, and you WILL get antag's that you have disabled.
If no admins are online you cannot use your antag token.
The antag token is subtracted 30 seconds after the round starts, incase of errors.

Admins, you just have to click Approve or Ignore.
It will send a message if something fails.


FOR ADMINS:
No more Google Sheets!

System is simple:
If you want to give an online player a token, (perhaps the round after a crash) you can find these 3 new buttons in the Player Panel.
![image](https://user-images.githubusercontent.com/5618080/82249459-14928e00-994a-11ea-8a23-9dc3b77f3271.png)
Give antag token gives them a token, it automatically checks if they already have one.
Redeem checks if they have an unredeemed one, and redeems it. YOU STILL HAVE TO GIVE THEM ANTAG WHEN THE ROUND STARTS.
See Antag Tokens open a panel that shows their antag token history. You can redeem/deny tokens from in here.

![image](https://user-images.githubusercontent.com/5618080/82249537-3db31e80-994a-11ea-98b0-2a6db6a5dffc.png)
This is the "Show Antag Tokens" menu.
As you can see it shows the date of the token being given, the round ID they admin input. (RoundID of the crash or whatever)
It shows the reason too.

![image](https://user-images.githubusercontent.com/5618080/82249603-61766480-994a-11ea-9acd-3d3f32d1f923.png)
A denied token.

![image](https://user-images.githubusercontent.com/5618080/82249622-69ce9f80-994a-11ea-8e2f-f16ed7f7b93e.png)
A redeemed token.

There's a new verb called "Redeemable Antag Tokens" in the 'Admin' tab
![image](https://user-images.githubusercontent.com/5618080/82249586-56233900-994a-11ea-9e89-7cdbfa5c40ab.png)
It shows this menu, which is a list of all unique ckeys that have an antag token that is unredeembed.
Clicking the ckey takes you to their antag token panel.

If you want to find a players antag token history you can use the search button in the Antag Token Panel, which can be accessed with the "Antag Token Panel" verb in 'Admin'

If you want to give an antag token to an offline player, there's a new verb in 'Admin' called Give Antag Token.
You input Ckey, roundID of the crash and the reason.
It checks if they have one so you can't apply duplicate tokens.

It can't , and doesn't, check if the CKEY is valid. DOUBLE CHECK IT BEFORE PRESSING ENTER.


#### Changelog

:cl:  
rscadd: Antag Tokens are easier to handle
/:cl:
