### PR TITLE
Space vines pry open doors now

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -508,6 +508,30 @@
 		if(!locate(/obj/structure/spacevine, stepturf))
 			if(master)
 				master.spawn_spacevine_piece(stepturf, src)
+	else if(locate(/obj/machinery/door, stepturf) && !locate(/obj/structure/spacevine, stepturf)) //if there's a door in the way
+		var/obj/machinery/door/D = locate(/obj/machinery/door, stepturf)
+		if(D)
+			if(!D.locked && !D.welded)
+				if(!locate(/obj/structure/spacevine, stepturf))
+					if(istype(D, /obj/machinery/door/airlock))
+						if(!istype(D, /obj/machinery/door/airlock/external))
+							var/obj/machinery/door/airlock/A = D
+							playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, 1)
+							sleep(60)
+							A.open(2)
+							for(var/datum/spacevine_mutation/SM in mutations)
+								SM.on_spread(src, stepturf)
+								stepturf = get_step(src,direction)
+							if(master)
+								master.spawn_spacevine_piece(stepturf, src)
+					else
+						if(!istype(D, /obj/machinery/door/firedoor))
+							D.open()
+							for(var/datum/spacevine_mutation/SM in mutations)
+								SM.on_spread(src, stepturf)
+								stepturf = get_step(src,direction)
+							if(master)
+								master.spawn_spacevine_piece(stepturf, src)
 
 /obj/structure/spacevine/ex_act(severity, target)
 	if(istype(target, type)) //if its agressive spread vine dont do anything


### PR DESCRIPTION
Kudzu will pry open airlocks, similar to how the jaws of life would pry open one, allowing them to leave small rooms and expand more, making the event an actual threat rather than a bunch of silly string stuck in a small maint room nobody will check.

The vines aren't able to open airlocks leading to space or firelocks in order to avoid mass depressurization.

:cl:  
rscadd: Kudzu opens airlocks
/:cl:
