### PR TITLE
No more accidental megafauna

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -569,9 +569,7 @@
 				setTimer(20)
 				return
 		if(SHUTTLE_IGNITING)
-			if(checknearmobs())
-				var/obj/machinery/computer/shuttle/S = getControlConsole()
-				S.say("Hostile environment detected, please clear out shuttle before launch")
+			if(checkminingmobs())
 				mode = SHUTTLE_IDLE
 				return
 			if(check_transit_zone() != TRANSIT_READY)
@@ -728,12 +726,17 @@
 	else
 		. = "unknown"
 
-/obj/docking_port/mobile/proc/checknearmobs()
-	for(var/place in shuttle_areas)
-		var/area/shuttle/shuttle_area = place
-		for(var/mob/living/simple_animal/hostile/h in shuttle_area)
-			if(h && !h.mind)
-				return TRUE
+/obj/docking_port/mobile/proc/checkminingmobs()
+	var/area/A = get_area(loc)
+	if(istype(A, /area/shuttle/mining))
+		say("[A.type]")
+		for(var/obj/machinery/computer/shuttle/mining/M in A)
+			if(M.obj_flags & EMAGGED) //Emag can overide check
+				return FALSE
+			for(var/mob/living/simple_animal/hostile/h in A)
+				if(h && !h.mind)
+					M.say("Hostile environment detected, please clear out shuttle before launch")
+					return TRUE
 	return FALSE
 
 // attempts to locate /obj/machinery/computer/shuttle with matching ID inside the shuttle

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -569,6 +569,11 @@
 				setTimer(20)
 				return
 		if(SHUTTLE_IGNITING)
+			if(checknearmobs())
+				var/obj/machinery/computer/shuttle/S = getControlConsole()
+				S.say("Hostile environment detected, please clear out shuttle before launch")
+				mode = SHUTTLE_IDLE
+				return
 			if(check_transit_zone() != TRANSIT_READY)
 				setTimer(20)
 				return
@@ -723,6 +728,13 @@
 	else
 		. = "unknown"
 
+/obj/docking_port/mobile/proc/checknearmobs()
+	for(var/place in shuttle_areas)
+		var/area/shuttle/shuttle_area = place
+		for(var/mob/living/simple_animal/hostile/h in shuttle_area)
+			if(h && !h.mind)
+				return TRUE
+	return FALSE
 
 // attempts to locate /obj/machinery/computer/shuttle with matching ID inside the shuttle
 /obj/docking_port/mobile/proc/getControlConsole()


### PR DESCRIPTION
Prevents hostile mobs from leaving on the mining shuttle,

Can be overriden with emag

Sentient minds can still go on shuttle

#### Changelog

:cl:  
rscadd: Mining shuttle checks for Hostiles 
/:cl:
