### PR TITLE
[admin] Applies retmin tracking to all staff

### DIFF
--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -71,7 +71,7 @@ SUBSYSTEM_DEF(server_maint)
 				continue
 
 		if(can_tracking)
-			if(C.holder?.rank.name == "RetiredAdmin" && C.is_afk() && C.connection_number)
+			if(C.holder && C.is_afk() && C.connection_number)
 				world.sync_logout_with_db(C.connection_number)
 				C.connection_number = null
 			if(!C.is_afk() && !C.connection_number) //no connection number but not inactive


### PR DESCRIPTION
### Intent of your Pull Request

Personally I don't think that making it so anyone who has the game on in the background doesn't get counted for hours is a good idea, although mostly because back in the day that's how lowpop was handled. However, I see the merits when applied to cases where a lot of admins are on at once, and people join and just sit around doing nothing.

Either way, if you're going to apply this policy it should be applied equally :)

#### Changelog

:cl:  
tweak: Admin tracking now doesn't count AFK for all staff rather than just retmins
/:cl:
