### PR TITLE
removes kill objective from creep

### DIFF
--- a/code/modules/antagonists/creep/creep.dm
+++ b/code/modules/antagonists/creep/creep.dm
@@ -87,18 +87,16 @@
 				jealous.owner = owner
 				jealous.target = obsessionmind//will reroll into a coworker on the objective itself
 				objectives += jealous
-
-	if(prob(50))
-		var/datum/objective/protect/yandere_one = new
-		yandere_one.owner = owner
-		yandere_one.target = obsessionmind
-		yandere_one.update_explanation_text()
-		objectives += yandere_one
-		var/datum/objective/maroon/yandere_two = new
-		yandere_two.owner = owner
-		yandere_two.target = obsessionmind
-		yandere_two.update_explanation_text() //usually called in find_target()
-		objectives += yandere_two
+	var/datum/objective/protect/yandere_one = new
+	yandere_one.owner = owner
+	yandere_one.target = obsessionmind
+	yandere_one.update_explanation_text()
+	objectives += yandere_one
+	var/datum/objective/maroon/yandere_two = new
+	yandere_two.owner = owner
+	yandere_two.target = obsessionmind
+	yandere_two.update_explanation_text() //usually called in find_target()
+	objectives += yandere_two
 	for(var/datum/objective/O in objectives)
 		O.update_explanation_text()
 

--- a/code/modules/antagonists/creep/creep.dm
+++ b/code/modules/antagonists/creep/creep.dm
@@ -99,11 +99,6 @@
 		yandere_two.target = obsessionmind
 		yandere_two.update_explanation_text() //usually called in find_target()
 		objectives += yandere_two
-	else
-		var/datum/objective/assassinate/obsessed/kill = new
-		kill.owner = owner
-		kill.target = obsessionmind
-		objectives += kill//finally add the assassinate last, because you'd have to complete it last to greentext.
 	for(var/datum/objective/O in objectives)
 		O.update_explanation_text()
 


### PR DESCRIPTION
it's time to force the playerbase to learn how to read

:cl:  
rscdel: creep final objective is only the protect/maroon
/:cl:
