### PR TITLE
Port my SM rework to Yogstation

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -2,7 +2,7 @@
 //Please do not bother them with bugs from this port, however, as it has been modified quite a bit.
 //Modifications include removing the world-ending full supermatter variation, and leaving only the shard.
 
-#SUPERMATTER_MAXIMUM_ENERGY 1e6
+#define SUPERMATTER_MAXIMUM_ENERGY 1e6
 
 #define PLASMA_HEAT_PENALTY 15     // Higher == Bigger heat and waste penalty from having the crystal surrounded by this gas. Negative numbers reduce penalty.
 #define OXYGEN_HEAT_PENALTY 1

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -384,9 +384,9 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		co2comp = max(removed.get_moles(/datum/gas/carbon_dioxide)/combined_gas, 0)
 		n2ocomp = max(removed.get_moles(/datum/gas/nitrous_oxide)/combined_gas, 0)
 		n2comp = max(removed.get_moles(/datum/gas/nitrogen)/combined_gas, 0)
-		pluoxiumcomp = max(removed.gases[/datum/gas/pluoxium][MOLES]/combined_gas, 0)
-		tritiumcomp = max(removed.gases[/datum/gas/tritium][MOLES]/combined_gas, 0)
-		bzcomp = max(removed.gases[/datum/gas/bz][MOLES]/combined_gas, 0)
+		pluoxiumcomp = max(removed.get_moles(/datum/gas/pluoxium)/combined_gas, 0)
+		tritiumcomp = max(removed.get_moles(/datum/gas/tritium)/combined_gas, 0)
+		bzcomp = max(removed.get_moles(/datum/gas/bz][MOLES)/combined_gas, 0)
 		
 		if(pluoxiumcomp >= 0.15)
 			pluoxiumbonus = 1	// Bad code probably /shrug

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -390,7 +390,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		tritiumcomp = max(removed.get_moles(/datum/gas/tritium)/combined_gas, 0)
 		bzcomp = max(removed.get_moles(/datum/gas/bz)/combined_gas, 0)
 		
-		if(pluoxiumcomp >= 0.15)
+		if(pluoxiumcomp >= 0.02) // used to be 15% but moved it down to 2% as it's hard to achieve while farming pluoxium
 			pluoxiumbonus = 1	// Bad code probably /shrug
 		else
 			pluoxiumbonus = 0

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -10,7 +10,7 @@
 #define PLUOXIUM_HEAT_PENALTY -1
 #define TRITIUM_HEAT_PENALTY 10
 #define BZ_HEAT_PENALTY 5
-#define NITROGEN_HEAT_MODIFIER -1.5
+#define NITROGEN_HEAT_PENALTY -1.5
 
 #define OXYGEN_TRANSMIT_MODIFIER 1.5   //Higher == Bigger bonus to power generation.
 #define PLASMA_TRANSMIT_MODIFIER 4
@@ -386,7 +386,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		n2comp = max(removed.get_moles(/datum/gas/nitrogen)/combined_gas, 0)
 		pluoxiumcomp = max(removed.get_moles(/datum/gas/pluoxium)/combined_gas, 0)
 		tritiumcomp = max(removed.get_moles(/datum/gas/tritium)/combined_gas, 0)
-		bzcomp = max(removed.get_moles(/datum/gas/bz][MOLES)/combined_gas, 0)
+		bzcomp = max(removed.get_moles(/datum/gas/bz)/combined_gas, 0)
 		
 		if(pluoxiumcomp >= 0.15)
 			pluoxiumbonus = 1	// Bad code probably /shrug


### PR DESCRIPTION
### Intent of your Pull Request
   
- Tritium which has a heat penalty of 10(Plasma is 15) as strong as plasma but makes the Supermatter emit up-to 3x radiation at 100%

-  Pluoxium is a **stronger**~~weaker~~ form of n2o. It makes the SM produce less heat at -1(Nitrogen has -1.5), Reduces radiation by 2x at 100%(2500 compared to 7500), and has a heat buff of 12~~6~~(N2O is 6)

-  BZ starts emitting rad balls at concentrations above 40% up-to 50% and additional radballs(at 80%) per 150 mols. BZ will also increase radiation and waste gas output. Carries a heat penalty of 5(Plasma is 15) and also emits up-to 5x radiation at 100% (but has a power transmission debuff to make the radiation not increase the power to insane levels)

_Original_: https://github.com/tgstation/tgstation/pull/45676

### Patches/CCchanges:
Patch 1: https://github.com/austation/austation/pull/1047
Change 1: Moved pluoxium requirements down to 2%(only existed because people dunga'd) so there isnt a hitch
Change 2: Remove pluoxiumbonus code and buffed it, and also made bz radballs more common and can shoot out more.

#### Changelog

:cl:  
add: Added support for 3 new gasses; Tritium, Pluoxium, and BZ
/:cl:
