### PR TITLE
Greytide virus no longer affects doors the AI can't control

### DIFF
--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -50,7 +50,8 @@
 				temp.update_icon()
 			else if(istype(O, /obj/machinery/door/airlock))
 				var/obj/machinery/door/airlock/temp = O
-				if(temp.critical_machine) //Skip doors in critical positions, such as the SM chamber.
+				//Skip doors in critical positions, such as the SM chamber, and skip doors the AI can't control since it's a virus
+				if(temp.critical_machine || !temp.canAIControl()) 
 					continue
 				temp.prison_open()
 			else if(istype(O, /obj/machinery/door_timer))


### PR DESCRIPTION
If it's a virus that infects the systems, it kinda makes sense that it can only affect stuff the AI can control.

:cl:
tweak: Greytide Event now only affects stuff the AI can control.
/:cl: