### PR TITLE
Adds holotool to Omegastation

### DIFF
--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -32954,6 +32954,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/holotool,
 /turf/open/floor/plasteel/dark,
 /area/science/research)
 "aXJ" = (


### PR DESCRIPTION
Adds the experimental holotool to Omegastation. It's placed on the table in the RD server room. Without this change there's a chance that antags are tasked with stealing the holotool, which is impossible because it doesn't exist (without admin intervention, at least). I tested the change and sure enough, it's on the table.

#### Changelog

:cl:  
tweak: Added holotool to RD server room.
/:cl:
