### PR TITLE
Revert "Borg security module now takes uranium instead of diamonds"

### DIFF
--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -683,7 +683,7 @@
 	id = "borg_transform_security"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/transform/security
-	materials = list(MAT_METAL = 15000, MAT_GLASS = 15000, MAT_URANIUM = 3000)
+	materials = list(MAT_METAL = 15000, MAT_GLASS = 15000, MAT_DIAMOND = 3000)
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 


### PR DESCRIPTION
Reverts yogstation13/Yogstation#8075

Alright, we've had 4 months to play with this I think Alex had the idea right the first time before he changed it to uranium for some reason.

**What this will do:**
Security cyborgs will now need diamond to be built instead of uranium as per his original PR before the change.

**Why:**
Security cyborgs are really common again as this change almost undid what the original PR was going for (making them rarer)