### PR TITLE
Fixes huge scrubber's unmovable/connect to port bug

### DIFF
--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -151,8 +151,7 @@
 	if(default_unfasten_wrench(user, W))
 		if(!movable)
 			on = FALSE
-	else
-		return ..()
+	return ..()
 
 /obj/machinery/portable_atmospherics/scrubber/CtrlShiftClick(mob/user)
 	if(!user.canUseTopic(src, BE_CLOSE))


### PR DESCRIPTION
Fixes an issue where using a wrench to secure the huge scrubber to the floor would not call the parent function, making it unable to connect to connector ports.

:cl:  
bugfix: Huge scrubbers can now connect to gas ports. 
/:cl:
