### PR TITLE
locks romerol behind hijack and martyr objectives

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -629,6 +629,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndie_kit/romerol
 	cost = 25
 	cant_discount = TRUE
+	include_objectives = list(/datum/objective/hijack, /datum/objective/martyr) //because it can basically become an entire new gamemode
 
 /datum/uplink_item/stealthy_weapons/sleepy_pen
 	name = "Sleepy Pen"


### PR DESCRIPTION
ive found it kind of stupid that we have this thing that any traitor can buy regardless of objective, but if you use it you get banned, despite the server already having the ability to lock items behind objective. ive just found it kind of dumb

:cl:  
tweak: romerol is FINALLY locked behind hijack and martyr
/:cl:
