### PR TITLE
fixes morgue trays being over items

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -318,6 +318,7 @@ GLOBAL_LIST_EMPTY(crematoriums)
 	var/obj/structure/bodycontainer/connected = null
 	anchored = TRUE
 	pass_flags = LETPASSTHROW
+	layer = TABLE_LAYER
 	max_integrity = 350
 
 /obj/structure/tray/Destroy()


### PR DESCRIPTION
### Intent of your Pull Request
Makes morgue trays the same item level as tables, meaning items and bodybags will show up over them