### PR TITLE
Reduced fake armblade damage

### DIFF
--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -123,8 +123,7 @@
 
 /obj/item/melee/arm_blade/false
 	desc = "A grotesque mass of flesh that used to be your arm. On the bright side, at least you can cut wood with this."
-	force = 30 //yogs -- Prevents dual-stinging people with this sting to render them defenseless.
-	//daily reminder that xantam is a closet furry
+	force = 8
 	fake = TRUE
 
 /datum/action/changeling/sting/false_armblade/can_sting(mob/user, mob/target)

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -123,7 +123,7 @@
 
 /obj/item/melee/arm_blade/false
 	desc = "A grotesque mass of flesh that used to be your arm. On the bright side, at least you can cut wood with this."
-	force = 8
+	force = 5
 	fake = TRUE
 
 /datum/action/changeling/sting/false_armblade/can_sting(mob/user, mob/target)
@@ -133,6 +133,9 @@
 		var/mob/living/L = target
 		if((HAS_TRAIT(L, TRAIT_HUSK)) || !L.has_dna())
 			to_chat(user, "<span class='warning'>Our sting appears ineffective against its DNA.</span>")
+			return 0
+		for(var/obj/item/melee/arm_blade/A in L.held_items)
+			to_chat(user, "<span class='warning'>Their DNA already codes for a blade!</span>")
 			return 0
 	return 1
 


### PR DESCRIPTION
### Intent of your Pull Request
The changeling armblade sting got stealthnerfed so hard the description didn't even get updated.  "Gives your target a free esword" isn't quite worth 20 chemicals and an ability slot.

This PR also prevents double-stinging people to block both their hands.

#### Changelog

:cl:  
tweak: The armblades given by the 'fake armblade sting' aren't as good as the real thing anymore.
tweak: Changelings can only give victims one fake armblade at a time.
/:cl:
