### PR TITLE
Arrivals shuttle additions!

### DIFF
--- a/_maps/shuttles/arrival_box.dmm
+++ b/_maps/shuttles/arrival_box.dmm
@@ -13,25 +13,37 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/shuttle/arrival)
+"d" = (
+/obj/machinery/holopad,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/arrival)
 "e" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
+/obj/item/storage/toolbox/emergency,
+/obj/item/storage/toolbox/emergency,
+/obj/machinery/status_display/ai{
+	pixel_x = -32
+	},
+/obj/item/storage/firstaid/regular{
+	pixel_y = 4
+	},
+/obj/structure/table/reinforced,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "f" = (
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "g" = (
-/obj/machinery/computer/arcade,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/arrival)
-"h" = (
-/obj/structure/closet/wardrobe/green,
+/obj/structure/sign/poster/official/enlist{
+	pixel_y = 32
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "i" = (
@@ -64,10 +76,16 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plating/airless,
 /area/shuttle/arrival)
 "n" = (
 /obj/structure/shuttle/engine/propulsion/burst/right{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -92,10 +110,13 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/arrival)
 "s" = (
 /obj/structure/shuttle/engine/propulsion{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -110,14 +131,11 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/arrival)
 "u" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 4
-	},
 /obj/docking_port/mobile/arrivals,
-/turf/open/floor/plating/airless,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/arrival)
 "v" = (
 /obj/structure/chair/comfy/shuttle{
@@ -135,11 +153,31 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "x" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/crate/internals,
+/obj/item/storage/firstaid/o2,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/clothing/mask/breath,
+/obj/machinery/status_display/evac{
+	pixel_x = -32
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "y" = (
 /obj/machinery/light,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -29
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "z" = (
@@ -154,10 +192,43 @@
 /obj/structure/shuttle/engine/propulsion/burst/left{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plating/airless,
 /area/shuttle/arrival)
+"D" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 32;
+	use_power = 0
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/arrival)
+"H" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/arrival)
+"O" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Arrivals Shuttle Airlock"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/stripes/end,
+/turf/open/floor/plating,
+/area/shuttle/arrival)
+"Q" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/arrival)
 "S" = (
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/arrival)
+"U" = (
+/obj/structure/closet/wardrobe/white,
+/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 
 (1,1,1) = {"
@@ -197,13 +268,13 @@ b
 b
 "}
 (5,1,1) = {"
-b
+H
 e
 S
 S
 S
 x
-b
+H
 "}
 (6,1,1) = {"
 c
@@ -212,7 +283,7 @@ r
 r
 r
 f
-c
+O
 "}
 (7,1,1) = {"
 b
@@ -225,7 +296,7 @@ b
 "}
 (8,1,1) = {"
 o
-h
+i
 r
 r
 r
@@ -234,9 +305,9 @@ o
 "}
 (9,1,1) = {"
 o
-i
+k
 f
-f
+d
 f
 f
 o
@@ -252,7 +323,7 @@ o
 "}
 (11,1,1) = {"
 o
-k
+U
 f
 f
 f
@@ -272,26 +343,26 @@ b
 c
 f
 S
-S
+D
 S
 f
-c
+O
 "}
 (14,1,1) = {"
 b
 m
 m
-m
+Q
 m
 m
 b
 "}
 (15,1,1) = {"
-b
+Q
 n
 s
 u
 s
 A
-b
+Q
 "}

--- a/_maps/shuttles/arrival_box.dmm
+++ b/_maps/shuttles/arrival_box.dmm
@@ -13,7 +13,8 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/stripes/end{
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -221,17 +222,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/arrival)
-"O" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Arrivals Shuttle Airlock"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/stripes/end,
-/turf/open/floor/plating,
-/area/shuttle/arrival)
 "Q" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/arrival)
@@ -299,7 +289,7 @@ r
 r
 r
 f
-O
+c
 "}
 (7,1,1) = {"
 b
@@ -362,7 +352,7 @@ S
 S
 S
 f
-O
+c
 "}
 (14,1,1) = {"
 b

--- a/_maps/shuttles/arrival_box.dmm
+++ b/_maps/shuttles/arrival_box.dmm
@@ -201,10 +201,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/arrival)
-"F" = (
-/obj/structure/sign/poster/official/no_erp,
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/arrival)
 "H" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall/mineral/titanium,
@@ -277,7 +273,7 @@ a
 (4,1,1) = {"
 b
 b
-F
+V
 t
 V
 b

--- a/_maps/shuttles/arrival_box.dmm
+++ b/_maps/shuttles/arrival_box.dmm
@@ -23,13 +23,12 @@
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/arrival)
 "e" = (
-/obj/item/storage/toolbox/emergency,
+/obj/item/storage/toolbox/emergency{
+	pixel_y = 5
+	},
 /obj/item/storage/toolbox/emergency,
 /obj/machinery/status_display/ai{
 	pixel_x = -32
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_y = 4
 	},
 /obj/structure/table/reinforced,
 /turf/open/floor/mineral/titanium/blue,
@@ -41,8 +40,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/sign/poster/official/enlist{
-	pixel_y = 32
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_y = 32;
+	use_power = 0
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
@@ -135,7 +136,13 @@
 /area/shuttle/arrival)
 "u" = (
 /obj/docking_port/mobile/arrivals,
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/shuttle/engine/propulsion{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
 /area/shuttle/arrival)
 "v" = (
 /obj/structure/chair/comfy/shuttle{
@@ -163,9 +170,6 @@
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/item/tank/internals/emergency_oxygen,
 /obj/item/clothing/mask/breath,
 /obj/machinery/status_display/evac{
@@ -197,17 +201,25 @@
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/arrival)
-"D" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 32;
-	use_power = 0
-	},
-/turf/open/floor/mineral/titanium/white,
+"F" = (
+/obj/structure/sign/poster/official/no_erp,
+/turf/closed/wall/mineral/titanium,
 /area/shuttle/arrival)
 "H" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall/mineral/titanium,
+/area/shuttle/arrival)
+"N" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/shuttle/engine/heater{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
 /area/shuttle/arrival)
 "O" = (
 /obj/machinery/door/airlock/titanium{
@@ -229,6 +241,10 @@
 "U" = (
 /obj/structure/closet/wardrobe/white,
 /turf/open/floor/mineral/titanium/blue,
+/area/shuttle/arrival)
+"V" = (
+/obj/structure/sign/poster/official/random,
+/turf/closed/wall/mineral/titanium,
 /area/shuttle/arrival)
 
 (1,1,1) = {"
@@ -261,9 +277,9 @@ a
 (4,1,1) = {"
 b
 b
-b
+F
 t
-b
+V
 b
 b
 "}
@@ -343,7 +359,7 @@ b
 c
 f
 S
-D
+S
 S
 f
 O
@@ -352,7 +368,7 @@ O
 b
 m
 m
-Q
+N
 m
 m
 b

--- a/_maps/shuttles/arrival_delta.dmm
+++ b/_maps/shuttles/arrival_delta.dmm
@@ -172,7 +172,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plating,
 /area/shuttle/arrival)
 "o" = (
 /obj/effect/turf_decal/tile/neutral{

--- a/_maps/shuttles/arrival_delta.dmm
+++ b/_maps/shuttles/arrival_delta.dmm
@@ -131,8 +131,11 @@
 /area/shuttle/arrival)
 "k" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/toolbox/emergency,
+/obj/item/storage/toolbox/emergency{
+	pixel_y = 5
+	},
 /obj/effect/turf_decal/bot,
+/obj/item/storage/toolbox/emergency,
 /turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "l" = (
@@ -140,12 +143,11 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
 	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/regular,
 /obj/effect/turf_decal/bot,
+/obj/item/storage/toolbox/emergency{
+	pixel_y = 5
+	},
+/obj/item/storage/toolbox/emergency,
 /turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "m" = (
@@ -290,6 +292,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/radio/intercom{
+	pixel_x = -30
+	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
 	},
@@ -323,6 +328,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "F" = (
@@ -346,9 +354,6 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/turf_decal/bot,
-/obj/item/radio/intercom{
-	pixel_x = -30
-	},
 /turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "H" = (
@@ -503,9 +508,9 @@ X
 X
 X
 X
-z
-n
 g
+n
+z
 g
 a
 a
@@ -655,9 +660,9 @@ X
 X
 X
 X
-z
-n
 g
+n
+z
 g
 a
 a

--- a/_maps/shuttles/arrival_omega.dmm
+++ b/_maps/shuttles/arrival_omega.dmm
@@ -52,8 +52,12 @@
 /obj/machinery/vending/wallmed{
 	pixel_y = 32
 	},
-/obj/item/storage/toolbox/emergency,
-/obj/item/storage/toolbox/emergency,
+/obj/item/storage/toolbox/emergency{
+	pixel_y = -2
+	},
+/obj/item/storage/toolbox/emergency{
+	pixel_y = 2
+	},
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/suit/hazardvest,
@@ -120,14 +124,14 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/sign/poster/official/enlist{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/arrival)

--- a/_maps/shuttles/arrival_omega.dmm
+++ b/_maps/shuttles/arrival_omega.dmm
@@ -91,9 +91,11 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 1;
-	icon_state = "warn_end"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/shuttle/arrival)
@@ -276,6 +278,15 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/shuttle/arrival)
+"R" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
+/obj/effect/turf_decal/stripes/end{
+	dir = 1;
+	icon_state = "warn_end"
+	},
+/turf/open/floor/plating,
+/area/shuttle/arrival)
 
 (1,1,1) = {"
 a
@@ -283,7 +294,7 @@ d
 f
 j
 f
-A
+R
 A
 d
 A

--- a/_maps/shuttles/arrival_omega.dmm
+++ b/_maps/shuttles/arrival_omega.dmm
@@ -88,8 +88,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/end{
-	icon_state = "warn_end";
-	dir = 1
+	dir = 1;
+	icon_state = "warn_end"
 	},
 /turf/open/floor/plating,
 /area/shuttle/arrival)
@@ -145,6 +145,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/status_display/ai{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "q" = (
@@ -181,6 +184,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/status_display/evac{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/arrival)
@@ -261,6 +267,11 @@
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/arrival)
+"Q" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/shuttle/arrival)
 
 (1,1,1) = {"
 a
@@ -306,7 +317,7 @@ l
 l
 l
 l
-l
+Q
 l
 l
 l

--- a/_maps/shuttles/arrival_pubby.dmm
+++ b/_maps/shuttles/arrival_pubby.dmm
@@ -13,14 +13,20 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "e" = (
-/obj/structure/table,
+/obj/item/storage/toolbox/emergency,
 /obj/item/storage/firstaid/regular{
 	pixel_y = 4
 	},
-/obj/item/storage/toolbox/emergency,
+/obj/machinery/status_display/ai{
+	pixel_x = -32
+	},
+/obj/structure/table/reinforced,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "f" = (
@@ -61,10 +67,16 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plating/airless,
 /area/shuttle/arrival)
 "l" = (
 /obj/structure/shuttle/engine/propulsion/burst/right{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -87,10 +99,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "o" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/arrival)
 "p" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -100,6 +109,9 @@
 	height = 13;
 	name = "pubby arrivals shuttle";
 	width = 6
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/arrival)
@@ -111,13 +123,30 @@
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plating/airless,
 /area/shuttle/arrival)
 "s" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/crate/internals,
 /obj/item/storage/firstaid/o2,
 /obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
 /obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/clothing/mask/breath,
+/obj/machinery/status_display/evac{
+	pixel_x = -32
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "t" = (
@@ -139,10 +168,50 @@
 /obj/structure/shuttle/engine/propulsion/burst/left{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plating/airless,
 /area/shuttle/arrival)
 "C" = (
-/turf/open/floor/mineral/titanium,
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/arrival)
+"D" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Arrivals Shuttle Airlock"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/stripes/end,
+/turf/open/floor/plating,
+/area/shuttle/arrival)
+"F" = (
+/obj/structure/closet/wardrobe/white,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/arrival)
+"M" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/arrival)
+"N" = (
+/obj/machinery/holopad,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/arrival)
+"O" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/arrival)
+"X" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_y = 32;
+	use_power = 0
+	},
+/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 
 (1,1,1) = {"
@@ -156,7 +225,7 @@ a
 (2,1,1) = {"
 a
 b
-f
+X
 q
 b
 a
@@ -170,12 +239,12 @@ b
 b
 "}
 (4,1,1) = {"
-b
+O
 e
-C
-C
+f
+f
 s
-b
+O
 "}
 (5,1,1) = {"
 c
@@ -183,7 +252,7 @@ f
 o
 o
 f
-c
+D
 "}
 (6,1,1) = {"
 b
@@ -196,42 +265,42 @@ b
 (7,1,1) = {"
 m
 h
-o
-o
+C
+C
 f
 m
 "}
 (8,1,1) = {"
 m
 i
-C
-C
+o
+N
 f
 m
 "}
 (9,1,1) = {"
 m
-f
-o
-o
+F
+C
+C
 f
 m
 "}
 (10,1,1) = {"
 b
 j
-o
-o
+C
+C
 u
 b
 "}
 (11,1,1) = {"
 c
 f
-C
-C
+o
+o
 f
-c
+D
 "}
 (12,1,1) = {"
 b
@@ -242,10 +311,10 @@ k
 b
 "}
 (13,1,1) = {"
-b
+M
 l
 p
 r
 v
-b
+M
 "}

--- a/_maps/shuttles/arrival_pubby.dmm
+++ b/_maps/shuttles/arrival_pubby.dmm
@@ -13,8 +13,11 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/stripes/end{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
 	},
 /turf/open/floor/plating,
 /area/shuttle/arrival)
@@ -175,17 +178,6 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/arrival)
-"D" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Arrivals Shuttle Airlock"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/stripes/end,
-/turf/open/floor/plating,
-/area/shuttle/arrival)
 "F" = (
 /obj/structure/closet/wardrobe/white,
 /turf/open/floor/mineral/titanium/blue,
@@ -240,7 +232,7 @@ f
 o
 o
 f
-D
+c
 "}
 (6,1,1) = {"
 b
@@ -288,7 +280,7 @@ f
 o
 o
 f
-D
+c
 "}
 (12,1,1) = {"
 b

--- a/_maps/shuttles/arrival_pubby.dmm
+++ b/_maps/shuttles/arrival_pubby.dmm
@@ -20,9 +20,6 @@
 /area/shuttle/arrival)
 "e" = (
 /obj/item/storage/toolbox/emergency,
-/obj/item/storage/firstaid/regular{
-	pixel_y = 4
-	},
 /obj/machinery/status_display/ai{
 	pixel_x = -32
 	},
@@ -36,8 +33,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/sign/poster/official/enlist{
-	pixel_y = 32
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_y = 32;
+	use_power = 0
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
@@ -139,9 +138,6 @@
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/item/tank/internals/emergency_oxygen,
 /obj/item/clothing/mask/breath,
 /obj/machinery/status_display/evac{
@@ -205,14 +201,6 @@
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/arrival)
-"X" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_y = 32;
-	use_power = 0
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/arrival)
 
 (1,1,1) = {"
 a
@@ -225,7 +213,7 @@ a
 (2,1,1) = {"
 a
 b
-X
+f
 q
 b
 a


### PR DESCRIPTION
(While I was tempted to include a whole NTSCDOSD writeup here, I decided that it'd be better to save it for more "major" shuttle-related projects.)

This PR incorporates some of the better features of the Omega and Delta arrivals shuttles, as well as ensuring every arrivals shuttle has a consistent set of features.

More specifically, that each shuttle has, among the "obvious" features:

- An emergency NanoMed
- At least one emergency toolbox
- A crate containing internals and other emergency supplies
- A fire extinguisher
- An AI and evacuation status display
- A holopad
- At least two NanoTrasen signs

<details>
   <summary>Old</summary>

**Box:**
![image](https://user-images.githubusercontent.com/29339701/87359695-53058d00-c536-11ea-98e8-5afde73e169e.png)

**Pubby:**
![image](https://user-images.githubusercontent.com/29339701/87359661-42551700-c536-11ea-8df0-962954fddef1.png)

</details>

<details>
  <summary>New</summary>

**Box:** 
![image](https://user-images.githubusercontent.com/29339701/87470892-75a5ad80-c5eb-11ea-9ed9-44f8158d74a5.png)

**Pubby:** 
![image](https://user-images.githubusercontent.com/29339701/87470946-8a824100-c5eb-11ea-94fa-96d333d10427.png)


</details>

In addition to these changes, AI and evac status displays have been added to the OmegaStation arrivals shuttle, and all of the medkits have been removed, except for the oxygen deprivation kits.

#### Changelog

:cl:  
rscadd: The arrivals shuttles for Box, Pubby, and Omega have now been fitted with emergency NanoMeds, toolboxes, and status displays, as well as additional NanoTrasen branding.
rscdel: Removed the public medkits in all of the arrivals shuttles.
/:cl:
