### PR TITLE
Change free miner engineer uniform

### DIFF
--- a/yogstation/code/datums/ruins/free_miners.dm
+++ b/yogstation/code/datums/ruins/free_miners.dm
@@ -88,11 +88,11 @@
 	prompt_name = "a free miner engineer"
 
 /datum/outfit/freeminer/engi
+	uniform = /obj/item/clothing/under/overalls
 	l_pocket = null
 	r_pocket = null
 	gloves = /obj/item/clothing/gloves/color/yellow
 	belt = /obj/item/storage/belt/utility/full
-
 
 /obj/effect/mob_spawn/human/free_miner/captain
 	name = "Free Miner Captain"


### PR DESCRIPTION
Simply changing the Free Miner Engineer's uniform from the purple shirt/yellow overalls of the grunt Free Miners to a blue shirt/yellow overalls. The captain gets a different uniform, and I figure the engineer would be the de facto second in command (which is going to be a whole different PR), so why not give the engineer one?

#### Changelog

:cl:  
tweak: Changed free miner engineer's uniform
/:cl:
