### PR TITLE
Animate pointing to move from the pointer to the pointed

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -331,11 +331,13 @@
 	if(istype(A, /obj/effect/temp_visual/point))
 		return FALSE
 
-	var/tile = get_turf(A)
+	var/turf/tile = get_turf(A)
 	if (!tile)
 		return FALSE
 
-	new /obj/effect/temp_visual/point(A,invisibility)
+	var/turf/our_tile = get_turf(src)
+	var/obj/visual = new /obj/effect/temp_visual/point(our_tile, invisibility)
+	animate(visual, pixel_x = (tile.x - our_tile.x) * world.icon_size + A.pixel_x, pixel_y = (tile.y - our_tile.y) * world.icon_size + A.pixel_y, time = 1.7, easing = EASE_OUT)
 
 	return TRUE
 


### PR DESCRIPTION
Ports tgstation/tgstation#51751
"
![85127165-c6d8a200-b1e3-11ea-865f-43cf923eb8ae](https://user-images.githubusercontent.com/24533979/85421200-c456af00-b539-11ea-8fbf-91c9a45e47e4.gif)

Why It's Good For The Game
----

This not only just looks better than an arrow instantly appearing, but it also makes it more obvious when something is pointed to. Occasionally I will ask where something is, someone will point, and I will just look around my screen to find it. With this, ideally it'll catch your eye faster.
"

#### Changelog

:cl:  Jared-Fogle , Hopek
rscadd: Pointing will now animate starting from you to the object you pointed at.
/:cl:
