### PR TITLE
[Admin] Removes retmin tracking

### DIFF
--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -70,13 +70,6 @@ SUBSYSTEM_DEF(server_maint)
 				QDEL_IN(C, 1) //to ensure they get our message before getting disconnected
 				continue
 
-		if(can_tracking)
-			if(C.holder?.rank.name == "RetiredAdmin" && C.is_afk() && C.connection_number)
-				world.sync_logout_with_db(C.connection_number)
-				C.connection_number = null
-			if(!C.is_afk() && !C.connection_number) //no connection number but not inactive
-				C.sync_login_with_db() 
-
 		if (!(!C || world.time - C.connection_time < PING_BUFFER_TIME || C.inactivity >= (wait-1)))
 			winset(C, null, "command=.update_ping+[world.time+world.tick_lag*TICK_USAGE_REAL/100]")
 

--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -55,7 +55,6 @@ SUBSYSTEM_DEF(server_maint)
 
 	var/kick_inactive = CONFIG_GET(flag/kick_inactive)
 	var/afk_period
-	var/can_tracking = SSdbcore.Connect()
 
 	if(kick_inactive)
 		afk_period = CONFIG_GET(number/afk_period)


### PR DESCRIPTION
Alternative to #8689.

Some admins might AFK on the server while doing something else, but still handle tickets. Best solution might be to only do this if there are 2 or more admins online. /shrug
