### PR TITLE
fix monastary pod exterior shuttle controls

### DIFF
--- a/code/modules/shuttle/monastery.dm
+++ b/code/modules/shuttle/monastery.dm
@@ -2,6 +2,6 @@
 	name = "monastery shuttle console"
 	desc = "Used to control the monastery shuttle."
 	circuit = /obj/item/circuitboard/computer/monastery_shuttle
-	shuttleId = "pod1"
+	shuttleId = "pod"
 	possible_destinations = "monastery_shuttle_asteroid;monastery_shuttle_station"
 	no_destination_swap = TRUE


### PR DESCRIPTION
these are set to pod1 but the shuttle id is pod
podders
:cl:  
bugfix: monastery shuttle now can be called from the consoles at each docking point as intended
/:cl:
