### PR TITLE
Revamps the CentCom recovery ship

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -3736,6 +3736,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
+"jA" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external{
+	name = "Emergency Recovery Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/centcom/evac)
 "jB" = (
 /obj/structure/noticeboard{
 	dir = 8;
@@ -4818,6 +4834,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
+"lS" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/centcom/evac)
 "lT" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
@@ -7466,10 +7488,6 @@
 "qE" = (
 /turf/closed/indestructible/riveted/uranium,
 /area/wizard_station)
-"qF" = (
-/obj/machinery/light/small,
-/turf/open/floor/mineral/titanium,
-/area/centcom/evac)
 "qG" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -8170,6 +8188,16 @@
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
+"rY" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "sa" = (
 /obj/structure/table/wood,
 /obj/item/lighter,
@@ -8242,6 +8270,18 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating/airless,
 /area/syndicate_mothership/control)
+"sm" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/item/cardboard_cutout{
+	desc = "They seem to be ignoring you... Typical.";
+	dir = 8;
+	icon_state = "cutout_ntsec";
+	name = "Private Security Officer"
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/evac)
 "sn" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light{
@@ -8659,6 +8699,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
+"sZ" = (
+/obj/machinery/light,
+/obj/structure/table,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"ta" = (
+/turf/open/floor/carpet/blue,
+/area/centcom/evac)
 "tc" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/fancy/cigarettes/cigars/havana,
@@ -8793,6 +8845,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
+"tv" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "tx" = (
 /obj/structure/table/wood,
 /obj/item/storage/pill_bottle/dice,
@@ -9806,6 +9868,13 @@
 /obj/item/toy/nuke,
 /turf/open/floor/wood,
 /area/syndicate_mothership/control)
+"vy" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/structure/closet/crate/bin,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "vA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/directions/engineering{
@@ -10551,6 +10620,16 @@
 	},
 /turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
+"wT" = (
+/obj/docking_port/stationary{
+	dwidth = 1;
+	height = 4;
+	id = "pod2_away";
+	name = "recovery ship";
+	width = 3
+	},
+/turf/open/space/basic,
+/area/space)
 "wV" = (
 /obj/structure/table/wood,
 /obj/item/paicard,
@@ -10800,6 +10879,10 @@
 /obj/machinery/light,
 /turf/open/floor/carpet,
 /area/wizard_station)
+"xA" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "xB" = (
 /mob/living/simple_animal/bot/medbot{
 	desc = "When engaged in combat, the vanquishing of thine enemy can be the warrior's only concern.";
@@ -10809,6 +10892,13 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"xC" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/centcom/evac)
 "xD" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral,
@@ -11317,6 +11407,15 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/grass,
 /area/wizard_station)
+"yL" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/o2{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/centcom/evac)
 "yM" = (
 /obj/structure/table/wood/bar,
 /obj/structure/safe/floor,
@@ -11481,6 +11580,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
+"zc" = (
+/obj/structure/shuttle/engine/propulsion/right{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/centcom/evac)
 "zd" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
@@ -11884,6 +11989,11 @@
 	},
 /turf/open/floor/grass,
 /area/wizard_station)
+"zS" = (
+/obj/structure/bed,
+/obj/item/bedsheet/nanotrasen,
+/turf/open/floor/carpet/blue,
+/area/centcom/evac)
 "zT" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -11924,6 +12034,14 @@
 /obj/item/soap/deluxe,
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
+"zY" = (
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/fernybush,
+/obj/structure/window/shuttle,
+/turf/open/floor/grass,
+/area/centcom/evac)
 "zZ" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -12446,6 +12564,12 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/xeno,
 /turf/open/floor/grass,
 /area/wizard_station)
+"Bj" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "Bk" = (
 /obj/structure/table/wood,
 /obj/item/seeds/kudzu,
@@ -12530,6 +12654,16 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
+"Bw" = (
+/obj/docking_port/stationary{
+	dwidth = 1;
+	height = 4;
+	id = "pod3_away";
+	name = "recovery ship";
+	width = 3
+	},
+/turf/open/space/basic,
+/area/space)
 "Bx" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/fancy/donut_box,
@@ -13027,6 +13161,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
+"Cr" = (
+/obj/machinery/computer/arcade/minesweeper,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "Cs" = (
 /obj/structure/bookcase/random,
 /obj/machinery/light,
@@ -13610,6 +13748,26 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Dl" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/evac)
+"Dm" = (
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 2;
+	height = 7;
+	id = "pod_away";
+	name = "recovery ship";
+	width = 5
+	},
+/turf/open/space/basic,
+/area/space)
 "Dn" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien17";
@@ -15056,6 +15214,14 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Gt" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/eight,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/centcom/evac)
 "Gu" = (
 /obj/machinery/door/airlock/silver{
 	name = "Shower"
@@ -16213,6 +16379,11 @@
 "Il" = (
 /turf/closed/indestructible/fakeglass,
 /area/tdome/tdomeobserve)
+"Im" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/centcom/evac)
 "Io" = (
 /obj/item/storage/box/matches{
 	pixel_x = -3;
@@ -16951,6 +17122,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/tdomeadmin)
+"JW" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/centcom/evac)
 "JX" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -17419,71 +17599,58 @@
 "KH" = (
 /turf/closed/wall/mineral/titanium,
 /area/centcom/evac)
-"KI" = (
-/obj/structure/shuttle/engine/propulsion/right{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/centcom/evac)
-"KJ" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/centcom/evac)
-"KK" = (
-/obj/structure/shuttle/engine/propulsion/left{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/centcom/evac)
 "KL" = (
-/obj/docking_port/stationary{
-	dwidth = 1;
-	height = 4;
-	id = "pod4_away";
-	name = "recovery ship";
-	width = 3
-	},
-/turf/open/space,
-/area/space)
-"KM" = (
-/obj/docking_port/stationary{
-	dwidth = 1;
-	height = 4;
-	id = "pod3_away";
-	name = "recovery ship";
-	width = 3
-	},
-/turf/open/space,
-/area/space)
-"KN" = (
-/obj/structure/window/reinforced,
-/obj/structure/shuttle/engine/heater{
+/obj/item/storage/box/donkpockets,
+/obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/turf/open/floor/plating/airless,
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"KM" = (
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium,
+/area/centcom/evac)
+"KN" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
+	},
+/turf/open/floor/mineral/titanium,
 /area/centcom/evac)
 "KO" = (
-/obj/machinery/door/airlock/titanium,
-/turf/open/floor/plating,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/reagent_containers/food/drinks/bottle/lizardwine,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/table,
+/turf/open/floor/plasteel,
 /area/centcom/evac)
 "KP" = (
-/obj/structure/window/shuttle,
-/obj/structure/grille,
-/turf/open/floor/plating,
+/obj/machinery/door/window/eastleft,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/centcom/evac)
 "KQ" = (
 /turf/open/floor/plating,
 /area/centcom/evac)
-"KR" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/centcom/evac)
 "KS" = (
-/turf/closed/wall/mineral/titanium/interior,
+/obj/machinery/door/window/northright{
+	name = "Security Desk";
+	req_access_txt = "103"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
 /area/centcom/evac)
 "KT" = (
 /obj/structure/window/reinforced{
@@ -17498,246 +17665,69 @@
 "KV" = (
 /turf/open/floor/mineral/titanium,
 /area/centcom/evac)
-"KW" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/toxin{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/storage/firstaid/toxin,
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
 "KX" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/fire{
-	pixel_x = -2;
-	pixel_y = 4
+/obj/structure/table/wood/bar{
+	boot_dir = 8
 	},
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/centcom/evac)
 "KY" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 2
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
 	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = -2;
-	pixel_y = 4
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/chair/stool/bar{
+	can_buckle = 1;
+	name = "buckleable bar stool"
 	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/plasteel,
 /area/centcom/evac)
 "KZ" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/sleeper{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/centcom/evac)
-"La" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/mineral/titanium/white,
 /area/centcom/evac)
 "Lb" = (
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/evac)
-"Lc" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"Ld" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/evac)
-"Le" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/fancy/donut_box,
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/evac)
-"Lf" = (
-/obj/structure/table/reinforced,
-/obj/item/pen,
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/evac)
-"Lg" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/evac)
-"Lh" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
 "Li" = (
-/obj/structure/chair{
-	dir = 8
+/obj/structure/window/reinforced,
+/obj/machinery/computer/secure_data/laptop{
+	dir = 1;
+	pixel_y = 4
 	},
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"Lj" = (
-/obj/machinery/computer/secure_data{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/evac)
-"Lk" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/evac)
-"Ll" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/evac)
-"Lm" = (
 /obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/stamp,
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/evac)
-"Ln" = (
-/obj/structure/table,
-/obj/item/assembly/flash/handheld,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/evac)
 "Lo" = (
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/evac)
 "Lp" = (
-/obj/structure/chair{
-	dir = 4
-	},
+/obj/machinery/vending/cola/blue,
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/evac)
-"Lq" = (
-/obj/structure/table,
-/obj/item/storage/box/handcuffs,
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/evac)
-"Lr" = (
-/obj/machinery/door/window/northright{
-	dir = 4;
-	name = "Security Desk";
-	req_access_txt = "103"
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/evac)
-"Ls" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 1;
-	height = 4;
-	id = "pod2_away";
-	name = "recovery ship";
-	width = 3
-	},
-/turf/open/space,
-/area/space)
 "Lt" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/centcom/evac)
-"Lu" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium,
-/area/centcom/evac)
-"Lv" = (
-/obj/structure/bed,
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
 "Lw" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/centcom/evac)
-"Lx" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"Ly" = (
-/obj/machinery/door/airlock/titanium,
-/turf/open/floor/mineral/titanium,
-/area/centcom/evac)
-"Lz" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 2;
-	height = 7;
-	id = "pod_away";
-	name = "recovery ship";
-	width = 5
-	},
-/turf/open/space,
-/area/space)
-"LA" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"LB" = (
-/obj/structure/table,
-/obj/item/hand_labeler,
-/obj/machinery/light,
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"LC" = (
-/obj/structure/table,
-/obj/item/storage/box/donkpockets,
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"LD" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Cockpit";
-	req_access_txt = "109"
-	},
+/obj/structure/chair/office/dark,
 /turf/open/floor/mineral/titanium,
 /area/centcom/evac)
 "LE" = (
 /obj/structure/table,
 /obj/item/radio/off,
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"LF" = (
-/obj/structure/chair{
-	dir = 4;
-	name = "Prosecution"
-	},
-/turf/open/floor/mineral/titanium,
-/area/centcom/evac)
-"LG" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"LH" = (
-/obj/structure/table,
-/obj/item/storage/box/donkpockets,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"LI" = (
-/obj/structure/chair,
-/turf/open/floor/mineral/titanium,
-/area/centcom/evac)
-"LJ" = (
-/obj/structure/table,
-/obj/item/radio/off,
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/evac)
 "LK" = (
@@ -17761,10 +17751,6 @@
 "LN" = (
 /obj/structure/table,
 /obj/item/storage/lockbox,
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"LO" = (
-/obj/structure/table,
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/evac)
 "LP" = (
@@ -17975,6 +17961,12 @@
 	},
 /turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
+"Mo" = (
+/obj/structure/shuttle/engine/propulsion/left{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/centcom/evac)
 "Mp" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -18800,6 +18792,23 @@
 /obj/effect/landmark/bluespace_locker_origin,
 /turf/open/floor/plasteel/dark,
 /area/bluespace_locker)
+"Ox" = (
+/obj/machinery/vending/autodrobe,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"Oy" = (
+/obj/structure/table/wood/bar{
+	boot_dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/item/storage/box/mre,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "Oz" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -18900,6 +18909,30 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/centcom/testchamber)
+"OK" = (
+/obj/machinery/door/airlock/external{
+	name = "Emergency Recovery Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/centcom/evac)
+"OL" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/centcom/evac)
 "OM" = (
 /obj/structure/table/reinforced,
 /obj/item/gun/energy/pulse,
@@ -18950,6 +18983,13 @@
 /obj/item/clothing/under/roman,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"OV" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "OW" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -18976,6 +19016,11 @@
 /obj/machinery/washing_machine,
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
+"Pd" = (
+/obj/structure/table,
+/obj/item/assembly/flash/handheld,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "Pg" = (
 /obj/structure/table/wood,
 /obj/item/twohanded/dualsaber/purple{
@@ -19059,6 +19104,15 @@
 /obj/structure/closet/secure_closet/ertCom,
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
+"Pu" = (
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/stamp,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/evac)
 "Pv" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -19199,6 +19253,12 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/bluespace,
 /area/centcom/testchamber)
+"PS" = (
+/obj/machinery/computer/shuttle{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "PT" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -19534,6 +19594,22 @@
 /obj/item/gun/medbeam,
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
+"QK" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external{
+	name = "Emergency Recovery Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/centcom/evac)
 "QL" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -19750,6 +19826,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
+"Rl" = (
+/obj/machinery/vending/toyliberationstation{
+	pixel_x = -1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "Rm" = (
 /obj/structure/chair/wood/wings{
 	dir = 3
@@ -19821,6 +19903,10 @@
 /obj/machinery/door/window/westleft,
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
+"Ry" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/centcom/evac)
 "RA" = (
 /obj/structure/lattice/catwalk/swarmer_catwalk,
 /mob/living/simple_animal/hostile/retaliate/goat/king,
@@ -19876,6 +19962,15 @@
 /obj/machinery/vending/syndichem,
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
+"RI" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "RK" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -19896,6 +19991,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
+"RL" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/centcom/evac)
 "RM" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -20065,6 +20167,17 @@
 /obj/mecha/combat/marauder/seraph,
 /turf/open/floor/mech_bay_recharge_floor/dark,
 /area/centcom/ferry)
+"Sl" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external{
+	name = "Emergency Recovery Airlock"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/centcom/evac)
 "So" = (
 /obj/structure/lattice/catwalk/swarmer_catwalk,
 /obj/effect/decal/cleanable/blood/gibs/body,
@@ -20201,6 +20314,27 @@
 /obj/item/mop,
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
+"SO" = (
+/obj/machinery/microwave{
+	desc = "Cooks and boils stuff, somehow.";
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"SQ" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "SS" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -20331,6 +20465,12 @@
 /obj/item/gun/ballistic/automatic/tommygun,
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
+"Th" = (
+/obj/machinery/stasis{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/centcom/evac)
 "Ti" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -20355,6 +20495,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod)
+"Tk" = (
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 1;
+	height = 4;
+	id = "pod4_away";
+	name = "recovery ship";
+	width = 3
+	},
+/turf/open/space/basic,
+/area/space)
 "Tl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -20427,6 +20578,13 @@
 /obj/structure/closet/chefcloset,
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
+"Tt" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "Tu" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -20527,6 +20685,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
+"TF" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/carpet/blue,
+/area/centcom/evac)
 "TG" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
 	dir = 1
@@ -20573,6 +20737,13 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"TM" = (
+/obj/structure/table,
+/obj/item/gps{
+	gpstag = "RECOV"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "TN" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4;
@@ -20643,6 +20814,12 @@
 	},
 /turf/open/floor/engine,
 /area/centcom/testchamber)
+"Ua" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/centcom/evac)
 "Ub" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/item/storage/pill_bottle/stimulant,
@@ -20683,22 +20860,15 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
-"Uk" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+"Ui" = (
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/mecha/combat/reticence{
-	internals_req_access = list(303,302)
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
 	},
-/turf/open/floor/engine,
-/area/centcom/testchamber)
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "Ul" = (
 /obj/structure/closet/lasertag/blue,
 /turf/open/floor/wood,
@@ -20733,12 +20903,26 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
+"Uo" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium/white,
+/area/centcom/evac)
 "Up" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien14";
 	opacity = 0
 	},
 /area/bluespace_locker)
+"Ur" = (
+/obj/machinery/computer/arcade/orion_trail,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "Ut" = (
 /obj/structure/closet/bluespace/internal,
 /turf/open/indestructible{
@@ -20813,10 +20997,32 @@
 /obj/structure/table/wood/fancy,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
+"UC" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/mecha/combat/reticence,
+/turf/open/floor/engine,
+/area/centcom/testchamber)
 "UE" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"UF" = (
+/obj/machinery/vending/boozeomat,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "UH" = (
 /obj/machinery/light{
 	dir = 8
@@ -20882,6 +21088,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod)
+"UN" = (
+/obj/machinery/computer/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "UO" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
@@ -20933,9 +21145,25 @@
 /obj/item/gun/ballistic/automatic/sniper_rifle,
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
+"UZ" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/centcom/evac)
 "Va" = (
 /turf/open/floor/plasteel/dark,
 /area/bluespace_locker)
+"Vc" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/centcom/evac)
 "Ve" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -21121,6 +21349,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
+"VD" = (
+/obj/machinery/vending/snack/blue,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "VE" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -21168,6 +21400,15 @@
 	},
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/basketball)
+"VL" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "VN" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -21203,12 +21444,30 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/centcom/testchamber)
+"VT" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "VU" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
 /turf/closed/indestructible/riveted,
 /area/centcom/testchamber)
+"VV" = (
+/obj/machinery/chem_dispenser/drinks/fullupgrade{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "VW" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -21351,12 +21610,33 @@
 /obj/item/reagent_containers/pill/adminordrazine,
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
+"Wl" = (
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "Wm" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
+"Wn" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium/white,
+/area/centcom/evac)
 "Wo" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/item/reagent_containers/pill/adminordrazine,
@@ -21384,12 +21664,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/four)
-"Ww" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium,
-/area/centcom/evac)
 "Wx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -21400,6 +21674,10 @@
 	opacity = 0
 	},
 /area/bluespace_locker)
+"WA" = (
+/obj/machinery/computer/arcade/battle,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "WB" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -21541,6 +21819,17 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/bluespace,
 /area/centcom/testchamber)
+"WP" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Cockpit";
+	req_access_txt = "109"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium,
+/area/centcom/evac)
 "WQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
@@ -21555,6 +21844,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
+"WR" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/eight,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/centcom/evac)
+"WS" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "WU" = (
 /obj/structure/table/wood,
 /obj/structure/glowshroom/single,
@@ -21628,6 +21934,21 @@
 "Xh" = (
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/four)
+"Xj" = (
+/obj/machinery/door/airlock/external{
+	name = "Emergency Recovery Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/centcom/evac)
 "Xk" = (
 /turf/open/floor/wood,
 /area/centcom/holding)
@@ -21795,6 +22116,27 @@
 /obj/item/switchblade,
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
+"XA" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	use_power = 0
+	},
+/turf/closed/wall/mineral/titanium,
+/area/centcom/evac)
+"XB" = (
+/obj/structure/table/wood/bar{
+	boot_dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/item/reagent_containers/food/snacks/pizzaslice/donkpocket,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "XC" = (
 /obj/item/reagent_containers/food/snacks/egg/rainbow{
 	desc = "I bet you think you're pretty clever... well you are.";
@@ -21938,6 +22280,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/space/basic,
 /area/centcom/supplypod)
+"XU" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "XV" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien10";
@@ -22104,6 +22455,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
+"Yw" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "Yx" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien11";
@@ -22260,6 +22615,10 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"YW" = (
+/obj/machinery/vending/toyliberationstation,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "YX" = (
 /obj/machinery/airalarm/directional/west{
 	pixel_x = -24
@@ -22275,12 +22634,6 @@
 /obj/item/reagent_containers/syringe/gluttony,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
-"YZ" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium,
-/area/centcom/evac)
 "Za" = (
 /obj/machinery/door/airlock/wood{
 	id_tag = "lmrestroom"
@@ -22475,6 +22828,19 @@
 /obj/machinery/portable_atmospherics/canister/miasma,
 /turf/open/floor/plasteel/dark,
 /area/centcom/testchamber)
+"ZB" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/storage/box/zipties,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/evac)
 "ZD" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -22569,6 +22935,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/evac)
+"ZL" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Living Quarters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/centcom/evac)
 "ZM" = (
 /obj/machinery/door/poddoor/shuttledock,
 /obj/effect/turf_decal/delivery,
@@ -22618,6 +22996,12 @@
 /obj/item/gun/magic/staff/spellblade,
 /turf/open/floor/wood,
 /area/centcom/testchamber)
+"ZS" = (
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/turf/open/floor/carpet/blue,
+/area/centcom/evac)
 "ZT" = (
 /mob/living/simple_animal/cow,
 /turf/open/floor/grass,
@@ -22643,6 +23027,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
+"ZY" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/recharger,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/evac)
 "ZZ" = (
 /obj/structure/lattice/catwalk/swarmer_catwalk,
 /mob/living/simple_animal/hostile/carp/ranged/chaos,
@@ -47294,11 +47695,11 @@ aa
 aa
 aa
 aa
-KH
-KH
-KH
-KH
-KH
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -47551,12 +47952,12 @@ aa
 aa
 aa
 aa
-KI
-KN
-KQ
-KQ
-KH
-KH
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -47808,12 +48209,12 @@ aa
 aa
 aa
 aa
-KJ
-KN
-KR
-KQ
-KQ
-KH
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -48065,22 +48466,22 @@ aa
 aa
 aa
 aa
-KK
-KN
-KS
-KH
-KO
-KH
-KH
-KH
-KH
-KH
-KH
-KH
-KH
-KH
-KH
-KH
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -48319,26 +48720,26 @@ aa
 aa
 aa
 aa
+Dm
 aa
 aa
 aa
-KH
-KH
-KS
-La
-Lb
-Ld
-Lj
-Ln
-Lq
-KH
-Lv
-Lv
-Lx
-Lv
-Lv
-KH
-KH
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -48573,6 +48974,18 @@ aa
 aa
 aa
 aa
+KH
+KH
+KH
+QK
+KH
+KH
+KH
+KH
+KH
+KH
+KH
+KH
 aa
 aa
 aa
@@ -48580,25 +48993,13 @@ aa
 aa
 aa
 aa
-KH
-KU
-Lb
-KV
-Le
-Lk
-Lo
-Lo
-KH
-Ww
-KV
-KV
-KV
-qF
-KH
-KH
-KH
-KH
-KH
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -48830,32 +49231,32 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+zc
+Vc
+KQ
+KQ
+Ry
+KH
 KL
 KO
-KV
-KV
-KV
-Lf
-Ll
-Lo
-Lo
+Wl
+VV
+UF
 KH
-Lv
-Lv
-KV
-Lv
-Lv
 KH
-LE
-LH
-LN
-Lw
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -49087,32 +49488,32 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Ua
+Vc
+WR
+KQ
+KQ
 KH
-KW
-Lb
-KV
-Lg
-Lm
-Lg
-Lr
-Lt
+SO
+Tt
+Tt
+Tt
+Tt
+Tt
 KH
 KH
-Ly
-KH
-KH
-KH
-YZ
-KV
-LO
-Lw
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -49344,32 +49745,32 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Mo
+Vc
+KH
+Xj
+KH
+KH
+KH
 KP
 KX
-Lb
-KV
-KV
-KV
-KV
-KV
-Lu
-KV
-KV
-KV
-KV
-KV
-LD
-KV
-LI
-LP
-Lw
+XB
+Oy
+KX
+Lt
+KH
+KH
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -49601,32 +50002,32 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 KH
+KH
+KH
+KV
+Ui
+WS
+OV
+KV
 KY
-Lb
-KV
-Lh
-Lb
-Li
-Li
-Lb
-Li
-Li
-KV
-Lb
-LA
+KY
+KY
+KY
+vy
+Yw
 KH
-LF
-KV
-LQ
-Lw
+KH
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -49859,31 +50260,31 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-KM
-KO
-KV
-KV
-KV
-Lb
-Lb
-Lp
-Lp
-Lb
-Lp
-Lp
-KV
-Lb
-LB
 KH
-LG
-LJ
-LR
-Lw
+KU
+KV
+KV
+KV
+KM
+KV
+KV
+KV
+KV
+KV
+KV
+Lp
+KH
+KH
+KH
+KH
+KH
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -50115,32 +50516,32 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+wT
+Sl
+KV
+KV
+KV
+XU
+rY
+KV
+ZY
+Pu
+Dl
+ZB
+KV
+sZ
 KH
-KU
-Lb
-KV
-KV
-KV
-KV
-KV
-KV
-KV
-KV
-KV
-Lb
-LC
-KH
-KH
-KH
-KH
-KH
+PS
+LE
+LN
+Im
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -50373,28 +50774,28 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
 KH
-KH
+YW
+Lb
+KV
+SQ
+tv
+KV
 KS
-Lc
-Lb
-Li
-Li
-Li
-KV
-Li
-Li
+Lo
+sm
 Li
 KV
 Lb
-KU
 KH
-KH
+JW
+KV
+LR
+Im
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -50630,27 +51031,27 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-KI
+xC
+xA
+Lb
+KV
+KV
+KM
 KN
-KS
 KH
-KO
-KH
-KH
-KH
-KO
-KH
+zY
+zY
+XA
+KV
+KV
+WP
+KV
 Lw
-KH
-KO
-KH
-KH
-KH
+LP
+Im
+aa
+aa
+aa
 aa
 aa
 aa
@@ -50887,24 +51288,24 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-KJ
-KN
-KZ
-KQ
-KQ
 KH
-aa
-aa
-Ls
-aa
-aa
-aa
-Lz
+Rl
+Lb
+KV
+XU
+rY
+KV
+KZ
+Th
+yL
+Uo
+KV
+Lb
+KH
+UZ
+KV
+LQ
+Im
 aa
 aa
 aa
@@ -51143,25 +51544,25 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-KK
-KN
-KQ
-KQ
+Bw
+Sl
+KV
+KV
+KV
+SQ
+tv
+KV
+OL
+lS
+lS
+Wn
+KV
+sZ
 KH
-KH
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+UN
+Pd
+TM
+Im
 aa
 aa
 aa
@@ -51401,24 +51802,24 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+KH
+KU
+KV
+KV
+KV
+KM
+KV
+KV
+KV
+KV
+KV
+KV
+Ox
 KH
 KH
 KH
 KH
 KH
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -51657,22 +52058,22 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+KH
+KH
+KH
+KV
+VL
+RI
+VT
+Lb
+Ur
+WA
+Cr
+KV
+Bj
+VD
+KH
+KH
 aa
 aa
 aa
@@ -51914,21 +52315,21 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+zc
+Vc
+KH
+OK
+KH
+KH
+KH
+KH
+KH
+KH
+KH
+ZL
+KH
+KH
+KH
 aa
 aa
 aa
@@ -52171,20 +52572,20 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Ua
+Vc
+Gt
+KQ
+KQ
+KH
+ZS
+ta
+TF
+ta
+ta
+ta
+KH
+KH
 aa
 aa
 aa
@@ -52428,19 +52829,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Mo
+Vc
+KQ
+KQ
+Ry
+KH
+zS
+zS
+zS
+zS
+zS
+KH
+KH
 aa
 aa
 aa
@@ -52685,18 +53086,18 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+KH
+KH
+KH
+jA
+KH
+KH
+KH
+RL
+RL
+RL
+KH
+KH
 aa
 aa
 aa
@@ -52945,7 +53346,7 @@ aa
 aa
 aa
 aa
-aa
+Tk
 aa
 aa
 aa
@@ -63739,7 +64140,7 @@ Zd
 wS
 YF
 wS
-Uk
+UC
 Zk
 Nt
 We

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -9868,13 +9868,6 @@
 /obj/item/toy/nuke,
 /turf/open/floor/wood,
 /area/syndicate_mothership/control)
-"vy" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
 "vA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/directions/engineering{
@@ -11580,12 +11573,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
-"zc" = (
-/obj/structure/shuttle/engine/propulsion/right{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/centcom/evac)
 "zd" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
@@ -13107,6 +13094,12 @@
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
+"Cj" = (
+/obj/structure/shuttle/engine/propulsion/right{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/centcom/evac)
 "Ck" = (
 /obj/structure/table/wood,
 /obj/item/hierophant_club,
@@ -13550,6 +13543,21 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"CU" = (
+/obj/structure/table/wood/bar{
+	boot_dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/snacks/pizza/donkpocket,
+/obj/item/kitchen/knife,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "CV" = (
 /obj/structure/chair/stool,
 /turf/open/floor/wood,
@@ -15001,6 +15009,15 @@
 /obj/machinery/mech_bay_recharge_port,
 /turf/open/floor/circuit/green,
 /area/centcom/ferry)
+"FV" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/centcom/evac)
 "FW" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -17122,15 +17139,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/tdomeadmin)
-"JW" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium,
-/area/centcom/evac)
 "JX" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -17612,12 +17620,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/mineral/titanium,
 /area/centcom/evac)
-"KN" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
-/turf/open/floor/mineral/titanium,
-/area/centcom/evac)
 "KO" = (
 /obj/item/storage/box/drinkingglasses,
 /obj/item/reagent_containers/food/drinks/bottle/lizardwine,
@@ -17689,17 +17691,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/evac)
-"KZ" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/centcom/evac)
 "Lb" = (
 /turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"Ld" = (
+/obj/structure/dresser,
+/turf/open/floor/carpet/blue,
 /area/centcom/evac)
 "Li" = (
 /obj/structure/window/reinforced,
@@ -17710,6 +17707,17 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/mineral/plastitanium/red,
+/area/centcom/evac)
+"Lk" = (
+/obj/machinery/sleeper{
+	controls_inside = 1;
+	dir = 4;
+	use_power = 0
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
 /area/centcom/evac)
 "Lo" = (
 /turf/open/floor/mineral/plastitanium/red,
@@ -17961,12 +17969,6 @@
 	},
 /turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
-"Mo" = (
-/obj/structure/shuttle/engine/propulsion/left{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/centcom/evac)
 "Mp" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -18133,6 +18135,12 @@
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
+"MJ" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/centcom/evac)
 "MK" = (
 /obj/structure/mineral_door/paperframe{
 	name = "Dojo"
@@ -18401,6 +18409,12 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Nz" = (
+/obj/structure/shuttle/engine/propulsion/left{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/centcom/evac)
 "NA" = (
 /obj/machinery/doppler_array/research/science{
 	dir = 4
@@ -19539,6 +19553,13 @@
 /obj/effect/decal/cleanable/shreds,
 /turf/open/space/basic,
 /area/centcom/testchamber)
+"QF" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/centcom/evac)
 "QG" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -20160,6 +20181,10 @@
 	},
 /turf/open/floor/bluespace,
 /area/centcom/testchamber)
+"Sh" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/centcom/evac)
 "Si" = (
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/two)
@@ -20814,12 +20839,6 @@
 	},
 /turf/open/floor/engine,
 /area/centcom/testchamber)
-"Ua" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/centcom/evac)
 "Ub" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/item/storage/pill_bottle/stimulant,
@@ -20997,20 +21016,6 @@
 /obj/structure/table/wood/fancy,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
-"UC" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/mecha/combat/reticence,
-/turf/open/floor/engine,
-/area/centcom/testchamber)
 "UE" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood,
@@ -21145,25 +21150,9 @@
 /obj/item/gun/ballistic/automatic/sniper_rifle,
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
-"UZ" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium,
-/area/centcom/evac)
 "Va" = (
 /turf/open/floor/plasteel/dark,
 /area/bluespace_locker)
-"Vc" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/centcom/evac)
 "Ve" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -22123,20 +22112,6 @@
 	},
 /turf/closed/wall/mineral/titanium,
 /area/centcom/evac)
-"XB" = (
-/obj/structure/table/wood/bar{
-	boot_dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/item/reagent_containers/food/snacks/pizzaslice/donkpocket,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/centcom/evac)
 "XC" = (
 /obj/item/reagent_containers/food/snacks/egg/rainbow{
 	desc = "I bet you think you're pretty clever... well you are.";
@@ -22165,6 +22140,12 @@
 /obj/machinery/portable_atmospherics/canister/nitryl,
 /turf/open/floor/bluespace,
 /area/centcom/testchamber)
+"XG" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "XH" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -22276,6 +22257,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bluespace_locker)
+"XS" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/mecha/combat/reticence{
+	internals_req_access = list(303,302)
+	},
+/turf/open/floor/engine,
+/area/centcom/testchamber)
 "XT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/space/basic,
@@ -22373,6 +22370,12 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Yj" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/open/floor/mineral/titanium,
+/area/centcom/evac)
 "Yk" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -23013,6 +23016,15 @@
 	},
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
+"ZV" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/centcom/evac)
 "ZW" = (
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
@@ -49231,9 +49243,9 @@ aa
 aa
 aa
 aa
-zc
-Vc
-KQ
+Cj
+QF
+Sh
 KQ
 Ry
 KH
@@ -49488,8 +49500,8 @@ aa
 aa
 aa
 aa
-Ua
-Vc
+MJ
+QF
 WR
 KQ
 KQ
@@ -49745,8 +49757,8 @@ aa
 aa
 aa
 aa
-Mo
-Vc
+Nz
+QF
 KH
 Xj
 KH
@@ -49754,7 +49766,7 @@ KH
 KH
 KP
 KX
-XB
+CU
 Oy
 KX
 Lt
@@ -50014,7 +50026,7 @@ KY
 KY
 KY
 KY
-vy
+XG
 Yw
 KH
 KH
@@ -50788,7 +50800,7 @@ Li
 KV
 Lb
 KH
-JW
+FV
 KV
 LR
 Im
@@ -51037,7 +51049,7 @@ Lb
 KV
 KV
 KM
-KN
+Yj
 KH
 zY
 zY
@@ -51295,14 +51307,14 @@ KV
 XU
 rY
 KV
-KZ
+Lk
 Th
 yL
 Uo
 KV
 Lb
 KH
-UZ
+ZV
 KV
 LQ
 Im
@@ -52315,8 +52327,8 @@ aa
 aa
 aa
 aa
-zc
-Vc
+Cj
+QF
 KH
 OK
 KH
@@ -52572,8 +52584,8 @@ aa
 aa
 aa
 aa
-Ua
-Vc
+MJ
+QF
 Gt
 KQ
 KQ
@@ -52583,7 +52595,7 @@ ta
 TF
 ta
 ta
-ta
+KV
 KH
 KH
 aa
@@ -52829,13 +52841,13 @@ aa
 aa
 aa
 aa
-Mo
-Vc
+Nz
+QF
 KQ
 KQ
 Ry
 KH
-zS
+Ld
 zS
 zS
 zS
@@ -64140,7 +64152,7 @@ Zd
 wS
 YF
 wS
-UC
+XS
 Zk
 Nt
 We


### PR DESCRIPTION
<details>
<summary>Old</summary>

![image](https://user-images.githubusercontent.com/29339701/88582370-9c68d880-d01c-11ea-87b3-9a9d93f47c2e.png)

[MapDiff version](https://camo.githubusercontent.com/4b3c412f19fbfcaddf7f2be9c468c2b21a51d68a/68747470733a2f2f6d64622e616666656374656461726330372e636f2e756b2f46696c65732f3132303936363333362f3931363034393038372f302f6265666f72652e706e67)
</details>

<details>
<summary>New</summary>

![image](https://user-images.githubusercontent.com/29339701/88580625-e8fee480-d019-11ea-8e8e-e01e6a9abc2c.png)

[MapDiff version](https://camo.githubusercontent.com/fb6ed08215cb884819e5440a5922e618ae5b5e7e/68747470733a2f2f6d64622e616666656374656461726330372e636f2e756b2f46696c65732f3132303936363333362f3931363034393038372f302f61667465722e706e67)
</details>

Additions consist of:
- An expanded and designated medical area, adding an LSU.
- Additional food and drink vending machines, as well as two Donksoft vending machines stolen directly from the Syndicate.
- A goddamn bar, complete with fully-upgraded soda and booze machines, microwave, donk pocket box, and lizard wine.
- Internal firelocks.
- Enhanced seating. (No more uncomfortable metal chairs)
- Three arcade machines: Orion Trail, Minesweeper, and the battle game.
- Fancier sleeping quarters. You've had a long shift, you deserve it.

#### Changelog

:cl:  
tweak: Changes the CentCom recovery ship to include a small bar and additional medical supplies, among other small amenities.
/:cl:
