### PR TITLE
Spreads the items out in robotics so they're not in a single space

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -29222,32 +29222,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"blE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/storage/firstaid/regular{
-	empty = 1;
-	name = "First-Aid (empty)"
-	},
-/obj/item/storage/firstaid/regular{
-	empty = 1;
-	name = "First-Aid (empty)"
-	},
-/obj/item/storage/firstaid/regular{
-	empty = 1;
-	name = "First-Aid (empty)"
-	},
-/obj/item/healthanalyzer,
-/obj/item/healthanalyzer,
-/obj/item/healthanalyzer,
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 29
-	},
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
 "blF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -29404,24 +29378,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
-"bma" = (
-/obj/structure/table,
-/obj/item/stack/sheet/plasteel{
-	amount = 10
-	},
-/obj/item/stack/cable_coil,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
 "bmb" = (
 /obj/machinery/holopad,
 /obj/structure/cable{
@@ -30675,32 +30631,6 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
 "bou" = (
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
-"bov" = (
-/obj/structure/table,
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/crowbar,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "bow" = (
@@ -51044,6 +50974,37 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"iCV" = (
+/obj/structure/table,
+/obj/item/assembly/prox_sensor{
+	pixel_x = -2;
+	pixel_y = 9
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = -10;
+	pixel_y = 8
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = -10
+	},
+/obj/item/stock_parts/cell/high/plus{
+	pixel_x = 7;
+	pixel_y = 2
+	},
+/obj/item/stock_parts/cell/high/plus{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/item/crowbar,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "iDv" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -57563,6 +57524,46 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
+"sLO" = (
+/obj/structure/table,
+/obj/item/stack/sheet/plasteel{
+	amount = 10;
+	pixel_x = -1;
+	pixel_y = 4
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_x = -10;
+	pixel_y = 10
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_x = -10;
+	pixel_y = 4
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_x = -10;
+	pixel_y = -1
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_x = 9;
+	pixel_y = 11
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_x = 9;
+	pixel_y = 5
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_x = 10
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "sNe" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -60631,6 +60632,46 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"xYx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 29
+	},
+/obj/item/healthanalyzer{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/item/storage/firstaid/regular{
+	empty = 1;
+	name = "First-Aid (empty)";
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/obj/item/healthanalyzer{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/regular{
+	empty = 1;
+	name = "First-Aid (empty)";
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/healthanalyzer{
+	pixel_x = 4
+	},
+/obj/item/storage/firstaid/regular{
+	empty = 1;
+	name = "First-Aid (empty)";
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "xYL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
@@ -107992,9 +108033,9 @@ bfX
 bhy
 biP
 bko
-blE
-bma
-bov
+xYx
+sLO
+iCV
 bpU
 brq
 bsW


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/24533979/86486203-4efc9280-bd20-11ea-9fac-084db8642e95.png)

Yes the medkits and analysts are layered and in a weave 

#### Changelog

:cl:  Hopek
tweak: Spread items out in Robotics so they're not all in a single space
/:cl:
