### PR TITLE
fixes scarabs not spawning on clock rounds

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -184,8 +184,8 @@ Credit where due:
 		equip_servant(L)
 		add_servant_of_ratvar(L, TRUE)
 	var/list/cog_spawns = GLOB.servant_spawns_scarabs.Copy()
-	for(var/obj/effect/landmark/L in cog_spawns)
-		new /obj/item/clockwork/construct_chassis/cogscarab(get_turf(L))
+	for(var/turf/T in cog_spawns)
+		new /obj/item/clockwork/construct_chassis/cogscarab(T)
 	var/obj/structure/destructible/clockwork/massive/celestial_gateway/G = GLOB.ark_of_the_clockwork_justiciar //that's a mouthful
 	G.final_countdown(ark_time)
 	..()


### PR DESCRIPTION
the landmark deletes itself after being loaded and sets the turf it's on to be in the spawns list so checking for the landmark won't actually spawn a scarab

:cl:  
bugfix: scarabs spawn on clock rounds again
/:cl:
