### PR TITLE
probably actually fixes chiro screech vs ear protection

### DIFF
--- a/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -267,7 +267,7 @@
 	user.visible_message("<span class='warning'>[user] lets out an ear piercing shriek!</span>", "<span class='warning'>You let out a loud shriek.</span>", "<span class='warning'>You hear a loud painful shriek!</span>")
 	for(var/mob/living/carbon/C in hearers(4))
 		if(!C == user  || !is_vampire(C))
-			if(ishuman(C) && !C.get_ear_protection())
+			if(ishuman(C) && C.soundbang_act(1, 0))
 				to_chat(C, "<span class='warning'><font size='3'><b>You hear a ear piercing shriek and your senses dull!</font></b></span>")
 				C.Knockdown(40)
 				C.adjustEarDamage(0, 30)


### PR DESCRIPTION
get_ear_protection only targets actual ears and not any outside protection so it is completely useless
fixes #8841
:cl:  
bugfix: vampire screech is blocked by gamer headphones
/:cl:
