### PR TITLE
Removes Reebe Meta - Loads Reebe without lag on Clock Mode

### DIFF
--- a/_maps/map_files/generic/City_of_Cogs.dmm
+++ b/_maps/map_files/generic/City_of_Cogs.dmm
@@ -130,11 +130,6 @@
 	},
 /turf/open/floor/clockwork/reebe,
 /area/reebe/city_of_cogs)
-"aB" = (
-/obj/structure/table/reinforced/brass,
-/obj/item/clockwork/construct_chassis/cogscarab,
-/turf/open/floor/clockwork/reebe,
-/area/reebe/city_of_cogs)
 "aC" = (
 /obj/machinery/sleeper/clockwork{
 	dir = 1
@@ -232,6 +227,11 @@
 	name = "paper - 'Station Radio Frequencies'"
 	},
 /turf/closed/wall/clockwork,
+/area/reebe/city_of_cogs)
+"Vl" = (
+/obj/structure/table/reinforced/brass,
+/obj/effect/landmark/servant_of_ratvar/scarab,
+/turf/open/floor/clockwork/reebe,
 /area/reebe/city_of_cogs)
 
 (1,1,1) = {"
@@ -3552,7 +3552,7 @@ aj
 aj
 ah
 aj
-aB
+Vl
 ai
 aj
 aj
@@ -3915,7 +3915,7 @@ aj
 aj
 aj
 aj
-aB
+Vl
 az
 ah
 ai
@@ -4002,7 +4002,7 @@ aj
 aj
 aj
 ai
-aB
+Vl
 aj
 aj
 aj

--- a/code/_globalvars/lists/mapping.dm
+++ b/code/_globalvars/lists/mapping.dm
@@ -37,6 +37,7 @@ GLOBAL_LIST_EMPTY(secequipment) //sec equipment lockers that scale with the numb
 GLOBAL_LIST_EMPTY(deathsquadspawn)
 GLOBAL_LIST_EMPTY(emergencyresponseteamspawn)
 GLOBAL_LIST_EMPTY(servant_spawns) //Servants of Ratvar spawn here
+GLOBAL_LIST_EMPTY(servant_spawns_scarabs) //Servants of Ratvar spawn here
 GLOBAL_LIST_EMPTY(city_of_cogs_spawns) //Anyone entering the City of Cogs spawns here
 GLOBAL_LIST_EMPTY(ruin_landmarks)
 

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -112,6 +112,15 @@ SUBSYSTEM_DEF(mapping)
 	seedStation()
 	loading_ruins = FALSE
 #endif
+
+	//Load Reebe
+	var/list/errorList = list()
+	var/list/reebes = SSmapping.LoadGroup(errorList, "Reebe", "map_files/generic", "City_of_Cogs.dmm", default_traits = ZTRAITS_REEBE, silent = TRUE)
+	if(errorList.len)	// reebe failed to load
+		message_admins("Reebe failed to load!")
+		log_game("Reebe failed to load!")
+	for(var/datum/parsed_map/PM in reebes)
+		PM.initTemplateBounds()
 	// Add the transit level
 	transit = add_new_zlevel("Transit/Reserved", list(ZTRAIT_RESERVED = TRUE))
 	repopulate_sorted_areas()

--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -148,14 +148,6 @@ Credit where due:
 	var/datum/team/clockcult/main_clockcult
 
 /datum/game_mode/clockwork_cult/pre_setup()
-	var/list/errorList = list()
-	var/list/reebes = SSmapping.LoadGroup(errorList, "Reebe", "map_files/generic", "City_of_Cogs.dmm", default_traits = ZTRAITS_REEBE, silent = TRUE)
-	if(errorList.len)	// reebe failed to load
-		message_admins("Reebe failed to load!")
-		log_game("Reebe failed to load!")
-		return FALSE
-	for(var/datum/parsed_map/PM in reebes)
-		PM.initTemplateBounds()
 	if(CONFIG_GET(flag/protect_roles_from_antagonist))
 		restricted_jobs += protected_jobs
 	if(CONFIG_GET(flag/protect_assistant_from_antagonist))
@@ -191,6 +183,9 @@ Credit where due:
 		greet_servant(L)
 		equip_servant(L)
 		add_servant_of_ratvar(L, TRUE)
+	var/list/cog_spawns = GLOB.servant_spawns_scarabs.Copy()
+	for(var/obj/effect/landmark/L in cog_spawns)
+		new /obj/item/clockwork/construct_chassis/cogscarab(get_turf(L))
 	var/obj/structure/destructible/clockwork/massive/celestial_gateway/G = GLOB.ark_of_the_clockwork_justiciar //that's a mouthful
 	G.final_countdown(ark_time)
 	..()

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -306,7 +306,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 	GLOB.xeno_spawn += loc
 	return INITIALIZE_HINT_QDEL
 
-//objects with the stationloving component (nuke disk) respawn here. 
+//objects with the stationloving component (nuke disk) respawn here.
 //also blobs that have their spawn forcemoved (running out of time when picking their spawn spot), santa and respawning devils
 /obj/effect/landmark/blobstart
 	name = "blobstart"
@@ -401,6 +401,17 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 /obj/effect/landmark/servant_of_ratvar/Initialize(mapload)
 	..()
 	GLOB.servant_spawns += loc
+	return INITIALIZE_HINT_QDEL
+
+//Servant spawn locations
+/obj/effect/landmark/servant_of_ratvar/scarab
+	name = "servant of ratvar spawn"
+	icon_state = "clockwork_orange"
+	layer = MOB_LAYER
+
+/obj/effect/landmark/servant_of_ratvar/scarab/Initialize(mapload)
+	..()
+	GLOB.servant_spawns_scarabs += loc
 	return INITIALIZE_HINT_QDEL
 
 //City of Cogs entrances


### PR DESCRIPTION
Removes Reebe Meta - Loads the map all the time now during normal map setup, reduces setup time on clock cult gamemode preventing meta spotting.

Also means dynamic can now use clock cult as well.

### Changelog

:cl:  
rscdel: Reebe Load lag on clock round
/:cl:
