### PR TITLE
Fixes #2895 - Refunding a syndie spawner now gives you the correct amount of money back

### DIFF
--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -108,12 +108,18 @@ GLOBAL_LIST_EMPTY(uplinks)
 			var/path = UI.refund_path || UI.item
 			var/cost = UI.refund_amount || UI.cost
 			if(I.type == path && UI.refundable && I.check_uplink_validity())
-				telecrystals += cost
-				if(purchase_log)
-					purchase_log.total_spent -= cost
-				to_chat(user, "<span class='notice'>[I] refunded.</span>")
-				qdel(I)
+				var/obj/item/antag_spawner/S = I
+				refundAntagSpawner(cost, S, user)
 				return
+
+/datum/component/uplink/proc/refundAntagSpawner(cost, obj/item/antag_spawner/I, mob/user)
+	if (I.discountPrice)
+		cost = I.discountPrice
+	telecrystals += cost
+	if(purchase_log)
+		purchase_log.total_spent -= cost
+		to_chat(user, "<span class='notice'>[I] refunded.</span>")
+	qdel(I)
 
 /datum/component/uplink/proc/interact(datum/source, mob/user)
 	if(locked)

--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -3,6 +3,7 @@
 	throw_range = 5
 	w_class = WEIGHT_CLASS_TINY
 	var/used = FALSE
+	var/discountPrice = 0 //if this is discounted, we keep track of that, for refund purposes
 
 /obj/item/antag_spawner/proc/spawn_antag(client/C, turf/T, kind = "", datum/mind/user)
 	return
@@ -37,7 +38,7 @@
 		dat += "<I>Your apprentice is training to cast spells that will aid your survival. They know Forcewall and Charge and come with a Staff of Healing.</I><BR>"
 		dat += "<A href='byond://?src=[REF(src)];school=[APPRENTICE_ROBELESS]'>Robeless</A><BR>"
 		dat += "<I>Your apprentice is training to cast spells without their robes. They know Knock and Mindswap.</I><BR>"
-	
+
 	dat += "</BODY></HTML>"
 	user << browse(dat, "window=radio")
 	onclose(user, "radio")

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -67,8 +67,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 		var/discount = A.get_discount()
 		var/list/disclaimer = list("Void where prohibited.", "Not recommended for children.", "Contains small parts.", "Check local laws for legality in region.", "Do not taunt.", "Not responsible for direct, indirect, incidental or consequential damages resulting from any defect, error or failure to perform.", "Keep away from fire or flames.", "Product is provided \"as is\" without any implied or expressed warranties.", "As seen on TV.", "For recreational use only.", "Use only as directed.", "16% sales tax will be charged for orders originating within Space Nebraska.")
 		A.limited_stock = limited_stock
-		I.refundable = FALSE //THIS MAN USES ONE WEIRD TRICK TO GAIN FREE TC, CODERS HATES HIM!
-		A.refundable = FALSE
 		if(A.cost >= 20) //Tough love for nuke ops
 			discount *= 0.5
 		A.category = category_name
@@ -76,7 +74,10 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 		A.name += " ([round(((initial(A.cost)-A.cost)/initial(A.cost))*100)]% off!)"
 		A.desc += " Normally costs [initial(A.cost)] TC. All sales final. [pick(disclaimer)]"
 		A.item = I.item
-
+		if (A.refundable)
+			var/obj/item/antag_spawner/S = new A.item()
+			S.discountPrice = A.cost
+			A.item = S
 		uplink_items[category_name][A.name] = A
 
 


### PR DESCRIPTION
### Intent of your Pull Request
Fixes #2895 
This affects nukie reinforcements, nukie borgs, and holoparasites, as well as any future antag spawners you can buy with TC. Shouldn't affect wizards or other such antag spawners that you don't buy with an uplink, cause those don't go on sale.

I would like the HC's to take a look at this code. It works, and is tested, but there might be better ways to do it.

#### Changelog

:cl:  
bugfix: You can no longer buy an on sale syndie item and sell it back for full price. 
/:cl:
