### PR TITLE
Mjor's clone attack now respects armor and gives a message

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
@@ -112,10 +112,9 @@
 			original.copies -= src
 			for(var/c in original.copies)
 				qdel(c)
-		for(var/mob/living/L in range(5,src))
-			if(L == original || istype(L, type))
-				continue
-			L.adjustBruteLoss(50)
+		for(var/mob/living/carbon/L in range(5,src))
+			L.apply_damage(40)
+			to_chat(L, "<span class='userdanger'>The damaged clone showers you with paper cuts!</span>")
 		qdel(src)
 	else
 		. = ..()


### PR DESCRIPTION
### Intent of your Pull Request
Mjor the Creative has a clone attack, where he spawns a bunch of clones and deals a large amount of damage if you hit one.

I have two issues with this attack.  First of all, it ignores armor and magically applies 50(!) brute damage.  Second of all, it doesn't actually tell you that you take damage from killing the clones; I had to go code diving to figure out how he was hitting so hard.

Hence, his attack now does 40 damage, respects armor, and gives a nice big bold message telling you you're taking damage.  I'm open to discussion on how much damage it should do, but 40 seems like a reasonable baseline with armor.

#### Changelog
:cl:  
tweak: Mjor the Creative's clones have been stripped of their magic and told to telegraph their attacks better.
/:cl:
