### PR TITLE
Adds sheep cubes, cow cubes, and strange seeds to the biogenerator

### DIFF
--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -16,7 +16,7 @@
 	var/productivity = 0
 	var/max_items = 40
 	var/datum/techweb/stored_research
-	var/list/show_categories = list("Food", "Botany Chemicals", "Organic Materials")
+	var/list/show_categories = list("Food", "Botanical Chemicals", "Organic Materials", "Special")
 	/// Currently selected category in the UI
 	var/selected_cat
 

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -2,6 +2,8 @@
 ///////Biogenerator Designs ///////
 ///////////////////////////////////
 
+//Food//
+
 /datum/design/milk
 	name = "10 Milk"
 	id = "milk"
@@ -75,13 +77,15 @@
 	build_path = /obj/item/reagent_containers/food/snacks/monkeycube
 	category = list("initial", "Food")
 
+//Botanical Chemicals//
+
 /datum/design/ez_nut
 	name = "E-Z Nutrient"
 	id = "ez_nut"
 	build_type = BIOGENERATOR
 	materials = list(MAT_BIOMASS = 10)
 	build_path = /obj/item/reagent_containers/glass/bottle/nutrient/ez
-	category = list("initial","Botany Chemicals")
+	category = list("initial","Botanical Chemicals")
 
 /datum/design/l4z_nut
 	name = "Left 4 Zed"
@@ -89,7 +93,7 @@
 	build_type = BIOGENERATOR
 	materials = list(MAT_BIOMASS = 20)
 	build_path = /obj/item/reagent_containers/glass/bottle/nutrient/l4z
-	category = list("initial","Botany Chemicals")
+	category = list("initial","Botanical Chemicals")
 
 /datum/design/rh_nut
 	name = "Robust Harvest"
@@ -97,7 +101,7 @@
 	build_type = BIOGENERATOR
 	materials = list(MAT_BIOMASS = 25)
 	build_path = /obj/item/reagent_containers/glass/bottle/nutrient/rh
-	category = list("initial","Botany Chemicals")
+	category = list("initial","Botanical Chemicals")
 
 /datum/design/weed_killer
 	name = "Weed Killer"
@@ -105,7 +109,7 @@
 	build_type = BIOGENERATOR
 	materials = list(MAT_BIOMASS = 50)
 	build_path = /obj/item/reagent_containers/glass/bottle/killer/weedkiller
-	category = list("initial","Botany Chemicals")
+	category = list("initial","Botanical Chemicals")
 
 /datum/design/pest_spray
 	name = "Pest Killer"
@@ -113,7 +117,7 @@
 	build_type = BIOGENERATOR
 	materials = list(MAT_BIOMASS = 50)
 	build_path = /obj/item/reagent_containers/glass/bottle/killer/pestkiller
-	category = list("initial","Botany Chemicals")
+	category = list("initial","Botanical Chemicals")
 
 /datum/design/botany_bottle
 	name = "Empty Bottle"
@@ -121,7 +125,9 @@
 	build_type = BIOGENERATOR
 	materials = list(MAT_BIOMASS = 5)
 	build_path = /obj/item/reagent_containers/glass/bottle/nutrient/empty
-	category = list("initial", "Botany Chemicals")
+	category = list("initial", "Botanical Chemicals")
+
+//Organic Materials//
 
 /datum/design/cloth
 	name = "Roll of Cloth"

--- a/yogstation/code/modules/research/designs/biogenerator_designs.dm
+++ b/yogstation/code/modules/research/designs/biogenerator_designs.dm
@@ -1,15 +1,45 @@
+//Botanical Chemicals//
+
 /datum/design/mutagen
 	name = "Unstable Mutagen"
 	id = "unstable_mutagen"
 	build_type = BIOGENERATOR
 	materials = list(MAT_BIOMASS = 600)
 	build_path = /obj/item/reagent_containers/glass/bottle/mutagen
-	category = list("initial","Botany Chemicals")
+	category = list("initial","Botanical Chemicals")
+
+//Food//
 
 /datum/design/goat_cube
 	name = "Goat Cube"
 	id = "gcube"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 350)
+	materials = list(MAT_BIOMASS = 300)
 	build_path = /obj/item/reagent_containers/food/snacks/monkeycube/goat
 	category = list("initial", "Food")
+
+/datum/design/sheep_cube
+	name = "Sheep Cube"
+	id = "scube"
+	build_type = BIOGENERATOR
+	materials = list(MAT_BIOMASS = 450)
+	build_path = /obj/item/reagent_containers/food/snacks/monkeycube/sheep
+	category = list("initial", "Food")
+
+/datum/design/cow_cube
+	name = "Cow Cube"
+	id = "ccube"
+	build_type = BIOGENERATOR
+	materials = list(MAT_BIOMASS = 600)
+	build_path = /obj/item/reagent_containers/food/snacks/monkeycube/cow
+	category = list("initial", "Food")
+
+//Special//
+
+/datum/design/xpod_seeds
+	name = "Xpod Seeds"
+	id = "xpodseeds"
+	build_type = BIOGENERATOR
+	materials = list(MAT_BIOMASS = 40000)
+	build_path = /obj/item/seeds/random
+	category = list("initial", "Special")


### PR DESCRIPTION
As the title says, this PR adds some more products to the biogenerator, such as sheep cubes, cow cubes, and (likely most controversially) strange seeds. The former two are to give more variety to the animals that botany can produce (and that the chef can slaughter for meat), and the latter to allow botany to acquire more than the three available from a hacked vending machine without having to request cargo to order an exotic seed crate for the two out of fourteen seeds they actually want.

The base biomass costs for each are as follows:
- Sheep cubes: 450
- Cow cubes: 600
- Strange seeds: **40,000**

However, like the other products of the biogenerator, with further upgrades, the cost of each item decreases down to, with Tier 4 parts:
- Sheep cubes: 112.5
- Cow cubes: 150
- Strange seeds: 10,000

Included in this PR are a few minor tweaks, which are:
- Changing the base price of goat cubes to 300 biomass, from the original 350.
- Changing the name of the Botany Chemicals category to "Botanical Chemicals".

#### Changelog

:cl:  MrHorizons
rscadd: Added sheep cubes, cow cubes, and strange seeds to biogenerator products
tweak: Changed base price of goat cubes to 300 biomass
/:cl:
