### PR TITLE
Fixes incinerator airlock cycling on all maps

### DIFF
--- a/_maps/map_files/EclipseStation/EclipseStation.dmm
+++ b/_maps/map_files/EclipseStation/EclipseStation.dmm
@@ -61647,12 +61647,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
-"cuG" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/meson,
-/obj/item/poster/neverforget,
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "cuH" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -61789,22 +61783,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
-"cuU" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
-"cuV" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
-"cuW" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "cuZ" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -61838,13 +61816,6 @@
 	},
 /turf/open/floor/plating,
 /area/tcommsat/entrance)
-"cvc" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
 "cvd" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -62102,13 +62073,6 @@
 	icon_state = "white"
 	},
 /area/crew_quarters/heads/hor)
-"cvB" = (
-/obj/machinery/door/poddoor{
-	id = "burnvent";
-	name = "Burn Chamber Vent"
-	},
-/turf/open/floor/engine/vacuum,
-/area/engine/atmos_distro)
 "cvC" = (
 /obj/structure/cable{
 	icon_state = "4-8";
@@ -62143,59 +62107,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"cvE" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Burn Chamber";
-	network = list("turbine")
-	},
-/turf/open/floor/engine/vacuum,
-/area/engine/atmos_distro)
-"cvF" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
-"cvG" = (
-/obj/machinery/doorButtons/access_button{
-	idDoor = "incinerator_airlock_exterior";
-	idSelf = "incinerator_access_control";
-	name = "Incinerator airlock control";
-	pixel_x = 24;
-	pixel_y = -8
-	},
-/obj/structure/sign/warning/fire{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/atmos_distro)
-"cvH" = (
-/obj/machinery/doorButtons/airlock_controller{
-	idExterior = "incinerator_airlock_exterior";
-	idInterior = "incinerator_airlock_interior";
-	idSelf = "incinerator_access_control";
-	name = "Incinerator Access Console";
-	pixel_x = -24;
-	pixel_y = -6;
-	req_one_access_txt = "12"
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Burn Injector"
-	},
-/obj/machinery/button/ignition{
-	id = "Incinerator";
-	pixel_x = -24;
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "cvI" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/machinery/meter,
@@ -62208,13 +62119,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/medical/paramedic/a)
-"cvK" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "cvL" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -62321,13 +62225,6 @@
 	},
 /turf/open/space/basic,
 /area/engine/atmos_distro)
-"cvT" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "cvU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -62341,46 +62238,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
-"cvV" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Lab to Burn"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
-"cvW" = (
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
-"cvX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "cvY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -64109,24 +63966,10 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/science/mixing)
-"czm" = (
-/obj/machinery/door/airlock/public/glass/incinerator/atmos_interior{
-	id_tag = "incinerator_airlock_interior";
-	name = "Incinerator Interior Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/atmos_distro)
 "czn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"czo" = (
-/turf/open/floor/engine,
-/area/engine/atmos_distro)
 "czp" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -64243,21 +64086,6 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"czA" = (
-/obj/machinery/door/airlock/public/glass{
-	autoclose = 0;
-	frequency = 1449;
-	heat_proof = 1;
-	id_tag = "incinerator_airlock_exterior";
-	name = "Incinerator Exterior Airlock";
-	req_access_txt = "32"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/atmos_distro)
 "czB" = (
 /obj/structure/cable{
 	icon_state = "1-2";
@@ -64272,12 +64100,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"czD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "czE" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -64288,19 +64110,6 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/engine,
 /area/science/mixing)
-"czG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
-"czH" = (
-/obj/machinery/atmospherics/pipe/simple/brown/visible{
-	dir = 6
-	},
-/mob/living/simple_animal/mouse,
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "czI" = (
 /obj/machinery/airlock_sensor{
 	id_tag = "tox_airlock_sensor";
@@ -64387,14 +64196,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"czS" = (
-/obj/machinery/atmospherics/pipe/simple/brown/visible{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "czT" = (
 /obj/structure/transit_tube/diagonal{
 	dir = 4
@@ -64405,13 +64206,6 @@
 /obj/structure/transit_tube/diagonal,
 /turf/open/space/basic,
 /area/space/nearstation)
-"czV" = (
-/obj/machinery/atmospherics/pipe/simple/brown/visible{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "czW" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced/shutter,
@@ -64431,13 +64225,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"czZ" = (
-/obj/machinery/atmospherics/pipe/simple/brown/visible{
-	dir = 8
-	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "cAa" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -64445,13 +64232,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/tcoms)
-"cAb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/brown/visible{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
 "cAc" = (
 /obj/structure/table/reinforced,
 /obj/item/extinguisher{
@@ -64734,33 +64514,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos_distro)
-"cAJ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/sparker{
-	id = "Incinerator";
-	pixel_x = 25
-	},
-/turf/open/floor/engine/vacuum,
-/area/engine/atmos_distro)
-"cAK" = (
-/obj/machinery/doorButtons/access_button{
-	idDoor = "incinerator_airlock_interior";
-	idSelf = "incinerator_access_control";
-	layer = 3.1;
-	name = "Incinerator airlock control";
-	pixel_x = -22;
-	pixel_y = 8
-	},
-/obj/structure/sign/warning/fire{
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/atmos_distro)
 "cAL" = (
 /obj/structure/transit_tube/junction,
 /turf/open/space/basic,
@@ -64870,20 +64623,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"cAV" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
-/obj/machinery/meter,
-/obj/machinery/button/door{
-	id = "burnvent";
-	name = "Burn Chamber Vent Control";
-	pixel_x = -25;
-	pixel_y = 8;
-	req_access_txt = "12"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "cAW" = (
 /obj/item/wrench,
 /obj/machinery/door/poddoor/preopen{
@@ -64969,33 +64708,10 @@
 /obj/structure/transit_tube,
 /turf/open/space/basic,
 /area/space/nearstation)
-"cBf" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Cooling Loop Bypass"
-	},
-/obj/machinery/computer/security/telescreen/turbine{
-	dir = 1;
-	icon_state = "telescreen";
-	name = "burn chamber monitor";
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
-"cBg" = (
-/obj/machinery/atmospherics/pipe/manifold/brown/visible{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "cBh" = (
 /obj/structure/tank_dispenser,
 /turf/open/floor/plating,
 /area/science/mixing)
-"cBi" = (
-/obj/machinery/atmospherics/pipe/manifold4w/brown/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "cBj" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 4
@@ -65004,15 +64720,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"cBl" = (
-/obj/machinery/atmospherics/pipe/simple/brown/visible{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Lab to Mix"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "cBm" = (
 /obj/structure/sign/directions/command{
 	dir = 1;
@@ -65028,13 +64735,6 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"cBn" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Lab to Reactor"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "cBo" = (
 /obj/structure/cable{
 	icon_state = "4-8";
@@ -65246,29 +64946,6 @@
 	},
 /turf/open/floor/plating,
 /area/solar/starboard/aft)
-"cBG" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Burn to Loop"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
-"cBH" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Loop to Lab"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
-"cBI" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Mix to Lab"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "cBJ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -65340,12 +65017,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"cBR" = (
-/obj/machinery/computer/atmos_control/tank/mix_tank{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "cBS" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -65616,11 +65287,6 @@
 /obj/machinery/light,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"cCu" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/machinery/meter,
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "cCv" = (
 /obj/structure/cable{
 	icon_state = "4-8";
@@ -65786,16 +65452,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
-"cCL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction,
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
-"cCM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
 "cCN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
@@ -82887,6 +82543,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"dMT" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "dOn" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -82975,6 +82634,13 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/teleporter/hub/security)
+"dWC" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Lab to Reactor"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "dYX" = (
 /turf/closed/wall,
 /area/solar/port/aft)
@@ -83146,6 +82812,16 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"eLj" = (
+/obj/structure/table,
+/obj/item/clothing/glasses/meson,
+/obj/item/poster/neverforget,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "eMp" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -83387,6 +83063,21 @@
 /obj/structure/table,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"fwY" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/disposal/incinerator";
+	dir = 1;
+	name = "Incinerator APC";
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "fxg" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/red,
@@ -83405,6 +83096,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"fyU" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction,
+/turf/open/floor/plating,
+/area/maintenance/disposal/incinerator)
 "fzE" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -83534,6 +83230,12 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/wood,
 /area/maintenance/department/chapel)
+"fNO" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "fOs" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -83606,6 +83308,16 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/department/security)
+"fYR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/sparker{
+	id = "Incinerator";
+	pixel_x = 25
+	},
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "gat" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/effect/turf_decal/tile/brown{
@@ -83694,6 +83406,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"glx" = (
+/obj/machinery/door/poddoor{
+	id = "burnvent";
+	name = "Burn Chamber Vent"
+	},
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "gnG" = (
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -83844,6 +83563,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"gLS" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "gOy" = (
 /turf/closed/wall,
 /area/solar/port/fore)
@@ -83886,6 +83611,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"gUB" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "gVp" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -83950,6 +83680,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/ai_monitored/storage/eva)
+"hap" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal/incinerator)
 "haX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -84080,6 +83817,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"htF" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics Burn Chamber";
+	network = list("turbine")
+	},
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "hwX" = (
 /obj/machinery/requests_console{
 	department = "Science";
@@ -84154,6 +83901,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/teleporter/hub/science)
+"hGo" = (
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "hJa" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -84265,6 +84015,20 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"hRG" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Lab to Burn"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4";
+	tag = ""
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "hTd" = (
 /obj/structure/easel,
 /turf/open/floor/plasteel,
@@ -84287,6 +84051,13 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
+"hVV" = (
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "hWN" = (
 /obj/machinery/vending/assist,
 /turf/open/floor/plasteel,
@@ -84487,6 +84258,20 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"isy" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/item/radio/intercom{
+	freerange = 1;
+	name = "Common Channel";
+	pixel_x = 5;
+	pixel_y = 28
+	},
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "iuP" = (
 /obj/structure/headpike,
 /turf/open/floor/plating,
@@ -84576,6 +84361,15 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"iKI" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Burn to Loop"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "iKX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
@@ -84813,6 +84607,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms/b)
+"jsp" = (
+/obj/machinery/doorButtons/airlock_controller{
+	idExterior = "incinerator_airlock_exterior";
+	idInterior = "incinerator_airlock_interior";
+	idSelf = "incinerator_access_control";
+	name = "Incinerator Access Console";
+	pixel_x = -24;
+	pixel_y = -6;
+	req_one_access_txt = "12"
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Burn Injector"
+	},
+/obj/machinery/button/ignition{
+	id = "Incinerator";
+	pixel_x = -24;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "jEo" = (
 /obj/effect/turf_decal/tile/white{
 	dir = 1
@@ -85079,6 +84894,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"kBu" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plating,
+/area/maintenance/disposal/incinerator)
+"kCQ" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "kDF" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -85096,6 +84920,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"kEU" = (
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
+	dir = 8
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "kEV" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -85158,20 +84989,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/teleporter/hub/bridge)
-"kKR" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/item/radio/intercom{
-	freerange = 1;
-	name = "Common Channel";
-	pixel_x = 5;
-	pixel_y = 28
-	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#c1caff"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "kKT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -85184,6 +85001,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"kPz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "kQN" = (
 /obj/structure/cable{
 	icon_state = "4-8";
@@ -85418,6 +85251,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
+"lCt" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "lCE" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -85497,6 +85335,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"lKV" = (
+/obj/machinery/doorButtons/access_button{
+	idDoor = "incinerator_airlock_interior";
+	idSelf = "incinerator_access_control";
+	layer = 3.1;
+	name = "Incinerator airlock control";
+	pixel_x = -22;
+	pixel_y = 8
+	},
+/obj/structure/sign/warning/fire{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "lOl" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -85638,6 +85493,13 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"mgB" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Loop to Lab"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "mhL" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/light{
@@ -85748,6 +85610,12 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"muC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "mwK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/chair{
@@ -85797,6 +85665,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"mKh" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "mLx" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/costume,
@@ -85997,6 +85872,12 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"nnn" = (
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "noz" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -86502,6 +86383,13 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"oUd" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "oUw" = (
 /obj/structure/sign/departments/minsky/medical/chemistry/chemical2,
 /turf/closed/wall,
@@ -86668,6 +86556,17 @@
 /obj/effect/spawner/lootdrop/gloves,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"plG" = (
+/obj/machinery/door/airlock/public/glass/incinerator/atmos_interior{
+	id_tag = "incinerator_airlock_interior";
+	name = "Incinerator Interior Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "pnk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/machinery/firealarm{
@@ -86759,6 +86658,19 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"pAS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "pCt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/layer3,
@@ -86862,6 +86774,13 @@
 /obj/effect/spawner/lootdrop/costume,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"qfL" = (
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
+"qgH" = (
+/obj/machinery/atmospherics/pipe/manifold4w/brown/visible,
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "qhE" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/camera{
@@ -87051,6 +86970,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"qUj" = (
+/obj/machinery/computer/atmos_control/tank/mix_tank{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "qUT" = (
 /obj/structure/rack,
 /obj/machinery/light/small{
@@ -87058,6 +86983,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"qWa" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
+/obj/machinery/meter,
+/obj/machinery/button/door{
+	id = "burnvent";
+	name = "Burn Chamber Vent Control";
+	pixel_x = -25;
+	pixel_y = 8;
+	req_access_txt = "12"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "qXo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -87103,6 +87042,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"reg" = (
+/obj/machinery/atmospherics/pipe/manifold/brown/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "rev" = (
 /obj/effect/turf_decal/tile/white{
 	dir = 8;
@@ -87330,6 +87275,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"rBL" = (
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Lab to Mix"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "rFP" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/light{
@@ -87417,6 +87371,13 @@
 /obj/item/stack/sheet/glass,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"scm" = (
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
+	dir = 6
+	},
+/mob/living/simple_animal/mouse,
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "scF" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
@@ -87569,6 +87530,12 @@
 	icon_state = "white"
 	},
 /area/science/explab)
+"swJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "szL" = (
 /obj/structure/light_construct/small,
 /turf/open/floor/wood,
@@ -87678,6 +87645,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"sTv" = (
+/obj/structure/table,
+/obj/machinery/camera{
+	c_tag = "Atmospherics Lab";
+	dir = 1;
+	network = list("ss13","Eng")
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "sVa" = (
 /obj/item/radio/intercom{
 	freerange = 1;
@@ -87792,6 +87768,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"tmo" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "tnL" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
@@ -87815,6 +87798,21 @@
 /obj/structure/table,
 /turf/open/floor/plating,
 /area/vacant_room)
+"trU" = (
+/obj/machinery/door/airlock/public/glass{
+	autoclose = 0;
+	frequency = 1449;
+	heat_proof = 1;
+	id_tag = "incinerator_airlock_exterior";
+	name = "Incinerator Exterior Airlock";
+	req_access_txt = "32"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "tsE" = (
 /obj/machinery/button/door{
 	id = "commissarydoor";
@@ -88286,6 +88284,22 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/hallway/primary/fore)
+"uIP" = (
+/obj/machinery/doorButtons/access_button{
+	idDoor = "incinerator_airlock_exterior";
+	idSelf = "incinerator_access_control";
+	name = "Incinerator airlock control";
+	pixel_x = 24;
+	pixel_y = -8
+	},
+/obj/structure/sign/warning/fire{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "uJo" = (
 /obj/effect/turf_decal/tile/white{
 	dir = 8;
@@ -88394,6 +88408,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"uZB" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "vat" = (
 /obj/effect/turf_decal/tile/white,
 /obj/effect/turf_decal/tile/red{
@@ -88575,11 +88596,25 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"vxY" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Mix to Lab"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "vAt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/security/processing)
+"vCX" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal/incinerator)
 "vFg" = (
 /obj/machinery/camera{
 	c_tag = "Port Hall East 7";
@@ -88609,13 +88644,6 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
-"vKx" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "vLm" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -88895,6 +88923,12 @@
 "wud" = (
 /turf/closed/wall,
 /area/science/test_area)
+"wuF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "wvB" = (
 /obj/structure/cable{
 	icon_state = "4-8";
@@ -88931,15 +88965,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/teleporter/hub/bridge)
-"wyi" = (
-/obj/structure/table,
-/obj/machinery/camera{
-	c_tag = "Atmospherics Lab";
+"wyg" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Cooling Loop Bypass"
+	},
+/obj/machinery/computer/security/telescreen/turbine{
 	dir = 1;
-	network = list("ss13","Eng")
+	icon_state = "telescreen";
+	name = "burn chamber monitor";
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/maintenance/disposal/incinerator)
 "wBc" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -89072,6 +89110,19 @@
 "wWS" = (
 /turf/closed/wall,
 /area/solar/starboard/aft)
+"wWU" = (
+/obj/machinery/atmospherics/pipe/manifold/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "wXx" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
@@ -89093,6 +89144,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"xcw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/disposal/incinerator)
 "xfI" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -89263,6 +89318,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"xOk" = (
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "xUN" = (
 /obj/structure/rack,
 /obj/machinery/light/small,
@@ -89291,6 +89354,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"xZN" = (
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "yai" = (
 /obj/item/radio/intercom{
 	freerange = 1;
@@ -89349,6 +89415,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"yeg" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "yiF" = (
 /obj/structure/easel,
 /obj/machinery/firealarm{
@@ -138653,11 +138725,11 @@ cqM
 csR
 csR
 aaa
-bRo
-cvB
-cvB
-cvB
-bRo
+dMT
+glx
+glx
+glx
+dMT
 aaa
 csR
 csR
@@ -138910,11 +138982,11 @@ cqM
 csR
 csR
 aaa
-bRo
-cvE
-czi
-cAJ
-bRo
+dMT
+htF
+hGo
+fYR
+dMT
 aaa
 csR
 csR
@@ -139167,11 +139239,11 @@ cfu
 csR
 csR
 aaa
-bRo
-cvF
-czm
-cvF
-bRo
+dMT
+yeg
+plG
+yeg
+dMT
 aaa
 csR
 csR
@@ -139424,11 +139496,11 @@ chi
 chk
 csR
 aaa
-bRo
-cvG
-czo
-cAK
-bRo
+dMT
+uIP
+xZN
+lKV
+dMT
 aaa
 aaa
 csR
@@ -139680,13 +139752,13 @@ bRo
 bRo
 chl
 csR
-bRo
-bRo
-cvF
-czA
-cvF
-bRo
-bRo
+dMT
+dMT
+yeg
+trU
+yeg
+dMT
+dMT
 aaa
 csR
 csR
@@ -139937,13 +140009,13 @@ ciJ
 bRo
 chl
 csR
-bRo
-cuG
-cvH
-bTg
-cAV
-cBG
-cCL
+dMT
+eLj
+jsp
+qfL
+qWa
+iKI
+fyU
 bXu
 bYy
 bXu
@@ -140194,13 +140266,13 @@ coh
 bRo
 chl
 cuF
-bRo
-cuU
-cvI
-czD
-cBf
-wyi
-bRo
+dMT
+kCQ
+lCt
+wuF
+wyg
+sTv
+dMT
 bXz
 bYz
 bXz
@@ -140451,13 +140523,13 @@ bUw
 chj
 chm
 bSH
-bRo
-cuU
-cvK
-czG
-cBg
-cBH
-cCL
+dMT
+kCQ
+tmo
+swJ
+reg
+mgB
+fyU
 bXu
 bKs
 bKs
@@ -140708,13 +140780,13 @@ cov
 bRo
 cqM
 iUv
-bRo
-kKR
-cvT
-czH
-cBi
-cBI
-cCM
+dMT
+isy
+mKh
+scm
+qgH
+vxY
+kBu
 bXP
 cEm
 cFz
@@ -140966,12 +141038,12 @@ bRo
 ccP
 ceC
 cuA
-cuV
-cvV
-czR
-czR
-cBR
-bPG
+fNO
+hRG
+nnn
+nnn
+qUj
+xcw
 bXR
 bPG
 cFI
@@ -141222,13 +141294,13 @@ bRo
 bRo
 bRo
 bRo
-bRo
-cuW
-cvW
-czS
-cBl
-cCu
-cCM
+dMT
+gLS
+wWU
+xOk
+rBL
+gUB
+kBu
 bXP
 cEm
 cFR
@@ -141479,13 +141551,13 @@ coV
 cqV
 csS
 cty
-bRo
-bWp
-cvX
-czV
-czV
-bZn
-bRo
+dMT
+fwY
+kPz
+hVV
+hVV
+muC
+dMT
 bXR
 bKs
 bKs
@@ -141736,13 +141808,13 @@ bUv
 bUv
 bUv
 ctz
-bRo
-bZt
-cvY
-czZ
-cBn
-vKx
-bRo
+dMT
+uZB
+pAS
+kEU
+dWC
+oUd
+dMT
 bXz
 bYB
 bYB
@@ -141993,12 +142065,12 @@ ceo
 cre
 csT
 ctC
-bRo
-cvc
+dMT
+hap
 cvZ
-cAb
-cAb
-bRo
+vCX
+vCX
+dMT
 cBE
 cBE
 cBE

--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -14619,30 +14619,6 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/starboard)
-"avx" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "avy" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -34763,25 +34739,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"bcz" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "bcA" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -34904,55 +34861,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port)
-"bcP" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"bcQ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4;
-	level = 2
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "bcR" = (
 /obj/structure/table/wood,
 /obj/item/instrument/guitar,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"bcS" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "bcT" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -38629,13 +38543,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/server)
-"bYE" = (
-/obj/structure/sign/warning/fire,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "bYO" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -38682,6 +38589,24 @@
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
 	},
+/area/engine/atmos)
+"ceo" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "cfz" = (
 /obj/machinery/hydroponics/constructable,
@@ -38764,6 +38689,13 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
+"csn" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "ctH" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/cable/white{
@@ -38919,6 +38851,30 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
+"cWP" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "cWT" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -39066,13 +39022,6 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"dMl" = (
-/obj/structure/sign/warning/fire,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "dNl" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
@@ -39148,6 +39097,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"enY" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "eoY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -39191,14 +39146,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"eyu" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
-	},
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/engine,
-/area/maintenance/disposal/incinerator)
 "ezi" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -39406,18 +39353,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"fsJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume{
-	dir = 2;
-	frequency = 1449;
-	id = "incinerator_airlock_pump"
-	},
-/turf/open/floor/engine,
-/area/maintenance/disposal/incinerator)
 "fuM" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -39509,6 +39444,43 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"fGI" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/disposal/incinerator";
+	dir = 8;
+	name = "Incinerator APC";
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/engine/atmos)
+"fHb" = (
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/public/glass{
+	autoclose = 0;
+	frequency = 1449;
+	heat_proof = 1;
+	id_tag = "incinerator_airlock_interior";
+	name = "Incinerator Interior Airlock";
+	req_access_txt = "12"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "fHT" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/nanite_program_hub,
@@ -39632,12 +39604,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"gdA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "ggq" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -39706,6 +39672,13 @@
 /area/engine/engineering)
 "goT" = (
 /obj/effect/landmark/start/chief_engineer,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"grd" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "gtP" = (
@@ -39802,26 +39775,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"gSv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "gUn" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -40035,13 +39988,6 @@
 	},
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
-"hUG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "hUL" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
@@ -40053,6 +39999,9 @@
 /obj/machinery/nanite_chamber,
 /turf/open/floor/plasteel/dark,
 /area/science/research)
+"hWZ" = (
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "hXn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -40113,13 +40062,6 @@
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
-"ixk" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "iye" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/incinerator_output{
 	dir = 4
@@ -40187,16 +40129,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"iKp" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/meter/atmos,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "iTc" = (
 /obj/structure/tank_dispenser,
 /obj/structure/sign/directions/engineering{
@@ -40260,13 +40192,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"jkl" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "jnK" = (
 /obj/machinery/light_switch{
 	pixel_y = 24
@@ -40317,13 +40242,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"jtZ" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "juT" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -40344,6 +40262,13 @@
 	},
 /turf/closed/wall,
 /area/hallway/primary/fore)
+"jxk" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/structure/sign/warning/fire,
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "jBp" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
@@ -40376,6 +40301,12 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"jQJ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "kaA" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -40503,6 +40434,20 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"kBW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/checker,
+/area/engine/atmos)
 "kCU" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -40571,6 +40516,15 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"kYe" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "kZa" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -40668,6 +40622,20 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"llz" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/meter/atmos,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/engine/atmos)
 "lqz" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -40700,17 +40668,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/hallway/secondary/entry)
-"lvw" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/meter/atmos,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
-/area/engine/atmos)
 "lAs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom{
@@ -40747,10 +40704,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"lFw" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
-/turf/open/floor/plating/asteroid/airless,
-/area/asteroid/nearstation)
 "lHG" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -40992,19 +40945,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"mJP" = (
-/obj/machinery/igniter{
-	id = "Incinerator"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/air_sensor/atmos/incinerator_tank{
-	pixel_x = -32;
-	pixel_y = 32
-	},
-/turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
 "mKa" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -41083,6 +41023,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"mZd" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "mZw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
@@ -41150,12 +41099,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
-"nhU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "niM" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line,
@@ -41236,6 +41179,24 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"nKh" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "nTi" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall,
@@ -41250,6 +41211,35 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/corner,
+/area/engine/atmos)
+"nVI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/doorButtons/airlock_controller{
+	idExterior = "incinerator_airlock_exterior";
+	idInterior = "incinerator_airlock_interior";
+	idSelf = "incinerator_access_control";
+	name = "Incinerator Access Console";
+	pixel_x = -24;
+	pixel_y = 25;
+	req_one_access_txt = "12"
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "nZf" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -41464,13 +41454,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"oJp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "oOk" = (
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
@@ -41602,26 +41585,6 @@
 /obj/structure/cable/white,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"pvX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/disposal/incinerator";
-	dir = 8;
-	name = "Incinerator APC";
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/checker,
-/area/engine/atmos)
 "pyf" = (
 /obj/structure/girder,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
@@ -41695,6 +41658,16 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"pUN" = (
+/obj/effect/decal/cleanable/oil,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "pUR" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = -32
@@ -41761,6 +41734,19 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
+"qkT" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname{
+	dir = 2
+	},
+/turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "qlf" = (
 /obj/structure/chair/comfy/brown{
@@ -41896,6 +41882,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"qWq" = (
+/obj/structure/sign/warning/fire,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "rae" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -41929,25 +41919,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"rjV" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/airlock_sensor{
-	id_tag = "incinerator_airlock_sensor";
-	master_tag = "incinerator_airlock_control";
-	pixel_y = 24
-	},
-/obj/machinery/camera/autoname{
-	dir = 2
-	},
-/turf/open/floor/engine,
-/area/maintenance/disposal/incinerator)
 "rnq" = (
 /obj/structure/table/reinforced,
 /obj/structure/sign/warning/nosmoking{
@@ -42006,6 +41977,15 @@
 	},
 /turf/open/floor/plating/airless,
 /area/asteroid/nearstation)
+"rTY" = (
+/obj/machinery/igniter{
+	id = "Incinerator"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "rVj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/atmos/air_output{
 	dir = 1
@@ -44100,6 +44080,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"tcm" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/meter/atmos,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "tcp" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -44261,14 +44254,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"ueC" = (
-/obj/effect/decal/cleanable/oil,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "ueG" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 6
@@ -44398,10 +44383,6 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/crew_quarters/lounge)
-"uvg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "uvO" = (
 /obj/machinery/vr_sleeper,
 /obj/effect/turf_decal/tile/red{
@@ -44470,9 +44451,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical)
-"uVJ" = (
+"vcG" = (
 /obj/effect/decal/cleanable/oil,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -44644,12 +44625,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"vuN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "vCw" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -44667,6 +44642,13 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/dorms)
+"vIK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "vJk" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -44773,10 +44755,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"wkG" = (
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "wkO" = (
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -44851,6 +44829,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"wwL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "wxr" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -44887,6 +44874,13 @@
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
 /area/crew_quarters/dorms)
+"wLu" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
+/obj/machinery/light/small,
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "wOJ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -26
@@ -44988,59 +44982,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"xrf" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
-/area/engine/atmos)
-"xtL" = (
-/obj/machinery/button/ignition{
-	id = "Incinerator";
-	pixel_x = 8;
-	pixel_y = -36
-	},
-/obj/machinery/button/door{
-	id = "turbinevent";
-	name = "Turbine Vent Control";
-	pixel_x = -8;
-	pixel_y = -36;
-	req_access_txt = "12"
-	},
-/obj/machinery/button/door{
-	id = "auxincineratorvent";
-	name = "Auxiliary Vent Control";
-	pixel_x = -8;
-	pixel_y = -24;
-	req_access_txt = "12"
-	},
-/obj/machinery/computer/turbine_computer{
-	dir = 1;
-	id = "incineratorturbine"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/checker,
-/area/maintenance/disposal/incinerator)
 "xwu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -45134,6 +45075,43 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"xKP" = (
+/obj/machinery/button/ignition{
+	id = "Incinerator";
+	pixel_x = 8;
+	pixel_y = -36
+	},
+/obj/machinery/button/door{
+	id = "turbinevent";
+	name = "Turbine Vent Control";
+	pixel_x = -8;
+	pixel_y = -36;
+	req_access_txt = "12"
+	},
+/obj/machinery/button/door{
+	id = "auxincineratorvent";
+	name = "Auxiliary Vent Control";
+	pixel_x = -8;
+	pixel_y = -24;
+	req_access_txt = "12"
+	},
+/obj/machinery/computer/turbine_computer{
+	dir = 1;
+	id = "incineratorturbine"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/checker,
+/area/maintenance/disposal/incinerator)
 "xLm" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -45152,33 +45130,25 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"xZO" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/public/glass{
-	autoclose = 0;
-	frequency = 1449;
-	heat_proof = 1;
-	id_tag = "incinerator_airlock_interior";
-	name = "Incinerator Interior Airlock";
-	req_access_txt = "12"
-	},
+"yam" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/doorButtons/access_button{
+	idDoor = "incinerator_airlock_exterior";
+	idSelf = "incinerator_access_control";
+	name = "Incinerator airlock control";
+	pixel_x = 24;
+	pixel_y = 24
 	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	airpump_tag = "incinerator_airlock_pump";
-	exterior_door_tag = "incinerator_airlock_exterior";
-	id_tag = "incinerator_airlock_control";
-	interior_door_tag = "incinerator_airlock_interior";
-	name = "Incinerator Access Console";
-	pixel_x = -8;
-	pixel_y = 35;
-	req_access_txt = "12";
-	sanitize_external = 1;
-	sensor_tag = "incinerator_airlock_sensor"
+/obj/machinery/doorButtons/access_button{
+	idDoor = "incinerator_airlock_interior";
+	idSelf = "incinerator_access_control";
+	layer = 3.1;
+	name = "Incinerator airlock control";
+	pixel_x = -24;
+	pixel_y = -24
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
@@ -45236,15 +45206,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"yhg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "ymj" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -69791,7 +69752,7 @@ sNM
 oIG
 mqF
 oIG
-wkG
+hWZ
 aaa
 aaa
 aaa
@@ -70560,7 +70521,7 @@ aac
 aaa
 uhz
 iye
-mJP
+rTY
 qgC
 cCp
 lrg
@@ -70816,9 +70777,9 @@ aad
 aad
 aad
 uhz
-bpn
+jxk
 eYe
-bYE
+bpn
 uhz
 lrg
 aad
@@ -71072,12 +71033,12 @@ aad
 aad
 aad
 aad
-gdA
-rjV
-fsJ
-eyu
-uvg
-lFw
+uhz
+qkT
+yam
+wLu
+uhz
+aMY
 aad
 aac
 aac
@@ -71328,11 +71289,11 @@ aqz
 aqz
 aqz
 aqz
-aqz
-nhU
+qWq
+uhz
 bpn
-xZO
-dMl
+fHb
+enY
 uhz
 aMY
 aad
@@ -71585,11 +71546,11 @@ ttA
 chJ
 vJt
 fbH
-lvw
-xrf
-pvX
-gSv
-xtL
+llz
+fGI
+kBW
+nVI
+xKP
 uhz
 aMY
 aad
@@ -71838,12 +71799,12 @@ aad
 aqz
 lAs
 qTa
-oJp
-hUG
-yhg
-hUG
-hUG
-ueC
+vIK
+wwL
+kYe
+wwL
+wwL
+pUN
 qMr
 kiw
 nUk
@@ -72097,12 +72058,12 @@ jpv
 msJ
 rjQ
 rjQ
-jtZ
+csn
 rjQ
 bGL
-vuN
-jkl
-bcP
+bcr
+mae
+jQJ
 bcU
 aqz
 aqz
@@ -72354,12 +72315,12 @@ uuJ
 tdN
 oql
 oql
-ixk
+grd
 oql
 mkN
-iKp
+tcm
 tgp
-bcQ
+mZd
 fYx
 aqz
 acF
@@ -72611,12 +72572,12 @@ oiL
 kCU
 rzq
 awI
-uVJ
+vcG
 diG
 mTv
-avx
-bcz
-bcS
+cWP
+nKh
+ceo
 xyo
 hNO
 aad

--- a/_maps/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/map_files/YogsDelta/YogsDelta.dmm
@@ -11162,42 +11162,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
-"ath" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_atmos{
-	pixel_y = 27
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/maintenance/disposal/incinerator)
-"ati" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/disposal/incinerator)
 "atj" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -11207,23 +11171,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
-"atk" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "atl" = (
@@ -12166,20 +12113,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/security/execution/education)
-"auG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/oil,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "auH" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -22786,12 +22719,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"aLg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark/corner,
-/area/maintenance/disposal/incinerator)
 "aLh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23889,19 +23816,6 @@
 "aMG" = (
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
-"aMH" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "aMI" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/security_space_law,
@@ -24551,17 +24465,6 @@
 	icon_state = "0-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
-"aNR" = (
-/obj/machinery/igniter/incinerator_atmos,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/air_sensor/atmos/incinerator_tank{
-	pixel_x = -32;
-	pixel_y = 32
-	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "aNS" = (
@@ -112826,18 +112729,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"dnA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
-"dnB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "dnC" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral{
@@ -112899,25 +112790,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
-"dnH" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
-/area/maintenance/disposal/incinerator)
 "dnI" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -113297,20 +113169,6 @@
 /obj/item/gun/energy/laser/practice,
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
-"dop" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/airlock_sensor/incinerator_atmos{
-	pixel_y = 24
-	},
-/turf/open/floor/engine,
-/area/maintenance/disposal/incinerator)
 "doq" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Turbine Generator Access";
@@ -113690,16 +113548,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"doK" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos{
-	dir = 2
-	},
-/turf/open/floor/engine,
-/area/maintenance/disposal/incinerator)
 "doL" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -113842,14 +113690,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"doW" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
-	},
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/turf/open/floor/engine,
-/area/maintenance/disposal/incinerator)
 "doX" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -113969,10 +113809,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"dpj" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "dpk" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -126154,6 +125990,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/science)
+"eDz" = (
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "eFD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -126218,6 +126071,28 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/storage_shared)
+"feD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/doorButtons/access_button{
+	idDoor = "incinerator_airlock_exterior";
+	idSelf = "incinerator_access_control";
+	name = "Incinerator airlock control";
+	pixel_x = 24;
+	pixel_y = 23
+	},
+/obj/machinery/doorButtons/access_button{
+	idDoor = "incinerator_airlock_interior";
+	idSelf = "incinerator_access_control";
+	layer = 3.1;
+	name = "Incinerator airlock control";
+	pixel_x = -23;
+	pixel_y = -24
+	},
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "fjK" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "transitlock";
@@ -126416,14 +126291,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/nuke_storage)
-"hFo" = (
-/obj/structure/lattice,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/space,
-/area/space/nearstation)
 "hLm" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -126449,6 +126316,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/research)
+"idQ" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/structure/sign/warning/fire,
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "iiu" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -126471,6 +126345,16 @@
 /mob/living/simple_animal/hostile/retaliate/goose/vomit,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"iAl" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "iMT" = (
 /obj/machinery/status_display/evac{
 	pixel_x = 32
@@ -126610,6 +126494,13 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"kaQ" = (
+/obj/machinery/igniter/incinerator_atmos,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "kwx" = (
 /obj/effect/turf_decal/loading_area,
 /obj/effect/turf_decal/tile/purple,
@@ -126758,6 +126649,16 @@
 /obj/item/paper_bin,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"mtF" = (
+/obj/structure/lattice,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "mvm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
@@ -126804,6 +126705,13 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"naS" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
+/obj/machinery/light/small,
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "ncP" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/engine,
@@ -126921,6 +126829,22 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/science/storage)
+"onD" = (
+/obj/machinery/status_display/evac{
+	pixel_x = -32
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/maintenance/disposal/incinerator)
 "oue" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/closed/wall/r_wall,
@@ -127248,6 +127172,31 @@
 	},
 /turf/open/floor/plating/airless,
 /area/maintenance/port)
+"rsg" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/doorButtons/airlock_controller{
+	idExterior = "incinerator_airlock_exterior";
+	idInterior = "incinerator_airlock_interior";
+	idSelf = "incinerator_access_control";
+	name = "Incinerator Access Console";
+	pixel_x = -24;
+	pixel_y = 23;
+	req_one_access_txt = "12"
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal/incinerator)
 "rzc" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/turf_decal/bot,
@@ -127257,6 +127206,19 @@
 "rCv" = (
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
+"rDI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "rOf" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/delivery,
@@ -127387,6 +127349,9 @@
 	},
 /turf/open/floor/plating,
 /area/science/robotics/lab)
+"ueh" = (
+/turf/open/floor/plasteel/dark/corner,
+/area/maintenance/disposal/incinerator)
 "urn" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/line{
@@ -127427,6 +127392,17 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"uWW" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/oil,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "uYS" = (
 /obj/machinery/door/airlock/atmos/glass/critical{
 	heat_proof = 1;
@@ -148200,7 +148176,7 @@ aIm
 aJE
 aFr
 aMu
-aNR
+kaQ
 aPx
 aRo
 aSR
@@ -148456,9 +148432,9 @@ aGN
 aIn
 aJF
 aFr
-aMv
+idQ
 aNS
-aPy
+aMv
 aFr
 aSQ
 aRF
@@ -148712,12 +148688,12 @@ aFq
 aGO
 aLf
 aFL
-dnA
-dop
-doK
-doW
-dpj
-hFo
+aFr
+iAl
+feD
+naS
+aFr
+mtF
 aRF
 aWt
 aXV
@@ -148969,9 +148945,9 @@ aFq
 aFq
 aLi
 arw
-dnB
+aFr
 aMv
-ath
+eDz
 aPy
 aFr
 aSQ
@@ -149226,9 +149202,9 @@ aFr
 aGP
 aLJ
 aJI
-dnH
+onD
 aMy
-ati
+rsg
 aPA
 aFr
 aSR
@@ -149483,7 +149459,7 @@ aHX
 aGQ
 aMi
 aJJ
-auG
+uWW
 aMz
 atj
 aPB
@@ -149738,9 +149714,9 @@ aad
 aad
 aFr
 amj
-aMH
-atk
-aLg
+rDI
+aJK
+ueh
 aPC
 cNb
 cZT

--- a/_maps/map_files/YogsPubby/YogsPubby.dmm
+++ b/_maps/map_files/YogsPubby/YogsPubby.dmm
@@ -40258,21 +40258,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"bwj" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/airlock_sensor/incinerator_atmos{
-	pixel_y = 22
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/layer1{
-	id_tag = "atmos_incinerator_airlock_pump"
-	},
-/turf/open/floor/engine,
-/area/maintenance/disposal/incinerator)
 "bwk" = (
 /obj/machinery/light{
 	dir = 8
@@ -40370,17 +40355,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
-"bwq" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
-	},
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
-	dir = 1;
-	icon_state = "vent_map-2"
-	},
-/turf/open/floor/engine,
-/area/maintenance/disposal/incinerator)
 "bwr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -43891,70 +43865,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/janitor)
-"bCu" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/disposal/incinerator)
-"bCv" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/disposal/incinerator)
-"bCw" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
-/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_atmos{
-	pixel_x = -6;
-	pixel_y = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/maintenance/disposal/incinerator)
-"bCx" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/maintenance/disposal/incinerator)
 "bCy" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
@@ -45487,15 +45397,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
-"bEP" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/disposal/incinerator)
 "bEQ" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -53098,17 +52999,6 @@
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
-"caO" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/igniter/incinerator_atmos,
-/obj/machinery/air_sensor/atmos/incinerator_tank{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
 "caP" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -57767,6 +57657,27 @@
 	},
 /turf/open/floor/carpet,
 /area/maintenance/department/crew_quarters/dorms)
+"gxg" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/doorButtons/access_button{
+	idDoor = "incinerator_airlock_interior";
+	idSelf = "incinerator_access_control";
+	layer = 3.1;
+	name = "Incinerator airlock control";
+	pixel_x = 24;
+	pixel_y = -24
+	},
+/obj/machinery/doorButtons/access_button{
+	idDoor = "incinerator_airlock_exterior";
+	idSelf = "incinerator_access_control";
+	name = "Incinerator airlock control";
+	pixel_x = -23;
+	pixel_y = 24
+	},
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "gxq" = (
 /obj/structure/chair{
 	dir = 4
@@ -58996,6 +58907,13 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"lrV" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/igniter/incinerator_atmos,
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "lzJ" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet,
@@ -59536,6 +59454,20 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"nAD" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "nBw" = (
 /obj/machinery/computer/crew{
 	dir = 1
@@ -59732,6 +59664,15 @@
 /obj/item/wrench/medical,
 /turf/open/floor/engine,
 /area/medical/chemistry)
+"ooi" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal/incinerator)
 "ooq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -59795,6 +59736,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"oxE" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/doorButtons/airlock_controller{
+	idExterior = "incinerator_airlock_exterior";
+	idInterior = "incinerator_airlock_interior";
+	idSelf = "incinerator_access_control";
+	name = "Incinerator Access Console";
+	pixel_x = 24;
+	pixel_y = -23;
+	req_one_access_txt = "12"
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal/incinerator)
 "oyF" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -60240,6 +60200,13 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/lawoffice)
+"pXY" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
+/obj/machinery/light/small,
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "pYw" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-03"
@@ -60686,6 +60653,15 @@
 /obj/item/ammo_casing/shotgun/improvised,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"rNS" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "rPg" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -61244,6 +61220,15 @@
 	},
 /turf/closed/wall,
 /area/engine/engineering)
+"tPJ" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal/incinerator)
 "tRc" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating{
@@ -100747,8 +100732,8 @@ bWL
 bKE
 bKJ
 bwg
-bEP
-bCu
+ooi
+tPJ
 cbB
 ccq
 cdh
@@ -101005,7 +100990,7 @@ bKG
 bYv
 bet
 bZQ
-bCv
+oxE
 cbC
 ccr
 bJL
@@ -101262,7 +101247,7 @@ bwb
 bLj
 bLj
 bMx
-bCw
+nAD
 bMz
 bYw
 bgc
@@ -101518,9 +101503,9 @@ bWS
 wJP
 aht
 bYw
-bwj
-bCx
-bwq
+rNS
+gxg
+pXY
 bYw
 bge
 ced
@@ -102033,7 +102018,7 @@ bJP
 aht
 bYw
 bZU
-caO
+lrV
 cbF
 ccs
 cdm

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -42615,18 +42615,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"bwz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "bwA" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
@@ -45107,48 +45095,11 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"bBd" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/sign/warning/fire{
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1
-	},
-/obj/machinery/airlock_sensor/incinerator_atmos{
-	pixel_x = -8;
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/layer1{
-	dir = 4;
-	icon_state = "vent_map-1"
-	},
-/turf/open/floor/engine,
-/area/maintenance/disposal/incinerator)
 "bBe" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"bBf" = (
-/obj/structure/sign/warning/fire{
-	pixel_x = 32
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 2
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/layer3{
-	dir = 8;
-	icon_state = "vent_map-3";
-	id_tag = "toxmix_airlock_pump"
-	},
-/turf/open/floor/engine,
-/area/maintenance/disposal/incinerator)
 "bBg" = (
 /turf/open/floor/wood,
 /area/vacant_room/office)
@@ -49258,20 +49209,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"bIG" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "bIH" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -62673,15 +62610,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
-"cgx" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "cgy" = (
 /obj/machinery/telecomms/server/presets/service,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -64235,25 +64163,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"cja" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_atmos{
-	pixel_x = 40;
-	pixel_y = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/engine,
-/area/maintenance/disposal/incinerator)
 "cjb" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/closed/wall/r_wall,
@@ -65162,18 +65071,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"ckE" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/maintenance/disposal/incinerator)
 "ckF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -65885,19 +65782,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"clP" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "clQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -66584,17 +66468,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
-"cne" = (
-/obj/machinery/igniter/incinerator_atmos,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/air_sensor/atmos/incinerator_tank{
-	pixel_x = -32;
-	pixel_y = -32
-	},
-/turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
 "cnf" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = -32
@@ -82327,6 +82200,19 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/engine/supermatter)
+"djy" = (
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "djM" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -83138,6 +83024,18 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
+"faA" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/sign/warning/fire{
+	pixel_x = -32
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "fdr" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -83867,6 +83765,18 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"myu" = (
+/obj/structure/sign/warning/fire{
+	pixel_x = 32
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 2
+	},
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "mGq" = (
 /obj/machinery/door/airlock/external{
 	req_one_access_txt = "13,8"
@@ -83917,6 +83827,13 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
+"nCT" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "nLf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -83997,6 +83914,13 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/aisat)
+"oBU" = (
+/obj/machinery/igniter/incinerator_atmos,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "oQe" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 8;
@@ -84298,6 +84222,27 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"saV" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/doorButtons/access_button{
+	idDoor = "incinerator_airlock_exterior";
+	idSelf = "incinerator_access_control";
+	name = "Incinerator airlock control";
+	pixel_x = -24;
+	pixel_y = 23
+	},
+/obj/machinery/doorButtons/access_button{
+	idDoor = "incinerator_airlock_interior";
+	idSelf = "incinerator_access_control";
+	layer = 3.1;
+	name = "Incinerator airlock control";
+	pixel_x = 23;
+	pixel_y = -23
+	},
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "siF" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -84378,6 +84323,22 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"ter" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/doorButtons/airlock_controller{
+	idExterior = "incinerator_airlock_exterior";
+	idInterior = "incinerator_airlock_interior";
+	idSelf = "incinerator_access_control";
+	name = "Incinerator Access Console";
+	pixel_x = -24;
+	pixel_y = -24;
+	req_one_access_txt = "12"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "tys" = (
 /obj/machinery/computer/cryopod{
 	dir = 4;
@@ -84564,6 +84525,15 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
+"vUZ" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "wiZ" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock";
@@ -84738,6 +84708,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"xIa" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
+"xMj" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "xTR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -124529,13 +124517,13 @@ cjE
 cjU
 bxG
 cli
-clP
+vUZ
 cmH
 bVo
 aju
 apP
 ciZ
-bBd
+faA
 ciZ
 atF
 cgz
@@ -124786,15 +124774,15 @@ cjF
 apc
 bZE
 caZ
-bIG
-bwz
-cgx
-cgx
-cgx
-cja
-ckE
+xMj
+xIa
+nCT
+nCT
+ter
+djy
+saV
 cmd
-cne
+oBU
 cNw
 cOa
 crf
@@ -125049,7 +125037,7 @@ aiW
 czH
 cLC
 cjb
-bBf
+myu
 cjb
 cnf
 cgz


### PR DESCRIPTION
### Intent of your Pull Request
Fixes #5710

All the maps but boxstation used some weird elaborate system to measure the gas contents and open the doors based on that. Well it didn't work well so i just changed them all to regular cycling like on box.
Eclipse also gets a separate area for it's incin so there's an air alarm for it.
#### Changelog

:cl:  
bugfix: fixes airlock cycling for incinerators on all maps but box
/:cl:
