### PR TITLE
removes the prison jumpskirts from the brig lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -200,7 +200,6 @@
 /obj/structure/closet/secure_closet/brig/PopulateContents()
 	..()
 	new /obj/item/clothing/under/rank/prisoner( src )
-	new /obj/item/clothing/under/rank/prisoner/skirt( src )
 	new /obj/item/clothing/shoes/sneakers/orange( src )
 
 /obj/structure/closet/secure_closet/courtroom


### PR DESCRIPTION
it is straight up fetish content and there's no reason for them to be in there, you dont have a choice on if you want it on or not.

#### Changelog

:cl:  
rscdel: removes the prison jumpskirts from the brig locker
/:cl:
