### PR TITLE
adds a upload console to ai sat on box

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -59532,18 +59532,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
-"vZa" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/darkblue{
-	dir = 1
-	},
-/obj/structure/sign/departments/minsky/command/charge{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "vZM" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -59773,6 +59761,21 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"wvD" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/structure/sign/departments/minsky/command/charge{
+	pixel_y = 32
+	},
+/obj/machinery/computer/upload/ai{
+	name = "\improper Remote AI upload console"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "wvK" = (
 /obj/machinery/button/door{
 	id = "maint2";
@@ -101594,7 +101597,7 @@ fSL
 piS
 tmG
 pnH
-vZa
+wvD
 lZD
 vpQ
 jOp


### PR DESCRIPTION
moving tcomms to on the station was a definite antag nerf and this helps to alleviate that by adding a upload console to the ai sat while still keeping its turrets and the like intact
:cl:  
rscadd: Added a ai upload console to ai sat on box
/:cl:
