### PR TITLE
Mining Base 2: Electric Boogaloo

### DIFF
--- a/_maps/RandomRuins/LavaRuins/miningbase.dmm
+++ b/_maps/RandomRuins/LavaRuins/miningbase.dmm
@@ -178,6 +178,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
+"aF" = (
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/obj/item/dice/d4,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "aG" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -189,17 +201,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
-"aH" = (
-/obj/structure/closet/crate,
-/obj/item/dice/d4,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -252,18 +253,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/mine/production)
-"aX" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/structure/sign/departments/minsky/supply/mining{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "aY" = (
@@ -511,19 +500,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"ck" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
 "cm" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
@@ -575,14 +551,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/production)
-"cB" = (
-/obj/machinery/camera{
-	c_tag = "Crew Area Hallway West";
-	network = list("mine")
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "cD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -628,25 +596,6 @@
 	},
 /turf/open/floor/plating,
 /area/mine/living_quarters)
-"cP" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Shuttle Docking Foyer";
-	dir = 8;
-	network = list("mine")
-	},
-/obj/machinery/newscaster{
-	pixel_x = 30;
-	pixel_y = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
 "cU" = (
 /turf/closed/wall,
 /area/mine/maintenance)
@@ -1462,6 +1411,13 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/mine/living_quarters)
+"ik" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "iy" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/wintercoat,
@@ -1506,16 +1462,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"iT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"jr" = (
+/obj/machinery/camera{
+	c_tag = "Shuttle Docking Foyer";
+	dir = 8;
+	network = list("mine")
+	},
+/obj/machinery/newscaster{
+	pixel_x = 30;
+	pixel_y = 1
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/mine/production)
 "jQ" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"jS" = (
-/obj/vehicle/ridden/atv,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/dark,
-/area/mine/production)
 "jV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -1732,6 +1705,18 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/mine/production)
+"og" = (
+/obj/structure/closet/secure_closet/mmedical,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/light,
+/turf/open/floor/plasteel/white,
+/area/mine/production)
 "pw" = (
 /obj/machinery/computer/operating{
 	dir = 4
@@ -1773,6 +1758,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/production)
+"qc" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "qr" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -1786,10 +1780,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
+"qD" = (
+/obj/vehicle/ridden/atv,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/mine/production)
 "qK" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
+"qR" = (
+/obj/structure/sign/departments/minsky/medical/medical2{
+	pixel_y = -32
+	},
+/obj/machinery/camera{
+	c_tag = "Sleeper Room";
+	dir = 1;
+	network = list("mine")
+	},
+/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/mine/production)
 "qT" = (
@@ -1870,6 +1881,22 @@
 "tB" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/mine/production)
+"tP" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
@@ -1971,10 +1998,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
+"yD" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/structure/ore_box,
+/turf/open/floor/plasteel,
+/area/mine/production)
 "yM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/mine/living_quarters)
+"yW" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/mine/production)
 "zh" = (
 /obj/machinery/door/airlock{
 	id_tag = "miningdorm1";
@@ -2102,17 +2148,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/production)
-"BS" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/table/wood,
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "Cr" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -2143,19 +2178,6 @@
 /obj/structure/sign/departments/minsky/supply/mining,
 /turf/closed/wall,
 /area/mine/eva)
-"CB" = (
-/obj/machinery/light,
-/obj/structure/sign/departments/minsky/medical/medical2{
-	pixel_y = -32
-	},
-/obj/machinery/camera{
-	c_tag = "Sleeper Room";
-	dir = 1;
-	network = list("mine")
-	},
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/white,
-/area/mine/production)
 "CH" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/tile/purple{
@@ -2299,6 +2321,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/production)
+"Eo" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/structure/sign/departments/minsky/supply/mining{
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/mine/production)
 "Ew" = (
 /obj/machinery/mineral/equipment_vendor,
 /obj/effect/turf_decal/tile/brown{
@@ -2321,18 +2358,6 @@
 	},
 /obj/machinery/door/airlock/medical/glass{
 	name = "Infirmary"
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
-"EN" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
@@ -2630,16 +2655,6 @@
 /obj/machinery/mineral/processing_unit_console,
 /turf/closed/wall,
 /area/mine/living_quarters)
-"MV" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "mining_internal"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "Nl" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -2667,6 +2682,18 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/mine/production)
+"OD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "OK" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -2799,17 +2826,6 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/mine/production)
-"RN" = (
-/obj/structure/closet/secure_closet/mmedical,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
 /area/mine/production)
 "RR" = (
 /obj/effect/turf_decal/tile/brown,
@@ -3050,6 +3066,13 @@
 /obj/structure/chair/stool/bar,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"Ya" = (
+/obj/machinery/camera{
+	c_tag = "Crew Area Hallway West";
+	network = list("mine")
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "Yj" = (
 /obj/structure/table,
 /obj/item/surgical_drapes{
@@ -3094,6 +3117,18 @@
 /obj/item/reagent_containers/blood,
 /turf/open/floor/plasteel/white,
 /area/mine/production)
+"YH" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "YL" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -3369,7 +3404,7 @@ di
 di
 wK
 wK
-MV
+iE
 bQ
 ak
 ab
@@ -3458,8 +3493,8 @@ cU
 cU
 cU
 cU
-cB
-de
+Ya
+cZ
 gh
 pL
 Pz
@@ -3586,8 +3621,8 @@ kc
 di
 di
 cY
-dl
-cZ
+ik
+de
 di
 bQ
 zh
@@ -3624,7 +3659,7 @@ di
 rD
 dX
 ef
-dL
+qc
 dX
 dl
 dL
@@ -3656,7 +3691,7 @@ bL
 ub
 dY
 bL
-bL
+iT
 dY
 ep
 bL
@@ -3683,8 +3718,8 @@ dp
 cJ
 bQ
 dq
-dj
-dN
+YH
+di
 bQ
 bQ
 cY
@@ -3843,10 +3878,10 @@ bQ
 bQ
 bQ
 di
-cZ
-di
+OD
+dN
 bQ
-BS
+aF
 fx
 OK
 bU
@@ -4287,8 +4322,8 @@ jV
 aY
 lo
 Qx
-EN
-ck
+yW
+tP
 da
 aT
 dD
@@ -4312,7 +4347,7 @@ ab
 ac
 ak
 FB
-aH
+yD
 aC
 lZ
 RB
@@ -4347,7 +4382,7 @@ FB
 an
 aE
 Sb
-aX
+Eo
 be
 CI
 bq
@@ -4384,7 +4419,7 @@ bM
 aw
 cc
 cx
-cP
+jr
 OC
 xs
 nw
@@ -4513,7 +4548,7 @@ aw
 DW
 VJ
 Yj
-jS
+qD
 Fe
 Qs
 dc
@@ -4549,7 +4584,7 @@ aw
 dQ
 mx
 mx
-RN
+og
 aw
 ak
 ak
@@ -4581,7 +4616,7 @@ ai
 Ac
 mx
 mx
-CB
+qR
 aw
 ak
 ak

--- a/_maps/RandomRuins/LavaRuins/miningbase.dmm
+++ b/_maps/RandomRuins/LavaRuins/miningbase.dmm
@@ -61,23 +61,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/mine/eva)
-"as" = (
-/obj/machinery/computer/security/mining{
-	dir = 4;
-	icon_state = "computer"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/white,
-/area/mine/living_quarters)
 "at" = (
 /obj/structure/table,
 /obj/item/pickaxe,
@@ -169,15 +152,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"aD" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/mine/living_quarters)
 "aE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -194,20 +168,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"aF" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/vehicle/ridden/atv,
-/turf/open/floor/plasteel/white,
-/area/mine/living_quarters)
 "aG" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -263,13 +223,6 @@
 "aO" = (
 /obj/machinery/atmospherics/components/unary/tank/nitrogen,
 /turf/open/floor/plating,
-/area/mine/living_quarters)
-"aP" = (
-/obj/machinery/computer/crew{
-	dir = 4;
-	icon_state = "computer"
-	},
-/turf/open/floor/plasteel/white,
 /area/mine/living_quarters)
 "aQ" = (
 /obj/machinery/atmospherics/components/unary/tank/oxygen,
@@ -355,55 +308,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/mine/production)
-"bg" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/mine/living_quarters)
-"bh" = (
-/obj/structure/closet/secure_closet/mmedical,
-/turf/open/floor/plasteel/white,
-/area/mine/living_quarters)
-"bi" = (
-/obj/machinery/camera{
-	c_tag = "Sleeper Room";
-	dir = 1;
-	network = list("mine")
-	},
-/turf/open/floor/plasteel/white,
-/area/mine/living_quarters)
-"bj" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood/AMinus,
-/obj/item/reagent_containers/blood/BMinus{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/blood/BPlus{
-	pixel_x = 1;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/reagent_containers/blood/OPlus{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/APlus,
-/obj/item/reagent_containers/blood/random,
-/obj/machinery/light,
-/obj/structure/sign/departments/minsky/medical/medical2{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/white,
-/area/mine/living_quarters)
 "bk" = (
 /obj/docking_port/stationary{
 	area_type = /area/lavaland/surface/outdoors;
@@ -422,15 +326,6 @@
 	},
 /turf/closed/wall,
 /area/mine/living_quarters)
-"bn" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
 "bp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -483,10 +378,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
-"by" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/white,
-/area/mine/living_quarters)
 "bB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4;
@@ -559,6 +450,14 @@
 "bT" = (
 /turf/closed/wall/r_wall,
 /area/mine/maintenance)
+"bU" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "bV" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -623,47 +522,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"cd" = (
-/obj/machinery/mineral/mint{
-	input_dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
-"ce" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
-"cf" = (
-/obj/structure/closet/crate,
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/mine/production)
-"cg" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
-	},
-/obj/structure/table,
-/obj/item/paper/fluff/stations/lavaland/orm_notice,
-/turf/open/floor/plasteel,
-/area/mine/production)
-"ch" = (
-/obj/structure/ore_box,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/mine/production)
-"ci" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/mine/production)
 "ck" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -684,10 +542,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/mine/production)
-"co" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/plasteel,
-/area/mine/production)
 "cr" = (
 /obj/structure/table,
 /obj/item/analyzer,
@@ -706,10 +560,6 @@
 	},
 /turf/open/floor/plating,
 /area/mine/living_quarters)
-"ct" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/mine/production)
 "cu" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -725,23 +575,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/mine/production)
-"cy" = (
-/obj/effect/turf_decal/loading_area,
-/turf/open/floor/plasteel,
-/area/mine/production)
-"cz" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
-"cA" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "cB" = (
@@ -778,19 +611,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"cH" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
 "cJ" = (
 /obj/structure/cable,
 /obj/structure/cable{
@@ -810,50 +630,12 @@
 	},
 /turf/open/floor/plating,
 /area/mine/living_quarters)
-"cL" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
 "cM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
-"cN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
-"cO" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
@@ -875,42 +657,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/mine/production)
-"cQ" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/mine/production)
-"cS" = (
-/obj/machinery/camera{
-	c_tag = "Processing Area Room";
-	dir = 8;
-	network = list("mine")
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
-"cT" = (
-/obj/machinery/mineral/unloading_machine{
-	dir = 1;
-	icon_state = "unloader-corner";
-	input_dir = 1;
-	output_dir = 2
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plating,
 /area/mine/production)
 "cU" = (
 /turf/closed/wall,
@@ -937,10 +683,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"db" = (
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/mine/production)
 "dc" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -961,27 +703,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"df" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "mining_internal";
-	name = "mining conveyor"
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
-"dg" = (
-/obj/machinery/conveyor{
-	dir = 2;
-	id = "mining_internal"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/mine/production)
 "di" = (
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
@@ -1204,20 +925,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"dE" = (
-/obj/machinery/mineral/processing_unit_console,
-/turf/closed/wall,
-/area/mine/production)
-"dF" = (
-/obj/machinery/mineral/processing_unit{
-	dir = 1;
-	output_dir = 2
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/mine/production)
 "dG" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -1236,13 +943,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
-"dJ" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
@@ -1287,27 +987,13 @@
 /turf/open/floor/plasteel,
 /area/mine/production)
 "dS" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/structure/table,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/mine/living_quarters)
-"dT" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/white,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "dU" = (
 /obj/structure/bed,
@@ -1363,29 +1049,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"ea" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
-	},
-/turf/open/floor/plasteel/white,
-/area/mine/living_quarters)
-"eb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/mine/living_quarters)
-"ec" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
-	},
-/turf/open/floor/plasteel/white,
-/area/mine/living_quarters)
 "ed" = (
 /obj/structure/table,
 /turf/open/floor/carpet,
@@ -1418,16 +1081,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"eg" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "eh" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -1436,78 +1089,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4;
 	icon_state = "vent_map_on-1"
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
-"ei" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
-"ej" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/beer{
-	pixel_x = 7;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/drinks/beer{
-	pixel_x = -1;
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/food/drinks/beer{
-	pixel_x = -8
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
-"ek" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
-"el" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
-"em" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
@@ -1604,19 +1185,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/mine/living_quarters)
-"eA" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
-"eB" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
 "eC" = (
 /obj/machinery/button/door{
 	id = "miningbathroom";
@@ -1732,46 +1300,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"eM" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
-"eN" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "mining_internal"
-	},
-/obj/structure/plasticflaps,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/mine/production)
-"eO" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "mining_internal"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/mine/production)
-"eP" = (
-/obj/machinery/conveyor{
-	dir = 10;
-	id = "mining_internal"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/mine/production)
 "eQ" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/plating,
@@ -1846,85 +1374,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"fd" = (
-/obj/machinery/vending/cigarette,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
-"fe" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 6
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
-"fn" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
-"fy" = (
-/obj/structure/table,
-/obj/item/storage/box/donkpockets,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
-"fA" = (
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
-"fB" = (
-/obj/machinery/camera{
-	c_tag = "Crew Area";
-	dir = 1;
-	network = list("mine")
-	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -32
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
-"fC" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "fD" = (
 /obj/structure/sink{
 	dir = 4;
@@ -1946,6 +1395,16 @@
 	},
 /turf/open/floor/plating,
 /area/mine/eva)
+"fQ" = (
+/obj/machinery/computer/operating{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
+"gh" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "gm" = (
 /obj/machinery/space_heater,
 /obj/machinery/light/small{
@@ -1953,6 +1412,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/maintenance)
+"gr" = (
+/obj/structure/table,
+/obj/item/surgical_drapes,
+/obj/structure/window/reinforced,
+/obj/item/book/manual/wiki/surgery,
+/turf/open/floor/plasteel/white,
+/area/mine/production)
+"hc" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Morgue"
+	},
+/turf/open/floor/plasteel,
+/area/mine/production)
 "ht" = (
 /obj/structure/ore_box,
 /obj/effect/turf_decal/tile/brown{
@@ -1963,6 +1435,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"hH" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	name = "Infirmary"
+	},
+/turf/open/floor/plasteel,
+/area/mine/production)
 "ia" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 9
@@ -1990,6 +1474,16 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/mine/living_quarters)
+"ii" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Sleeper Room";
+	network = list("mine")
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
 "iy" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/wintercoat,
@@ -2011,6 +1505,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/mine/maintenance)
+"iz" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining Station Bridge";
+	req_access_txt = "48"
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "jV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -2067,6 +1574,19 @@
 	},
 /turf/open/floor/plating,
 /area/mine/eva)
+"lf" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/item/storage/box/donkpockets,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "lo" = (
 /obj/item/radio/intercom{
 	dir = 8;
@@ -2099,6 +1619,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
+"lM" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/chair,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "lZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2110,6 +1641,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
+/area/mine/production)
+"mx" = (
+/turf/open/floor/plasteel/white,
+/area/mine/production)
+"mz" = (
+/obj/structure/chair/office/dark,
+/turf/open/floor/plasteel/white,
 /area/mine/production)
 "nf" = (
 /obj/machinery/door/airlock/mining/glass{
@@ -2133,6 +1671,45 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"nh" = (
+/obj/machinery/camera{
+	c_tag = "Processing Area Room";
+	dir = 8;
+	network = list("mine")
+	},
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
+"nl" = (
+/obj/machinery/conveyor{
+	dir = 9;
+	id = "mining_internal"
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"np" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"or" = (
+/obj/structure/window/reinforced,
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/white,
+/area/mine/production)
+"pl" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mining_internal"
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "qr" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -2146,6 +1723,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
+"qK" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
 "qT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2168,6 +1751,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
+"rv" = (
+/obj/structure/table,
+/obj/item/circular_saw,
+/obj/item/scalpel{
+	pixel_y = 12
+	},
+/obj/item/retractor,
+/turf/open/floor/plasteel/white,
+/area/mine/production)
 "rD" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -2190,6 +1782,26 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/mine/maintenance)
+"sd" = (
+/obj/structure/table,
+/obj/item/hemostat,
+/obj/item/cautery{
+	pixel_x = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
+"sP" = (
+/obj/machinery/vending/boozeomat,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"tS" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/plasteel/white,
+/area/mine/production)
 "tY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -2233,6 +1845,18 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/mine/eva)
+"wD" = (
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
+"wF" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "yj" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2251,10 +1875,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
+"yl" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -5;
+	pixel_y = 30
+	},
+/turf/closed/wall,
+/area/mine/production)
 "yM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/mine/living_quarters)
+"zd" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
 "zh" = (
 /obj/machinery/door/airlock{
 	id_tag = "miningdorm1";
@@ -2274,6 +1911,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"At" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
 "AK" = (
 /obj/machinery/camera{
 	c_tag = "Storage";
@@ -2295,6 +1947,19 @@
 /obj/structure/closet/crate/secure/loot,
 /turf/open/floor/plating,
 /area/mine/living_quarters)
+"Bn" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining Station Bridge";
+	req_access_txt = "48"
+	},
+/turf/open/floor/plasteel,
+/area/mine/production)
 "Bo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -2319,6 +1984,31 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/mine/maintenance)
+"By" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mining_internal"
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"BS" = (
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"Cp" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4;
+	icon_state = "vent_map_on-1"
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "Cr" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -2394,6 +2084,17 @@
 	},
 /turf/open/floor/plating,
 /area/mine/eva)
+"CN" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/conveyor{
+	dir = 2;
+	id = "mining_internal"
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "CO" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -2405,6 +2106,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"Dk" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
 "Dr" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -2419,6 +2126,39 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
+/area/mine/production)
+"Du" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood/AMinus,
+/obj/item/reagent_containers/blood/BMinus{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/blood/BPlus{
+	pixel_x = 1;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OPlus{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/APlus,
+/obj/item/reagent_containers/blood/random,
+/obj/machinery/light,
+/obj/structure/sign/departments/minsky/medical/medical2{
+	pixel_y = -32
+	},
+/obj/machinery/camera{
+	c_tag = "Sleeper Room";
+	dir = 1;
+	network = list("mine")
+	},
+/turf/open/floor/plasteel/white,
 /area/mine/production)
 "Ew" = (
 /obj/machinery/mineral/equipment_vendor,
@@ -2439,23 +2179,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"EN" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
-"ES" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Processing Area";
-	req_access_txt = "48"
-	},
+"EI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -2468,7 +2192,54 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/machinery/door/airlock/medical/glass{
+	name = "Infirmary"
+	},
 /turf/open/floor/plasteel,
+/area/mine/production)
+"EN" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/mine/production)
+"ET" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/mineral/processing_unit{
+	dir = 1;
+	output_dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"Fd" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"Fe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
 /area/mine/production)
 "FB" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
@@ -2489,19 +2260,22 @@
 	},
 /turf/open/floor/plating,
 /area/mine/living_quarters)
-"FW" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Processing Area";
-	req_access_txt = "48"
+"Gb" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "Crew Area";
+	dir = 1;
+	network = list("mine")
 	},
 /turf/open/floor/plasteel,
-/area/mine/production)
+/area/mine/living_quarters)
 "Gf" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -2515,6 +2289,21 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/mine/eva)
+"Gj" = (
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "Gl" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Station Bridge";
@@ -2543,6 +2332,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/maintenance)
+"Ho" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/vending/games,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"HE" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Processing Area Room";
+	dir = 4;
+	network = list("mine")
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "HH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2595,6 +2403,16 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/mine/living_quarters)
+"Kz" = (
+/obj/machinery/computer/crew{
+	dir = 1;
+	icon_state = "computer"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
 "KB" = (
 /obj/machinery/airalarm/tcomms{
 	pixel_y = 24
@@ -2602,6 +2420,103 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/circuit/telecomms,
 /area/mine/maintenance)
+"KF" = (
+/obj/machinery/mineral/unloading_machine{
+	dir = 1;
+	icon_state = "unloader-corner";
+	input_dir = 1;
+	output_dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"Mc" = (
+/obj/machinery/computer/security/mining{
+	dir = 1;
+	icon_state = "computer"
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
+"Md" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"MP" = (
+/obj/vehicle/ridden/atv,
+/turf/open/floor/plasteel/white,
+/area/mine/production)
+"MS" = (
+/obj/machinery/mineral/mint{
+	input_dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"Nl" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"Nn" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
+"NE" = (
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "mining_internal"
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"NZ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
+"Od" = (
+/obj/structure/table/optable{
+	name = "Robotics Operating Table"
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
+"OB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/conveyor_switch/oneway{
+	id = "mining_internal";
+	name = "mining conveyor"
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"OK" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/structure/table/wood,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "OT" = (
 /obj/structure/ore_box,
 /obj/effect/turf_decal/tile/purple{
@@ -2612,6 +2527,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
+"Pk" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/stool/bar,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"Qs" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
 "Qx" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -2733,17 +2662,12 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"Uq" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Infirmary"
+"Up" = (
+/obj/machinery/conveyor{
+	dir = 10;
+	id = "mining_internal"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "Uy" = (
 /obj/machinery/airalarm{
@@ -2770,6 +2694,15 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
+/area/mine/production)
+"UP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/mine/production)
 "UX" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -2815,6 +2748,26 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/mine/maintenance)
+"Vt" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
+"Wl" = (
+/obj/structure/closet/secure_closet/mmedical,
+/turf/open/floor/plasteel/white,
+/area/mine/production)
+"WB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/mineral/processing_unit_console{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "WJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2831,6 +2784,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
+"WV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "WW" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 10
@@ -2853,6 +2813,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
+"Xo" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/chair/stool/bar,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"Xv" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
+"XB" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
 "YL" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -2881,6 +2867,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/mine/maintenance)
+"YZ" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_x = -1;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 
 (1,1,1) = {"
 ab
@@ -3061,9 +3066,9 @@ ba
 ba
 ba
 bQ
-ba
-ba
-ba
+bQ
+bQ
+bQ
 bQ
 bI
 bI
@@ -3089,13 +3094,13 @@ bT
 GP
 gm
 cU
+MS
 di
-di
-di
-bQ
-as
-aP
-bh
+Cp
+wF
+HE
+NE
+nl
 bQ
 ak
 ab
@@ -3123,11 +3128,11 @@ WJ
 cU
 cu
 di
-dv
+Md
+di
+bB
 cY
-dS
-ea
-bi
+pl
 bQ
 ak
 ab
@@ -3155,11 +3160,11 @@ rU
 kM
 To
 EF
-dK
-Uq
-dT
-eb
-bj
+WV
+WB
+OB
+cY
+By
 bQ
 ak
 ab
@@ -3187,11 +3192,11 @@ iy
 cU
 dl
 cZ
-dL
+di
+bQ
 cY
-aD
-ec
-by
+bQ
+By
 bQ
 ak
 bI
@@ -3219,11 +3224,11 @@ cU
 cU
 cB
 de
-dM
-bQ
-aF
-bg
-by
+gh
+KF
+CN
+ET
+Up
 bQ
 bI
 bP
@@ -3251,7 +3256,7 @@ Je
 bQ
 dn
 cZ
-di
+dM
 bQ
 bQ
 bQ
@@ -3480,7 +3485,7 @@ bQ
 eZ
 fb
 eh
-fA
+Gj
 bQ
 eq
 ex
@@ -3509,10 +3514,10 @@ cD
 do
 dv
 cY
+Ho
 fb
-fb
-ei
-fb
+lM
+YZ
 bQ
 er
 ey
@@ -3542,9 +3547,9 @@ eV
 dK
 Ct
 dZ
-eg
-ej
-fB
+dZ
+Nl
+Fd
 bQ
 bQ
 ez
@@ -3573,10 +3578,10 @@ eT
 de
 dL
 cY
-fb
-fb
-el
-fC
+Pk
+Pk
+Xo
+Gb
 bQ
 es
 eC
@@ -3605,10 +3610,10 @@ di
 cZ
 di
 bQ
-fd
-fb
-em
-fb
+BS
+np
+OK
+bU
 bQ
 et
 eD
@@ -3637,10 +3642,10 @@ di
 cZ
 di
 bQ
-fe
-fn
-fy
-fD
+fb
+fb
+fb
+fb
 bQ
 bQ
 bQ
@@ -3669,10 +3674,10 @@ dv
 du
 dO
 bQ
-ba
-ba
-ba
-ba
+sP
+lf
+dS
+fD
 bQ
 bI
 bI
@@ -3699,13 +3704,13 @@ ac
 ba
 ba
 nf
+iz
 ba
 ba
-ak
-ak
-ak
-ak
-bI
+ba
+ba
+ba
+bQ
 bI
 bI
 ak
@@ -3731,10 +3736,10 @@ ac
 ac
 ba
 dx
+di
 ba
 ak
 ak
-ac
 ac
 ac
 ac
@@ -3763,9 +3768,9 @@ ac
 ac
 ba
 dy
+di
 ba
 ak
-ac
 ac
 ac
 ac
@@ -3795,8 +3800,8 @@ ac
 ac
 ba
 dy
+di
 ba
-ak
 ac
 ac
 ac
@@ -3827,8 +3832,8 @@ ac
 ac
 ba
 dy
+di
 ba
-ak
 ac
 ac
 ac
@@ -3859,8 +3864,8 @@ ac
 ak
 FB
 dz
+aT
 FB
-ak
 ac
 ac
 ac
@@ -3891,9 +3896,9 @@ ac
 ak
 FB
 dz
+aT
 FB
 ak
-ac
 ac
 ac
 ac
@@ -3923,9 +3928,9 @@ ac
 ak
 FB
 dz
+aT
 FB
 ak
-ac
 ac
 ac
 ac
@@ -3955,8 +3960,8 @@ ac
 ak
 FB
 dA
+aT
 FB
-ak
 ak
 ac
 ac
@@ -3987,7 +3992,7 @@ ak
 FB
 FB
 Gl
-FB
+Bn
 FB
 ak
 ak
@@ -4144,10 +4149,10 @@ aw
 cc
 cx
 cP
-db
-cH
-eB
-eA
+aT
+cM
+aT
+aT
 eL
 FB
 ak
@@ -4177,8 +4182,8 @@ aw
 ax
 aw
 dc
-ES
-FW
+EI
+hH
 dc
 aw
 aw
@@ -4205,14 +4210,14 @@ bt
 ao
 bO
 aw
-cd
-cy
-cQ
-dd
-cL
-bn
-bE
-aT
+fQ
+Od
+or
+qK
+At
+Vt
+Dk
+Kz
 FB
 ak
 ak
@@ -4237,14 +4242,14 @@ bu
 ao
 aw
 aw
-ce
-aT
-aT
-aT
-cM
-db
-eB
-eM
+ii
+mx
+mx
+mx
+UP
+mx
+mz
+Mc
 aw
 ak
 ak
@@ -4269,14 +4274,14 @@ bv
 ao
 bP
 aw
-cf
-aT
-co
-ct
-cN
-dJ
+sd
+rv
+gr
+MP
+Fe
+Qs
+dc
 aw
-eN
 aw
 ak
 ak
@@ -4301,14 +4306,14 @@ CL
 ao
 bI
 aw
-cg
-aT
-cS
-df
-cO
-ek
-dc
-eO
+aw
+aw
+aw
+aw
+Nn
+mx
+mx
+Wl
 aw
 ak
 ak
@@ -4333,14 +4338,14 @@ Xc
 ao
 bI
 aw
-ch
-cz
-aw
-dc
-dE
-dc
-dc
-eO
+zd
+mx
+mx
+hc
+mx
+mx
+mx
+Du
 aw
 ak
 ak
@@ -4365,14 +4370,14 @@ OT
 ao
 bI
 aw
-ci
-cA
-cT
-dg
-dF
-dg
-dg
-eP
+XB
+Xv
+nh
+aw
+NZ
+mx
+wD
+tS
 aw
 ak
 ak
@@ -4403,7 +4408,7 @@ aw
 aw
 aw
 aw
-aw
+yl
 aw
 aw
 ak

--- a/_maps/RandomRuins/LavaRuins/miningbase.dmm
+++ b/_maps/RandomRuins/LavaRuins/miningbase.dmm
@@ -400,12 +400,6 @@
 	},
 /turf/open/floor/plating,
 /area/mine/living_quarters)
-"bE" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
 "bF" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 5
@@ -630,15 +624,6 @@
 	},
 /turf/open/floor/plating,
 /area/mine/living_quarters)
-"cM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
 "cP" = (
 /obj/machinery/light{
 	dir = 4
@@ -1293,6 +1278,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
+"eO" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "eQ" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/plating,
@@ -1378,6 +1371,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"fJ" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "fO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -1405,18 +1407,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/maintenance)
-"gr" = (
-/obj/structure/table,
-/obj/item/surgical_drapes,
-/obj/structure/window/reinforced,
-/obj/item/book/manual/wiki/surgery,
-/turf/open/floor/plasteel/white,
-/area/mine/production)
-"gC" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+"gq" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "mining_internal"
 	},
-/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "ht" = (
@@ -1512,16 +1507,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"iO" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "jV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -1534,17 +1519,6 @@
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
-"kF" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/conveyor{
-	dir = 2;
-	id = "mining_internal"
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
@@ -1712,13 +1686,13 @@
 /obj/structure/table/wood,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"nO" = (
-/obj/machinery/conveyor{
-	dir = 2;
-	id = "mining_internal"
+"nw" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
-/area/mine/living_quarters)
+/area/mine/production)
 "or" = (
 /obj/structure/window/reinforced,
 /obj/item/twohanded/required/kirbyplants/random,
@@ -1732,6 +1706,13 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"px" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/mine/production)
 "qr" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -1792,6 +1773,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"rM" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/bed/roller,
+/turf/open/floor/plasteel/white,
+/area/mine/production)
 "rU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -1804,6 +1792,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/mine/maintenance)
+"rX" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/mine/production)
 "sd" = (
 /obj/structure/table,
 /obj/item/hemostat,
@@ -1820,6 +1817,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"tB" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/mine/production)
 "tS" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
@@ -1857,6 +1860,17 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/mine/maintenance)
+"uG" = (
+/obj/structure/bed/roller,
+/turf/open/floor/plasteel/white,
+/area/mine/production)
+"uM" = (
+/obj/machinery/mineral/processing_unit{
+	dir = 1;
+	output_dir = 2
+	},
+/turf/open/floor/plating,
+/area/mine/living_quarters)
 "vD" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
 	dir = 1
@@ -1867,18 +1881,39 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/mine/eva)
+"wc" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Processing Area Room";
+	dir = 4;
+	network = list("mine")
+	},
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "wD" = (
 /obj/machinery/sleeper{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/production)
-"wF" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
+"xs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
-/area/mine/living_quarters)
+/area/mine/production)
 "yj" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1933,13 +1968,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"zV" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "mining_internal"
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "zW" = (
 /obj/machinery/mineral/unloading_machine{
 	dir = 1;
@@ -1964,6 +1992,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/production)
+"AG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "AK" = (
 /obj/machinery/camera{
 	c_tag = "Storage";
@@ -2038,13 +2075,6 @@
 	dir = 1
 	},
 /obj/structure/table/wood,
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
-"Cp" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
-	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "Cr" = (
@@ -2187,13 +2217,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/production)
-"Dy" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "Ew" = (
 /obj/machinery/mineral/equipment_vendor,
 /obj/effect/turf_decal/tile/brown{
@@ -2338,12 +2361,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
+"Gs" = (
+/obj/machinery/conveyor{
+	dir = 2;
+	id = "mining_internal"
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "GP" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/maintenance)
+"Hh" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "Ho" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -2358,17 +2396,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/production)
-"HE" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Processing Area Room";
-	dir = 4;
-	network = list("mine")
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "HH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2438,6 +2465,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/circuit/telecomms,
 /area/mine/maintenance)
+"Lx" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "Mc" = (
 /obj/machinery/computer/security/mining{
 	dir = 1;
@@ -2445,6 +2476,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/production)
+"Mo" = (
+/obj/machinery/mineral/processing_unit_console,
+/turf/closed/wall,
+/area/mine/living_quarters)
 "MP" = (
 /obj/vehicle/ridden/atv,
 /turf/open/floor/plasteel/white,
@@ -2486,17 +2521,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"NZ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/mine/production)
 "Od" = (
 /obj/structure/table/optable{
 	name = "Robotics Operating Table"
 	},
 /turf/open/floor/plasteel/white,
+/area/mine/production)
+"OC" = (
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
 /area/mine/production)
 "OK" = (
 /obj/effect/turf_decal/tile/bar,
@@ -2520,6 +2553,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
+"OU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "Pk" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -2527,13 +2566,6 @@
 	},
 /obj/structure/chair/stool/bar,
 /turf/open/floor/plasteel,
-/area/mine/living_quarters)
-"PG" = (
-/obj/machinery/mineral/processing_unit{
-	dir = 1;
-	output_dir = 2
-	},
-/turf/open/floor/plating,
 /area/mine/living_quarters)
 "Qs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -2649,6 +2681,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"TY" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "mining_internal"
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "Ub" = (
 /obj/machinery/door/airlock/mining{
 	name = "Mining Station Storage";
@@ -2669,6 +2707,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"Uu" = (
+/obj/structure/table,
+/obj/item/surgical_drapes{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/obj/structure/window/reinforced,
+/obj/item/book/manual/wiki/surgery{
+	pixel_x = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
 "Uy" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -2748,6 +2798,13 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/mine/maintenance)
+"Vr" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "Vt" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -2825,12 +2882,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/production)
-"Yt" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "gulag"
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "YL" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -2877,10 +2928,6 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
-/area/mine/living_quarters)
-"ZE" = (
-/obj/machinery/mineral/processing_unit_console,
-/turf/closed/wall,
 /area/mine/living_quarters)
 
 (1,1,1) = {"
@@ -3090,13 +3137,13 @@ bT
 GP
 gm
 cU
+Lx
+OU
 di
-di
-di
-wF
-HE
+Vr
+wc
 NE
-zV
+gq
 nl
 bQ
 ak
@@ -3123,8 +3170,8 @@ CK
 WJ
 cU
 cu
-Cp
-di
+AG
+dN
 di
 MS
 cY
@@ -3155,10 +3202,10 @@ YV
 rU
 kM
 To
-iO
-eT
-Dy
-Yt
+Hh
+di
+di
+TY
 di
 cY
 pl
@@ -3191,7 +3238,7 @@ cZ
 di
 bQ
 cY
-ZE
+Mo
 cY
 By
 bQ
@@ -3222,9 +3269,9 @@ cB
 de
 gh
 zW
-kF
-PG
-nO
+Gs
+uM
+Gs
 Up
 bQ
 bP
@@ -3668,7 +3715,7 @@ ak
 ba
 dv
 du
-gC
+eO
 bQ
 sP
 lf
@@ -3732,7 +3779,7 @@ ac
 ac
 ba
 dx
-di
+fJ
 ba
 ak
 ak
@@ -3956,7 +4003,7 @@ ac
 ak
 FB
 dA
-aT
+px
 FB
 ak
 ac
@@ -4020,7 +4067,7 @@ aw
 FB
 dd
 dC
-bE
+rX
 FB
 aw
 ak
@@ -4145,10 +4192,10 @@ aw
 cc
 cx
 cP
-aT
-cM
-aT
-aT
+OC
+xs
+nw
+tB
 eL
 FB
 ak
@@ -4272,7 +4319,7 @@ bP
 aw
 sd
 rv
-gr
+Uu
 MP
 Fe
 Qs
@@ -4370,8 +4417,8 @@ XB
 Xv
 nh
 aw
-NZ
-mx
+rM
+uG
 wD
 tS
 aw

--- a/_maps/RandomRuins/LavaRuins/miningbase.dmm
+++ b/_maps/RandomRuins/LavaRuins/miningbase.dmm
@@ -1419,6 +1419,16 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"gP" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "ht" = (
 /obj/structure/ore_box,
 /obj/effect/turf_decal/tile/brown{
@@ -1511,6 +1521,13 @@
 	req_access_txt = "48"
 	},
 /turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"jL" = (
+/obj/machinery/mineral/processing_unit_console{
+	dir = 2;
+	machinedir = 8
+	},
+/turf/closed/wall,
 /area/mine/living_quarters)
 "jV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -1764,15 +1781,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"rH" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "gulag"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "rU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -1895,6 +1903,19 @@
 	},
 /turf/closed/wall,
 /area/mine/production)
+"yt" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1;
+	icon_state = "scrub_map_on-3"
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/living_quarters)
+"yA" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "gulag"
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "yM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -1923,10 +1944,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/mine/living_quarters)
-"zz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/white,
 /area/mine/living_quarters)
 "zW" = (
 /obj/machinery/mineral/unloading_machine{
@@ -2182,18 +2199,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"EF" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "EI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -2414,6 +2419,16 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/mine/living_quarters)
+"Kn" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/machinery/mineral/processing_unit_console{
+	dir = 8;
+	machinedir = 4
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "Kz" = (
 /obj/machinery/computer/crew{
 	dir = 1;
@@ -2431,13 +2446,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/circuit/telecomms,
 /area/mine/maintenance)
-"LH" = (
-/obj/machinery/mineral/processing_unit_console{
-	dir = 2;
-	machinedir = 4
-	},
-/turf/closed/wall,
-/area/mine/living_quarters)
 "Mc" = (
 /obj/machinery/computer/security/mining{
 	dir = 1;
@@ -2445,12 +2453,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/production)
-"Md" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "MP" = (
 /obj/vehicle/ridden/atv,
 /turf/open/floor/plasteel/white,
@@ -2648,6 +2650,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"TD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/mineral/processing_unit_console{
+	dir = 2;
+	machinedir = 4
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "Ub" = (
 /obj/machinery/door/airlock/mining{
 	name = "Mining Station Storage";
@@ -2771,6 +2789,13 @@
 /obj/structure/closet/secure_closet/mmedical,
 /turf/open/floor/plasteel/white,
 /area/mine/production)
+"Wx" = (
+/obj/machinery/mineral/processing_unit_console{
+	dir = 8;
+	machinedir = 8
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "WJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2787,13 +2812,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
-"WV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "WW" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 10
@@ -3097,9 +3115,9 @@ bT
 GP
 gm
 cU
-MS
 di
-Cp
+di
+di
 wF
 HE
 NE
@@ -3130,10 +3148,10 @@ CK
 WJ
 cU
 cu
+Cp
 di
-Md
 di
-bB
+MS
 cY
 pl
 bQ
@@ -3162,10 +3180,10 @@ YV
 rU
 kM
 To
-EF
-WV
-zz
-rH
+gP
+eT
+yt
+yA
 cY
 By
 bQ
@@ -3193,10 +3211,10 @@ QA
 Bx
 iy
 cU
-dl
-cZ
-di
-LH
+Kn
+TD
+Wx
+jL
 cY
 bQ
 By

--- a/_maps/RandomRuins/LavaRuins/miningbase.dmm
+++ b/_maps/RandomRuins/LavaRuins/miningbase.dmm
@@ -1419,16 +1419,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"gP" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "ht" = (
 /obj/structure/ore_box,
 /obj/effect/turf_decal/tile/brown{
@@ -1522,12 +1512,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"jL" = (
-/obj/machinery/mineral/processing_unit_console{
-	dir = 2;
-	machinedir = 8
+"iO" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
 	},
-/turf/closed/wall,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "jV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -1734,6 +1727,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
+"qy" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1;
+	icon_state = "scrub_map_on-3"
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/living_quarters)
 "qK" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -1903,19 +1903,6 @@
 	},
 /turf/closed/wall,
 /area/mine/production)
-"yt" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
-	},
-/turf/open/floor/plasteel/white,
-/area/mine/living_quarters)
-"yA" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "gulag"
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "yM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -2419,16 +2406,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/mine/living_quarters)
-"Kn" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/machinery/mineral/processing_unit_console{
-	dir = 8;
-	machinedir = 4
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "Kz" = (
 /obj/machinery/computer/crew{
 	dir = 1;
@@ -2581,6 +2558,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
+"RF" = (
+/obj/machinery/mineral/processing_unit_console{
+	dir = 2;
+	machinedir = 8
+	},
+/turf/closed/wall,
+/area/mine/living_quarters)
 "RR" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -2647,22 +2631,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
-"TD" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/mineral/processing_unit_console{
-	dir = 2;
-	machinedir = 4
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
@@ -2789,13 +2757,6 @@
 /obj/structure/closet/secure_closet/mmedical,
 /turf/open/floor/plasteel/white,
 /area/mine/production)
-"Wx" = (
-/obj/machinery/mineral/processing_unit_console{
-	dir = 8;
-	machinedir = 8
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "WJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2860,6 +2821,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/production)
+"Yt" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "gulag"
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "YL" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -3180,10 +3147,10 @@ YV
 rU
 kM
 To
-gP
+iO
 eT
-yt
-yA
+qy
+Yt
 cY
 By
 bQ
@@ -3211,10 +3178,10 @@ QA
 Bx
 iy
 cU
-Kn
-TD
-Wx
-jL
+dl
+cZ
+di
+RF
 cY
 bQ
 By

--- a/_maps/RandomRuins/LavaRuins/miningbase.dmm
+++ b/_maps/RandomRuins/LavaRuins/miningbase.dmm
@@ -1764,6 +1764,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"rH" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "gulag"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "rU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -1835,6 +1844,16 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/mine/maintenance)
+"vJ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/mineral/processing_unit{
+	dir = 1;
+	output_dir = 2
+	},
+/turf/open/floor/plating,
+/area/mine/living_quarters)
 "vS" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -1904,6 +1923,19 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"zz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/white,
+/area/mine/living_quarters)
+"zW" = (
+/obj/machinery/mineral/unloading_machine{
+	dir = 1;
+	icon_state = "unloader-corner";
+	input_dir = 1;
+	output_dir = 2
+	},
+/turf/open/floor/plating,
 /area/mine/living_quarters)
 "At" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -2078,17 +2110,6 @@
 	},
 /turf/open/floor/plating,
 /area/mine/eva)
-"CN" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/conveyor{
-	dir = 2;
-	id = "mining_internal"
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "CO" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -2203,16 +2224,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"ET" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/mineral/processing_unit{
-	dir = 1;
-	output_dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "Fd" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -32
@@ -2420,14 +2431,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/circuit/telecomms,
 /area/mine/maintenance)
-"KF" = (
-/obj/machinery/mineral/unloading_machine{
-	dir = 1;
-	icon_state = "unloader-corner";
-	input_dir = 1;
-	output_dir = 2
+"LH" = (
+/obj/machinery/mineral/processing_unit_console{
+	dir = 2;
+	machinedir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/closed/wall,
 /area/mine/living_quarters)
 "Mc" = (
 /obj/machinery/computer/security/mining{
@@ -2495,16 +2504,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/production)
-"OB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "mining_internal";
-	name = "mining conveyor"
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "OK" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -2720,6 +2719,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
+"Vk" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/conveyor{
+	dir = 2;
+	id = "mining_internal"
+	},
+/turf/open/floor/plating,
+/area/mine/living_quarters)
 "Vn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2761,13 +2771,6 @@
 /obj/structure/closet/secure_closet/mmedical,
 /turf/open/floor/plasteel/white,
 /area/mine/production)
-"WB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/mineral/processing_unit_console{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "WJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -3161,8 +3164,8 @@ kM
 To
 EF
 WV
-WB
-OB
+zz
+rH
 cY
 By
 bQ
@@ -3193,7 +3196,7 @@ cU
 dl
 cZ
 di
-bQ
+LH
 cY
 bQ
 By
@@ -3225,9 +3228,9 @@ cU
 cB
 de
 gh
-KF
-CN
-ET
+zW
+Vk
+vJ
 Up
 bQ
 bI

--- a/_maps/RandomRuins/LavaRuins/miningbase.dmm
+++ b/_maps/RandomRuins/LavaRuins/miningbase.dmm
@@ -972,13 +972,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"dO" = (
-/obj/machinery/light/small,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "dP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1;
@@ -1419,12 +1412,13 @@
 /obj/item/book/manual/wiki/surgery,
 /turf/open/floor/plasteel/white,
 /area/mine/production)
-"hc" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Morgue"
+"gC" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel,
-/area/mine/production)
+/area/mine/living_quarters)
 "ht" = (
 /obj/structure/ore_box,
 /obj/effect/turf_decal/tile/brown{
@@ -2340,6 +2334,12 @@
 /obj/machinery/vending/games,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"Hp" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Morgue"
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
 "HE" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -3672,7 +3672,7 @@ ak
 ba
 dv
 du
-dO
+gC
 bQ
 sP
 lf
@@ -4341,7 +4341,7 @@ aw
 zd
 mx
 mx
-hc
+Hp
 mx
 mx
 mx

--- a/_maps/RandomRuins/LavaRuins/miningbase.dmm
+++ b/_maps/RandomRuins/LavaRuins/miningbase.dmm
@@ -15,6 +15,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"ai" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Morgue"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
 "aj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
@@ -385,21 +395,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"bD" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	icon_state = "pump_on_map-2";
-	name = "Mining Waste In";
-	on = 1;
-	target_pressure = 4500
-	},
-/turf/open/floor/plating,
-/area/mine/living_quarters)
 "bF" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 5
@@ -571,6 +566,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
+"cz" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
 "cB" = (
 /obj/machinery/camera{
 	c_tag = "Crew Area Hallway West";
@@ -729,12 +733,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
-"dn" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
@@ -946,10 +944,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"dM" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "dN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1;
@@ -964,15 +958,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"dS" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+"dQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8;
+	icon_state = "scrub_map_on-3"
 	},
-/obj/machinery/reagentgrinder,
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
 "dU" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -1329,15 +1327,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"eW" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/sign/departments/minsky/engineering/atmospherics{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "eY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	external_pressure_bound = 120;
@@ -1357,6 +1346,25 @@
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"fx" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_x = -1;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_x = -8
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
@@ -1390,12 +1398,6 @@
 	},
 /turf/open/floor/plating,
 /area/mine/eva)
-"fQ" = (
-/obj/machinery/computer/operating{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/mine/production)
 "gh" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -1407,13 +1409,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/maintenance)
-"gq" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "mining_internal"
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "ht" = (
 /obj/structure/ore_box,
 /obj/effect/turf_decal/tile/brown{
@@ -1436,6 +1431,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
+"hN" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/closed/wall,
+/area/mine/living_quarters)
 "ia" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 9
@@ -1463,16 +1462,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/mine/living_quarters)
-"ii" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Sleeper Room";
-	network = list("mine")
-	},
-/turf/open/floor/plasteel/white,
-/area/mine/production)
 "iy" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/wintercoat,
@@ -1507,11 +1496,39 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"iE" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mining_internal"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"jQ" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"jS" = (
+/obj/vehicle/ridden/atv,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/dark,
+/area/mine/production)
 "jV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
+/area/mine/production)
+"ka" = (
+/obj/structure/window/reinforced,
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/mine/production)
 "kc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -1522,6 +1539,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"kh" = (
+/obj/machinery/computer/security/mining{
+	dir = 1;
+	icon_state = "computer"
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
 "kM" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Mining Station Communications";
@@ -1545,6 +1576,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/mine/maintenance)
+"kN" = (
+/obj/machinery/conveyor{
+	dir = 9;
+	id = "mining_internal"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "kT" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/structure/reagent_dispensers/fueltank,
@@ -1631,6 +1672,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
+"mr" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/vending/boozeomat/all_access,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "mx" = (
 /turf/open/floor/plasteel/white,
 /area/mine/production)
@@ -1638,6 +1687,22 @@
 /obj/structure/chair/office/dark,
 /turf/open/floor/plasteel/white,
 /area/mine/production)
+"mI" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	icon_state = "pump_on_map-2";
+	name = "Mining Waste In";
+	on = 1;
+	target_pressure = 4500
+	},
+/obj/structure/closet/crate/secure/loot,
+/turf/open/floor/plating,
+/area/mine/living_quarters)
 "nf" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Station Bridge";
@@ -1660,32 +1725,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"nh" = (
-/obj/machinery/camera{
-	c_tag = "Processing Area Room";
-	dir = 8;
-	network = list("mine")
-	},
-/obj/structure/bodycontainer/morgue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/mine/production)
-"nl" = (
-/obj/machinery/conveyor{
-	dir = 9;
-	id = "mining_internal"
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
-"np" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/table/wood,
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "nw" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -1693,25 +1732,46 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/mine/production)
-"or" = (
-/obj/structure/window/reinforced,
-/obj/item/twohanded/required/kirbyplants/random,
+"pw" = (
+/obj/machinery/computer/operating{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/mine/production)
-"pl" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "mining_internal"
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "px" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
+/area/mine/production)
+"pL" = (
+/obj/machinery/mineral/unloading_machine{
+	dir = 1;
+	icon_state = "unloader-corner";
+	input_dir = 1;
+	output_dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/mine/living_quarters)
+"pM" = (
+/obj/machinery/camera{
+	c_tag = "Infirmary Surgery";
+	network = list("mine")
+	},
+/turf/open/floor/plasteel/white,
 /area/mine/production)
 "qr" = (
 /obj/effect/turf_decal/tile/brown,
@@ -1754,15 +1814,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
-"rv" = (
-/obj/structure/table,
-/obj/item/circular_saw,
-/obj/item/scalpel{
-	pixel_y = 12
+"rk" = (
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/item/retractor,
-/turf/open/floor/plasteel/white,
-/area/mine/production)
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4
+	},
+/obj/machinery/mineral/mint{
+	input_dir = 4
+	},
+/turf/open/floor/plating,
+/area/mine/living_quarters)
 "rD" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -1773,13 +1836,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"rM" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/bed/roller,
-/turf/open/floor/plasteel/white,
-/area/mine/production)
 "rU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -1801,18 +1857,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"sd" = (
-/obj/structure/table,
-/obj/item/hemostat,
-/obj/item/cautery{
-	pixel_x = 4
+"sJ" = (
+/obj/machinery/conveyor{
+	dir = 10;
+	id = "mining_internal"
 	},
-/turf/open/floor/plasteel/white,
-/area/mine/production)
-"sP" = (
-/obj/machinery/vending/boozeomat,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -1822,10 +1872,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/mine/production)
-"tS" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/white,
 /area/mine/production)
 "tY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -1851,6 +1897,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"ul" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/reagentgrinder/kitchen,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "uv" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1864,13 +1919,6 @@
 /obj/structure/bed/roller,
 /turf/open/floor/plasteel/white,
 /area/mine/production)
-"uM" = (
-/obj/machinery/mineral/processing_unit{
-	dir = 1;
-	output_dir = 2
-	},
-/turf/open/floor/plating,
-/area/mine/living_quarters)
 "vD" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
 	dir = 1
@@ -1881,26 +1929,17 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/mine/eva)
-"wc" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Processing Area Room";
-	dir = 4;
-	network = list("mine")
-	},
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "wD" = (
 /obj/machinery/sleeper{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/production)
+"wK" = (
+/obj/effect/spawner/structure/window,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating,
+/area/mine/living_quarters)
 "xs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -1932,23 +1971,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
-"yl" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
-	},
-/turf/closed/wall,
-/area/mine/production)
 "yM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/mine/living_quarters)
-"zd" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/mine/production)
 "zh" = (
 /obj/machinery/door/airlock{
 	id_tag = "miningdorm1";
@@ -1968,15 +1994,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"zW" = (
-/obj/machinery/mineral/unloading_machine{
-	dir = 1;
-	icon_state = "unloader-corner";
-	input_dir = 1;
-	output_dir = 2
+"zw" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"Ac" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
 "At" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -2012,16 +2045,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"AQ" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
-	},
-/obj/structure/closet/crate/secure/loot,
-/turf/open/floor/plating,
-/area/mine/living_quarters)
 "Bn" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -2048,6 +2071,17 @@
 /obj/machinery/telecomms/relay/preset/mining,
 /turf/open/floor/circuit/green/telecomms,
 /area/mine/maintenance)
+"Bu" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mining_internal"
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "Bx" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -2059,13 +2093,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/mine/maintenance)
-"By" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "mining_internal"
+"BC" = (
+/obj/structure/table/optable{
+	name = "Robotics Operating Table"
 	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
 "BS" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -2107,6 +2143,19 @@
 /obj/structure/sign/departments/minsky/supply/mining,
 /turf/closed/wall,
 /area/mine/eva)
+"CB" = (
+/obj/machinery/light,
+/obj/structure/sign/departments/minsky/medical/medical2{
+	pixel_y = -32
+	},
+/obj/machinery/camera{
+	c_tag = "Sleeper Room";
+	dir = 1;
+	network = list("mine")
+	},
+/obj/machinery/iv_drip,
+/turf/open/floor/plasteel/white,
+/area/mine/production)
 "CH" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/tile/purple{
@@ -2152,6 +2201,17 @@
 	},
 /turf/open/floor/plating,
 /area/mine/eva)
+"CM" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "CO" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -2161,6 +2221,21 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"CX" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/sign/departments/minsky/engineering/atmospherics{
+	pixel_y = 32
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "Dk" = (
@@ -2184,36 +2259,43 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"Du" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood/AMinus,
-/obj/item/reagent_containers/blood/BMinus{
-	pixel_x = -4;
-	pixel_y = 4
+"DT" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/item/reagent_containers/blood/BPlus{
-	pixel_x = 1;
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"DW" = (
+/obj/structure/table,
+/obj/item/hemostat{
+	pixel_x = 4;
 	pixel_y = 2
 	},
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/reagent_containers/blood/OPlus{
-	pixel_x = -2;
-	pixel_y = -1
+/obj/item/cautery{
+	pixel_x = 7
 	},
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/APlus,
-/obj/item/reagent_containers/blood/random,
-/obj/machinery/light,
-/obj/structure/sign/departments/minsky/medical/medical2{
-	pixel_y = -32
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Sleeper Room";
-	dir = 1;
-	network = list("mine")
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/item/surgicaldrill{
+	pixel_x = -1;
+	pixel_y = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/production)
@@ -2276,6 +2358,30 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/production)
+"Fi" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/bed/roller,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
+"Fs" = (
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "mining_internal"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "FB" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -2361,11 +2467,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"Gs" = (
-/obj/machinery/conveyor{
-	dir = 2;
-	id = "mining_internal"
+"GO" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
 	},
+/obj/structure/table,
+/obj/item/toy/cards/deck,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "GP" = (
@@ -2390,18 +2498,40 @@
 /obj/machinery/vending/games,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"Hp" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Morgue"
-	},
-/turf/open/floor/plasteel/white,
-/area/mine/production)
 "HH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple,
 /turf/open/floor/plating,
+/area/mine/living_quarters)
+"HO" = (
+/obj/machinery/computer/crew{
+	dir = 1;
+	icon_state = "computer"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
+"IN" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Processing Area Room";
+	dir = 4;
+	network = list("mine")
+	},
+/turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "Je" = (
 /obj/structure/closet/secure_closet/miner,
@@ -2448,16 +2578,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/mine/living_quarters)
-"Kz" = (
-/obj/machinery/computer/crew{
-	dir = 1;
-	icon_state = "computer"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/mine/production)
 "KB" = (
 /obj/machinery/airalarm/tcomms{
 	pixel_y = 24
@@ -2465,28 +2585,58 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/circuit/telecomms,
 /area/mine/maintenance)
-"Lx" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+"Lk" = (
+/obj/structure/noticeboard{
+	dir = 1;
+	pixel_y = -27
+	},
+/obj/item/paper/fluff/stations/lavaland/orm_notice,
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"Mc" = (
-/obj/machinery/computer/security/mining{
-	dir = 1;
-	icon_state = "computer"
+"Ll" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/white,
-/area/mine/production)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"LY" = (
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "Mo" = (
 /obj/machinery/mineral/processing_unit_console,
 /turf/closed/wall,
 /area/mine/living_quarters)
-"MP" = (
-/obj/vehicle/ridden/atv,
-/turf/open/floor/plasteel/white,
-/area/mine/production)
-"MS" = (
-/obj/machinery/mineral/mint{
-	input_dir = 4
+"MV" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mining_internal"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
@@ -2503,30 +2653,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"Nn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+"Ot" = (
+/obj/machinery/light,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/white,
-/area/mine/production)
-"NE" = (
-/obj/structure/plasticflaps,
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "mining_internal"
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"Od" = (
-/obj/structure/table/optable{
-	name = "Robotics Operating Table"
-	},
-/turf/open/floor/plasteel/white,
-/area/mine/production)
 "OC" = (
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
@@ -2559,12 +2695,45 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"Pj" = (
+/obj/machinery/mineral/processing_unit{
+	dir = 1;
+	output_dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/mine/living_quarters)
 "Pk" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
 /obj/structure/chair/stool/bar,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"Pz" = (
+/obj/machinery/conveyor{
+	dir = 2;
+	id = "mining_internal"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"Qk" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "mining_internal"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "Qs" = (
@@ -2598,6 +2767,25 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/mine/maintenance)
+"Rf" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/production)
+"Rl" = (
+/obj/machinery/light,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "Ru" = (
 /obj/structure/sign/warning/docking,
 /obj/effect/spawner/structure/window/reinforced/shutter,
@@ -2611,6 +2799,17 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
+/area/mine/production)
+"RN" = (
+/obj/structure/closet/secure_closet/mmedical,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white,
 /area/mine/production)
 "RR" = (
 /obj/effect/turf_decal/tile/brown,
@@ -2681,12 +2880,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"TY" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "mining_internal"
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "Ub" = (
 /obj/machinery/door/airlock/mining{
 	name = "Mining Station Storage";
@@ -2700,25 +2893,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"Up" = (
-/obj/machinery/conveyor{
-	dir = 10;
-	id = "mining_internal"
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
-"Uu" = (
-/obj/structure/table,
-/obj/item/surgical_drapes{
-	pixel_x = -5;
-	pixel_y = 6
-	},
-/obj/structure/window/reinforced,
-/obj/item/book/manual/wiki/surgery{
-	pixel_x = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/mine/production)
 "Uy" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -2798,13 +2972,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/mine/maintenance)
-"Vr" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "Vt" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -2814,10 +2981,26 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/production)
-"Wl" = (
-/obj/structure/closet/secure_closet/mmedical,
+"VJ" = (
+/obj/structure/table,
+/obj/item/circular_saw,
+/obj/item/scalpel{
+	pixel_y = 12
+	},
+/obj/item/retractor,
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/mine/production)
+"VK" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "mining_internal";
+	name = "Smelter Conveyor Control Switch"
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "WJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2867,19 +3050,48 @@
 /obj/structure/chair/stool/bar,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"Xv" = (
-/obj/machinery/light/small{
-	dir = 4
+"Yj" = (
+/obj/structure/table,
+/obj/item/surgical_drapes{
+	pixel_x = -5;
+	pixel_y = 6
 	},
-/obj/structure/bodycontainer/morgue{
-	dir = 8
+/obj/structure/window/reinforced,
+/obj/item/book/manual/wiki/surgery{
+	pixel_x = 5
 	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/mine/production)
-"XB" = (
-/obj/structure/bodycontainer/morgue{
+"Yy" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/APlus,
+/obj/item/reagent_containers/blood/BMinus{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/OPlus{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/BPlus{
+	pixel_x = 1;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/blood/AMinus,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
 /turf/open/floor/plasteel/white,
 /area/mine/production)
 "YL" = (
@@ -2910,25 +3122,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/mine/maintenance)
-"YZ" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/beer{
-	pixel_x = -8
-	},
-/obj/item/reagent_containers/food/drinks/beer{
-	pixel_x = -1;
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/food/drinks/beer{
-	pixel_x = 7;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 
 (1,1,1) = {"
 ab
@@ -3111,8 +3304,8 @@ ba
 bQ
 bQ
 bQ
-bQ
-bQ
+hN
+hN
 bQ
 bI
 ab
@@ -3137,14 +3330,14 @@ bT
 GP
 gm
 cU
-Lx
+zw
 OU
 di
-Vr
-wc
-NE
-gq
-nl
+CM
+IN
+Fs
+Qk
+kN
 bQ
 ak
 ab
@@ -3173,10 +3366,10 @@ cu
 AG
 dN
 di
-MS
-cY
-cY
-By
+di
+wK
+wK
+MV
 bQ
 ak
 ab
@@ -3203,12 +3396,12 @@ rU
 kM
 To
 Hh
+jQ
 di
 di
-TY
-di
-cY
-pl
+VK
+wK
+Bu
 bQ
 ak
 ab
@@ -3235,12 +3428,12 @@ iy
 cU
 dl
 cZ
-di
+Lk
 bQ
 cY
 Mo
 cY
-By
+iE
 bQ
 bI
 bI
@@ -3268,11 +3461,11 @@ cU
 cB
 de
 gh
-zW
-Gs
-uM
-Gs
-Up
+pL
+Pz
+Pj
+Pz
+sJ
 bQ
 bP
 bI
@@ -3297,9 +3490,9 @@ CH
 ui
 Je
 bQ
-dn
-cZ
-dM
+LY
+DT
+Rl
 bQ
 bQ
 bQ
@@ -3521,9 +3714,9 @@ HH
 eG
 cK
 bQ
-eW
-cZ
-dM
+CX
+Ll
+Ot
 bQ
 eZ
 fb
@@ -3560,7 +3753,7 @@ cY
 Ho
 fb
 lM
-YZ
+GO
 bQ
 er
 ey
@@ -3612,8 +3805,8 @@ ak
 ak
 yM
 bZ
-AQ
-bD
+rk
+mI
 kT
 cr
 cF
@@ -3654,7 +3847,7 @@ cZ
 di
 bQ
 BS
-np
+fx
 OK
 bU
 bQ
@@ -3717,9 +3910,9 @@ dv
 du
 eO
 bQ
-sP
+mr
 lf
-dS
+ul
 fD
 bQ
 bI
@@ -4253,14 +4446,14 @@ bt
 ao
 bO
 aw
-fQ
-Od
-or
+pw
+BC
+ka
 qK
 At
 Vt
 Dk
-Kz
+HO
 FB
 ak
 ak
@@ -4285,14 +4478,14 @@ bu
 ao
 aw
 aw
-ii
+pM
 mx
 mx
 mx
 UP
 mx
 mz
-Mc
+kh
 aw
 ak
 ak
@@ -4317,10 +4510,10 @@ bv
 ao
 bP
 aw
-sd
-rv
-Uu
-MP
+DW
+VJ
+Yj
+jS
 Fe
 Qs
 dc
@@ -4353,10 +4546,10 @@ aw
 aw
 aw
 aw
-Nn
+dQ
 mx
 mx
-Wl
+RN
 aw
 ak
 ak
@@ -4381,14 +4574,14 @@ Xc
 ao
 bI
 aw
-zd
+cz
+Dk
+Dk
+ai
+Ac
 mx
 mx
-Hp
-mx
-mx
-mx
-Du
+CB
 aw
 ak
 ak
@@ -4413,14 +4606,14 @@ OT
 ao
 bI
 aw
-XB
-Xv
-nh
+Rf
+Rf
+Rf
 aw
-rM
+Fi
 uG
 wD
-tS
+Yy
 aw
 ak
 ak
@@ -4450,8 +4643,8 @@ aw
 aw
 aw
 aw
+FB
 aw
-yl
 aw
 aw
 ak

--- a/_maps/RandomRuins/LavaRuins/miningbase.dmm
+++ b/_maps/RandomRuins/LavaRuins/miningbase.dmm
@@ -1537,6 +1537,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"kF" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/conveyor{
+	dir = 2;
+	id = "mining_internal"
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "kM" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Mining Station Communications";
@@ -1701,18 +1712,18 @@
 /obj/structure/table/wood,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"nO" = (
+/obj/machinery/conveyor{
+	dir = 2;
+	id = "mining_internal"
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "or" = (
 /obj/structure/window/reinforced,
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/mine/production)
-"ov" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "mining_internal"
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "pl" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -1734,13 +1745,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
-"qy" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
-	},
-/turf/open/floor/plasteel/white,
-/area/mine/living_quarters)
 "qK" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -1929,6 +1933,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"zV" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "mining_internal"
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "zW" = (
 /obj/machinery/mineral/unloading_machine{
 	dir = 1;
@@ -1953,10 +1964,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/production)
-"Av" = (
-/obj/machinery/mineral/processing_unit_console,
-/turf/closed/wall,
-/area/mine/living_quarters)
 "AK" = (
 /obj/machinery/camera{
 	c_tag = "Storage";
@@ -2180,6 +2187,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/production)
+"Dy" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1;
+	icon_state = "scrub_map_on-3"
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "Ew" = (
 /obj/machinery/mineral/equipment_vendor,
 /obj/effect/turf_decal/tile/brown{
@@ -2362,13 +2376,6 @@
 /obj/machinery/atmospherics/pipe/simple,
 /turf/open/floor/plating,
 /area/mine/living_quarters)
-"IO" = (
-/obj/machinery/conveyor{
-	dir = 2;
-	id = "mining_internal"
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "Je" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/turf_decal/tile/purple{
@@ -2471,13 +2478,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/production)
-"Np" = (
-/obj/machinery/mineral/processing_unit{
-	dir = 1;
-	output_dir = 2
-	},
-/turf/open/floor/plating,
-/area/mine/living_quarters)
 "NE" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
@@ -2527,6 +2527,13 @@
 	},
 /obj/structure/chair/stool/bar,
 /turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"PG" = (
+/obj/machinery/mineral/processing_unit{
+	dir = 1;
+	output_dir = 2
+	},
+/turf/open/floor/plating,
 /area/mine/living_quarters)
 "Qs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -2713,17 +2720,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
-"Vk" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/conveyor{
-	dir = 2;
-	id = "mining_internal"
-	},
-/turf/open/floor/plating,
-/area/mine/living_quarters)
 "Vn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2881,6 +2877,10 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
+/area/mine/living_quarters)
+"ZE" = (
+/obj/machinery/mineral/processing_unit_console,
+/turf/closed/wall,
 /area/mine/living_quarters)
 
 (1,1,1) = {"
@@ -3096,7 +3096,7 @@ di
 wF
 HE
 NE
-ov
+zV
 nl
 bQ
 ak
@@ -3157,7 +3157,7 @@ kM
 To
 iO
 eT
-qy
+Dy
 Yt
 di
 cY
@@ -3191,7 +3191,7 @@ cZ
 di
 bQ
 cY
-Av
+ZE
 cY
 By
 bQ
@@ -3222,9 +3222,9 @@ cB
 de
 gh
 zW
-Vk
-Np
-IO
+kF
+PG
+nO
 Up
 bQ
 bP

--- a/_maps/RandomRuins/LavaRuins/miningbase.dmm
+++ b/_maps/RandomRuins/LavaRuins/miningbase.dmm
@@ -1706,6 +1706,13 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/mine/production)
+"ov" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "mining_internal"
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "pl" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -1852,16 +1859,6 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/mine/maintenance)
-"vJ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/mineral/processing_unit{
-	dir = 1;
-	output_dir = 2
-	},
-/turf/open/floor/plating,
-/area/mine/living_quarters)
 "vS" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -1956,6 +1953,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/production)
+"Av" = (
+/obj/machinery/mineral/processing_unit_console,
+/turf/closed/wall,
+/area/mine/living_quarters)
 "AK" = (
 /obj/machinery/camera{
 	c_tag = "Storage";
@@ -2361,6 +2362,13 @@
 /obj/machinery/atmospherics/pipe/simple,
 /turf/open/floor/plating,
 /area/mine/living_quarters)
+"IO" = (
+/obj/machinery/conveyor{
+	dir = 2;
+	id = "mining_internal"
+	},
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "Je" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/turf_decal/tile/purple{
@@ -2463,6 +2471,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/production)
+"Np" = (
+/obj/machinery/mineral/processing_unit{
+	dir = 1;
+	output_dir = 2
+	},
+/turf/open/floor/plating,
+/area/mine/living_quarters)
 "NE" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
@@ -2558,13 +2573,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"RF" = (
-/obj/machinery/mineral/processing_unit_console{
-	dir = 2;
-	machinedir = 8
-	},
-/turf/closed/wall,
-/area/mine/living_quarters)
 "RR" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -3058,7 +3066,7 @@ bQ
 bQ
 bQ
 bQ
-bI
+bQ
 bI
 ab
 ab
@@ -3088,10 +3096,10 @@ di
 wF
 HE
 NE
+ov
 nl
 bQ
 ak
-ab
 ab
 ab
 ab
@@ -3120,10 +3128,10 @@ di
 di
 MS
 cY
-pl
+cY
+By
 bQ
 ak
-ab
 ab
 ab
 ab
@@ -3151,11 +3159,11 @@ iO
 eT
 qy
 Yt
+di
 cY
-By
+pl
 bQ
 ak
-ab
 ab
 ab
 ab
@@ -3181,12 +3189,12 @@ cU
 dl
 cZ
 di
-RF
-cY
 bQ
+cY
+Av
+cY
 By
 bQ
-ak
 bI
 bI
 ab
@@ -3215,10 +3223,10 @@ de
 gh
 zW
 Vk
-vJ
+Np
+IO
 Up
 bQ
-bI
 bP
 bI
 bI


### PR DESCRIPTION
Decided to re-work the mining base on feedback from some miner mains. The main change was swapping smeltery and the infirmary to allow the medic easier access to the miners. Also keeps the infirmary close to the shuttle.

Also includes QoL changes, such as a 2x2 hallway bridge instead of a 1x1. Based on the feedback I also added a mini-bar and a games vendor, for 'enhanced miner roleplay'. Whatever, now you have something to do after you go to lavaland during revs.

Current mining base

![](https://i.gyazo.com/1b8308f3f6bbb09a2286c0bb3d04e9a4.png)

Picture of the NEW BASE!

![](https://i.gyazo.com/87c173afa502e70dd4091ce6fc489c79.png)


:cl:  
tweak: The Lavaland Mining Base has been tweaked!
rscadd: Mining Medic area moved to the Smelter area, now features a morgue and surgical area!
rscadd: MIning Base crew rest area now has a mini-bar and a games vendor. Now when you run there to escape the blob, you can play UNO while ignoring the screams of your fellow crewmembers on the station.
rscdel: Deleted the old smelter.
tweak: The old Mining Base Infirmary is now home to a mini-smelter. Kinda mini. It's still pretty large.
/:cl:
