### PR TITLE
pAI door hack speed increase

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -137,7 +137,7 @@
 /mob/living/silicon/pai/proc/process_hack()
 
 	if(cable && cable.machine && istype(cable.machine, /obj/machinery/door) && cable.machine == hackdoor && get_dist(src, hackdoor) <= 1)
-		hackprogress = clamp(hackprogress + 4, 0, 100)
+		hackprogress = clamp(hackprogress + 20, 0, 100)
 	else
 		temp = "Door Jack: Connection to airlock has been lost. Hack aborted."
 		hackprogress = 0


### PR DESCRIPTION
**Why:**
The current duration of this hack is 25 seconds.

This is a hack that
- Requires 2 players (pAI)
- Requires screwdriver to open door
- Welder + crowbar too if reinforced
- notifies the AI
- Can't do anything if bolted

**What usually happens:**
AI gets notified of your hack
AI sets you to arrest
AI probably bolts the door you're trying to hack (not always so putting this as a maybe)
you wait 25 seconds to get arrested


Without a pAI normal door hacking right now (timed by me) takes 3-4-ish seconds to open when I know the wires so this also makes that part of the game more accessible for people that aren't as robust at hacking doors (because of the tool switching required for fast speed). The new speed for hack is slightly longer than 7 seconds if the pAI immediately activates their hacking jack as you approach the door (because you have to screwdriver, pick up the jack and stick it in the door before it can start)

Might change the hacking process later too (not in this PR) because it's awkward at the moment.

**Current process:**
Tell pAI you want to hack > they let their jack out sometime after playing with their menu > open door with screwdriver > pick up jack and put in door > wait for pAI to refresh their interface to start hacking > hack happens. (after this PR this ordeal should probably take around 15-20 seconds at least). Before this PR it really felt like a 40-second ordeal. 

#### Changelog

:cl:  Hopek
tweak: pAI door hack speed has been increased to not be terrible. 
/:cl:
