### PR TITLE
probalby fixes transcendent olfaction plus slight miasma resist

### DIFF
--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -42,7 +42,7 @@
 /obj/effect/proc_holder/spell/targeted/olfaction/cast(list/targets, mob/living/user = usr)
 	//can we sniff? is there miasma in the air?
 	var/datum/gas_mixture/air = user.loc.return_air()
-	if(air.get_moles(/datum/gas/miasma))
+	if(air.get_moles(/datum/gas/miasma) >= 0.1)
 		user.adjust_disgust(sensitivity * 45)
 		to_chat(user, "<span class='warning'>With your overly sensitive nose, you get a whiff of stench and feel sick! Try moving to a cleaner area!</span>")
 		return
@@ -77,19 +77,20 @@
 	on_the_trail(user)
 
 /obj/effect/proc_holder/spell/targeted/olfaction/proc/on_the_trail(mob/living/user)
+	var/turf/pos = get_turf(tracking_target)
 	if(!tracking_target)
 		to_chat(user,"<span class='warning'>You're not tracking a scent, but the game thought you were. Something's gone wrong! Report this as a bug.</span>")
 		return
 	if(tracking_target == user)
 		to_chat(user,"<span class='warning'>You smell out the trail to yourself. Yep, it's you.</span>")
 		return
-	if(usr.z < tracking_target.z)
+	if(usr.z < pos.z)
 		to_chat(user,"<span class='warning'>The trail leads... way up above you? Huh. They must be really, really far away.</span>")
 		return
-	else if(usr.z > tracking_target.z)
+	else if(usr.z > pos.z)
 		to_chat(user,"<span class='warning'>The trail leads... way down below you? Huh. They must be really, really far away.</span>")
 		return
-	var/direction_text = "[dir2text(get_dir(usr, tracking_target))]"
+	var/direction_text = "[dir2text(get_dir(usr, pos))]"
 	if(direction_text)
 		to_chat(user,"<span class='notice'>You consider [tracking_target]'s scent. The trail leads <b>[direction_text].</b></span>")
 

--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -77,13 +77,13 @@
 	on_the_trail(user)
 
 /obj/effect/proc_holder/spell/targeted/olfaction/proc/on_the_trail(mob/living/user)
-	var/turf/pos = get_turf(tracking_target)
 	if(!tracking_target)
 		to_chat(user,"<span class='warning'>You're not tracking a scent, but the game thought you were. Something's gone wrong! Report this as a bug.</span>")
 		return
 	if(tracking_target == user)
 		to_chat(user,"<span class='warning'>You smell out the trail to yourself. Yep, it's you.</span>")
 		return
+	var/turf/pos = get_turf(tracking_target)
 	if(usr.z < pos.z)
 		to_chat(user,"<span class='warning'>The trail leads... way up above you? Huh. They must be really, really far away.</span>")
 		return


### PR DESCRIPTION
transcendent olfaction just checks for the existence of miasma, so even 0.0000000001 moles of it on the tile it's being used on will cause it to fail. Since the entire station is generally coated in a very thin layer of miasma after the 20 minute mark this generally means it's completely useless
to increase uselessness the ability also can't find people in lockers

so instead of checking for the person themself, it checks for their turf, which can't be in a locker
additionally, the miasma backfire will now only trigger when there's 0.1 moles or greater of miasma in the air instead of just any miasma being present at all

:cl:  
bugfix: transcendent olfaction can now smell people through lockers since another two inches of metal shouldn't stop it any more than the 5 walls it's already working through
tweak: transcendent olfaction now will only obliterate the user's nose if the miasma mole count is 0.1 or over
/:cl:
