### PR TITLE
Removes the happy cluwne mask from the autodrobe

### DIFF
--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -115,7 +115,6 @@
         			/obj/item/clothing/head/wig/random = 3, // yogs added a ,
         			/obj/item/clothing/under/yogs/ronaldmcdonald = 1, // yogs clothes for autodrobe start here
 					/obj/item/clothing/mask/yogs/ronald = 1,
-					/obj/item/clothing/mask/yogs/cluwne/happy_cluwne = 1,
 					/obj/item/clothing/mask/yogs/bananamask = 1,
 					/obj/item/storage/backpack/banana = 1,
 					/obj/item/clothing/mask/yogs/gigglesmask = 1,


### PR DESCRIPTION
### Intent of your Pull Request
In another case of cluwne things slowly getting more and more broken over time the happy cluwne mask now rather then being a chance always cluwnes whoever wears it and since im too lazy to fix it im just gonna remove it from easy access for now.
#### Changelog

:cl:  
rscdel:  Happy Cluwne Mask gone from autodrobe 
/:cl:
