### PR TITLE
2 New Clown ERTs

### DIFF
--- a/code/datums/ert.dm
+++ b/code/datums/ert.dm
@@ -119,7 +119,7 @@
 	teamsize = 7
 	opendoors = FALSE
 	rename_team = "The Circus"
-	mission = "Provide vital morale support to the station in this time of crisis"
+	mission = "Provide vital moral support to the station in this time of crisis"
 	code = "Banana"
 
 /datum/ert/honk

--- a/code/datums/ert.dm
+++ b/code/datums/ert.dm
@@ -114,10 +114,20 @@
 	polldesc = "a Nanotrasen Janitorial Response Team"
 
 /datum/ert/clown
-	roles = list(/datum/antagonist/ert/clown, /datum/antagonist/ert/clown/robust)
-	leader_role = /datum/antagonist/ert/clown/robust
+	roles = list(/datum/antagonist/ert/clown)
+	leader_role = /datum/antagonist/ert/clown
 	teamsize = 7
 	opendoors = FALSE
+	rename_team = "The Circus"
+	mission = "Provide vital morale support to the station in this time of crisis"
+	code = "Banana"
+
+/datum/ert/honk
+	roles = list(/datum/antagonist/ert/clown/honk)
+	leader_role = /datum/antagonist/ert/clown/honk
+	teamsize = 5
+	opendoors = TRUE
 	rename_team = "HONK Squad"
-	mission = "Bring joy and happiness to all the crew the only way a clown can. Honk!"
-	polldesc = "a Nanotrasen Clown Response Team"
+	mission = "HONK them into submission"
+	polldesc = "an elite Nanotrasen tactical pranking squad"
+	code = "HOOOOOOOOOONK"

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -288,7 +288,7 @@
 
 /obj/item/pneumatic_cannon/pie/selfcharge/compact
 	name = "honkinator-4 compact pie cannon"
-	desc = "A compact, self loading pie cannon for tactical pranking action."
+	desc = "A compact, self-loading pie cannon for tactical pranking action."
 	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/pneumatic_cannon/pie/selfcharge/cyborg

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -286,6 +286,11 @@
 	charge_type = /obj/item/reagent_containers/food/snacks/pie/cream
 	maxWeightClass = 60	//20 pies.
 
+/obj/item/pneumatic_cannon/pie/selfcharge/compact
+	name = "honkinator-4 compact pie cannon"
+	desc = "A compact, self loading pie cannon for tactical pranking action."
+	w_class = WEIGHT_CLASS_NORMAL
+
 /obj/item/pneumatic_cannon/pie/selfcharge/cyborg
 	name = "low velocity pie cannon"
 	automatic = FALSE

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -46,6 +46,12 @@
 	item_flags = NO_MAT_REDEMPTION
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 50)
 	component_type = /datum/component/storage/concrete/bluespace/bag_of_holding
+	
+/obj/item/storage/backpack/holding/clown
+	name = "bag of honking"
+	desc = "An advanced clowning backpack for holding large quantities of pranking gear"
+	icon_state = "clownpack"
+	item_state = "clownpack"
 
 /obj/item/storage/backpack/holding/ComponentInitialize()
 	. = ..()

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -49,7 +49,7 @@
 	
 /obj/item/storage/backpack/holding/clown
 	name = "bag of honking"
-	desc = "An advanced clowning backpack for holding large quantities of pranking gear"
+	desc = "An advanced clowning backpack for holding large quantities of pranking gear."
 	icon_state = "clownpack"
 	item_state = "clownpack"
 

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -33,6 +33,10 @@
 /datum/antagonist/ert/deathsquad/New()
 	. = ..()
 	name_source = GLOB.commando_names
+	
+/datum/antagonist/ert/clown/New()
+	. = ..()
+	name_source = GLOB.clown_names
 
 /datum/antagonist/ert/deathsquad/apply_innate_effects(mob/living/mob_override)
 	ADD_TRAIT(owner, TRAIT_DISK_VERIFIER, DEATHSQUAD_TRAIT)
@@ -141,6 +145,16 @@
 	outfit = /datum/outfit/amber/commander
 	role = "Commander"
 
+/datum/antagonist/ert/clown
+	name = "Comedy Response Officer"
+	outfit = /datum/outfit/centcom_clown
+	role = "Prankster"
+
+/datum/antagonist/ert/clown/honk
+	name = "HONK Squad Trooper"
+	outfit = /datum/outfit/centcom_clown/honk_squad
+	role = "HONKER"
+
 /datum/antagonist/ert/create_team(datum/team/ert/new_team)
 	if(istype(new_team))
 		ert_team = new_team
@@ -190,3 +204,17 @@
 
 	missiondesc += "<BR><B>Your Mission</B> : [ert_team.mission.explanation_text]"
 	to_chat(owner,missiondesc)
+
+/datum/antagonist/ert/clown/greet()
+	if(!ert_team)
+		return
+
+	to_chat(owner, "<B><font size=3 color=red>You are the [name].</font></B>")
+
+	var/missiondesc = "Your squad is being sent on a mission to [station_name()] by Nanotrasen's Comedy Division."
+	if(leader) //If Squad Leader
+		missiondesc += " You are the worst clown here. As such, you were able to stop slipping the admiral for long enough to be given command. Good luck, honk!"
+	else
+		missiondesc += " Follow orders given to you by your squad leader in order to ensure maximum laughs."
+
+		missiondesc += " Be the funniest Prankster possible!"

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -120,16 +120,6 @@
 	outfit = /datum/outfit/death_commando
 	role = "Officer"
 
-/datum/antagonist/ert/clown/robust
-	name = "Clown Commander"
-	outfit = /datum/outfit/ert/clown/leader
-	role = "Clown Commander"
-
-/datum/antagonist/ert/clown
-	name = "Clown"
-	outfit = /datum/outfit/ert/clown
-	role = "Clown"
-
 /datum/antagonist/ert/amber
 	name = "Amber Soldier"
 	outfit = /datum/outfit/amber

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -301,7 +301,7 @@
 	id = /obj/item/card/id/centcom
 	belt = /obj/item/pda/clown
 	ears = /obj/item/radio/headset/headset_cent
-	uniform = /obj/item/clothing/under/rank/civilian/clown
+	uniform = /obj/item/clothing/under/rank/clown
 	back = /obj/item/storage/backpack/clown
 	shoes = /obj/item/clothing/shoes/clown_shoes
 	mask = /obj/item/clothing/mask/gas/clown_hat
@@ -337,7 +337,7 @@
 /datum/outfit/centcom_clown/honk_squad
 	name = "HONK Squad Trooper"
 	back = /obj/item/storage/backpack/holding/clown
-	shoes = /obj/item/clothing/shoes/clown_shoes/taeclowndo
+	shoes = /obj/item/clothing/shoes/clown_shoes/combat
 	suit = /obj/item/clothing/suit/space/hardsuit/shielded/swat/honk
 	suit_store = /obj/item/tank/internals/emergency_oxygen/double
 	l_pocket = /obj/item/bikehorn/golden

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -296,39 +296,58 @@
 		/obj/item/melee/classic_baton/telescopic=1,\
 		/obj/item/grenade/clusterbuster/cleaner=3)
 
-/datum/outfit/ert/clown
-	name = "Honk Squad Clown"
-	id = /obj/item/card/id/ert/clown
+/datum/outfit/centcom_clown
+	name = "Code Banana ERT"
+	id = /obj/item/card/id/centcom
 	belt = /obj/item/pda/clown
 	ears = /obj/item/radio/headset/headset_cent
-	uniform = /obj/item/clothing/under/rank/clown
+	uniform = /obj/item/clothing/under/rank/civilian/clown
+	back = /obj/item/storage/backpack/clown
 	shoes = /obj/item/clothing/shoes/clown_shoes
 	mask = /obj/item/clothing/mask/gas/clown_hat
 	l_pocket = /obj/item/bikehorn
-	r_hand = /obj/item/pneumatic_cannon/pie/selfcharge
 	backpack_contents = list(
 		/obj/item/stamp/clown = 1,
-		/obj/item/reagent_containers/spray/waterflower = 1,
+		/obj/item/reagent_containers/spray/waterflower/lube = 1,
 		/obj/item/reagent_containers/food/snacks/grown/banana = 1,
 		/obj/item/instrument/bikehorn = 1,
+		/obj/item/megaphone/clown = 1,
 		)
-	implants = list(/obj/item/implant/sad_trombone)
-	back = /obj/item/storage/backpack/clown
-	box = /obj/item/storage/box/hug/survival
-	chameleon_extras = /obj/item/stamp/clown
 
-/datum/outfit/ert/clown/leader
-	name = "Honk Squad Leader"
-	id = /obj/item/card/id/ert/clown
-	uniform = /obj/item/clothing/under/rank/clown
-	shoes = /obj/item/clothing/shoes/clown_shoes
-	gloves = /obj/item/clothing/gloves/color/black
-	mask = /obj/item/clothing/mask/gas/clown_hat
-	ears = /obj/item/radio/headset/headset_cent
-	glasses = /obj/item/clothing/glasses/thermal/monocle
-	suit = /obj/item/clothing/suit/hooded/chaplain_hoodie
-	back = /obj/item/storage/backpack/clown
-	l_pocket = /obj/item/reagent_containers/food/snacks/grown/banana
-	r_pocket = /obj/item/bikehorn
-	r_hand = /obj/item/twohanded/fireaxe
+	implants = list(/obj/item/implant/sad_trombone)
+
+
+/datum/outfit/centcom_clown/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	if(visualsOnly)
+		return
+
+	var/obj/item/implant/mindshield/L = new/obj/item/implant/mindshield(H)
+	L.implant(H, null, 1)
+
+	var/obj/item/radio/R = H.ears
+	R.set_frequency(FREQ_CENTCOM)
+	R.freqlock = TRUE
+
+	var/obj/item/card/id/W = H.wear_id
+	W.registered_name = H.real_name
+	W.access += ACCESS_THEATRE
+	W.update_label(W.registered_name, W.assignment)
+	H.dna.add_mutation(CLOWNMUT)
+
+/datum/outfit/centcom_clown/honk_squad
+	name = "HONK Squad Trooper"
+	back = /obj/item/storage/backpack/holding/clown
+	shoes = /obj/item/clothing/shoes/clown_shoes/taeclowndo
+	suit = /obj/item/clothing/suit/space/hardsuit/shielded/swat/honk
+	suit_store = /obj/item/tank/internals/emergency_oxygen/double
+	l_pocket = /obj/item/bikehorn/golden
+	r_pocket = /obj/item/shield/energy/bananium
 	l_hand = /obj/item/pneumatic_cannon/pie/selfcharge
+	backpack_contents = list(
+		/obj/item/stamp/clown = 1,
+		/obj/item/reagent_containers/spray/waterflower/lube = 1,
+		/obj/item/reagent_containers/food/snacks/grown/banana = 1,
+		/obj/item/instrument/bikehorn = 1,
+		/obj/item/megaphone/clown = 1,
+		/obj/item/reagent_containers/spray/chemsprayer/janitor/clown = 1,
+		)

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -1047,7 +1047,7 @@
 
 /obj/item/clothing/head/helmet/space/hardsuit/shielded/swat/honk
 	name = "honk squad helmet"
-	desc = "A hilarious helmet with built in anti-mime propaganda shielding."
+	desc = "A hilarious helmet with built-in anti-mime propaganda shielding."
 	icon_state = "hardsuit0-clown"
 	item_state = "hardsuit0-clown"
 	item_color = "clown"

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -1036,6 +1036,21 @@
 	strip_delay = 130
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	actions_types = list()
+	
+/obj/item/clothing/suit/space/hardsuit/shielded/swat/honk
+	name = "honk squad spacesuit"
+	desc = "A hilarious hardsuit favored by HONK squad troopers for use in special pranks."
+	icon_state = "hardsuit-clown"
+	item_state = "clown_hardsuit"
+	item_color = "clown"
+	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/shielded/swat/honk
+
+/obj/item/clothing/head/helmet/space/hardsuit/shielded/swat/honk
+	name = "honk squad helmet"
+	desc = "A hilarious helmet with built in anti-mime propaganda shielding."
+	icon_state = "hardsuit0-clown"
+	item_state = "hardsuit0-clown"
+	item_color = "clown"
 
 //POWERARMORS
 //Currently are no different from normal hardsuits, except maybe for the higher armor ratings.

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -119,6 +119,10 @@
 			return get_ert_access("med")
 		if("CentCom Bartender")
 			return list(ACCESS_CENT_GENERAL, ACCESS_CENT_LIVING, ACCESS_CENT_BAR)
+		if("Comedy Response Officer")
+			return list(ACCESS_CENT_GENERAL, ACCESS_CENT_LIVING)
+		if("HONK Squad Trooper")
+			return list(ACCESS_CENT_GENERAL, ACCESS_CENT_SPECOPS, ACCESS_CENT_LIVING, ACCESS_CENT_STORAGE)
 
 /proc/get_all_accesses()
 	return list(ACCESS_SECURITY, ACCESS_SEC_DOORS, ACCESS_BRIG, ACCESS_ARMORY, ACCESS_FORENSICS_LOCKERS, ACCESS_COURT,
@@ -364,7 +368,7 @@
 	return get_all_jobs() + list("Prisoner")
 
 /proc/get_all_centcom_jobs()
-	return list("VIP Guest","Custodian","Thunderdome Overseer","CentCom Official","Medical Officer","Research Officer","Special Ops Officer","Admiral","CentCom Commander","Emergency Response Team Commander","Security Response Officer","Engineer Response Officer", "Medical Response Officer","CentCom Bartender", "Janitorial Response Officer", "Religious Response Officer", "CentCom Captain", "CentCom Major", "CentCom Commodore", "CentCom Colonel", "CentCom Rear-Admiral", "CentCom Admiral", "CentCom Grand Admiral")
+	return list("VIP Guest","Custodian","Thunderdome Overseer","CentCom Official","Medical Officer","Research Officer","Special Ops Officer","Admiral","CentCom Commander","Emergency Response Team Commander","Security Response Officer","Engineer Response Officer", "Medical Response Officer","CentCom Bartender", "Janitorial Response Officer", "Religious Response Officer", "CentCom Captain", "CentCom Major", "CentCom Commodore", "CentCom Colonel", "CentCom Rear-Admiral", "CentCom Admiral", "CentCom Grand Admiral", "Comedy Response Officer", "HONK Squad Trooper")
 
 /proc/get_all_task_force_jobs()
 	return list("Amber Soldier","Amber Commander","Amber Medic","Amber Task Force")

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -362,7 +362,7 @@
 
 /obj/item/reagent_containers/spray/chemsprayer/janitor/clown
 	name = "lubinator 8000"
-	desc = "A modified industrial cleaning sprayer, capable of coating entire hallways in high performance lubricant, honk!"
+	desc = "A modified industrial cleaning sprayer capable of coating entire hallways in a high-performance lubricant, honk!"
 	icon_state = "chemsprayer"
 	item_state = "chemsprayer"
 	list_reagents = list(/datum/reagent/lube = 1000)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -360,6 +360,14 @@
 	last_generate = world.time
 	reagents.add_reagent(generate_type, generate_amount)
 
+/obj/item/reagent_containers/spray/chemsprayer/janitor/clown
+	name = "lubinator 8000"
+	desc = "A modified industrial cleaning sprayer, capable of coating entire hallways in high performance lubricant, honk!"
+	icon_state = "chemsprayer"
+	item_state = "chemsprayer"
+	list_reagents = list(/datum/reagent/lube = 1000)
+	generate_type = /datum/reagent/lube
+
 // Plant-B-Gone
 /obj/item/reagent_containers/spray/plantbgone // -- Skie
 	name = "Plant-B-Gone"


### PR DESCRIPTION
### Intent of your Pull Request

https://github.com/BeeStation/BeeStation-Hornet/pull/1890

Replaces our old boring clown ERT (leader/troopers) with 2 new ones:

> Adds two new ERTs: the Code Banana ERT and the HONK Squad.

>Code Banana ERTs are just clowns with centcomm access, megaphones and lube flowers, making them even weaker than interns.

>The HONK Squad is much stronger. They get a special clown version of the death commando hardsuit, a new clown BoH, golden bikehorn, bananium eshield, combat clown shoes, a pie cannon and a self refilling lube sprayer.

Code Banana ERTs are much weaker and a way for some minor fun.

The actual HONK squad is slightly buffed, with new items (BOH version of the giggles von honkerton) as well as a HONK squad chempsrayer. It's much more powerful, and consequently intended for a funnier alternative to more tense situations.

#### Changelog

:cl:  
rscadd: Adds Code Banana ERT and new HONK squad  
rscdel: Old HONK Squad replaced
/:cl:
