### PR TITLE
Clown bugs no longer spawn a new bikehorn everytime it dies

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/cockroach.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cockroach.dm
@@ -71,5 +71,4 @@
 	if(T)
 		new /mob/living/simple_animal/cockroach/clownbug(T)
 		playsound(loc, 'sound/items/bikehorn.ogg', 100, 0)
-	new /obj/item/bikehorn(src.loc)
 	..()


### PR DESCRIPTION
### Intent of your Pull Request
Already makes a honk noise on death no need to stack it

#### Changelog

:cl:  
tweak: no more bikehorns dropped
/:cl:
