### PR TITLE
Adds 2 more lizard hides to the "gasthelizards" ruin

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
@@ -95,24 +95,32 @@
 /turf/open/floor/plasteel/airless/dark,
 /area/ruin/space/has_grav/gasthelizard)
 "m" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/stack/sheet/animalhide/lizard,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
-"o" = (
-/obj/structure/closet/crate/freezer,
+/obj/structure/closet/crate/freezer{
+	name = "subject 3"
+	},
 /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
 /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
 /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
 /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
 /obj/item/clothing/under/rank/prisoner,
 /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/obj/item/stack/sheet/animalhide/lizard,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
+"o" = (
+/obj/structure/closet/crate/freezer{
+	name = "subject 2"
+	},
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/obj/machinery/light{
+	dir = 1
+	},
 /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
 /obj/item/stack/sheet/animalhide/lizard,
 /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
@@ -350,18 +358,16 @@
 "W" = (
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/gasthelizard)
-"Y" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
-/obj/machinery/light{
-	dir = 1
+"X" = (
+/obj/structure/closet/crate/freezer{
+	name = "subject 1"
 	},
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
 /obj/item/stack/sheet/animalhide/lizard,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
 /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
 /turf/open/floor/plasteel/airless/dark,
 /area/ruin/space/has_grav/gasthelizard)
@@ -602,7 +608,7 @@ a
 b
 b
 c
-m
+X
 r
 x
 C
@@ -618,7 +624,7 @@ a
 b
 b
 c
-Y
+o
 r
 r
 r
@@ -634,7 +640,7 @@ a
 a
 b
 c
-o
+m
 r
 y
 D

--- a/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
@@ -105,20 +105,6 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
 /turf/open/floor/plasteel/airless/dark,
 /area/ruin/space/has_grav/gasthelizard)
-"n" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
-/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
-/turf/open/floor/plasteel/airless/dark,
-/area/ruin/space/has_grav/gasthelizard)
 "o" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
@@ -128,6 +114,7 @@
 /obj/item/clothing/under/rank/prisoner,
 /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
 /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/obj/item/stack/sheet/animalhide/lizard,
 /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
 /turf/open/floor/plasteel/airless/dark,
 /area/ruin/space/has_grav/gasthelizard)
@@ -362,6 +349,21 @@
 /area/ruin/space/has_grav/gasthelizard)
 "W" = (
 /turf/open/floor/plating,
+/area/ruin/space/has_grav/gasthelizard)
+"Y" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/obj/item/stack/sheet/animalhide/lizard,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/turf/open/floor/plasteel/airless/dark,
 /area/ruin/space/has_grav/gasthelizard)
 "Z" = (
 /obj/machinery/door/airlock/external,
@@ -616,7 +618,7 @@ a
 b
 b
 c
-n
+Y
 r
 r
 r


### PR DESCRIPTION
There are 3 corpse remains and 3 sets of meat yet only 1 lizard hide.
Adds 2 more lizard hides to destroy this inconsistency

Before:
-----
![image](https://user-images.githubusercontent.com/24533979/86302593-ce7a4c80-bbce-11ea-8069-923797e6e744.png)


After:
----
![image](https://user-images.githubusercontent.com/24533979/86302671-ff5a8180-bbce-11ea-91de-04ff58cdba91.png)


#### Changelog

:cl:  Hopek
rscadd: Added 2 more lizard hides to match the number of lizard remains in the "gasthelizards" ruin.
/:cl:
