### PR TITLE
Budget Card Changes

### DIFF
--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -126,10 +126,17 @@ SUBSYSTEM_DEF(economy)
 	if(D)
 		D.adjust_money(min(cash_to_grant, MAX_GRANT_SECMEDSRV))
 
+	var/service_passive_income = (rand(1, 6) * 400) //min 400, max 2400
+	var/datum/bank_account/SRV = get_dep_account(ACCOUNT_SRV)
+	if(SRV)
+		SRV.adjust_money(service_passive_income)
+
 /datum/controller/subsystem/economy/proc/sci_payout()
 	var/science_bounty = 0
 	for(var/mob/living/simple_animal/slime/S in GLOB.mob_list)
 		if(S.stat == DEAD)
+			continue
+		if(!is_station_level(S.z))
 			continue
 		science_bounty += slime_bounty[S.colour]
 	var/datum/bank_account/D = get_dep_account(ACCOUNT_SCI)


### PR DESCRIPTION
### Intent of your Pull Request

Slimes on lavaland no longer make Science money

Service gets paid between 400 and 2400 credits per cycle, to compensate for mood not being mandatory on yogs

#### Changelog

:cl:  
rscadd: Service gets paid between 400 and 2400 credits per Economic Cycle
bugfix: Slimes not on the station no longer generate money for Science
/:cl:
