### PR TITLE
Broken walls now trigger an air update

### DIFF
--- a/code/game/turfs/simulated/wall/misc_walls.dm
+++ b/code/game/turfs/simulated/wall/misc_walls.dm
@@ -90,24 +90,6 @@
 		animate(src, color = previouscolor, time = 8)
 		addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 8)
 
-/turf/closed/wall/clockwork/dismantle_wall(devastated=0, explode=0)
-	if(devastated)
-		devastate_wall()
-		ScrapeAway()
-	else
-		playsound(src, 'sound/items/welder.ogg', 100, 1)
-		var/newgirder = break_wall()
-		if(newgirder) //maybe we want a gear!
-			transfer_fingerprints_to(newgirder)
-		ScrapeAway()
-
-	for(var/obj/O in src) //Eject contents!
-		if(istype(O, /obj/structure/sign/poster))
-			var/obj/structure/sign/poster/P = O
-			P.roll_and_drop(src)
-		else
-			O.forceMove(src)
-
 /turf/closed/wall/clockwork/devastate_wall()
 	for(var/i in 1 to 2)
 		new/obj/item/clockwork/alloy_shards/large(src)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -70,7 +70,8 @@
 			var/obj/structure/sign/poster/P = O
 			P.roll_and_drop(src)
 
-	ScrapeAway()
+	var/turf/new_floor = ScrapeAway()
+	new_floor.air_update_turf()
 
 /turf/closed/wall/proc/break_wall()
 	new sheet_type(src, sheet_amount)


### PR DESCRIPTION
### Intent of your Pull Request
Fixes the bug where breaking a wall won't in itself trigger an atmos update.  You can test this out yourself by C4ing a wall to space and enjoying the magical invisible airlock.

#### Changelog
:cl:  
bugfix: Destroyed walls no longer hold air very well.
/:cl:
