### PR TITLE
https://forums.yogstation.net/index.php?threads/add-confimation-window-to-shunt-malf-ability.21643/

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1027,6 +1027,8 @@
 		return
 	if(!is_station_level(z))
 		return
+	if(alert("Are you sure you want to shunt into this APC?", "Confirm Shunt", "Yes", "No") != "Yes")
+		return
 	occupier = new /mob/living/silicon/ai(src, malf.laws, malf) //DEAR GOD WHY?	//IKR????
 	occupier.adjustOxyLoss(malf.getOxyLoss())
 	if(!findtext(occupier.name, "APC Copy"))


### PR DESCRIPTION
https://forums.yogstation.net/index.php?threads/add-confimation-window-to-shunt-malf-ability.21643/

:cl:
tweak: AIs now get a confirmation box when they try to shunt into an APC
/:cl: