### PR TITLE
Airlocks don't feel clunky anymore

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1282,7 +1282,7 @@
 	layer = CLOSED_DOOR_LAYER
 	if(air_tight)
 		air_update_turf(1)
-	sleep(2)
+	sleep(1)
 	density = TRUE
 	if(!air_tight)
 		density = TRUE

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1237,8 +1237,9 @@
 	sleep(1)
 	set_opacity(0)
 	update_freelook_sight()
+	sleep(1)
 	density = FALSE
-	sleep(4)
+	sleep(3)
 	air_update_turf(1)
 	sleep(1)
 	layer = OPEN_DOOR_LAYER

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1237,8 +1237,8 @@
 	sleep(1)
 	set_opacity(0)
 	update_freelook_sight()
-	sleep(4)
 	density = FALSE
+	sleep(4)
 	air_update_turf(1)
 	sleep(1)
 	layer = OPEN_DOOR_LAYER

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1281,9 +1281,9 @@
 	update_icon(AIRLOCK_CLOSING, 1)
 	layer = CLOSED_DOOR_LAYER
 	if(air_tight)
-		density = TRUE
 		air_update_turf(1)
-	sleep(1)
+	sleep(2)
+	density = TRUE
 	if(!air_tight)
 		density = TRUE
 		air_update_turf(1)


### PR DESCRIPTION
This ancient airlock code hasn't been touched for 3 years.

Before:
------
![9ptsUpqXBI](https://user-images.githubusercontent.com/24533979/83831883-f0ef7780-a6ad-11ea-9c0f-3743ce1205c8.gif)

After:
------
EDIT:
-----
Fine-tuned the speed as it looked too early initially.

Here is how it looks now:
![2Cgm6W0LwM](https://user-images.githubusercontent.com/24533979/83833291-395c6480-a6b1-11ea-83ab-bd44d2d2c054.gif)


EDIT 2:
--------

Per Monster's suggestion did the same thing to closing doors.

**Before:**
![gAS4sIeGQD](https://user-images.githubusercontent.com/24533979/83836328-b17a5880-a6b8-11ea-9e99-734e7bdf860f.gif)

**After:**
![a6F5eom0W0](https://user-images.githubusercontent.com/24533979/83836303-a0314c00-a6b8-11ea-9793-77da492ec954.gif)


#### Changelog

:cl:  Hopek
tweak: Makes airlocks feel less clunky by allowing you to walk through them when they're open on-screen vs when the full animation is done.
tweak: Makes airlocks feel even less clunky by allowing you to walk through them while closing when the on-screen animation has a gap VS you crashing into an invisible wall as soon as the animation starts.
/:cl:
