### PR TITLE
Changes the MiniStation shuttle up.

### DIFF
--- a/_maps/shuttles/emergency_mini.dmm
+++ b/_maps/shuttles/emergency_mini.dmm
@@ -1,71 +1,38 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
-/turf/template_noop,
-/area/template_noop)
-"b" = (
+"bP" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"bT" = (
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"cc" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"dd" = (
+/obj/structure/extinguisher_cabinet,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"c" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/shuttle/escape)
-"d" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/shuttle/escape)
-"e" = (
-/obj/item/storage/firstaid/regular{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/structure/table,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"f" = (
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"g" = (
-/obj/machinery/stasis,
+"dt" = (
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"h" = (
+"dM" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/turf/open/floor/mineral/plastitanium/red/brig,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"i" = (
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"j" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"k" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"l" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 28
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"m" = (
+"dV" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
@@ -74,22 +41,160 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"n" = (
+"ev" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom";
+	pixel_x = -26
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"ge" = (
+/obj/structure/table/optable,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"jx" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"o" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Escape Shuttle Cell";
-	req_access_txt = "2"
+"jC" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/fire,
+/obj/item/extinguisher,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"kp" = (
+/obj/machinery/computer/emergency_shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"kT" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"lo" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"mf" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Escape Shuttle Cockpit";
+	req_access_txt = "19"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/plastitanium/red/brig,
+/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"p" = (
+"mK" = (
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/structure/closet{
+	icon_state = "emergency"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"mU" = (
+/turf/template_noop,
+/area/template_noop)
+"pH" = (
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"rh" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"rA" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Escape Shuttle Infirmary"
 	},
@@ -99,70 +204,58 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"q" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/escape)
-"r" = (
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"s" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"t" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"u" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"w" = (
+"rI" = (
 /obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"x" = (
-/obj/structure/chair/comfy/shuttle{
+"rV" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"sc" = (
+/obj/structure/shuttle/engine/heater{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium/blue,
+/obj/structure/window/reinforced,
+/turf/open/floor/plating/airless,
 /area/shuttle/escape)
-"y" = (
+"tB" = (
 /obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"z" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed"
-	},
+"uE" = (
+/obj/machinery/stasis,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"wb" = (
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/window/shuttle,
+/turf/open/floor/grass,
+/area/shuttle/escape)
+"xi" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"A" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/obj/machinery/light{
+"xU" = (
+/obj/machinery/computer/security{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"B" = (
+"yx" = (
+/obj/structure/table,
+/obj/item/clothing/suit/apron/surgical,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"za" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"ze" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Emergency Shuttle Airlock"
 	},
@@ -181,100 +274,161 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"D" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/crowbar,
-/obj/item/extinguisher,
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"E" = (
-/obj/machinery/light,
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"G" = (
-/obj/structure/table/optable,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"H" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
-"I" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Escape Shuttle Cockpit";
-	req_access_txt = "19"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"J" = (
-/obj/machinery/computer/atmos_alert{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"K" = (
-/obj/structure/chair/comfy/shuttle{
+"zy" = (
+/obj/machinery/computer/communications{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"L" = (
+"zU" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = 24
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"M" = (
+"zX" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Ap" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom";
+	pixel_x = 26
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"Da" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Et" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"EQ" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Escape Shuttle Cell";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"GX" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Hm" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"HO" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Kk" = (
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"My" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"N" = (
-/obj/machinery/computer/security{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"O" = (
+"Nb" = (
 /obj/machinery/computer/crew{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"P" = (
-/obj/machinery/computer/communications{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"Q" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/fire,
-/obj/item/extinguisher,
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"R" = (
-/obj/structure/chair/comfy/shuttle,
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"S" = (
-/obj/machinery/computer/emergency_shuttle{
+"NB" = (
+/obj/machinery/light{
 	dir = 1
 	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Pt" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/button/flasher{
+	id = "shuttle_flasher";
+	pixel_x = -24;
+	pixel_y = -6
+	},
+/obj/machinery/flasher{
+	id = "shuttle_flasher";
+	pixel_x = -24;
+	pixel_y = 6
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"PK" = (
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/fernybush,
+/obj/structure/window/shuttle,
+/turf/open/floor/grass,
+/area/shuttle/escape)
+"Rs" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"RB" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"RH" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"SO" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"ST" = (
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"T" = (
+"Ug" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular{
 	pixel_x = 2;
@@ -283,234 +437,272 @@
 /obj/item/crowbar,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"U" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only{
+"Uh" = (
+/obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"W" = (
-/obj/structure/table,
-/obj/item/clothing/suit/apron/surgical,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"X" = (
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"Y" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"UI" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 28
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"UW" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"Vv" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed"
+	},
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"Xn" = (
+/obj/item/storage/firstaid/regular{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/storage/firstaid/regular{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/structure/table,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Yz" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/crowbar,
+/obj/item/extinguisher,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Zp" = (
+/obj/machinery/computer/atmos_alert{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Zy" = (
+/obj/machinery/light,
+/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 
 (1,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-U
-U
-U
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
+mU
+xi
+xi
+xi
+xi
+xi
+xi
+xi
+Hm
+Hm
+Hm
+xi
+xi
+xi
+xi
+xi
+xi
+xi
+xi
+xi
+mU
 "}
 (2,1,1) = {"
-b
-b
-e
-k
-X
-p
-f
-M
-M
-M
-M
-M
-f
-M
-M
-D
-b
-J
-O
-q
-b
+xi
+xi
+Xn
+bP
+ev
+rA
+pH
+cc
+My
+My
+My
+dM
+pH
+My
+My
+Yz
+xi
+Zp
+Nb
+za
+xi
 "}
 (3,1,1) = {"
-c
-d
-W
-X
-X
-n
-f
-f
-f
-f
-f
-f
-f
-f
-f
-r
-b
-K
-K
-Q
-w
+UW
+sc
+yx
+dt
+dt
+rI
+pH
+RB
+pH
+pH
+pH
+bT
+pH
+pH
+pH
+ST
+xi
+HO
+HO
+jC
+RH
 "}
 (4,1,1) = {"
-c
-d
-G
-l
-g
-n
-f
-K
-K
-K
-y
-K
-K
-K
-f
-r
-H
-t
-f
-R
-w
+UW
+sc
+ge
+UI
+uE
+rI
+pH
+rh
+HO
+HO
+Uh
+kT
+HO
+HO
+pH
+ST
+SO
+NB
+pH
+rV
+RH
 "}
 (5,1,1) = {"
-c
-d
-b
-b
-b
-q
-t
-x
-n
-n
-z
-n
-n
-R
-f
-f
-I
-f
-f
-S
-w
+UW
+sc
+xi
+xi
+xi
+za
+zX
+dd
+PK
+wb
+Vv
+wb
+PK
+mK
+lo
+lo
+mf
+pH
+pH
+kp
+RH
 "}
 (6,1,1) = {"
-c
-d
-h
-h
-n
-r
-f
-M
-M
-M
-A
-M
-M
-M
-f
-E
-b
-L
-f
-R
-w
+UW
+sc
+Pt
+tB
+Et
+rI
+pH
+cc
+My
+My
+Da
+My
+My
+My
+pH
+Zy
+xi
+zU
+pH
+rV
+RH
 "}
 (7,1,1) = {"
-c
-d
-i
-i
-o
-f
-f
-f
-f
-f
-f
-f
-f
-f
-f
-r
-b
-M
-M
-T
-w
+UW
+sc
+Kk
+Kk
+Kk
+rI
+pH
+RB
+pH
+pH
+pH
+bT
+pH
+pH
+pH
+ST
+xi
+My
+My
+Ug
+RH
 "}
 (8,1,1) = {"
-b
-b
-j
-m
-n
-s
-f
-K
-K
-K
-K
-K
-f
-K
-K
-D
-b
-N
-P
-q
-b
+xi
+xi
+Rs
+dV
+Ap
+EQ
+pH
+rh
+HO
+HO
+HO
+kT
+pH
+HO
+HO
+Yz
+xi
+xU
+zy
+za
+xi
 "}
 (9,1,1) = {"
-a
-b
-b
-b
-b
-b
-u
-b
-b
-Y
-b
-b
-B
-b
-b
-b
-b
-b
-b
-b
-a
+mU
+xi
+xi
+xi
+xi
+xi
+GX
+xi
+jx
+jx
+jx
+xi
+ze
+xi
+xi
+xi
+xi
+xi
+xi
+xi
+mU
 "}

--- a/_maps/shuttles/emergency_mini.dmm
+++ b/_maps/shuttles/emergency_mini.dmm
@@ -1,13 +1,42 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aj" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
 "bP" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium/white,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "bT" = (
 /obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "cc" = (
 /obj/structure/chair/comfy/shuttle{
@@ -16,21 +45,29 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "dd" = (
 /obj/structure/extinguisher_cabinet,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "dt" = (
-/turf/open/floor/mineral/titanium/white,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "dM" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "dV" = (
 /obj/structure/chair/comfy/shuttle{
@@ -46,11 +83,67 @@
 	name = "Station Intercom";
 	pixel_x = -26
 	},
-/turf/open/floor/mineral/titanium/white,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"ew" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"fr" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/slightlydarkerblue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "ge" = (
 /obj/structure/table/optable,
-/turf/open/floor/mineral/titanium/white,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"gj" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"gB" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/slightlydarkerblue,
+/turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "jx" = (
 /obj/machinery/door/firedoor/border_only{
@@ -61,28 +154,63 @@
 /area/shuttle/escape)
 "jC" = (
 /obj/structure/table,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 2;
+	pixel_y = 3
+	},
 /obj/item/storage/firstaid/fire,
+/obj/item/crowbar,
 /obj/item/extinguisher,
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"jG" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "kp" = (
 /obj/machinery/computer/emergency_shuttle{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/tile/slightlydarkerblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/slightlydarkerblue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "kT" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "lo" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "mf" = (
 /obj/machinery/door/airlock/command/glass{
@@ -177,13 +305,28 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/bot,
+/obj/item/storage/firstaid/o2,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "mU" = (
 /turf/template_noop,
 /area/template_noop)
 "pH" = (
-/turf/open/floor/mineral/titanium,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"qe" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "rh" = (
 /obj/structure/chair/comfy/shuttle{
@@ -192,7 +335,8 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "rA" = (
 /obj/machinery/door/airlock/medical/glass{
@@ -202,15 +346,23 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "rI" = (
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "rV" = (
-/obj/structure/chair/comfy/shuttle,
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/tile/slightlydarkerblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/slightlydarkerblue{
+	dir = 1
+	},
+/obj/structure/chair/comfy/brown{
+	color = "#596479"
+	},
+/turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "sc" = (
 /obj/structure/shuttle/engine/heater{
@@ -218,6 +370,44 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"sp" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"sQ" = (
+/obj/effect/turf_decal/tile/slightlydarkerblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/slightlydarkerblue{
+	dir = 8
+	},
+/obj/structure/chair/comfy/brown{
+	color = "#596479";
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"tw" = (
+/obj/effect/turf_decal/tile/slightlydarkerblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/slightlydarkerblue{
+	dir = 4
+	},
+/obj/structure/chair/comfy/brown{
+	color = "#596479"
+	},
+/turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "tB" = (
 /obj/structure/chair/comfy/shuttle{
@@ -227,7 +417,13 @@
 /area/shuttle/escape)
 "uE" = (
 /obj/machinery/stasis,
-/turf/open/floor/mineral/titanium/white,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "wb" = (
 /obj/structure/flora/ausbushes/grassybush,
@@ -237,6 +433,13 @@
 /obj/structure/window/shuttle,
 /turf/open/floor/grass,
 /area/shuttle/escape)
+"wC" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
 "xi" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
@@ -244,13 +447,19 @@
 /obj/machinery/computer/security{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "yx" = (
 /obj/structure/table,
 /obj/item/clothing/suit/apron/surgical,
 /obj/item/storage/backpack/duffelbag/med/surgery,
-/turf/open/floor/mineral/titanium/white,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "za" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -272,24 +481,46 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "zy" = (
 /obj/machinery/computer/communications{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "zU" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = 24
 	},
-/turf/open/floor/mineral/titanium,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "zX" = (
-/obj/machinery/light{
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -297,10 +528,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "Ap" = (
 /obj/item/radio/intercom{
@@ -316,7 +547,21 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"Db" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "Et" = (
 /obj/structure/table/reinforced,
@@ -344,7 +589,13 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "Hm" = (
 /obj/effect/spawner/structure/window/shuttle,
@@ -357,28 +608,63 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "Kk" = (
 /turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"Lk" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "My" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "Nb" = (
 /obj/machinery/computer/crew{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Ny" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "NB" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "Pt" = (
 /obj/structure/chair/comfy/shuttle{
@@ -414,7 +700,17 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "RH" = (
 /obj/effect/spawner/structure/window/shuttle,
@@ -426,16 +722,16 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "ST" = (
-/turf/open/floor/mineral/titanium/blue,
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "Ug" = (
 /obj/structure/table,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/crowbar,
-/turf/open/floor/mineral/titanium/blue,
+/obj/item/storage/box/fancy/donut_box,
+/turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "Uh" = (
 /obj/structure/chair/comfy/shuttle{
@@ -444,14 +740,32 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"Uv" = (
+/obj/effect/turf_decal/tile/slightlydarkerblue,
+/obj/effect/turf_decal/tile/slightlydarkerblue{
+	dir = 4
+	},
+/obj/structure/chair/comfy/brown{
+	color = "#596479";
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "UI" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	pixel_x = 28
 	},
-/turf/open/floor/mineral/titanium/white,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "UW" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -468,14 +782,23 @@
 "Xn" = (
 /obj/item/storage/firstaid/regular{
 	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = -2;
 	pixel_y = 4
 	},
 /obj/structure/table,
-/turf/open/floor/mineral/titanium,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/item/storage/firstaid/toxin{
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/regular{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "Yz" = (
 /obj/structure/table,
@@ -486,17 +809,21 @@
 	},
 /obj/item/crowbar,
 /obj/item/extinguisher,
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "Zp" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "Zy" = (
 /obj/machinery/light,
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -535,7 +862,7 @@ My
 My
 My
 dM
-pH
+qe
 My
 My
 Yz
@@ -554,17 +881,17 @@ dt
 rI
 pH
 RB
-pH
-pH
-pH
+aj
+aj
+aj
 bT
-pH
-pH
-pH
+aj
+aj
+jG
 ST
 xi
-HO
-HO
+Uv
+Uv
 jC
 RH
 "}
@@ -583,11 +910,11 @@ Uh
 kT
 HO
 HO
-pH
-ST
+jG
+wC
 SO
 NB
-pH
+fr
 rV
 RH
 "}
@@ -607,10 +934,10 @@ wb
 PK
 mK
 lo
-lo
+Ny
 mf
-pH
-pH
+NB
+sp
 kp
 RH
 "}
@@ -629,12 +956,12 @@ Da
 My
 My
 My
-pH
+jG
 Zy
 xi
 zU
-pH
-rV
+gB
+tw
 RH
 "}
 (7,1,1) = {"
@@ -645,18 +972,18 @@ Kk
 Kk
 rI
 pH
-RB
-pH
-pH
-pH
-bT
-pH
-pH
-pH
+Lk
+Db
+Db
+Db
+gj
+jG
+jG
+jG
 ST
 xi
-My
-My
+sQ
+sQ
 Ug
 RH
 "}
@@ -667,13 +994,13 @@ Rs
 dV
 Ap
 EQ
-pH
+ew
 rh
 HO
 HO
 HO
 kT
-pH
+ew
 HO
 HO
 Yz

--- a/_maps/shuttles/emergency_mini.dmm
+++ b/_maps/shuttles/emergency_mini.dmm
@@ -300,7 +300,8 @@
 	name = "emergency lifejacket"
 	},
 /obj/structure/closet{
-	icon_state = "emergency"
+	icon_state = "emergency";
+	name = "emergency closet"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8

--- a/_maps/shuttles/emergency_mini.dmm
+++ b/_maps/shuttles/emergency_mini.dmm
@@ -13,30 +13,30 @@
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "bP" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "bT" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/obj/structure/table,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "cc" = (
 /obj/structure/chair/comfy/shuttle{
@@ -47,10 +47,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/shuttle/escape)
-"dd" = (
-/obj/structure/extinguisher_cabinet,
-/turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "dt" = (
 /obj/effect/turf_decal/tile/blue{
@@ -65,29 +61,34 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "dV" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "ev" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom";
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom";
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
@@ -108,27 +109,28 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
-"ge" = (
-/obj/structure/table/optable,
-/obj/effect/turf_decal/tile/blue{
+"fC" = (
+/obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/effect/turf_decal/bot,
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = -28
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "gj" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/turf_decal/bot,
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 28
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
@@ -189,11 +191,17 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "kT" = (
-/obj/structure/chair/comfy/shuttle{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "lo" = (
@@ -209,6 +217,9 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
@@ -317,7 +328,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
-/obj/item/storage/firstaid/o2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "mU" = (
@@ -337,6 +350,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "rh" = (
@@ -427,13 +441,13 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "uE" = (
-/obj/machinery/stasis,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/stasis,
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "wb" = (
@@ -451,6 +465,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
+"xb" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
 "xi" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
@@ -458,11 +477,16 @@
 /obj/machinery/computer/security{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "yx" = (
 /obj/structure/table,
-/obj/item/clothing/suit/apron/surgical,
+/obj/item/clothing/suit/apron/surgical{
+	pixel_y = 2
+	},
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -471,6 +495,20 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"yU" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "za" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -641,6 +679,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
+"Lt" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
 "My" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -652,7 +700,18 @@
 /obj/machinery/computer/crew{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Nw" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "Ny" = (
 /obj/machinery/door/firedoor/border_only{
@@ -661,6 +720,9 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
@@ -785,16 +847,14 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "Vv" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed"
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
 	},
-/turf/closed/wall/mineral/titanium,
+/obj/effect/turf_decal/bot,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "Xn" = (
-/obj/item/storage/firstaid/regular{
-	pixel_x = 2;
-	pixel_y = 4
-	},
 /obj/structure/table,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -802,24 +862,23 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/item/storage/firstaid/o2{
+	pixel_x = 3;
+	pixel_y = 4
+	},
 /obj/item/storage/firstaid/toxin{
+	pixel_x = 1;
 	pixel_y = 3
 	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = -2;
+/obj/item/storage/firstaid/fire{
+	pixel_x = -1;
 	pixel_y = 2
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "Yz" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/crowbar,
-/obj/item/extinguisher,
+/obj/effect/turf_decal/delivery,
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "Zp" = (
@@ -868,13 +927,13 @@ bP
 ev
 rA
 pH
-cc
-My
-My
-My
 dM
-qe
 My
+My
+My
+My
+qe
+fC
 My
 Yz
 xi
@@ -888,15 +947,15 @@ UW
 sc
 yx
 dt
-dt
+bT
 rI
 pH
 RB
 aj
 aj
 aj
-bT
 aj
+kT
 aj
 jG
 ST
@@ -909,7 +968,7 @@ RH
 (4,1,1) = {"
 UW
 sc
-ge
+uE
 UI
 uE
 rI
@@ -918,8 +977,8 @@ rh
 HO
 HO
 Uh
-kT
 HO
+Vv
 HO
 jG
 wC
@@ -937,10 +996,10 @@ xi
 xi
 za
 zX
-dd
+mK
 PK
 wb
-Vv
+xi
 wb
 PK
 mK
@@ -965,7 +1024,7 @@ My
 My
 Da
 My
-My
+Nw
 My
 jG
 Zy
@@ -987,8 +1046,8 @@ Lk
 Db
 Db
 Db
-gj
-jG
+Db
+yU
 jG
 jG
 ST
@@ -1006,13 +1065,13 @@ dV
 Ap
 EQ
 ew
-rh
+gj
 HO
 HO
 HO
-kT
-ew
 HO
+xb
+Lt
 HO
 Yz
 xi

--- a/_maps/shuttles/emergency_mini.dmm
+++ b/_maps/shuttles/emergency_mini.dmm
@@ -221,7 +221,17 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium,
+/obj/effect/turf_decal/tile/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/white{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "mK" = (
 /obj/item/clothing/mask/breath{


### PR DESCRIPTION
_To bring the aging, so-called "Mini" emergency crew extraction shuttle in line with its more modern and/or reliable counterparts, we at the NTSCDOSD (NanoTrasen Shuttle Construction, Design, and Other Stuff Divison) has decided to refit the few still active with others' features. These include:_
- _Internal firelocks have been added, to avoid a breach of either window causing the entire main body of the shuttle to depressurize._
- _The port window has been widened to_ [three tiles]_, for "aesthetic purposes"._
- _More thorough emergency gear, now consisting of five sets of breath masks and emergency oxygen tanks, five lifejackets, five protective hats, and an oxygen deprivation medkit._
- _An additional status display and fire extinguisher cabinet has been added to the rear of the shuttle._
- _The floors have been redone and decals added beneath the chairs and external airlocks._
- _The shuttle cockpit's chairs have been replaced with comfy black ones._
- _A construction worker left their box of donuts in the cockpit and it is now a part of the shuttle._

_We wish you and your crew the best end of your shift and a ~~safe~~ trip back to CentCom!_

All faux-IC document pretense aside, I find the MiniStation shuttle to be quite charming, but in need of some upgrades. This PR is intended to implement said upgrades.

<details>
  <summary>Before</summary>

![image](https://user-images.githubusercontent.com/29339701/85953714-74645780-b940-11ea-99f0-7236a1382927.png)

</details>

<details>
  <summary>After</summary>

![image](https://user-images.githubusercontent.com/29339701/85953710-6e6e7680-b940-11ea-84ff-5f19abad71f1.png)

</details>

#### Changelog

:cl:  
tweak: Changed up the MiniStation shuttle.
/:cl:
