### PR TITLE
Disables Revs for dynamic for the time being

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -338,7 +338,6 @@
 	name = "Revolution"
 	persistent = TRUE
 	antag_flag = ROLE_REV_HEAD
-	antag_flag_override = ROLE_REV
 	antag_datum = /datum/antagonist/rev/head
 	minimum_required_age = 14
 	restricted_roles = list("AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director")
@@ -346,7 +345,7 @@
 	weight = 1
 	delay = 7 MINUTES
 	cost = 35
-	requirements = list(70,70,60,40,30,20,10,10,10,10)
+	requirements = list(101,101,101,101,101,101,101,101,101,101)
 	high_population_requirement = 10
 	flags = TRAITOR_RULESET
 	// I give up, just there should be enough heads with 35 players...


### PR DESCRIPTION
Xoxeyos - Fix soon 6/25/2020

:cl:  
tweak: Disables Revs for the time being by setting their requirement to 101, thus making it admin only.
/:cl:
