### PR TITLE
removes the extra hop access request form from the hop clipboard

### DIFF
--- a/yogstation/code/game/objects/items/premadepapers.dm
+++ b/yogstation/code/game/objects/items/premadepapers.dm
@@ -390,7 +390,6 @@
 	new /obj/item/paper/paperwork/complaint_form(src)
 	new /obj/item/paper/paperwork/hopaccessrequestform(src)
 	new /obj/item/paper/paperwork/hop_job_change_form(src)
-	new /obj/item/paper/paperwork/hopaccessrequestform(src)
 	new /obj/item/paper/paperwork/incident_report(src)
 	toppaper = contents[contents.len]
 	update_icon()


### PR DESCRIPTION
why didn't i notice this sooner
:cl:  
rscdel: Removed the extra HoP access request form from the HoP's paperwork clipboard
/:cl:
