### PR TITLE
You can now shoot pirates down with the BSA before they arrive at the station

### DIFF
--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -207,3 +207,34 @@ GLOBAL_LIST_EMPTY(GPS_list)
 	tagged = null
 	STOP_PROCESSING(SSfastprocess, src)
 	. = ..()
+
+/**
+  * # Pirate GPS
+  *
+  *	Pirate GPS used for targeting by the [Blue Space Artillery] [/obj/machinery/computer/bsa_control]
+  *
+  * When shot at, relays the fact that it was shot at to [the pirate event] [/datum/round_event/pirates] so it cancels
+  */
+
+/obj/item/gps/pirate
+
+/**
+  *	Initializes the GPS with the correct name, taken from the pirate ship's name
+  *	If no name is provided, it'll default to "Jolly Robuster"
+  *
+  *	Arguments:
+  *	* ship_name - The name that of the ship that we're pretending to be, defaults to "Jolly Robuster"
+  */
+/obj/item/gps/pirate/Initialize(ship_name = "Jolly Robuster")
+	.=..()
+	if(ship_name)
+		name = ship_name
+		gpstag = ship_name
+
+/**
+  * Relays that the [Blue Space Artillery] [/obj/machinery/computer/bsa_control] has shot the ship to the event, then qdels
+  */
+/obj/item/gps/pirate/proc/on_shoot()
+	var/datum/round_event/pirates/r = locate() in SSevents.running
+	r?.shot_down()
+	qdel(src)

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -78,7 +78,7 @@
 		spawn_shuttle()
 
 /datum/round_event/pirates/proc/spawn_shuttle()
-	qdel(gps)
+	qdel(beacon)
 	shuttle_spawned = TRUE
 
 	var/list/candidates = pollGhostCandidates("Do you wish to be considered for pirate crew?", ROLE_TRAITOR)

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -21,9 +21,12 @@
 	var/paid_off = FALSE
 	var/ship_name = "Space Privateers Association"
 	var/shuttle_spawned = FALSE
+	/// The beacon that the crew can shoot to cancel the event. See [/obj/item/gps/pirate] and [/obj/machinery/computer/bsa_control]
+	var/obj/item/gps/pirate/beacon
 
 /datum/round_event/pirates/setup()
 	ship_name = pick(strings(PIRATE_NAMES_FILE, "ship_names"))
+	beacon = new(ship_name)
 
 /datum/round_event/pirates/announce(fake)
 	priority_announce("Incoming subspace communication. Secure channel opened at all communication consoles.", "Incoming Message", 'sound/ai/commandreport.ogg')
@@ -40,7 +43,7 @@
 	SScommunications.send_message(threat,unique = TRUE)
 
 /datum/round_event/pirates/proc/answered()
-	if(threat && threat.answered == 1)
+	if(threat && threat.answered == 1 && !paid_off)
 		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 		if(D)
 			if(D.adjust_money(-payoff))
@@ -49,16 +52,33 @@
 				return
 			else
 				priority_announce("Trying to cheat us? You'll regret this!",sender_override = ship_name)
-	if(!shuttle_spawned)
+	if(!shuttle_spawned && !paid_off)
 		spawn_shuttle()
 
 
+/**
+  * Called when the ship is shot down, cancels the event and calls [/datum/round_event/pirates/proc/announce_shot_down] after 20 seconds
+  */
+/datum/round_event/pirates/proc/shot_down()
+	addtimer(CALLBACK(src, .proc/announce_shot_down), 200)
+	paid_off = TRUE
+
+/**
+  * Called 20 seconds after [/datum/round_event/pirates/proc/shot_down], announces that it was shot down, and that debris is coming
+  * spawns a weak wave of meteors as the "debris"
+  */
+/datum/round_event/pirates/proc/announce_shot_down()
+	priority_announce("Unidentified ship with trajectory towards the station has exploded, expect debris.")
+	// small amount of meteors instead of a pirate boarding seems like a good deal
+	spawn_meteors(2, GLOB.meteors_normal)
+	
 
 /datum/round_event/pirates/start()
 	if(!paid_off && !shuttle_spawned)
 		spawn_shuttle()
 
 /datum/round_event/pirates/proc/spawn_shuttle()
+	qdel(gps)
 	shuttle_spawned = TRUE
 
 	var/list/candidates = pollGhostCandidates("Do you wish to be considered for pirate crew?", ROLE_TRAITOR)

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -279,11 +279,25 @@
 	else if(istype(target, /obj/item/gps))
 		return get_turf(target)
 
+/**
+  * Fires the BSA (duh) if it has power
+  * 
+  * If its target is the [pirate gps] [/obj/item/gps/pirate], it'll just fire at the edge of the map then call the [GPS' on_shoot proc] [/obj/item/gps/pirate/proc/on_shoot]
+  *
+  * Arguments:
+  *	* user - The [/mob] that fired the cannon, assumed to exist and will *probably* runtime without it.
+  */
 /obj/machinery/computer/bsa_control/proc/fire(mob/user)
 	if(cannon.stat)
 		notice = "Cannon unpowered!"
 		return
 	notice = null
+	if(istype(target, /obj/item/gps/pirate))
+		var/obj/item/gps/pirate/p = target
+		p.on_shoot()
+		cannon.fire(user, cannon.get_target_turf())
+		target = null
+		return
 	cannon.fire(user, get_impact_turf())
 
 /obj/machinery/computer/bsa_control/proc/deploy(force=FALSE)


### PR DESCRIPTION
PR is more comment than code l m a o

Allows you to shoot the pirate ship down between the announcement that they're coming, and them actually turning up. I don't really want the players to be able to do it *after* they arrived, since that's kinda dick-ish ngl.

Anywho, it spawns a very small meteor wave after the ship has been shot down. I feel like this is is a pretty good deal, and it gives players something to actually use the BSA for.

🆑 
rscadd: Central Command has issued new targeting systems with its BSA kits, allowing any stations that build them to shoot down any pirates that may attempt to board the station
/:cl:

(Also if anyone tries to make this apply to nukies I'll fucking glass em)