### PR TITLE
makes tentacle less uselessby giving tentacle grab a very small immobilize so it isnt countered by walking away 2 steps

### DIFF
--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -376,6 +376,7 @@
 
 					if(INTENT_GRAB)
 						C.visible_message("<span class='danger'>[L] is grabbed by [H]'s tentacle!</span>","<span class='userdanger'>A tentacle grabs you and pulls you towards [H]!</span>")
+						C.Immobilize(2) //0.2 seconds of immobilize so the effect probably actually does something
 						C.throw_at(get_step_towards(H,C), 8, 2, H, TRUE, TRUE, callback=CALLBACK(src, .proc/tentacle_grab, H, C))
 						return BULLET_ACT_HIT
 


### PR DESCRIPTION
this costs 2 gamer points and is worse than like everything else you can get
except for like
i dunno hallucinate sting
:cl:
rscadd: changeling tentacle grab effect has a short immobilize so the grab actually goes through
/:cl:
