### PR TITLE
Yogbot, HTTPS edition

### DIFF
--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -1,6 +1,10 @@
 // rust_g.dm - DM API for rust_g extension library
 #define RUST_G "rust_g"
 
+#define RUSTG_JOB_NO_RESULTS_YET "NO RESULTS YET"
+#define RUSTG_JOB_NO_SUCH_JOB "NO SUCH JOB"
+#define RUSTG_JOB_ERROR "JOB PANICKED"
+
 #define rustg_dmi_strip_metadata(fname) call(RUST_G, "dmi_strip_metadata")(fname)
 #define rustg_dmi_create_png(fname,width,height,data) call(RUST_G, "dmi_create_png")(fname,width,height,data)
 
@@ -9,3 +13,15 @@
 
 #define rustg_log_write(fname, text, format) call(RUST_G, "log_write")(fname, text, format)
 /proc/rustg_log_close_all() return call(RUST_G, "log_close_all")()
+
+// RUST-G defines & procs for HTTP component
+#define RUSTG_HTTP_METHOD_GET "get"
+#define RUSTG_HTTP_METHOD_POST "post"
+#define RUSTG_HTTP_METHOD_PUT "put"
+#define RUSTG_HTTP_METHOD_DELETE "delete"
+#define RUSTG_HTTP_METHOD_PATCH "patch"
+#define RUSTG_HTTP_METHOD_HEAD "head"
+
+#define rustg_http_request_blocking(method, url, body, headers) call(RUST_G, "http_request_blocking")(method, url, body, headers)
+#define rustg_http_request_async(method, url, body, headers) call(RUST_G, "http_request_async")(method, url, body, headers)
+#define rustg_http_check_request(req_id) call(RUST_G, "http_check_request")(req_id)

--- a/code/datums/http.dm
+++ b/code/datums/http.dm
@@ -30,7 +30,7 @@
 	id = rustg_http_request_async(method, url, body, headers)
 
 	if (isnull(text2num(id)))
-		CRASH("Proc error: [id]")
+		stack_trace("Proc error: [id]")
 		_raw_response = "Proc error: [id]"
 	else
 		in_progress = TRUE

--- a/code/datums/http.dm
+++ b/code/datums/http.dm
@@ -1,0 +1,74 @@
+/datum/http_request
+	var/id
+	var/in_progress = FALSE
+
+	var/method
+	var/body
+	var/headers
+	var/url
+
+	var/_raw_response
+
+/datum/http_request/proc/prepare(method, url, body = "", list/headers)
+	if (!length(headers))
+		headers = ""
+	else
+		headers = json_encode(headers)
+
+	src.method = method
+	src.url = url
+	src.body = body
+	src.headers = headers
+
+/datum/http_request/proc/execute_blocking()
+	_raw_response = rustg_http_request_blocking(method, url, body, headers)
+
+/datum/http_request/proc/begin_async()
+	if (in_progress)
+		CRASH("Attempted to re-use a request object.")
+
+	id = rustg_http_request_async(method, url, body, headers)
+
+	if (isnull(text2num(id)))
+		CRASH("Proc error: [id]")
+		_raw_response = "Proc error: [id]"
+	else
+		in_progress = TRUE
+
+/datum/http_request/proc/is_complete()
+	if (isnull(id))
+		return TRUE
+
+	if (!in_progress)
+		return TRUE
+
+	var/r = rustg_http_check_request(id)
+
+	if (r == RUSTG_JOB_NO_RESULTS_YET)
+		return FALSE
+	else
+		_raw_response = r
+		in_progress = FALSE
+		return TRUE
+
+/datum/http_request/proc/into_response()
+	var/datum/http_response/R = new()
+
+	try
+		var/list/L = json_decode(_raw_response)
+		R.status_code = L["status_code"]
+		R.headers = L["headers"]
+		R.body = L["body"]
+	catch
+		R.errored = TRUE
+		R.error = _raw_response
+
+	return R
+
+/datum/http_response
+	var/status_code
+	var/body
+	var/list/headers
+
+	var/errored = FALSE
+	var/error

--- a/config/config.txt
+++ b/config/config.txt
@@ -498,8 +498,8 @@ DEFAULT_VIEW 15x15
 ## You probably shouldn't ever be changing this, but it's here if you want to.
 DEFAULT_VIEW_SQUARE 15x15
 
-##Used to send round data to a webhook. Address must use HTTP without SSL because byond is horrible.
-#WEBHOOK_ADDRESS http://example.com
+##Used to send round data to a webhook. Can now use HTTPS thanks to rust_g
+#WEBHOOK_ADDRESS https://example.com
 #WEBHOOK_KEY webkey
 
 ## Comment this out if you want to use the SQL based mentor system, the legacy system uses mentors.txt.

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -334,6 +334,7 @@
 #include "code\datums\explosion.dm"
 #include "code\datums\forced_movement.dm"
 #include "code\datums\holocall.dm"
+#include "code\datums\http.dm"
 #include "code\datums\hud.dm"
 #include "code\datums\map_config.dm"
 #include "code\datums\martial.dm"

--- a/yogstation/code/modules/webhook/webhook.dm
+++ b/yogstation/code/modules/webhook/webhook.dm
@@ -2,9 +2,10 @@
 	if(!CONFIG_GET(string/webhook_address) || !CONFIG_GET(string/webhook_key))
 		return
 
-	var/query = "[CONFIG_GET(string/webhook_address)]?key=[CONFIG_GET(string/webhook_key)]&method=[method]&data=[json_encode(data)]"
-	spawn(-1)
-		world.Export(query)
+	var/url = "[CONFIG_GET(string/webhook_address)]?key=[CONFIG_GET(string/webhook_key)]&method=[method]&data=[json_encode(data)]"
+	var/datum/http_request/req = new()
+	req.prepare(RUSTG_HTTP_METHOD_GET, url, "", list())
+	req.begin_async() //why would we ever want to track the results of the request, meme made by yogstation gang
 
 /proc/webhook(var/ckey, var/message)
 	return list("ckey" = url_encode(ckey), "message" = url_encode(message))


### PR DESCRIPTION
Webhooks can now use HTTPS meaning we dont need to rely on HTTP for yogbot