### PR TITLE
[admin] Adds ERT Mech Bay

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -10551,13 +10551,6 @@
 	},
 /turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
-"wT" = (
-/obj/structure/noticeboard{
-	dir = 4;
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
 "wV" = (
 /obj/structure/table/wood,
 /obj/item/paicard,
@@ -11005,6 +10998,11 @@
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
+"yc" = (
+/obj/machinery/door/poddoor/deathsquad,
+/obj/effect/turf_decal/delivery/red,
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "yd" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -11954,21 +11952,6 @@
 /obj/item/lighter,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"Ad" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/secure/briefcase,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
 "Ae" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/regular,
@@ -12547,12 +12530,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
-"Bw" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/taperecorder,
-/turf/open/floor/plasteel/grimy,
-/area/centcom/ferry)
 "Bx" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/fancy/donut_box,
@@ -13050,25 +13027,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
-"Cr" = (
-/obj/structure/table/wood,
-/obj/item/folder/red,
-/obj/item/lighter,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
 "Cs" = (
 /obj/structure/bookcase/random,
 /obj/machinery/light,
@@ -13458,10 +13416,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/wood,
 /area/centcom/holding)
-"CW" = (
-/obj/mecha/combat/marauder/seraph,
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
 "CX" = (
 /obj/structure/closet/secure_closet/security,
 /obj/item/storage/belt/security/full,
@@ -13690,6 +13644,13 @@
 /obj/item/ammo_box/magazine/sniper_rounds/soporific,
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
+"Dp" = (
+/obj/effect/turf_decal/arrows/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot_red,
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "Dq" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/turf_decal/stripes/line{
@@ -14560,6 +14521,17 @@
 "Ff" = (
 /turf/open/floor/engine/vacuum,
 /area/centcom/testchamber)
+"Fg" = (
+/obj/effect/turf_decal/loading_area/red,
+/obj/effect/turf_decal/bot_red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "Fh" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
@@ -14867,6 +14839,10 @@
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
+"FU" = (
+/obj/machinery/mech_bay_recharge_port,
+/turf/open/floor/circuit/green,
+/area/centcom/ferry)
 "FW" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -15737,6 +15713,10 @@
 /obj/machinery/vending/magivend,
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
+"Hz" = (
+/obj/effect/turf_decal/caution/red,
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "HA" = (
 /obj/structure/sink{
 	dir = 8;
@@ -18247,10 +18227,6 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/bluespace,
 /area/centcom/testchamber)
-"MY" = (
-/obj/mecha/combat/marauder/loaded,
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
 "MZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -19113,6 +19089,13 @@
 	},
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
+"PB" = (
+/obj/effect/turf_decal/loading_area/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot_red,
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "PC" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -19153,10 +19136,6 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
-"PG" = (
-/obj/machinery/mech_bay_recharge_port,
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
 "PI" = (
 /obj/machinery/biogenerator,
 /obj/effect/turf_decal/tile/green{
@@ -19337,6 +19316,10 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/centcom/holding)
+"Ql" = (
+/obj/mecha/combat/marauder/loaded,
+/turf/open/floor/mech_bay_recharge_floor/dark,
+/area/centcom/ferry)
 "Qm" = (
 /obj/singularity/wizard/mapped,
 /turf/open/indestructible/binary,
@@ -19623,6 +19606,14 @@
 	smooth = 1
 	},
 /area/centcom/holding)
+"QU" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/taperecorder,
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/ferry)
 "QV" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien13";
@@ -19635,6 +19626,26 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
+"QX" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/secure/briefcase,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/storage/briefcase{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/storage/secure/briefcase,
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "Ra" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -19778,10 +19789,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
-"Rr" = (
-/obj/machinery/door/poddoor/deathsquad,
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
 "Rt" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -20054,6 +20061,10 @@
 "Si" = (
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/two)
+"Sk" = (
+/obj/mecha/combat/marauder/seraph,
+/turf/open/floor/mech_bay_recharge_floor/dark,
+/area/centcom/ferry)
 "So" = (
 /obj/structure/lattice/catwalk/swarmer_catwalk,
 /obj/effect/decal/cleanable/blood/gibs/body,
@@ -20523,6 +20534,12 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
+"TH" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/circuit,
+/area/centcom/ferry)
 "TI" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -21016,6 +21033,9 @@
 	},
 /turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
+"Vp" = (
+/turf/open/floor/circuit,
+/area/centcom/ferry)
 "Vq" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -21101,12 +21121,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
-"VB" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
 "VE" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -21809,6 +21823,26 @@
 /obj/machinery/portable_atmospherics/canister/nitryl,
 /turf/open/floor/bluespace,
 /area/centcom/testchamber)
+"XH" = (
+/obj/structure/table/wood,
+/obj/item/folder/red,
+/obj/item/lighter,
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/radio/headset/headset_cent,
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "XI" = (
 /obj/structure/lattice/catwalk/swarmer_catwalk,
 /turf/open/space/basic,
@@ -22226,6 +22260,15 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"YX" = (
+/obj/machinery/airalarm/directional/west{
+	pixel_x = -24
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/circuit,
+/area/centcom/ferry)
 "YY" = (
 /obj/structure/table/reinforced,
 /obj/item/modular_computer/laptop/preset/civillian,
@@ -22269,15 +22312,6 @@
 /obj/item/gun/grenadelauncher,
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
-"Ze" = (
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
 "Zf" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -57745,12 +57779,12 @@ Xy
 oe
 vB
 mD
-PG
-VB
-zA
-wT
-Ze
-PG
+FU
+TH
+Vp
+Vp
+YX
+FU
 mD
 aa
 aa
@@ -58002,12 +58036,12 @@ xe
 wr
 yo
 nU
-MY
-zA
-zA
-zA
-zA
-CW
+Ql
+Fg
+Dp
+Dp
+PB
+Sk
 mD
 aa
 aa
@@ -58259,12 +58293,12 @@ xf
 ws
 yp
 mD
-PG
-zA
-zA
-zA
-zA
-PG
+FU
+Hz
+Dp
+Dp
+Hz
+FU
 mD
 aa
 aa
@@ -58516,12 +58550,12 @@ xg
 wt
 yq
 mD
-MY
-zA
-zA
-zA
-zA
-CW
+Ql
+Fg
+Dp
+Dp
+PB
+Sk
 mD
 aa
 aa
@@ -58774,10 +58808,10 @@ wu
 mD
 mD
 rz
-Rr
-Rr
-Rr
-Rr
+yc
+yc
+yc
+yc
 rz
 mD
 aa
@@ -59292,7 +59326,7 @@ pg
 pg
 pg
 pg
-Cr
+XH
 mD
 aa
 aa
@@ -59804,7 +59838,7 @@ zb
 pg
 Ac
 AK
-Bw
+QU
 pg
 Ct
 nT
@@ -60316,7 +60350,7 @@ wB
 yr
 sw
 Vl
-Ad
+QX
 AL
 Bx
 Vl

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6889,11 +6889,7 @@
 	smooth = 1
 	},
 /area/centcom/holding)
-"pA" = (
-/obj/mecha/combat/marauder/loaded,
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
-"pC" = (
+"pB" = (
 /obj/machinery/door/poddoor/deathsquad,
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
@@ -13643,6 +13639,10 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Dm" = (
+/obj/machinery/firealarm,
+/turf/closed/indestructible/riveted,
+/area/centcom/ferry)
 "Dn" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien17";
@@ -15559,12 +15559,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
-"Hl" = (
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
 "Hm" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -17988,12 +17982,6 @@
 	},
 /turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
-"Mo" = (
-/obj/structure/sign/nanotrasen{
-	pixel_y = 32
-	},
-/turf/closed/indestructible/riveted,
-/area/centcom/ferry)
 "Mp" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -18215,6 +18203,10 @@
 	},
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
+"MS" = (
+/obj/mecha/combat/marauder/loaded,
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "MT" = (
 /obj/machinery/processor,
 /turf/open/floor/plasteel/cafeteria,
@@ -18305,10 +18297,6 @@
 /obj/item/kitchen/knife/envy,
 /turf/open/floor/wood,
 /area/centcom/testchamber)
-"Nj" = (
-/obj/mecha/combat/marauder/seraph,
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
 "Nk" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Thunderdome";
@@ -18999,6 +18987,12 @@
 /obj/machinery/washing_machine,
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
+"Pf" = (
+/obj/structure/sign/nanotrasen{
+	pixel_y = 32
+	},
+/turf/closed/indestructible/riveted,
+/area/centcom/ferry)
 "Pg" = (
 /obj/structure/table/wood,
 /obj/item/twohanded/dualsaber/purple{
@@ -19060,13 +19054,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
-"Pp" = (
-/obj/structure/noticeboard{
-	dir = 4;
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
 "Pq" = (
 /turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
@@ -19780,6 +19767,15 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
+"Rq" = (
+/obj/machinery/airalarm/directional/west{
+	pixel_x = -24
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "Rt" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -19843,6 +19839,13 @@
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /turf/open/floor/bluespace,
 /area/centcom/testchamber)
+"RE" = (
+/obj/structure/noticeboard{
+	dir = 4;
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "RF" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -20798,6 +20801,10 @@
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"UG" = (
+/obj/machinery/mech_bay_recharge_port,
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "UH" = (
 /obj/machinery/light{
 	dir = 8
@@ -21069,10 +21076,6 @@
 /obj/machinery/reagentgrinder,
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
-"Vw" = (
-/obj/machinery/firealarm,
-/turf/closed/indestructible/riveted,
-/area/centcom/ferry)
 "Vx" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien12";
@@ -21359,6 +21362,12 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/bluespace,
 /area/centcom/testchamber)
+"Wr" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "Wt" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -21642,6 +21651,10 @@
 	},
 /turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
+"Xm" = (
+/obj/mecha/combat/marauder/seraph,
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "Xo" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/plasteel/cafeteria,
@@ -21805,10 +21818,6 @@
 /obj/machinery/portable_atmospherics/canister/nitryl,
 /turf/open/floor/bluespace,
 /area/centcom/testchamber)
-"XF" = (
-/obj/machinery/mech_bay_recharge_port,
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
 "XI" = (
 /obj/structure/lattice/catwalk/swarmer_catwalk,
 /turf/open/space/basic,
@@ -57480,9 +57489,9 @@ oe
 yn
 mD
 mD
-Vw
+Dm
 mD
-Mo
+Pf
 mD
 mD
 mD
@@ -57736,12 +57745,12 @@ Xy
 oe
 vB
 mD
-XF
+UG
+Wr
 zA
-zA
-Pp
-Hl
-XF
+RE
+Rq
+UG
 mD
 aa
 aa
@@ -57993,12 +58002,12 @@ xe
 wr
 yo
 nU
-pA
+MS
 zA
 zA
 zA
 zA
-Nj
+Xm
 mD
 aa
 aa
@@ -58250,12 +58259,12 @@ xf
 ws
 yp
 Tw
-XF
+UG
 zA
 zA
 zA
 zA
-XF
+UG
 mD
 aa
 aa
@@ -58507,12 +58516,12 @@ xg
 wt
 yq
 mD
-pA
+MS
 zA
 zA
 zA
 zA
-Nj
+Xm
 mD
 aa
 aa
@@ -58765,10 +58774,10 @@ wu
 mD
 mD
 rz
-pC
-pC
-pC
-pC
+pB
+pB
+pB
+pB
 rz
 mD
 aa

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6889,6 +6889,14 @@
 	smooth = 1
 	},
 /area/centcom/holding)
+"pA" = (
+/obj/mecha/combat/marauder/loaded,
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
+"pC" = (
+/obj/machinery/door/poddoor/deathsquad,
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "pD" = (
 /obj/structure/destructible/cult/tome,
 /obj/item/shuttle_curse,
@@ -12524,22 +12532,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
-"Bu" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen/fourcolor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
 "Bv" = (
 /obj/machinery/computer/card/centcom{
 	dir = 1
@@ -12880,22 +12872,6 @@
 /obj/item/toy/figure/syndie,
 /turf/open/floor/plating/asteroid/snow/airless,
 /area/syndicate_mothership)
-"BZ" = (
-/obj/structure/table/wood,
-/obj/item/clipboard,
-/obj/item/radio/headset/headset_cent,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
 "Ca" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -15583,6 +15559,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
+"Hl" = (
+/obj/machinery/airalarm/directional/west{
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "Hm" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -18006,6 +17988,12 @@
 	},
 /turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
+"Mo" = (
+/obj/structure/sign/nanotrasen{
+	pixel_y = 32
+	},
+/turf/closed/indestructible/riveted,
+/area/centcom/ferry)
 "Mp" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -18317,6 +18305,10 @@
 /obj/item/kitchen/knife/envy,
 /turf/open/floor/wood,
 /area/centcom/testchamber)
+"Nj" = (
+/obj/mecha/combat/marauder/seraph,
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "Nk" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Thunderdome";
@@ -19068,6 +19060,13 @@
 	},
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
+"Pp" = (
+/obj/structure/noticeboard{
+	dir = 4;
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "Pq" = (
 /turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
@@ -21070,6 +21069,10 @@
 /obj/machinery/reagentgrinder,
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
+"Vw" = (
+/obj/machinery/firealarm,
+/turf/closed/indestructible/riveted,
+/area/centcom/ferry)
 "Vx" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien12";
@@ -21802,6 +21805,10 @@
 /obj/machinery/portable_atmospherics/canister/nitryl,
 /turf/open/floor/bluespace,
 /area/centcom/testchamber)
+"XF" = (
+/obj/machinery/mech_bay_recharge_port,
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "XI" = (
 /obj/structure/lattice/catwalk/swarmer_catwalk,
 /turf/open/space/basic,
@@ -57472,13 +57479,13 @@ xd
 oe
 yn
 mD
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+mD
+Vw
+mD
+Mo
+mD
+mD
+mD
 aa
 aa
 aa
@@ -57729,13 +57736,13 @@ Xy
 oe
 vB
 mD
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+XF
+zA
+zA
+Pp
+Hl
+XF
+mD
 aa
 aa
 aa
@@ -57986,13 +57993,13 @@ xe
 wr
 yo
 nU
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+pA
+zA
+zA
+zA
+zA
+Nj
+mD
 aa
 aa
 aa
@@ -58243,13 +58250,13 @@ xf
 ws
 yp
 Tw
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+XF
+zA
+zA
+zA
+zA
+XF
+mD
 aa
 aa
 aa
@@ -58500,13 +58507,13 @@ xg
 wt
 yq
 mD
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+pA
+zA
+zA
+zA
+zA
+Nj
+mD
 aa
 aa
 aa
@@ -58757,12 +58764,12 @@ xh
 wu
 mD
 mD
-Tw
-Tw
-nU
-Tw
-Tw
-mD
+rz
+pC
+pC
+pC
+pC
+rz
 mD
 aa
 aa
@@ -59015,10 +59022,10 @@ wv
 mD
 yY
 zz
-oA
-uV
-Bu
-BZ
+sw
+sw
+sw
+sw
 Cq
 mD
 aa

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6890,8 +6890,8 @@
 	},
 /area/centcom/holding)
 "pB" = (
-/obj/machinery/door/poddoor/deathsquad,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/firealarm,
+/turf/closed/indestructible/riveted,
 /area/centcom/ferry)
 "pD" = (
 /obj/structure/destructible/cult/tome,
@@ -8180,6 +8180,12 @@
 /obj/machinery/vending/snack,
 /turf/open/floor/plasteel,
 /area/centcom/supplypod)
+"sd" = (
+/obj/structure/sign/nanotrasen{
+	pixel_y = 32
+	},
+/turf/closed/indestructible/riveted,
+/area/centcom/ferry)
 "se" = (
 /obj/machinery/light{
 	dir = 8
@@ -10545,6 +10551,13 @@
 	},
 /turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
+"wT" = (
+/obj/structure/noticeboard{
+	dir = 4;
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "wV" = (
 /obj/structure/table/wood,
 /obj/item/paicard,
@@ -13445,6 +13458,10 @@
 /obj/structure/chair/stool,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"CW" = (
+/obj/mecha/combat/marauder/seraph,
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "CX" = (
 /obj/structure/closet/secure_closet/security,
 /obj/item/storage/belt/security/full,
@@ -13639,10 +13656,6 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
-"Dm" = (
-/obj/machinery/firealarm,
-/turf/closed/indestructible/riveted,
-/area/centcom/ferry)
 "Dn" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien17";
@@ -18203,10 +18216,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
-"MS" = (
-/obj/mecha/combat/marauder/loaded,
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
 "MT" = (
 /obj/machinery/processor,
 /turf/open/floor/plasteel/cafeteria,
@@ -18238,6 +18247,10 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/bluespace,
 /area/centcom/testchamber)
+"MY" = (
+/obj/mecha/combat/marauder/loaded,
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "MZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -18987,12 +19000,6 @@
 /obj/machinery/washing_machine,
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
-"Pf" = (
-/obj/structure/sign/nanotrasen{
-	pixel_y = 32
-	},
-/turf/closed/indestructible/riveted,
-/area/centcom/ferry)
 "Pg" = (
 /obj/structure/table/wood,
 /obj/item/twohanded/dualsaber/purple{
@@ -19146,6 +19153,10 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"PG" = (
+/obj/machinery/mech_bay_recharge_port,
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "PI" = (
 /obj/machinery/biogenerator,
 /obj/effect/turf_decal/tile/green{
@@ -19767,13 +19778,8 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
-"Rq" = (
-/obj/machinery/airalarm/directional/west{
-	pixel_x = -24
-	},
-/obj/machinery/light{
-	dir = 8
-	},
+"Rr" = (
+/obj/machinery/door/poddoor/deathsquad,
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "Rt" = (
@@ -19839,13 +19845,6 @@
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /turf/open/floor/bluespace,
 /area/centcom/testchamber)
-"RE" = (
-/obj/structure/noticeboard{
-	dir = 4;
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
 "RF" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -20801,10 +20800,6 @@
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood,
 /area/centcom/holding)
-"UG" = (
-/obj/machinery/mech_bay_recharge_port,
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
 "UH" = (
 /obj/machinery/light{
 	dir = 8
@@ -21106,6 +21101,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
+"VB" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "VE" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -21362,12 +21363,6 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/bluespace,
 /area/centcom/testchamber)
-"Wr" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
 "Wt" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -21651,10 +21646,6 @@
 	},
 /turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
-"Xm" = (
-/obj/mecha/combat/marauder/seraph,
-/turf/open/floor/plasteel/dark,
-/area/centcom/ferry)
 "Xo" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/plasteel/cafeteria,
@@ -22278,6 +22269,15 @@
 /obj/item/gun/grenadelauncher,
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
+"Ze" = (
+/obj/machinery/airalarm/directional/west{
+	pixel_x = -24
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/ferry)
 "Zf" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -57489,9 +57489,9 @@ oe
 yn
 mD
 mD
-Dm
+pB
 mD
-Pf
+sd
 mD
 mD
 mD
@@ -57745,12 +57745,12 @@ Xy
 oe
 vB
 mD
-UG
-Wr
+PG
+VB
 zA
-RE
-Rq
-UG
+wT
+Ze
+PG
 mD
 aa
 aa
@@ -58002,12 +58002,12 @@ xe
 wr
 yo
 nU
-MS
+MY
 zA
 zA
 zA
 zA
-Xm
+CW
 mD
 aa
 aa
@@ -58258,13 +58258,13 @@ ws
 xf
 ws
 yp
-Tw
-UG
+mD
+PG
 zA
 zA
 zA
 zA
-UG
+PG
 mD
 aa
 aa
@@ -58516,12 +58516,12 @@ xg
 wt
 yq
 mD
-MS
+MY
 zA
 zA
 zA
 zA
-Xm
+CW
 mD
 aa
 aa
@@ -58774,10 +58774,10 @@ wu
 mD
 mD
 rz
-pB
-pB
-pB
-pB
+Rr
+Rr
+Rr
+Rr
 rz
 mD
 aa

--- a/code/datums/ert.dm
+++ b/code/datums/ert.dm
@@ -39,6 +39,7 @@
 	roles = list(/datum/antagonist/ert/deathsquad)
 	leader_role = /datum/antagonist/ert/deathsquad/leader
 	rename_team = "Deathsquad"
+	openmech = TRUE
 	code = "Delta"
 	mission = "Leave no witnesses."
 	polldesc = "an elite Nanotrasen Strike Team"

--- a/code/datums/ert.dm
+++ b/code/datums/ert.dm
@@ -2,6 +2,7 @@
 	var/mobtype = /mob/living/carbon/human
 	var/team = /datum/team/ert
 	var/opendoors = TRUE
+	var/openmech = FALSE
 	var/leader_role = /datum/antagonist/ert/commander
 	var/enforce_human = TRUE
 	var/roles = list(/datum/antagonist/ert/security, /datum/antagonist/ert/medic, /datum/antagonist/ert/engineer) //List of possible roles to be assigned to ERT members.

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -1,4 +1,4 @@
-/obj/machinery/door/poddoor
+/obj/machinery/door/poddoo
 	name = "blast door"
 	desc = "A heavy duty blast door that opens mechanically."
 	icon = 'icons/obj/doors/blastdoor.dmi'

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -1,4 +1,4 @@
-/obj/machinery/door/poddoo
+/obj/machinery/door/poddoor
 	name = "blast door"
 	desc = "A heavy duty blast door that opens mechanically."
 	icon = 'icons/obj/doors/blastdoor.dmi'

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -22,11 +22,11 @@
 	opacity = 0
 
 /obj/machinery/door/poddoor/ert
-	name = "Armory door"
+	name = "ERT Armory door"
 	desc = "A heavy duty blast door that only opens for dire emergencies."
 	
 /obj/machinery/door/poddoor/deathsquad
-	name = "Mech Bay door"
+	name = "ERT Mech Bay door"
 	desc = "A heavy duty blast door that only opens for extreme emergencies."
 
 //special poddoors that open when emergency shuttle docks at centcom

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -22,9 +22,11 @@
 	opacity = 0
 
 /obj/machinery/door/poddoor/ert
+	name = "Armory door"
 	desc = "A heavy duty blast door that only opens for dire emergencies."
 	
 /obj/machinery/door/poddoor/deathsquad
+	name = "Mech Bay door"
 	desc = "A heavy duty blast door that only opens for extreme emergencies."
 
 //special poddoors that open when emergency shuttle docks at centcom

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -23,6 +23,9 @@
 
 /obj/machinery/door/poddoor/ert
 	desc = "A heavy duty blast door that only opens for dire emergencies."
+	
+/obj/machinery/door/poddoor/deathsquad
+	desc = "A heavy duty blast door that only opens for extreme emergencies."
 
 //special poddoors that open when emergency shuttle docks at centcom
 /obj/machinery/door/poddoor/shuttledock

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -288,6 +288,7 @@
 	.["mainsettings"]["mission"]["value"] = newtemplate.mission
 	.["mainsettings"]["polldesc"]["value"] = newtemplate.polldesc
 	.["mainsettings"]["open_armory"]["value"] = newtemplate.opendoors ? "Yes" : "No"
+	.["mainsettings"]["open_mechbay"]["value"] = newtemplate.openmech ? "Yes" : "No"
 
 
 /datum/admins/proc/equipAntagOnDummy(mob/living/carbon/human/dummy/mannequin, datum/antagonist/antag)
@@ -356,6 +357,7 @@
 		"polldesc" = list("desc" = "Ghost poll description", "type" = "string", "value" = ertemplate.polldesc),
 		"enforce_human" = list("desc" = "Enforce human authority", "type" = "boolean", "value" = "[(CONFIG_GET(flag/enforce_human_authority) ? "Yes" : "No")]"),
 		"open_armory" = list("desc" = "Open armory doors", "type" = "boolean", "value" = "[(ertemplate.opendoors ? "Yes" : "No")]"),
+		"open_mechbay" = list("desc" = "Open Mech Bay", "type" = "boolean", "value" = "[(ertemplate.openmechbay ? "Yes" : "No")]"),
 		)
 	)
 
@@ -379,6 +381,7 @@
 		ertemplate.polldesc = prefs["polldesc"]["value"]
 		ertemplate.enforce_human = prefs["enforce_human"]["value"] == "Yes" ? TRUE : FALSE
 		ertemplate.opendoors = prefs["open_armory"]["value"] == "Yes" ? TRUE : FALSE
+		ertemplate.openmechbay = prefs["open_mechbay"]["value"] == "Yes" ? TRUE : FALSE
 
 		var/list/mob/dead/observer/candidates = pollGhostCandidates("Do you wish to be considered for [ertemplate.polldesc] ?", "deathsquad", null)
 		var/teamSpawned = FALSE
@@ -442,6 +445,15 @@
 			//Open the Armory doors
 			if(ertemplate.opendoors)
 				for(var/obj/machinery/door/poddoor/ert/door in GLOB.airlocks)
+					door.open()
+					CHECK_TICK
+			return TRUE
+		else
+			return FALSE
+			
+			//Open the Mech Bay
+			if(ertemplate.openmechbay)
+				for(var/obj/machinery/door/poddoor/deathsquad/door in GLOB.airlocks)
 					door.open()
 					CHECK_TICK
 			return TRUE

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -288,7 +288,7 @@
 	.["mainsettings"]["mission"]["value"] = newtemplate.mission
 	.["mainsettings"]["polldesc"]["value"] = newtemplate.polldesc
 	.["mainsettings"]["open_armory"]["value"] = newtemplate.opendoors ? "Yes" : "No"
-	.["mainsettings"]["open_mechbay"]["value"] = newtemplate.openmechbay ? "Yes" : "No"
+	.["mainsettings"]["open_mechbay"]["value"] = newtemplate.openmech ? "Yes" : "No"
 
 
 /datum/admins/proc/equipAntagOnDummy(mob/living/carbon/human/dummy/mannequin, datum/antagonist/antag)
@@ -357,7 +357,7 @@
 		"polldesc" = list("desc" = "Ghost poll description", "type" = "string", "value" = ertemplate.polldesc),
 		"enforce_human" = list("desc" = "Enforce human authority", "type" = "boolean", "value" = "[(CONFIG_GET(flag/enforce_human_authority) ? "Yes" : "No")]"),
 		"open_armory" = list("desc" = "Open armory doors", "type" = "boolean", "value" = "[(ertemplate.opendoors ? "Yes" : "No")]"),
-		"open_mechbay" = list("desc" = "Open Mech Bay", "type" = "boolean", "value" = "[(ertemplate.openmechbay ? "Yes" : "No")]"),
+		"open_mechbay" = list("desc" = "Open Mech Bay", "type" = "boolean", "value" = "[(ertemplate.openmech ? "Yes" : "No")]"),
 		)
 	)
 
@@ -381,7 +381,7 @@
 		ertemplate.polldesc = prefs["polldesc"]["value"]
 		ertemplate.enforce_human = prefs["enforce_human"]["value"] == "Yes" ? TRUE : FALSE
 		ertemplate.opendoors = prefs["open_armory"]["value"] == "Yes" ? TRUE : FALSE
-		ertemplate.openmechbay = prefs["open_mechbay"]["value"] == "Yes" ? TRUE : FALSE
+		ertemplate.openmech = prefs["open_mechbay"]["value"] == "Yes" ? TRUE : FALSE
 
 		var/list/mob/dead/observer/candidates = pollGhostCandidates("Do you wish to be considered for [ertemplate.polldesc] ?", "deathsquad", null)
 		var/teamSpawned = FALSE
@@ -447,12 +447,9 @@
 				for(var/obj/machinery/door/poddoor/ert/door in GLOB.airlocks)
 					door.open()
 					CHECK_TICK
-			return TRUE
-		else
-			return FALSE
-			
+
 			//Open the Mech Bay
-			if(ertemplate.openmechbay)
+			if(ertemplate.openmech)
 				for(var/obj/machinery/door/poddoor/deathsquad/door in GLOB.airlocks)
 					door.open()
 					CHECK_TICK

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -288,7 +288,7 @@
 	.["mainsettings"]["mission"]["value"] = newtemplate.mission
 	.["mainsettings"]["polldesc"]["value"] = newtemplate.polldesc
 	.["mainsettings"]["open_armory"]["value"] = newtemplate.opendoors ? "Yes" : "No"
-	.["mainsettings"]["open_mechbay"]["value"] = newtemplate.openmech ? "Yes" : "No"
+	.["mainsettings"]["open_mechbay"]["value"] = newtemplate.openmechbay ? "Yes" : "No"
 
 
 /datum/admins/proc/equipAntagOnDummy(mob/living/carbon/human/dummy/mannequin, datum/antagonist/antag)

--- a/code/modules/security_levels/security_levels.dm
+++ b/code/modules/security_levels/security_levels.dm
@@ -67,6 +67,7 @@ GLOBAL_VAR_INIT(security_level, SEC_LEVEL_GREEN)
 			if(SEC_LEVEL_EPSILON)
 				minor_announce(CONFIG_GET(string/alert_epsilon), "Attention! Epsilon security level reached!", TRUE)
 				SEND_SOUND(world, 'sound/misc/epsilon_alert.ogg')
+				to_chat(world, "<span class='notice'>You get a bad feeling as you hear the Epsilon alert siren.</span>")
 				if(GLOB.security_level < SEC_LEVEL_EPSILON)
 					modTimer = 1
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/39781787/87864286-15d13e80-c92c-11ea-969c-490300c4b133.png)

ERT Mech Bay. Contains 2 seraphs, 2 marauders. Amount can be changed at an admins will by them using the delete button.

By default, the mech bay doors only open to deathsquads. Regular ERT and Task Forces do not have the open door. There is a button in the panel where ERTs are made that allows admins to open the mech bay. They are able to judge when mechs are necessary for a non-deathsquad situation.


#### Changelog

:cl:  
rscadd: Adds ERT Mech Bay
/:cl:
