### PR TITLE
hypnotize is now uninterruptible and causes effects on cast

### DIFF
--- a/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -117,7 +117,7 @@
 	for(var/mob/living/carbon/target in targets)
 		user.visible_message("<span class='warning'>[user]'s eyes flash briefly as [user.p_they()] stares into [target]'s eyes</span>")
 		target.silent = 2 //this is actually roughly 4 seconds due to how silent works
-		if(target.flash_act(1)
+		if(target.flash_act(1))
 			target.adjustStaminaLoss(40) //minor slowdown if they aren't protected
 		if(do_mob(user, target, 30, TRUE) && (target in view(user))) //effect stops working if the target escapes line of sight
 			to_chat(user, "<span class='warning'>Your piercing gaze knocks out [target].</span>")

--- a/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -108,6 +108,7 @@
 	action_icon_state = "hypnotize"
 	blood_used = 0
 	charge_max = 1500
+	range = 2
 	action_icon = 'yogstation/icons/mob/vampire.dmi'
 	action_background_icon_state = "bg_demon"
 	vamp_req = TRUE
@@ -115,7 +116,10 @@
 /obj/effect/proc_holder/spell/targeted/hypnotise/cast(list/targets, mob/user = usr)
 	for(var/mob/living/carbon/target in targets)
 		user.visible_message("<span class='warning'>[user]'s eyes flash briefly as he stares into [target]'s eyes</span>")
-		if(do_mob(user, target, 30))
+		target.silent = 2 //this is actually roughly 4 seconds due to how silent works
+		if(target.flash_act(1)
+			target.adjustStaminaLoss(40) //minor slowdown if they aren't protected
+		if(do_mob(user, target, 30, TRUE) && (target in view(user))) //effect stops working if the target escapes line of sight
 			to_chat(user, "<span class='warning'>Your piercing gaze knocks out [target].</span>")
 			to_chat(target, "<span class='warning'>You find yourself unable to move or speak.</span>")
 			target.Paralyze(150)

--- a/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -115,7 +115,7 @@
 
 /obj/effect/proc_holder/spell/targeted/hypnotise/cast(list/targets, mob/user = usr)
 	for(var/mob/living/carbon/target in targets)
-		user.visible_message("<span class='warning'>[user]'s eyes flash briefly as he stares into [target]'s eyes</span>")
+		user.visible_message("<span class='warning'>[user]'s eyes flash briefly as [user.p_they()] stares into [target]'s eyes</span>")
 		target.silent = 2 //this is actually roughly 4 seconds due to how silent works
 		if(target.flash_act(1)
 			target.adjustStaminaLoss(40) //minor slowdown if they aren't protected


### PR DESCRIPTION
this might be a bit unintuitive
Hypnotize has always been terrible and that's because it's delayed
instead of making it not delayed I have elected to make it stay delayed but be harder to break
hypnotize now mutes for 4 seconds on being cast and deals 40 stamina damage to the victim as well if they are not wearing flash protection
after 3 seconds, if the victim is still in range of the user, they are stunned fully as normal, otherwise the spell isn't cast since the cooldown is like 5 minutes or something
also it has an initiation range of 2 meters instead of whatever the fuck it was before hopefully Ididn't screw this part up
:cl:  
rscadd: Vampire hypnotize spell has a mute attached to the start and is now uninterruptible, it can be broken if you break line of sight with the vampire when it activates
rscadd: Vampire hypnotize spell now requires the target to be within 2 meters to be used
/:cl:
