### PR TITLE
Tcomms can no longer translate every language

### DIFF
--- a/yogstation/code/modules/scripting/Implementations/Telecomms.dm
+++ b/yogstation/code/modules/scripting/Implementations/Telecomms.dm
@@ -13,7 +13,7 @@
 #define DRACONIC 64
 #define BEACHTONGUE 128
 GLOBAL_LIST_INIT(allowed_custom_spans,list(SPAN_ROBOT,SPAN_YELL,SPAN_ITALICS,SPAN_SANS,SPAN_COMMAND,SPAN_CLOWN))//Span classes that players are allowed to set in a radio transmission.
-GLOBAL_LIST_INIT(allowed_translations,list(HUMAN,ROBOT,DRACONIC))// languages that players are allowed to translate to in a radio transmission.
+GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/common,/datum/language/machine,/datum/language/draconic))// language datums that players are allowed to translate to in a radio transmission.
 
 /n_Interpreter/TCS_Interpreter
 	var/datum/TCS_Compiler/Compiler
@@ -212,10 +212,11 @@ GLOBAL_LIST_INIT(allowed_translations,list(HUMAN,ROBOT,DRACONIC))// languages th
 	signal.virt.verb_ask		= script_signal.get_clean_property("ask")
 	signal.virt.verb_yell		= script_signal.get_clean_property("yell")
 	signal.virt.verb_exclaim	= script_signal.get_clean_property("exclaim")
-	var/newlang = script_signal.get_clean_property("language")
+	var/newlang = LangBit2Datum(script_signal.get_clean_property("language"))
 	if(newlang != oldlang)// makes sure that we only clean out unallowed languages when a translation is taking place otherwise we run an unnecessary proc to filter newlang on foreign untranslated languages.
-		newlang &= GLOB.allowed_translations // cleans out any unallowed translations. Tcomms powergaming is dead! - Hopek
-	signal.language = LangBit2Datum(newlang) || oldlang
+		if(!LAZYFIND(GLOB.allowed_translations, newlang)) // cleans out any unallowed translations by making sure the new language is on the allowed translation list. Tcomms powergaming is dead! - Hopek
+			newlang = oldlang
+	signal.language = newlang || oldlang
 	var/list/setspans 			= script_signal.get_clean_property("filters") //Save the span vector/list to a holder list
 	if(islist(setspans)) //Players cannot be trusted with ANYTHING. At all. Ever.
 		setspans &= GLOB.allowed_custom_spans //Prune out any illegal ones. Go ahead, comment this line out. See the horror you can unleash!

--- a/yogstation/code/modules/scripting/Implementations/Telecomms.dm
+++ b/yogstation/code/modules/scripting/Implementations/Telecomms.dm
@@ -13,6 +13,7 @@
 #define DRACONIC 64
 #define BEACHTONGUE 128
 GLOBAL_LIST_INIT(allowed_custom_spans,list(SPAN_ROBOT,SPAN_YELL,SPAN_ITALICS,SPAN_SANS,SPAN_COMMAND,SPAN_CLOWN))//Span classes that players are allowed to set in a radio transmission.
+GLOBAL_LIST_INIT(allowed_translations,list(HUMAN,ROBOT,DRACONIC))
 
 /n_Interpreter/TCS_Interpreter
 	var/datum/TCS_Compiler/Compiler
@@ -212,6 +213,7 @@ GLOBAL_LIST_INIT(allowed_custom_spans,list(SPAN_ROBOT,SPAN_YELL,SPAN_ITALICS,SPA
 	signal.virt.verb_yell		= script_signal.get_clean_property("yell")
 	signal.virt.verb_exclaim	= script_signal.get_clean_property("exclaim")
 	var/newlang = script_signal.get_clean_property("language")
+	newlang &= GLOB.allowed_translations // cleans out any unallowed translations. Tcomms powergaming is dead! - Hopek
 	signal.language = LangBit2Datum(newlang) || oldlang
 	var/list/setspans 			= script_signal.get_clean_property("filters") //Save the span vector/list to a holder list
 	if(islist(setspans)) //Players cannot be trusted with ANYTHING. At all. Ever.

--- a/yogstation/code/modules/scripting/Implementations/Telecomms.dm
+++ b/yogstation/code/modules/scripting/Implementations/Telecomms.dm
@@ -13,7 +13,7 @@
 #define DRACONIC 64
 #define BEACHTONGUE 128
 GLOBAL_LIST_INIT(allowed_custom_spans,list(SPAN_ROBOT,SPAN_YELL,SPAN_ITALICS,SPAN_SANS,SPAN_COMMAND,SPAN_CLOWN))//Span classes that players are allowed to set in a radio transmission.
-GLOBAL_LIST_INIT(allowed_translations,list(HUMAN,ROBOT,DRACONIC))// languages that players are allowed to translate to in a radio transmission
+GLOBAL_LIST_INIT(allowed_translations,list(HUMAN,ROBOT,DRACONIC))// languages that players are allowed to translate to in a radio transmission.
 
 /n_Interpreter/TCS_Interpreter
 	var/datum/TCS_Compiler/Compiler

--- a/yogstation/code/modules/scripting/Implementations/Telecomms.dm
+++ b/yogstation/code/modules/scripting/Implementations/Telecomms.dm
@@ -214,7 +214,7 @@ GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/common,/datum/languag
 	signal.virt.verb_exclaim	= script_signal.get_clean_property("exclaim")
 	var/newlang = LangBit2Datum(script_signal.get_clean_property("language"))
 	if(newlang != oldlang)// makes sure that we only clean out unallowed languages when a translation is taking place otherwise we run an unnecessary proc to filter newlang on foreign untranslated languages.
-		if(!LAZYFIND(GLOB.allowed_translations, newlang)) // cleans out any unallowed translations by making sure the new language is on the allowed translation list. Tcomms powergaming is dead! - Hopek
+		if(!LAZYFIND(GLOB.allowed_translations, oldlang)) // cleans out any unallowed translations by making sure the new language is on the allowed translation list. Tcomms powergaming is dead! - Hopek
 			newlang = oldlang
 	signal.language = newlang || oldlang
 	var/list/setspans 			= script_signal.get_clean_property("filters") //Save the span vector/list to a holder list

--- a/yogstation/code/modules/scripting/Implementations/Telecomms.dm
+++ b/yogstation/code/modules/scripting/Implementations/Telecomms.dm
@@ -213,7 +213,8 @@ GLOBAL_LIST_INIT(allowed_translations,list(HUMAN,ROBOT,DRACONIC))
 	signal.virt.verb_yell		= script_signal.get_clean_property("yell")
 	signal.virt.verb_exclaim	= script_signal.get_clean_property("exclaim")
 	var/newlang = script_signal.get_clean_property("language")
-	newlang &= GLOB.allowed_translations // cleans out any unallowed translations. Tcomms powergaming is dead! - Hopek
+	if(newlang != oldlang)
+		newlang &= GLOB.allowed_translations // cleans out any unallowed translations. Tcomms powergaming is dead! - Hopek
 	signal.language = LangBit2Datum(newlang) || oldlang
 	var/list/setspans 			= script_signal.get_clean_property("filters") //Save the span vector/list to a holder list
 	if(islist(setspans)) //Players cannot be trusted with ANYTHING. At all. Ever.

--- a/yogstation/code/modules/scripting/Implementations/Telecomms.dm
+++ b/yogstation/code/modules/scripting/Implementations/Telecomms.dm
@@ -13,7 +13,7 @@
 #define DRACONIC 64
 #define BEACHTONGUE 128
 GLOBAL_LIST_INIT(allowed_custom_spans,list(SPAN_ROBOT,SPAN_YELL,SPAN_ITALICS,SPAN_SANS,SPAN_COMMAND,SPAN_CLOWN))//Span classes that players are allowed to set in a radio transmission.
-GLOBAL_LIST_INIT(allowed_translations,list(HUMAN,ROBOT,DRACONIC))
+GLOBAL_LIST_INIT(allowed_translations,list(HUMAN,ROBOT,DRACONIC))// languages that players are allowed to translate to in a radio transmission
 
 /n_Interpreter/TCS_Interpreter
 	var/datum/TCS_Compiler/Compiler
@@ -213,7 +213,7 @@ GLOBAL_LIST_INIT(allowed_translations,list(HUMAN,ROBOT,DRACONIC))
 	signal.virt.verb_yell		= script_signal.get_clean_property("yell")
 	signal.virt.verb_exclaim	= script_signal.get_clean_property("exclaim")
 	var/newlang = script_signal.get_clean_property("language")
-	if(newlang != oldlang)
+	if(newlang != oldlang)// makes sure that we only clean out unallowed languages when a translation is taking place otherwise we run an unnecessary proc to filter newlang on foreign untranslated languages.
 		newlang &= GLOB.allowed_translations // cleans out any unallowed translations. Tcomms powergaming is dead! - Hopek
 	signal.language = LangBit2Datum(newlang) || oldlang
 	var/list/setspans 			= script_signal.get_clean_property("filters") //Save the span vector/list to a holder list


### PR DESCRIPTION
Removes some signal tech powergaming by only allowing them to translate the base languages (So they can't translate codespeak, Japanese, cult speaks etc).

Having them be able to translate antagonist languages has been a bug for a while as it was never intended to be able to translate these languages (full list of intended languages in the file).

Signal techs now only can translate the base languages.

fixes #8948

**EDIT:**
Altoid's wants me to make an easier to search changelog for documentation sake::

I broke your NTSL script, here is how:
- Your new language bitflag under newlang is converted to a language datum, and compared to the old language datum. 
- If there is a difference between the newlang and oldlang datums at this stage: newlang is compared against the allowed datums in the new global allowed list under allowed_translations. 
- If newlang contains a datum that isn't on the global allowed_translations list : newlang is set to oldlang so that no translation takes place.

#### Changelog

:cl:  Hopek
bugfix: Signal techs can no longer power game by translating antagonist languages.
tweak: Signal techs can now only translate the base languages.
/:cl:
