### PR TITLE
[ADMIN QOL] The Nuclear Device Code is now set automatically to a random value.

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -3748,7 +3748,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/item/paper/fluff/stations/centcom/nuke_code_paper,
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "jB" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -3736,6 +3736,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
+"jA" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/paper/fluff/stations/centcom/nuke_code_paper,
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "jB" = (
 /obj/structure/noticeboard{
 	dir = 8;
@@ -12244,21 +12259,6 @@
 /obj/item/stamp,
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/grimy,
-/area/centcom/ferry)
-"AL" = (
-/obj/structure/table/reinforced,
-/obj/item/flashlight/seclite,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "AM" = (
 /obj/machinery/shuttle_manipulator,
@@ -60293,7 +60293,7 @@ yr
 sw
 Vl
 Ad
-AL
+jA
 Bx
 Vl
 Cv

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -723,9 +723,10 @@ This is here to make the tiles around the station mininuke change when it's arme
 //==========CENTCOM NUKE CODE BACKUP==========
 
 /obj/item/paper/fluff/stations/centcom/nuke_code_paper
-	name = "paper- 'Backup Nuclear Code'"
+	name = "paper- 'NUCLEAR CODE: DO NOT LOSE'"
+	icon_state = "docs_blue"
 	info = null
-	infolang = /datum/language/common
+	infolang = null
 	New()
 		..()
-		info = "The Nuke Code is [nuke_code]"
+		info = "#The Nuke Code is [nuke_code]"

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -1,3 +1,5 @@
+var/nuke_code = random_nukecode()
+
 /obj/machinery/nuclearbomb
 	name = "nuclear fission explosive"
 	desc = "You probably shouldn't stick around to see if this is armed."
@@ -33,6 +35,8 @@
 	var/proper_bomb = TRUE //Please
 	var/obj/effect/countdown/nuclearbomb/countdown
 
+
+
 /obj/machinery/nuclearbomb/Initialize()
 	. = ..()
 	countdown = new(src)
@@ -43,7 +47,7 @@
 	GLOB.poi_list |= src
 	previous_level = get_security_level()
 	if(r_code == null)
-		r_code = random_nukecode()
+		r_code = nuke_code
 
 /obj/machinery/nuclearbomb/Destroy()
 	safety = FALSE
@@ -714,3 +718,14 @@ This is here to make the tiles around the station mininuke change when it's arme
 /obj/item/disk/nuclear/fake/obvious
 	name = "cheap plastic imitation of the nuclear authentication disk"
 	desc = "How anyone could mistake this for the real thing is beyond you."
+
+
+//==========CENTCOM NUKE CODE BACKUP==========
+
+/obj/item/paper/fluff/stations/centcom/nuke_code_paper
+	name = "paper- 'Backup Nuclear Code'"
+	info = null
+	infolang = /datum/language/common
+	New()
+		..()
+		info = "The Nuke Code is [nuke_code]"

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -20,7 +20,7 @@
 	var/exploding = FALSE
 	var/exploded = FALSE
 	var/detonation_timer = null
-	var/r_code = "ADMIN"
+	var/r_code = null
 	var/yes_code = FALSE
 	var/safety = TRUE
 	var/obj/item/disk/nuclear/auth = null
@@ -42,6 +42,8 @@
 	update_icon()
 	GLOB.poi_list |= src
 	previous_level = get_security_level()
+	if(r_code == null)
+		r_code = random_nukecode()
 
 /obj/machinery/nuclearbomb/Destroy()
 	safety = FALSE

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -231,10 +231,8 @@
 		var/obj/machinery/nuclearbomb/selfdestruct/nuke = locate() in GLOB.nuke_list
 		if(nuke)
 			nuke_team.tracked_nuke = nuke
-			if(nuke.r_code == "ADMIN")
-				nuke.r_code = nuke_team.memorized_code
-			else //Already set by admins/something else?
-				nuke_team.memorized_code = nuke.r_code
+			nuke.r_code = nuke_team.memorized_code
+
 		else
 			stack_trace("Station self destruct not found during lone op team creation.")
 			nuke_team.memorized_code = null

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -70,10 +70,7 @@
 		var/obj/machinery/nuclearbomb/syndicate/nuke = find_nuke() //Yogs -- Puts find_nuke() here to fix bananium nukes fucking up normal nuke ops
 		if(nuke)
 			nuke_team.tracked_nuke = nuke
-			if(nuke.r_code == "ADMIN")
-				nuke.r_code = nuke_team.memorized_code
-			else //Already set by admins/something else?
-				nuke_team.memorized_code = nuke.r_code
+			nuke_team.memorized_code = nuke.r_code
 			for(var/obj/machinery/nuclearbomb/beer/beernuke in GLOB.nuke_list)
 				beernuke.r_code = nuke_team.memorized_code
 		else


### PR DESCRIPTION
Whenever an admin wants to have the nuke be used, they have to manually edit the code to a random value. This is cumbersome, and since there is already a proc to randomize the code anyway, I just made it create one at roundstart. The code is a random 5 digit code like normal.

The odds of someone randomly guessing the code are essentially impossible, so that is not a concern.

All this really does is reduce a step for admins to let the captain/crew scuttle the station, because it is a hassle to manually varedit the self destruct device and change it to a 5 digit value and we might as well streamline it. This also lets admins without the power to edit variables approve self destruct requests, which removes cases of valid requests going unanswered because all the staff online are unable to set the code.

This does not break nuke ops, I checked, and it actually removes some back and forth shitcode by automatically giving the self destruct device a code regardless of nuke ops triggering or not.

 
:cl:  
tweak: Instead of admins needing to manually set it to use it, the station self destruct device now has a random passcode. Admins can quickly check and send the code to the station or ERTs.
/:cl:
