### PR TITLE
wizard academy doesn't spawn

### DIFF
--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -305,6 +305,7 @@
 		of the area exists in any records. After all, it's not like \
 		some doofus with an EVA suit and jetpack can just waltz around \
 		in space and find it..."
+	unpickable = TRUE
 
 /datum/map_template/ruin/space/spacebar
 	id = "spacebar"


### PR DESCRIPTION
A ruin that is defended by basic simplemobs and has a bunch of loot is ass to balance 

:cl:  
rscdel: wizard academy no longer spawns
/:cl:
