### PR TITLE
Cere Shuttle runtime

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -233,7 +233,7 @@ SUBSYSTEM_DEF(air)
 		var/turf/open/T = currentrun[currentrun.len]
 		currentrun.len--
 		if (T)
-			if(istype(T, /turf/open))
+			if(istype(T))
 				T.equalize_pressure_in_zone(fire_count)
 			//equalize_pressure_in_zone(T, fire_count)
 		if (MC_TICK_CHECK)

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -233,7 +233,8 @@ SUBSYSTEM_DEF(air)
 		var/turf/open/T = currentrun[currentrun.len]
 		currentrun.len--
 		if (T)
-			T.equalize_pressure_in_zone(fire_count)
+			if(istype(T, /turf/open))
+				T.equalize_pressure_in_zone(fire_count)
 			//equalize_pressure_in_zone(T, fire_count)
 		if (MC_TICK_CHECK)
 			return


### PR DESCRIPTION
### Intent of your Pull Request

Fixes rare shuttle runtime (Cere)

[2020-05-26 18:03:56.991] runtime error: undefined proc or verb /turf/closed/wall/mineral/titanium/equalize pressure in zone().
 - 
 - proc name: process turf equalize (/datum/controller/subsystem/air/proc/process_turf_equalize)
 -   source file: air.dm,236

#### Changelog

:cl:  
bugfix: Cere Shuttle runtime
/:cl:
