### PR TITLE
Toe stubbs now display to others

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -40,7 +40,7 @@
 		return ..()
 	if(prob(5))
 		to_chat(H, "<span class='warning'>You stub your toe on the [name]!</span>")
-		H.visible_message("[H] stubs [H.p_their] toe on the [name].") 
+		H.visible_message("[H] stubs their toe on the [name].") 
 		H.emote("scream")
 		H.apply_damage(2, BRUTE, def_zone = pick(BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT))
 		H.Paralyze(20)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -40,6 +40,7 @@
 		return ..()
 	if(prob(5))
 		to_chat(H, "<span class='warning'>You stub your toe on the [name]!</span>")
+		H.visible_message("[H] stubs [H.p_their] toe on the [name].") 
 		H.emote("scream")
 		H.apply_damage(2, BRUTE, def_zone = pick(BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT))
 		H.Paralyze(20)


### PR DESCRIPTION
At the moment when you stub your toe on a table, it doesn't display a message for anyone except the person that got their toe stubbed.

This PR gives them a message so they know why you suddenly dropped on the floor.

#### Changelog

:cl:  Hopek
rscadd: Toe stubbs on tables now broadcast to other players informing them of your stubbed toe.
/:cl:
