### PR TITLE
Increased changeling transformation cap

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -17,7 +17,7 @@
 
 	var/list/stored_profiles = list() //list of datum/changelingprofile
 	var/datum/changelingprofile/first_prof = null
-	var/dna_max = 6 //How many extra DNA strands the changeling can store for transformation.
+	var/dna_max = 12 //How many extra DNA strands the changeling can store for transformation.
 	var/absorbedcount = 0
 	var/trueabsorbs = 0//dna gained using absorb, not dna sting
 	var/chem_charges = 20


### PR DESCRIPTION
Apparently changelings are limited to 6 absorbs causing them to miss their objectives if they don't absorb their target in their first 6.

Changed this to 12

#### Changelog

:cl:  
tweak: doubled the arbitrary ling absorb transformation limit.
/:cl:
