### PR TITLE
Removes Budget Cards

### DIFF
--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -1,11 +1,12 @@
 #define STARTING_PAYCHECKS 5
 
-#define PAYCHECK_ASSISTANT 5
-#define PAYCHECK_MINIMAL 5
-#define PAYCHECK_EASY 20
-#define PAYCHECK_MEDIUM 30
-#define PAYCHECK_HARD 40
-#define PAYCHECK_COMMAND 100
+///these defines are the % of budget they get on payday
+#define PAYCHECK_ASSISTANT 1
+#define PAYCHECK_MINIMAL 1
+#define PAYCHECK_EASY 2
+#define PAYCHECK_MEDIUM 3
+#define PAYCHECK_HARD 4
+#define PAYCHECK_COMMAND 10
 
 
 #define MAX_GRANT_CIV 2500

--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -83,10 +83,9 @@ SUBSYSTEM_DEF(economy)
 
 
 /datum/controller/subsystem/economy/proc/car_payout()
-	var/cargo_cash = 500
 	var/datum/bank_account/D = get_dep_account(ACCOUNT_CAR)
 	if(D)
-		D.adjust_money(cargo_cash)
+		D.adjust_money(500)
 
 /datum/controller/subsystem/economy/proc/secmedsrv_payout()
 	var/crew

--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -60,6 +60,7 @@ SUBSYSTEM_DEF(economy)
 	sci_payout() // Payout based on slimes.
 	secmedsrv_payout() // Payout based on crew safety, health, and mood.
 	civ_payout() // Payout based on ??? Profit
+	car_payout() // Cargo's natural gain in the cash moneys.
 	for(var/A in bank_accounts)
 		var/datum/bank_account/B = A
 		B.payday(1)
@@ -79,6 +80,13 @@ SUBSYSTEM_DEF(economy)
 	var/datum/bank_account/D = get_dep_account(ACCOUNT_ENG)
 	if(D)
 		D.adjust_money(engineering_cash)
+
+
+/datum/controller/subsystem/economy/proc/car_payout()
+	var/cargo_cash = 500
+	var/datum/bank_account/D = get_dep_account(ACCOUNT_CAR)
+	if(D)
+		D.adjust_money(cargo_cash)
 
 /datum/controller/subsystem/economy/proc/secmedsrv_payout()
 	var/crew

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -646,30 +646,6 @@ update_label("John Doe", "Clowny")
 	SSeconomy.dep_cards -= src
 	return ..()
 
-/obj/item/card/id/departmental_budget/civ
-	department_ID = ACCOUNT_CIV
-	department_name = ACCOUNT_CIV_NAME
-
-/obj/item/card/id/departmental_budget/eng
-	department_ID = ACCOUNT_ENG
-	department_name = ACCOUNT_ENG_NAME
-
-/obj/item/card/id/departmental_budget/sci
-	department_ID = ACCOUNT_SCI
-	department_name = ACCOUNT_SCI_NAME
-
-/obj/item/card/id/departmental_budget/med
-	department_ID = ACCOUNT_MED
-	department_name = ACCOUNT_MED_NAME
-
-/obj/item/card/id/departmental_budget/srv
-	department_ID = ACCOUNT_SRV
-	department_name = ACCOUNT_SRV_NAME
-
 /obj/item/card/id/departmental_budget/car
 	department_ID = ACCOUNT_CAR
 	department_name = ACCOUNT_CAR_NAME
-
-/obj/item/card/id/departmental_budget/sec
-	department_ID = ACCOUNT_SEC
-	department_name = ACCOUNT_SEC_NAME

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -24,7 +24,6 @@
 	new /obj/item/storage/photo_album/CE(src)
 	new /obj/item/energy_harvester(src)
 	new /obj/item/clipboard/yog/paperwork/ce(src)
-	new /obj/item/card/id/departmental_budget/eng(src)
 	new /obj/item/poster/firstsingularity(src)
 	new /obj/item/storage/backpack/duffelbag/engineering/chief/clothing(src)
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -69,7 +69,6 @@
 	new /obj/item/circuitboard/machine/techfab/department/medical(src)
 	new /obj/item/storage/photo_album/CMO(src)
 	new /obj/item/clipboard/yog/paperwork/cmo(src)
-	new /obj/item/card/id/departmental_budget/med(src)
 	new /obj/item/storage/backpack/duffelbag/med/chief/clothing(src)
 
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -19,5 +19,4 @@
 	new /obj/item/circuitboard/machine/techfab/department/science(src)
 	new /obj/item/storage/photo_album/RD(src)
 	new /obj/item/clipboard/yog/paperwork/rd(src)
-	new /obj/item/card/id/departmental_budget/sci(src)
 	new /obj/item/storage/backpack/duffelbag/rd/clothing(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -17,7 +17,6 @@
 	new /obj/item/card/id/captains_spare(src)
 	new /obj/item/storage/photo_album/Captain(src)
 	new /obj/item/clipboard/yog/paperwork/captain(src)
-	new /obj/item/card/id/departmental_budget/civ(src)
 	new /obj/item/radio/security(src)
 
 /obj/structure/closet/secure_closet/hop
@@ -43,7 +42,6 @@
 	new /obj/item/circuitboard/machine/techfab/department/service(src)
 	new /obj/item/storage/photo_album/HoP(src)
 	new /obj/item/clipboard/yog/paperwork/hop(src)
-	new /obj/item/card/id/departmental_budget/srv(src)
 	new /obj/item/gun/energy/e_gun/mini(src) //hop doesn't get a proper gun
 	new /obj/item/storage/backpack/duffelbag/hop/clothing(src)
 
@@ -94,7 +92,6 @@
 	new /obj/item/door_remote/head_of_security(src)
 	new /obj/item/gun/ballistic/shotgun/automatic/combat/compact(src)
 	new /obj/item/clipboard/yog/paperwork/warden(src)
-	new /obj/item/card/id/departmental_budget/sec(src)
 	new /obj/item/radio/security(src)
 	new /obj/item/storage/backpack/duffelbag/sec/warden/clothing(src)
 

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -60,11 +60,11 @@
 /datum/bank_account/proc/payday(amt_of_paychecks, free = FALSE)
 	var/money_to_transfer = account_job.paycheck * amt_of_paychecks
 	if(free)
-		adjust_money(money_to_transfer)
+		adjust_money(money_to_transfer*10)
 	else
 		var/datum/bank_account/D = SSeconomy.get_dep_account(account_job.paycheck_department)
 		if(D)
-			if(!transfer_money(D, money_to_transfer))
+			if(!transfer_money(D, round(money_to_transfer*(D.account_balance*0.01),1)))
 				bank_card_talk("ERROR: Payday aborted, departmental funds insufficient.")
 				return FALSE
 			else


### PR DESCRIPTION
### Intent of your Pull Request
Ports https://github.com/tgstation/tgstation/pull/47256
Ports https://github.com/tgstation/tgstation/pull/47303

### Alternative to #9134 


Paychecks are now % based on the budget account.
Assistants get 1% of the service budget. Old: 5 credits
Minimal Paycheck Category: 1% of budget. Old: 5 credits
Easy: 2% Old: 20
Medium: 3% Old: 30
Hard: 4% Old: 40
Command: 10% Old: 100


No longer will warops/revs/whatever make Cargo obsolete.

Budget cards are primarily used for buying stuff like mindshields or guns during warops.
Removing budget cards makes sure that cargo is required to actually do their job.

How does this affect balance you may ask?

It's a nerf to the crew, obviously. Especially so until people realize they need to help cargo gather stuff.
War ops won't be about getting the budget cards and sitting in cargo for 20 minutes, but ripping the station bare to buy whatever guns we can.

We made due before Budget cards, and I think we should go back to that.


Closes #9134 

#### Changelog

:cl:  
rscdel: Budget cards removed. Get to work Cargo!
/:cl:
