### PR TITLE
Reveal ghosts when the round ends

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -425,6 +425,8 @@ GLOBAL_LIST_EMPTY(species_list)
 			override = TRUE
 		if(HAS_TRAIT(M, TRAIT_SIXTHSENSE))
 			override = TRUE
+		if(SSticker.current_state == GAME_STATE_FINISHED)
+			override = TRUE
 		if(isnewplayer(M) && !override)
 			continue
 		if(M.stat != DEAD && !override)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -200,6 +200,8 @@
 	if(length(CONFIG_GET(keyed_list/cross_server)))
 		send_news_report()
 
+	set_observer_default_invisibility(0, "<span class='warning'>The round is over! You are now visible to the living.</span>")
+	
 	CHECK_TICK
 
 	//These need update to actually reflect the real antagonists


### PR DESCRIPTION
ports tgstation/tgstation#51572

"
About The Pull Request
--------------

When the round ends, ghosts will now be revealed to the alive players.

Why It's Good For The Game
--------------

It sounds fun to me to see who the ghosts were all orbiting when the round ends without having to ghost myself and not take part in the end round grief.
"
#### Changelog

:cl:  Jared-Fogle , Hopek
rscadd: Ghosts will now be revealed when the round is over. 
/:cl:
