### PR TITLE
Significantly buffs the greytide virus

### DIFF
--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -63,24 +63,20 @@
 				// 75% chance we just leave it be, to not kill the AI/CE's joy *too much*
 				if(prob(75))
 					continue
-				var/option = pick(list(1, 2, 3, 4))
+				var/option = rand(1, 3)
 				switch(option)
-					// As if a multitool was used on it
-					if(1)
-						temp.setViewRange((view_range == initial(view_range)) ? short_range : initial(view_range))
-
 					// As if EMPed
-					if(2)
+					if(1)
 						temp.emp_act(2)
 					
 					// EMP-proof it, but with a 50/50 chance we don't tell them
-					if(3)
+					if(2)
 						var/secret = prob(50)
 						temp.upgradeEmpProof(secret)
 
 					// Give it a proximity alarm, can be either a boon or a curse depending on which camera gets it.
 					// Either way, the CE/Engineers can always just take the camera down and replace it.
-					if(4)
+					if(3)
 						temp.upgradeMotion()
 			
 			// If we hit 2 keycard auths we'll open maint unless it's already open

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -42,6 +42,7 @@
 			L.flicker(10)
 
 /datum/round_event/grey_tide/end()
+	var/keycard_auths_found = 0
 	for(var/area/A in areasToOpen)
 		for(var/obj/O in A)
 			if(istype(O, /obj/structure/closet/secure_closet))
@@ -56,4 +57,47 @@
 			else if(istype(O, /obj/machinery/door_timer))
 				var/obj/machinery/door_timer/temp = O
 				temp.timer_end(forced = TRUE)
+
+			else if(istype(O, /obj/machinery/camera))
+				var/obj/machinery/camera/temp = O
+				// 75% chance we just leave it be, to not kill the AI/CE's joy *too much*
+				if(prob(75))
+					continue
+				var/option = pick(list(1, 2, 3, 4))
+				switch(option)
+					// As if a multitool was used on it
+					if(1)
+						temp.setViewRange((view_range == initial(view_range)) ? short_range : initial(view_range))
+
+					// As if EMPed
+					if(2)
+						temp.emp_act(2)
+					
+					// EMP-proof it, but with a 50/50 chance we don't tell them
+					if(3)
+						var/secret = prob(50)
+						temp.upgradeEmpProof(secret)
+
+					// Give it a proximity alarm, can be either a boon or a curse depending on which camera gets it.
+					// Either way, the CE/Engineers can always just take the camera down and replace it.
+					if(4)
+						temp.upgradeMotion()
+			
+			// If we hit 2 keycard auths we'll open maint unless it's already open
+			// If we opened maint, we'll red alert at 4 keycard auths
+			else if(istype(O, /obj/machinery/keycard_auth))
+				var/obj/machinery/keycard_auth/temp = O
+				keycard_auths_found++
+				// Simulate the confirmation requirement
+				if(!(keycard_auths_found % 2) || keycard_auths_found > 4)
+					continue
+				if(!GLOB.emergency_access)
+					make_maint_all_access()
+				else if(GLOB.security_level != SEC_LEVEL_DELTA)
+					set_security_level(SEC_LEVEL_RED)
+
+
+
+
+				
 

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -82,7 +82,6 @@
 			// If we hit 2 keycard auths we'll open maint unless it's already open
 			// If we opened maint, we'll red alert at 4 keycard auths
 			else if(istype(O, /obj/machinery/keycard_auth))
-				var/obj/machinery/keycard_auth/temp = O
 				keycard_auths_found++
 				// Simulate the confirmation requirement
 				if(!(keycard_auths_found % 2) || keycard_auths_found > 4)


### PR DESCRIPTION
It can now affect cameras, which it has a 75% chance of not doing (due to the sheer mass of cameras)
If it does affect a camera, it'll do one of the following:

- emp it
- emp-proof it (with a 50% chance it's done in secret, like the malf upgrade)
- motion-activate it (which really can be a massive pain if it's in a location like the medbay)

It can also affect key-card auths, which will do the following:
When it reaches 2 auths, it'll open maint if it's not already open, otherwise it'll red alert
When it reaches 4 auths, it'll red alert

None of this is impossible to deal with, even the camera upgrades just require an engineer/engiborg to detach and retach the camera. The alert/maintenance can be dealt with from any command console by an AI/headofstaff

:cl:
rscadd: Greytide Virus now affects both cameras and keycard auths
/:cl: 

Any additional suggestions to either more stuff to affect or changes to the already affected items are welcome