### PR TITLE
Emagged hug engine rework

### DIFF
--- a/yogstation/code/modules/power/hugbox.dm
+++ b/yogstation/code/modules/power/hugbox.dm
@@ -6,21 +6,16 @@
 	density = TRUE
 	anchored = FALSE
 	use_power = NO_POWER_USE
+	can_buckle = 1
+	buckle_lying = 0
 
 	var/power_per_hug = 1000000
-	var/crunching = FALSE
 
 /obj/machinery/power/hugbox_engine/emag_act(mob/user)
 	if(obj_flags & EMAGGED)
 		return
 	obj_flags |= EMAGGED
 	to_chat(user, "<span class='warning'>You crank up the love harvesting regulator to hardware maximum.</span>")
-
-/obj/machinery/power/hugbox_engine/crowbar_act(mob/living/user, obj/item/I)
-	if(crunching)
-		to_chat(user, "<span class='notice'>You forcefully yank the emergency release.</span>")
-		crunching = FALSE
-	return TRUE
 
 /obj/machinery/power/hugbox_engine/wrench_act(mob/living/user, obj/item/I)
 	if(!anchored && !isinspace())
@@ -29,7 +24,7 @@
 		anchored = TRUE
 		playsound(src.loc, 'sound/items/deconstruct.ogg', 50, 1)
 	else if(anchored)
-		if(crunching)
+		if(has_buckled_mobs())
 			to_chat(user, "<span class='warning'>You can't detach [src] from the floor, it's holding on too tightly!</span>")
 			return TRUE
 		disconnect_from_network()
@@ -44,13 +39,18 @@
 	var/mob/living/carbon/C = user
 	if(!istype(C))
 		return
-	if(crunching)
+	if(has_buckled_mobs())
+		var/mob/living/carbon/H = buckled_mobs[1]
+		to_chat(C, "<span class='notice'>You press the ermegency release button.</span>")
+		unbuckle_mob(H)
 		return
 	if(obj_flags & EMAGGED)
 		to_chat(C, "<span class='userdanger'>[src] grips you with its manipulators tightly!</span>")
 		C.forceMove(get_turf(src))
 		playsound(src, 'sound/machines/honkbot_evil_laugh.ogg', 50, 1)
 		C.notransform = TRUE
+		buckle_mob(C, TRUE, TRUE)
+		C.Stun(30) //So they can't escape by themselves
 		sleep(30) //better beg for help
 		crunch(C)
 		return
@@ -60,17 +60,41 @@
 	return ..()
 
 /obj/machinery/power/hugbox_engine/proc/crunch(mob/living/carbon/crunched)
-	crunching = TRUE
-	while(crunching && crunched.stat != DEAD)
-		crunched.visible_message("<span class='danger'>[src] hugs [crunched]!</span>", "<span class='userdanger'>[src] hugs you!</span>")
-		crunched.adjustBruteLoss(15)
-		shake_camera(crunched, 3, 1)
-		crunched.emote("scream")
+	while(crunched.buckled)
 		var/turf/location = get_turf(crunched)
-		crunched.add_splatter_floor(location)
-		playsound(src, "desceration", 60, 1)
-		add_avail(power_per_hug*50) //5 MW
-		sleep(20)
-	crunching = FALSE
+		if(crunched.health > 25)
+			crunched.visible_message("<span class='danger'>[src] hugs [crunched]!</span>", "<span class='userdanger'>[src] hugs you!</span>")
+			crunched.adjustBruteLoss(15)
+			playsound(src, "desceration", 60, 1)
+			shake_camera(crunched, 3, 1)
+			crunched.add_splatter_floor(location)
+			add_avail(power_per_hug*50) //5 MW
+			crunched.Stun(20)
+			sleep(20)
+		else if(crunched.health <= 25)
+			crunched.visible_message("<span class='danger'>[src] hugs [crunched] tighter!</span>", "<span class='userdanger'>[src] starts hugging you tighter!</span>")
+			crunched.Stun(30)
+			crunched.adjustBruteLoss(4)
+			sleep(30)
+			if(crunched.buckled) //Are they still buckled?
+				crunched.visible_message("<span class='danger'>[src] hugs [crunched] tighter!</span>", "<span class='userdanger'>WAY TOO TIGHT.</span>")
+				crunched.Stun(40)
+				crunched.adjustBruteLoss(4)
+				sleep(40)
+			if(crunched.buckled)
+				crunched.visible_message("<span class='danger'>You hear a loud snap coming from [crunched]!</span>", "<span class='colossus'>SNAP</span>")
+				crunched.add_splatter_floor(location)
+				crunched.emote("scream")
+				crunched.adjustBruteLoss(5)
+				add_avail(power_per_hug*50)
+				shake_camera(crunched, 3, 1)
+				playsound(src, "sound/magic/demon_consume.ogg", 60, 1)
+				crunched.gain_trauma(/datum/brain_trauma/severe/paralysis/paraplegic, TRAUMA_RESILIENCE_SURGERY)
+				sleep(30)
+			unbuckle_mob(crunched, TRUE)
+		else
+			unbuckle_mob(crunched, TRUE)
+
 	crunched.notransform = FALSE
-	visible_message("<span class='warning'>[src] lets go of [crunched].</span>")
+	crunched.Knockdown(40)
+	crunched.visible_message("<span class='warning'>[src] lets go of [crunched].</span>", "<span class='warning'>[src] lets you go.</span>")

--- a/yogstation/code/modules/power/hugbox.dm
+++ b/yogstation/code/modules/power/hugbox.dm
@@ -6,8 +6,8 @@
 	density = TRUE
 	anchored = FALSE
 	use_power = NO_POWER_USE
-	can_buckle = 1
-	buckle_lying = 0
+	can_buckle = TRUE
+	buckle_lying = FALSE
 
 	var/power_per_hug = 1000000
 
@@ -71,15 +71,15 @@
 			add_avail(power_per_hug*50) //5 MW
 			crunched.Stun(20)
 			sleep(20)
-		else if(crunched.health <= 25)
+		else
 			crunched.visible_message("<span class='danger'>[src] hugs [crunched] tighter!</span>", "<span class='userdanger'>[src] starts hugging you tighter!</span>")
 			crunched.Stun(30)
-			crunched.adjustBruteLoss(4)
+			crunched.adjustBruteLoss(5)
 			sleep(30)
 			if(crunched.buckled) //Are they still buckled?
 				crunched.visible_message("<span class='danger'>[src] hugs [crunched] tighter!</span>", "<span class='userdanger'>WAY TOO TIGHT.</span>")
 				crunched.Stun(40)
-				crunched.adjustBruteLoss(4)
+				crunched.adjustBruteLoss(5)
 				sleep(40)
 			if(crunched.buckled)
 				crunched.visible_message("<span class='danger'>You hear a loud crunch coming from [crunched]!</span>", "<span class='colossus'>CRUNCH</span>")
@@ -91,8 +91,6 @@
 				playsound(src, "sound/magic/demon_consume.ogg", 60, 1)
 				crunched.gain_trauma(/datum/brain_trauma/severe/paralysis/paraplegic, TRAUMA_RESILIENCE_SURGERY)
 				sleep(30)
-			unbuckle_mob(crunched, TRUE)
-		else
 			unbuckle_mob(crunched, TRUE)
 
 	crunched.notransform = FALSE

--- a/yogstation/code/modules/power/hugbox.dm
+++ b/yogstation/code/modules/power/hugbox.dm
@@ -82,7 +82,7 @@
 				crunched.adjustBruteLoss(4)
 				sleep(40)
 			if(crunched.buckled)
-				crunched.visible_message("<span class='danger'>You hear a loud snap coming from [crunched]!</span>", "<span class='colossus'>SNAP</span>")
+				crunched.visible_message("<span class='danger'>You hear a loud crunch coming from [crunched]!</span>", "<span class='colossus'>CRUNCH</span>")
 				crunched.add_splatter_floor(location)
 				crunched.emote("scream")
 				crunched.adjustBruteLoss(5)


### PR DESCRIPTION
Emagged hugbox engine, once hugged, will buckle you to itself and cause brute damage until you reach 25 or less health, after which it crunches your spine, turning you paraplegic. 
The paraplegia is a severe brain trauma, meaning it can be healed via brain surgery, but not with neurine.
It is possible to rescue someone that is being crunched by simply unbuckling them from the machine.
Originally, the machine would just move you onto itself and cause brute damage until death.
:cl:  
rscadd: New emagged hugbox effect
tweak: Changed the variable check to a buckle check
/:cl:
