### PR TITLE
CentCom Galactic Ban DB

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -490,3 +490,5 @@
 /datum/config_entry/flag/protect_AI_from_traitor
 
 /datum/config_entry/flag/everyone_is_donator
+
+/datum/config_entry/string/centcom_ban_db	// URL for the CentCom Galactic Ban DB API

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -47,6 +47,11 @@
 
 	if(M.client)
 		body += "<br>\[<b>First Seen:</b> [M.client.player_join_date]\]\[<b>Byond account registered on:</b> [M.client.account_join_date]\]"
+		body += "<br><br><b>CentCom Galactic Ban DB: </b> "
+		if(CONFIG_GET(string/centcom_ban_db))
+			body += "<a href='?_src_=holder;[HrefToken()];centcomlookup=[M.client.ckey]'>Search</a>"
+		else
+			body += "<i>Disabled</i>"
 		body += "<br><br><b>Show related accounts by:</b> "
 		body += "\[ <a href='?_src_=holder;[HrefToken()];showrelatedacc=cid;client=[REF(M.client)]'>CID</a> | "
 		body += "<a href='?_src_=holder;[HrefToken()];showrelatedacc=ip;client=[REF(M.client)]'>IP</a> \]"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2412,7 +2412,7 @@
 
 		var/list/bans
 
-		var/list/dat = list("<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><body>")
+		var/list/dat = list()
 
 		if(response.errored)
 			dat += "<br>Failed to connect to CentCom."
@@ -2440,10 +2440,10 @@
 						dat += "<br>"
 					dat += "<hr>"
 
-		dat += "<br></body>"
+		dat += "<br>"
 		var/datum/browser/popup = new(usr, "centcomlookup-[ckey]", "<div align='center'>Central Command Galactic Ban Database</div>", 700, 600)
 		popup.set_content(dat.Join())
-		popup.open(0)
+		popup.open(FALSE)
 
 	else if(href_list["modantagrep"])
 		if(!check_rights(R_ADMIN))

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2390,6 +2390,60 @@
 		dat += "</BODY></HTML>"
 
 		usr << browse(dat.Join("<br>"), "window=related_[C];size=420x300")
+	
+	else if(href_list["centcomlookup"])
+		if(!check_rights(R_ADMIN))
+			return
+
+		if(!CONFIG_GET(string/centcom_ban_db))
+			to_chat(usr, "<span class='warning'>Centcom Galactic Ban DB is disabled!</span>")
+			return
+
+		var/ckey = href_list["centcomlookup"]
+
+		// Make the request
+		var/datum/http_request/request = new()
+		request.prepare(RUSTG_HTTP_METHOD_GET, "[CONFIG_GET(string/centcom_ban_db)]/[ckey]", "", "")
+		request.begin_async()
+		UNTIL(request.is_complete() || !usr)
+		if (!usr)
+			return
+		var/datum/http_response/response = request.into_response()
+
+		var/list/bans
+
+		var/list/dat = list("<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><body>")
+
+		if(response.errored)
+			dat += "<br>Failed to connect to CentCom."
+		else if(response.status_code != 200)
+			dat += "<br>Failed to connect to CentCom. Status code: [response.status_code]"
+		else
+			if(response.body == "[]")
+				dat += "<center><b>0 bans detected for [ckey]</b></center>"
+			else
+				bans = json_decode(response["body"])
+				dat += "<center><b>[bans.len] ban\s detected for [ckey]</b></center>"
+				for(var/list/ban in bans)
+					dat += "<b>Server: </b> [sanitize(ban["sourceName"])]<br>"
+					dat += "<b>RP Level: </b> [sanitize(ban["sourceRoleplayLevel"])]<br>"
+					dat += "<b>Type: </b> [sanitize(ban["type"])]<br>"
+					dat += "<b>Banned By: </b> [sanitize(ban["bannedBy"])]<br>"
+					dat += "<b>Reason: </b> [sanitize(ban["reason"])]<br>"
+					dat += "<b>Datetime: </b> [sanitize(ban["bannedOn"])]<br>"
+					var/expiration = ban["expires"]
+					dat += "<b>Expires: </b> [expiration ? "[sanitize(expiration)]" : "Permanent"]<br>"
+					if(ban["type"] == "job")
+						dat += "<b>Jobs: </b> "
+						var/list/jobs = ban["jobs"]
+						dat += sanitize(jobs.Join(", "))
+						dat += "<br>"
+					dat += "<hr>"
+
+		dat += "<br></body>"
+		var/datum/browser/popup = new(usr, "centcomlookup-[ckey]", "<div align='center'>Central Command Galactic Ban Database</div>", 700, 600)
+		popup.set_content(dat.Join())
+		popup.open(0)
 
 	else if(href_list["modantagrep"])
 		if(!check_rights(R_ADMIN))

--- a/config/config.txt
+++ b/config/config.txt
@@ -512,3 +512,7 @@ DEFAULT_VIEW_SQUARE 15x15
 
 ## Uncomment below to make everyone a donator
 #EVERYONE_IS_DONATOR
+
+## Uncomment to enable global ban DB using the provided URL. The API should expect to receive a ckey at the end of the URL.
+## More API details can be found here: https://centcom.melonmesa.com
+CENTCOM_BAN_DB https://centcom.melonmesa.com/ban/search


### PR DESCRIPTION
Ports https://github.com/BeeStation/BeeStation-Hornet/pull/2207

Admins will now be able to look up a player's bans from several other servers via the player panel.

My hope is that porting this to as many servers as possible will encourage more servers to make their bans publicly viewable so they can be included in this system. Direct access to a server's database is not required (or even supported).

Supported servers: 
* BeeStation 
* /vg/station
* OracleStation
* FTL13

Planned support that bobbah is working on:
* World Server
* Halo: SSE
* Any other server willing to make their bans publicly visible.

API: https://centcom.melonmesa.com
Source: https://github.com/bobbahbrown/CentCom

:cl: ike709 and bobbahbrown
rscadd: Admins can now see your bans on (some) other servers.
/:cl: