### PR TITLE
Removes the gamer spawners from the gamer ruin

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/gameroom.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gameroom.dmm
@@ -676,12 +676,6 @@
 /obj/structure/chair/stool/bar,
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/powered/gaming)
-"Ct" = (
-/obj/effect/mob_spawn/human/gamer{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/ruin/space/has_grav/powered/gaming)
 "CT" = (
 /obj/machinery/vending/autodrobe/all_access,
 /obj/machinery/door/firedoor/border_only{

--- a/_maps/RandomRuins/SpaceRuins/gameroom.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gameroom.dmm
@@ -1345,7 +1345,6 @@ yS
 Ag
 yR
 Ag
-Ct
 wT
 og
 og
@@ -1377,7 +1376,6 @@ yS
 Ag
 Ag
 Ag
-Ct
 wT
 og
 og
@@ -1409,7 +1407,7 @@ yS
 Ag
 Ag
 Ag
-Ct
+
 wT
 og
 og
@@ -1441,7 +1439,6 @@ yS
 Ag
 Ag
 Ag
-Ct
 wT
 og
 og

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -597,26 +597,3 @@
 
 /obj/effect/mob_spawn/human/pirate/gunner
 	rank = "Gunner"
-
-/obj/effect/mob_spawn/human/gamer
-	name = "gamer sleeper"
-	desc = "A humming cryo pod."
-	mob_name = "a gamer"
-	icon = 'icons/obj/machines/sleeper.dmi'
-	icon_state = "sleeper"
-	roundstart = FALSE
-	death = FALSE
-	random = TRUE
-	mob_species = /datum/species/human
-	short_desc = "You are a person who just wants to have fun with their friends."
-	flavour_text = "How did I get here? What is this place? \
-	My last memory is looking around for a place I could rent to play games with my friends. \
-	Trying to leave just pulls me back here, better stay and defend the Snack Vault, if we lose the pizza box, we will probably starve to death. \
-	Seeing as the food supply is limitless and I'm having a great time, I might as well stay and enjoy myself."
-	important_info = "Do not abandon your friends and defend the Snack Vault, you are free to invite guests to play with you."
-	outfit = /datum/outfit/hotelstaff
-	assignedrole = "Gamer"
-
-/obj/effect/mob_spawn/human/gamer/Destroy()
-	new/obj/structure/showcase/machinery/oldpod/used(drop_location())
-	return ..()

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -86,7 +86,7 @@ GLOBAL_LIST_INIT(exp_jobsmap, list(
 GLOBAL_LIST_INIT(exp_specialmap, list(
 	EXP_TYPE_LIVING = list(), // all living mobs
 	EXP_TYPE_ANTAG = list(),
-	EXP_TYPE_SPECIAL = list("Lifebringer","Ash Walker","Exile","Servant Golem","Free Golem","Hermit","Translocated Vet","Escaped Prisoner","Hotel Staff","SuperFriend","Space Syndicate","Ancient Crew","Space Doctor","Space Bartender","Beach Bum","Skeleton","Zombie","Space Bar Patron","Lavaland Syndicate","Ghost Role","Gamer"), // Ghost roles
+	EXP_TYPE_SPECIAL = list("Lifebringer","Ash Walker","Exile","Servant Golem","Free Golem","Hermit","Translocated Vet","Escaped Prisoner","Hotel Staff","SuperFriend","Space Syndicate","Ancient Crew","Space Doctor","Space Bartender","Beach Bum","Skeleton","Zombie","Space Bar Patron","Lavaland Syndicate","Ghost Role"), // Ghost roles
 	EXP_TYPE_GHOST = list() // dead people, observers
 ))
 GLOBAL_PROTECT(exp_jobsmap)


### PR DESCRIPTION
## Intent of your Pull Request

The gamer ruin is a ruin for being chill and relaxing in. People who are ghosts do not want to chill or relax, and tend to either use the teleporter setup to steal shit, suicide, or act antagonistically for no reason

this is furthered by the "protect the snack vault at all costs" objective, which may lead to the idea gamers can kill or maim people who enter the gamer ruin on account of "they might steal the snack vault"

#### Changelog

:cl:  
rscdel: Gamer spawners are removed from the gamer ruin. You know what you did.
/:cl:
