### PR TITLE
Security officers get a bola instead of a flash

### DIFF
--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -144,7 +144,7 @@ GLOBAL_LIST_INIT(available_depts_sec, list(SEC_DEPT_ENGINEERING, SEC_DEPT_MEDICA
 	suit = /obj/item/clothing/suit/armor/vest/alt
 	shoes = /obj/item/clothing/shoes/jackboots
 	l_pocket = /obj/item/restraints/handcuffs
-	r_pocket = /obj/item/assembly/flash/handheld
+	r_pocket = /obj/item/restraints/legcuffs/bola/energy
 	suit_store = /obj/item/gun/energy/disabler
 	backpack_contents = list(/obj/item/melee/baton/loaded=1)
 


### PR DESCRIPTION
### Intent of your Pull Request

They already get one in their sec belt, and energy bolas are more useful, imo.

Lewdelf wanted this

#### Changelog

:cl:  
tweak: security officers start with an energy bola instead of a flash in their pocket  
/:cl:
