### PR TITLE
Heads can now call ERTs on Rev Rounds

### DIFF
--- a/code/datums/components/revs_security_code.dm
+++ b/code/datums/components/revs_security_code.dm
@@ -31,6 +31,6 @@ GLOBAL_LIST_EMPTY(all_rev_security_codes)
   *	* list/examine_list - The list of examines which we pass new ones to
   */
 /datum/component/revs_security_code/proc/examine(datum/source, mob/user, list/examine_list)
-	if(!locate(user.mind) in get_all_heads())
+	if(!locate(user.mind) in SSjob.get_all_heads())
 		return
 	examine_list += "<span class='notice'>There's a note with a [code] scribbled on it...</span>"

--- a/code/datums/components/revs_security_code.dm
+++ b/code/datums/components/revs_security_code.dm
@@ -1,0 +1,36 @@
+GLOBAL_LIST_EMPTY(all_rev_security_codes)
+
+/**
+  *
+  * Contains the component code for rev security codes, used by heads to call in ERTs
+  *
+  */
+
+/datum/component/revs_security_code
+	var/code
+
+/datum/component/revs_security_code/Initialize()
+	if(!isitem(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	code = random_nukecode()
+
+	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/examine)
+
+	GLOB.all_rev_security_codes += src
+
+/datum/component/revs_security_code/Destroy()
+	GLOB.all_rev_security_codes -= src
+	..()
+
+/**
+  * Runs when the parent is examined
+  * Arguments:
+  * * datum/source - The source of the examine
+  * * mob/user - The user examining
+  *	* list/examine_list - The list of examines which we pass new ones to
+  */
+/datum/component/revs_security_code/proc/examine(datum/source, mob/user, list/examine_list)
+	if(!locate(user.mind) in get_all_heads())
+		return
+	examine_list += "<span class='notice'>There's a note with a [code] scribbled on it...</span>"

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -38,6 +38,9 @@
 
 	var/victory_timer_ended = FALSE
 
+	///The item that holds the security code for the heads
+	var/code_holder
+
 ///////////////////////////////////////////////////////////////////////////////
 //Gets the round setup, cancelling if there's not enough players at the start//
 ///////////////////////////////////////////////////////////////////////////////
@@ -108,10 +111,14 @@
 	revolution.update_heads()
 
 	SSshuttle.registerHostileEnvironment(src)
+
+	code_holder = pick(GLOB.all_rev_security_codes)
 	..()
 
 
 /datum/game_mode/revolution/process()
+	if(!code_holder || !code_holder.parent || QDELETED(code_holder) || QDELETED(code_holder.parent))
+		code_holder = pick(GLOB.all_rev_security_codes)
 	check_counter++
 	if(check_counter >= 5)
 		if(!finished)
@@ -211,6 +218,15 @@
 		who then follow their orders without question and work towards dethroning departmental leaders. Watch for behavior such as this with caution. If the crew attempts a mutiny, you and \
 		your heads of staff are fully authorized to execute them using lethal weaponry - they will be later cloned and interrogated at Central Command."
 
+/**
+  * Notifies heads of where the security code is
+  */
+/datum/game_mode/revolution/proc/notify_heads_possible_securitycode()
+	for(var/datum/objective/mutiny/objective in revolution.objectives)
+		if(objective.target)
+			to_chat(objective.target, "<span class='userdanger'>You suddenly remember that the security code is scribbled on [code_holder.parent]</span>")
+
+
 /datum/game_mode/revolution/extended
 	name = "extended_revolution"
 	config_tag = "extended_revolution"
@@ -237,3 +253,4 @@
 					N.timer_set = 200
 					N.set_safety()
 					N.set_active()
+

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -51,6 +51,10 @@
 	var/legend = FALSE	//Viewing the wire legend
 
 
+/obj/item/areaeditor/blueprints/Initialize()
+	..()
+	AddComponent(/datum/component/revs_security_code)
+
 /obj/item/areaeditor/blueprints/Destroy()
 	clear_viewer()
 	return ..()

--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -23,6 +23,7 @@
 /obj/item/pinpointer/Initialize()
 	. = ..()
 	GLOB.pinpointer_list += src
+	AddComponent(/datum/component/revs_security_code)
 
 /obj/item/pinpointer/Destroy()
 	STOP_PROCESSING(SSfastprocess, src)

--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -166,6 +166,10 @@
 	volume = 90
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF //steal objective items are hard to destroy.
 
+/obj/item/tank/jetpack/oxygen/captain/Initialize()
+	. = ..()
+	AddComponent(/datum/component/revs_security_code)
+
 /obj/item/tank/jetpack/oxygen/security
 	name = "security jetpack (oxygen)"
 	desc = "A tank of compressed oxygen for use as propulsion in zero-gravity areas by security forces."

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -139,6 +139,7 @@
 /obj/item/hand_tele/Initialize()
 	. = ..()
 	active_portal_pairs = list()
+	AddComponent(/datum/component/revs_security_code)
 
 /obj/item/hand_tele/pre_attack(atom/target, mob/user, params)
 	if(try_dispel_portal(target, user))

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -637,6 +637,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 /obj/item/disk/nuclear/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/stationloving, !fake)
+	AddComponent(/datum/component/revs_security_code)
 
 /obj/item/disk/nuclear/process()
 	if(fake)

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -52,6 +52,10 @@
 	slowdown_active = SHOES_SLOWDOWN
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
+/obj/item/clothing/shoes/magboots/advance/Initialize()
+	. = ..()
+	AddComponent(/datum/component/revs_security_code)
+
 /obj/item/clothing/shoes/magboots/syndie
 	desc = "Reverse-engineered magnetic boots that have a heavy magnetic pull. Property of Gorlex Marauders."
 	name = "blood-red magboots"

--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -68,6 +68,10 @@
 	var/rad_amount= 15
 	reactivearmor_cooldown_duration = 100
 
+/obj/item/clothing/suit/armor/reactive/teleport/Initialize()
+	..()
+	AddComponent(/datum/component/revs_security_code)
+
 /obj/item/clothing/suit/armor/reactive/teleport/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)
 		return 0

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -209,6 +209,10 @@
 	desc = "A golden medal awarded exclusively to those promoted to the rank of captain. It signifies the codified responsibilities of a captain to Nanotrasen, and their undisputable authority over their crew."
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
+/obj/item/clothing/accessory/medal/gold/captain/Initialize()
+	. = ..()
+	AddComponent(/datum/component/revs_security_code)
+
 /obj/item/clothing/accessory/medal/gold/heroism
 	name = "medal of exceptional heroism"
 	desc = "An extremely rare golden medal awarded only by CentCom. To receive such a medal is the highest honor and as such, very few exist. This medal is almost never awarded to anybody but commanders."

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -60,6 +60,10 @@
 	ammo_x_offset = 4
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
+/obj/item/gun/energy/e_gun/hos/Initialize()
+	. = ..()
+	AddComponent(/datum/component/revs_security_code)
+
 /obj/item/gun/energy/e_gun/dragnet
 	name = "\improper DRAGnet"
 	desc = "The \"Dynamic Rapid-Apprehension of the Guilty\" net is a revolution in law enforcement technology. Alt+click it to set a destination for the netting mode if a teleporter is set up."

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -39,6 +39,10 @@
 	selfcharge = 1
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
+/obj/item/gun/energy/laser/captain/Initialize()
+	. = ..()
+	AddComponent(/datum/component/revs_security_code)
+
 /obj/item/gun/energy/laser/captain/scattershot
 	name = "scatter shot laser rifle"
 	icon_state = "lasercannon"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -72,6 +72,10 @@
 	list_reagents = list(/datum/reagent/medicine/omnizine = 30)
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
+/obj/item/reagent_containers/hypospray/CMO/Initialize()
+	..()
+	AddComponent(/datum/component/revs_security_code)
+
 /obj/item/reagent_containers/hypospray/combat
 	name = "combat stimulant injector"
 	desc = "A modified air-needle autoinjector, used by support operatives to quickly heal injuries in combat."

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -411,6 +411,7 @@
 #include "code\datums\components\radioactive.dm"
 #include "code\datums\components\religious_tool.dm"
 #include "code\datums\components\remote_materials.dm"
+#include "code\datums\components\revs_security_code.dm"
 #include "code\datums\components\riding.dm"
 #include "code\datums\components\rot.dm"
 #include "code\datums\components\rotation.dm"


### PR DESCRIPTION
### Intent of your Pull Request

Currently a draft.
Current idea:

Upon X amounts of revs being deconverted the heads are alerted of a specific head item (HoS gun, Captains Jetpack, etc) that has a code scribbled on it.

If they send a CC message with this code CC will automatically dispatch an Amber ERT

#### Changelog

:cl:  
rscadd: Heads now get a personalized security code when Revs are detected. Use this in a message to CentCom to call in an ERT!
/:cl:
