### PR TITLE
Doubles amount of Favor gained from power cells

### DIFF
--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -171,7 +171,7 @@
 	if(the_cell.charge < 3000)
 		to_chat(L,"<span class='notice'>[GLOB.deity] does not accept pity amounts of power.</span>")
 		return
-	adjust_favor(round(the_cell.charge/3000), L)
+	adjust_favor(round(the_cell.charge/1500), L)
 	to_chat(L, "<span class='notice'>You offer [the_cell]'s power to [GLOB.deity], pleasing them.</span>")
 	qdel(I)
 	return TRUE


### PR DESCRIPTION
This was suggested by someone in the Yog Discord, and made sense to me. 

Apparently, as-is, to gain enough Favor to convert one person to an android, you have to sacrifice approximately 27 fully-charged bluespace cells (or an equivalent of such). This is absurd, and relies on:
- Mining getting the necessary materials to build 27 bluespace power cells
- Science being competent enough to make 27 bluespace power cells
- Science being willing to fork over 27 bluespace power cells

That's just for _one_ conversion. If you want to start a whole sect of androidpeople, good luck with that.

So all this PR does is change the formula for adjustment from `[Cell Charge] / 3000` to `[Cell Charge] / *1500*`, doubling the amount of Favor gained from a cell's charge.

Note that the minimum cell charge required to sacrifice is still 3,000.

#### Changelog

:cl:  
tweak: The amount of Favor granted from cells is doubled.
/:cl:
