### PR TITLE
Syndicate toolbox fits in bags TAKE 2

### DIFF
--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -144,6 +144,7 @@
 	item_state = "toolbox_syndi"
 	force = 15
 	throwforce = 18
+	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/storage/toolbox/syndicate/ComponentInitialize()
 	. = ..()

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1362,8 +1362,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/device_tools/toolbox
 	name = "Full Syndicate Toolbox"
-	desc = "The Syndicate toolbox is a suspicious black and red. It comes loaded with a full tool set including a \
-			multitool and combat gloves that are resistant to shocks and heat."
+	desc = "A suspicious black and red syndicate toolbox. It comes loaded with a full tool set including a \
+			multitool and combat gloves that are resistant to shocks and heat. It is very compact and will \
+			fit in any standard Nanotrasen backpack."
 	item = /obj/item/storage/toolbox/syndicate
 	cost = 1
 


### PR DESCRIPTION
THIS TIME I DIDN'T DESTROY THE CODE I PROMISE

The syndicate toolbox will become a normal sized item, allowing players to shove it into their bag, like we used to be able to ages ago. This will make the syndicate toolbox a viable investment since you wont need to find a toolbelt to avoid walking around with a big valid target stuck to your hand.
The description of the item in the uplink will be changed to reflect this change.

:cl:  
tweak: makes the syndicate toolbox a medium sized item
tweak: uplink toolbox description updated to mention it's size
/:cl:
