### PR TITLE
Database will now self heal after a crash and set activity properly

### DIFF
--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -132,6 +132,9 @@ SUBSYSTEM_DEF(dbcore)
 	query_round_last_id.Execute(async = FALSE)
 	if(query_round_last_id.NextRow(async = FALSE))
 		GLOB.round_id = query_round_last_id.item[1]
+		var/datum/DBQuery/query_fix_connections = SSdbcore.NewQuery("UPDATE [format_table_name("connection_log")] SET 'left' = NOW() WHERE erro_connection_log.left IS NULL AND round_id = [GLOB.round_id - 1]")
+		query_fix_connections.Execute()
+		qdel(query_fix_connections)
 	qdel(query_round_last_id)
 
 /datum/controller/subsystem/dbcore/proc/SetRoundStart()

--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -132,7 +132,7 @@ SUBSYSTEM_DEF(dbcore)
 	query_round_last_id.Execute(async = FALSE)
 	if(query_round_last_id.NextRow(async = FALSE))
 		GLOB.round_id = query_round_last_id.item[1]
-		var/datum/DBQuery/query_fix_connections = SSdbcore.NewQuery("UPDATE [format_table_name("connection_log")] SET 'left' = NOW() WHERE erro_connection_log.left IS NULL AND round_id = [GLOB.round_id - 1]")
+		var/datum/DBQuery/query_fix_connections = SSdbcore.NewQuery("UPDATE [format_table_name("connection_log")] SET 'left' = NOW() WHERE 'left' IS NULL AND round_id = [GLOB.round_id - 1]")
 		query_fix_connections.Execute()
 		qdel(query_fix_connections)
 	qdel(query_round_last_id)

--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -132,7 +132,7 @@ SUBSYSTEM_DEF(dbcore)
 	query_round_last_id.Execute(async = FALSE)
 	if(query_round_last_id.NextRow(async = FALSE))
 		GLOB.round_id = query_round_last_id.item[1]
-		var/datum/DBQuery/query_fix_connections = SSdbcore.NewQuery("UPDATE [format_table_name("connection_log")] SET 'left' = NOW() WHERE 'left' IS NULL AND round_id = [GLOB.round_id - 1]")
+		var/datum/DBQuery/query_fix_connections = SSdbcore.NewQuery("UPDATE [format_table_name("connection_log")] SET 'left' = NOW() WHERE 'left' IS NULL AND round_id = [text2num(GLOB.round_id) - 1]")
 		query_fix_connections.Execute()
 		qdel(query_fix_connections)
 	qdel(query_round_last_id)


### PR DESCRIPTION
see title

sets the left value to the time where the round reboots