### PR TITLE
Should fix radiation runtime that caused server crash

### DIFF
--- a/code/__HELPERS/radiation.dm
+++ b/code/__HELPERS/radiation.dm
@@ -15,7 +15,7 @@
 	while(processing_list.len)
 		var/atom/thing = processing_list[1]
 		processing_list -= thing
-		if(ignored_things[thing.type])
+		if(ignored_things[thing?.type])
 			continue
 		. += thing
 		if((thing.rad_flags & RAD_PROTECT_CONTENTS) || (SEND_SIGNAL(thing, COMSIG_ATOM_RAD_PROBE) & COMPONENT_BLOCK_RADIATION))

--- a/code/__HELPERS/radiation.dm
+++ b/code/__HELPERS/radiation.dm
@@ -15,7 +15,9 @@
 	while(processing_list.len)
 		var/atom/thing = processing_list[1]
 		processing_list -= thing
-		if(ignored_things[thing?.type])
+		if(!thing)
+			continue
+		if(ignored_things[thing.type])
 			continue
 		. += thing
 		if((thing.rad_flags & RAD_PROTECT_CONTENTS) || (SEND_SIGNAL(thing, COMSIG_ATOM_RAD_PROBE) & COMPONENT_BLOCK_RADIATION))


### PR DESCRIPTION
Should fix the radiation runtime

#### Changelog

:cl:  
bugfix: Runtime fix for rad storm 
/:cl:

[2020-05-28 19:53:29.522] runtime error: Cannot read null.type
 - proc name: get rad contents (/proc/get_rad_contents)
 -   source file: radiation.dm,18
 -   usr: (src)
 -   src: null
 -   call stack:
 - get rad contents(null)
 - /datum/radiation_wave (/datum/radiation_wave): get rad atoms()
 - /datum/radiation_wave (/datum/radiation_wave): process(10)
 - Radiation (/datum/controller/subsystem/processing/radiation): fire(1)
 - Radiation (/datum/controller/subsystem/processing/radiation): ignite(1)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop()
 - Master (/datum/controller/master): StartProcessing(0)