### PR TITLE
Debugging works again

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -3,7 +3,7 @@
 GLOBAL_VAR(restart_counter)
 
 /world/proc/enable_debugger()
-    var/dll = (fexists("./byond-extools.dll") && "./byond-extools.dll")
+    var/dll = (fexists(EXTOOLS) && EXTOOLS)
     if (dll)
         call(dll, "debug_initialize")()
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -3,7 +3,7 @@
 GLOBAL_VAR(restart_counter)
 
 /world/proc/enable_debugger()
-    var/dll = world.GetConfig("env", "EXTOOLS_DLL") || (fexists("./extools.dll") && "./extools.dll")
+    var/dll = (fexists("./byond-extools.dll") && "./byond-extools.dll")
     if (dll)
         call(dll, "debug_initialize")()
 


### PR DESCRIPTION
### Intent of your Pull Request
The VScode debugger no longer uses the wrong version of extools.
#### Changelog
:cl:  
bugfix: Debugging works again
/:cl:
