### PR TITLE
No gravity no longer screws over shadowlings

### DIFF
--- a/yogstation/code/game/gamemodes/shadowling/shadowling.dm
+++ b/yogstation/code/game/gamemodes/shadowling/shadowling.dm
@@ -152,7 +152,7 @@ Made by Xhuis
 	var/shadow_charges = 3
 	var/last_charge = 0
 
-/datum/species/shadow/ling/negates_gravity(mob/living/carbon/human/C)
+/datum/species/shadow/ling/negates_gravity(mob/living/carbon/human/H)
 	return TRUE
 
 /datum/species/shadow/ling/on_species_gain(mob/living/carbon/human/C)

--- a/yogstation/code/game/gamemodes/shadowling/shadowling.dm
+++ b/yogstation/code/game/gamemodes/shadowling/shadowling.dm
@@ -152,6 +152,9 @@ Made by Xhuis
 	var/shadow_charges = 3
 	var/last_charge = 0
 
+/datum/species/shadow/ling/negates_gravity(mob/living/carbon/human/C)
+	return TRUE
+
 /datum/species/shadow/ling/on_species_gain(mob/living/carbon/human/C)
 	C.draw_yogs_parts(TRUE)
 	eyes_overlay = mutable_appearance('yogstation/icons/mob/sling.dmi', "eyes", 25)


### PR DESCRIPTION
### Intent of your Pull Request

Shadowling: NOOO YOU CANT COMPLETELY NEGATE MY SPEED AND MOVEMENT CAPABILITYS JUST BY SHUTTING DOWN THE GRAVITY GEN

AI: hehe gravity off button go bonk
:cl:  
tweak: shadowlings should no longer get screwed over by no grav   
/:cl:

Tested!