### PR TITLE
Borgs now get a message when unlocked/locked

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -388,7 +388,7 @@
 				return
 			if(health > 0)
 				return //safety check to prevent spam clciking and queing
-		
+
 		adjustBruteLoss(-30)
 		updatehealth()
 		add_fingerprint(user)
@@ -506,6 +506,7 @@
 			if(allowed(usr))
 				locked = !locked
 				to_chat(user, "<span class='notice'>You [ locked ? "lock" : "unlock"] [src]'s cover.</span>")
+				to_chat(src, "<span class='notice'>[usr] [locked ? "locks" : "unlocks"] your cover.</span>")
 				update_icons()
 				if(emagged)
 					to_chat(user, "<span class='notice'>The cover interface glitches out for a split second.</span>")


### PR DESCRIPTION
### Intent of your Pull Request
Increase borg powercreep.

Borgs can now see if the roboticist actually locked them before they roll out of the shop.  The old way of doing this was to use the Unlock Cover verb, which fails silently when the cover is unlocked.  I'm just making it obvious.
#### Changelog

:cl:  
tweak: Borgs can tell when someone locks or unlocks their cover.
/:cl:
