### PR TITLE
Energy harvesting module now goes directly into the cargo account

### DIFF
--- a/code/modules/power/energyharvester.dm
+++ b/code/modules/power/energyharvester.dm
@@ -57,6 +57,6 @@
 			return
 		power_avaliable = min(power_avaliable, drain_rate)
 		attached.add_delayedload(power_avaliable)
-		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_ENG)
+		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 		if(D)
 			D.adjust_money(power_avaliable * 0.000005)


### PR DESCRIPTION

:cl:  Xoxeyos
tweak: Since the engineering budget card now no longer can be found on the station, this routes the cash to cargo.
/:cl:
