### PR TITLE
Lillith's pact refunds blood when it fails

### DIFF
--- a/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -326,9 +326,11 @@
 	for(var/mob/living/carbon/target in targets)
 		if(is_vampire(target))
 			to_chat(user, "<span class='warning'>They're already a vampire!</span>")
+			vamp.usable_blood += blood_used	// Refund cost
 			continue
 		if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
 			to_chat(user, "<span class='warning'>[target]'s mind is too strong!</span>")
+			vamp.usable_blood += blood_used	// Refund cost
 			continue
 		user.visible_message("<span class='warning'>[user] latches onto [target]'s neck, pure dread eminating from them.</span>", "<span class='warning'>You latch onto [target]'s neck, preparing to transfer your unholy blood to them.</span>", "<span class='warning'>A dreadful feeling overcomes you</span>")
 		target.reagents.add_reagent(/datum/reagent/medicine/salbutamol, 10) //incase you're choking the victim
@@ -345,6 +347,7 @@
 			if(!do_mob(user, target, 70))
 				to_chat(user, "<span class='danger'>The pact has failed! [target] has not became a vampire.</span>")
 				to_chat(target, "<span class='notice'>The visions stop, and you relax.</span>")
+				vamp.usable_blood += blood_used / 2	// Refund half the cost
 				return
 		if(!QDELETED(user) && !QDELETED(target))
 			to_chat(user, "<span class='notice'>. . .</span>")


### PR DESCRIPTION
### Intent of your Pull Request
The vampire ability Lillith's Pact now refunds your blood if the target is unconvertable (ie already a vamp or mindshielded.)  You only get half your blood back if you interrupt the process halfway, since that's probably a mistake you made.

#### Why it's good for the game
It's a bad thing to waste an entire person's worth of blood because you picked someone mindshielded or a random vampire.  This doesn't add difficulty, just annoyance.

inb4 intentional: Making things frustrating to use isn't good game balance, it's crappy game design.  It's better to fix this and nerf something else in compensation.

#### Changelog

:cl:  
tweak: Failed attempts at siring vampires now refund some blood.
/:cl:
