### PR TITLE
[boring] Limits the amount of of active turfs at roundstart 

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_I.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_I.dmm
@@ -205,9 +205,6 @@
 "P" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"Q" = (
-/turf/open/floor/plasteel/dark,
-/area/lavaland/surface/outdoors)
 "R" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -216,6 +213,12 @@
 /obj/effect/mob_spawn/human/skeleton,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"T" = (
+/turf/open/floor/plasteel/dark/lavaland,
+/area/lavaland/surface/outdoors)
+"U" = (
+/turf/open/floor/plasteel/dark/lavaland,
+/area/ruin/unpowered)
 
 (1,1,1) = {"
 a
@@ -511,7 +514,7 @@ b
 a
 P
 P
-Q
+T
 P
 P
 O
@@ -542,7 +545,7 @@ a
 P
 P
 P
-Q
+T
 O
 O
 O
@@ -597,11 +600,11 @@ i
 h
 b
 b
-h
-h
+U
+U
 P
 P
-Q
+T
 P
 O
 O
@@ -626,12 +629,12 @@ b
 M
 h
 k
-h
-h
-h
-Q
-Q
-Q
+U
+U
+U
+T
+T
+T
 O
 O
 O
@@ -657,8 +660,8 @@ b
 k
 b
 b
-h
-h
+U
+U
 P
 P
 P

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_cafe_of_broken_dreams.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_cafe_of_broken_dreams.dmm
@@ -5,15 +5,6 @@
 "ab" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"ac" = (
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/lavaland/surface/outdoors)
-"ad" = (
-/obj/effect/turf_decal/sand,
-/mob/living/simple_animal/hostile/asteroid/hivelord/legion,
-/turf/open/floor/plasteel,
-/area/lavaland/surface/outdoors)
 "af" = (
 /turf/closed/wall/r_wall/rust,
 /area/lavaland/surface/outdoors)
@@ -37,29 +28,6 @@
 	icon_state = "wood-broken6"
 	},
 /area/ruin/powered)
-"ak" = (
-/obj/item/crowbar,
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/lavaland/surface/outdoors)
-"al" = (
-/obj/structure/grille{
-	density = 0;
-	icon_state = "brokengrille"
-	},
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/lavaland/surface/outdoors)
-"am" = (
-/obj/structure/grille/broken,
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/lavaland/surface/outdoors)
-"an" = (
-/obj/vehicle/ridden/atv,
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/lavaland/surface/outdoors)
 "ao" = (
 /obj/structure/table/wood/bar,
 /obj/item/toy/cards/deck/cas,
@@ -80,13 +48,6 @@
 /obj/structure/table/wood/bar,
 /obj/item/toy/cards/deck/cas/black,
 /turf/open/floor/wood,
-/area/ruin/powered)
-"as" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
 /area/ruin/powered)
 "at" = (
 /mob/living/simple_animal/hostile/asteroid/goliath/beast,
@@ -114,13 +75,6 @@
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/wood,
 /area/ruin/powered)
-"az" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/ruin/powered)
 "aA" = (
 /obj/structure/girder/reinforced,
 /turf/open/floor/plating{
@@ -132,13 +86,6 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/ruin/powered)
-"aC" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
 /area/ruin/powered)
 "aD" = (
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion,
@@ -158,11 +105,6 @@
 "aG" = (
 /obj/structure/closet/cardboard,
 /turf/open/floor/wood,
-/area/ruin/powered)
-"aH" = (
-/obj/machinery/light/small,
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
 /area/ruin/powered)
 "aI" = (
 /obj/structure/bookcase/random,
@@ -207,18 +149,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/powered)
-"aQ" = (
-/obj/item/reagent_containers/glass/bottle/potass_iodide,
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/lavaland/surface/outdoors)
-"aR" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/lavaland/surface/outdoors)
 "aS" = (
 /obj/structure/dresser,
 /turf/open/floor/wood,
@@ -248,11 +178,6 @@
 "aW" = (
 /turf/closed/wall/r_wall/rust,
 /area/ruin/powered)
-"aX" = (
-/obj/item/wrench,
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/lavaland/surface/outdoors)
 "aY" = (
 /obj/item/clothing/suit/jacket/leather,
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion,
@@ -310,8 +235,8 @@
 /area/ruin/powered)
 "bi" = (
 /obj/machinery/light{
-	icon_state = "tube";
-	dir = 8
+	dir = 8;
+	icon_state = "tube"
 	},
 /turf/open/floor/wood,
 /area/ruin/powered)
@@ -357,13 +282,6 @@
 /obj/item/toy/cards/cardhand,
 /turf/open/floor/wood,
 /area/ruin/powered)
-"br" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/lavaland/surface/outdoors)
 "bs" = (
 /obj/structure/ladder,
 /turf/open/floor/wood,
@@ -372,11 +290,6 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/wood,
 /area/ruin/powered)
-"bu" = (
-/obj/vehicle/ridden/scooter,
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/lavaland/surface/outdoors)
 "bv" = (
 /obj/structure/chair/comfy/beige{
 	dir = 4;
@@ -389,11 +302,6 @@
 /obj/item/reagent_containers/food/drinks/beer,
 /turf/open/floor/wood,
 /area/ruin/powered)
-"bx" = (
-/obj/structure/barricade/wooden,
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/lavaland/surface/outdoors)
 "by" = (
 /mob/living/simple_animal/pet/dog/corgi/Ian{
 	atmos_requirements = list("min_oxy" = 4, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 3, "min_co2" = 0, "max_co2" = 7, "min_n2" = 0, "max_n2" = 1);
@@ -410,21 +318,13 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/powered)
-"bA" = (
-/obj/structure/closet/crate/bin,
-/obj/item/reagent_containers/food/snacks/deadmouse,
-/obj/item/trash/can,
-/obj/item/trash/can,
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/lavaland/surface/outdoors)
 "bC" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube";
-	dir = 8
+	dir = 8;
+	icon_state = "tube"
 	},
 /turf/open/floor/wood,
 /area/ruin/powered)
@@ -435,8 +335,8 @@
 /area/ruin/powered)
 "bE" = (
 /obj/machinery/light{
-	icon_state = "tube";
-	dir = 4
+	dir = 4;
+	icon_state = "tube"
 	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken4"
@@ -471,8 +371,8 @@
 "bR" = (
 /obj/structure/table/wood,
 /obj/machinery/light{
-	icon_state = "tube";
-	dir = 8
+	dir = 8;
+	icon_state = "tube"
 	},
 /turf/open/floor/wood,
 /area/ruin/powered)
@@ -484,16 +384,65 @@
 /mob/living/simple_animal/hostile/asteroid/marrowweaver,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"iU" = (
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/lavaland,
+/area/lavaland/surface/outdoors)
+"ka" = (
+/obj/effect/turf_decal/sand,
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion,
+/turf/open/floor/plasteel/lavaland,
+/area/lavaland/surface/outdoors)
+"lc" = (
+/obj/item/crowbar,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/lavaland,
+/area/lavaland/surface/outdoors)
+"rP" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/lavaland,
+/area/lavaland/surface/outdoors)
+"st" = (
+/obj/structure/closet/crate/bin,
+/obj/item/reagent_containers/food/snacks/deadmouse,
+/obj/item/trash/can,
+/obj/item/trash/can,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/lavaland,
+/area/lavaland/surface/outdoors)
+"tD" = (
+/obj/item/wrench,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/lavaland,
+/area/lavaland/surface/outdoors)
+"vc" = (
+/obj/structure/grille{
+	density = 0;
+	icon_state = "brokengrille"
+	},
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/lavaland,
+/area/lavaland/surface/outdoors)
 "xf" = (
 /obj/item/clothing/suit/space/hardsuit/powerarmor_t45b,
 /turf/open/floor/wood,
 /area/ruin/powered)
 "zW" = (
 /obj/machinery/light{
-	icon_state = "tube";
-	dir = 1
+	dir = 1;
+	icon_state = "tube"
 	},
 /turf/open/floor/wood,
+/area/ruin/powered)
+"Dx" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/lavaland,
 /area/ruin/powered)
 "FQ" = (
 /obj/structure/sign/barsign{
@@ -501,10 +450,61 @@
 	},
 /turf/closed/wall/r_wall/rust,
 /area/ruin/powered)
+"Gm" = (
+/obj/item/reagent_containers/glass/bottle/potass_iodide,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/lavaland,
+/area/lavaland/surface/outdoors)
+"Jg" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/powered)
+"Jk" = (
+/obj/structure/barricade/wooden,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/lavaland,
+/area/lavaland/surface/outdoors)
+"ML" = (
+/obj/vehicle/ridden/scooter,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/lavaland,
+/area/lavaland/surface/outdoors)
+"Pr" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/powered)
+"RS" = (
+/obj/vehicle/ridden/atv,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/lavaland,
+/area/lavaland/surface/outdoors)
+"Si" = (
+/obj/machinery/light/small,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/powered)
+"Sz" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/lavaland,
+/area/lavaland/surface/outdoors)
 "Vo" = (
 /obj/machinery/light,
 /turf/open/floor/wood,
 /area/ruin/powered)
+"VZ" = (
+/obj/structure/grille/broken,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/lavaland,
+/area/lavaland/surface/outdoors)
 
 (1,1,1) = {"
 aa
@@ -534,7 +534,7 @@ ab
 ab
 ab
 ab
-ac
+iU
 aa
 aa
 aa
@@ -577,12 +577,12 @@ aa
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 ab
 ab
 ab
-ac
+iU
 aa
 aa
 aa
@@ -624,14 +624,14 @@ ab
 ab
 ab
 ab
-ac
-ac
-ac
-ac
+iU
+iU
+iU
+iU
 ab
 ab
-ac
-ac
+iU
+iU
 aa
 aa
 aa
@@ -672,15 +672,15 @@ ab
 ab
 ab
 ab
-ac
-ac
-ac
-ac
+iU
+iU
+iU
+iU
 ab
 ab
-ac
-ac
-ac
+iU
+iU
+iU
 aa
 aa
 aa
@@ -720,16 +720,16 @@ ab
 ab
 ab
 ab
-ac
-ac
-ac
-ac
-ac
+iU
+iU
+iU
+iU
+iU
 ab
-ac
-ac
-ac
-ac
+iU
+iU
+iU
+iU
 aa
 aa
 aa
@@ -769,16 +769,16 @@ ab
 ab
 ab
 ab
-ac
-ac
-ac
-ac
+iU
+iU
+iU
+iU
 ab
-ac
-ac
-ac
-ac
-ac
+iU
+iU
+iU
+iU
+iU
 aa
 aa
 aa
@@ -808,9 +808,9 @@ aa
 ab
 ab
 ab
-ac
-ac
-ac
+iU
+iU
+iU
 ab
 ab
 ab
@@ -818,11 +818,11 @@ ab
 ab
 ab
 ab
-ac
-ac
-ac
+iU
+iU
+iU
 ab
-ac
+iU
 ab
 ab
 ab
@@ -856,26 +856,26 @@ ab
 ab
 ab
 ab
-ac
-ac
-ac
-ac
+iU
+iU
+iU
+iU
 ab
 ab
 ab
 ab
 ab
 ab
-ac
-ac
-ac
+iU
+iU
+iU
 ab
-ac
-ab
-ab
+iU
 ab
 ab
-ac
+ab
+ab
+iU
 aa
 aa
 aa
@@ -903,9 +903,9 @@ ab
 ab
 ab
 ab
-ac
-ac
-ac
+iU
+iU
+iU
 aW
 aW
 ap
@@ -923,7 +923,7 @@ aW
 ap
 aq
 aq
-ac
+iU
 aa
 aa
 aa
@@ -950,10 +950,10 @@ ab
 ab
 ab
 ab
-ac
-ac
-ac
-ac
+iU
+iU
+iU
+iU
 aW
 ai
 ai
@@ -971,8 +971,8 @@ ai
 bj
 ai
 ap
-ac
-ac
+iU
+iU
 aa
 aa
 aa
@@ -993,15 +993,15 @@ aa
 aa
 ab
 ab
-ac
-ac
+iU
+iU
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 ab
-ac
+iU
 ap
 ai
 bl
@@ -1019,9 +1019,9 @@ ai
 ai
 ai
 ap
-ac
-ac
-ac
+iU
+iU
+iU
 aa
 aa
 aa
@@ -1041,15 +1041,15 @@ aa
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 ab
-ac
+iU
 aq
 bk
 bl
@@ -1067,9 +1067,9 @@ ai
 aW
 aW
 aW
-ac
-ac
-ac
+iU
+iU
+iU
 aa
 aa
 aa
@@ -1089,15 +1089,15 @@ ab
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 ab
-ac
+iU
 ap
 ai
 av
@@ -1115,10 +1115,10 @@ ai
 ai
 aS
 aW
-ac
-ac
-ac
-ac
+iU
+iU
+iU
+iU
 aa
 aa
 aa
@@ -1133,19 +1133,19 @@ aa
 (14,1,1) = {"
 aa
 ab
-ac
+iU
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 ab
 ab
 ab
-ac
-ac
-an
-ac
+iU
+iU
+RS
+iU
 aW
 ai
 ai
@@ -1163,11 +1163,11 @@ ai
 bk
 bU
 aW
-aX
-ac
-ac
-ac
-ac
+tD
+iU
+iU
+iU
+iU
 aa
 aa
 aa
@@ -1180,20 +1180,20 @@ aa
 "}
 (15,1,1) = {"
 ab
-ac
-ac
+iU
+iU
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 ab
 ab
 ab
-ac
-ac
-ac
-ac
+iU
+iU
+iU
+iU
 aW
 aW
 ay
@@ -1214,8 +1214,8 @@ aW
 aW
 aW
 aW
-ac
-ac
+iU
+iU
 aa
 aa
 aa
@@ -1228,28 +1228,28 @@ aa
 "}
 (16,1,1) = {"
 ab
-ac
-ac
+iU
+iU
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 ab
 ab
 ab
 ab
 ab
-ac
-ac
-as
-ac
-ac
-ac
-ac
-ac
-as
-ac
+iU
+iU
+Jg
+iU
+iU
+iU
+iU
+iU
+Jg
+iU
 ab
 ab
 aW
@@ -1262,9 +1262,9 @@ aW
 xf
 aY
 aW
-ac
-ac
-ac
+iU
+iU
+iU
 aa
 aa
 aa
@@ -1275,28 +1275,28 @@ aa
 aa
 "}
 (17,1,1) = {"
-ac
-ac
-ad
+iU
+iU
+ka
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 ab
 ab
 ab
 ab
 ab
 ab
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+iU
+iU
+iU
+iU
+iU
+iU
+iU
+iU
 ab
 ab
 ab
@@ -1310,8 +1310,8 @@ bo
 ai
 ai
 aU
-ac
-ac
+iU
+iU
 ab
 ab
 aa
@@ -1358,8 +1358,8 @@ aW
 aB
 aZ
 aW
-ac
-ac
+iU
+iU
 ab
 ab
 ab
@@ -1406,8 +1406,8 @@ aW
 aW
 aW
 aW
-am
-ac
+VZ
+iU
 ab
 ab
 ab
@@ -1443,7 +1443,7 @@ ab
 ab
 ab
 ab
-ac
+iU
 aW
 aK
 ai
@@ -1454,8 +1454,8 @@ aW
 ai
 ai
 aW
-ac
-ac
+iU
+iU
 ab
 ab
 ab
@@ -1470,28 +1470,28 @@ aa
 aa
 aa
 aa
-ac
-ac
-ac
+iU
+iU
+iU
 ab
 ab
 ab
 ab
 ab
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+iU
+iU
+iU
+iU
+iU
+iU
+iU
+iU
+iU
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 aU
 ai
 ai
@@ -1502,8 +1502,8 @@ bo
 ai
 ai
 aU
-ac
-ac
+iU
+iU
 ab
 ab
 ab
@@ -1519,27 +1519,27 @@ aa
 aa
 aa
 ab
-ac
-ac
+iU
+iU
 ab
 ab
 ab
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-az
-ac
+iU
+iU
+iU
+iU
+iU
+iU
+iU
+iU
+Pr
+iU
 ab
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 aW
 aM
 aB
@@ -1550,8 +1550,8 @@ aW
 aB
 ba
 aW
-ac
-ac
+iU
+iU
 ab
 ab
 ab
@@ -1567,11 +1567,11 @@ aa
 aa
 aa
 aa
-ac
-ac
-ac
+iU
+iU
+iU
 ab
-ac
+iU
 aW
 aW
 aU
@@ -1586,8 +1586,8 @@ ab
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 aW
 aW
 aW
@@ -1598,8 +1598,8 @@ aW
 aW
 aW
 aW
-ac
-ac
+iU
+iU
 ab
 ab
 ab
@@ -1618,8 +1618,8 @@ aa
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 aW
 ai
 ai
@@ -1634,8 +1634,8 @@ ab
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 aW
 ai
 aO
@@ -1646,8 +1646,8 @@ aW
 ai
 ai
 aW
-ac
-ac
+iU
+iU
 ab
 ab
 ab
@@ -1666,8 +1666,8 @@ aa
 aa
 ab
 ab
-ac
-ac
+iU
+iU
 aW
 ai
 ao
@@ -1677,13 +1677,13 @@ ai
 ai
 at
 aU
-ac
-ac
+iU
+iU
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 aU
 ai
 bj
@@ -1694,8 +1694,8 @@ bo
 bj
 ai
 aU
-ac
-bu
+iU
+ML
 ab
 ab
 ab
@@ -1715,7 +1715,7 @@ aa
 aa
 ab
 ab
-ac
+iU
 aW
 ai
 ai
@@ -1725,13 +1725,13 @@ ai
 bj
 ai
 aW
-ac
-ac
+iU
+iU
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 aW
 aN
 aB
@@ -1742,8 +1742,8 @@ aW
 aB
 bg
 aW
-ac
-ac
+iU
+iU
 ab
 ab
 ab
@@ -1773,13 +1773,13 @@ bv
 ai
 ai
 aW
-ac
-ac
+iU
+iU
 ab
 ab
 ab
-ac
-aH
+iU
+Si
 aW
 aW
 aW
@@ -1790,8 +1790,8 @@ aW
 aW
 aW
 aW
-ac
-ac
+iU
+iU
 ab
 ab
 ab
@@ -1799,7 +1799,7 @@ ab
 ab
 ab
 ab
-ac
+iU
 aa
 "}
 (28,1,1) = {"
@@ -1821,13 +1821,13 @@ bl
 ai
 ai
 ay
-ac
-ac
+iU
+iU
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 aW
 ai
 bi
@@ -1838,8 +1838,8 @@ ai
 bC
 ai
 aW
-ac
-ac
+iU
+iU
 ab
 ab
 ab
@@ -1847,8 +1847,8 @@ ab
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 "}
 (29,1,1) = {"
 aa
@@ -1869,13 +1869,13 @@ ai
 ai
 ai
 aW
-aC
-ac
+Dx
+iU
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 aU
 ai
 ai
@@ -1886,16 +1886,16 @@ bk
 bl
 ai
 aU
-ac
-ac
-ac
-ac
-ac
-ac
+iU
+iU
+iU
+iU
+iU
+iU
 ab
 ab
 ab
-ac
+iU
 ab
 "}
 (30,1,1) = {"
@@ -1917,13 +1917,13 @@ ai
 at
 bk
 aW
-ac
-ac
+iU
+iU
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 aW
 bb
 ai
@@ -1934,16 +1934,16 @@ ai
 bD
 ai
 aW
-ac
-ac
-ac
-ac
-ac
-ac
+iU
+iU
+iU
+iU
+iU
+iU
 ab
 ab
 ab
-ac
+iU
 ab
 "}
 (31,1,1) = {"
@@ -1965,13 +1965,13 @@ ai
 ai
 ai
 aU
-ac
-ac
+iU
+iU
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 aW
 bc
 ai
@@ -1986,8 +1986,8 @@ aW
 aU
 aW
 aW
-ac
-ac
+iU
+iU
 ab
 ab
 ab
@@ -2013,13 +2013,13 @@ ai
 ai
 ai
 aW
-ac
-ac
+iU
+iU
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 aW
 bb
 bj
@@ -2034,8 +2034,8 @@ bR
 bl
 ai
 aW
-ac
-ac
+iU
+iU
 ab
 ab
 ab
@@ -2061,13 +2061,13 @@ aW
 aW
 aW
 aW
-ac
+iU
 ab
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 aU
 ai
 ai
@@ -2082,8 +2082,8 @@ bN
 ai
 ai
 aU
-ac
-ac
+iU
+iU
 ab
 ab
 ab
@@ -2101,21 +2101,21 @@ aa
 aa
 ab
 ab
-ak
-al
-am
-ac
-ac
-ac
-ac
-ac
+lc
+vc
+VZ
+iU
+iU
+iU
+iU
+iU
 ab
 ab
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 FQ
 ai
 ai
@@ -2130,8 +2130,8 @@ bl
 ai
 bk
 aW
-ac
-ac
+iU
+iU
 ab
 ab
 ab
@@ -2152,18 +2152,18 @@ ab
 ab
 ab
 ab
-ac
-ac
-ac
-ac
-ac
+iU
+iU
+iU
+iU
+iU
 ab
 ab
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 aW
 aW
 bk
@@ -2178,8 +2178,8 @@ ai
 ai
 ai
 aW
-ac
-ac
+iU
+iU
 ab
 ab
 ab
@@ -2205,7 +2205,7 @@ af
 ag
 af
 af
-ac
+iU
 ab
 ab
 ab
@@ -2226,8 +2226,8 @@ ai
 ai
 Vo
 aW
-aC
-ac
+Dx
+iU
 ab
 ab
 ab
@@ -2253,8 +2253,8 @@ ab
 ab
 aF
 af
-ac
-ac
+iU
+iU
 ab
 ab
 ab
@@ -2274,12 +2274,12 @@ bz
 ai
 ai
 aW
-ac
-ac
+iU
+iU
 ab
 ab
 ab
-ac
+iU
 ab
 "}
 (38,1,1) = {"
@@ -2301,12 +2301,12 @@ ab
 ab
 ab
 ag
-ac
+iU
 ab
 ab
 ab
 ab
-ac
+iU
 ab
 ab
 bd
@@ -2322,12 +2322,12 @@ ai
 ai
 ai
 aW
-bA
-ac
+st
+iU
 ab
 ab
 ab
-ac
+iU
 aa
 "}
 (39,1,1) = {"
@@ -2354,8 +2354,8 @@ ab
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 aW
 aW
 ai
@@ -2370,12 +2370,12 @@ ai
 ai
 ai
 aU
-ac
-ac
+iU
+iU
 ab
 ab
 ab
-ac
+iU
 aa
 "}
 (40,1,1) = {"
@@ -2397,13 +2397,13 @@ ab
 ab
 ab
 af
-ac
-ac
+iU
+iU
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 aW
 ai
 ai
@@ -2418,8 +2418,8 @@ ai
 bk
 ai
 aW
-ac
-ac
+iU
+iU
 ab
 ab
 ab
@@ -2445,13 +2445,13 @@ ab
 ab
 ab
 af
-ac
-ac
+iU
+iU
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 aU
 ai
 ai
@@ -2466,8 +2466,8 @@ ai
 ai
 ai
 aW
-ac
-ac
+iU
+iU
 ab
 ab
 ab
@@ -2493,13 +2493,13 @@ aa
 ab
 ab
 ag
-ac
-ac
+iU
+iU
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 aW
 be
 bl
@@ -2514,8 +2514,8 @@ be
 bl
 Vo
 aW
-aC
-ac
+Dx
+iU
 ab
 ab
 ab
@@ -2542,12 +2542,12 @@ ab
 ab
 af
 aL
-ac
+iU
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 aW
 zW
 bm
@@ -2562,8 +2562,8 @@ ai
 ai
 ai
 aW
-ac
-ac
+iU
+iU
 ab
 ab
 aa
@@ -2590,12 +2590,12 @@ aa
 ab
 aA
 ab
-ac
+iU
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 aW
 ai
 ai
@@ -2610,8 +2610,8 @@ ai
 bk
 ai
 aW
-ac
-ac
+iU
+iU
 ab
 ab
 aa
@@ -2638,12 +2638,12 @@ aa
 ab
 au
 ab
-ac
+iU
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 aU
 ai
 bj
@@ -2658,8 +2658,8 @@ ai
 ai
 ai
 aU
-ac
-ac
+iU
+iU
 ab
 ab
 aa
@@ -2686,12 +2686,12 @@ aa
 aa
 ab
 ab
-ac
+iU
 ab
 ab
 ab
-ac
-ac
+iU
+iU
 aW
 ai
 ai
@@ -2706,8 +2706,8 @@ ai
 ai
 ai
 aW
-ac
-ac
+iU
+iU
 ab
 aa
 aa
@@ -2738,8 +2738,8 @@ ab
 ab
 ab
 ab
-ac
-aH
+iU
+Si
 aW
 aW
 aU
@@ -2754,8 +2754,8 @@ aW
 aU
 aW
 aW
-ac
-ac
+iU
+iU
 ab
 aa
 aa
@@ -2786,11 +2786,11 @@ ab
 ab
 ab
 ab
-ac
-ac
-ac
-ac
-aQ
+iU
+iU
+iU
+iU
+Gm
 aW
 bk
 ai
@@ -2799,10 +2799,10 @@ ai
 bh
 bs
 aW
-ac
-ac
-ac
-ac
+iU
+iU
+iU
+iU
 ab
 ab
 aa
@@ -2834,11 +2834,11 @@ ab
 ab
 ab
 ab
-ac
-ac
-ac
-ac
-ac
+iU
+iU
+iU
+iU
+iU
 aW
 zW
 ai
@@ -2847,9 +2847,9 @@ ai
 bn
 bh
 aW
-bx
-ac
-ac
+Jk
+iU
+iU
 ab
 ab
 aa
@@ -2884,9 +2884,9 @@ ab
 ab
 ab
 ab
-ac
-ac
-ac
+iU
+iU
+iU
 aW
 aW
 aU
@@ -2895,7 +2895,7 @@ aW
 aU
 aW
 aW
-ac
+iU
 ab
 ab
 ab
@@ -2930,20 +2930,20 @@ aa
 ab
 ab
 ab
-ac
-ac
-ac
-ac
-ac
-aR
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+iU
+iU
+iU
+iU
+iU
+rP
+iU
+iU
+iU
+iU
+iU
+iU
+iU
+iU
 ab
 ab
 ab
@@ -3127,17 +3127,17 @@ aa
 ab
 ab
 ab
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+iU
+iU
+iU
+iU
+iU
+iU
+iU
+iU
+iU
+iU
+iU
 aa
 aa
 aa
@@ -3176,14 +3176,14 @@ ab
 ab
 ab
 ab
-ac
-ac
-ac
-ac
-br
-ac
-ac
-ac
+iU
+iU
+iU
+iU
+Sz
+iU
+iU
+iU
 aa
 aa
 aa
@@ -3230,7 +3230,7 @@ af
 af
 af
 aA
-ac
+iU
 aa
 aa
 aa

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_chemistry.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_chemistry.dmm
@@ -17,12 +17,12 @@
 /area/ruin/powered)
 "f" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion_l";
-	dir = 4
+	dir = 4;
+	icon_state = "propulsion_l"
 	},
 /obj/structure/window/reinforced/tinted{
-	icon_state = "twindow";
-	dir = 4
+	dir = 4;
+	icon_state = "twindow"
 	},
 /turf/closed/wall/mineral/plastitanium,
 /area/ruin/powered)
@@ -49,24 +49,24 @@
 /obj/structure/table,
 /obj/item/flashlight/lamp,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "l" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/item/extinguisher,
 /turf/open/floor/plasteel/white,
@@ -76,21 +76,18 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "n" = (
-/obj/item/paper/crumpled/bloody{
-	info = "Week 2, day 6. <B>Success!<B> I've managed to synthesize a small amount of solid plasma! The block I created took days to stabilize and cool down, but after running some tests it's exceeding all my expectactions. I'll have to refine the process more before sending a sample to Centcom, but soon we won't have to waste thousands of credits sending those miners to work in this... hellscape anymore. The rest of my mineral samples remained stable too. I'll just have to hope those Space Pirates won't track me down after I stole their trisulfideoxide again... I've hidden the recipe in the safe for now. Code is 8124."
-	},
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating,
+/obj/item/wrench,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/lavaland/surface/outdoors)
 "o" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/item/reagent_containers/glass/bottle/plasma,
 /obj/item/reagent_containers/glass/bottle/plasma,
@@ -98,45 +95,35 @@
 /area/ruin/powered)
 "p" = (
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "q" = (
 /obj/structure/fans,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
-"r" = (
-/obj/item/clothing/under/pirate,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating,
-/area/lavaland/surface/outdoors)
-"s" = (
-/obj/item/clothing/head/helmet/space/pirate,
-/turf/open/floor/plating,
-/area/lavaland/surface/outdoors)
 "t" = (
-/obj/item/stack/sheet/metal,
-/turf/open/floor/plating,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/lavaland/surface/outdoors)
 "u" = (
 /obj/structure/closet/wardrobe/chemistry_white,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
@@ -146,15 +133,19 @@
 /turf/open/floor/plating,
 /area/ruin/powered)
 "w" = (
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/plating,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/lavaland/surface/outdoors)
 "x" = (
-/turf/open/floor/plating,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/lavaland/surface/outdoors)
 "y" = (
-/obj/item/wrench,
-/turf/open/floor/plating,
+/obj/item/paper/crumpled/bloody{
+	info = "Week 2, day 6. <B>Success!<B> I've managed to synthesize a small amount of solid plasma! The block I created took days to stabilize and cool down, but after running some tests it's exceeding all my expectactions. I'll have to refine the process more before sending a sample to Centcom, but soon we won't have to waste thousands of credits sending those miners to work in this... hellscape anymore. The rest of my mineral samples remained stable too. I'll just have to hope those Space Pirates won't track me down after I stole their trisulfideoxide again... I've hidden the recipe in the safe for now. Code is 8124."
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/lavaland/surface/outdoors)
 "z" = (
 /obj/item/storage/secure/safe,
@@ -170,12 +161,12 @@
 "B" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/item/reagent_containers/glass/beaker/bluespace,
 /obj/item/reagent_containers/glass/beaker/bluespace,
@@ -184,12 +175,12 @@
 /area/ruin/powered)
 "C" = (
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /mob/living/simple_animal/hostile/pirate,
 /turf/open/floor/plasteel/white,
@@ -197,35 +188,35 @@
 "D" = (
 /obj/effect/decal/cleanable/chem_pile,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "E" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "F" = (
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /mob/living/simple_animal/hostile/pirate/ranged,
 /turf/open/floor/plasteel/white,
@@ -234,48 +225,48 @@
 /obj/structure/table,
 /obj/item/stack/sheet/mineral/silver,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "H" = (
 /obj/effect/mob_spawn/human/corpse/damaged,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "I" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "J" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
@@ -290,12 +281,12 @@
 	pixel_x = 3
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
@@ -303,12 +294,12 @@
 /obj/structure/table,
 /obj/item/stack/sheet/mineral/diamond,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
@@ -319,12 +310,12 @@
 	},
 /obj/item/stack/sheet/mineral/gold,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
@@ -342,12 +333,12 @@
 /obj/structure/table,
 /obj/item/stack/cable_coil/yellow,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
@@ -394,6 +385,11 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/powered)
+"V" = (
+/obj/item/clothing/under/pirate,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/lavaland_baseturf,
+/area/lavaland/surface/outdoors)
 "W" = (
 /obj/machinery/power/port_gen/pacman{
 	sheets = 100
@@ -401,6 +397,10 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/ruin/powered)
+"Y" = (
+/obj/item/clothing/head/helmet/space/pirate,
+/turf/open/floor/plating/lavaland_baseturf,
+/area/lavaland/surface/outdoors)
 "Z" = (
 /turf/open/floor/plating,
 /area/ruin/powered)
@@ -609,8 +609,8 @@ b
 b
 b
 b
-r
-s
+V
+Y
 v
 Z
 v
@@ -630,7 +630,7 @@ b
 b
 b
 b
-n
+y
 m
 m
 A
@@ -655,8 +655,8 @@ b
 b
 b
 m
-t
-y
+w
+n
 A
 u
 F
@@ -676,9 +676,9 @@ b
 b
 b
 m
-t
 w
 x
+t
 A
 p
 N
@@ -699,8 +699,8 @@ a
 a
 a
 m
-x
-x
+t
+t
 A
 z
 A

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_cursedtoyshop.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_cursedtoyshop.dmm
@@ -159,8 +159,8 @@
 /obj/item/clothing/under/roman,
 /obj/item/clothing/head/helmet/roman,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/open/floor/wood,
 /area/ruin/powered)
@@ -359,11 +359,6 @@
 /obj/item/toy/figure/captain,
 /turf/open/floor/wood,
 /area/ruin/powered)
-"aQ" = (
-/turf/open/floor/wood{
-	icon_state = "wood-broken4"
-	},
-/area/ruin/powered)
 "aR" = (
 /obj/machinery/light{
 	dir = 1
@@ -402,8 +397,8 @@
 /obj/structure/table/wood,
 /obj/item/toy/nuke,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/open/floor/wood,
 /area/ruin/powered)
@@ -466,8 +461,8 @@
 	},
 /obj/item/toy/figure/cmo,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/open/floor/wood,
 /area/ruin/powered)
@@ -549,11 +544,6 @@
 /obj/item/toy/figure/ninja,
 /turf/open/floor/wood,
 /area/ruin/powered)
-"bh" = (
-/turf/open/floor/wood{
-	icon_state = "wood-broken7"
-	},
-/area/ruin/powered)
 "bi" = (
 /obj/structure/table/wood,
 /obj/item/toy/spinningtoy,
@@ -604,14 +594,6 @@
 	},
 /turf/closed/wall/mineral/wood,
 /area/ruin/powered)
-"bn" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken7"
-	},
-/area/ruin/powered)
 "bo" = (
 /obj/structure/table/wood,
 /obj/item/toy/plush/stuffedmonkey{
@@ -641,12 +623,6 @@
 	},
 /obj/item/clothing/mask/cowmask,
 /obj/item/clothing/mask/fakemoustache,
-/turf/open/floor/wood,
-/area/ruin/powered)
-"bs" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/open/floor/wood,
 /area/ruin/powered)
 "bt" = (
@@ -697,11 +673,6 @@
 /obj/structure/table/wood,
 /obj/item/banhammer,
 /turf/open/floor/wood,
-/area/ruin/powered)
-"bz" = (
-/turf/open/floor/wood{
-	icon_state = "wood-broken3"
-	},
 /area/ruin/powered)
 "bA" = (
 /turf/open/floor/light,
@@ -793,8 +764,8 @@
 /area/ruin/powered)
 "bM" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/open/floor/wood,
 /area/ruin/powered)
@@ -815,6 +786,28 @@
 /obj/effect/mob_spawn/human/clown/corpse,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/wood,
+/area/ruin/powered)
+"pE" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood/lavaland,
+/area/ruin/powered)
+"yW" = (
+/turf/open/floor/wood/lavaland,
+/area/ruin/powered)
+"Pj" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood/lavaland{
+	broken = 1
+	},
+/area/ruin/powered)
+"Zw" = (
+/turf/open/floor/wood/lavaland{
+	broken = 1
+	},
 /area/ruin/powered)
 
 (1,1,1) = {"
@@ -1098,14 +1091,14 @@ ao
 ao
 aF
 aa
-aQ
-aX
-aX
-aX
-bn
-aX
-bs
-bz
+Zw
+yW
+yW
+yW
+Pj
+yW
+pE
+Zw
 aa
 aX
 bN
@@ -1120,13 +1113,13 @@ aA
 aG
 aa
 aR
-aX
+yW
 aS
-bh
-aX
-aX
+Zw
+yW
+yW
 aS
-aX
+yW
 aa
 bJ
 bO

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_gas_station.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_gas_station.dmm
@@ -8,15 +8,6 @@
 "ac" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface)
-"af" = (
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/lavaland/surface)
-"ag" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/ruin/powered/gasstation)
 "ah" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -40,32 +31,6 @@
 /obj/machinery/atmospherics/pipe/simple,
 /turf/closed/wall/rust,
 /area/ruin/powered/gasstation)
-"an" = (
-/obj/item/trash/syndi_cakes,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"ao" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"ap" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
 "aq" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -73,197 +38,9 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel/white,
 /area/ruin/powered/gasstation)
-"ar" = (
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"as" = (
-/obj/structure/sink,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"at" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"au" = (
-/obj/structure/table,
-/obj/item/storage/box/donkpockets,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"av" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#c1caff"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"ax" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"ay" = (
-/obj/machinery/vending/cola,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"az" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/ruin/powered/gasstation)
-"aA" = (
-/obj/machinery/door/airlock/hatch,
-/obj/structure/fans/tiny,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"aB" = (
-/obj/item/trash/candy,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"aC" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
-	},
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/ruin/powered/gasstation)
-"aD" = (
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/mirror{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"aF" = (
-/obj/item/trash/raisins,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"aG" = (
-/obj/machinery/vending/boozeomat{
-	products = list(/obj/item/reagent_containers/food/drinks/bottle/gin = 2, /obj/item/reagent_containers/food/drinks/bottle/whiskey = 2, /obj/item/reagent_containers/food/drinks/bottle/tequila = 3, /obj/item/reagent_containers/food/drinks/bottle/vodka = 1, /obj/item/reagent_containers/food/drinks/bottle/vermouth = 3, /obj/item/reagent_containers/food/drinks/bottle/rum = 5, /obj/item/reagent_containers/food/drinks/bottle/wine = 2, /obj/item/reagent_containers/food/drinks/bottle/cognac = 3, /obj/item/reagent_containers/food/drinks/bottle/kahlua = 1, /obj/item/reagent_containers/food/drinks/bottle/absinthe = 2, /obj/item/reagent_containers/food/drinks/ale = 3, /obj/item/reagent_containers/food/drinks/flask = 1)
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"aH" = (
-/obj/machinery/vending/cigarette{
-	products = list(/obj/item/storage/box/fancy/cigarettes = 3, /obj/item/storage/box/fancy/cigarettes/cigpack_uplift = 2, /obj/item/storage/box/fancy/cigarettes/cigpack_robust = 1, /obj/item/storage/box/fancy/cigarettes/cigpack_carp = 0, /obj/item/storage/box/fancy/cigarettes/cigpack_midori = 0, /obj/item/storage/box/matches = 4, /obj/item/lighter/greyscale = 1, /obj/item/storage/box/fancy/rollingpapers = 3)
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"aI" = (
-/obj/structure/table/reinforced,
-/obj/item/trash/raisins,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "cashiershutters";
-	name = "Cashier Shutters"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"aJ" = (
-/obj/structure/table,
-/obj/structure/window,
-/obj/item/reagent_containers/food/snacks/burrito,
-/obj/item/reagent_containers/food/snacks/carneburrito,
-/obj/item/reagent_containers/food/snacks/poppypretzel,
-/obj/item/reagent_containers/food/snacks/poppypretzel,
-/obj/structure/rack,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"aK" = (
-/obj/structure/table,
-/obj/structure/window,
-/obj/item/reagent_containers/food/snacks/popcorn,
-/obj/item/reagent_containers/food/snacks/popcorn,
-/obj/item/reagent_containers/food/snacks/nachos,
-/obj/structure/rack,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
 "aL" = (
-/obj/structure/table,
-/obj/structure/window,
-/obj/item/toy/cards/deck/cas,
-/obj/item/toy/cards/deck/cas/black,
-/obj/structure/rack,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"aM" = (
-/obj/structure/table,
-/obj/structure/window,
-/obj/item/toy/plush/teddybear,
-/obj/item/toy/plush/goatplushie,
-/obj/item/toy/plush/flowerbunch,
-/obj/item/toy/plush/stuffedmonkey,
-/obj/structure/rack,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
+/obj/item/trash/candy,
+/turf/open/floor/plasteel/white,
 /area/ruin/powered/gasstation)
 "aN" = (
 /obj/structure/closet,
@@ -279,71 +56,15 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/powered/gasstation)
-"aP" = (
-/obj/structure/table/reinforced,
-/obj/item/newspaper,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "cashiershutters";
-	name = "Cashier Shutters"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"aQ" = (
-/obj/structure/table,
-/obj/structure/window{
-	dir = 4
-	},
-/obj/item/reagent_containers/food/snacks/syndicake,
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/donut,
-/obj/item/reagent_containers/food/snacks/donut,
-/obj/item/reagent_containers/food/snacks/donut,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"aR" = (
-/obj/structure/table,
-/obj/structure/window{
-	dir = 8
-	},
-/obj/item/reagent_containers/food/snacks/dolphincereal,
-/obj/item/reagent_containers/food/snacks/dolphincereal,
-/obj/item/reagent_containers/food/snacks/dolphincereal,
-/obj/structure/rack,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
 "aS" = (
 /obj/structure/table,
 /obj/structure/window{
 	dir = 4
 	},
-/obj/item/toy/foamblade,
+/obj/item/reagent_containers/food/snacks/honeybun,
+/obj/item/reagent_containers/food/snacks/honeybun,
 /obj/structure/rack,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"aT" = (
-/obj/structure/table,
-/obj/structure/window{
-	dir = 8
-	},
-/obj/item/toy/toyballoon,
-/obj/item/toy/heartballoon,
-/obj/structure/rack,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
+/turf/open/floor/plasteel/white,
 /area/ruin/powered/gasstation)
 "aU" = (
 /obj/machinery/door/airlock/centcom{
@@ -354,60 +75,6 @@
 /area/ruin/powered/gasstation)
 "aV" = (
 /turf/open/floor/plating,
-/area/ruin/powered/gasstation)
-"aW" = (
-/obj/structure/table/reinforced,
-/obj/machinery/paystand/register{
-	dir = 8;
-	icon_state = "register"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "cashiershutters";
-	name = "Cash Register Blast Door"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"aX" = (
-/obj/machinery/icecream_vat,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"aY" = (
-/obj/structure/window{
-	dir = 4
-	},
-/obj/structure/displaycase/labcage{
-	desc = "For displaying of more valuable items you have acquired.";
-	name = "Shop Display Case";
-	req_access = null;
-	req_access_txt = "36";
-	start_showpiece_type = null
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"aZ" = (
-/obj/structure/window{
-	dir = 8
-	},
-/obj/structure/displaycase/labcage{
-	desc = "For displaying of more valuable items you have acquired.";
-	name = "Shop Display Case";
-	req_access = null;
-	req_access_txt = "36";
-	start_showpiece_type = null
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
 /area/ruin/powered/gasstation)
 "bb" = (
 /obj/structure/table,
@@ -431,245 +98,9 @@
 /obj/item/hand_labeler,
 /turf/open/floor/plating,
 /area/ruin/powered/gasstation)
-"bd" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen/fourcolor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "cashiershutters";
-	name = "Cashier Shutters"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"be" = (
-/obj/structure/table,
-/obj/structure/window{
-	dir = 4
-	},
-/obj/item/reagent_containers/food/snacks/honeybun,
-/obj/item/reagent_containers/food/snacks/honeybun,
-/obj/structure/rack,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"bf" = (
-/obj/structure/table,
-/obj/structure/window{
-	dir = 8
-	},
-/obj/item/reagent_containers/food/snacks/sosjerky,
-/obj/item/reagent_containers/food/snacks/sosjerky,
-/obj/structure/rack,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"bg" = (
-/obj/structure/table,
-/obj/structure/window{
-	dir = 4
-	},
-/obj/item/toy/sword,
-/obj/item/toy/sword,
-/obj/structure/rack,
-/obj/item/toy/katana,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"bh" = (
-/obj/item/trash/chips,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/ruin/powered/gasstation)
-"bi" = (
-/obj/machinery/door/window{
-	req_access = null;
-	req_access_txt = "36"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "cashiershutters";
-	name = "Cashier Shutters"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"bj" = (
-/obj/structure/window{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/chocolatebar,
-/obj/item/reagent_containers/food/snacks/chocolatebar,
-/obj/item/reagent_containers/food/snacks/candy,
-/obj/item/reagent_containers/food/snacks/candy,
-/obj/item/reagent_containers/food/snacks/candy_corn,
-/obj/structure/rack,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"bk" = (
-/obj/structure/window{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/chips,
-/obj/item/reagent_containers/food/snacks/chips,
-/obj/item/reagent_containers/food/snacks/cheesiehonkers,
-/obj/structure/rack,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"bl" = (
-/obj/structure/window{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/toy/gun,
-/obj/item/toy/gun/toyglock,
-/obj/structure/rack,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"bm" = (
-/obj/structure/window{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/toy/ammo/gun,
-/obj/item/toy/ammo/gun,
-/obj/structure/rack,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"bn" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/vehicle/ridden/atv,
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/lavaland/surface)
-"bo" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/vehicle/ridden/scooter,
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/lavaland/surface)
-"bp" = (
-/obj/item/trash/chips,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"bq" = (
-/obj/item/trash/popcorn,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"br" = (
-/obj/machinery/door/airlock/glass_large{
-	doorOpen = 'sound/machines/defib_success.ogg'
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "gasstation"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"bs" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "gasstation"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"bt" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/ruin/powered/gasstation)
-"bu" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/lavaland/surface)
-"bv" = (
-/obj/item/trash/chips,
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/lavaland/surface)
-"bw" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/ruin/powered/gasstation)
-"bx" = (
-/obj/item/melee/skateboard{
-	dir = 4
-	},
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/lavaland/surface)
-"by" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/powered)
 "bz" = (
 /obj/structure/sign/warning/nosmoking,
 /turf/closed/wall/rust,
-/area/ruin/powered)
-"bA" = (
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/plasteel,
 /area/ruin/powered)
 "bB" = (
 /obj/structure/sign/warning/fire,
@@ -681,24 +112,52 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/powered)
-"bD" = (
-/obj/structure/tank_dispenser/plasma,
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"bE" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plasteel,
-/area/ruin/powered)
 "bF" = (
 /obj/structure/extinguisher_cabinet,
 /turf/closed/wall/rust,
 /area/ruin/powered)
-"cU" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
+"bZ" = (
+/obj/effect/turf_decal/sand,
+/obj/machinery/camera{
+	c_tag = "Outside Entrance Camera";
+	dir = 2;
+	name = "security camera";
+	network = list("gasstation")
 	},
+/turf/open/floor/plasteel/lavaland,
+/area/lavaland/surface)
+"cK" = (
+/obj/item/trash/chips,
+/obj/effect/turf_decal/sand,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/powered/gasstation)
+"cS" = (
+/obj/effect/turf_decal/sand,
+/obj/machinery/camera{
+	c_tag = "Outside Backroom Camera";
+	dir = 8;
+	name = "security camera";
+	network = list("gasstation")
+	},
+/turf/open/floor/plasteel/lavaland,
+/area/lavaland/surface)
+"cV" = (
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"dC" = (
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/lavaland,
+/area/lavaland/surface)
+"dI" = (
+/obj/structure/table,
+/obj/machinery/computer/security/telescreen{
+	name = "Gas Station Surveillance";
+	network = list("gasstation")
+	},
+/turf/open/floor/plasteel/white,
 /area/ruin/powered/gasstation)
 "dQ" = (
 /obj/machinery/camera{
@@ -709,50 +168,153 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered/gasstation)
-"fP" = (
-/obj/structure/toilet{
-	dir = 4;
-	icon_state = "toilet00"
+"fB" = (
+/obj/structure/table,
+/obj/structure/window{
+	dir = 8
 	},
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
+/obj/item/storage/box/snappops,
+/obj/structure/rack,
+/obj/item/toy/figure/clown,
+/turf/open/floor/plasteel/white,
 /area/ruin/powered/gasstation)
-"gV" = (
-/obj/machinery/camera{
-	c_tag = "Inside Right Side Gas Station Camera";
-	dir = 8;
-	name = "security camera";
-	network = list("gasstation")
+"fI" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/powered)
+"fO" = (
+/obj/effect/turf_decal/sand,
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
+/turf/open/floor/plasteel/lavaland,
 /area/ruin/powered/gasstation)
-"lg" = (
-/obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "Inside Entrance Camera";
-	dir = 1;
-	name = "security camera";
-	network = list("gasstation")
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"md" = (
+"gd" = (
 /obj/machinery/shower{
 	dir = 1;
 	icon_state = "shower"
 	},
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"gZ" = (
+/obj/machinery/door/airlock/hatch{
+	req_access = null;
+	req_access_txt = "36"
 	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"ha" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/powered/gasstation)
+"hy" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/obj/effect/mob_spawn/human/gasstation_clerk,
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"ii" = (
+/obj/item/trash/chips,
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"iq" = (
+/obj/machinery/door/window{
+	req_access = null;
+	req_access_txt = "36"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "cashiershutters";
+	name = "Cashier Shutters"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"ir" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"js" = (
+/obj/structure/table,
+/obj/structure/window{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/snacks/syndicake,
+/obj/structure/rack,
+/obj/item/reagent_containers/food/snacks/donut,
+/obj/item/reagent_containers/food/snacks/donut,
+/obj/item/reagent_containers/food/snacks/donut,
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"kg" = (
+/obj/structure/window{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/chocolatebar,
+/obj/item/reagent_containers/food/snacks/chocolatebar,
+/obj/item/reagent_containers/food/snacks/candy,
+/obj/item/reagent_containers/food/snacks/candy,
+/obj/item/reagent_containers/food/snacks/candy_corn,
+/obj/structure/rack,
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"kR" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"lg" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/vehicle/ridden/scooter,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/lavaland,
+/area/lavaland/surface)
+"lM" = (
+/obj/structure/toilet{
+	dir = 4;
+	icon_state = "toilet00"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"lN" = (
+/obj/machinery/door/airlock,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "gasstation"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/powered/gasstation)
+"md" = (
+/obj/structure/sink,
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"mf" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"mo" = (
+/obj/structure/table,
+/obj/structure/window,
+/obj/item/reagent_containers/food/snacks/popcorn,
+/obj/item/reagent_containers/food/snacks/popcorn,
+/obj/item/reagent_containers/food/snacks/nachos,
+/obj/structure/rack,
+/turf/open/floor/plasteel/white,
 /area/ruin/powered/gasstation)
 "qd" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -760,53 +322,92 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered/gasstation)
+"qf" = (
+/obj/structure/table,
+/obj/structure/window,
+/obj/item/toy/cards/deck/cas,
+/obj/item/toy/cards/deck/cas/black,
+/obj/structure/rack,
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"qD" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
 "rp" = (
 /obj/structure/fans/tiny,
 /turf/open/floor/plasteel,
 /area/ruin/powered/gasstation)
-"rr" = (
-/obj/item/gps/internal{
-	desc = "You can just FEEL the money oozing out of this signal.";
-	gpstag = "Capitalistic Signal";
-	name = "gas station signal"
+"rs" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"rL" = (
+/obj/item/instrument/piano_synth,
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"rQ" = (
+/obj/structure/window{
+	dir = 1
 	},
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
+/obj/structure/table,
+/obj/item/toy/gun,
+/obj/item/toy/gun/toyglock,
+/obj/structure/rack,
+/turf/open/floor/plasteel/white,
 /area/ruin/powered/gasstation)
 "sp" = (
 /obj/machinery/teleport/station,
 /turf/open/floor/plasteel,
 /area/ruin/powered/gasstation)
-"su" = (
-/obj/machinery/light/small{
-	brightness = 3;
+"sJ" = (
+/obj/structure/table,
+/obj/structure/window{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
+/obj/item/toy/toyballoon,
+/obj/item/toy/heartballoon,
+/obj/structure/rack,
+/turf/open/floor/plasteel/white,
 /area/ruin/powered/gasstation)
-"tZ" = (
-/obj/machinery/camera{
-	c_tag = "Inside Back Exit Camera";
-	name = "security camera";
-	network = list("gasstation")
+"sY" = (
+/obj/machinery/vending/cigarette{
+	products = list(/obj/item/storage/box/fancy/cigarettes = 3, /obj/item/storage/box/fancy/cigarettes/cigpack_uplift = 2, /obj/item/storage/box/fancy/cigarettes/cigpack_robust = 1, /obj/item/storage/box/fancy/cigarettes/cigpack_carp = 0, /obj/item/storage/box/fancy/cigarettes/cigpack_midori = 0, /obj/item/storage/box/matches = 4, /obj/item/lighter/greyscale = 1, /obj/item/storage/box/fancy/rollingpapers = 3)
 	},
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
+/turf/open/floor/plasteel/white,
 /area/ruin/powered/gasstation)
-"uH" = (
-/obj/item/instrument/piano_synth,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
+"ts" = (
+/obj/structure/tank_dispenser/plasma,
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/powered)
+"ul" = (
+/obj/structure/window{
+	dir = 1
 	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/chips,
+/obj/item/reagent_containers/food/snacks/chips,
+/obj/item/reagent_containers/food/snacks/cheesiehonkers,
+/obj/structure/rack,
+/turf/open/floor/plasteel/white,
 /area/ruin/powered/gasstation)
+"uq" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/powered/gasstation)
+"vk" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/powered)
 "vn" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4;
@@ -815,64 +416,121 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plasteel,
 /area/ruin/powered/gasstation)
+"vo" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
 "wF" = (
 /obj/structure/sign/poster/contraband/smoke,
 /turf/closed/wall/rust,
 /area/ruin/powered/gasstation)
-"wQ" = (
-/obj/machinery/computer/arcade/orion_trail,
+"wL" = (
+/obj/item/trash/raisins,
 /obj/machinery/light{
-	dir = 1;
-	light_color = "#c1caff"
+	dir = 4;
+	light_color = "#e8eaff"
 	},
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
+/turf/open/floor/plasteel/white,
 /area/ruin/powered/gasstation)
-"xf" = (
-/obj/machinery/door/airlock/hatch{
-	req_access = null;
-	req_access_txt = "36"
+"xm" = (
+/obj/effect/turf_decal/sand,
+/obj/machinery/light{
+	dir = 4
 	},
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/powered/gasstation)
+"zS" = (
+/obj/machinery/door/airlock/hatch,
 /obj/structure/fans/tiny,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
+/turf/open/floor/plasteel/white,
 /area/ruin/powered/gasstation)
 "Aj" = (
 /obj/machinery/teleport/hub,
 /turf/open/floor/plasteel,
 /area/ruin/powered/gasstation)
-"AD" = (
+"An" = (
 /obj/structure/table/reinforced,
+/obj/machinery/paystand/register{
+	dir = 8;
+	icon_state = "register"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "cashiershutters";
+	name = "Cash Register Blast Door"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"Bp" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "cashiershutters";
 	name = "Cashier Shutters"
 	},
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
+/turf/open/floor/plasteel/white,
 /area/ruin/powered/gasstation)
-"DY" = (
-/obj/effect/turf_decal/sand,
+"BK" = (
+/obj/structure/table,
+/obj/structure/window,
+/obj/item/reagent_containers/food/snacks/burrito,
+/obj/item/reagent_containers/food/snacks/carneburrito,
+/obj/item/reagent_containers/food/snacks/poppypretzel,
+/obj/item/reagent_containers/food/snacks/poppypretzel,
+/obj/structure/rack,
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"Ec" = (
 /obj/machinery/camera{
-	c_tag = "Outside Backroom Camera";
+	c_tag = "Inside Right Side Gas Station Camera";
 	dir = 8;
 	name = "security camera";
 	network = list("gasstation")
 	},
-/turf/open/floor/plasteel,
-/area/lavaland/surface)
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
 "Ez" = (
 /obj/item/beacon,
 /turf/open/floor/plasteel,
 /area/ruin/powered/gasstation)
+"EA" = (
+/obj/structure/table/reinforced,
+/obj/item/trash/raisins,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "cashiershutters";
+	name = "Cashier Shutters"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"EM" = (
+/obj/item/melee/skateboard{
+	dir = 4
+	},
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/lavaland,
+/area/lavaland/surface)
 "FJ" = (
 /obj/machinery/light_switch,
 /turf/closed/wall/rust,
+/area/ruin/powered/gasstation)
+"Ga" = (
+/obj/effect/turf_decal/sand,
+/obj/machinery/camera{
+	c_tag = "Outside Side Gas Station Camera";
+	dir = 4;
+	name = "security camera";
+	network = list("gasstation")
+	},
+/turf/open/floor/plasteel/lavaland,
+/area/lavaland/surface)
+"Gk" = (
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/plasteel/white,
 /area/ruin/powered/gasstation)
 "GR" = (
 /obj/machinery/computer/teleporter{
@@ -885,14 +543,70 @@
 "GX" = (
 /turf/open/floor/plasteel,
 /area/ruin/powered/gasstation)
-"Hu" = (
-/obj/machinery/light/small{
+"HU" = (
+/obj/structure/table,
+/obj/structure/window{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
+/obj/item/reagent_containers/food/snacks/dolphincereal,
+/obj/item/reagent_containers/food/snacks/dolphincereal,
+/obj/item/reagent_containers/food/snacks/dolphincereal,
+/obj/structure/rack,
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"Iw" = (
+/obj/structure/sink{
+	dir = 8;
+	icon_state = "sink";
+	pixel_x = -12;
+	pixel_y = 2
 	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"JL" = (
+/obj/machinery/light,
+/obj/machinery/camera{
+	c_tag = "Inside Entrance Camera";
+	dir = 1;
+	name = "security camera";
+	network = list("gasstation")
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"JS" = (
+/obj/structure/table,
+/obj/structure/window{
+	dir = 4
+	},
+/obj/item/toy/foamblade,
+/obj/structure/rack,
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"Ko" = (
+/obj/machinery/icecream_vat,
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"KF" = (
+/obj/machinery/vending/boozeomat{
+	products = list(/obj/item/reagent_containers/food/drinks/bottle/gin = 2, /obj/item/reagent_containers/food/drinks/bottle/whiskey = 2, /obj/item/reagent_containers/food/drinks/bottle/tequila = 3, /obj/item/reagent_containers/food/drinks/bottle/vodka = 1, /obj/item/reagent_containers/food/drinks/bottle/vermouth = 3, /obj/item/reagent_containers/food/drinks/bottle/rum = 5, /obj/item/reagent_containers/food/drinks/bottle/wine = 2, /obj/item/reagent_containers/food/drinks/bottle/cognac = 3, /obj/item/reagent_containers/food/drinks/bottle/kahlua = 1, /obj/item/reagent_containers/food/drinks/bottle/absinthe = 2, /obj/item/reagent_containers/food/drinks/ale = 3, /obj/item/reagent_containers/food/drinks/flask = 1)
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"KZ" = (
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/displaycase/labcage{
+	desc = "For displaying of more valuable items you have acquired.";
+	name = "Shop Display Case";
+	req_access = null;
+	req_access_txt = "36";
+	start_showpiece_type = null
+	},
+/turf/open/floor/plasteel/white,
 /area/ruin/powered/gasstation)
 "Lb" = (
 /obj/machinery/button/door{
@@ -902,17 +616,15 @@
 	},
 /turf/closed/wall/rust,
 /area/ruin/powered/gasstation)
-"Lo" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/obj/effect/mob_spawn/human/gasstation_clerk,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
+"LF" = (
+/obj/machinery/vending/cola,
+/turf/open/floor/plasteel/white,
 /area/ruin/powered/gasstation)
+"LK" = (
+/obj/item/trash/chips,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/lavaland,
+/area/lavaland/surface)
 "LQ" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/glass_large,
@@ -922,57 +634,130 @@
 /obj/structure/sign/poster/contraband/robust_softdrinks,
 /turf/closed/wall/rust,
 /area/ruin/powered/gasstation)
-"NI" = (
-/obj/structure/table,
-/obj/structure/window{
+"MN" = (
+/obj/machinery/computer/arcade/orion_trail,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"Ni" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/powered/gasstation)
+"NE" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/item/storage/box/snappops,
-/obj/structure/rack,
-/obj/item/toy/figure/clown,
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"PN" = (
-/obj/structure/table,
-/obj/machinery/computer/security/telescreen{
-	name = "Gas Station Surveillance";
-	network = list("gasstation")
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"Ql" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white";
-	temperature = 273.15
-	},
-/area/ruin/powered/gasstation)
-"Qu" = (
+/obj/vehicle/ridden/atv,
 /obj/effect/turf_decal/sand,
-/obj/machinery/camera{
-	c_tag = "Outside Side Gas Station Camera";
-	dir = 4;
-	name = "security camera";
-	network = list("gasstation")
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/lavaland,
 /area/lavaland/surface)
-"VK" = (
-/obj/machinery/door/airlock,
+"NL" = (
+/obj/machinery/door/airlock/glass_large{
+	doorOpen = 'sound/machines/defib_success.ogg'
+	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "gasstation"
 	},
-/turf/open/floor/plating,
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/white,
 /area/ruin/powered/gasstation)
+"NO" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/powered)
+"OC" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"OI" = (
+/obj/structure/table,
+/obj/structure/window{
+	dir = 4
+	},
+/obj/item/toy/sword,
+/obj/item/toy/sword,
+/obj/structure/rack,
+/obj/item/toy/katana,
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"PS" = (
+/obj/item/gps/internal{
+	desc = "You can just FEEL the money oozing out of this signal.";
+	gpstag = "Capitalistic Signal";
+	name = "gas station signal"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"Qm" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "cashiershutters";
+	name = "Cashier Shutters"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"Qw" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/displaycase/labcage{
+	desc = "For displaying of more valuable items you have acquired.";
+	name = "Shop Display Case";
+	req_access = null;
+	req_access_txt = "36";
+	start_showpiece_type = null
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"Ro" = (
+/obj/machinery/camera{
+	c_tag = "Inside Back Exit Camera";
+	name = "security camera";
+	network = list("gasstation")
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"RE" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"RV" = (
+/obj/structure/table,
+/obj/structure/window,
+/obj/item/toy/plush/teddybear,
+/obj/item/toy/plush/goatplushie,
+/obj/item/toy/plush/flowerbunch,
+/obj/item/toy/plush/stuffedmonkey,
+/obj/structure/rack,
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"Tu" = (
+/obj/structure/table/reinforced,
+/obj/item/newspaper,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "cashiershutters";
+	name = "Cashier Shutters"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"Ut" = (
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/lavaland,
+/area/lavaland/surface)
 "Wf" = (
 /obj/machinery/button/door{
 	id = "gasstation";
@@ -981,16 +766,10 @@
 	},
 /turf/closed/wall/rust,
 /area/ruin/powered/gasstation)
-"WI" = (
-/obj/effect/turf_decal/sand,
-/obj/machinery/camera{
-	c_tag = "Outside Entrance Camera";
-	dir = 2;
-	name = "security camera";
-	network = list("gasstation")
-	},
-/turf/open/floor/plasteel,
-/area/lavaland/surface)
+"Wg" = (
+/obj/item/trash/popcorn,
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
 "WY" = (
 /obj/machinery/light{
 	dir = 1
@@ -1001,6 +780,16 @@
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/plasteel,
 /area/ruin/powered/gasstation)
+"Xf" = (
+/obj/structure/window{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/toy/ammo/gun,
+/obj/item/toy/ammo/gun,
+/obj/structure/rack,
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
 "Xr" = (
 /obj/structure/sign/poster/official/foam_force_ad,
 /turf/closed/wall/rust,
@@ -1008,6 +797,33 @@
 "Xt" = (
 /obj/structure/sign/poster/contraband/donut_corp,
 /turf/closed/wall/rust,
+/area/ruin/powered/gasstation)
+"XI" = (
+/obj/structure/table,
+/obj/structure/window{
+	dir = 8
+	},
+/obj/item/reagent_containers/food/snacks/sosjerky,
+/obj/item/reagent_containers/food/snacks/sosjerky,
+/obj/structure/rack,
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"Yp" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "gasstation"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"Zj" = (
+/obj/structure/table,
+/obj/item/storage/box/donkpockets,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
+"ZN" = (
+/obj/item/trash/syndi_cakes,
+/turf/open/floor/plasteel/white,
 /area/ruin/powered/gasstation)
 
 (1,1,1) = {"
@@ -1066,19 +882,19 @@ aa
 aa
 aa
 ab
-af
-af
-af
-az
-af
-af
-DY
-af
-af
-bh
-af
-af
-af
+dC
+dC
+dC
+xm
+dC
+dC
+cS
+dC
+dC
+cK
+dC
+dC
+dC
 ac
 ac
 ac
@@ -1092,7 +908,7 @@ aa
 aa
 aa
 ab
-af
+dC
 aj
 aj
 aj
@@ -1102,14 +918,14 @@ aj
 aU
 aj
 aj
-bn
-af
-af
+NE
+dC
+dC
 ac
-by
+NO
 ac
 ac
-by
+NO
 ac
 ac
 aa
@@ -1118,19 +934,19 @@ aa
 aa
 aa
 ab
-af
+dC
 aj
-fP
-Hu
-aD
+lM
+RE
+Iw
 aj
 aN
 aV
 bb
 aj
-bo
-af
-af
+lg
+dC
+dC
 ac
 bz
 ac
@@ -1144,24 +960,24 @@ aa
 aa
 aa
 ab
-af
+dC
 aj
-an
-ar
-md
+ZN
+cV
+gd
 aj
 ah
 aV
 bc
 aj
-bo
-af
-af
+lg
+dC
+dC
 ac
-bA
+fI
 ac
 ac
-bA
+fI
 ac
 ac
 aa
@@ -1170,19 +986,19 @@ aa
 ab
 ab
 ab
-ag
+Ni
 aj
 aj
-aA
+zS
 aj
 aj
 Wf
-xf
+gZ
 Lb
 aj
 aj
 aj
-bt
+uq
 ac
 ac
 ac
@@ -1198,17 +1014,17 @@ aj
 aj
 aj
 aj
-ao
-ar
+ir
+cV
 FJ
-aG
-Lo
-ar
-su
-bi
-ar
+KF
+hy
+cV
+qD
+iq
+cV
 aj
-af
+dC
 ac
 ac
 ac
@@ -1224,22 +1040,22 @@ aj
 vn
 GX
 aj
-ap
-ar
+rs
+cV
 aj
-PN
-uH
-ar
-ar
-AD
-ar
+dI
+rL
+cV
+cV
+Qm
+cV
 aj
-bu
+Ut
 ac
-bA
+fI
 ac
 ac
-bA
+fI
 ac
 ac
 ac
@@ -1251,16 +1067,16 @@ qd
 Xe
 ak
 aq
-ar
+cV
 aj
-aI
-aP
-aW
-bd
-AD
-cU
+EA
+Tu
+An
+Bp
+Qm
+vo
 Mq
-WI
+bZ
 ac
 bB
 ac
@@ -1276,17 +1092,17 @@ LQ
 GX
 dQ
 wF
-wQ
-ar
-su
-ar
-ar
-ar
-ar
-ar
-ar
-br
-af
+MN
+cV
+qD
+cV
+cV
+cV
+cV
+cV
+cV
+NL
+dC
 ac
 bC
 ac
@@ -1301,23 +1117,23 @@ ab
 rp
 GX
 GX
-VK
-ar
-ar
-ar
-ar
-ar
-aX
-ar
-ar
-ar
-bs
-af
+lN
+cV
+cV
+cV
+cV
+cV
+Ko
+cV
+cV
+cV
+Yp
+dC
 ac
-by
+NO
 ac
 ac
-by
+NO
 ac
 ac
 ac
@@ -1328,17 +1144,17 @@ aj
 WY
 GX
 Xt
-tZ
-ar
-ar
-ar
-ar
-ar
-ar
-ar
-lg
+Ro
+cV
+cV
+cV
+cV
+cV
+cV
+cV
+JL
 Xr
-af
+dC
 ac
 bz
 ac
@@ -1354,22 +1170,22 @@ aj
 GX
 GR
 aj
-as
-ar
-ar
-aJ
-aQ
-aY
-be
-bj
-ar
+md
+cV
+cV
+BK
+js
+KZ
+aS
+kg
+cV
 aj
-af
+dC
 ac
-bD
+ts
 ac
 ac
-bD
+ts
 ac
 ac
 ac
@@ -1380,17 +1196,17 @@ aj
 Ez
 sp
 aj
-at
-ar
-ar
-aK
-aR
-aZ
-bf
-bk
-ar
+mf
+cV
+cV
+mo
+HU
+Qw
+XI
+ul
+cV
 aj
-af
+dC
 ac
 ac
 ac
@@ -1406,17 +1222,17 @@ aj
 GX
 Aj
 aj
-au
-aB
-ar
-ar
-ar
-rr
-ar
-ar
-bp
+Zj
+aL
+cV
+cV
+cV
+PS
+cV
+cV
+ii
 aj
-af
+dC
 ac
 ac
 ac
@@ -1432,22 +1248,22 @@ aj
 aj
 aj
 aj
-av
-ar
-ar
-ar
-ar
-ar
-ar
-ar
-cU
+Gk
+cV
+cV
+cV
+cV
+cV
+cV
+cV
+vo
 aj
-bv
+LK
 ac
-bE
+vk
 ac
 ac
-bE
+vk
 ac
 ac
 ac
@@ -1456,19 +1272,19 @@ ac
 ab
 ab
 ab
-ag
+Ni
 aj
-aH
-ar
-ar
-aL
-aS
-aY
-bg
-bl
-ar
+sY
+cV
+cV
+qf
+JS
+KZ
+OI
+rQ
+cV
 aj
-bw
+ha
 ac
 bB
 ac
@@ -1482,19 +1298,19 @@ ac
 aa
 aa
 ab
-af
+dC
 aj
-ax
-ar
-ar
-aM
-aT
-aZ
-NI
-bm
-ar
+OC
+cV
+cV
+RV
+sJ
+Qw
+fB
+Xf
+cV
 aj
-af
+dC
 ac
 bC
 ac
@@ -1508,19 +1324,19 @@ ac
 aa
 aa
 ab
-af
+dC
 aj
-ay
-ar
-aF
-ar
-gV
-ar
-ar
-Ql
-bq
+LF
+cV
+wL
+cV
+Ec
+cV
+cV
+kR
+Wg
 aj
-af
+dC
 ac
 ac
 ac
@@ -1534,7 +1350,7 @@ aa
 aa
 aa
 ab
-af
+dC
 aj
 aj
 aj
@@ -1546,7 +1362,7 @@ aj
 aj
 aj
 aj
-bx
+EM
 ac
 ac
 ac
@@ -1560,19 +1376,19 @@ aa
 aa
 aa
 ab
-af
-af
-af
-aC
-af
-af
-Qu
-af
-af
-aC
-af
-af
-af
+dC
+dC
+dC
+fO
+dC
+dC
+Ga
+dC
+dC
+fO
+dC
+dC
+dC
 ac
 ac
 ac

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_medical.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_medical.dmm
@@ -43,15 +43,15 @@
 /obj/structure/table,
 /obj/item/stack/medical/gauze,
 /obj/machinery/light{
-	icon_state = "tube";
-	dir = 4
+	dir = 4;
+	icon_state = "tube"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "ak" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -92,8 +92,8 @@
 /obj/item/bedsheet/medical,
 /obj/effect/mob_spawn/human/orion_doctor,
 /obj/machinery/light{
-	icon_state = "tube";
-	dir = 1
+	dir = 1;
+	icon_state = "tube"
 	},
 /turf/open/floor/carpet,
 /area/ruin/powered)
@@ -109,8 +109,8 @@
 /obj/item/bedsheet/medical,
 /obj/effect/mob_spawn/human/orion_doctor,
 /obj/machinery/light{
-	icon_state = "tube";
-	dir = 1
+	dir = 1;
+	icon_state = "tube"
 	},
 /mob/living/carbon/monkey,
 /turf/open/floor/carpet,
@@ -118,12 +118,12 @@
 "at" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "tile_corner"
 	},
 /obj/structure/toilet{
-	icon_state = "toilet00";
-	dir = 4
+	dir = 4;
+	icon_state = "toilet00"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered)
@@ -131,12 +131,12 @@
 /obj/effect/mob_spawn/human/orion_doctor,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "tile_corner"
 	},
 /obj/machinery/light{
-	icon_state = "tube";
-	dir = 1
+	dir = 1;
+	icon_state = "tube"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered)
@@ -164,8 +164,8 @@
 	},
 /obj/machinery/door/window/southleft,
 /obj/machinery/light/small{
-	icon_state = "bulb";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb"
 	},
 /mob/living/carbon/monkey,
 /turf/open/floor/plasteel/white,
@@ -185,8 +185,8 @@
 /obj/item/lipstick/random,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered)
@@ -198,8 +198,8 @@
 	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "tile_corner"
 	},
 /mob/living/carbon/monkey,
 /turf/open/floor/plasteel,
@@ -306,8 +306,8 @@
 "aS" = (
 /obj/machinery/vending/snack,
 /obj/machinery/light{
-	icon_state = "tube";
-	dir = 1
+	dir = 1;
+	icon_state = "tube"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
@@ -315,8 +315,8 @@
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
 /obj/machinery/light/small{
-	icon_state = "bulb";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
@@ -362,8 +362,8 @@
 /obj/item/reagent_containers/glass/beaker/large/charcoal,
 /obj/item/reagent_containers/glass/beaker/large/charcoal,
 /obj/machinery/light/small{
-	icon_state = "bulb";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
@@ -430,8 +430,8 @@
 "bm" = (
 /obj/machinery/computer/cloning,
 /obj/machinery/light{
-	icon_state = "tube";
-	dir = 1
+	dir = 1;
+	icon_state = "tube"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
@@ -493,8 +493,8 @@
 /obj/structure/table,
 /obj/item/defibrillator/loaded,
 /obj/machinery/light/small{
-	icon_state = "bulb";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
@@ -508,16 +508,16 @@
 "bw" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/yellow{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/yellow{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered)
@@ -530,24 +530,24 @@
 /area/ruin/powered)
 "by" = (
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "bz" = (
 /obj/item/cigbutt/cigarbutt,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
@@ -576,12 +576,12 @@
 /obj/item/coin/silver,
 /obj/item/clothing/head/festive,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
@@ -590,12 +590,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
@@ -622,16 +622,16 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/yellow{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/yellow{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered)
@@ -645,12 +645,12 @@
 /obj/structure/table/glass,
 /obj/item/dice/d20,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
@@ -659,16 +659,16 @@
 /obj/item/folder/white,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/yellow{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/yellow{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered)
@@ -684,16 +684,16 @@
 /obj/item/bedsheet,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "tile_corner"
 	},
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel,
@@ -701,16 +701,16 @@
 "bP" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered)
@@ -720,16 +720,16 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered)
@@ -737,16 +737,16 @@
 /obj/structure/showcase,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered)
@@ -757,16 +757,16 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered)
@@ -774,16 +774,16 @@
 /obj/machinery/door/airlock/glass_large,
 /obj/structure/fans/tiny/invisible,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "bU" = (
 /obj/structure/fans/tiny/invisible,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
@@ -792,16 +792,16 @@
 /obj/structure/grille,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered)
@@ -809,16 +809,16 @@
 /obj/item/flashlight/seclite,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered)
@@ -826,16 +826,16 @@
 /obj/item/tank/internals/emergency_oxygen/double,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered)
@@ -843,20 +843,20 @@
 /obj/effect/mob_spawn/human/orion_security,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "tile_corner"
 	},
 /obj/machinery/light{
-	icon_state = "tube";
-	dir = 1
+	dir = 1;
+	icon_state = "tube"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered)
@@ -864,32 +864,32 @@
 /obj/structure/table,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered)
 "ca" = (
 /obj/structure/bed/roller,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/machinery/light/small{
-	icon_state = "bulb";
-	dir = 8
+	dir = 8;
+	icon_state = "bulb"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
@@ -897,16 +897,16 @@
 /obj/structure/chair/office/light,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered)
@@ -916,16 +916,16 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered)
@@ -936,28 +936,28 @@
 /obj/item/melee/baton/loaded,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered)
 "ce" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
@@ -971,16 +971,16 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered)
@@ -991,16 +991,16 @@
 /obj/item/clothing/head/collectable/HoS,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered)
@@ -1011,16 +1011,16 @@
 /obj/item/storage/belt/security,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "tile_corner"
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel,
@@ -1032,16 +1032,16 @@
 /obj/item/stack/medical/ointment,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered)
@@ -1050,16 +1050,16 @@
 /obj/machinery/recharger,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered)
@@ -1073,12 +1073,12 @@
 	},
 /obj/structure/fans/tiny/invisible,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
@@ -1089,59 +1089,20 @@
 /obj/item/emptysandbag,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"co" = (
-/obj/effect/decal/remains/human,
-/obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/ruin/powered)
-"cp" = (
-/obj/item/emptysandbag,
-/obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/ruin/powered)
 "cq" = (
 /obj/structure/table,
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
 /obj/machinery/light{
-	icon_state = "tube";
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/ruin/powered)
-"hA" = (
-/obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
-	},
-/obj/machinery/light/small{
-	icon_state = "bulb";
-	dir = 1
+	dir = 4;
+	icon_state = "tube"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "kw" = (
 /obj/machinery/light/small{
-	icon_state = "bulb";
-	dir = 8
+	dir = 8;
+	icon_state = "bulb"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
@@ -1154,48 +1115,48 @@
 /obj/item/bedsheet,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/red{
-	icon_state = "tile_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered)
 "wO" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/yellow{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/yellow{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/machinery/light{
-	icon_state = "tube";
-	dir = 8
+	dir = 8;
+	icon_state = "tube"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered)
 "yM" = (
 /obj/structure/fans/tiny/invisible,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
@@ -1204,60 +1165,110 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/machinery/light{
-	icon_state = "tube";
-	dir = 4
+	dir = 4;
+	icon_state = "tube"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "Aw" = (
 /obj/structure/bed/roller,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "BI" = (
 /obj/machinery/light{
-	icon_state = "tube";
-	dir = 8
+	dir = 8;
+	icon_state = "tube"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "Hy" = (
 /obj/machinery/light/small{
-	icon_state = "bulb";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb"
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "Lk" = (
 /obj/structure/bed/roller,
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "tile_corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	icon_state = "tile_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "tile_corner"
 	},
 /obj/machinery/light/small{
-	icon_state = "bulb";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb"
 	},
 /turf/open/floor/plasteel/white,
+/area/ruin/powered)
+"Tk" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4;
+	icon_state = "tile_corner"
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	icon_state = "bulb"
+	},
+/turf/open/floor/plasteel/white/lavaland,
+/area/ruin/powered)
+"Vx" = (
+/obj/item/emptysandbag,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4;
+	icon_state = "tile_corner"
+	},
+/turf/open/floor/plasteel/white/lavaland,
+/area/ruin/powered)
+"Yg" = (
+/obj/effect/decal/remains/human,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4;
+	icon_state = "tile_corner"
+	},
+/turf/open/floor/plasteel/white/lavaland,
+/area/ruin/powered)
+"ZO" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4;
+	icon_state = "tile_corner"
+	},
+/turf/open/floor/plasteel/white/lavaland,
 /area/ruin/powered)
 
 (1,1,1) = {"
@@ -1617,7 +1628,7 @@ cd
 cj
 ab
 cm
-by
+ZO
 cm
 "}
 (13,1,1) = {"
@@ -1646,8 +1657,8 @@ ab
 ab
 ab
 an
-by
-by
+ZO
+ZO
 cm
 "}
 (14,1,1) = {"
@@ -1675,9 +1686,9 @@ ab
 ca
 ce
 ck
-hA
+Tk
 cn
-by
+ZO
 ab
 "}
 (15,1,1) = {"
@@ -1705,8 +1716,8 @@ bT
 by
 by
 cl
-by
-co
+ZO
+Yg
 cn
 cm
 "}
@@ -1735,9 +1746,9 @@ bU
 by
 by
 yM
-by
-cp
-by
+ZO
+Vx
+ZO
 cm
 "}
 (17,1,1) = {"
@@ -1765,8 +1776,8 @@ ab
 Lk
 Aw
 ck
-hA
-by
+Tk
+ZO
 ab
 cm
 "}
@@ -1797,7 +1808,7 @@ ab
 an
 cm
 cn
-by
+ZO
 cm
 "}
 (19,1,1) = {"
@@ -1825,8 +1836,8 @@ aa
 aa
 aa
 aa
-by
-by
+ZO
+ZO
 ab
 cm
 "}
@@ -1855,7 +1866,7 @@ aa
 aa
 aa
 aa
-by
+ZO
 cm
 cm
 cm
@@ -1885,7 +1896,7 @@ aa
 aa
 aa
 aa
-by
+ZO
 cm
 cm
 cm

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_pizzaparty.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_pizzaparty.dmm
@@ -13,57 +13,6 @@
 /turf/closed/wall,
 /area/ruin/unpowered)
 "e" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
-/area/ruin/unpowered)
-"f" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/cups,
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
-/area/ruin/unpowered)
-"g" = (
-/obj/structure/reagent_dispensers/water_cooler{
-	name = "punch cooler";
-	reagent_id = /datum/reagent/consumable/ethanol/bacchus_blessing
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
-/area/ruin/unpowered)
-"h" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
-/area/ruin/unpowered)
-"i" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
-/area/ruin/unpowered)
-"j" = (
-/obj/item/reagent_containers/food/snacks/pizzaslice/mushroom,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
-/area/ruin/unpowered)
-"k" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/pizzaparty,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
-/area/ruin/unpowered)
-"l" = (
 /obj/machinery/light{
 	dir = 4
 	},
@@ -71,73 +20,82 @@
 /obj/effect/spawner/lootdrop/pizzaparty,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+/turf/open/floor/wood/lavaland,
+/area/ruin/unpowered)
+"g" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/lavaland,
+/area/ruin/unpowered)
+"h" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/a_gift,
+/turf/open/floor/wood/lavaland,
+/area/ruin/unpowered)
+"i" = (
+/obj/structure/glowshroom/single,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/lavaland,
+/area/ruin/unpowered)
+"j" = (
+/obj/item/reagent_containers/food/snacks/pizzaslice/mushroom,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/lavaland_baseturf,
+/area/ruin/unpowered)
+"k" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/pizzaslice/margherita,
+/obj/item/trash/plate,
+/turf/open/floor/wood/lavaland,
+/area/ruin/unpowered)
+"l" = (
+/obj/structure/chair/wood/wings{
+	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/ruin/unpowered)
 "m" = (
-/obj/item/chair/wood/wings,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
+/obj/structure/table/wood,
+/obj/item/trash/plate,
+/turf/open/floor/wood/lavaland,
 /area/ruin/unpowered)
 "n" = (
 /obj/structure/glowshroom/single,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
+/turf/open/floor/wood/lavaland,
 /area/ruin/unpowered)
 "o" = (
-/obj/item/trash/plate,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
+/obj/structure/table/wood,
+/obj/item/storage/box/cups,
+/turf/open/floor/wood/lavaland,
 /area/ruin/unpowered)
 "p" = (
-/obj/effect/decal/remains/human,
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/pizzaparty,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
+/turf/open/floor/wood/lavaland,
 /area/ruin/unpowered)
 "q" = (
 /obj/item/chair/wood/wings,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
+/turf/open/floor/wood/lavaland,
 /area/ruin/unpowered)
 "r" = (
-/obj/structure/chair/wood/wings,
-/obj/effect/decal/remains/human,
-/obj/item/clothing/head/festive{
-	desc = "A festive party hat with the name 'timmy' scribbled on the front.";
-	name = "party hat"
+/obj/structure/reagent_dispensers/water_cooler{
+	name = "punch cooler";
+	reagent_id = /datum/reagent/consumable/ethanol/bacchus_blessing
 	},
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
-/area/ruin/unpowered)
-"s" = (
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/lavaland,
 /area/ruin/unpowered)
 "t" = (
-/obj/structure/chair/wood/wings,
-/obj/effect/decal/remains/human,
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/ruin/unpowered)
 "u" = (
-/obj/structure/glowshroom/single,
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/pizzaslice/meat,
+/turf/open/floor/wood/lavaland,
 /area/ruin/unpowered)
 "v" = (
 /obj/structure/lattice,
@@ -145,122 +103,74 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "w" = (
+/obj/structure/table/wood,
+/obj/item/trash/plate,
 /obj/item/kitchen/fork,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
+/turf/open/floor/wood/lavaland,
 /area/ruin/unpowered)
 "x" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/pizzaparty,
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
+/obj/structure/glowshroom/single,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/ruin/unpowered)
 "y" = (
-/obj/structure/table/wood,
-/obj/item/trash/plate,
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
-/area/ruin/unpowered)
-"z" = (
-/obj/structure/table/wood,
-/obj/structure/glowshroom/single,
-/obj/item/a_gift,
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
-/area/ruin/unpowered)
-"A" = (
-/obj/structure/table/wood,
-/obj/item/trash/plate,
-/obj/item/kitchen/fork,
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
-/area/ruin/unpowered)
-"C" = (
-/obj/structure/chair/wood/wings{
+/obj/machinery/light{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
+/turf/open/floor/wood/lavaland,
 /area/ruin/unpowered)
-"D" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/pizzaslice/margherita,
-/obj/item/trash/plate,
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
+"z" = (
+/obj/item/kitchen/knife,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/lavaland,
 /area/ruin/unpowered)
-"E" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/pizzaslice/meat,
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
-/area/ruin/unpowered)
-"F" = (
+"A" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/store/cake/birthday,
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+/turf/open/floor/wood/lavaland,
+/area/ruin/unpowered)
+"B" = (
+/obj/item/trash/plate,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/lavaland,
+/area/ruin/unpowered)
+"C" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/lavaland,
+/area/ruin/unpowered)
+"D" = (
+/obj/structure/chair/wood/wings,
+/obj/effect/decal/remains/human,
+/obj/item/clothing/head/festive{
+	desc = "A festive party hat with the name 'timmy' scribbled on the front.";
+	name = "party hat"
 	},
+/turf/open/floor/wood/lavaland,
 /area/ruin/unpowered)
 "G" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/lavaland,
 /area/ruin/unpowered)
 "H" = (
 /obj/item/chair/wood/wings,
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
-/area/ruin/unpowered)
-"I" = (
-/obj/item/kitchen/fork,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
-/area/ruin/unpowered)
-"J" = (
-/obj/structure/glowshroom/single,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
+/turf/open/floor/wood/lavaland,
 /area/ruin/unpowered)
 "K" = (
-/obj/structure/chair/wood/wings{
-	dir = 1
-	},
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/pizzaparty,
+/turf/open/floor/wood/lavaland,
 /area/ruin/unpowered)
 "L" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
+/obj/structure/chair/wood/wings,
+/obj/effect/decal/remains/human,
+/turf/open/floor/wood/lavaland,
 /area/ruin/unpowered)
 "M" = (
+/obj/item/kitchen/fork,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/a_gift,
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
+/turf/open/floor/wood/lavaland,
 /area/ruin/unpowered)
 "N" = (
 /obj/structure/lattice,
@@ -268,25 +178,43 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "O" = (
-/obj/item/kitchen/knife,
+/obj/item/chair/wood/wings,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
+/turf/open/floor/plating/lavaland_baseturf,
 /area/ruin/unpowered)
 "P" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/lavaland_baseturf,
 /area/ruin/unpowered)
 "Q" = (
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+/obj/item/kitchen/fork,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/lavaland_baseturf,
+/area/ruin/unpowered)
+"T" = (
+/obj/structure/table/wood,
+/obj/structure/glowshroom/single,
+/obj/item/a_gift,
+/turf/open/floor/wood/lavaland,
+/area/ruin/unpowered)
+"U" = (
+/turf/open/floor/plating/lavaland_baseturf,
+/area/ruin/unpowered)
+"W" = (
+/turf/open/floor/wood/lavaland,
+/area/ruin/unpowered)
+"X" = (
+/obj/structure/chair/wood/wings{
+	dir = 1
 	},
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/lavaland,
+/area/ruin/unpowered)
+"Z" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood/lavaland,
 /area/ruin/unpowered)
 
 (1,1,1) = {"
@@ -340,8 +268,8 @@ b
 b
 c
 c
-e
-e
+t
+t
 c
 c
 b
@@ -358,12 +286,12 @@ d
 b
 c
 c
-e
-h
-h
-e
-Q
-e
+t
+C
+C
+t
+U
+t
 d
 b
 b
@@ -376,14 +304,14 @@ b
 b
 d
 b
-m
-e
-w
-h
-w
-h
-h
-e
+O
+t
+M
+C
+M
+C
+C
+t
 d
 b
 b
@@ -395,14 +323,14 @@ b
 b
 b
 d
-f
-n
-h
-h
+o
+i
+C
+C
 c
-e
-M
-e
+t
+h
+t
 c
 b
 b
@@ -415,13 +343,13 @@ b
 b
 b
 d
-g
-o
-h
-h
+r
+B
 C
-J
-h
+C
+l
+x
+C
 d
 b
 b
@@ -434,14 +362,14 @@ b
 b
 b
 b
-e
-h
-p
+t
+C
+g
 q
-x
-D
 K
-M
+k
+X
+h
 d
 b
 b
@@ -454,14 +382,14 @@ b
 b
 b
 c
-e
-i
-h
-r
-y
-E
-h
-h
+t
+G
+C
+D
+m
+u
+C
+C
 c
 b
 b
@@ -474,12 +402,12 @@ b
 b
 b
 c
-e
+t
 j
-h
-s
-z
-F
+C
+W
+T
+A
 q
 N
 c
@@ -494,14 +422,14 @@ b
 b
 b
 b
-e
-e
-h
 t
-A
-G
+t
+C
+L
+w
+Z
 q
-h
+C
 c
 b
 b
@@ -515,13 +443,13 @@ b
 b
 b
 d
-k
-h
-s
-s
+p
+C
+W
+W
 H
-h
-O
+C
+z
 d
 b
 b
@@ -535,13 +463,13 @@ b
 b
 b
 d
-k
-h
-u
-s
-s
-o
+p
+C
 n
+W
+W
+B
+i
 d
 b
 b
@@ -555,13 +483,13 @@ b
 b
 b
 d
-l
-i
-h
 e
-I
-L
+G
+C
+t
+Q
 P
+y
 d
 b
 b
@@ -576,11 +504,11 @@ b
 b
 d
 d
-e
-e
+t
+t
 N
-e
-e
+t
+t
 d
 d
 b

--- a/_maps/RandomRuins/LavaRuins/miningbase.dmm
+++ b/_maps/RandomRuins/LavaRuins/miningbase.dmm
@@ -255,9 +255,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
-"aL" = (
-/turf/open/lava/smooth,
-/area/lavaland/surface/outdoors)
 "aM" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/tile/purple,
@@ -288,10 +285,6 @@
 "aT" = (
 /turf/open/floor/plasteel,
 /area/mine/production)
-"aU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on,
-/turf/open/floor/plating,
-/area/mine/living_quarters)
 "aW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -428,10 +421,6 @@
 	dir = 10
 	},
 /turf/closed/wall,
-/area/mine/living_quarters)
-"bm" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
 /area/mine/living_quarters)
 "bn" = (
 /obj/effect/turf_decal/tile/brown{
@@ -2042,6 +2031,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/mine/maintenance)
+"iD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on,
+/turf/open/floor/plating/lavaland_baseturf,
+/area/mine/living_quarters)
 "jV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -2879,6 +2872,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/mine/maintenance)
+"YY" = (
+/obj/structure/grille,
+/turf/open/floor/plating/lavaland_baseturf,
+/area/mine/living_quarters)
 
 (1,1,1) = {"
 ab
@@ -3303,7 +3300,7 @@ ab
 ab
 ac
 ac
-aL
+ac
 ac
 bP
 bQ
@@ -3333,9 +3330,9 @@ ab
 ab
 ab
 ab
-aL
-aL
-aL
+ac
+ac
+ac
 ac
 ak
 bQ
@@ -3365,8 +3362,8 @@ ab
 ab
 ab
 ab
-aL
-aL
+ac
+ac
 ac
 ak
 Kc
@@ -3396,9 +3393,9 @@ ab
 ab
 ab
 ab
-aL
-aL
-aL
+ac
+ac
+ac
 bQ
 bQ
 ba
@@ -3428,9 +3425,9 @@ ab
 ab
 ab
 ab
-aL
-aL
-aL
+ac
+ac
+ac
 bQ
 aO
 bb
@@ -3460,9 +3457,9 @@ ak
 ab
 ab
 ab
-aL
-aL
-aL
+ac
+ac
+ac
 bQ
 bQ
 WW
@@ -3491,10 +3488,10 @@ bI
 (20,1,1) = {"
 ab
 ab
-aL
-aL
-aL
-aL
+ac
+ac
+ac
+ac
 bQ
 aQ
 bb
@@ -3523,10 +3520,10 @@ ak
 (21,1,1) = {"
 ab
 ab
-aL
-aL
-aL
-aL
+ac
+ac
+ac
+ac
 bQ
 bQ
 bl
@@ -3556,11 +3553,11 @@ ab
 ab
 ab
 ab
-aL
 ac
 ac
-bm
-aU
+ac
+YY
+iD
 bZ
 AQ
 bD
@@ -3654,7 +3651,7 @@ ab
 ab
 ac
 ac
-ak
+ac
 ac
 ac
 ac

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -45625,6 +45625,14 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cmp" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/tracker,
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/fore)
 "cmq" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating{
@@ -48040,13 +48048,6 @@
 /obj/item/gun/syringe,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"dDR" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/tracker,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/fore)
 "dEb" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -49414,6 +49415,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"fZJ" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/solarpanel,
+/area/solar/starboard/aft)
 "gaW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -50549,6 +50555,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/service)
+"hNq" = (
+/obj/machinery/power/tracker,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/solar/port/aft)
 "hNI" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -50720,13 +50734,6 @@
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"ibz" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/tracker,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/fore)
 "ibZ" = (
 /obj/structure/transit_tube/crossing/horizontal,
 /turf/open/space/basic,
@@ -51719,6 +51726,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"jFV" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/solarpanel,
+/area/solar/port/aft)
 "jGO" = (
 /obj/machinery/light{
 	dir = 1
@@ -51737,13 +51751,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"jHC" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/fore)
 "jIe" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden/layer1{
 	dir = 8
@@ -52923,6 +52930,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"los" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/solarpanel,
+/area/solar/port/fore)
 "loA" = (
 /obj/machinery/requests_console{
 	department = "Medbay";
@@ -53419,13 +53432,6 @@
 "mof" = (
 /turf/closed/wall/r_wall,
 /area/quartermaster/sorting)
-"moi" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/aft)
 "mqK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -55292,12 +55298,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"plY" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/fore)
 "pmW" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -56439,13 +56439,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"qOf" = (
-/obj/machinery/power/tracker,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/aft)
 "qOl" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -56902,13 +56895,6 @@
 /obj/structure/sign/departments/minsky/research/research,
 /turf/closed/wall/r_wall,
 /area/science/lab)
-"ryg" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
 "rzM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -57203,11 +57189,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"saA" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
 "saK" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -57464,6 +57445,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/construction)
+"swh" = (
+/obj/structure/cable,
+/obj/machinery/power/tracker,
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
 "swo" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/hidden,
 /obj/effect/turf_decal/tile/purple{
@@ -57612,6 +57599,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"sHU" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/solarpanel,
+/area/solar/port/fore)
 "sJh" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -59014,6 +59008,14 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"uRq" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/tracker,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/solar/port/fore)
 "uRs" = (
 /obj/machinery/light/small,
 /obj/structure/closet/crate/hydroponics,
@@ -59038,11 +59040,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plating,
 /area/construction)
-"uXN" = (
-/obj/structure/cable,
-/obj/machinery/power/tracker,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
 "uXY" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -59148,13 +59145,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"veR" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/fore)
 "vfv" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment{
@@ -59454,6 +59444,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"vFi" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/solarpanel,
+/area/solar/port/aft)
 "vFw" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
@@ -59572,6 +59569,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"vOD" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/solarpanel,
+/area/solar/port/fore)
 "vPm" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment{
@@ -59784,6 +59786,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"wfJ" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/solarpanel,
+/area/solar/starboard/fore)
 "wfU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -59990,11 +59999,6 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
-"wxR" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/fore)
 "wyh" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/reagent_containers/blood,
@@ -60060,13 +60064,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"wzy" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/aft)
 "wAc" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/atmospherics/miner/toxins,
@@ -60109,6 +60106,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/main)
+"wCF" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/solarpanel,
+/area/solar/starboard/fore)
 "wCM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
@@ -60279,11 +60281,6 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/storage/tech)
-"wQs" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/fore)
 "wRK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -60467,6 +60464,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"xnl" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/solarpanel,
+/area/solar/starboard/aft)
 "xnF" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -77116,7 +77120,7 @@ aaa
 aaa
 aaS
 aaf
-qOf
+hNq
 aaf
 aaS
 aaa
@@ -77530,17 +77534,17 @@ aaa
 aaa
 abY
 aaa
-veR
+sHU
 adv
-wxR
+vOD
 aaa
-veR
+sHU
 adv
-wxR
+vOD
 aaa
-veR
+sHU
 adv
-wxR
+vOD
 aaa
 aaS
 aaf
@@ -77787,17 +77791,17 @@ aaa
 aaa
 abY
 aaf
-veR
+sHU
 adu
-wxR
+vOD
 aaa
-veR
+sHU
 adu
-wxR
+vOD
 aaa
-veR
+sHU
 adu
-wxR
+vOD
 aaf
 aaf
 aaa
@@ -77881,19 +77885,19 @@ aaa
 aaa
 aaS
 aaf
-moi
-moi
-moi
-moi
-moi
+vFi
+vFi
+vFi
+vFi
+vFi
 aaa
 chK
 aaa
-moi
-moi
-moi
-moi
-moi
+vFi
+vFi
+vFi
+vFi
+vFi
 aaf
 aaS
 aaa
@@ -78044,17 +78048,17 @@ aaa
 aaa
 abY
 aaa
-veR
+sHU
 adu
-wxR
+vOD
 aaf
-veR
+sHU
 adu
-wxR
+vOD
 aaf
-veR
+sHU
 adu
-wxR
+vOD
 aaa
 aaf
 aaa
@@ -78301,17 +78305,17 @@ aaa
 aaa
 aaf
 aaf
-veR
+sHU
 adu
-wxR
+vOD
 aaa
-veR
+sHU
 adu
-wxR
+vOD
 aaa
-veR
+sHU
 adu
-wxR
+vOD
 aaf
 aaf
 aaf
@@ -78395,19 +78399,19 @@ aaa
 aaf
 aaS
 aaf
-wzy
-wzy
-wzy
-wzy
-wzy
+jFV
+jFV
+jFV
+jFV
+jFV
 aaa
 eZX
 aaa
-wzy
-wzy
-wzy
-wzy
-wzy
+jFV
+jFV
+jFV
+jFV
+jFV
 aaf
 aaS
 aaa
@@ -78558,17 +78562,17 @@ aaS
 aaS
 aaf
 aaa
-veR
+sHU
 adu
-wxR
+vOD
 aaa
-veR
+sHU
 adu
-wxR
+vOD
 aaa
-veR
+sHU
 adu
-wxR
+vOD
 aaa
 aaf
 aaa
@@ -78909,19 +78913,19 @@ aaa
 aaf
 aaS
 aaf
-moi
-moi
-moi
-moi
-moi
+vFi
+vFi
+vFi
+vFi
+vFi
 aaa
 chL
 aaa
-moi
-moi
-moi
-moi
-moi
+vFi
+vFi
+vFi
+vFi
+vFi
 aaf
 aaS
 aaa
@@ -79069,7 +79073,7 @@ aaa
 aaa
 aaS
 aaf
-dDR
+uRq
 abZ
 abZ
 acW
@@ -79423,19 +79427,19 @@ aaa
 aaf
 aaS
 acy
-wzy
-wzy
-wzy
-wzy
-wzy
+jFV
+jFV
+jFV
+jFV
+jFV
 aaa
 chL
 aaa
-wzy
-wzy
-wzy
-wzy
-wzy
+jFV
+jFV
+jFV
+jFV
+jFV
 aaf
 aaS
 aaa
@@ -79586,17 +79590,17 @@ aba
 aaS
 aaf
 aaa
-veR
+sHU
 adz
-plY
+los
 aaa
-veR
+sHU
 adz
-wxR
+vOD
 aaa
-veR
+sHU
 adz
-wxR
+vOD
 aaa
 aaf
 aaa
@@ -79843,17 +79847,17 @@ aaa
 aaa
 aaf
 aaf
-veR
+sHU
 adz
-plY
+los
 aaa
-veR
+sHU
 adz
-wxR
+vOD
 aaa
-veR
+sHU
 adz
-wxR
+vOD
 aaf
 aaf
 aaa
@@ -79937,19 +79941,19 @@ aaa
 aaf
 aaS
 aaf
-moi
-moi
-moi
-moi
-moi
+vFi
+vFi
+vFi
+vFi
+vFi
 aaa
 chL
 aaa
-moi
-moi
-moi
-moi
-moi
+vFi
+vFi
+vFi
+vFi
+vFi
 aaf
 aaS
 aaa
@@ -80100,17 +80104,17 @@ aaa
 aaa
 aaS
 aaa
-veR
+sHU
 adz
-plY
+los
 aaf
-veR
+sHU
 adz
-wxR
+vOD
 aaf
-veR
+sHU
 adz
-wxR
+vOD
 aaa
 aaf
 aaf
@@ -80357,17 +80361,17 @@ aaa
 aaa
 aaS
 aaf
-veR
+sHU
 adz
-plY
+los
 aaa
-veR
+sHU
 adz
-wxR
+vOD
 aaa
-veR
+sHU
 adz
-wxR
+vOD
 aaf
 aaf
 aaa
@@ -80451,19 +80455,19 @@ aoV
 aaa
 aaS
 aaf
-wzy
-wzy
-wzy
-wzy
-wzy
+jFV
+jFV
+jFV
+jFV
+jFV
 aaa
 chL
 aaa
-wzy
-wzy
-wzy
-wzy
-wzy
+jFV
+jFV
+jFV
+jFV
+jFV
 aaf
 aaS
 aaa
@@ -80614,17 +80618,17 @@ aaa
 aaa
 aaS
 aaa
-veR
+sHU
 adA
-plY
+los
 aaa
-veR
+sHU
 adA
-wxR
+vOD
 aaa
-veR
+sHU
 adA
-wxR
+vOD
 aaa
 aaS
 aaa
@@ -102459,17 +102463,17 @@ aaa
 aaa
 aaS
 aaa
-jHC
+wfJ
 adS
-wQs
+wCF
 aaa
-jHC
+wfJ
 adS
-wQs
+wCF
 aaa
-jHC
+wfJ
 adS
-wQs
+wCF
 aaa
 aaS
 aaf
@@ -102716,17 +102720,17 @@ aaa
 aaa
 aaS
 aaf
-jHC
+wfJ
 adT
-wQs
+wCF
 aaa
-jHC
+wfJ
 adT
-wQs
+wCF
 aaa
-jHC
+wfJ
 adT
-wQs
+wCF
 aaf
 aaf
 aaa
@@ -102973,17 +102977,17 @@ aaa
 aaa
 aaS
 aaa
-jHC
+wfJ
 adT
-wQs
+wCF
 aaf
-jHC
+wfJ
 adT
-wQs
+wCF
 aaf
-jHC
+wfJ
 adT
-wQs
+wCF
 aaa
 aaf
 aaa
@@ -103230,17 +103234,17 @@ aaa
 aaa
 aaf
 aaf
-jHC
+wfJ
 adT
-wQs
+wCF
 aaa
-jHC
+wfJ
 adT
-wQs
+wCF
 aaa
-jHC
+wfJ
 adT
-wQs
+wCF
 aaf
 aaf
 aaf
@@ -103487,17 +103491,17 @@ aaS
 aaS
 aaf
 aaa
-jHC
+wfJ
 adT
-wQs
+wCF
 aaa
-jHC
+wfJ
 adT
-wQs
+wCF
 aaa
-jHC
+wfJ
 adT
-wQs
+wCF
 aaa
 aaf
 aaa
@@ -103998,7 +104002,7 @@ aaa
 aaa
 aaS
 aaf
-ibz
+cmp
 acx
 acx
 adt
@@ -104515,17 +104519,17 @@ aba
 aaS
 acy
 aaa
-jHC
+wfJ
 adW
-wQs
+wCF
 aaa
-jHC
+wfJ
 adW
-wQs
+wCF
 aaa
-jHC
+wfJ
 adW
-wQs
+wCF
 aaa
 aaf
 aaa
@@ -104772,17 +104776,17 @@ aaa
 aaa
 aaf
 aaf
-jHC
+wfJ
 adW
-wQs
+wCF
 aaa
-jHC
+wfJ
 adW
-wQs
+wCF
 aaa
-jHC
+wfJ
 adW
-wQs
+wCF
 aaf
 aaf
 aaf
@@ -105029,17 +105033,17 @@ aaa
 aaa
 aaS
 aaa
-jHC
+wfJ
 adW
-wQs
+wCF
 aaf
-jHC
+wfJ
 adW
-wQs
+wCF
 aaf
-jHC
+wfJ
 adW
-wQs
+wCF
 aaa
 aaf
 aaa
@@ -105286,17 +105290,17 @@ aaa
 aaa
 aaS
 aaf
-jHC
+wfJ
 adW
-wQs
+wCF
 aaa
-jHC
+wfJ
 adW
-wQs
+wCF
 aaa
-jHC
+wfJ
 adW
-wQs
+wCF
 aaf
 aaf
 aaa
@@ -105543,17 +105547,17 @@ aaa
 aaa
 aaS
 aaa
-jHC
+wfJ
 adY
-wQs
+wCF
 aaa
-jHC
+wfJ
 adY
-wQs
+wCF
 aaa
-jHC
+wfJ
 adY
-wQs
+wCF
 aaa
 aaS
 aaf
@@ -111309,17 +111313,17 @@ aaa
 aaa
 aaS
 aaa
-ryg
+xnl
 crB
-saA
+fZJ
 aaa
-ryg
+xnl
 crB
-saA
+fZJ
 aaa
-ryg
+xnl
 crB
-saA
+fZJ
 aaa
 aaS
 aaa
@@ -111566,17 +111570,17 @@ aaa
 aaa
 aba
 aaf
-ryg
+xnl
 crC
-saA
+fZJ
 aaa
-ryg
+xnl
 crC
-saA
+fZJ
 aaa
-ryg
+xnl
 crC
-saA
+fZJ
 aaf
 aaS
 aaa
@@ -111823,17 +111827,17 @@ aaa
 aaa
 aaf
 aaa
-ryg
+xnl
 crC
-saA
+fZJ
 aaf
-ryg
+xnl
 crC
-saA
+fZJ
 aaf
-ryg
+xnl
 crC
-saA
+fZJ
 aaa
 aaS
 aaa
@@ -112080,17 +112084,17 @@ aaf
 aaf
 aaf
 aaf
-ryg
+xnl
 crC
-saA
+fZJ
 aaa
-ryg
+xnl
 crC
-saA
+fZJ
 aaa
-ryg
+xnl
 crC
-saA
+fZJ
 aaf
 aaf
 aaa
@@ -112337,17 +112341,17 @@ aaa
 aaa
 aaf
 aaa
-ryg
+xnl
 crC
-saA
+fZJ
 aaa
-ryg
+xnl
 crC
-saA
+fZJ
 aaa
-ryg
+xnl
 crC
-saA
+fZJ
 aaa
 aaf
 aaS
@@ -112864,7 +112868,7 @@ crk
 tyu
 cpi
 cpi
-uXN
+swh
 aaf
 aaS
 aaa
@@ -113365,17 +113369,17 @@ aaa
 aaa
 aaf
 aaa
-ryg
+xnl
 crE
-saA
+fZJ
 aaa
-ryg
+xnl
 crE
-saA
+fZJ
 aaa
-ryg
+xnl
 crE
-saA
+fZJ
 aaa
 aaf
 aaS
@@ -113622,17 +113626,17 @@ aaf
 aaf
 aaf
 aaf
-ryg
+xnl
 crE
-saA
+fZJ
 aaa
-ryg
+xnl
 crE
-saA
+fZJ
 aaa
-ryg
+xnl
 crE
-saA
+fZJ
 aaf
 aaf
 aaa
@@ -113879,17 +113883,17 @@ aaa
 aaa
 aaf
 aaa
-ryg
+xnl
 crE
-saA
+fZJ
 aaf
-ryg
+xnl
 crE
-saA
+fZJ
 aaf
-ryg
+xnl
 crE
-saA
+fZJ
 aaa
 aaS
 aaa
@@ -114136,17 +114140,17 @@ aaf
 aaf
 aaf
 aaf
-ryg
+xnl
 crE
-saA
+fZJ
 aaa
-ryg
+xnl
 crE
-saA
+fZJ
 aaa
-ryg
+xnl
 crE
-saA
+fZJ
 aaf
 aaS
 aaa
@@ -114393,17 +114397,17 @@ aaa
 aaa
 aba
 aaa
-ryg
+xnl
 crG
-saA
+fZJ
 aaa
-ryg
+xnl
 crG
-saA
+fZJ
 aaa
-ryg
+xnl
 crG
-saA
+fZJ
 aaa
 aaS
 aaa

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -11055,17 +11055,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"axb" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
 "axc" = (
 /obj/structure/rack,
 /obj/item/electronics/airlock,
@@ -11135,15 +11124,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"axi" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "axj" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Firefighting equipment";
@@ -11158,18 +11138,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"axk" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "axl" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -11179,20 +11147,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"axn" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
 "axo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11389,19 +11343,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"axH" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "axI" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -11695,18 +11636,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"ayr" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner,
-/area/hallway/secondary/entry)
 "ays" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -11857,13 +11786,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"ayJ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "ayK" = (
 /obj/structure/closet/crate/rcd,
 /obj/machinery/camera/motion{
@@ -12066,15 +11988,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"azg" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "azh" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -12242,14 +12155,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"azC" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "azD" = (
@@ -16650,16 +16555,6 @@
 "aIR" = (
 /obj/structure/sign/map/right{
 	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"aIS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -25851,17 +25746,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "beM" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"beN" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
 /obj/structure/chair{
 	dir = 1
 	},
@@ -36721,6 +36605,12 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/janitor)
+"bAX" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "bAY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/white,
@@ -40173,6 +40063,12 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine/air,
 /area/engine/atmos_distro)
+"bKK" = (
+/obj/machinery/air_sensor{
+	id_tag = "air_sensor"
+	},
+/turf/open/floor/engine/vacuum,
+/area/engine/atmos_distro)
 "bKL" = (
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 4;
@@ -43331,6 +43227,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
+"bXA" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "bXD" = (
 /obj/structure/table,
 /obj/item/hand_labeler,
@@ -46206,6 +46110,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"csL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"csQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "csZ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -47731,6 +47648,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"cWD" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "cXq" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -47772,6 +47701,13 @@
 /obj/effect/turf_decal/tile/darkblue,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"dau" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "daW" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -48150,17 +48086,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"dJo" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
 "dMP" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/stripes/line{
@@ -48236,6 +48161,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/medical/virology)
+"dSH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "dSR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -48550,17 +48484,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"eAT" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
 "eBC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -48867,6 +48790,10 @@
 /obj/item/clothing/under/color/rainbow,
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
+"eYV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "eZE" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/food/snacks/grown/poppy,
@@ -49034,15 +48961,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/processing)
-"foJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "foN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -49457,6 +49375,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
+"fXp" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "fXq" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/darkblue{
@@ -49540,6 +49469,18 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"gce" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "gdi" = (
 /obj/machinery/light,
 /obj/structure/sign/warning/nosmoking{
@@ -49620,6 +49561,15 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/engine/atmos_distro)
+"grK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "grO" = (
 /obj/machinery/camera{
 	c_tag = "Central Hallway South-East";
@@ -50033,13 +49983,6 @@
 /obj/effect/spawner/lootdrop/techstorage/tcomms,
 /turf/open/floor/plasteel/white,
 /area/storage/tech)
-"gRo" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/aft)
 "gUn" = (
 /obj/machinery/button/door{
 	id = "atmos";
@@ -50174,20 +50117,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
-"hfM" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
 "hgw" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -50768,15 +50697,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"hZm" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "hZA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -50829,6 +50749,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"ifM" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"igu" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "igK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -50985,6 +50927,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"ixh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "ixi" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/security/wooden_tv,
@@ -51040,6 +50988,23 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"iCJ" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "iDv" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -51477,6 +51442,22 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/main)
+"jlS" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "jmH" = (
 /obj/structure/sign/warning/vacuum,
 /turf/closed/wall,
@@ -51667,13 +51648,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"jzn" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "jBJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -51963,6 +51937,12 @@
 /obj/structure/altar_of_gods,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"jWi" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/port/fore)
 "jWz" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -52243,11 +52223,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"kkD" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/fore)
 "klX" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -52316,6 +52291,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"kpQ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "kvW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -52790,6 +52774,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/science/server)
+"lda" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "ldM" = (
 /obj/machinery/recharge_station,
 /obj/structure/sign/departments/minsky/command/charge{
@@ -52903,6 +52896,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
+"lmt" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "lmH" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -52910,11 +52920,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"lnt" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
 "lop" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
@@ -53066,6 +53071,17 @@
 	},
 /turf/open/floor/plating,
 /area/security/detectives_office)
+"lyi" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "lyB" = (
 /obj/machinery/light_switch{
 	pixel_x = 27
@@ -53117,6 +53133,11 @@
 "lFe" = (
 /turf/closed/wall,
 /area/tcommsat/computer)
+"lGx" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
 "lGE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -53449,6 +53470,16 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
+"mvu" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "mwV" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 1
@@ -53620,15 +53651,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"mIY" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "mJk" = (
 /obj/structure/showcase/cyborg/old{
 	dir = 8;
@@ -53874,6 +53896,13 @@
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
+"mXk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "mXC" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -53926,6 +53955,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"nag" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/port/fore)
 "nao" = (
 /obj/item/clothing/gloves/color/black,
 /obj/item/clothing/mask/breath,
@@ -54329,6 +54365,13 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
+"nCm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "nCC" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -54394,6 +54437,12 @@
 /obj/item/assembly/flash/handheld,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"nGg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "nJW" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/plasteel/dark,
@@ -54539,6 +54588,26 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
+"nXL" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "nYC" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -54748,17 +54817,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"ooX" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
 "opj" = (
 /mob/living/simple_animal/moonrat{
 	name = "Joe"
@@ -54961,6 +55019,13 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"oIh" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
 "oJh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -55278,6 +55343,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/security/main)
+"ppQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "prH" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -55490,6 +55564,13 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"pFu" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/port/aft)
 "pGe" = (
 /obj/structure/lattice,
 /turf/open/space,
@@ -55810,6 +55891,18 @@
 	},
 /turf/template_noop,
 /area/crew_quarters/dorms)
+"pWW" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner,
+/area/hallway/secondary/entry)
 "pXe" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable{
@@ -55908,12 +56001,6 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel,
 /area/science/nanite)
-"qgv" = (
-/obj/machinery/air_sensor{
-	id_tag = "air_sensor"
-	},
-/turf/open/floor/engine/air,
-/area/engine/atmos_distro)
 "qhA" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -56112,6 +56199,12 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"qwF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "qxr" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
 	dir = 8
@@ -56376,6 +56469,24 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"qOw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "qOB" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 8;
@@ -56387,13 +56498,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"qPm" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/fore)
 "qPC" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -56502,6 +56606,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
+"qWJ" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner,
+/area/hallway/secondary/entry)
 "qYd" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/camera{
@@ -56543,6 +56662,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/tcoms)
+"rdL" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "reN" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -56758,15 +56891,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"rvS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "rwD" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/tcommsat/computer";
@@ -56947,12 +57071,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
-"rNg" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/fore)
 "rPc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -57833,6 +57951,13 @@
 "tfA" = (
 /turf/template_noop,
 /area/space)
+"tfB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "tfC" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -57907,13 +58032,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"tiV" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
 "tkf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -57980,6 +58098,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"toE" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "tpq" = (
 /obj/item/coin/silver{
 	pixel_x = 7;
@@ -58176,6 +58301,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
+"tCM" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "tEo" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -58202,6 +58341,18 @@
 /obj/effect/landmark/stationroom/box/dorm_edoor,
 /turf/template_noop,
 /area/space)
+"tGm" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/port/fore)
+"tGn" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/port/aft)
 "tHN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -58272,11 +58423,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"tOV" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/fore)
 "tPc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -58473,6 +58619,10 @@
 /obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel,
 /area/storage/tools)
+"uiF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "uiY" = (
 /obj/machinery/telecomms/receiver/preset_right{
 	name = "subspace receiver B"
@@ -58563,16 +58713,6 @@
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
-"unF" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "unP" = (
 /obj/machinery/light{
 	dir = 4
@@ -58583,6 +58723,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
+"uoW" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "upt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -58684,6 +58838,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"uwX" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "uxu" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 5
@@ -58731,6 +58891,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
+"uzF" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/fore)
 "uAQ" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -58802,18 +58967,6 @@
 	},
 /turf/template_noop,
 /area/crew_quarters/dorms)
-"uKu" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "uKK" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -59104,13 +59257,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"vpf" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "vpy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -59752,13 +59898,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"wpZ" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/fore)
 "wqI" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -59781,20 +59920,17 @@
 /obj/item/stock_parts/subspace/analyzer,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/tcoms)
-"wrz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
+"wrN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"wtQ" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/aft)
 "wuM" = (
 /obj/machinery/meter,
 /obj/machinery/button/door{
@@ -59838,6 +59974,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/nanite)
+"wwf" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/fore)
 "wwh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59975,6 +60118,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/main)
+"wCM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "wDq" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -59990,6 +60137,20 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"wDB" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "wEx" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -60187,6 +60348,18 @@
 /obj/item/storage/secure/briefcase,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"wVW" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "wWS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -60794,6 +60967,16 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"yjF" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "ykC" = (
 /obj/machinery/flasher{
 	id = "AI";
@@ -72239,8 +72422,8 @@ apN
 apN
 apN
 apJ
-ooX
-wrz
+bXA
+ppQ
 vrz
 dsT
 aCK
@@ -72496,8 +72679,8 @@ apN
 apN
 apN
 apJ
-dJo
-vpf
+bXA
+mvu
 awW
 asE
 aSm
@@ -72753,8 +72936,8 @@ apN
 apN
 apN
 apJ
-dJo
-hZm
+bXA
+gce
 azz
 aAF
 aSm
@@ -72767,7 +72950,7 @@ aaa
 aaa
 aSm
 aOf
-azz
+dSH
 cVx
 aRY
 aSm
@@ -72777,9 +72960,9 @@ aaa
 aaa
 aaa
 aSm
-vDC
-aym
-azz
+wDB
+dau
+aLM
 aAF
 aSm
 aaa
@@ -73010,9 +73193,9 @@ apN
 apN
 apN
 apJ
-dJo
-rvS
-ayl
+bXA
+csQ
+bAX
 aAE
 aSm
 aaa
@@ -73024,8 +73207,8 @@ aaa
 aaa
 aSm
 aOe
-ayl
-rzM
+nGg
+nCm
 aRY
 aSm
 aaa
@@ -73267,8 +73450,8 @@ apN
 apN
 apN
 apJ
-eAT
-jzn
+bXA
+grK
 ayl
 aAH
 aSm
@@ -73281,8 +73464,8 @@ aaa
 aaa
 aSm
 aOh
-ayl
-rzM
+csL
+tfB
 aRY
 aSm
 aaa
@@ -73291,8 +73474,8 @@ aaa
 aaa
 aaa
 aSm
-vDC
-ayl
+tCM
+qwF
 ayl
 bgi
 aSm
@@ -73781,8 +73964,8 @@ apN
 apN
 apN
 apJ
-axb
-unF
+iCJ
+jlS
 awW
 asE
 aSm
@@ -73796,8 +73979,8 @@ aaa
 aSm
 asE
 awW
-upt
-aRY
+qOw
+pWW
 aSm
 aaa
 aaa
@@ -73805,8 +73988,8 @@ aaa
 aaa
 aaa
 aSm
-vDC
-ayk
+nXL
+yjF
 awW
 asE
 aSm
@@ -74038,8 +74221,8 @@ asF
 asF
 asF
 apJ
-hfM
-mIY
+lmt
+kpQ
 vrz
 qCv
 aCK
@@ -74295,8 +74478,8 @@ avY
 atI
 auc
 avp
-axi
-ayJ
+cWD
+ayk
 awW
 aEa
 aSm
@@ -74552,8 +74735,8 @@ aqr
 aCX
 aub
 aLu
-axH
-azg
+fXp
+aym
 azB
 aSm
 aaa
@@ -74809,9 +74992,9 @@ aCT
 atb
 aIH
 apJ
-axk
-ayl
-azC
+ifM
+eYV
+lyi
 arB
 arB
 arB
@@ -74833,9 +75016,9 @@ fMS
 awW
 baF
 asE
-uKu
-ayl
-beN
+wVW
+eYV
+rdL
 arB
 aaf
 qdN
@@ -75066,22 +75249,22 @@ apJ
 apJ
 apJ
 apJ
-axn
-ayl
+uoW
+ixh
 aym
 aAI
 aBH
 azz
 azz
-azz
-azz
-azz
-azz
-aIS
-aBH
-azz
-aPu
-rzM
+nMn
+mXk
+mXk
+mXk
+wrN
+igu
+mXk
+toE
+tfB
 ayl
 xML
 aym
@@ -75089,9 +75272,9 @@ nMn
 lze
 aLM
 aPu
-ayl
-foJ
-ayl
+xML
+csQ
+ixh
 beM
 aAC
 aaf
@@ -75324,7 +75507,7 @@ amC
 aus
 bEJ
 axo
-ayr
+qWJ
 azD
 aAJ
 azD
@@ -75336,9 +75519,9 @@ ayl
 ayl
 ayl
 aNb
-ayl
-ayl
-rzM
+wCM
+uiF
+nCm
 ayl
 aTr
 aUM
@@ -75346,9 +75529,9 @@ ayl
 bcz
 aUo
 baG
-tQA
+lda
 dhy
-ayl
+uwX
 beM
 asE
 aaa
@@ -77351,17 +77534,17 @@ aaa
 aaa
 abY
 aaa
-wpZ
+nag
 adv
-kkD
+tGm
 aaa
-wpZ
+nag
 adv
-kkD
+tGm
 aaa
-wpZ
+nag
 adv
-kkD
+tGm
 aaa
 aaS
 aaf
@@ -77608,17 +77791,17 @@ aaa
 aaa
 abY
 aaf
-wpZ
+nag
 adu
-kkD
+tGm
 aaa
-wpZ
+nag
 adu
-kkD
+tGm
 aaa
-wpZ
+nag
 adu
-kkD
+tGm
 aaf
 aaf
 aaa
@@ -77702,19 +77885,19 @@ aaa
 aaa
 aaS
 aaf
-gRo
-gRo
-gRo
-gRo
-gRo
+tGn
+tGn
+tGn
+tGn
+tGn
 aaa
 chK
 aaa
-gRo
-gRo
-gRo
-gRo
-gRo
+tGn
+tGn
+tGn
+tGn
+tGn
 aaf
 aaS
 aaa
@@ -77865,17 +78048,17 @@ aaa
 aaa
 abY
 aaa
-wpZ
+nag
 adu
-kkD
+tGm
 aaf
-wpZ
+nag
 adu
-kkD
+tGm
 aaf
-wpZ
+nag
 adu
-kkD
+tGm
 aaa
 aaf
 aaa
@@ -78122,17 +78305,17 @@ aaa
 aaa
 aaf
 aaf
-wpZ
+nag
 adu
-kkD
+tGm
 aaa
-wpZ
+nag
 adu
-kkD
+tGm
 aaa
-wpZ
+nag
 adu
-kkD
+tGm
 aaf
 aaf
 aaf
@@ -78216,19 +78399,19 @@ aaa
 aaf
 aaS
 aaf
-wtQ
-wtQ
-wtQ
-wtQ
-wtQ
+pFu
+pFu
+pFu
+pFu
+pFu
 aaa
 eZX
 aaa
-wtQ
-wtQ
-wtQ
-wtQ
-wtQ
+pFu
+pFu
+pFu
+pFu
+pFu
 aaf
 aaS
 aaa
@@ -78379,17 +78562,17 @@ aaS
 aaS
 aaf
 aaa
-wpZ
+nag
 adu
-kkD
+tGm
 aaa
-wpZ
+nag
 adu
-kkD
+tGm
 aaa
-wpZ
+nag
 adu
-kkD
+tGm
 aaa
 aaf
 aaa
@@ -78730,19 +78913,19 @@ aaa
 aaf
 aaS
 aaf
-gRo
-gRo
-gRo
-gRo
-gRo
+tGn
+tGn
+tGn
+tGn
+tGn
 aaa
 chL
 aaa
-gRo
-gRo
-gRo
-gRo
-gRo
+tGn
+tGn
+tGn
+tGn
+tGn
 aaf
 aaS
 aaa
@@ -79244,19 +79427,19 @@ aaa
 aaf
 aaS
 acy
-wtQ
-wtQ
-wtQ
-wtQ
-wtQ
+pFu
+pFu
+pFu
+pFu
+pFu
 aaa
 chL
 aaa
-wtQ
-wtQ
-wtQ
-wtQ
-wtQ
+pFu
+pFu
+pFu
+pFu
+pFu
 aaf
 aaS
 aaa
@@ -79407,17 +79590,17 @@ aba
 aaS
 aaf
 aaa
-wpZ
+nag
 adz
-rNg
+jWi
 aaa
-wpZ
+nag
 adz
-kkD
+tGm
 aaa
-wpZ
+nag
 adz
-kkD
+tGm
 aaa
 aaf
 aaa
@@ -79664,17 +79847,17 @@ aaa
 aaa
 aaf
 aaf
-wpZ
+nag
 adz
-rNg
+jWi
 aaa
-wpZ
+nag
 adz
-kkD
+tGm
 aaa
-wpZ
+nag
 adz
-kkD
+tGm
 aaf
 aaf
 aaa
@@ -79758,19 +79941,19 @@ aaa
 aaf
 aaS
 aaf
-gRo
-gRo
-gRo
-gRo
-gRo
+tGn
+tGn
+tGn
+tGn
+tGn
 aaa
 chL
 aaa
-gRo
-gRo
-gRo
-gRo
-gRo
+tGn
+tGn
+tGn
+tGn
+tGn
 aaf
 aaS
 aaa
@@ -79921,17 +80104,17 @@ aaa
 aaa
 aaS
 aaa
-wpZ
+nag
 adz
-rNg
+jWi
 aaf
-wpZ
+nag
 adz
-kkD
+tGm
 aaf
-wpZ
+nag
 adz
-kkD
+tGm
 aaa
 aaf
 aaf
@@ -80178,17 +80361,17 @@ aaa
 aaa
 aaS
 aaf
-wpZ
+nag
 adz
-rNg
+jWi
 aaa
-wpZ
+nag
 adz
-kkD
+tGm
 aaa
-wpZ
+nag
 adz
-kkD
+tGm
 aaf
 aaf
 aaa
@@ -80272,19 +80455,19 @@ aoV
 aaa
 aaS
 aaf
-wtQ
-wtQ
-wtQ
-wtQ
-wtQ
+pFu
+pFu
+pFu
+pFu
+pFu
 aaa
 chL
 aaa
-wtQ
-wtQ
-wtQ
-wtQ
-wtQ
+pFu
+pFu
+pFu
+pFu
+pFu
 aaf
 aaS
 aaa
@@ -80435,17 +80618,17 @@ aaa
 aaa
 aaS
 aaa
-wpZ
+nag
 adA
-rNg
+jWi
 aaa
-wpZ
+nag
 adA
-kkD
+tGm
 aaa
-wpZ
+nag
 adA
-kkD
+tGm
 aaa
 aaS
 aaa
@@ -95693,7 +95876,7 @@ avy
 aaa
 bvA
 bKw
-qgv
+bKK
 bKR
 bvA
 bLG
@@ -102280,17 +102463,17 @@ aaa
 aaa
 aaS
 aaa
-qPm
+wwf
 adS
-tOV
+uzF
 aaa
-qPm
+wwf
 adS
-tOV
+uzF
 aaa
-qPm
+wwf
 adS
-tOV
+uzF
 aaa
 aaS
 aaf
@@ -102537,17 +102720,17 @@ aaa
 aaa
 aaS
 aaf
-qPm
+wwf
 adT
-tOV
+uzF
 aaa
-qPm
+wwf
 adT
-tOV
+uzF
 aaa
-qPm
+wwf
 adT
-tOV
+uzF
 aaf
 aaf
 aaa
@@ -102794,17 +102977,17 @@ aaa
 aaa
 aaS
 aaa
-qPm
+wwf
 adT
-tOV
+uzF
 aaf
-qPm
+wwf
 adT
-tOV
+uzF
 aaf
-qPm
+wwf
 adT
-tOV
+uzF
 aaa
 aaf
 aaa
@@ -103051,17 +103234,17 @@ aaa
 aaa
 aaf
 aaf
-qPm
+wwf
 adT
-tOV
+uzF
 aaa
-qPm
+wwf
 adT
-tOV
+uzF
 aaa
-qPm
+wwf
 adT
-tOV
+uzF
 aaf
 aaf
 aaf
@@ -103308,17 +103491,17 @@ aaS
 aaS
 aaf
 aaa
-qPm
+wwf
 adT
-tOV
+uzF
 aaa
-qPm
+wwf
 adT
-tOV
+uzF
 aaa
-qPm
+wwf
 adT
-tOV
+uzF
 aaa
 aaf
 aaa
@@ -104336,17 +104519,17 @@ aba
 aaS
 acy
 aaa
-qPm
+wwf
 adW
-tOV
+uzF
 aaa
-qPm
+wwf
 adW
-tOV
+uzF
 aaa
-qPm
+wwf
 adW
-tOV
+uzF
 aaa
 aaf
 aaa
@@ -104593,17 +104776,17 @@ aaa
 aaa
 aaf
 aaf
-qPm
+wwf
 adW
-tOV
+uzF
 aaa
-qPm
+wwf
 adW
-tOV
+uzF
 aaa
-qPm
+wwf
 adW
-tOV
+uzF
 aaf
 aaf
 aaf
@@ -104850,17 +105033,17 @@ aaa
 aaa
 aaS
 aaa
-qPm
+wwf
 adW
-tOV
+uzF
 aaf
-qPm
+wwf
 adW
-tOV
+uzF
 aaf
-qPm
+wwf
 adW
-tOV
+uzF
 aaa
 aaf
 aaa
@@ -105107,17 +105290,17 @@ aaa
 aaa
 aaS
 aaf
-qPm
+wwf
 adW
-tOV
+uzF
 aaa
-qPm
+wwf
 adW
-tOV
+uzF
 aaa
-qPm
+wwf
 adW
-tOV
+uzF
 aaf
 aaf
 aaa
@@ -105364,17 +105547,17 @@ aaa
 aaa
 aaS
 aaa
-qPm
+wwf
 adY
-tOV
+uzF
 aaa
-qPm
+wwf
 adY
-tOV
+uzF
 aaa
-qPm
+wwf
 adY
-tOV
+uzF
 aaa
 aaS
 aaf
@@ -111130,17 +111313,17 @@ aaa
 aaa
 aaS
 aaa
-tiV
+oIh
 crB
-lnt
+lGx
 aaa
-tiV
+oIh
 crB
-lnt
+lGx
 aaa
-tiV
+oIh
 crB
-lnt
+lGx
 aaa
 aaS
 aaa
@@ -111387,17 +111570,17 @@ aaa
 aaa
 aba
 aaf
-tiV
+oIh
 crC
-lnt
+lGx
 aaa
-tiV
+oIh
 crC
-lnt
+lGx
 aaa
-tiV
+oIh
 crC
-lnt
+lGx
 aaf
 aaS
 aaa
@@ -111644,17 +111827,17 @@ aaa
 aaa
 aaf
 aaa
-tiV
+oIh
 crC
-lnt
+lGx
 aaf
-tiV
+oIh
 crC
-lnt
+lGx
 aaf
-tiV
+oIh
 crC
-lnt
+lGx
 aaa
 aaS
 aaa
@@ -111901,17 +112084,17 @@ aaf
 aaf
 aaf
 aaf
-tiV
+oIh
 crC
-lnt
+lGx
 aaa
-tiV
+oIh
 crC
-lnt
+lGx
 aaa
-tiV
+oIh
 crC
-lnt
+lGx
 aaf
 aaf
 aaa
@@ -112158,17 +112341,17 @@ aaa
 aaa
 aaf
 aaa
-tiV
+oIh
 crC
-lnt
+lGx
 aaa
-tiV
+oIh
 crC
-lnt
+lGx
 aaa
-tiV
+oIh
 crC
-lnt
+lGx
 aaa
 aaf
 aaS
@@ -113186,17 +113369,17 @@ aaa
 aaa
 aaf
 aaa
-tiV
+oIh
 crE
-lnt
+lGx
 aaa
-tiV
+oIh
 crE
-lnt
+lGx
 aaa
-tiV
+oIh
 crE
-lnt
+lGx
 aaa
 aaf
 aaS
@@ -113443,17 +113626,17 @@ aaf
 aaf
 aaf
 aaf
-tiV
+oIh
 crE
-lnt
+lGx
 aaa
-tiV
+oIh
 crE
-lnt
+lGx
 aaa
-tiV
+oIh
 crE
-lnt
+lGx
 aaf
 aaf
 aaa
@@ -113700,17 +113883,17 @@ aaa
 aaa
 aaf
 aaa
-tiV
+oIh
 crE
-lnt
+lGx
 aaf
-tiV
+oIh
 crE
-lnt
+lGx
 aaf
-tiV
+oIh
 crE
-lnt
+lGx
 aaa
 aaS
 aaa
@@ -113957,17 +114140,17 @@ aaf
 aaf
 aaf
 aaf
-tiV
+oIh
 crE
-lnt
+lGx
 aaa
-tiV
+oIh
 crE
-lnt
+lGx
 aaa
-tiV
+oIh
 crE
-lnt
+lGx
 aaf
 aaS
 aaa
@@ -114214,17 +114397,17 @@ aaa
 aaa
 aba
 aaa
-tiV
+oIh
 crG
-lnt
+lGx
 aaa
-tiV
+oIh
 crG
-lnt
+lGx
 aaa
-tiV
+oIh
 crG
-lnt
+lGx
 aaa
 aaS
 aaa

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -20846,6 +20846,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"aTn" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/port/aft)
 "aTo" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -48866,6 +48873,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"eXO" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/port/fore)
 "eYN" = (
 /obj/item/clothing/gloves/color/rainbow,
 /obj/item/clothing/head/soft/rainbow,
@@ -48919,6 +48933,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/construction)
+"fem" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/port/fore)
 "feu" = (
 /obj/machinery/nuclearbomb/selfdestruct,
 /obj/effect/turf_decal/tile/neutral,
@@ -49107,6 +49126,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"frM" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
 "ftM" = (
 /obj/structure/extraction_point{
 	name = "Xenobiology Fulton Retriever"
@@ -49453,6 +49479,11 @@
 /obj/item/t_scanner,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"fWT" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
 "fXn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -49492,11 +49523,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"fZJ" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/solarpanel,
-/area/solar/starboard/aft)
 "gaW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -51751,13 +51777,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"jFV" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/solarpanel,
-/area/solar/port/aft)
 "jGO" = (
 /obj/machinery/light{
 	dir = 1
@@ -52347,6 +52366,11 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"kxx" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/fore)
 "kxR" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -52920,12 +52944,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"los" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/solarpanel,
-/area/solar/port/fore)
 "loA" = (
 /obj/machinery/requests_console{
 	department = "Medbay";
@@ -53696,6 +53714,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"mLb" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/port/fore)
 "mLv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -54401,6 +54425,13 @@
 /obj/item/assembly/flash/handheld,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"nIl" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/fore)
 "nJW" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/plasteel/dark,
@@ -57483,13 +57514,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"sHU" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/solarpanel,
-/area/solar/port/fore)
 "sJh" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -59305,13 +59329,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"vFi" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/solarpanel,
-/area/solar/port/aft)
 "vFw" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
@@ -59430,11 +59447,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"vOD" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/solarpanel,
-/area/solar/port/fore)
 "vPm" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment{
@@ -59504,6 +59516,13 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/wood,
 /area/maintenance/fore)
+"vUu" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/port/aft)
 "vVV" = (
 /obj/structure/table,
 /obj/item/folder/white,
@@ -59647,13 +59666,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"wfJ" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/solarpanel,
-/area/solar/starboard/fore)
 "wfU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -59963,11 +59975,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/main)
-"wCF" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/solarpanel,
-/area/solar/starboard/fore)
 "wDq" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -60291,13 +60298,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"xnl" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/solarpanel,
-/area/solar/starboard/aft)
 "xnF" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -77351,17 +77351,17 @@ aaa
 aaa
 abY
 aaa
-sHU
+eXO
 adv
-vOD
+fem
 aaa
-sHU
+eXO
 adv
-vOD
+fem
 aaa
-sHU
+eXO
 adv
-vOD
+fem
 aaa
 aaS
 aaf
@@ -77608,17 +77608,17 @@ aaa
 aaa
 abY
 aaf
-sHU
+eXO
 adu
-vOD
+fem
 aaa
-sHU
+eXO
 adu
-vOD
+fem
 aaa
-sHU
+eXO
 adu
-vOD
+fem
 aaf
 aaf
 aaa
@@ -77702,19 +77702,19 @@ aaa
 aaa
 aaS
 aaf
-vFi
-vFi
-vFi
-vFi
-vFi
+vUu
+vUu
+vUu
+vUu
+vUu
 aaa
 chK
 aaa
-vFi
-vFi
-vFi
-vFi
-vFi
+vUu
+vUu
+vUu
+vUu
+vUu
 aaf
 aaS
 aaa
@@ -77865,17 +77865,17 @@ aaa
 aaa
 abY
 aaa
-sHU
+eXO
 adu
-vOD
+fem
 aaf
-sHU
+eXO
 adu
-vOD
+fem
 aaf
-sHU
+eXO
 adu
-vOD
+fem
 aaa
 aaf
 aaa
@@ -78122,17 +78122,17 @@ aaa
 aaa
 aaf
 aaf
-sHU
+eXO
 adu
-vOD
+fem
 aaa
-sHU
+eXO
 adu
-vOD
+fem
 aaa
-sHU
+eXO
 adu
-vOD
+fem
 aaf
 aaf
 aaf
@@ -78216,19 +78216,19 @@ aaa
 aaf
 aaS
 aaf
-jFV
-jFV
-jFV
-jFV
-jFV
+aTn
+aTn
+aTn
+aTn
+aTn
 aaa
 eZX
 aaa
-jFV
-jFV
-jFV
-jFV
-jFV
+aTn
+aTn
+aTn
+aTn
+aTn
 aaf
 aaS
 aaa
@@ -78379,17 +78379,17 @@ aaS
 aaS
 aaf
 aaa
-sHU
+eXO
 adu
-vOD
+fem
 aaa
-sHU
+eXO
 adu
-vOD
+fem
 aaa
-sHU
+eXO
 adu
-vOD
+fem
 aaa
 aaf
 aaa
@@ -78730,19 +78730,19 @@ aaa
 aaf
 aaS
 aaf
-vFi
-vFi
-vFi
-vFi
-vFi
+vUu
+vUu
+vUu
+vUu
+vUu
 aaa
 chL
 aaa
-vFi
-vFi
-vFi
-vFi
-vFi
+vUu
+vUu
+vUu
+vUu
+vUu
 aaf
 aaS
 aaa
@@ -79244,19 +79244,19 @@ aaa
 aaf
 aaS
 acy
-jFV
-jFV
-jFV
-jFV
-jFV
+aTn
+aTn
+aTn
+aTn
+aTn
 aaa
 chL
 aaa
-jFV
-jFV
-jFV
-jFV
-jFV
+aTn
+aTn
+aTn
+aTn
+aTn
 aaf
 aaS
 aaa
@@ -79407,17 +79407,17 @@ aba
 aaS
 aaf
 aaa
-sHU
+eXO
 adz
-los
+mLb
 aaa
-sHU
+eXO
 adz
-vOD
+fem
 aaa
-sHU
+eXO
 adz
-vOD
+fem
 aaa
 aaf
 aaa
@@ -79664,17 +79664,17 @@ aaa
 aaa
 aaf
 aaf
-sHU
+eXO
 adz
-los
+mLb
 aaa
-sHU
+eXO
 adz
-vOD
+fem
 aaa
-sHU
+eXO
 adz
-vOD
+fem
 aaf
 aaf
 aaa
@@ -79758,19 +79758,19 @@ aaa
 aaf
 aaS
 aaf
-vFi
-vFi
-vFi
-vFi
-vFi
+vUu
+vUu
+vUu
+vUu
+vUu
 aaa
 chL
 aaa
-vFi
-vFi
-vFi
-vFi
-vFi
+vUu
+vUu
+vUu
+vUu
+vUu
 aaf
 aaS
 aaa
@@ -79921,17 +79921,17 @@ aaa
 aaa
 aaS
 aaa
-sHU
+eXO
 adz
-los
+mLb
 aaf
-sHU
+eXO
 adz
-vOD
+fem
 aaf
-sHU
+eXO
 adz
-vOD
+fem
 aaa
 aaf
 aaf
@@ -80178,17 +80178,17 @@ aaa
 aaa
 aaS
 aaf
-sHU
+eXO
 adz
-los
+mLb
 aaa
-sHU
+eXO
 adz
-vOD
+fem
 aaa
-sHU
+eXO
 adz
-vOD
+fem
 aaf
 aaf
 aaa
@@ -80272,19 +80272,19 @@ aoV
 aaa
 aaS
 aaf
-jFV
-jFV
-jFV
-jFV
-jFV
+aTn
+aTn
+aTn
+aTn
+aTn
 aaa
 chL
 aaa
-jFV
-jFV
-jFV
-jFV
-jFV
+aTn
+aTn
+aTn
+aTn
+aTn
 aaf
 aaS
 aaa
@@ -80435,17 +80435,17 @@ aaa
 aaa
 aaS
 aaa
-sHU
+eXO
 adA
-los
+mLb
 aaa
-sHU
+eXO
 adA
-vOD
+fem
 aaa
-sHU
+eXO
 adA
-vOD
+fem
 aaa
 aaS
 aaa
@@ -102280,17 +102280,17 @@ aaa
 aaa
 aaS
 aaa
-wfJ
+nIl
 adS
-wCF
+kxx
 aaa
-wfJ
+nIl
 adS
-wCF
+kxx
 aaa
-wfJ
+nIl
 adS
-wCF
+kxx
 aaa
 aaS
 aaf
@@ -102537,17 +102537,17 @@ aaa
 aaa
 aaS
 aaf
-wfJ
+nIl
 adT
-wCF
+kxx
 aaa
-wfJ
+nIl
 adT
-wCF
+kxx
 aaa
-wfJ
+nIl
 adT
-wCF
+kxx
 aaf
 aaf
 aaa
@@ -102794,17 +102794,17 @@ aaa
 aaa
 aaS
 aaa
-wfJ
+nIl
 adT
-wCF
+kxx
 aaf
-wfJ
+nIl
 adT
-wCF
+kxx
 aaf
-wfJ
+nIl
 adT
-wCF
+kxx
 aaa
 aaf
 aaa
@@ -103051,17 +103051,17 @@ aaa
 aaa
 aaf
 aaf
-wfJ
+nIl
 adT
-wCF
+kxx
 aaa
-wfJ
+nIl
 adT
-wCF
+kxx
 aaa
-wfJ
+nIl
 adT
-wCF
+kxx
 aaf
 aaf
 aaf
@@ -103308,17 +103308,17 @@ aaS
 aaS
 aaf
 aaa
-wfJ
+nIl
 adT
-wCF
+kxx
 aaa
-wfJ
+nIl
 adT
-wCF
+kxx
 aaa
-wfJ
+nIl
 adT
-wCF
+kxx
 aaa
 aaf
 aaa
@@ -104336,17 +104336,17 @@ aba
 aaS
 acy
 aaa
-wfJ
+nIl
 adW
-wCF
+kxx
 aaa
-wfJ
+nIl
 adW
-wCF
+kxx
 aaa
-wfJ
+nIl
 adW
-wCF
+kxx
 aaa
 aaf
 aaa
@@ -104593,17 +104593,17 @@ aaa
 aaa
 aaf
 aaf
-wfJ
+nIl
 adW
-wCF
+kxx
 aaa
-wfJ
+nIl
 adW
-wCF
+kxx
 aaa
-wfJ
+nIl
 adW
-wCF
+kxx
 aaf
 aaf
 aaf
@@ -104850,17 +104850,17 @@ aaa
 aaa
 aaS
 aaa
-wfJ
+nIl
 adW
-wCF
+kxx
 aaf
-wfJ
+nIl
 adW
-wCF
+kxx
 aaf
-wfJ
+nIl
 adW
-wCF
+kxx
 aaa
 aaf
 aaa
@@ -105107,17 +105107,17 @@ aaa
 aaa
 aaS
 aaf
-wfJ
+nIl
 adW
-wCF
+kxx
 aaa
-wfJ
+nIl
 adW
-wCF
+kxx
 aaa
-wfJ
+nIl
 adW
-wCF
+kxx
 aaf
 aaf
 aaa
@@ -105364,17 +105364,17 @@ aaa
 aaa
 aaS
 aaa
-wfJ
+nIl
 adY
-wCF
+kxx
 aaa
-wfJ
+nIl
 adY
-wCF
+kxx
 aaa
-wfJ
+nIl
 adY
-wCF
+kxx
 aaa
 aaS
 aaf
@@ -111130,17 +111130,17 @@ aaa
 aaa
 aaS
 aaa
-xnl
+frM
 crB
-fZJ
+fWT
 aaa
-xnl
+frM
 crB
-fZJ
+fWT
 aaa
-xnl
+frM
 crB
-fZJ
+fWT
 aaa
 aaS
 aaa
@@ -111387,17 +111387,17 @@ aaa
 aaa
 aba
 aaf
-xnl
+frM
 crC
-fZJ
+fWT
 aaa
-xnl
+frM
 crC
-fZJ
+fWT
 aaa
-xnl
+frM
 crC
-fZJ
+fWT
 aaf
 aaS
 aaa
@@ -111644,17 +111644,17 @@ aaa
 aaa
 aaf
 aaa
-xnl
+frM
 crC
-fZJ
+fWT
 aaf
-xnl
+frM
 crC
-fZJ
+fWT
 aaf
-xnl
+frM
 crC
-fZJ
+fWT
 aaa
 aaS
 aaa
@@ -111901,17 +111901,17 @@ aaf
 aaf
 aaf
 aaf
-xnl
+frM
 crC
-fZJ
+fWT
 aaa
-xnl
+frM
 crC
-fZJ
+fWT
 aaa
-xnl
+frM
 crC
-fZJ
+fWT
 aaf
 aaf
 aaa
@@ -112158,17 +112158,17 @@ aaa
 aaa
 aaf
 aaa
-xnl
+frM
 crC
-fZJ
+fWT
 aaa
-xnl
+frM
 crC
-fZJ
+fWT
 aaa
-xnl
+frM
 crC
-fZJ
+fWT
 aaa
 aaf
 aaS
@@ -113186,17 +113186,17 @@ aaa
 aaa
 aaf
 aaa
-xnl
+frM
 crE
-fZJ
+fWT
 aaa
-xnl
+frM
 crE
-fZJ
+fWT
 aaa
-xnl
+frM
 crE
-fZJ
+fWT
 aaa
 aaf
 aaS
@@ -113443,17 +113443,17 @@ aaf
 aaf
 aaf
 aaf
-xnl
+frM
 crE
-fZJ
+fWT
 aaa
-xnl
+frM
 crE
-fZJ
+fWT
 aaa
-xnl
+frM
 crE
-fZJ
+fWT
 aaf
 aaf
 aaa
@@ -113700,17 +113700,17 @@ aaa
 aaa
 aaf
 aaa
-xnl
+frM
 crE
-fZJ
+fWT
 aaf
-xnl
+frM
 crE
-fZJ
+fWT
 aaf
-xnl
+frM
 crE
-fZJ
+fWT
 aaa
 aaS
 aaa
@@ -113957,17 +113957,17 @@ aaf
 aaf
 aaf
 aaf
-xnl
+frM
 crE
-fZJ
+fWT
 aaa
-xnl
+frM
 crE
-fZJ
+fWT
 aaa
-xnl
+frM
 crE
-fZJ
+fWT
 aaf
 aaS
 aaa
@@ -114214,17 +114214,17 @@ aaa
 aaa
 aba
 aaa
-xnl
+frM
 crG
-fZJ
+fWT
 aaa
-xnl
+frM
 crG
-fZJ
+fWT
 aaa
-xnl
+frM
 crG
-fZJ
+fWT
 aaa
 aaS
 aaa

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -45625,14 +45625,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cmp" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/tracker,
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/fore)
 "cmq" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating{
@@ -48048,6 +48040,13 @@
 /obj/item/gun/syringe,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"dDR" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/tracker,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/port/fore)
 "dEb" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -50550,14 +50549,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/service)
-"hNq" = (
-/obj/machinery/power/tracker,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/solar/port/aft)
 "hNI" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -50729,6 +50720,13 @@
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"ibz" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/tracker,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/fore)
 "ibZ" = (
 /obj/structure/transit_tube/crossing/horizontal,
 /turf/open/space/basic,
@@ -51739,6 +51737,13 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"jHC" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/fore)
 "jIe" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden/layer1{
 	dir = 8
@@ -51937,12 +51942,6 @@
 /obj/structure/altar_of_gods,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"jWi" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/fore)
 "jWz" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -53133,11 +53132,6 @@
 "lFe" = (
 /turf/closed/wall,
 /area/tcommsat/computer)
-"lGx" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
 "lGE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -53425,6 +53419,13 @@
 "mof" = (
 /turf/closed/wall/r_wall,
 /area/quartermaster/sorting)
+"moi" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/port/aft)
 "mqK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -53955,13 +53956,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"nag" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/fore)
 "nao" = (
 /obj/item/clothing/gloves/color/black,
 /obj/item/clothing/mask/breath,
@@ -55019,13 +55013,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"oIh" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
 "oJh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -55305,6 +55292,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"plY" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/port/fore)
 "pmW" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -55564,13 +55557,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"pFu" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/aft)
 "pGe" = (
 /obj/structure/lattice,
 /turf/open/space,
@@ -56453,6 +56439,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"qOf" = (
+/obj/machinery/power/tracker,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/port/aft)
 "qOl" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -56909,6 +56902,13 @@
 /obj/structure/sign/departments/minsky/research/research,
 /turf/closed/wall/r_wall,
 /area/science/lab)
+"ryg" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
 "rzM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -57203,6 +57203,11 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"saA" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
 "saK" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -57459,12 +57464,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/construction)
-"swh" = (
-/obj/structure/cable,
-/obj/machinery/power/tracker,
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
 "swo" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/hidden,
 /obj/effect/turf_decal/tile/purple{
@@ -58341,18 +58340,6 @@
 /obj/effect/landmark/stationroom/box/dorm_edoor,
 /turf/template_noop,
 /area/space)
-"tGm" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/fore)
-"tGn" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/aft)
 "tHN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -58891,11 +58878,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"uzF" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/fore)
 "uAQ" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -59032,14 +59014,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"uRq" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/tracker,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/solar/port/fore)
 "uRs" = (
 /obj/machinery/light/small,
 /obj/structure/closet/crate/hydroponics,
@@ -59064,6 +59038,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plating,
 /area/construction)
+"uXN" = (
+/obj/structure/cable,
+/obj/machinery/power/tracker,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
 "uXY" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -59169,6 +59148,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"veR" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/port/fore)
 "vfv" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment{
@@ -59974,13 +59960,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/nanite)
-"wwf" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/fore)
 "wwh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -60011,6 +59990,11 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
+"wxR" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/port/fore)
 "wyh" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/reagent_containers/blood,
@@ -60076,6 +60060,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"wzy" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/port/aft)
 "wAc" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/atmospherics/miner/toxins,
@@ -60288,6 +60279,11 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/storage/tech)
+"wQs" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/fore)
 "wRK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -77120,7 +77116,7 @@ aaa
 aaa
 aaS
 aaf
-hNq
+qOf
 aaf
 aaS
 aaa
@@ -77534,17 +77530,17 @@ aaa
 aaa
 abY
 aaa
-nag
+veR
 adv
-tGm
+wxR
 aaa
-nag
+veR
 adv
-tGm
+wxR
 aaa
-nag
+veR
 adv
-tGm
+wxR
 aaa
 aaS
 aaf
@@ -77791,17 +77787,17 @@ aaa
 aaa
 abY
 aaf
-nag
+veR
 adu
-tGm
+wxR
 aaa
-nag
+veR
 adu
-tGm
+wxR
 aaa
-nag
+veR
 adu
-tGm
+wxR
 aaf
 aaf
 aaa
@@ -77885,19 +77881,19 @@ aaa
 aaa
 aaS
 aaf
-tGn
-tGn
-tGn
-tGn
-tGn
+moi
+moi
+moi
+moi
+moi
 aaa
 chK
 aaa
-tGn
-tGn
-tGn
-tGn
-tGn
+moi
+moi
+moi
+moi
+moi
 aaf
 aaS
 aaa
@@ -78048,17 +78044,17 @@ aaa
 aaa
 abY
 aaa
-nag
+veR
 adu
-tGm
+wxR
 aaf
-nag
+veR
 adu
-tGm
+wxR
 aaf
-nag
+veR
 adu
-tGm
+wxR
 aaa
 aaf
 aaa
@@ -78305,17 +78301,17 @@ aaa
 aaa
 aaf
 aaf
-nag
+veR
 adu
-tGm
+wxR
 aaa
-nag
+veR
 adu
-tGm
+wxR
 aaa
-nag
+veR
 adu
-tGm
+wxR
 aaf
 aaf
 aaf
@@ -78399,19 +78395,19 @@ aaa
 aaf
 aaS
 aaf
-pFu
-pFu
-pFu
-pFu
-pFu
+wzy
+wzy
+wzy
+wzy
+wzy
 aaa
 eZX
 aaa
-pFu
-pFu
-pFu
-pFu
-pFu
+wzy
+wzy
+wzy
+wzy
+wzy
 aaf
 aaS
 aaa
@@ -78562,17 +78558,17 @@ aaS
 aaS
 aaf
 aaa
-nag
+veR
 adu
-tGm
+wxR
 aaa
-nag
+veR
 adu
-tGm
+wxR
 aaa
-nag
+veR
 adu
-tGm
+wxR
 aaa
 aaf
 aaa
@@ -78913,19 +78909,19 @@ aaa
 aaf
 aaS
 aaf
-tGn
-tGn
-tGn
-tGn
-tGn
+moi
+moi
+moi
+moi
+moi
 aaa
 chL
 aaa
-tGn
-tGn
-tGn
-tGn
-tGn
+moi
+moi
+moi
+moi
+moi
 aaf
 aaS
 aaa
@@ -79073,7 +79069,7 @@ aaa
 aaa
 aaS
 aaf
-uRq
+dDR
 abZ
 abZ
 acW
@@ -79427,19 +79423,19 @@ aaa
 aaf
 aaS
 acy
-pFu
-pFu
-pFu
-pFu
-pFu
+wzy
+wzy
+wzy
+wzy
+wzy
 aaa
 chL
 aaa
-pFu
-pFu
-pFu
-pFu
-pFu
+wzy
+wzy
+wzy
+wzy
+wzy
 aaf
 aaS
 aaa
@@ -79590,17 +79586,17 @@ aba
 aaS
 aaf
 aaa
-nag
+veR
 adz
-jWi
+plY
 aaa
-nag
+veR
 adz
-tGm
+wxR
 aaa
-nag
+veR
 adz
-tGm
+wxR
 aaa
 aaf
 aaa
@@ -79847,17 +79843,17 @@ aaa
 aaa
 aaf
 aaf
-nag
+veR
 adz
-jWi
+plY
 aaa
-nag
+veR
 adz
-tGm
+wxR
 aaa
-nag
+veR
 adz
-tGm
+wxR
 aaf
 aaf
 aaa
@@ -79941,19 +79937,19 @@ aaa
 aaf
 aaS
 aaf
-tGn
-tGn
-tGn
-tGn
-tGn
+moi
+moi
+moi
+moi
+moi
 aaa
 chL
 aaa
-tGn
-tGn
-tGn
-tGn
-tGn
+moi
+moi
+moi
+moi
+moi
 aaf
 aaS
 aaa
@@ -80104,17 +80100,17 @@ aaa
 aaa
 aaS
 aaa
-nag
+veR
 adz
-jWi
+plY
 aaf
-nag
+veR
 adz
-tGm
+wxR
 aaf
-nag
+veR
 adz
-tGm
+wxR
 aaa
 aaf
 aaf
@@ -80361,17 +80357,17 @@ aaa
 aaa
 aaS
 aaf
-nag
+veR
 adz
-jWi
+plY
 aaa
-nag
+veR
 adz
-tGm
+wxR
 aaa
-nag
+veR
 adz
-tGm
+wxR
 aaf
 aaf
 aaa
@@ -80455,19 +80451,19 @@ aoV
 aaa
 aaS
 aaf
-pFu
-pFu
-pFu
-pFu
-pFu
+wzy
+wzy
+wzy
+wzy
+wzy
 aaa
 chL
 aaa
-pFu
-pFu
-pFu
-pFu
-pFu
+wzy
+wzy
+wzy
+wzy
+wzy
 aaf
 aaS
 aaa
@@ -80618,17 +80614,17 @@ aaa
 aaa
 aaS
 aaa
-nag
+veR
 adA
-jWi
+plY
 aaa
-nag
+veR
 adA
-tGm
+wxR
 aaa
-nag
+veR
 adA
-tGm
+wxR
 aaa
 aaS
 aaa
@@ -102463,17 +102459,17 @@ aaa
 aaa
 aaS
 aaa
-wwf
+jHC
 adS
-uzF
+wQs
 aaa
-wwf
+jHC
 adS
-uzF
+wQs
 aaa
-wwf
+jHC
 adS
-uzF
+wQs
 aaa
 aaS
 aaf
@@ -102720,17 +102716,17 @@ aaa
 aaa
 aaS
 aaf
-wwf
+jHC
 adT
-uzF
+wQs
 aaa
-wwf
+jHC
 adT
-uzF
+wQs
 aaa
-wwf
+jHC
 adT
-uzF
+wQs
 aaf
 aaf
 aaa
@@ -102977,17 +102973,17 @@ aaa
 aaa
 aaS
 aaa
-wwf
+jHC
 adT
-uzF
+wQs
 aaf
-wwf
+jHC
 adT
-uzF
+wQs
 aaf
-wwf
+jHC
 adT
-uzF
+wQs
 aaa
 aaf
 aaa
@@ -103234,17 +103230,17 @@ aaa
 aaa
 aaf
 aaf
-wwf
+jHC
 adT
-uzF
+wQs
 aaa
-wwf
+jHC
 adT
-uzF
+wQs
 aaa
-wwf
+jHC
 adT
-uzF
+wQs
 aaf
 aaf
 aaf
@@ -103491,17 +103487,17 @@ aaS
 aaS
 aaf
 aaa
-wwf
+jHC
 adT
-uzF
+wQs
 aaa
-wwf
+jHC
 adT
-uzF
+wQs
 aaa
-wwf
+jHC
 adT
-uzF
+wQs
 aaa
 aaf
 aaa
@@ -104002,7 +103998,7 @@ aaa
 aaa
 aaS
 aaf
-cmp
+ibz
 acx
 acx
 adt
@@ -104519,17 +104515,17 @@ aba
 aaS
 acy
 aaa
-wwf
+jHC
 adW
-uzF
+wQs
 aaa
-wwf
+jHC
 adW
-uzF
+wQs
 aaa
-wwf
+jHC
 adW
-uzF
+wQs
 aaa
 aaf
 aaa
@@ -104776,17 +104772,17 @@ aaa
 aaa
 aaf
 aaf
-wwf
+jHC
 adW
-uzF
+wQs
 aaa
-wwf
+jHC
 adW
-uzF
+wQs
 aaa
-wwf
+jHC
 adW
-uzF
+wQs
 aaf
 aaf
 aaf
@@ -105033,17 +105029,17 @@ aaa
 aaa
 aaS
 aaa
-wwf
+jHC
 adW
-uzF
+wQs
 aaf
-wwf
+jHC
 adW
-uzF
+wQs
 aaf
-wwf
+jHC
 adW
-uzF
+wQs
 aaa
 aaf
 aaa
@@ -105290,17 +105286,17 @@ aaa
 aaa
 aaS
 aaf
-wwf
+jHC
 adW
-uzF
+wQs
 aaa
-wwf
+jHC
 adW
-uzF
+wQs
 aaa
-wwf
+jHC
 adW
-uzF
+wQs
 aaf
 aaf
 aaa
@@ -105547,17 +105543,17 @@ aaa
 aaa
 aaS
 aaa
-wwf
+jHC
 adY
-uzF
+wQs
 aaa
-wwf
+jHC
 adY
-uzF
+wQs
 aaa
-wwf
+jHC
 adY
-uzF
+wQs
 aaa
 aaS
 aaf
@@ -111313,17 +111309,17 @@ aaa
 aaa
 aaS
 aaa
-oIh
+ryg
 crB
-lGx
+saA
 aaa
-oIh
+ryg
 crB
-lGx
+saA
 aaa
-oIh
+ryg
 crB
-lGx
+saA
 aaa
 aaS
 aaa
@@ -111570,17 +111566,17 @@ aaa
 aaa
 aba
 aaf
-oIh
+ryg
 crC
-lGx
+saA
 aaa
-oIh
+ryg
 crC
-lGx
+saA
 aaa
-oIh
+ryg
 crC
-lGx
+saA
 aaf
 aaS
 aaa
@@ -111827,17 +111823,17 @@ aaa
 aaa
 aaf
 aaa
-oIh
+ryg
 crC
-lGx
+saA
 aaf
-oIh
+ryg
 crC
-lGx
+saA
 aaf
-oIh
+ryg
 crC
-lGx
+saA
 aaa
 aaS
 aaa
@@ -112084,17 +112080,17 @@ aaf
 aaf
 aaf
 aaf
-oIh
+ryg
 crC
-lGx
+saA
 aaa
-oIh
+ryg
 crC
-lGx
+saA
 aaa
-oIh
+ryg
 crC
-lGx
+saA
 aaf
 aaf
 aaa
@@ -112341,17 +112337,17 @@ aaa
 aaa
 aaf
 aaa
-oIh
+ryg
 crC
-lGx
+saA
 aaa
-oIh
+ryg
 crC
-lGx
+saA
 aaa
-oIh
+ryg
 crC
-lGx
+saA
 aaa
 aaf
 aaS
@@ -112868,7 +112864,7 @@ crk
 tyu
 cpi
 cpi
-swh
+uXN
 aaf
 aaS
 aaa
@@ -113369,17 +113365,17 @@ aaa
 aaa
 aaf
 aaa
-oIh
+ryg
 crE
-lGx
+saA
 aaa
-oIh
+ryg
 crE
-lGx
+saA
 aaa
-oIh
+ryg
 crE
-lGx
+saA
 aaa
 aaf
 aaS
@@ -113626,17 +113622,17 @@ aaf
 aaf
 aaf
 aaf
-oIh
+ryg
 crE
-lGx
+saA
 aaa
-oIh
+ryg
 crE
-lGx
+saA
 aaa
-oIh
+ryg
 crE
-lGx
+saA
 aaf
 aaf
 aaa
@@ -113883,17 +113879,17 @@ aaa
 aaa
 aaf
 aaa
-oIh
+ryg
 crE
-lGx
+saA
 aaf
-oIh
+ryg
 crE
-lGx
+saA
 aaf
-oIh
+ryg
 crE
-lGx
+saA
 aaa
 aaS
 aaa
@@ -114140,17 +114136,17 @@ aaf
 aaf
 aaf
 aaf
-oIh
+ryg
 crE
-lGx
+saA
 aaa
-oIh
+ryg
 crE
-lGx
+saA
 aaa
-oIh
+ryg
 crE
-lGx
+saA
 aaf
 aaS
 aaa
@@ -114397,17 +114393,17 @@ aaa
 aaa
 aba
 aaa
-oIh
+ryg
 crG
-lGx
+saA
 aaa
-oIh
+ryg
 crG
-lGx
+saA
 aaa
-oIh
+ryg
 crG
-lGx
+saA
 aaa
 aaS
 aaa

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -20846,13 +20846,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"aTn" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/aft)
 "aTo" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -40180,12 +40173,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine/air,
 /area/engine/atmos_distro)
-"bKK" = (
-/obj/machinery/air_sensor{
-	id_tag = "air_sensor"
-	},
-/turf/open/floor/engine/vacuum,
-/area/engine/atmos_distro)
 "bKL" = (
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 4;
@@ -48873,13 +48860,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"eXO" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/fore)
 "eYN" = (
 /obj/item/clothing/gloves/color/rainbow,
 /obj/item/clothing/head/soft/rainbow,
@@ -48933,11 +48913,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/construction)
-"fem" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/fore)
 "feu" = (
 /obj/machinery/nuclearbomb/selfdestruct,
 /obj/effect/turf_decal/tile/neutral,
@@ -49126,13 +49101,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"frM" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
 "ftM" = (
 /obj/structure/extraction_point{
 	name = "Xenobiology Fulton Retriever"
@@ -49479,11 +49447,6 @@
 /obj/item/t_scanner,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"fWT" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/aft)
 "fXn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -50070,6 +50033,13 @@
 /obj/effect/spawner/lootdrop/techstorage/tcomms,
 /turf/open/floor/plasteel/white,
 /area/storage/tech)
+"gRo" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/port/aft)
 "gUn" = (
 /obj/machinery/button/door{
 	id = "atmos";
@@ -52273,6 +52243,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"kkD" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/port/fore)
 "klX" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -52366,11 +52341,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"kxx" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/fore)
 "kxR" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -52940,6 +52910,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"lnt" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
 "lop" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
@@ -53714,12 +53689,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"mLb" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/fore)
 "mLv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -54425,13 +54394,6 @@
 /obj/item/assembly/flash/handheld,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"nIl" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/starboard/fore)
 "nJW" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/plasteel/dark,
@@ -55946,6 +55908,12 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel,
 /area/science/nanite)
+"qgv" = (
+/obj/machinery/air_sensor{
+	id_tag = "air_sensor"
+	},
+/turf/open/floor/engine/air,
+/area/engine/atmos_distro)
 "qhA" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -56419,6 +56387,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"qPm" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/fore)
 "qPC" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -56972,6 +56947,12 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
+"rNg" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/port/fore)
 "rPc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -57926,6 +57907,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"tiV" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/aft)
 "tkf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58284,6 +58272,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"tOV" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/starboard/fore)
 "tPc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -59516,13 +59509,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/wood,
 /area/maintenance/fore)
-"vUu" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/aft)
 "vVV" = (
 /obj/structure/table,
 /obj/item/folder/white,
@@ -59766,6 +59752,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"wpZ" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/port/fore)
 "wqI" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -59795,6 +59788,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"wtQ" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/spawner/structure/solars/solar_96,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/port/aft)
 "wuM" = (
 /obj/machinery/meter,
 /obj/machinery/button/door{
@@ -77351,17 +77351,17 @@ aaa
 aaa
 abY
 aaa
-eXO
+wpZ
 adv
-fem
+kkD
 aaa
-eXO
+wpZ
 adv
-fem
+kkD
 aaa
-eXO
+wpZ
 adv
-fem
+kkD
 aaa
 aaS
 aaf
@@ -77608,17 +77608,17 @@ aaa
 aaa
 abY
 aaf
-eXO
+wpZ
 adu
-fem
+kkD
 aaa
-eXO
+wpZ
 adu
-fem
+kkD
 aaa
-eXO
+wpZ
 adu
-fem
+kkD
 aaf
 aaf
 aaa
@@ -77702,19 +77702,19 @@ aaa
 aaa
 aaS
 aaf
-vUu
-vUu
-vUu
-vUu
-vUu
+gRo
+gRo
+gRo
+gRo
+gRo
 aaa
 chK
 aaa
-vUu
-vUu
-vUu
-vUu
-vUu
+gRo
+gRo
+gRo
+gRo
+gRo
 aaf
 aaS
 aaa
@@ -77865,17 +77865,17 @@ aaa
 aaa
 abY
 aaa
-eXO
+wpZ
 adu
-fem
+kkD
 aaf
-eXO
+wpZ
 adu
-fem
+kkD
 aaf
-eXO
+wpZ
 adu
-fem
+kkD
 aaa
 aaf
 aaa
@@ -78122,17 +78122,17 @@ aaa
 aaa
 aaf
 aaf
-eXO
+wpZ
 adu
-fem
+kkD
 aaa
-eXO
+wpZ
 adu
-fem
+kkD
 aaa
-eXO
+wpZ
 adu
-fem
+kkD
 aaf
 aaf
 aaf
@@ -78216,19 +78216,19 @@ aaa
 aaf
 aaS
 aaf
-aTn
-aTn
-aTn
-aTn
-aTn
+wtQ
+wtQ
+wtQ
+wtQ
+wtQ
 aaa
 eZX
 aaa
-aTn
-aTn
-aTn
-aTn
-aTn
+wtQ
+wtQ
+wtQ
+wtQ
+wtQ
 aaf
 aaS
 aaa
@@ -78379,17 +78379,17 @@ aaS
 aaS
 aaf
 aaa
-eXO
+wpZ
 adu
-fem
+kkD
 aaa
-eXO
+wpZ
 adu
-fem
+kkD
 aaa
-eXO
+wpZ
 adu
-fem
+kkD
 aaa
 aaf
 aaa
@@ -78730,19 +78730,19 @@ aaa
 aaf
 aaS
 aaf
-vUu
-vUu
-vUu
-vUu
-vUu
+gRo
+gRo
+gRo
+gRo
+gRo
 aaa
 chL
 aaa
-vUu
-vUu
-vUu
-vUu
-vUu
+gRo
+gRo
+gRo
+gRo
+gRo
 aaf
 aaS
 aaa
@@ -79244,19 +79244,19 @@ aaa
 aaf
 aaS
 acy
-aTn
-aTn
-aTn
-aTn
-aTn
+wtQ
+wtQ
+wtQ
+wtQ
+wtQ
 aaa
 chL
 aaa
-aTn
-aTn
-aTn
-aTn
-aTn
+wtQ
+wtQ
+wtQ
+wtQ
+wtQ
 aaf
 aaS
 aaa
@@ -79407,17 +79407,17 @@ aba
 aaS
 aaf
 aaa
-eXO
+wpZ
 adz
-mLb
+rNg
 aaa
-eXO
+wpZ
 adz
-fem
+kkD
 aaa
-eXO
+wpZ
 adz
-fem
+kkD
 aaa
 aaf
 aaa
@@ -79664,17 +79664,17 @@ aaa
 aaa
 aaf
 aaf
-eXO
+wpZ
 adz
-mLb
+rNg
 aaa
-eXO
+wpZ
 adz
-fem
+kkD
 aaa
-eXO
+wpZ
 adz
-fem
+kkD
 aaf
 aaf
 aaa
@@ -79758,19 +79758,19 @@ aaa
 aaf
 aaS
 aaf
-vUu
-vUu
-vUu
-vUu
-vUu
+gRo
+gRo
+gRo
+gRo
+gRo
 aaa
 chL
 aaa
-vUu
-vUu
-vUu
-vUu
-vUu
+gRo
+gRo
+gRo
+gRo
+gRo
 aaf
 aaS
 aaa
@@ -79921,17 +79921,17 @@ aaa
 aaa
 aaS
 aaa
-eXO
+wpZ
 adz
-mLb
+rNg
 aaf
-eXO
+wpZ
 adz
-fem
+kkD
 aaf
-eXO
+wpZ
 adz
-fem
+kkD
 aaa
 aaf
 aaf
@@ -80178,17 +80178,17 @@ aaa
 aaa
 aaS
 aaf
-eXO
+wpZ
 adz
-mLb
+rNg
 aaa
-eXO
+wpZ
 adz
-fem
+kkD
 aaa
-eXO
+wpZ
 adz
-fem
+kkD
 aaf
 aaf
 aaa
@@ -80272,19 +80272,19 @@ aoV
 aaa
 aaS
 aaf
-aTn
-aTn
-aTn
-aTn
-aTn
+wtQ
+wtQ
+wtQ
+wtQ
+wtQ
 aaa
 chL
 aaa
-aTn
-aTn
-aTn
-aTn
-aTn
+wtQ
+wtQ
+wtQ
+wtQ
+wtQ
 aaf
 aaS
 aaa
@@ -80435,17 +80435,17 @@ aaa
 aaa
 aaS
 aaa
-eXO
+wpZ
 adA
-mLb
+rNg
 aaa
-eXO
+wpZ
 adA
-fem
+kkD
 aaa
-eXO
+wpZ
 adA
-fem
+kkD
 aaa
 aaS
 aaa
@@ -95693,7 +95693,7 @@ avy
 aaa
 bvA
 bKw
-bKK
+qgv
 bKR
 bvA
 bLG
@@ -102280,17 +102280,17 @@ aaa
 aaa
 aaS
 aaa
-nIl
+qPm
 adS
-kxx
+tOV
 aaa
-nIl
+qPm
 adS
-kxx
+tOV
 aaa
-nIl
+qPm
 adS
-kxx
+tOV
 aaa
 aaS
 aaf
@@ -102537,17 +102537,17 @@ aaa
 aaa
 aaS
 aaf
-nIl
+qPm
 adT
-kxx
+tOV
 aaa
-nIl
+qPm
 adT
-kxx
+tOV
 aaa
-nIl
+qPm
 adT
-kxx
+tOV
 aaf
 aaf
 aaa
@@ -102794,17 +102794,17 @@ aaa
 aaa
 aaS
 aaa
-nIl
+qPm
 adT
-kxx
+tOV
 aaf
-nIl
+qPm
 adT
-kxx
+tOV
 aaf
-nIl
+qPm
 adT
-kxx
+tOV
 aaa
 aaf
 aaa
@@ -103051,17 +103051,17 @@ aaa
 aaa
 aaf
 aaf
-nIl
+qPm
 adT
-kxx
+tOV
 aaa
-nIl
+qPm
 adT
-kxx
+tOV
 aaa
-nIl
+qPm
 adT
-kxx
+tOV
 aaf
 aaf
 aaf
@@ -103308,17 +103308,17 @@ aaS
 aaS
 aaf
 aaa
-nIl
+qPm
 adT
-kxx
+tOV
 aaa
-nIl
+qPm
 adT
-kxx
+tOV
 aaa
-nIl
+qPm
 adT
-kxx
+tOV
 aaa
 aaf
 aaa
@@ -104336,17 +104336,17 @@ aba
 aaS
 acy
 aaa
-nIl
+qPm
 adW
-kxx
+tOV
 aaa
-nIl
+qPm
 adW
-kxx
+tOV
 aaa
-nIl
+qPm
 adW
-kxx
+tOV
 aaa
 aaf
 aaa
@@ -104593,17 +104593,17 @@ aaa
 aaa
 aaf
 aaf
-nIl
+qPm
 adW
-kxx
+tOV
 aaa
-nIl
+qPm
 adW
-kxx
+tOV
 aaa
-nIl
+qPm
 adW
-kxx
+tOV
 aaf
 aaf
 aaf
@@ -104850,17 +104850,17 @@ aaa
 aaa
 aaS
 aaa
-nIl
+qPm
 adW
-kxx
+tOV
 aaf
-nIl
+qPm
 adW
-kxx
+tOV
 aaf
-nIl
+qPm
 adW
-kxx
+tOV
 aaa
 aaf
 aaa
@@ -105107,17 +105107,17 @@ aaa
 aaa
 aaS
 aaf
-nIl
+qPm
 adW
-kxx
+tOV
 aaa
-nIl
+qPm
 adW
-kxx
+tOV
 aaa
-nIl
+qPm
 adW
-kxx
+tOV
 aaf
 aaf
 aaa
@@ -105364,17 +105364,17 @@ aaa
 aaa
 aaS
 aaa
-nIl
+qPm
 adY
-kxx
+tOV
 aaa
-nIl
+qPm
 adY
-kxx
+tOV
 aaa
-nIl
+qPm
 adY
-kxx
+tOV
 aaa
 aaS
 aaf
@@ -111130,17 +111130,17 @@ aaa
 aaa
 aaS
 aaa
-frM
+tiV
 crB
-fWT
+lnt
 aaa
-frM
+tiV
 crB
-fWT
+lnt
 aaa
-frM
+tiV
 crB
-fWT
+lnt
 aaa
 aaS
 aaa
@@ -111387,17 +111387,17 @@ aaa
 aaa
 aba
 aaf
-frM
+tiV
 crC
-fWT
+lnt
 aaa
-frM
+tiV
 crC
-fWT
+lnt
 aaa
-frM
+tiV
 crC
-fWT
+lnt
 aaf
 aaS
 aaa
@@ -111644,17 +111644,17 @@ aaa
 aaa
 aaf
 aaa
-frM
+tiV
 crC
-fWT
+lnt
 aaf
-frM
+tiV
 crC
-fWT
+lnt
 aaf
-frM
+tiV
 crC
-fWT
+lnt
 aaa
 aaS
 aaa
@@ -111901,17 +111901,17 @@ aaf
 aaf
 aaf
 aaf
-frM
+tiV
 crC
-fWT
+lnt
 aaa
-frM
+tiV
 crC
-fWT
+lnt
 aaa
-frM
+tiV
 crC
-fWT
+lnt
 aaf
 aaf
 aaa
@@ -112158,17 +112158,17 @@ aaa
 aaa
 aaf
 aaa
-frM
+tiV
 crC
-fWT
+lnt
 aaa
-frM
+tiV
 crC
-fWT
+lnt
 aaa
-frM
+tiV
 crC
-fWT
+lnt
 aaa
 aaf
 aaS
@@ -113186,17 +113186,17 @@ aaa
 aaa
 aaf
 aaa
-frM
+tiV
 crE
-fWT
+lnt
 aaa
-frM
+tiV
 crE
-fWT
+lnt
 aaa
-frM
+tiV
 crE
-fWT
+lnt
 aaa
 aaf
 aaS
@@ -113443,17 +113443,17 @@ aaf
 aaf
 aaf
 aaf
-frM
+tiV
 crE
-fWT
+lnt
 aaa
-frM
+tiV
 crE
-fWT
+lnt
 aaa
-frM
+tiV
 crE
-fWT
+lnt
 aaf
 aaf
 aaa
@@ -113700,17 +113700,17 @@ aaa
 aaa
 aaf
 aaa
-frM
+tiV
 crE
-fWT
+lnt
 aaf
-frM
+tiV
 crE
-fWT
+lnt
 aaf
-frM
+tiV
 crE
-fWT
+lnt
 aaa
 aaS
 aaa
@@ -113957,17 +113957,17 @@ aaf
 aaf
 aaf
 aaf
-frM
+tiV
 crE
-fWT
+lnt
 aaa
-frM
+tiV
 crE
-fWT
+lnt
 aaa
-frM
+tiV
 crE
-fWT
+lnt
 aaf
 aaS
 aaa
@@ -114214,17 +114214,17 @@ aaa
 aaa
 aba
 aaa
-frM
+tiV
 crG
-fWT
+lnt
 aaa
-frM
+tiV
 crG
-fWT
+lnt
 aaa
-frM
+tiV
 crG
-fWT
+lnt
 aaa
 aaS
 aaa

--- a/_maps/map_files/generic/City_of_Cogs.dmm
+++ b/_maps/map_files/generic/City_of_Cogs.dmm
@@ -19,12 +19,6 @@
 /obj/machinery/door/airlock/clockwork/brass,
 /turf/open/floor/clockwork/reebe,
 /area/reebe/city_of_cogs)
-"af" = (
-/obj/structure/table/reinforced/brass,
-/obj/item/kitchen/fork,
-/obj/item/kitchen/fork,
-/turf/open/floor/clockwork/reebe,
-/area/reebe/city_of_cogs)
 "ag" = (
 /obj/machinery/door/airlock/clockwork/brass{
 	name = "Summoning Chamber"
@@ -189,15 +183,6 @@
 	},
 /turf/open/indestructible/reebe_void,
 /area/reebe/city_of_cogs)
-"aL" = (
-/obj/structure/table/reinforced/brass,
-/obj/item/clockwork/slab,
-/obj/item/clockwork/slab,
-/obj/item/clockwork/slab,
-/obj/item/kitchen/fork,
-/obj/item/kitchen/fork,
-/turf/open/floor/clockwork/reebe,
-/area/reebe/city_of_cogs)
 "aM" = (
 /obj/structure/lattice/catwalk/clockwork,
 /obj/effect/clockwork/servant_blocker,
@@ -237,6 +222,63 @@
 	},
 /turf/closed/wall/clockwork,
 /area/reebe/city_of_cogs)
+"cC" = (
+/obj/structure/table/reinforced/brass,
+/obj/item/kitchen/fork{
+	pixel_x = 10
+	},
+/obj/item/kitchen/fork{
+	pixel_x = -4
+	},
+/turf/open/floor/clockwork/reebe,
+/area/reebe/city_of_cogs)
+"mj" = (
+/obj/structure/table/reinforced/brass,
+/obj/item/clockwork/slab{
+	pixel_x = 10;
+	pixel_y = 10
+	},
+/obj/item/clockwork/slab{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/item/clockwork/slab{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/clockwork/slab{
+	pixel_x = -2;
+	pixel_y = 1
+	},
+/obj/item/clockwork/slab{
+	pixel_x = -6;
+	pixel_y = -2
+	},
+/obj/item/clockwork/slab{
+	pixel_x = -10;
+	pixel_y = -5
+	},
+/turf/open/floor/clockwork/reebe,
+/area/reebe/city_of_cogs)
+"wm" = (
+/obj/structure/table/reinforced/brass,
+/obj/item/kitchen/fork{
+	pixel_x = -4
+	},
+/obj/item/kitchen/fork{
+	pixel_x = -11
+	},
+/obj/item/kitchen/fork{
+	pixel_x = 3
+	},
+/obj/item/kitchen/fork{
+	pixel_x = 10
+	},
+/turf/open/floor/clockwork/reebe,
+/area/reebe/city_of_cogs)
+"Ct" = (
+/turf/closed/indestructible/riveted,
+/area/reebe)
 "Vl" = (
 /obj/structure/table/reinforced/brass,
 /obj/effect/landmark/servant_of_ratvar/scarab,
@@ -244,97 +286,98 @@
 /area/reebe/city_of_cogs)
 
 (1,1,1) = {"
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 "}
 (2,1,1) = {"
+Ct
 ab
 ab
 ab
@@ -422,10 +465,10 @@ ab
 ab
 ab
 ab
-ab
-ab
+Ct
 "}
 (3,1,1) = {"
+Ct
 ab
 ab
 ab
@@ -513,10 +556,10 @@ ab
 ab
 ab
 ab
-ab
-ab
+Ct
 "}
 (4,1,1) = {"
+Ct
 ab
 ab
 ab
@@ -604,10 +647,10 @@ ab
 ab
 ab
 ab
-ab
-ab
+Ct
 "}
 (5,1,1) = {"
+Ct
 ab
 ab
 ab
@@ -695,10 +738,10 @@ ab
 ab
 ab
 ab
-ab
-ab
+Ct
 "}
 (6,1,1) = {"
+Ct
 ab
 ab
 ab
@@ -786,10 +829,10 @@ ab
 ab
 ab
 ab
-ab
-ab
+Ct
 "}
 (7,1,1) = {"
+Ct
 ab
 ab
 ab
@@ -877,11 +920,10 @@ ab
 ab
 ab
 ab
-ab
-ab
+Ct
 "}
 (8,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -969,10 +1011,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (9,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -1060,10 +1102,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (10,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -1151,10 +1193,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (11,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -1242,10 +1284,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (12,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -1333,10 +1375,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (13,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -1424,10 +1466,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (14,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -1515,10 +1557,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (15,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -1606,10 +1648,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (16,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -1697,10 +1739,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (17,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -1788,10 +1830,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (18,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -1879,10 +1921,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (19,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -1970,10 +2012,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (20,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -2061,10 +2103,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (21,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -2152,10 +2194,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (22,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -2243,10 +2285,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (23,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -2334,10 +2376,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (24,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -2425,10 +2467,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (25,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -2516,10 +2558,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (26,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -2607,10 +2649,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (27,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -2698,10 +2740,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (28,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -2789,10 +2831,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (29,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -2880,10 +2922,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (30,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -2971,10 +3013,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (31,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -3062,10 +3104,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (32,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -3153,10 +3195,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (33,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -3244,10 +3286,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (34,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -3335,10 +3377,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (35,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -3426,10 +3468,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (36,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -3517,10 +3559,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (37,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -3608,10 +3650,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (38,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -3650,7 +3692,7 @@ aj
 aj
 aj
 ah
-aL
+mj
 aj
 aj
 ag
@@ -3699,10 +3741,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (39,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -3790,10 +3832,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (40,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -3830,7 +3872,7 @@ aj
 aj
 aj
 ah
-aL
+wm
 ax
 aj
 aj
@@ -3881,10 +3923,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (41,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -3972,10 +4014,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (42,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -4063,10 +4105,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (43,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -4154,10 +4196,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (44,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -4245,10 +4287,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (45,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -4336,10 +4378,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (46,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -4427,10 +4469,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (47,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -4518,10 +4560,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (48,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -4609,10 +4651,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (49,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -4648,7 +4690,7 @@ aj
 aj
 aj
 ah
-af
+cC
 aj
 aj
 aj
@@ -4700,10 +4742,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (50,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -4791,10 +4833,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (51,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -4882,10 +4924,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (52,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -4973,10 +5015,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (53,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -5064,10 +5106,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (54,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -5155,10 +5197,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (55,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -5246,10 +5288,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (56,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -5337,10 +5379,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (57,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -5428,10 +5470,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (58,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -5519,10 +5561,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (59,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -5610,10 +5652,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (60,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -5701,10 +5743,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (61,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -5792,10 +5834,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (62,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -5883,10 +5925,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (63,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -5974,10 +6016,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (64,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -6065,10 +6107,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (65,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -6156,10 +6198,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (66,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -6247,10 +6289,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (67,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -6338,10 +6380,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (68,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -6429,10 +6471,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (69,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -6520,10 +6562,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (70,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -6611,10 +6653,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (71,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -6702,10 +6744,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (72,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -6793,10 +6835,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (73,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -6884,10 +6926,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (74,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -6975,10 +7017,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (75,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -7066,10 +7108,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (76,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -7157,10 +7199,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (77,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -7248,10 +7290,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (78,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -7339,10 +7381,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (79,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -7430,10 +7472,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (80,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -7521,10 +7563,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (81,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -7612,10 +7654,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (82,1,1) = {"
-ab
+Ct
 ab
 ab
 ab
@@ -7703,9 +7745,10 @@ ab
 ab
 ab
 ab
-ab
+Ct
 "}
 (83,1,1) = {"
+Ct
 ab
 ab
 ab
@@ -7793,10 +7836,10 @@ ab
 ab
 ab
 ab
-ab
-ab
+Ct
 "}
 (84,1,1) = {"
+Ct
 ab
 ab
 ab
@@ -7884,10 +7927,10 @@ ab
 ab
 ab
 ab
-ab
-ab
+Ct
 "}
 (85,1,1) = {"
+Ct
 ab
 ab
 ab
@@ -7975,10 +8018,10 @@ ab
 ab
 ab
 ab
-ab
-ab
+Ct
 "}
 (86,1,1) = {"
+Ct
 ab
 ab
 ab
@@ -8066,10 +8109,10 @@ ab
 ab
 ab
 ab
-ab
-ab
+Ct
 "}
 (87,1,1) = {"
+Ct
 ab
 ab
 ab
@@ -8157,10 +8200,10 @@ ab
 ab
 ab
 ab
-ab
-ab
+Ct
 "}
 (88,1,1) = {"
+Ct
 ab
 ab
 ab
@@ -8248,97 +8291,96 @@ ab
 ab
 ab
 ab
-ab
-ab
+Ct
 "}
 (89,1,1) = {"
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
+Ct
 "}

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -67,6 +67,9 @@
 /turf/open/floor/wood/airless
 	initial_gas_mix = AIRLESS_ATMOS
 
+/turf/open/floor/wood/lavaland
+	intial_gas_mix = LAVALAND_DEFAULT_ATMOS
+
 /turf/open/floor/grass
 	name = "grass patch"
 	desc = "You can't tell if this is real grass or just cheap plastic imitation."

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -68,7 +68,7 @@
 	initial_gas_mix = AIRLESS_ATMOS
 
 /turf/open/floor/wood/lavaland
-	intial_gas_mix = LAVALAND_DEFAULT_ATMOS
+	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
 
 /turf/open/floor/grass
 	name = "grass patch"

--- a/code/game/turfs/simulated/floor/plasteel_floor.dm
+++ b/code/game/turfs/simulated/floor/plasteel_floor.dm
@@ -19,7 +19,8 @@
 	initial_gas_mix = AIRLESS_ATMOS
 /turf/open/floor/plasteel/telecomms
 	initial_gas_mix = TCOMMS_ATMOS
-
+/turf/open/floor/plasteel/lavaland
+	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
 
 /turf/open/floor/plasteel/dark
 	icon_state = "darkfull"
@@ -33,6 +34,8 @@
 	icon_state = "dark"
 /turf/open/floor/plasteel/dark/corner
 	icon_state = "darkcorner"
+/turf/open/floor/plasteel/dark/lavaland
+	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
 /turf/open/floor/plasteel/checker
 	icon_state = "checker"
 
@@ -51,6 +54,8 @@
 	icon_state = "whitecorner"
 /turf/open/floor/plasteel/white/telecomms
 	initial_gas_mix = TCOMMS_ATMOS
+/turf/open/floor/plasteel/white/lavaland
+	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
 
 
 /turf/open/floor/plasteel/yellowsiding


### PR DESCRIPTION
### Intent of your Pull Request
See this?
![dreamseeker_9Wbb0A6ep7](https://user-images.githubusercontent.com/48154165/86302201-4d3fab80-bc08-11ea-8292-93978b194c00.png)

This is a bad thing. When round starts, this is the amount of turfs that have atmos contents different to their surroundings, we don't want that. The biggest culprits here are: 
Wizard academy, that is being handled in a separate PR,
Reebe, solved that by putting a wall around it,
Boxstation solars, some genius used regular solars turfs instead of airless, ill do this in a separate pr due to conflicts
Lavaland ruins, solved that by adding lavaland plasteel turfs and wood turfs and replacing them in the ones i can think of.

#### Changelog

:cl:  
rscadd: adds lavaland plasteel and wood
bugfix: fixes a lot of turfs to match their surrounding atmos
/:cl:
