### PR TITLE
fix bood shitcode

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -49,6 +49,7 @@
 	tools = list(/obj/item/screwdriver)
 	time = 120
 	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
 	always_availible = FALSE
 
 /datum/crafting_recipe/knifeboxing
@@ -58,6 +59,7 @@
 				/obj/item/kitchen/knife = 2)
 	time = 100
 	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
 	always_availible = FALSE
 
 //Normal recipes


### PR DESCRIPTION
fixes #8761
:cl:  
bugfix: laser rifle and knifeboxing gloves are no longer broken and will now actually show up in the crafting menu
/:cl:
