### PR TITLE
[admin] Amber task force back airtanks not droppable

### DIFF
--- a/code/game/objects/items/tanks/tank_types.dm
+++ b/code/game/objects/items/tanks/tank_types.dm
@@ -35,8 +35,12 @@
 
 /obj/item/tank/internals/oxygen/tactical
 	name = "tactical oxygen tank"
-	desc = "A tactically colored tank of oxygen."
+	desc = "A tactically colored tank of oxygen. The straps are on tight to prevent the [src] from being taken off on the field."
 	color = "#aeb08c"
+
+/obj/item/tank/internals/oxygen/Initialize()
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
 
 /obj/item/tank/internals/oxygen/empty/populate_gas()
 	return

--- a/code/game/objects/items/tanks/tank_types.dm
+++ b/code/game/objects/items/tanks/tank_types.dm
@@ -38,7 +38,7 @@
 	desc = "A tactically colored tank of oxygen. The straps are on tight to prevent the tank from being stolen on the field."
 	color = "#aeb08c"
 
-/obj/item/tank/internals/oxygen/Initialize()
+/obj/item/tank/internals/oxygen/tactical/Initialize()
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
 

--- a/code/game/objects/items/tanks/tank_types.dm
+++ b/code/game/objects/items/tanks/tank_types.dm
@@ -35,7 +35,7 @@
 
 /obj/item/tank/internals/oxygen/tactical
 	name = "tactical oxygen tank"
-	desc = "A tactically colored tank of oxygen. The straps are on tight to prevent the tank from being taken off on the field."
+	desc = "A tactically colored tank of oxygen. The straps are on tight to prevent the tank from being stolen on the field."
 	color = "#aeb08c"
 
 /obj/item/tank/internals/oxygen/Initialize()

--- a/code/game/objects/items/tanks/tank_types.dm
+++ b/code/game/objects/items/tanks/tank_types.dm
@@ -35,7 +35,7 @@
 
 /obj/item/tank/internals/oxygen/tactical
 	name = "tactical oxygen tank"
-	desc = "A tactically colored tank of oxygen. The straps are on tight to prevent the [src] from being taken off on the field."
+	desc = "A tactically colored tank of oxygen. The straps are on tight to prevent the tank from being taken off on the field."
 	color = "#aeb08c"
 
 /obj/item/tank/internals/oxygen/Initialize()


### PR DESCRIPTION
Personally didn't want to make them a non-droppable but this gets brought up as a negative from what I can tell.

**Why:**
One of the weaknesses that the amber task force was made in mind is that they do not have any backpacks. This further enforces this weakness so that they are unable to just use a backpack to remove this negative.

#### Changelog

:cl:  Hopek
tweak: The amber task force tactical oxygen tanks are non-droppable. Further enforcing the weaknesses of the amber task force.
/:cl:
