### PR TITLE
Dead cyborgs can't self destruct

### DIFF
--- a/yogstation/code/modules/mob/living/silicon/robot/robot.dm
+++ b/yogstation/code/modules/mob/living/silicon/robot/robot.dm
@@ -66,6 +66,10 @@
 	if(alert("WARNING: Are you sure you wish to self-destruct? This action cannot be undone!",,"Yes","No") != "Yes")
 		return
 
+	if(usr.stat == DEAD)
+		to_chat(usr, "<span class='danger'>You are already dead.</span>")
+		return //won't work if dead
+
 	var/turf/T = get_turf(usr)
 	message_admins("<span class='notice'>[ADMIN_LOOKUPFLW(usr)] detonated themselves at [ADMIN_VERBOSEJMP(T)]!</span>")
 	log_game("\<span class='notice'>[key_name(usr)] detonated themselves!</span>")


### PR DESCRIPTION
### Intent of your Pull Request
Tag this ided.

Cyborgs can leave the confirmation prompt for self destructing open as long as they want, letting them blow up at will.  I'm willing to accept that in principle; the confirm box is mostly just misclick prevention.  The issue is that the button still works after the borg dies.

You can't start the process while dead, so I'm calling this an oversight.  Borgs as permanent landmines sounds fun until it happens to you.

#### Changelog
:cl:  
bugfix: Cyborgs can no longer exploit the alert() function to self-destruct from beyond the grave.
/:cl:
