### PR TITLE
Vampires can now go loud and unlock all abilities

### DIFF
--- a/yogstation/code/datums/antagonists/vampire.dm
+++ b/yogstation/code/datums/antagonists/vampire.dm
@@ -68,7 +68,6 @@
 	give_objectives()
 	add_ability(/obj/effect/proc_holder/spell/self/nosferatu)
 	check_vampire_upgrade()
-	to_chat(owner, "<span class='notice bold'>DEBUG : Adding nosferatu on gain.</span>")
 	owner.special_role = "vampire"
 	owner.current.faction += "vampire"
 	SSticker.mode.update_vampire_icons_added(owner)
@@ -148,7 +147,6 @@
 /datum/antagonist/vampire/proc/remove_objective(var/datum/objective/O)
 	objectives -= O
 	objectives_given -= O
-	to_chat(owner, "<span class='notice bold'>DEBUG : Tried to remove objective.</span>")
 
 /datum/antagonist/vampire/proc/forge_single_objective() //Returns how many objectives are added
 	.=1
@@ -178,12 +176,17 @@
 /datum/antagonist/vampire/proc/give_transform_objectives()
 	for(var/objective_ in objectives)
 		if(istype(objective_, /datum/objective/blood))
-			to_chat(owner, "<span class='notice bold'>DEBUG : Found blood objective.</span>")
-			remove_objective(/datum/objective/blood)
+			remove_objective(objective_)
+		if(istype(objective_, /datum/objective/escape))
+			remove_objective(objective_)
 	var/datum/objective/more_blood/more_blood_objective = new
 	more_blood_objective.owner = owner
 	more_blood_objective.gen_higher_amount_goal()
 	add_objective(more_blood_objective)
+	var/datum/objective/escape/new_escape = new
+	new_escape.owner = owner
+	add_objective(new_escape)
+	owner.announce_objectives()
 	to_chat(owner, "<span class='notice bold'>Due to your increased strength, your blood goal has been increased.</span>")
 
 /datum/antagonist/vampire/proc/vamp_burn(var/severe_burn = FALSE)
@@ -325,6 +328,8 @@
 		var/level = upgrade_tiers[ptype]
 		if(total_blood >= level)
 			add_ability(ptype)
+		if(total_blood >= 75)
+			remove_ability(get_ability(/obj/effect/proc_holder/spell/self/nosferatu))
 	if(announce)
 		announce_new_power(old_powers)
 	owner.current.update_sight() //deal with sight abilities

--- a/yogstation/code/datums/antagonists/vampire.dm
+++ b/yogstation/code/datums/antagonists/vampire.dm
@@ -12,6 +12,7 @@
 	var/converted = 0
 	var/fullpower = FALSE
 	var/full_vampire = TRUE
+	var/transformed = FALSE
 	var/draining
 	var/list/objectives_given = list()
 
@@ -24,6 +25,7 @@
 	var/list/upgrade_tiers = list(
 		/obj/effect/proc_holder/spell/self/rejuvenate = 0,
 		/obj/effect/proc_holder/spell/targeted/hypnotise = 0,
+		/obj/effect/proc_holder/spell/self/nosferatu = 0,
 		/datum/vampire_passive/vision = 75,
 		/obj/effect/proc_holder/spell/self/shapeshift = 75,
 		/obj/effect/proc_holder/spell/self/cloak = 100,
@@ -142,6 +144,10 @@
 	objectives += O
 	objectives_given += O
 
+/datum/antagonist/vampire/proc/remove_objective(var/datum/objective/O)
+	objectives -= O
+	objectives_given -= O
+
 /datum/antagonist/vampire/proc/forge_single_objective() //Returns how many objectives are added
 	.=1
 	if(prob(50))
@@ -166,6 +172,20 @@
 		steal_objective.owner = owner
 		steal_objective.find_target()
 		add_objective(steal_objective)
+
+/datum/antagonist/vampire/proc/give_transform_objectives()
+	if(locate(/datum/objective/blood) in objectives)
+		var/datum/objective/blood/nosferatu/more_blood_objective = new
+		more_blood_objective.owner = owner
+		more_blood_objective.gen_amount_goal()
+		remove_objective(/datum/objective/blood)
+		add_objective(more_blood_objective)
+		to_chat(owner, "<span class='notice bold'>Due to your increased strength, your blood goal has been increased.</span>")
+	else 
+		var/datum/objective/blood/nosferatu/more_blood_objective = new
+		more_blood_objective.owner = owner
+		more_blood_objective.gen_amount_goal()
+		add_objective(more_blood_objective)
 
 /datum/antagonist/vampire/proc/vamp_burn(var/severe_burn = FALSE)
 	var/mob/living/L = owner.current

--- a/yogstation/code/datums/antagonists/vampire.dm
+++ b/yogstation/code/datums/antagonists/vampire.dm
@@ -175,17 +175,13 @@
 
 /datum/antagonist/vampire/proc/give_transform_objectives()
 	if(locate(/datum/objective/blood) in objectives)
-		var/datum/objective/blood/nosferatu/more_blood_objective = new
-		more_blood_objective.owner = owner
-		more_blood_objective.gen_amount_goal()
 		remove_objective(/datum/objective/blood)
-		add_objective(more_blood_objective)
-		to_chat(owner, "<span class='notice bold'>Due to your increased strength, your blood goal has been increased.</span>")
-	else 
-		var/datum/objective/blood/nosferatu/more_blood_objective = new
-		more_blood_objective.owner = owner
-		more_blood_objective.gen_amount_goal()
-		add_objective(more_blood_objective)
+	var/datum/objective/blood/nosferatu/more_blood_objective = new
+	more_blood_objective.owner = owner
+	more_blood_objective.gen_amount_goal()
+	add_objective(more_blood_objective)
+	to_chat(owner, "<span class='notice bold'>Due to your increased strength, your blood goal has been increased.</span>")
+
 
 /datum/antagonist/vampire/proc/vamp_burn(var/severe_burn = FALSE)
 	var/mob/living/L = owner.current

--- a/yogstation/code/datums/antagonists/vampire.dm
+++ b/yogstation/code/datums/antagonists/vampire.dm
@@ -25,7 +25,6 @@
 	var/list/upgrade_tiers = list(
 		/obj/effect/proc_holder/spell/self/rejuvenate = 0,
 		/obj/effect/proc_holder/spell/targeted/hypnotise = 0,
-		/obj/effect/proc_holder/spell/self/nosferatu = 0,
 		/datum/vampire_passive/vision = 75,
 		/obj/effect/proc_holder/spell/self/shapeshift = 75,
 		/obj/effect/proc_holder/spell/self/cloak = 100,
@@ -67,7 +66,9 @@
 /datum/antagonist/vampire/on_gain()
 	SSticker.mode.vampires += owner
 	give_objectives()
+	add_ability(/obj/effect/proc_holder/spell/self/nosferatu)
 	check_vampire_upgrade()
+	to_chat(owner, "<span class='notice bold'>DEBUG : Adding nosferatu on gain.</span>")
 	owner.special_role = "vampire"
 	owner.current.faction += "vampire"
 	SSticker.mode.update_vampire_icons_added(owner)
@@ -147,6 +148,7 @@
 /datum/antagonist/vampire/proc/remove_objective(var/datum/objective/O)
 	objectives -= O
 	objectives_given -= O
+	to_chat(owner, "<span class='notice bold'>DEBUG : Tried to remove objective.</span>")
 
 /datum/antagonist/vampire/proc/forge_single_objective() //Returns how many objectives are added
 	.=1
@@ -174,14 +176,15 @@
 		add_objective(steal_objective)
 
 /datum/antagonist/vampire/proc/give_transform_objectives()
-	if(locate(/datum/objective/blood) in objectives)
-		remove_objective(/datum/objective/blood)
-	var/datum/objective/blood/nosferatu/more_blood_objective = new
+	for(var/objective_ in objectives)
+		if(istype(objective_, /datum/objective/blood))
+			to_chat(owner, "<span class='notice bold'>DEBUG : Found blood objective.</span>")
+			remove_objective(/datum/objective/blood)
+	var/datum/objective/more_blood/more_blood_objective = new
 	more_blood_objective.owner = owner
-	more_blood_objective.gen_amount_goal()
+	more_blood_objective.gen_higher_amount_goal()
 	add_objective(more_blood_objective)
 	to_chat(owner, "<span class='notice bold'>Due to your increased strength, your blood goal has been increased.</span>")
-
 
 /datum/antagonist/vampire/proc/vamp_burn(var/severe_burn = FALSE)
 	var/mob/living/L = owner.current
@@ -308,6 +311,7 @@
 		powers -= ability
 		owner.spell_list.Remove(ability)
 		qdel(ability)
+		to_chat(owner, "<span class='notice bold'>DEBUG : Tried to remove an ability.</span>")
 
 
 /datum/antagonist/vampire/proc/remove_vampire_powers()

--- a/yogstation/code/datums/antagonists/vampire.dm
+++ b/yogstation/code/datums/antagonists/vampire.dm
@@ -12,7 +12,6 @@
 	var/converted = 0
 	var/fullpower = FALSE
 	var/full_vampire = TRUE
-	var/transformed = FALSE
 	var/draining
 	var/list/objectives_given = list()
 
@@ -314,7 +313,6 @@
 		powers -= ability
 		owner.spell_list.Remove(ability)
 		qdel(ability)
-		to_chat(owner, "<span class='notice bold'>DEBUG : Tried to remove an ability.</span>")
 
 
 /datum/antagonist/vampire/proc/remove_vampire_powers()

--- a/yogstation/code/game/gamemodes/vampire/vampire_objectives.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_objectives.dm
@@ -28,3 +28,17 @@
 		return TRUE
 	else
 		return FALSE
+
+/datum/objective/blood/nosferatu/proc/gen_higher_amount_goal(lowbound = 1000, highbound = 1500)
+	target_amount = rand (lowbound,highbound)
+	explanation_text = "Extract [target_amount] units of blood."
+	return target_amount
+
+/datum/objective/blood/nosferatu/check_completion()
+	if(!owner)
+		return FALSE
+	var/datum/antagonist/vampire/vamp = owner.has_antag_datum(/datum/antagonist/vampire)
+	if(vamp && target_amount <= vamp.total_blood)
+		return TRUE
+	else
+		return FALSE

--- a/yogstation/code/game/gamemodes/vampire/vampire_objectives.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_objectives.dm
@@ -29,12 +29,12 @@
 	else
 		return FALSE
 
-/datum/objective/blood/nosferatu/proc/gen_higher_amount_goal(notsolowbound = 1000, morehighbound = 1500)
-	target_amount = rand (notsolowbound,morehighbound)
+/datum/objective/more_blood/proc/gen_higher_amount_goal(lowbound = 1000, highbound = 1500)
+	target_amount = rand (lowbound,highbound)
 	explanation_text = "Extract [target_amount] units of blood."
 	return target_amount
 
-/datum/objective/blood/nosferatu/check_completion()
+/datum/objective/more_blood/check_completion()
 	if(!owner)
 		return FALSE
 	var/datum/antagonist/vampire/vamp = owner.has_antag_datum(/datum/antagonist/vampire)

--- a/yogstation/code/game/gamemodes/vampire/vampire_objectives.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_objectives.dm
@@ -29,8 +29,8 @@
 	else
 		return FALSE
 
-/datum/objective/blood/nosferatu/proc/gen_higher_amount_goal(lowbound = 1000, highbound = 1500)
-	target_amount = rand (lowbound,highbound)
+/datum/objective/blood/nosferatu/proc/gen_higher_amount_goal(notsolowbound = 1000, morehighbound = 1500)
+	target_amount = rand (notsolowbound,morehighbound)
 	explanation_text = "Extract [target_amount] units of blood."
 	return target_amount
 

--- a/yogstation/code/game/gamemodes/vampire/vampire_other.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_other.dm
@@ -37,6 +37,13 @@
 			if (vampire.total_blood >= 5 && vampire.usable_blood <= vampire.total_blood * 0.25)
 				vampire.usable_blood = min(vampire.usable_blood + 5, vampire.total_blood * 0.25) // 5 units every 20 seconds
 
+/obj/item/clothing/suit/draculacoat/nosferatu
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+
+/obj/item/clothing/suit/draculacoat/nosferatu/Initialize()
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
+
 /mob/living/carbon/human/handle_fire()
 	. = ..()
 	if(mind)

--- a/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -435,7 +435,6 @@
 		V.total_blood = 450
 		V.usable_blood = 450
 		V.check_vampire_upgrade()
-		V.transformed = TRUE
 		V.give_transform_objectives()
 		V.remove_ability(V.get_ability(/obj/effect/proc_holder/spell/self/nosferatu))
 		var/mob/living/carbon/human/H = usr

--- a/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -431,17 +431,13 @@
 		revert_cast()
 		return
 	var/datum/antagonist/vampire/V = user.mind.has_antag_datum(ANTAG_DATUM_VAMPIRE)
-	if(!V || V.transformed)
-		revert_cast()
-		to_chat(user, "<span class='notice bold'>DEBUG : Tried to use transform while already transformed or not vampire.</span>")
-		return
 	if(V)
 		V.total_blood = 450
 		V.usable_blood = 450
 		V.check_vampire_upgrade()
 		V.transformed = TRUE
 		V.give_transform_objectives()
-		V.remove_ability(/obj/effect/proc_holder/spell/self/nosferatu)
+		V.remove_ability(V.get_ability(/obj/effect/proc_holder/spell/self/nosferatu))
 		var/mob/living/carbon/human/H = usr
 		if(H.wear_suit)
 			var/obj/item/clothing/suit/W = H.wear_suit

--- a/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -421,6 +421,9 @@
 	name = "Nosferatu transformation"
 	desc = "Transform yourself into a hideous form in exchange for instantly unlocking all of your abilities. Be warned, you can no longer hide among the humans in this form."
 	blood_used = 0
+	action_icon = 'yogstation/icons/mob/vampire.dmi'
+	action_icon_state = "coat"
+	action_background_icon_state = "bg_demon"
 	vamp_req = TRUE
 
 /obj/effect/proc_holder/spell/self/nosferatu/cast(list/targets, mob/user = usr)
@@ -428,6 +431,9 @@
 		revert_cast()
 		return
 	var/datum/antagonist/vampire/V = user.mind.has_antag_datum(ANTAG_DATUM_VAMPIRE)
+	if(!V || V.transformed)
+		revert_cast()
+		return
 	if(V)
 		V.total_blood = 450
 		V.usable_blood = 450
@@ -435,10 +441,9 @@
 		V.transformed = TRUE
 		V.give_transform_objectives()
 		V.remove_ability(/obj/effect/proc_holder/spell/self/nosferatu = 0)
-		if(usr.wear_suit)
-			var/obj/item/clothing/suit/W = usr.wear_suit
-			usr.doUnEquip(W)
-			var/obj/item/clothing/suit/draculacoat/N = new
-			usr.equip_to_slot_if_possible(N, SLOT_WEAR_SUIT, 1)
-		var/obj/item/clothing/suit/draculacoat/N = new
-		usr.equip_to_slot_if_possible(N, SLOT_WEAR_SUIT)
+		var/mob/living/carbon/human/H = usr
+		if(H.wear_suit)
+			var/obj/item/clothing/suit/W = H.wear_suit
+			H.doUnEquip(W)
+		var/obj/item/clothing/suit/draculacoat/nosferatu/N = new
+		H.equip_to_slot_if_possible(N, SLOT_WEAR_SUIT)

--- a/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -416,3 +416,29 @@
 		bat.mind.transfer_to(bat.controller)
 		bat.controller = null //just so we don't accidently trigger the death() thing
 		qdel(bat)
+
+/obj/effect/proc_holder/spell/self/nosferatu
+	name = "Nosferatu transformation"
+	desc = "Transform yourself into a hideous form in exchange for instantly unlocking all of your abilities. Be warned, you can no longer hide among the humans in this form."
+	blood_used = 0
+	vamp_req = TRUE
+
+/obj/effect/proc_holder/spell/self/nosferatu/cast(list/targets, mob/user = usr)
+	if(!is_vampire(user) || !isliving(user))
+		revert_cast()
+		return
+	var/datum/antagonist/vampire/V = user.mind.has_antag_datum(ANTAG_DATUM_VAMPIRE)
+	if(V)
+		V.total_blood = 450
+		V.usable_blood = 450
+		V.check_vampire_upgrade()
+		V.transformed = TRUE
+		V.give_transform_objectives()
+		V.remove_ability(/obj/effect/proc_holder/spell/self/nosferatu = 0)
+		if(usr.wear_suit)
+			var/obj/item/clothing/suit/W = usr.wear_suit
+			usr.doUnEquip(W)
+			var/obj/item/clothing/suit/draculacoat/N = new
+			usr.equip_to_slot_if_possible(N, SLOT_WEAR_SUIT, 1)
+		var/obj/item/clothing/suit/draculacoat/N = new
+		usr.equip_to_slot_if_possible(N, SLOT_WEAR_SUIT)

--- a/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -433,6 +433,7 @@
 	var/datum/antagonist/vampire/V = user.mind.has_antag_datum(ANTAG_DATUM_VAMPIRE)
 	if(!V || V.transformed)
 		revert_cast()
+		to_chat(user, "<span class='notice bold'>DEBUG : Tried to use transform while already transformed or not vampire.</span>")
 		return
 	if(V)
 		V.total_blood = 450
@@ -440,10 +441,10 @@
 		V.check_vampire_upgrade()
 		V.transformed = TRUE
 		V.give_transform_objectives()
-		V.remove_ability(/obj/effect/proc_holder/spell/self/nosferatu = 0)
+		V.remove_ability(/obj/effect/proc_holder/spell/self/nosferatu)
 		var/mob/living/carbon/human/H = usr
 		if(H.wear_suit)
 			var/obj/item/clothing/suit/W = H.wear_suit
-			H.doUnEquip(W)
+			H.dropItemToGround(W)
 		var/obj/item/clothing/suit/draculacoat/nosferatu/N = new
 		H.equip_to_slot_if_possible(N, SLOT_WEAR_SUIT)


### PR DESCRIPTION
### Intent of your Pull Request
Vampires can now go loud and unlock all abilities instantly. Also gives them a pool of 450 useable blood to actually use their abilities

Forces them to have a blood objective that's equal to multiple kill objectives

Forces them to wear a dracula cape. No more hiding in plain sight.

They lose the ability to transform if they drink enough blood to unlock even one new power.

#### Changelog

:cl:  
rscadd: Gives vampires new transformation. Unlocking their true powers
/:cl:
