### PR TITLE
Remove Prisoner Clothing from Brig Lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -197,12 +197,6 @@
 	req_access_txt = "0"
 	req_one_access_txt = list(ACCESS_ARMORY, ACCESS_FORENSICS_LOCKERS)
 
-/obj/structure/closet/secure_closet/brig/PopulateContents()
-	..()
-	new /obj/item/clothing/under/rank/prisoner( src )
-	new /obj/item/clothing/under/rank/prisoner/skirt( src )
-	new /obj/item/clothing/shoes/sneakers/orange( src )
-
 /obj/structure/closet/secure_closet/courtroom
 	name = "courtroom locker"
 	req_access = list(ACCESS_COURT)

--- a/code/modules/jobs/job_types/ai.dm
+++ b/code/modules/jobs/job_types/ai.dm
@@ -15,6 +15,7 @@
 	exp_type_department = EXP_TYPE_SILICON
 	display_order = JOB_DISPLAY_ORDER_AI
 	var/do_special_check = TRUE
+	changed_maps = list("RebuildStation")
 
 /datum/job/ai/equip(mob/living/carbon/human/H, visualsOnly, announce, latejoin, datum/outfit/outfit_override, client/preference_source = null)
 	if(visualsOnly)
@@ -22,7 +23,7 @@
 	. = H.AIize(latejoin,preference_source)
 
 /datum/job/ai/proc/RebuildStationChanges()
-    return TRUE
+	return TRUE
 
 /datum/job/ai/after_spawn(mob/H, mob/M, latejoin)
 	. = ..()

--- a/code/modules/jobs/job_types/ai.dm
+++ b/code/modules/jobs/job_types/ai.dm
@@ -21,6 +21,9 @@
 		CRASH("dynamic preview is unsupported")
 	. = H.AIize(latejoin,preference_source)
 
+/datum/job/ai/proc/RebuildStationChanges()
+    return TRUE
+
 /datum/job/ai/after_spawn(mob/H, mob/M, latejoin)
 	. = ..()
 	if(latejoin)

--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -20,10 +20,10 @@
 	paycheck_department = ACCOUNT_ENG
 	display_order = JOB_DISPLAY_ORDER_ATMOSPHERIC_TECHNICIAN
 
-	changed_maps = list("OmegaStation")
+	changed_maps = list("OmegaStation", "RebuildStation")
 
 /datum/job/atmos/proc/RebuildStationChanges()
-    return TRUE
+	return TRUE
 
 /datum/job/atmos/proc/OmegaStationChanges()
 	total_positions = 3

--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -22,6 +22,9 @@
 
 	changed_maps = list("OmegaStation")
 
+/datum/job/atmos/proc/RebuildStationChanges()
+    return TRUE
+
 /datum/job/atmos/proc/OmegaStationChanges()
 	total_positions = 3
 	supervisors = "the captain and the head of personnel"

--- a/code/modules/jobs/job_types/bartender.dm
+++ b/code/modules/jobs/job_types/bartender.dm
@@ -18,14 +18,14 @@
 	paycheck_department = ACCOUNT_SRV
 	display_order = JOB_DISPLAY_ORDER_BARTENDER
 
-	changed_maps = list("OmegaStation")
+	changed_maps = list("OmegaStation", "RebuildStation")
 
 /datum/job/bartender/proc/OmegaStationChanges()
 	access = list(ACCESS_HYDROPONICS, ACCESS_BAR, ACCESS_KITCHEN, ACCESS_MORGUE, ACCESS_WEAPONS)
 	minimal_access = list(ACCESS_HYDROPONICS, ACCESS_BAR, ACCESS_KITCHEN, ACCESS_MORGUE, ACCESS_WEAPONS)
 
 /datum/job/bartender/proc/RebuildStationChanges()
-    return TRUE
+	return TRUE
 
 /datum/outfit/job/bartender
 	name = "Bartender"

--- a/code/modules/jobs/job_types/bartender.dm
+++ b/code/modules/jobs/job_types/bartender.dm
@@ -24,6 +24,9 @@
 	access = list(ACCESS_HYDROPONICS, ACCESS_BAR, ACCESS_KITCHEN, ACCESS_MORGUE, ACCESS_WEAPONS)
 	minimal_access = list(ACCESS_HYDROPONICS, ACCESS_BAR, ACCESS_KITCHEN, ACCESS_MORGUE, ACCESS_WEAPONS)
 
+/datum/job/bartender/proc/RebuildStationChanges()
+    return TRUE
+
 /datum/outfit/job/bartender
 	name = "Bartender"
 	jobtype = /datum/job/bartender

--- a/code/modules/jobs/job_types/botanist.dm
+++ b/code/modules/jobs/job_types/botanist.dm
@@ -17,14 +17,14 @@
 	paycheck_department = ACCOUNT_SRV
 	display_order = JOB_DISPLAY_ORDER_BOTANIST
 
-	changed_maps = list("OmegaStation")
+	changed_maps = list("OmegaStation", "RebuildStation")
 
 /datum/job/hydro/proc/OmegaStationChanges()
 	access = list(ACCESS_HYDROPONICS, ACCESS_BAR, ACCESS_KITCHEN, ACCESS_MORGUE, ACCESS_MAINT_TUNNELS)
 	minimal_access = list(ACCESS_HYDROPONICS, ACCESS_BAR, ACCESS_KITCHEN, ACCESS_MORGUE, ACCESS_MAINT_TUNNELS)
 
 /datum/job/hydro/proc/RebuildStationChanges()
-    return TRUE
+	return TRUE
 
 /datum/outfit/job/botanist
 	name = "Botanist"

--- a/code/modules/jobs/job_types/botanist.dm
+++ b/code/modules/jobs/job_types/botanist.dm
@@ -23,6 +23,9 @@
 	access = list(ACCESS_HYDROPONICS, ACCESS_BAR, ACCESS_KITCHEN, ACCESS_MORGUE, ACCESS_MAINT_TUNNELS)
 	minimal_access = list(ACCESS_HYDROPONICS, ACCESS_BAR, ACCESS_KITCHEN, ACCESS_MORGUE, ACCESS_MAINT_TUNNELS)
 
+/datum/job/hydro/proc/RebuildStationChanges()
+    return TRUE
+
 /datum/outfit/job/botanist
 	name = "Botanist"
 	jobtype = /datum/job/hydro

--- a/code/modules/jobs/job_types/cargo_technician.dm
+++ b/code/modules/jobs/job_types/cargo_technician.dm
@@ -27,6 +27,9 @@
 	minimal_access = list(ACCESS_MAINT_TUNNELS, ACCESS_MAILSORTING, ACCESS_CARGO, ACCESS_QM, ACCESS_MINING, ACCESS_MINING_STATION, ACCESS_MINERAL_STOREROOM)
 	supervisors = "the head of personnel"
 
+/datum/job/cargo_tech/proc/RebuildStationChanges()
+    return TRUE
+
 /datum/outfit/job/cargo_tech
 	name = "Cargo Technician"
 	jobtype = /datum/job/cargo_tech

--- a/code/modules/jobs/job_types/cargo_technician.dm
+++ b/code/modules/jobs/job_types/cargo_technician.dm
@@ -18,7 +18,7 @@
 
 	display_order = JOB_DISPLAY_ORDER_CARGO_TECHNICIAN
 
-	changed_maps = list("OmegaStation")
+	changed_maps = list("OmegaStation", "RebuildStation")
 
 /datum/job/cargo_tech/proc/OmegaStationChanges()
 	total_positions = 2
@@ -28,7 +28,7 @@
 	supervisors = "the head of personnel"
 
 /datum/job/cargo_tech/proc/RebuildStationChanges()
-    return TRUE
+	return TRUE
 
 /datum/outfit/job/cargo_tech
 	name = "Cargo Technician"

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -18,8 +18,10 @@
 
 	display_order = JOB_DISPLAY_ORDER_CHAPLAIN
 
+	changed_maps = list("RebuildStation")
+
 /datum/job/chaplain/proc/RebuildStationChanges()
-    return TRUE
+	return TRUE
 
 /datum/job/chaplain/after_spawn(mob/living/H, mob/M)
 	. = ..()

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -18,6 +18,8 @@
 
 	display_order = JOB_DISPLAY_ORDER_CHAPLAIN
 
+/datum/job/chaplain/proc/RebuildStationChanges()
+    return TRUE
 
 /datum/job/chaplain/after_spawn(mob/living/H, mob/M)
 	. = ..()

--- a/code/modules/jobs/job_types/chemist.dm
+++ b/code/modules/jobs/job_types/chemist.dm
@@ -20,13 +20,13 @@
 
 	display_order = JOB_DISPLAY_ORDER_CHEMIST
 
-	changed_maps = list("OmegaStation")
+	changed_maps = list("OmegaStation", "RebuildStation")
 
 /datum/job/chemist/proc/OmegaStationChanges()
 	return TRUE
 
 /datum/job/chemist/proc/RebuildStationChanges()
-    return TRUE
+	return TRUE
 
 /datum/outfit/job/chemist
 	name = "Chemist"

--- a/code/modules/jobs/job_types/chemist.dm
+++ b/code/modules/jobs/job_types/chemist.dm
@@ -25,6 +25,9 @@
 /datum/job/chemist/proc/OmegaStationChanges()
 	return TRUE
 
+/datum/job/chemist/proc/RebuildStationChanges()
+    return TRUE
+
 /datum/outfit/job/chemist
 	name = "Chemist"
 	jobtype = /datum/job/chemist

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -34,6 +34,9 @@
 /datum/job/cmo/proc/OmegaStationChanges()
 	return TRUE
 
+/datum/job/cmo/proc/RebuildStationChanges()
+    return TRUE
+
 /datum/outfit/job/cmo
 	name = "Chief Medical Officer"
 	jobtype = /datum/job/cmo

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -29,13 +29,13 @@
 
 	display_order = JOB_DISPLAY_ORDER_CHIEF_MEDICAL_OFFICER
 
-	changed_maps = list("OmegaStation")
+	changed_maps = list("OmegaStation", "RebuildStation")
 
 /datum/job/cmo/proc/OmegaStationChanges()
 	return TRUE
 
 /datum/job/cmo/proc/RebuildStationChanges()
-    return TRUE
+	return TRUE
 
 /datum/outfit/job/cmo
 	name = "Chief Medical Officer"

--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -18,6 +18,7 @@
 
 	display_order = JOB_DISPLAY_ORDER_CLOWN
 
+	changed_maps = list("RebuildStation")
 
 /datum/job/clown/after_spawn(mob/living/carbon/human/H, mob/M)
 	. = ..()
@@ -51,7 +52,7 @@
 	chameleon_extras = /obj/item/stamp/clown
 
 /datum/job/clown/proc/RebuildStationChanges()
-    return TRUE
+	return TRUE
 
 /datum/outfit/job/clown/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()

--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -50,6 +50,9 @@
 
 	chameleon_extras = /obj/item/stamp/clown
 
+/datum/job/clown/proc/RebuildStationChanges()
+    return TRUE
+
 /datum/outfit/job/clown/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
 	if(visualsOnly)

--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -19,14 +19,14 @@
 
 	display_order = JOB_DISPLAY_ORDER_COOK
 
-	changed_maps = list("OmegaStation")
+	changed_maps = list("OmegaStation", "RebuildStation")
 
 /datum/job/cook/proc/OmegaStationChanges()
 	access = list(ACCESS_HYDROPONICS, ACCESS_BAR, ACCESS_KITCHEN, ACCESS_MORGUE)
 	minimal_access = list(ACCESS_HYDROPONICS, ACCESS_BAR, ACCESS_KITCHEN, ACCESS_MORGUE)
 
 /datum/job/cook/proc/RebuildStationChanges()
-    return TRUE
+	return TRUE
 
 /datum/outfit/job/cook
 	name = "Cook"

--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -25,6 +25,9 @@
 	access = list(ACCESS_HYDROPONICS, ACCESS_BAR, ACCESS_KITCHEN, ACCESS_MORGUE)
 	minimal_access = list(ACCESS_HYDROPONICS, ACCESS_BAR, ACCESS_KITCHEN, ACCESS_MORGUE)
 
+/datum/job/cook/proc/RebuildStationChanges()
+    return TRUE
+
 /datum/outfit/job/cook
 	name = "Cook"
 	jobtype = /datum/job/cook

--- a/code/modules/jobs/job_types/curator.dm
+++ b/code/modules/jobs/job_types/curator.dm
@@ -42,3 +42,6 @@
 		return
 
 	H.grant_all_languages(TRUE, TRUE, TRUE, LANGUAGE_CURATOR)
+
+/datum/job/curator/proc/RebuildStationChanges()
+    return TRUE

--- a/code/modules/jobs/job_types/curator.dm
+++ b/code/modules/jobs/job_types/curator.dm
@@ -18,6 +18,8 @@
 
 	display_order = JOB_DISPLAY_ORDER_CURATOR
 
+	changed_maps = list("RebuildStation")
+
 /datum/outfit/job/curator
 	name = "Curator"
 	jobtype = /datum/job/curator
@@ -44,4 +46,4 @@
 	H.grant_all_languages(TRUE, TRUE, TRUE, LANGUAGE_CURATOR)
 
 /datum/job/curator/proc/RebuildStationChanges()
-    return TRUE
+	return TRUE

--- a/code/modules/jobs/job_types/detective.dm
+++ b/code/modules/jobs/job_types/detective.dm
@@ -23,7 +23,7 @@
 
 	display_order = JOB_DISPLAY_ORDER_DETECTIVE
 
-	changed_maps = list("OmegaStation")
+	changed_maps = list("OmegaStation", "RebuildStation")
 
 /datum/job/detective/proc/OmegaStationChanges()
 	access = list(ACCESS_SECURITY, ACCESS_SEC_DOORS, ACCESS_BRIG, ACCESS_ARMORY, ACCESS_COURT, ACCESS_MAINT_TUNNELS, ACCESS_MORGUE, ACCESS_WEAPONS, ACCESS_FORENSICS_LOCKERS)
@@ -31,7 +31,7 @@
 	supervisors = "the captain"
 
 /datum/job/detective/proc/RebuildStationChanges()
-    return TRUE
+	return TRUE
 
 /datum/outfit/job/detective
 	name = "Detective"

--- a/code/modules/jobs/job_types/detective.dm
+++ b/code/modules/jobs/job_types/detective.dm
@@ -30,6 +30,9 @@
 	minimal_access = list(ACCESS_SECURITY, ACCESS_SEC_DOORS, ACCESS_BRIG, ACCESS_ARMORY, ACCESS_COURT, ACCESS_MAINT_TUNNELS, ACCESS_MORGUE, ACCESS_WEAPONS, ACCESS_FORENSICS_LOCKERS)
 	supervisors = "the captain"
 
+/datum/job/detective/proc/RebuildStationChanges()
+    return TRUE
+
 /datum/outfit/job/detective
 	name = "Detective"
 	jobtype = /datum/job/detective

--- a/code/modules/jobs/job_types/geneticist.dm
+++ b/code/modules/jobs/job_types/geneticist.dm
@@ -20,13 +20,13 @@
 
 	display_order = JOB_DISPLAY_ORDER_GENETICIST
 
-	changed_maps = list("OmegaStation")
+	changed_maps = list("OmegaStation", "RebuildStation")
 
 /datum/job/geneticist/proc/OmegaStationChanges()
 	return TRUE
 
 /datum/job/geneticist/proc/RebuildStationChanges()
-    return TRUE
+	return TRUE
 
 /datum/outfit/job/geneticist
 	name = "Geneticist"

--- a/code/modules/jobs/job_types/geneticist.dm
+++ b/code/modules/jobs/job_types/geneticist.dm
@@ -25,6 +25,9 @@
 /datum/job/geneticist/proc/OmegaStationChanges()
 	return TRUE
 
+/datum/job/geneticist/proc/RebuildStationChanges()
+    return TRUE
+
 /datum/outfit/job/geneticist
 	name = "Geneticist"
 	jobtype = /datum/job/geneticist

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -37,14 +37,14 @@
 
 	display_order = JOB_DISPLAY_ORDER_HEAD_OF_PERSONNEL
 
-	changed_maps = list("OmegaStation")
+	changed_maps = list("OmegaStation", "RebuildStation")
 
 /datum/job/hop/proc/OmegaStationChanges()
 	access = get_all_accesses()
 	minimal_access = get_all_accesses()
 
 /datum/job/hop/proc/RebuildStationChanges()
-    return TRUE
+	return TRUE
 
 /datum/outfit/job/hop
 	name = "Head of Personnel"

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -43,6 +43,9 @@
 	access = get_all_accesses()
 	minimal_access = get_all_accesses()
 
+/datum/job/hop/proc/RebuildStationChanges()
+    return TRUE
+
 /datum/outfit/job/hop
 	name = "Head of Personnel"
 	jobtype = /datum/job/hop

--- a/code/modules/jobs/job_types/janitor.dm
+++ b/code/modules/jobs/job_types/janitor.dm
@@ -18,7 +18,7 @@
 
 	display_order = JOB_DISPLAY_ORDER_JANITOR
 
-	changed_maps = list("OmegaStation")
+	changed_maps = list("OmegaStation", "RebuildStation")
 
 /datum/job/janitor/proc/OmegaStationChanges()
 	access = list(ACCESS_JANITOR, ACCESS_HYDROPONICS, ACCESS_BAR, ACCESS_KITCHEN, ACCESS_MORGUE, ACCESS_MAINT_TUNNELS)
@@ -26,7 +26,7 @@
 	supervisors = "the captain and the head of personnel"
 
 /datum/job/janitor/proc/RebuildStationChanges()
-    return TRUE
+	return TRUE
 
 /datum/outfit/job/janitor
 	name = "Janitor"

--- a/code/modules/jobs/job_types/janitor.dm
+++ b/code/modules/jobs/job_types/janitor.dm
@@ -25,6 +25,9 @@
 	minimal_access = list(ACCESS_JANITOR, ACCESS_HYDROPONICS, ACCESS_BAR, ACCESS_KITCHEN, ACCESS_MORGUE, ACCESS_MAINT_TUNNELS)
 	supervisors = "the captain and the head of personnel"
 
+/datum/job/janitor/proc/RebuildStationChanges()
+    return TRUE
+
 /datum/outfit/job/janitor
 	name = "Janitor"
 	jobtype = /datum/job/janitor

--- a/code/modules/jobs/job_types/lawyer.dm
+++ b/code/modules/jobs/job_types/lawyer.dm
@@ -20,13 +20,13 @@
 
 	display_order = JOB_DISPLAY_ORDER_LAWYER
 
-	changed_maps = list("OmegaStation")
+	changed_maps = list("OmegaStation", "RebuildStation")
 
 /datum/job/lawyer/proc/OmegaStationChanges()
 	return TRUE
 
 /datum/job/lawyer/proc/RebuildStationChanges()
-    return TRUE
+	return TRUE
 
 /datum/outfit/job/lawyer
 	name = "Lawyer"

--- a/code/modules/jobs/job_types/lawyer.dm
+++ b/code/modules/jobs/job_types/lawyer.dm
@@ -25,6 +25,9 @@
 /datum/job/lawyer/proc/OmegaStationChanges()
 	return TRUE
 
+/datum/job/lawyer/proc/RebuildStationChanges()
+    return TRUE
+
 /datum/outfit/job/lawyer
 	name = "Lawyer"
 	jobtype = /datum/job/lawyer

--- a/code/modules/jobs/job_types/medical_doctor.dm
+++ b/code/modules/jobs/job_types/medical_doctor.dm
@@ -18,7 +18,7 @@
 
 	display_order = JOB_DISPLAY_ORDER_MEDICAL_DOCTOR
 
-	changed_maps = list("OmegaStation")
+	changed_maps = list("OmegaStation", "RebuildStation")
 
 /datum/job/doctor/proc/OmegaStationChanges()
 	selection_color = "#ffffff"

--- a/code/modules/jobs/job_types/medical_doctor.dm
+++ b/code/modules/jobs/job_types/medical_doctor.dm
@@ -28,6 +28,10 @@
 	minimal_access = list(ACCESS_MEDICAL, ACCESS_MORGUE, ACCESS_SURGERY, ACCESS_CHEMISTRY, ACCESS_VIROLOGY, ACCESS_GENETICS)
 	supervisors = "the captain and the head of personnel"
 
+/datum/job/doctor/proc/RebuildStationChanges()
+	total_positions = 20
+	spawn_positions = 20
+
 /datum/outfit/job/doctor
 	name = "Medical Doctor"
 	jobtype = /datum/job/doctor

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -48,6 +48,9 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/mime/speak(null))
 		H.mind.miming = 1
 
+/datum/job/mime/proc/RebuildStationChanges()
+    return TRUE
+
 /obj/item/book/mimery
 	name = "Guide to Dank Mimery"
 	desc = "A primer on basic pantomime."

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -18,6 +18,8 @@
 
 	display_order = JOB_DISPLAY_ORDER_MIME
 
+	changed_maps = list("RebuildStation")
+
 /datum/job/mime/after_spawn(mob/living/carbon/human/H, mob/M)
 	H.apply_pref_name("mime", M.client)
 
@@ -49,7 +51,7 @@
 		H.mind.miming = 1
 
 /datum/job/mime/proc/RebuildStationChanges()
-    return TRUE
+	return TRUE
 
 /obj/item/book/mimery
 	name = "Guide to Dank Mimery"

--- a/code/modules/jobs/job_types/quartermaster.dm
+++ b/code/modules/jobs/job_types/quartermaster.dm
@@ -18,13 +18,13 @@
 
 	display_order = JOB_DISPLAY_ORDER_QUARTERMASTER
 
-	changed_maps = list("OmegaStation")
+	changed_maps = list("OmegaStation", "RebuildStation")
 
 /datum/job/qm/proc/OmegaStationChanges()
 	return TRUE
 
 /datum/job/qm/proc/RebuildStationChanges()
-    return TRUE
+	return TRUE
 
 /datum/outfit/job/quartermaster
 	name = "Quartermaster"

--- a/code/modules/jobs/job_types/quartermaster.dm
+++ b/code/modules/jobs/job_types/quartermaster.dm
@@ -23,6 +23,9 @@
 /datum/job/qm/proc/OmegaStationChanges()
 	return TRUE
 
+/datum/job/qm/proc/RebuildStationChanges()
+    return TRUE
+
 /datum/outfit/job/quartermaster
 	name = "Quartermaster"
 	jobtype = /datum/job/qm

--- a/code/modules/jobs/job_types/research_director.dm
+++ b/code/modules/jobs/job_types/research_director.dm
@@ -38,6 +38,9 @@
 /datum/job/rd/proc/OmegaStationChanges()
 	return TRUE
 
+/datum/job/rd/proc/RebuildStationChanges()
+    return TRUE
+
 /datum/outfit/job/rd
 	name = "Research Director"
 	jobtype = /datum/job/rd

--- a/code/modules/jobs/job_types/research_director.dm
+++ b/code/modules/jobs/job_types/research_director.dm
@@ -33,13 +33,13 @@
 
 	display_order = JOB_DISPLAY_ORDER_RESEARCH_DIRECTOR
 
-	changed_maps = list("OmegaStation")
+	changed_maps = list("OmegaStation", "RebuildStation")
 
 /datum/job/rd/proc/OmegaStationChanges()
 	return TRUE
 
 /datum/job/rd/proc/RebuildStationChanges()
-    return TRUE
+	return TRUE
 
 /datum/outfit/job/rd
 	name = "Research Director"

--- a/code/modules/jobs/job_types/roboticist.dm
+++ b/code/modules/jobs/job_types/roboticist.dm
@@ -25,6 +25,9 @@
 /datum/job/roboticist/proc/OmegaStationChanges()
 	supervisors = "the captain and the head of personnel"
 
+/datum/job/roboticist/proc/RebuildStationChanges()
+    return TRUE
+
 /datum/outfit/job/roboticist
 	name = "Roboticist"
 	jobtype = /datum/job/roboticist

--- a/code/modules/jobs/job_types/roboticist.dm
+++ b/code/modules/jobs/job_types/roboticist.dm
@@ -20,13 +20,13 @@
 
 	display_order = JOB_DISPLAY_ORDER_ROBOTICIST
 
-	changed_maps = list("OmegaStation")
+	changed_maps = list("OmegaStation", "RebuildStation")
 
 /datum/job/roboticist/proc/OmegaStationChanges()
 	supervisors = "the captain and the head of personnel"
 
 /datum/job/roboticist/proc/RebuildStationChanges()
-    return TRUE
+	return TRUE
 
 /datum/outfit/job/roboticist
 	name = "Roboticist"

--- a/code/modules/jobs/job_types/scientist.dm
+++ b/code/modules/jobs/job_types/scientist.dm
@@ -21,7 +21,7 @@
 
 	display_order = JOB_DISPLAY_ORDER_SCIENTIST
 
-	changed_maps = list("OmegaStation")
+	changed_maps = list("OmegaStation", "RebuildStation")
 
 /datum/job/scientist/proc/OmegaStationChanges()
 	total_positions = 3
@@ -31,7 +31,7 @@
 	supervisors = "the captain and the head of personnel"
 
 /datum/job/scientist/proc/RebuildStationChanges()
-    return TRUE
+	return TRUE
 
 /datum/outfit/job/scientist
 	name = "Scientist"

--- a/code/modules/jobs/job_types/scientist.dm
+++ b/code/modules/jobs/job_types/scientist.dm
@@ -30,6 +30,9 @@
 	minimal_access = list(ACCESS_ROBOTICS, ACCESS_TOX, ACCESS_TOX_STORAGE, ACCESS_RESEARCH, ACCESS_XENOBIOLOGY, ACCESS_MINERAL_STOREROOM, ACCESS_TECH_STORAGE)
 	supervisors = "the captain and the head of personnel"
 
+/datum/job/scientist/proc/RebuildStationChanges()
+    return TRUE
+
 /datum/outfit/job/scientist
 	name = "Scientist"
 	jobtype = /datum/job/scientist

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -36,6 +36,10 @@
 	minimal_access = list(ACCESS_SECURITY, ACCESS_SEC_DOORS, ACCESS_BRIG, ACCESS_ARMORY, ACCESS_COURT, ACCESS_MAINT_TUNNELS, ACCESS_MORGUE, ACCESS_WEAPONS, ACCESS_FORENSICS_LOCKERS)
 	supervisors = "the captain"
 
+/datum/job/officer/proc/RebuildStationChanges()
+	total_positions = 5
+	spawn_positions = 5
+
 /datum/job/officer/get_access()
 	var/list/L = list()
 	L |= ..() | check_config_for_sec_maint()

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -23,7 +23,7 @@
 
 	display_order = JOB_DISPLAY_ORDER_SECURITY_OFFICER
 
-	changed_maps = list("YogsPubby", "OmegaStation")
+	changed_maps = list("YogsPubby", "OmegaStation", "RebuildStation")
 
 /datum/job/officer/proc/YogsPubbyChanges()
 	access += ACCESS_CREMATORIUM

--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -18,7 +18,7 @@
 
 	display_order = JOB_DISPLAY_ORDER_SHAFT_MINER
 
-	changed_maps = list("OmegaStation")
+	changed_maps = list("OmegaStation", "RebuildStation")
 
 /datum/job/mining/proc/OmegaStationChanges()
 	total_positions = 2
@@ -28,7 +28,7 @@
 	supervisors = "the head of personnel"
 
 /datum/job/mining/proc/RebuildStationChanges()
-    return TRUE
+	return TRUE
 
 /datum/outfit/job/miner
 	name = "Shaft Miner"

--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -28,7 +28,8 @@
 	supervisors = "the head of personnel"
 
 /datum/job/mining/proc/RebuildStationChanges()
-	return TRUE
+	total_positions = 3
+	spawn_positions = 3
 
 /datum/outfit/job/miner
 	name = "Shaft Miner"

--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -26,7 +26,10 @@
 	access = list(ACCESS_MAINT_TUNNELS, ACCESS_MAILSORTING, ACCESS_CARGO, ACCESS_QM, ACCESS_MINING, ACCESS_MINING_STATION, ACCESS_MINERAL_STOREROOM)
 	minimal_access = list(ACCESS_MAINT_TUNNELS, ACCESS_MAILSORTING, ACCESS_CARGO, ACCESS_QM, ACCESS_MINING, ACCESS_MINING_STATION, ACCESS_MINERAL_STOREROOM)
 	supervisors = "the head of personnel"
-	
+
+/datum/job/mining/proc/RebuildStationChanges()
+    return TRUE
+
 /datum/outfit/job/miner
 	name = "Shaft Miner"
 	jobtype = /datum/job/mining

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -31,6 +31,10 @@
 	minimal_access = list(ACCESS_EVA, ACCESS_ENGINE, ACCESS_ENGINE_EQUIP, ACCESS_TECH_STORAGE, ACCESS_MAINT_TUNNELS, ACCESS_EXTERNAL_AIRLOCKS, ACCESS_CONSTRUCTION, ACCESS_ATMOSPHERICS )
 	supervisors = "the captain and the head of personnel"
 
+/datum/job/engineer/proc/RebuildStationChanges()
+	total_positions = 30
+	spawn_positions = 30
+
 GLOBAL_LIST_INIT(available_depts_eng, list(ENG_DEPT_MEDICAL, ENG_DEPT_SCIENCE, ENG_DEPT_SUPPLY, ENG_DEPT_SERVICE))
 
 /datum/job/engineer/after_spawn(mob/living/carbon/human/H, mob/M)

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -22,7 +22,7 @@
 
 	display_order = JOB_DISPLAY_ORDER_STATION_ENGINEER
 
-	changed_maps = list("OmegaStation")
+	changed_maps = list("OmegaStation", "RebuildStation")
 
 /datum/job/engineer/proc/OmegaStationChanges()
 	total_positions = 2

--- a/code/modules/jobs/job_types/virologist.dm
+++ b/code/modules/jobs/job_types/virologist.dm
@@ -25,6 +25,9 @@
 /datum/job/virologist/proc/OmegaStationChanges()
 	return TRUE
 
+/datum/job/virologist/proc/RebuildStationChanges()
+    return TRUE
+
 /datum/outfit/job/virologist
 	name = "Virologist"
 	jobtype = /datum/job/virologist

--- a/code/modules/jobs/job_types/virologist.dm
+++ b/code/modules/jobs/job_types/virologist.dm
@@ -20,13 +20,13 @@
 
 	display_order = JOB_DISPLAY_ORDER_VIROLOGIST
 
-	changed_maps = list("OmegaStation")
+	changed_maps = list("OmegaStation", "RebuildStation")
 
 /datum/job/virologist/proc/OmegaStationChanges()
 	return TRUE
 
 /datum/job/virologist/proc/RebuildStationChanges()
-    return TRUE
+	return TRUE
 
 /datum/outfit/job/virologist
 	name = "Virologist"

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -23,7 +23,7 @@
 
 	display_order = JOB_DISPLAY_ORDER_WARDEN
 
-	changed_maps = list("YogsPubby", "OmegaStation")
+	changed_maps = list("YogsPubby", "OmegaStation", "RebuildStation")
 
 /datum/job/warden/proc/YogsPubbyChanges()
 	access += ACCESS_CREMATORIUM
@@ -33,7 +33,7 @@
 	return TRUE
 
 /datum/job/warden/proc/RebuildStationChanges()
-    return TRUE
+	return TRUE
 
 /datum/job/warden/get_access()
 	var/list/L = list()

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -32,6 +32,9 @@
 /datum/job/warden/proc/OmegaStationChanges()
 	return TRUE
 
+/datum/job/warden/proc/RebuildStationChanges()
+    return TRUE
+
 /datum/job/warden/get_access()
 	var/list/L = list()
 	L = ..() | check_config_for_sec_maint()


### PR DESCRIPTION
### Intent of your Pull Request
Space law clearly dictates that the dressing of prisoners into orange jumpsuits and shoes is only for permanent sentences. Yet as we are a new player friendly server, we get a lot of people who haven't fully read space law and do on occasion strip, and re-dress into prison gear for under 10 minute sentences. It's sort of like "baiting" them into doing it, seeing it there makes them think they have to do it. 

Remove the gear and place the clothing in the perma cells, rather than the lockers. 

#### Changelog

:cl:  
rscdel: Removed prisoner clothing from brig lockers
/:cl:
