### PR TITLE
makes felenids take toxin damage from chocolate

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -103,3 +103,9 @@
 
 	if(!silent)
 		to_chat(H, "You are no longer a cat.")
+
+/datum/species/human/felinid/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
+	. = ..()
+	
+	if(H.reagents.has_reagent(/datum/reagent/consumable/coco))
+		H.adjustToxLoss(2*REAGENTS_EFFECT_MULTIPLIER,FALSE,FALSE, BODYPART_ANY)

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -106,6 +106,5 @@
 
 /datum/species/human/felinid/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
 	. = ..()
-	
 	if(H.reagents.has_reagent(/datum/reagent/consumable/coco))
 		H.adjustToxLoss(2*REAGENTS_EFFECT_MULTIPLIER,FALSE,FALSE, BODYPART_ANY)


### PR DESCRIPTION
cats cant eat chocolate just like dogs. its just unlike dogs they wont actively go and eat it as it isnt appetizing to them.
#### Changelog

:cl:  
rscadd: Added felenids taking toxin damage from chocolate
/:cl:
