### PR TITLE
Fixes orbit offset (TG port)

### DIFF
--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -63,7 +63,9 @@
 	orbiters[orbiter] = TRUE
 	orbiter.orbiting = src
 	RegisterSignal(orbiter, COMSIG_MOVABLE_MOVED, .proc/orbiter_move_react)
+
 	var/matrix/initial_transform = matrix(orbiter.transform)
+	orbiters[orbiter] = initial_transform
 
 	// Head first!
 	if(pre_rotation)
@@ -87,7 +89,6 @@
 		orbiter.glide_size = AM.glide_size
 
 	//we stack the orbits up client side, so we can assign this back to normal server side without it breaking the orbit
-	orbiter.transform = initial_transform
 	orbiter.forceMove(get_turf(parent))
 	to_chat(orbiter, "<span class='notice'>Now orbiting [parent].</span>")
 
@@ -96,6 +97,8 @@
 		return
 	UnregisterSignal(orbiter, COMSIG_MOVABLE_MOVED)
 	orbiter.SpinAnimation(0, 0)
+	if(istype(orbiters[orbiter],/matrix)) //This is ugly.
+		orbiter.transform = orbiters[orbiter]
 	orbiters -= orbiter
 	orbiter.stop_orbit(src)
 	orbiter.orbiting = null


### PR DESCRIPTION
### Intent of your Pull Request

Fixes ghosts orbit being offset to the left. All credit to the original coder **AnturK**.
https://github.com/tgstation/tgstation/pull/51198

I've only ported half of the Above PR because the second part it adds (matrix VV preview), Yogs appears to not have the asset cache required for it to work, so I only included the orbit part.

Fixes #8357 

#### Changelog

:cl:  AnturK
bugfix: Fixes ghosts orbit being offset to the left.
/:cl:
