### PR TITLE
Final solution to the soapstone question

### DIFF
--- a/code/game/alternate_appearance.dm
+++ b/code/game/alternate_appearance.dm
@@ -36,6 +36,8 @@ GLOBAL_LIST_EMPTY(active_alternate_appearances)
 /datum/atom_hud/alternate_appearance/proc/onNewMob(mob/M)
 	if(mobShouldSee(M))
 		add_hud_to(M)
+	else
+		remove_hud_from(M)
 
 /datum/atom_hud/alternate_appearance/proc/mobShouldSee(mob/M)
 	return FALSE
@@ -60,6 +62,7 @@ GLOBAL_LIST_EMPTY(active_alternate_appearances)
 	var/image/theImage
 	var/add_ghost_version = FALSE
 	var/ghost_appearance
+	var/deleteIfNone = TRUE
 
 /datum/atom_hud/alternate_appearance/basic/New(key, image/I, options = AA_TARGET_SEE_APPEARANCE)
 	..()
@@ -92,7 +95,7 @@ GLOBAL_LIST_EMPTY(active_alternate_appearances)
 /datum/atom_hud/alternate_appearance/basic/remove_from_hud(atom/A)
 	. = ..()
 	A.hud_list -= appearance_key
-	if(. && !QDELETED(src))
+	if(. && !QDELETED(src) && deleteIfNone)
 		qdel(src)
 
 /datum/atom_hud/alternate_appearance/basic/copy_overlays(atom/other, cut_old)
@@ -190,3 +193,11 @@ datum/atom_hud/alternate_appearance/basic/onePerson
 	..(key, I, FALSE)
 	seer = M
 	add_hud_to(seer)
+
+/datum/atom_hud/alternate_appearance/basic/soapstone
+	deleteIfNone = FALSE
+
+/datum/atom_hud/alternate_appearance/basic/soapstone/mobShouldSee(mob/M)
+	if(M.client.prefs.seeSoaps)
+		return FALSE
+	return TRUE

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -44,6 +44,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/preferred_map = null
 	var/pda_style = MONO
 	var/pda_color = "#808000"
+	var/seeSoaps = TRUE
 
 	var/uses_glasses_colour = 0
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -157,6 +157,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["ignoring"]			>> ignoring
 	S["ghost_hud"]			>> ghost_hud
 	S["inquisitive_ghost"]	>> inquisitive_ghost
+	S["seeSoaps"] 			>> seeSoaps
 	S["uses_glasses_colour"]>> uses_glasses_colour
 	S["clientfps"]			>> clientfps
 	S["parallax"]			>> parallax
@@ -265,6 +266,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["ignoring"], ignoring)
 	WRITE_FILE(S["ghost_hud"], ghost_hud)
 	WRITE_FILE(S["inquisitive_ghost"], inquisitive_ghost)
+	WRITE_FILE(S["seeSoaps"], seeSoaps)
 	WRITE_FILE(S["uses_glasses_colour"], uses_glasses_colour)
 	WRITE_FILE(S["clientfps"], clientfps)
 	WRITE_FILE(S["parallax"], parallax)

--- a/code/modules/library/soapstone.dm
+++ b/code/modules/library/soapstone.dm
@@ -1,3 +1,4 @@
+GLOBAL_VAR_INIT(soapstones, 0)
 /obj/item/soapstone
 	name = "soapstone"
 	desc = "Leave informative messages for the crew, including the crew of future shifts!\nEven if out of uses, it can still be used to remove messages.\n(Not suitable for engraving on shuttles, off station or on cats. Side effects may include prompt beatings, psychotic clown incursions, and/or orbital bombardment.)"
@@ -138,6 +139,15 @@
 	if(!good_chisel_message_location(T))
 		persists = FALSE
 		return INITIALIZE_HINT_QDEL
+	var/image/I = image('icons/effects/effects.dmi', src, "nothing")
+	I.override = TRUE
+	GLOB.soapstones++
+	add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/soapstone, "soapstone[GLOB.soapstones]", I)
+	var/datum/atom_hud/alternate_appearance/AA = GLOB.active_alternate_appearances[GLOB.soapstones]
+	for(var/mob/M in GLOB.player_list)
+		AA.onNewMob(M)
+
+	
 
 /obj/structure/chisel_message/proc/register(mob/user, newmessage)
 	hidden_message = newmessage
@@ -200,6 +210,13 @@
 	if(persists)
 		SSpersistence.SaveChiselMessage(src)
 	SSpersistence.chisel_messages -= src
+	for(var/v in GLOB.active_alternate_appearances)
+		if(!v || !istype(v, /datum/atom_hud/alternate_appearance/basic))
+			continue
+		var/datum/atom_hud/alternate_appearance/basic/AA = v
+		if(AA.target != src)
+			continue
+		qdel(AA)
 	. = ..()
 
 /obj/structure/chisel_message/interact()

--- a/yogstation/code/modules/client/preferences_toggles.dm
+++ b/yogstation/code/modules/client/preferences_toggles.dm
@@ -16,3 +16,15 @@ TOGGLE_CHECKBOX(/datum/verbs/menu/Settings, ghost_ckey)()
 	usr.client.prefs.chat_toggles ^= GHOST_CKEY
 	usr.client.prefs.save_preferences()
 	to_chat(usr, "Your ckey is [(usr.client.prefs.chat_toggles & GHOST_CKEY) ? "no longer" : "now"] visible in deadchat.")
+
+TOGGLE_CHECKBOX(/datum/verbs/menu/Settings, seeSoaps)()
+	set name = "Show/Hide soapstones"
+	set category = "Preferences"
+	set desc = "Toggle soapstones"
+	usr.client.prefs.seeSoaps = !usr.client.prefs.seeSoaps
+	usr.client.prefs.save_preferences()
+	for(var/datum/atom_hud/alternate_appearance/basic/soapstone/AA in GLOB.active_alternate_appearances)
+		if(!AA)
+			continue
+		AA.onNewMob(usr)
+	to_chat(usr, "You will no[usr.client.prefs.seeSoaps ? "w" : " longer"] see soapstones on the station.")


### PR DESCRIPTION
Press the button in preferences to show/hide soapstones, and the magically appear/disappear. It really is that easy. 

They'll still show up in the right-click/alt-click menu, but no hitbox and can't be seen with the eye

:cl:
tweak: There's now a preference to see/not-see soapstones
/:cl: