### PR TITLE
Finally fixes the ancient camera bug

### DIFF
--- a/code/modules/photography/_pictures.dm
+++ b/code/modules/photography/_pictures.dm
@@ -38,6 +38,7 @@
 
 /datum/picture/proc/get_small_icon()
 	if(!picture_icon)
+		picture_icon = icon('icons/obj/items_and_weapons.dmi', "photo")// sets default icon if picture_icon doesn't exist.
 		regenerate_small_icon()
 	return picture_icon
 


### PR DESCRIPTION
After following the logic I found that if the image failed to generate the icon there was no backup for it (or at least the backup proc didn't actually do anything except call regenerate_small_icon() which didn't actually add an icon at the end).

I have not been able to re-create the camera bug anymore after this fix (tried 50+ photos for my sanity)

Fixes #6389

#### Changelog

:cl:  Hopek
bugfix: Fixed the ancient camera bug where a camera would generate an invisible photo breaking the camera.
/:cl:
