### PR TITLE
Allows plants to be renamed and makes hydroponic trays show the plant's name

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -362,7 +362,7 @@
 	pestlevel = 0 // Reset
 	update_icon()
 	visible_message("<span class='warning'>The [oldPlantName] is overtaken by some [myseed.plantname]!</span>")
-
+	update_name()
 
 /obj/machinery/hydroponics/proc/mutate(lifemut = 2, endmut = 5, productmut = 1, yieldmut = 2, potmut = 25, wrmut = 2, wcmut = 5, traitmut = 0) // Mutates the current seed
 	if(!myseed)
@@ -396,7 +396,7 @@
 	sleep(5) // Wait a while
 	update_icon()
 	visible_message("<span class='warning'>[oldPlantName] suddenly mutates into [myseed.plantname]!</span>")
-
+	update_name()
 
 /obj/machinery/hydroponics/proc/mutateweed() // If the weeds gets the mutagent instead. Mind you, this pretty much destroys the old plant
 	if( weedlevel > 5 )
@@ -416,9 +416,9 @@
 		sleep(5) // Wait a while
 		update_icon()
 		visible_message("<span class='warning'>The mutated weeds in [src] spawn some [myseed.plantname]!</span>")
+		update_name()
 	else
 		to_chat(usr, "<span class='warning'>The few weeds in [src] seem to react, but only for a moment...</span>")
-
 
 /obj/machinery/hydroponics/proc/plantdies() // OH NOES!!!!! I put this all in one function to make things easier
 	plant_health = 0
@@ -760,6 +760,7 @@
 			to_chat(user, "<span class='notice'>You plant [O].</span>")
 			dead = 0
 			myseed = O
+			update_name()
 			age = 1
 			plant_health = myseed.endurance
 			lastcycle = world.time
@@ -826,6 +827,7 @@
 					harvest = FALSE //To make sure they can't just put in another seed and insta-harvest it
 				qdel(myseed)
 				myseed = null
+				update_name()
 			weedlevel = 0 //Has a side effect of cleaning up those nasty weeds
 			update_icon()
 
@@ -857,6 +859,7 @@
 		to_chat(user, "<span class='notice'>You remove the dead plant from [src].</span>")
 		qdel(myseed)
 		myseed = null
+		update_name()
 		update_icon()
 	else
 		if(user)
@@ -874,6 +877,7 @@
 	if(!myseed.get_gene(/datum/plant_gene/trait/repeated_harvest))
 		qdel(myseed)
 		myseed = null
+		update_name()
 		dead = 0
 	update_icon()
 
@@ -910,6 +914,12 @@
 	visible_message("<span class='boldnotice'>[src] begins to glow with a beautiful light!</span>")
 	self_sustaining = TRUE
 	update_icon()
+
+/obj/machinery/hydroponics/proc/update_name()
+	if(myseed)
+		name = "[initial(name)] ([myseed.plantname])"
+	else
+		name = initial(name)
 
 ///////////////////////////////////////////////////////////////////////////////
 /obj/machinery/hydroponics/soil //Not actually hydroponics at all! Honk!

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -8,6 +8,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
 	var/plantname = "Plants"		// Name of plant when planted.
+	var/plantdesc					// Description of plant when planted
 	var/product						// A type path. The thing that is created when the plant is harvested.
 	var/species = ""				// Used to update icons. Should match the name in the sprites unless all icon_* are overridden.
 
@@ -79,6 +80,10 @@
 	S.potency = potency
 	S.weed_rate = weed_rate
 	S.weed_chance = weed_chance
+	S.name = name
+	S.plantname = plantname
+	S.desc = desc
+	S.plantdesc = plantdesc
 	S.genes = list()
 	for(var/g in genes)
 		var/datum/plant_gene/G = g
@@ -144,11 +149,19 @@
 	var/product_name
 	while(t_amount < getYield())
 		var/obj/item/reagent_containers/food/snacks/grown/t_prod = new product(output_loc, src)
+		if(parent.myseed.plantname != initial(parent.myseed.plantname))
+			t_prod.name = parent.myseed.plantname
+		if(parent.myseed.plantdesc)
+			t_prod.desc = parent.myseed.plantdesc
+		t_prod.seed.name = parent.myseed.name
+		t_prod.seed.desc = parent.myseed.desc
+		t_prod.seed.plantname = parent.myseed.plantname
+		t_prod.seed.plantdesc = parent.myseed.plantdesc
 		result.Add(t_prod) // User gets a consumable
 		if(!t_prod)
 			return
 		t_amount++
-		product_name = t_prod.name
+		product_name = t_prod.seed.plantname
 	if(getYield() >= 1)
 		SSblackbox.record_feedback("tally", "food_harvested", getYield(), product_name)
 	parent.update_tray(user)
@@ -320,6 +333,30 @@
 			to_chat(user, "<span class='notice'>[text]</span>")
 
 		return
+
+	if (istype(O, /obj/item/pen))
+		var/penchoice = input(user, "What would you like to edit?") as null|anything in list("Plant Name","Plant Description","Seed Description")
+		if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
+			return
+
+		if(penchoice == "Plant Name")
+			var/input = stripped_input(user,"What do you want to name the plant?", ,"", MAX_NAME_LEN)
+			if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
+				return
+			name = "pack of [input] seeds"
+			plantname = input
+
+		if(penchoice == "Plant Description")
+			var/input = stripped_input(user,"What do you want to change the description of \the plant to?", ,"", MAX_NAME_LEN)
+			if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
+				return
+			plantdesc = input
+
+		if(penchoice == "Seed Description")
+			var/input = stripped_input(user,"What do you want to change the description of \the seeds to?", ,"", MAX_NAME_LEN)
+			if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
+				return
+			desc = input
 	..() // Fallthrough to item/attackby() so that bags can pick seeds up
 
 


### PR DESCRIPTION
A botany QoL feature from Bee that I didn't think about until now.

Pretty much a port of [#1139](https://github.com/BeeStation/BeeStation-Hornet/pull/1139) from BeeStation, since there isn't much more to it. It leaves out the sugar canes being available from vendors, however, since I don't think that's particularly necessary.

#### Changelog

:cl:  
rscadd: You can now rename and change the description of plants with a pen.
rscadd: Hydroponic trays show the name of the plant in them.
/:cl:
