### PR TITLE
RPD mat cost from 112.5k mats to 82.5k (RCD costs 30k)

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -740,7 +740,7 @@
 	name = "Rapid Pipe Dispenser (RPD)"
 	id = "rpd"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 75000, MAT_GLASS = 37500)
+	materials = list(MAT_METAL = 45000, MAT_GLASS = 37500)
 	build_path = /obj/item/pipe_dispenser
 	category = list("hacked", "Construction")
 


### PR DESCRIPTION
The Rapid Pipe Dispenser (RPD) costs more metal than you can carry in a single full-stack for some reason and the RCD only costs 30 metal to make.

The RPD now costs 45 metal and 37.5 glass instead of 75 metal and 37.5 glass.

#### Changelog

:cl:  Hopek
tweak: The Rapid Pipe Dispenser (RPD) crafting cost is more reasonable. The RPD now costs 45 metal and 37.5 glass instead of 75 metal and 37.5 glass.
/:cl:
