### PR TITLE
mulebot bump causes a knockdown instead of a hard stun

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -635,7 +635,7 @@
 				if(!paicard)
 					log_combat(src, L, "knocked down")
 					visible_message("<span class='danger'>[src] knocks over [L]!</span>")
-					L.Paralyze(160)
+					L.Knockdown(8 SECONDS)
 	return ..()
 
 // called from mob/living/carbon/human/Crossed()


### PR DESCRIPTION
they really don't need one
tgstation/tgstation#51277
:cl:  
tweak: mulebots have an 8 second knockdown instead of a 16 second hard stun on bumping with safeties off
/:cl:
