### PR TITLE
Re-activates the shuttle manipulator

### DIFF
--- a/code/modules/shuttle/manipulator.dm
+++ b/code/modules/shuttle/manipulator.dm
@@ -8,6 +8,7 @@
 
 	icon = 'icons/obj/machines/shuttle_manipulator.dmi'
 	icon_state = "holograph_on"
+	layer = OBJ_LAYER
 
 	density = TRUE
 	

--- a/code/modules/shuttle/manipulator.dm
+++ b/code/modules/shuttle/manipulator.dm
@@ -10,3 +10,12 @@
 	icon_state = "holograph_on"
 
 	density = TRUE
+	
+/obj/machinery/shuttle_manipulator/update_icon()	
+	cut_overlays()	
+	var/mutable_appearance/hologram_projection = mutable_appearance(icon, "hologram_on")	
+	hologram_projection.pixel_y = 22	
+	var/mutable_appearance/hologram_ship = mutable_appearance(icon, "hologram_whiteship")	
+	hologram_ship.pixel_y = 27	
+	add_overlay(hologram_projection)	
+	add_overlay(hologram_ship)


### PR DESCRIPTION
The machine atleast, not the actual SShuttle manipulator.

![image](https://user-images.githubusercontent.com/39781787/87999029-4695ad00-cabf-11ea-9131-01be7a570463.png)

Fixes it cause someone left out the code for the machine icon overlays when they deleted it back in 2019

#### Changelog

:cl:  
tweak: Fixes the shuttle manipulator
/:cl:
