### PR TITLE
[admin] Only do staff tracking when there are more than 3 admin online

### DIFF
--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -71,7 +71,9 @@ SUBSYSTEM_DEF(server_maint)
 				continue
 
 		if(can_tracking)
-			if(C.holder?.rank.name == "RetiredAdmin" && C.is_afk() && C.connection_number)
+			var/list/adm = get_admin_counts()
+			var/nr_admins = adm["present"].len + adm["stealth"].len
+			if(C.is_afk() && C.connection_number && nr_admins >= 3)
 				world.sync_logout_with_db(C.connection_number)
 				C.connection_number = null
 			if(!C.is_afk() && !C.connection_number) //no connection number but not inactive

--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -72,7 +72,10 @@ SUBSYSTEM_DEF(server_maint)
 
 		if(can_tracking)
 			var/list/adm = get_admin_counts()
-			var/nr_admins = adm["present"].len + adm["stealth"].len + adm["afk"].len
+			var/list/afkmins = adm["afk"]
+			var/list/stealthmins = adm["stealth"]
+			var/list/presentmins = adm["afk"]
+			var/nr_admins = presentmins.len + stealthmins.len + afkmins.len
 			if(C.is_afk() && C.connection_number && nr_admins >= 3)
 				world.sync_logout_with_db(C.connection_number)
 				C.connection_number = null

--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -72,7 +72,7 @@ SUBSYSTEM_DEF(server_maint)
 
 		if(can_tracking)
 			var/list/adm = get_admin_counts()
-			var/nr_admins = adm["present"].len + adm["stealth"].len
+			var/nr_admins = adm["present"].len + adm["stealth"].len + adm["afk"].len
 			if(C.is_afk() && C.connection_number && nr_admins >= 3)
 				world.sync_logout_with_db(C.connection_number)
 				C.connection_number = null

--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -72,10 +72,7 @@ SUBSYSTEM_DEF(server_maint)
 
 		if(can_tracking)
 			var/list/adm = get_admin_counts()
-			var/list/afkmins = adm["afk"]
-			var/list/stealthmins = adm["stealth"]
-			var/list/presentmins = adm["afk"]
-			var/nr_admins = presentmins.len + stealthmins.len + afkmins.len
+			var/nr_admins = length(adm["present"]) + length(adm["stealth"]) + length(adm["afk"])
 			if(C.is_afk() && C.connection_number && nr_admins >= 3)
 				world.sync_logout_with_db(C.connection_number)
 				C.connection_number = null


### PR DESCRIPTION
Alternative to #8690 and #8689.

Will not count staff time when afk if there are 3 or more admins online (including the afk admin themselves). This applies to all staff, not only retmin.

#### Changelog

:cl:  
tweak: Staff tracking no longer tracks your time if you are AFK while there are other admins on the server.
/:cl:
