### PR TITLE
Rebalances Security Grenades

### DIFF
--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -23,7 +23,6 @@
 		return
 	M.show_message("<span class='userdanger'>BANG</span>", 2)
 	var/distance = max(0,get_dist(get_turf(src),T))
-	message_admins(distance)
 	if(!distance || loc == M || loc == M.loc)	//Stop allahu akbarring rooms with this.
 		M.Paralyze(200)
 		M.soundbang_act(1, 20, 10, 15)

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -21,16 +21,20 @@
 /obj/item/grenade/flashbang/proc/bang(turf/T , mob/living/M)
 	if(M.stat == DEAD)	//They're dead!
 		return
-	M.show_message("<span class='warning'>BANG</span>", 2)
+	M.show_message("<span class='userdanger'>BANG</span>", 2)
 	var/distance = max(0,get_dist(get_turf(src),T))
-
-//Flash
-	if(M.flash_act(affect_silicon = 1))
-		M.Paralyze(max(200/max(1,distance), 60))
-//Bang
+	message_admins(distance)
 	if(!distance || loc == M || loc == M.loc)	//Stop allahu akbarring rooms with this.
 		M.Paralyze(200)
-		M.soundbang_act(1, 200, 10, 15)
+		M.soundbang_act(1, 20, 10, 15)
+		return
 
-	else
-		M.soundbang_act(1, max(200/max(1,distance), 60), rand(0, 5))
+	var/flashed = M.flash_act(affect_silicon = 1)
+	var/banged = M.soundbang_act(1, 20/max(1,distance), rand(0, 5))
+
+	// If missing two resists
+	if(flashed > 0 && banged > 0)
+		M.Paralyze(max(150/max(1,distance), 60))
+	// If missing one resist
+	else if (flashed > 0 || banged > 0)
+		M.Paralyze(max(50/max(1, distance), 30))

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -32,8 +32,8 @@
 	var/banged = M.soundbang_act(1, 20/max(1,distance), rand(0, 5))
 
 	// If missing two resists
-	if(flashed > 0 && banged > 0)
+	if(flashed && banged)
 		M.Paralyze(max(150/max(1,distance), 60))
 	// If missing one resist
-	else if (flashed > 0 || banged > 0)
+	else if (flashed || banged)
 		M.Paralyze(max(50/max(1, distance), 30))

--- a/code/modules/mob/living/carbon/alien/alien_defense.dm
+++ b/code/modules/mob/living/carbon/alien/alien_defense.dm
@@ -123,7 +123,7 @@ In all, this is a lot like the monkey code. /N
 				Unconscious(20)
 			adjustEarDamage(15,60)
 
-/mob/living/carbon/alien/soundbang_act(intensity = 1, stun_pwr = 20, damage_pwr = 5, deafen_pwr = 15)
+/mob/living/carbon/alien/soundbang_act(intensity = 1, conf_pwr = 20, damage_pwr = 5, deafen_pwr = 15)
 	return 0
 
 /mob/living/carbon/alien/acid_act(acidpwr, acid_volume)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -340,7 +340,7 @@
 			mind.disrupt_spells(0)
 
 
-/mob/living/carbon/soundbang_act(intensity = 1, stun_pwr = 20, damage_pwr = 5, deafen_pwr = 15)
+/mob/living/carbon/soundbang_act(intensity = 1, conf_pwr = 20, damage_pwr = 5, deafen_pwr = 15)
 	var/list/reflist = list(intensity) // Need to wrap this in a list so we can pass a reference
 	SEND_SIGNAL(src, COMSIG_CARBON_SOUNDBANG, reflist)
 	intensity = reflist[1]
@@ -348,8 +348,8 @@
 	var/obj/item/organ/ears/ears = getorganslot(ORGAN_SLOT_EARS)
 	var/effect_amount = intensity - ear_safety
 	if(effect_amount > 0)
-		if(stun_pwr)
-			Paralyze(stun_pwr*effect_amount)
+		if(conf_pwr)
+			confused += conf_pwr*effect_amount
 
 		if(istype(ears) && (deafen_pwr || damage_pwr))
 			var/ear_damage = damage_pwr * effect_amount

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -871,21 +871,21 @@
 		if(M == H)
 			H.show_message("<span class='narsiesmall'>You cringe with pain as your body rings around you!</span>", 2)
 			H.playsound_local(H, 'sound/effects/gong.ogg', 100, TRUE)
-			H.soundbang_act(2, 0, 100, 1)
+			H.soundbang_act(2, 0, 10, 1)
 			H.jitteriness += 7
 		var/distance = max(0,get_dist(get_turf(H),get_turf(M)))
 		switch(distance)
 			if(0 to 1)
 				M.show_message("<span class='narsiesmall'>GONG!</span>", 2)
 				M.playsound_local(H, 'sound/effects/gong.ogg', 100, TRUE)
-				M.soundbang_act(1, 0, 30, 3)
+				M.soundbang_act(1, 0, 10, 3)
 				M.confused += 10
 				M.jitteriness += 4
 				SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "gonged", /datum/mood_event/loud_gong)
 			if(2 to 3)
 				M.show_message("<span class='cult'>GONG!</span>", 2)
 				M.playsound_local(H, 'sound/effects/gong.ogg', 75, TRUE)
-				M.soundbang_act(1, 0, 15, 2)
+				M.soundbang_act(1, 0, 5, 2)
 				M.jitteriness += 3
 				SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "gonged", /datum/mood_event/loud_gong)
 			else

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -275,6 +275,7 @@
 	description = "A chemical agent used for self-defense and in police work."
 	color = "#B31008" // rgb: 179, 16, 8
 	taste_description = "scorching agony"
+	metabolization_rate = 4 * REAGENTS_METABOLISM
 
 /datum/reagent/consumable/condensedcapsaicin/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	if(!ishuman(M) && !ismonkey(M))
@@ -313,8 +314,12 @@
 		victim.update_damage_hud()
 
 /datum/reagent/consumable/condensedcapsaicin/on_mob_life(mob/living/carbon/M)
-	if(prob(5))
-		M.visible_message("<span class='warning'>[M] [pick("dry heaves!","coughs!","splutters!")]</span>")
+	if(prob(10))
+		M.visible_message("<span class='warning'>[M] [pick("dry heaves!","splutters!")]</span>")
+	if(prob(15))
+		M.emote("cough")
+
+	M.adjustStaminaLoss(3)
 	..()
 
 /datum/reagent/consumable/sodiumchloride

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -327,7 +327,7 @@
 	var/location = get_turf(holder.my_atom)
 	playsound(location, 'sound/effects/bang.ogg', 25, 1)
 	for(var/mob/living/carbon/C in get_hearers_in_view(created_volume/3, location))
-		C.soundbang_act(1, 100, rand(0, 5))
+		C.soundbang_act(1, 10, rand(0, 5))
 
 /datum/chemical_reaction/sonic_powder_deafen
 	name = "sonic_powder_deafen"
@@ -339,7 +339,7 @@
 	var/location = get_turf(holder.my_atom)
 	playsound(location, 'sound/effects/bang.ogg', 25, 1)
 	for(var/mob/living/carbon/C in get_hearers_in_view(created_volume/10, location))
-		C.soundbang_act(1, 100, rand(0, 5))
+		C.soundbang_act(1, 10, rand(0, 5))
 
 /datum/chemical_reaction/phlogiston
 	name = /datum/reagent/phlogiston


### PR DESCRIPTION
### Intent of your Pull Request
Flashbangs are currently very strong and tear gas is very weak.  I've tried to balance the two with feedback from people who play more security than I do.

#### Flashbangs
Flashbangs are now more forgiving if you have only one type of protection (eye or ear.)  Being exposed to a flashbang without ear protection will cause a few seconds of confusion after the stun ends.  I'm trying to narrow its niche to opening an assault and forcing people out of cover, just like real flashbangs.
##### No protection
- Maximum stun length: 15s (down from 20s)
- Minimum stun length: 6s (unchanged)

##### Eye protection only
- Maximum stun length: 5s (down from 20s)
- Minimum stun length: 3s (down from 6s)
- Confusion: Up to 20s, decreases asymptotically with distance

##### Ear protection only
- Maximum stun length: 5s (down from 20s)
- Minimum stun length: 3s (down from 6s)
- Blindness: 3s (unchanged)

##### Full protection
- No effect (unchanged)

#### Tear Gas
In addition to its old effects, tear gas now lingers in the system causing stamina damage and coughing.  The cloud is unlikely to stamcrit directly unless the victim doesn't try to leave at all, but more than a few seconds of exposure will cause people to drop their items and move more slowly for a while.  The caveat is that officers are vulnerable to the smoke as well; Thus, the grenades are best for weakening fortified antagonist bases and covering retreats.

I'll consider adding tear gas to the secvend if enough people think it's a good idea, vote now in the comments.

* Even though I'm buffing condensed capsaicin, pepper spray delivers so little that it's almost unaffected.

### Why?
The flashbang is the lord and savior of medium range combat; if you can count to four you hardly even have to click on the enemy.  The obnoxious stun length is made more obnoxious by the fact that you have to get two separate counter items to survive, one of which is semi-obscure and not used for anything else.  There may be room in your galaxy-sized brain for the location of every bowman on the station, but newer antags don't deserve instant death just because someone managed to land a click in their zip code.

By contrast, tear gas is hardly worth the inventory space.  Masks block it partially and any sort of glasses block it completely, so it's essentially a glorified smoke grenade.  It's hard to use effectively and easy to counter.

With these changes, both grenades get a unique and useful tactical niche without being overbearing.  The flashbang disrupts any waiting enemies as you breach a room and forces people in cover to pull back; Tear gas softens up fortified enemies and creates cover for movement or retreat.  Both of these roles roughly match their real-life analogues, though that alone isn't justification for a balance decision.

I've tuned all the numbers based on what 'felt right' compared to normal combat; if something seems too high or too low, I'm open to change.

#### Changelog

:cl:  
tweak: The Space Geneva Convention has taken action against grenades of mass destruction; Flashbang payloads have been adjusted down in compliance.
tweak: NT officials noticed that the shipments marked 'tear gas' contained nothing but red food coloring and have found a new supplier.
/:cl:
