### PR TITLE
Fixes Component runtime,

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -120,6 +120,8 @@
 	signal_enabled = TRUE
 
 /datum/proc/UnregisterSignal(datum/target, sig_type_or_types)
+	if(!target)
+		return
 	var/list/lookup = target.comp_lookup
 	if(!signal_procs || !signal_procs[target] || !lookup)
 		return


### PR DESCRIPTION
### Intent of your Pull Request

Fixes Component runtime,

[22:01:58] Runtime in _component.dm, line 123: Cannot read null.comp_lookup
proc name: UnregisterSignal (/datum/proc/UnregisterSignal)
usr: Sgtdevel/(Corvus DK)
usr.loc: (Central Primary Hallway (137, 141, 2))
src: /datum/chatmessage (/datum/chatmessage)
call stack:
/datum/chatmessage (/datum/chatmessage): UnregisterSignal(null, null)
/datum/chatmessage (/datum/chatmessage): Destroy(0)
/datum/chatmessage (/datum/chatmessage): Destroy(0)
qdel(/datum/chatmessage (/datum/chatmessage), 0)
/datum/callback (/datum/callback): Invoke()
world: PushUsr(Corvus DK (/mob/living/carbon/human), /datum/callback (/datum/callback))
/datum/callback (/datum/callback): InvokeAsync()
Timer (/datum/controller/subsystem/timer): fire(0)
Timer (/datum/controller/subsystem/timer): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing(0)

#### Changelog

:cl:  
bugfix: RUNTIMES NOM NOM NOM
/:cl:
