### PR TITLE
antag_pick in darkspawn

### DIFF
--- a/yogstation/code/game/gamemodes/darkspawn/darkspawn.dm
+++ b/yogstation/code/game/gamemodes/darkspawn/darkspawn.dm
@@ -27,7 +27,7 @@
 		restricted_jobs += "Assistant"
 	var/darkbois = max(required_enemies, round(num_players()/14))
 	while(darkbois)
-		var/datum/mind/darkboi = pick(antag_candidates)
+		var/datum/mind/darkboi = antag_pick(antag_candidates)
 		darkspawn += darkboi
 		antag_candidates -= darkboi
 		darkboi.special_role = "Darkspawn"


### PR DESCRIPTION
yes
:cl:  
bugfix: darkspawn now use antag_pick, antag tokens should now work for darkspawn if they didnt already
/:cl:
