### PR TITLE
Blind people now heal blur damage

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -71,7 +71,7 @@
 			adjust_blindness(-3)
 		else
 			adjust_blindness(-1)
-	else if(eye_blurry)			//blurry eyes heal slowly
+	if(eye_blurry)			//blurry eyes heal slowly
 		adjust_blurriness(-1)
 
 	if (getOrganLoss(ORGAN_SLOT_BRAIN) >= 60)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -133,7 +133,7 @@
 				clear_fullscreen("blind")
 		else
 			eye_blind = max(eye_blind-1,1)
-	else if(eye_blurry)			//blurry eyes heal slowly
+	if(eye_blurry)			//blurry eyes heal slowly
 		eye_blurry = max(eye_blurry-1, 0)
 		if(client)
 			update_eye_blur()


### PR DESCRIPTION
### Intent of your Pull Request

Fixes #7331
Makes it so that getting blur when blind dosen't permanently give you blurred vision on top of being blind.
:cl:  
bugfix: Blur vision now works on blind people
/:cl:
