### PR TITLE
stops cogscarabs from spawning from debris spawns so they can't spawn off clock cult rounds

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -360,5 +360,4 @@ Credit where due:
 				/obj/item/clockwork/alloy_shards/large = 15,
 				/obj/structure/destructible/clockwork/wall_gear = 20,
 				/obj/structure/table_frame/brass = 20,
-				/obj/item/stack/tile/brass/ten = 23,
-				/obj/item/clockwork/construct_chassis/cogscarab = 1)
+				/obj/item/stack/tile/brass/ten = 23)


### PR DESCRIPTION
:cl:
bugfix: cogscarabs no longer have a random chance to spawn off of clock cult rounds
/:cl:
