### PR TITLE
fixes a paystand runtime when inserting money on an unregistered paystand

### DIFF
--- a/code/modules/economy/pay_stand.dm
+++ b/code/modules/economy/pay_stand.dm
@@ -30,6 +30,9 @@
 				return
 		var/obj/item/card/id/vbucks = W
 		if(vbucks.registered_account)
+			if(!my_card)
+				to_chat(user, "<span class='warning'>ERROR: No bank account assigned to pay stand.</span>")
+				return
 			var/momsdebitcard = input(user, "How much would you like to deposit?", "Money Deposit") as null|num
 			if(momsdebitcard < 1)
 				to_chat(user, "<span class='warning'>ERROR: Invalid amount designated.</span>")


### PR DESCRIPTION
[18:15:47] Runtime in pay_stand.dm, line 100: Cannot read null.registered_account