### PR TITLE
Overall mood is multiplied once instead of once per moodlet

### DIFF
--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -89,8 +89,8 @@
 		mood += event.mood_change
 		if(!event.hidden)
 			shown_mood += event.mood_change
-		mood *= mood_modifier
-		shown_mood *= mood_modifier
+	mood *= mood_modifier
+	shown_mood *= mood_modifier
 
 	switch(mood)
 		if(-INFINITY to MOOD_LEVEL_SAD4)


### PR DESCRIPTION
HELLO depressed moodlet
HELLO happy moodlet
...
![image](https://user-images.githubusercontent.com/24857008/89088619-68b4e800-d367-11ea-9bd8-97559ed52285.png)


:cl:  
bugfix: hypersensitive no longer completely  breaks your mood when you get a high level sadness or happiness before an opposing moodlet
/:cl:
