### PR TITLE
Amber task force knife tip/reminder

### DIFF
--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -172,6 +172,10 @@
 	missiondesc += "<BR><B>Your Mission</B> : [ert_team.mission.explanation_text]"
 	to_chat(owner,missiondesc)
 
+/datum/antagonist/ert/greet()
+	. = ..()
+	to_chat(owner,"<BR><B>Your Mission</B> : You also have a combat knife inside your boots.")
+
 /datum/antagonist/ert/deathsquad/greet()
 	if(!ert_team)
 		return

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -174,7 +174,7 @@
 
 /datum/antagonist/ert/amber/greet()
 	. = ..()
-	to_chat(owner,"<BR><B>Your Mission</B> : You also have a combat knife inside your boots.")
+	to_chat(owner,"You also have a combat knife inside your boots.")
 
 /datum/antagonist/ert/deathsquad/greet()
 	if(!ert_team)

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -172,7 +172,7 @@
 	missiondesc += "<BR><B>Your Mission</B> : [ert_team.mission.explanation_text]"
 	to_chat(owner,missiondesc)
 
-/datum/antagonist/ert/greet()
+/datum/antagonist/ert/amber/greet()
 	. = ..()
 	to_chat(owner,"<BR><B>Your Mission</B> : You also have a combat knife inside your boots.")
 


### PR DESCRIPTION
Lets the amber task force members know they have a combat knife in their boots.

**Why:**
I've been watching them attack objects and people with their jaws of life instead and it is hurting me on the inside.

Having items already be spawned inside of boots is a brand new feature in our codebase specific to only the amber task force so it makes sense that no-one expects it making this tip appropriate.

#### Changelog

:cl:  Hopek
rscadd: Amber task force members now get told they have a combat knife in their boots.
/:cl:
