### PR TITLE
PSA: if you change the name of a sprite, change all of it's references too!

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -541,13 +541,13 @@
 
 /obj/item/clothing/head/helmet/space/orange
 	name = "emergency space helmet"
-	icon_state = "syndicate-helm-orange"
-	item_state = "syndicate-helm-orange"
+	icon_state = "emergency"
+	item_state = "emergency"
 
 /obj/item/clothing/suit/space/orange
 	name = "emergency space suit"
-	icon_state = "syndicate-orange"
-	item_state = "syndicate-orange"
+	icon_state = "emergency"
+	item_state = "emergency"
 	slowdown = 3
 
 /obj/item/pickaxe/emergency


### PR DESCRIPTION
### Intent of your Pull Request
The psa is for identification 
Emergency Space suits have sprites
#### Changelog

:cl:  
bugfix: fixed emergency space suit sprites
/:cl:
