### PR TITLE
Changes to EclipseStation Gift Shop

### DIFF
--- a/_maps/map_files/EclipseStation/EclipseStation.dmm
+++ b/_maps/map_files/EclipseStation/EclipseStation.dmm
@@ -44955,18 +44955,6 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
-"bNt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/clerk)
 "bNu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
@@ -82531,6 +82519,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"dAJ" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "giftshop";
+	name = "Gift Shop Button";
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
+/area/clerk)
 "dCc" = (
 /obj/machinery/vending/snack/random,
 /obj/effect/turf_decal/tile/white,
@@ -85331,8 +85337,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5;
-	icon_state = "pipe11-3"
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -85770,7 +85775,7 @@
 	areastring = "/area/crew_quarters/theatre";
 	dir = 8;
 	name = "Theatre Backstage APC";
-	pixel_x = -26
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -86577,6 +86582,19 @@
 /obj/machinery/vending/boozeomat/all_access,
 /turf/closed/wall,
 /area/maintenance/department/chapel)
+"oYO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Gift Shop Maintenance";
+	req_one_access_txt = "36"
+	},
+/turf/open/floor/plating,
+/area/clerk)
 "pbv" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -107052,7 +107070,7 @@ cus
 cpA
 ccN
 bMK
-bNt
+oYO
 bOu
 bPp
 mlO
@@ -107570,7 +107588,7 @@ aGh
 bOv
 bPr
 bPv
-bPv
+dAJ
 bRw
 deW
 bPv

--- a/_maps/map_files/EclipseStation/EclipseStation.dmm
+++ b/_maps/map_files/EclipseStation/EclipseStation.dmm
@@ -82519,24 +82519,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"dAJ" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/button/door{
-	id = "giftshop";
-	name = "Gift Shop Button";
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
-/area/clerk)
 "dCc" = (
 /obj/machinery/vending/snack/random,
 /obj/effect/turf_decal/tile/white,
@@ -86342,6 +86324,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"orA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Gift Shop Maintenance";
+	req_one_access_txt = "36"
+	},
+/turf/open/floor/plating,
+/area/clerk)
 "osi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
@@ -86582,19 +86577,6 @@
 /obj/machinery/vending/boozeomat/all_access,
 /turf/closed/wall,
 /area/maintenance/department/chapel)
-"oYO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Gift Shop Maintenance";
-	req_one_access_txt = "36"
-	},
-/turf/open/floor/plating,
-/area/clerk)
 "pbv" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -89537,6 +89519,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"xQT" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "giftshop";
+	name = "Gift Shop Button";
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
+/area/clerk)
 "xUN" = (
 /obj/structure/rack,
 /obj/machinery/light/small,
@@ -107070,7 +107070,7 @@ cus
 cpA
 ccN
 bMK
-oYO
+orA
 bOu
 bPp
 mlO
@@ -107588,7 +107588,7 @@ aGh
 bOv
 bPr
 bPv
-dAJ
+xQT
 bRw
 deW
 bPv


### PR DESCRIPTION
We stopped PRs for less, god forbid we vet an actual map.
![Annotation 2020-07-13 231803](https://user-images.githubusercontent.com/62276730/88491078-3160c880-cf6e-11ea-9f29-4163877c6665.png)
Button is added to the gift shop that allows the shuttle to be lowered.
The backroom maintenance door has been modified so that the clerk can actually use it.
Hopefully other grating issues (No lights in the escape pod area, reworking the tool storage so it fits the high pop eclipse supposedly exists for, the existence of eclipse, etc) can be addressed and fixed in further PRs.

#### Changelog

:cl:  
rscadd: Button in the Gift Shop for the shutters  
rscadd: Changed vars on the Giftshop maint door to be named and give clerk access.
/:cl:
