### PR TITLE
allows you to find shock touch in ethereals but also keeps its normal recipe

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -18,6 +18,7 @@
 	inherent_traits = list(TRAIT_NOHUNGER)
 	sexes = FALSE //no fetish content allowed
 	toxic_food = NONE
+	inert_mutation = SHOCKTOUCH
 	var/current_color
 	var/EMPeffect = FALSE
 	var/emageffect = FALSE


### PR DESCRIPTION
it works like firebreath and lizards only findable with them but anyone can use but this also keeps its normal crafting of insulated + radioactivity incase you want to go the longer route
#### Changelog

:cl:  
rscadd: eletrical creatures should have this already
/:cl:
