### PR TITLE
Removes egg metagame

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_egg.dm
+++ b/code/modules/food_and_drinks/food/snacks_egg.dm
@@ -24,7 +24,7 @@
 /obj/item/reagent_containers/food/snacks/egg/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] RPs as [src]!</span>")
 	if(istype(user) && user.mind)
-		var/mob/living/brain/B = new(src)
+		var/mob/living/B = new(src)
 		B.real_name = name
 		B.name = name
 		B.stat = CONSCIOUS


### PR DESCRIPTION
### Intent of your Pull Request
Fixes #8153
Makes them mob/living rather than mob/living/brain so they don't get chat they shouldnt see.

#### Changelog

:cl:  
bugfix: Removes egg suicide metagame
/:cl:
