### PR TITLE
Plasma cutters are more expensive

### DIFF
--- a/code/modules/research/designs/mining_designs.dm
+++ b/code/modules/research/designs/mining_designs.dm
@@ -47,7 +47,7 @@
 	desc = "You could use it to cut limbs off of xenos! Or, you know, mine stuff."
 	id = "plasmacutter"
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 1500, MAT_GLASS = 500, MAT_PLASMA = 400)
+	materials = list(MAT_METAL = 1500, MAT_GLASS = 500, MAT_PLASMA = 1000, MAT_SILVER = 1000, MAT_URANIUM = 800)
 	build_path = /obj/item/gun/energy/plasmacutter
 	category = list("Mining Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO
@@ -57,7 +57,7 @@
 	desc = "It's an advanced plasma cutter, oh my god."
 	id = "plasmacutter_adv"
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 3000, MAT_GLASS = 1000, MAT_PLASMA = 2000, MAT_GOLD = 500)
+	materials = list(MAT_METAL = 3000, MAT_GLASS = 1000, MAT_PLASMA = 2000, MAT_GOLD = 2000, MAT_URANIUM = 3000, MAT_DIAMOND = 2000)
 	build_path = /obj/item/gun/energy/plasmacutter/adv
 	category = list("Mining Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO


### PR DESCRIPTION
### Intent of your Pull Request
Plasma cutters are hilariously cheap for how good they are.  If you have it in you to haul one plasma ore back to the station, your prize is a mining tool that blows every comparable tool out of the water.  For that plus a sheet of gold, you get an even better version of the same thing.

I don't fault plasma cutters their power since PKA mining is about as entertaining as banging your head against a wall.  However, there's no real point to mining before science gets mining tech since regular mining is so slow and inefficient.

So, here's the deal.  You want your shiny plasmacutter?  You have to find at least one uranium deposit the old fashioned way.  You want it advanced?  Either get lucky and find some diamonds or kill a watcher.

#### Why good 4 game
First, it makes sure the station at least has one sheet of everything before the miners run off to die to Bubblegum.  Second, it rewards people who mine before science researches advanced cutters.  Third, it might give some actual reason to use regular cutters besides science sucking out loud.  Fourth, it encourages people to take risks they might not usually take, like fighting a watcher rather than running straight past.

#### Changelog

:cl:  
tweak: Plasma cutters are more expensive.
/:cl:

_Disclaimer: numbers completely made up on a whim, feel free to suggest changes._
