### PR TITLE
godblood fountain starts with full icon because it STARTS FULL

### DIFF
--- a/code/game/objects/structures/divine.dm
+++ b/code/game/objects/structures/divine.dm
@@ -24,7 +24,7 @@
 	name = "healing fountain"
 	desc = "A fountain containing the waters of life."
 	icon = 'icons/obj/hand_of_god_structures.dmi'
-	icon_state = "fountain"
+	icon_state = "fountain-red"
 	anchored = TRUE
 	density = TRUE
 	var/time_between_uses = 1800


### PR DESCRIPTION
title

:cl:  
bugfix: godblood fountain on lavaland no longer fakes you out into thinking it's empty by spawning with the empty look but being full
/:cl:
