### PR TITLE
fixes #9023 and #9025 - Re-adds passdoor flag interaction that alexkar removed because he can't be bothered to actually read

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -132,8 +132,12 @@
 
 /obj/machinery/door/CanAllowThrough(atom/movable/mover, turf/target)
 	. = ..()
-	if(istype(mover) && (mover.pass_flags & PASSGLASS))
-		return !opacity
+	if(istype(mover)) //yogs start
+		if(mover.pass_flags & PASSGLASS)
+			return !opacity
+		else if(mover.pass_flags & PASSDOOR)
+			return TRUE //yogs end
+	return .
 
 /obj/machinery/door/proc/bumpopen(mob/user)
 	if(operating)


### PR DESCRIPTION

### Intent of your Pull Request
fixes #9023 
fixes #9025

As title.
#### Changelog

:cl:  
bugfix: passdoor now works again. Drones, mice etc can fit under doors again.
/:cl:
