### PR TITLE
Makes mori+guardian impossible (and a bugfix)

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -226,6 +226,9 @@
 	return ..()
 
 /obj/item/clothing/neck/necklace/memento_mori/proc/memento(mob/living/carbon/human/user)
+	if(user.hasparasites())
+		to_chat(user, "<span class='warning'>The pendant refuses to work with a guardian spirit...</span>")
+		return
 	to_chat(user, "<span class='warning'>You feel your life being drained by the pendant...</span>")
 	if(do_after(user, 40, target = user))
 		to_chat(user, "<span class='notice'>Your lifeforce is now linked to the pendant! You feel like removing it would kill you, and yet you instinctively know that until then, you won't die.</span>")

--- a/yogstation/code/modules/guardian/guardianbuilder.dm
+++ b/yogstation/code/modules/guardian/guardianbuilder.dm
@@ -180,6 +180,11 @@
 		to_chat("<span class='danger'>You don't have enough points for a Guardian like that!</span>")
 		used = FALSE
 		return FALSE
+	for(var/obj/I in all_items)) //Check for mori
+		if(istype(I, /obj/item/clothing/neck/necklace/memento_mori))
+			to_chat("<span class='danger'>The memento mori revolts at the sight of the guardian creator!</span>")
+			used = FALSE
+			return FALSE
 	// IMPORTANT - if we're debugging, the user gets thrown into the stand
 	var/list/mob/dead/observer/candidates = debug_mode ? list(user) : pollGhostCandidates("Do you want to play as the [mob_name] of [user.real_name]?", ROLE_HOLOPARASITE, null, FALSE, 100, POLL_IGNORE_HOLOPARASITE)
 	if(LAZYLEN(candidates))

--- a/yogstation/code/modules/guardian/guardianbuilder.dm
+++ b/yogstation/code/modules/guardian/guardianbuilder.dm
@@ -180,6 +180,7 @@
 		to_chat(user, "<span class='danger'>You don't have enough points for a Guardian like that!</span>")
 		used = FALSE
 		return FALSE
+	//alerts user in case they didn't know
 	var/list/all_items = user.GetAllContents()
 	for(var/obj/I in all_items) //Check for mori
 		if(istype(I, /obj/item/clothing/neck/necklace/memento_mori))
@@ -217,6 +218,13 @@
 		user.verbs += /mob/living/proc/guardian_comm
 		user.verbs += /mob/living/proc/guardian_recall
 		user.verbs += /mob/living/proc/guardian_reset
+		//surprise another check in case you tried to get around the first one and now you have no holoparasite :)
+		for(var/obj/H in all_items)
+			if(istype(H, /obj/item/clothing/neck/necklace/memento_mori))
+				to_chat(user, "<span class='danger'>The power of the [H] overtakes the [src]!</span>")
+				used = TRUE
+				G.Destroy()
+				return FALSE
 		return TRUE
 	else
 		to_chat(user, "[failure_message]")

--- a/yogstation/code/modules/guardian/guardianbuilder.dm
+++ b/yogstation/code/modules/guardian/guardianbuilder.dm
@@ -180,6 +180,7 @@
 		to_chat("<span class='danger'>You don't have enough points for a Guardian like that!</span>")
 		used = FALSE
 		return FALSE
+	var/list/all_items = user.current.GetAllContents()
 	for(var/obj/I in all_items) //Check for mori
 		if(istype(I, /obj/item/clothing/neck/necklace/memento_mori))
 			to_chat("<span class='danger'>The memento mori revolts at the sight of the guardian creator!</span>")

--- a/yogstation/code/modules/guardian/guardianbuilder.dm
+++ b/yogstation/code/modules/guardian/guardianbuilder.dm
@@ -177,13 +177,13 @@
 	used = TRUE
 	calc_points()
 	if(points < 0)
-		to_chat("<span class='danger'>You don't have enough points for a Guardian like that!</span>")
+		to_chat(user, "<span class='danger'>You don't have enough points for a Guardian like that!</span>")
 		used = FALSE
 		return FALSE
 	var/list/all_items = user.GetAllContents()
 	for(var/obj/I in all_items) //Check for mori
 		if(istype(I, /obj/item/clothing/neck/necklace/memento_mori))
-			to_chat("<span class='danger'>The memento mori revolts at the sight of the guardian creator!</span>")
+			to_chat(user, "<span class='danger'>The memento mori revolts at the sight of the guardian creator!</span>")
 			used = FALSE
 			return FALSE
 	// IMPORTANT - if we're debugging, the user gets thrown into the stand

--- a/yogstation/code/modules/guardian/guardianbuilder.dm
+++ b/yogstation/code/modules/guardian/guardianbuilder.dm
@@ -180,7 +180,7 @@
 		to_chat("<span class='danger'>You don't have enough points for a Guardian like that!</span>")
 		used = FALSE
 		return FALSE
-	for(var/obj/I in all_items)) //Check for mori
+	for(var/obj/I in all_items) //Check for mori
 		if(istype(I, /obj/item/clothing/neck/necklace/memento_mori))
 			to_chat("<span class='danger'>The memento mori revolts at the sight of the guardian creator!</span>")
 			used = FALSE

--- a/yogstation/code/modules/guardian/guardianbuilder.dm
+++ b/yogstation/code/modules/guardian/guardianbuilder.dm
@@ -180,7 +180,7 @@
 		to_chat("<span class='danger'>You don't have enough points for a Guardian like that!</span>")
 		used = FALSE
 		return FALSE
-	var/list/all_items = M.current.GetAllContents()
+	var/list/all_items = M.GetAllContents()
 	for(var/obj/I in all_items) //Check for mori
 		if(istype(I, /obj/item/clothing/neck/necklace/memento_mori))
 			to_chat("<span class='danger'>The memento mori revolts at the sight of the guardian creator!</span>")

--- a/yogstation/code/modules/guardian/guardianbuilder.dm
+++ b/yogstation/code/modules/guardian/guardianbuilder.dm
@@ -171,7 +171,7 @@
 		points -= minor.cost
 	return points
 
-/datum/guardianbuilder/proc/spawn_guardian(mob/living/user, mob/M)
+/datum/guardianbuilder/proc/spawn_guardian(mob/living/user)
 	if(!user || !iscarbon(user) || !user.mind)
 		return FALSE
 	used = TRUE
@@ -180,7 +180,7 @@
 		to_chat("<span class='danger'>You don't have enough points for a Guardian like that!</span>")
 		used = FALSE
 		return FALSE
-	var/list/all_items = M.GetAllContents()
+	var/list/all_items = user.GetAllContents()
 	for(var/obj/I in all_items) //Check for mori
 		if(istype(I, /obj/item/clothing/neck/necklace/memento_mori))
 			to_chat("<span class='danger'>The memento mori revolts at the sight of the guardian creator!</span>")

--- a/yogstation/code/modules/guardian/guardianbuilder.dm
+++ b/yogstation/code/modules/guardian/guardianbuilder.dm
@@ -171,7 +171,7 @@
 		points -= minor.cost
 	return points
 
-/datum/guardianbuilder/proc/spawn_guardian(mob/living/user)
+/datum/guardianbuilder/proc/spawn_guardian(mob/living/user, mob/M)
 	if(!user || !iscarbon(user) || !user.mind)
 		return FALSE
 	used = TRUE
@@ -180,7 +180,7 @@
 		to_chat("<span class='danger'>You don't have enough points for a Guardian like that!</span>")
 		used = FALSE
 		return FALSE
-	var/list/all_items = user.current.GetAllContents()
+	var/list/all_items = M.current.GetAllContents()
 	for(var/obj/I in all_items) //Check for mori
 		if(istype(I, /obj/item/clothing/neck/necklace/memento_mori))
 			to_chat("<span class='danger'>The memento mori revolts at the sight of the guardian creator!</span>")

--- a/yogstation/code/modules/guardian/guardianbuilder.dm
+++ b/yogstation/code/modules/guardian/guardianbuilder.dm
@@ -183,7 +183,7 @@
 	var/list/all_items = user.GetAllContents()
 	for(var/obj/I in all_items) //Check for mori
 		if(istype(I, /obj/item/clothing/neck/necklace/memento_mori))
-			to_chat(user, "<span class='danger'>The memento mori revolts at the sight of the guardian creator!</span>")
+			to_chat(user, "<span class='danger'>The [I] revolts at the sight of the [src]!</span>")
 			used = FALSE
 			return FALSE
 	// IMPORTANT - if we're debugging, the user gets thrown into the stand


### PR DESCRIPTION
### Intent of your Pull Request

Makes mori+guardian unusable when you have either
fuck atomization all my homies hate atomization

#### Changelog

:cl:  
tweak: Using memento mori and a guardian is now impossible
bugfix: You are now told when you attempt to create a guardian with too many points
/:cl:
