### PR TITLE
Cyborgs can see their master AI's objectives

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -317,6 +317,14 @@
 			. += "[st.name]: [st.energy]/[st.max_energy]"
 	if(connected_ai)
 		. += "Master AI: [connected_ai.name]"
+		if (connected_ai.mind)
+			var/datum/antagonist/traitor/A = connected_ai.mind.has_antag_datum(/datum/antagonist/traitor)
+			if (A && A.objectives && A.objectives.len)
+				. += ""
+				. += "<b><font color='#ff0000'>Accomplish the following:</font></b>"
+				var/counter = 1
+				for (var/datum/objective/O in A.objectives)
+					. += "[counter++]. [O.explanation_text]"
 
 /mob/living/silicon/robot/restrained(ignore_grab)
 	. = 0

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -317,7 +317,7 @@
 			. += "[st.name]: [st.energy]/[st.max_energy]"
 	if(connected_ai)
 		. += "Master AI: [connected_ai.name]"
-		if (connected_ai.mind)
+		if (connected_ai.mind && lawupdate)
 			var/datum/antagonist/traitor/A = connected_ai.mind.has_antag_datum(/datum/antagonist/traitor)
 			if (A && A.objectives && A.objectives.len)
 				. += ""


### PR DESCRIPTION
### Intent of your Pull Request
Synced cyborgs now see their master AI's objectives on the status panel.

I can't really think of any reason why this shouldn't be the case.  I'm sure the contrarians among you can, but I consider this a QoL improvement.  It helps the borgs act more independently and cuts down on the interminable 'wats going on' spam whenever a lot of borgs are being made.

#### Changelog

:cl:  
tweak: Cyborgs can see their master AI's objectives.
/:cl:
