### PR TITLE
Caps the strength of fire breath (Balance)

### DIFF
--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -105,11 +105,11 @@
 	instability = 30
 	energy_coeff = 1
 	power_coeff = 1
-
+	
 /datum/mutation/human/firebreath/modify()
 	if(power)
 		var/obj/effect/proc_holder/spell/aimed/firebreath/S = power
-		S.strength = GET_MUTATION_POWER(src)
+		S.strength = min(GET_MUTATION_POWER(src), S.strengthMax)
 
 /obj/effect/proc_holder/spell/aimed/firebreath
 	name = "Fire Breath"
@@ -126,7 +126,7 @@
 	deactive_msg = "You swallow the flame."
 	var/strength = 1
 	var/const/strengthMax = 3
-
+	
 /obj/effect/proc_holder/spell/aimed/firebreath/before_cast(list/targets)
 	. = ..()
 	if(iscarbon(usr))
@@ -141,8 +141,6 @@
 	if(!istype(P, /obj/item/projectile/magic/aoe/fireball))
 		return
 	var/obj/item/projectile/magic/aoe/fireball/F = P
-	if (strength > strengthMax)
-		strength = strengthMax
 	F.exp_light = strength-1
 	F.exp_fire += strength
 

--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -122,7 +122,7 @@
 	base_icon_state = "fireball"
 	action_icon_state = "fireball0"
 	sound = 'sound/magic/demon_dies.ogg' //horrifying lizard noises
-	active_msg = "You built up heat in your mouth."
+	active_msg = "You build up heat in your mouth."
 	deactive_msg = "You swallow the flame."
 	var/strength = 1
 
@@ -144,7 +144,8 @@
 		if(1 to 3)
 			F.exp_light = strength-1
 		if(4 to INFINITY)
-			F.exp_heavy = strength-3
+			strength = 3
+			F.exp_light = strength-1
 	F.exp_fire += strength
 
 obj/effect/proc_holder/spell/aimed/firebreath/fire_projectile(mob/user)

--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -141,11 +141,9 @@
 		return
 	var/obj/item/projectile/magic/aoe/fireball/F = P
 	switch(strength)
-		if(1 to 3)
-			F.exp_light = strength-1
 		if(4 to INFINITY)
 			strength = 3
-			F.exp_light = strength-1
+	F.exp_light = strength-1
 	F.exp_fire += strength
 
 obj/effect/proc_holder/spell/aimed/firebreath/fire_projectile(mob/user)

--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -125,6 +125,7 @@
 	active_msg = "You build up heat in your mouth."
 	deactive_msg = "You swallow the flame."
 	var/strength = 1
+	var/const/strengthMax = 3
 
 /obj/effect/proc_holder/spell/aimed/firebreath/before_cast(list/targets)
 	. = ..()
@@ -140,9 +141,8 @@
 	if(!istype(P, /obj/item/projectile/magic/aoe/fireball))
 		return
 	var/obj/item/projectile/magic/aoe/fireball/F = P
-	switch(strength)
-		if(4 to INFINITY)
-			strength = 3
+	if (strength > strengthMax)
+		strength = strengthMax
 	F.exp_light = strength-1
 	F.exp_fire += strength
 


### PR DESCRIPTION
### Intent of your Pull Request
Sort of requested by Dr. Derp.

At gene strength 1,2,3 the fireball is the same as it used to be.
At gene strength > 3 the fireball is now identical to the 3 strength one.

For reference, the fireball at strength = 3 is the same as the wizard one. Except it is more firey, and less bright. Meaning it does more damage than the wizard one, but it doesn't blind you.
At strength > 3, that is when the fireball used to start doing things like blow of limbs and stun you for a million years. 

#### Changelog

:cl:  
tweak: Firebreath's power is now capped at roughly the level of the wizard fireball.   
spellcheck: You **built** up heat in your mouth--> You **build** up heat in your mouth
/:cl:
