### PR TITLE
EMP act for cameras

### DIFF
--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -111,9 +111,11 @@
 	if(on) // EMP will only work on cameras that are on as it has power going through it
 		icon_state = state_off
 		on = FALSE
-		sleep(600/severity)
-		on = TRUE
-		icon_state = state_on
+		addtimer(CALLBACK(src, .proc/emp_after), (600/severity))
+
+/obj/item/camera/proc/emp_after()
+	on = TRUE
+	icon_state = state_on
 
 /obj/item/camera/afterattack(atom/target, mob/user, flag)
 	if (disk)

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -107,6 +107,14 @@
 			return FALSE
 	return TRUE
 
+/obj/item/camera/emp_act(severity)
+	if(on) // EMP will only work on cameras that are on as it has power going through it
+		icon_state = state_off
+		on = FALSE
+		sleep(600/severity)
+		on = TRUE
+		icon_state = state_on
+
 /obj/item/camera/afterattack(atom/target, mob/user, flag)
 	if (disk)
 		if(ismob(target))


### PR DESCRIPTION
Adds an EMP effect to cameras.

When EMP'd the camera will turn off for 60 seconds divided by EMP level (lower is more powerful)

So a level 1 EMP will turn it off for 60 seconds and a level 2 EMP will turn it off for 30 seconds

#### Changelog

:cl:  
rscadd: Cameras now have an EMP effect 
/:cl:
