### PR TITLE
L6 Saw Price increase (18TC --> 20TC)

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -451,7 +451,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A fully-loaded Aussec Armoury belt-fed machine gun. \
 			This deadly weapon has a massive 50-round magazine of devastating 7.12x82mm ammunition."
 	item = /obj/item/gun/ballistic/automatic/l6_saw
-	cost = 20 
+	cost = 20
 	surplus = 0
 	include_modes = list(/datum/game_mode/nuclear)
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -451,7 +451,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A fully-loaded Aussec Armoury belt-fed machine gun. \
 			This deadly weapon has a massive 50-round magazine of devastating 7.12x82mm ammunition."
 	item = /obj/item/gun/ballistic/automatic/l6_saw
-	cost = 20
+	cost = 20 
 	surplus = 0
 	include_modes = list(/datum/game_mode/nuclear)
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -451,7 +451,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A fully-loaded Aussec Armoury belt-fed machine gun. \
 			This deadly weapon has a massive 50-round magazine of devastating 7.12x82mm ammunition."
 	item = /obj/item/gun/ballistic/automatic/l6_saw
-	cost = 18
+	cost = 20
 	surplus = 0
 	include_modes = list(/datum/game_mode/nuclear)
 


### PR DESCRIPTION
### Intent of your Pull Request

Seeing how powerful the saw is as it has a large amount of ammo, can (apparently) one shot through armor, and shreds through objects, I feel like this is a decent way of nerfing it other than touching the gun directly.

I was debating making it a +4 increase instead of +2, but I feel like this would be okay till I get some feedback.

#### Changelog

:cl:  
tweak: Increases the price of the L6 Saw by +2 TC (18 --> 20)
/:cl:
