### PR TITLE
#9147 (Belt tweaks) Hotfix

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -38,6 +38,8 @@
 /obj/item/storage/belt/utility/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_items = 14
+	STR.max_w_class = WEIGHT_CLASS_NORMAL
 	STR.max_combined_w_class = 21
 	STR.set_holdable(list(
 		/obj/item/multitool/tricorder,			//yogs tricorder: 'cause making it into the yogs belt dm makes it the only thing a belt can hold
@@ -134,6 +136,7 @@
 /obj/item/storage/belt/medical/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_items = 14
 	STR.max_w_class = WEIGHT_CLASS_BULKY
 	STR.max_combined_w_class = 21
 	STR.set_holdable(list(


### PR DESCRIPTION
This is a PR that fixes a bug present in the original #9147 PR: RCDs and RPDs couldn't actually be put onto toolbelts, and especially not with a "full" one. This changes that.

#### Changelog

:cl:  
bugfix: Toolbelts and medical belts can now actually store additional items.
/:cl:
