### PR TITLE
Remove unreachable code in surgery.dm

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -128,8 +128,6 @@
 
 	if(locate(/obj/structure/table/optable, T) || locate(/obj/machinery/stasis, T)) //yogs: stasis beds work for surgery
 		propability = 1
-	else if(locate(/obj/machinery/stasis, T))
-		propability = 0.9
 	else if(locate(/obj/structure/table, T))
 		propability = 0.8
 	else if(locate(/obj/structure/bed, T))


### PR DESCRIPTION
Stasis beds are already in probability 1 of the else if string so their individual else of bit from tg is never reached
