### PR TITLE
Syndicate camera flash

### DIFF
--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -236,7 +236,7 @@
 		flash_carbon(M, user, 5, 1)
 		playsound(src, 'sound/weapons/flash.ogg', 100, TRUE)
 		flash_lighting_fx(8, light_power, light_color)
-		flash_cooldown(user)
+		flash_cooldown()
 		return TRUE
 	else if(issilicon(M))
 		var/mob/living/silicon/robot/R = M
@@ -246,7 +246,7 @@
 		R.confused += min(5, diff)
 		R.flash_act(affect_silicon = 1)
 		playsound(src, 'sound/weapons/flash.ogg', 100, TRUE)
-		flash_cooldown(user)
+		flash_cooldown()
 		flash_lighting_fx(8, light_power, light_color)
 		user.visible_message("<span class='disarm'>[user] overloads [R]'s sensors with the camera flash!</span>", "<span class='danger'>You overload [R]'s sensors with the flash!</span>") // second message generic
 		return TRUE
@@ -279,7 +279,7 @@
 			M.confused += min(power, diff)
 
 
-/obj/item/camera/syndicate/proc/flash_cooldown(mob/user)
+/obj/item/camera/syndicate/proc/flash_cooldown()
 	var/realcooldown = cooldown + 30 // longer delay to recharge than normal usage
 	icon_state = state_off
 	on = FALSE

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -229,7 +229,6 @@
 			picture.log_to_file()
 
 
-
 /obj/item/camera/syndicate/attack(mob/living/carbon/human/M, mob/user) // syndicate camera flash
 	if(!on)
 		return

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -281,13 +281,13 @@
 
 
 /obj/item/camera/syndicate/proc/flash_cooldown(mob/user)
-	var/realcooldown = cooldown
+	var/realcooldown = cooldown + 30 // longer delay to recharge than normal usage
 	if(user)
 		var/mob/living/carbon/human/H = user
 		if (HAS_TRAIT(H, TRAIT_PHOTOGRAPHER)) // yes; knowing how to use a camera will help you out here as well
 			realcooldown *= 0.5
 	icon_state = state_off
 	on = FALSE
-	sleep(realcooldown + 30) // longer delay to recharge than normal usage
+	sleep(realcooldown)
 	icon_state = state_on
 	on = TRUE

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -282,10 +282,6 @@
 
 /obj/item/camera/syndicate/proc/flash_cooldown(mob/user)
 	var/realcooldown = cooldown + 30 // longer delay to recharge than normal usage
-	if(user)
-		var/mob/living/carbon/human/H = user
-		if (HAS_TRAIT(H, TRAIT_PHOTOGRAPHER)) // yes; knowing how to use a camera will help you out here as well
-			realcooldown *= 0.5
 	icon_state = state_off
 	on = FALSE
 	sleep(realcooldown)

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -116,3 +116,10 @@
 	item = /obj/item/melee/fryingpan/bananium
 	cost = 40
 	cant_discount = TRUE
+
+/datum/uplink_item/stealthy_weapons/camera_flash
+	name = "Camera flash"
+	desc = "A camera with an upgraded flash. Can be used much like a flash except with a much longer cooldown between uses."
+	item = /obj/item/camera/syndicate
+	cost = 4
+	surplus = 20

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -121,5 +121,5 @@
 	name = "Camera flash"
 	desc = "A camera with an upgraded flash. Can be used much like a flash except with a much longer cooldown between uses."
 	item = /obj/item/camera/syndicate
-	cost = 4
+	cost = 2
 	surplus = 20


### PR DESCRIPTION
New syndicate stealth item:

Camera flash.
Its a camera with a powerful camera flash installed that can be used much like a regular flash except with a long cooldown between uses.

**EDIT:** 
Alex's suggestions implemented:
- Cooldown is now 9 seconds regardless of trait
- TC cost is now 2

Cooldown: 
regular: 9 seconds
with photography trait: 4.5 seconds

TC cost: 4

#### Changelog

:cl:  Hopek
rscadd: Added a new syndicate item: the camera flash.
/:cl:
