### PR TITLE
CentCom recovery ship mini-updates (mounted defib, bathroom, Captain Cleanbot, and a dead mouse)

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -21059,12 +21059,6 @@
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/plasteel,
 /area/centcom/evac)
-"UG" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Bathroom"
-	},
-/turf/open/floor/plasteel/freezer,
-/area/centcom/evac)
 "UH" = (
 /obj/machinery/light{
 	dir = 8
@@ -22158,6 +22152,16 @@
 	use_power = 0
 	},
 /turf/closed/wall/mineral/titanium,
+/area/centcom/evac)
+"XB" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Bathroom"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/freezer,
 /area/centcom/evac)
 "XC" = (
 /obj/item/reagent_containers/food/snacks/egg/rainbow{
@@ -52650,7 +52654,7 @@ KQ
 NP
 KH
 pC
-UG
+XB
 ta
 TF
 ta

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -12021,14 +12021,6 @@
 /obj/item/soap/deluxe,
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
-"zY" = (
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/fernybush,
-/obj/structure/window/shuttle,
-/turf/open/floor/grass,
-/area/centcom/evac)
 "zZ" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -12635,6 +12627,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
+"Bu" = (
+/obj/item/reagent_containers/food/snacks/deadmouse,
+/obj/effect/decal/cleanable/blood/gibs/core,
+/turf/open/floor/plating,
+/area/centcom/evac)
 "Bv" = (
 /obj/machinery/computer/card/centcom{
 	dir = 1
@@ -15277,6 +15274,16 @@
 	},
 /turf/open/lava/airless,
 /area/wizard_station)
+"GA" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/fire,
+/obj/machinery/door/firedoor/border_only,
+/obj/item/storage/firstaid/advanced{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/centcom/evac)
 "GB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/grille/ratvar,
@@ -17630,17 +17637,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/centcom/evac)
-"KP" = (
-/obj/machinery/door/window/eastleft,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/centcom/evac)
 "KQ" = (
 /turf/open/floor/plating,
 /area/centcom/evac)
@@ -17691,12 +17687,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/evac)
+"La" = (
+/obj/machinery/stasis{
+	dir = 4
+	},
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = -28;
+	pixel_y = -3
+	},
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/centcom/evac)
 "Lb" = (
 /turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"Ld" = (
-/obj/structure/dresser,
-/turf/open/floor/carpet/blue,
 /area/centcom/evac)
 "Li" = (
 /obj/structure/window/reinforced,
@@ -17728,10 +17733,6 @@
 /area/centcom/evac)
 "Lt" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/centcom/evac)
-"Lw" = (
-/obj/structure/chair/office/dark,
-/turf/open/floor/mineral/titanium,
 /area/centcom/evac)
 "LE" = (
 /obj/structure/table,
@@ -18982,6 +18983,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
+"OO" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "OP" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -19983,6 +19993,12 @@
 /obj/machinery/vending/syndichem,
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
+"RH" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/open/floor/plasteel/freezer,
+/area/centcom/evac)
 "RI" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -20174,6 +20190,14 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/two)
+"Sf" = (
+/obj/structure/chair/office/dark,
+/mob/living/simple_animal/bot/cleanbot{
+	desc = "A little cleaning robot that after years of hard work, got promoted to captain and was given his own ship!";
+	name = "Captain Cleanbot"
+	},
+/turf/open/floor/mineral/titanium,
+/area/centcom/evac)
 "Sg" = (
 /obj/machinery/light{
 	dir = 4;
@@ -20202,6 +20226,15 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
+/area/centcom/evac)
+"Sm" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
 /area/centcom/evac)
 "So" = (
 /obj/structure/lattice/catwalk/swarmer_catwalk,
@@ -20491,10 +20524,13 @@
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
 "Th" = (
-/obj/machinery/stasis{
-	dir = 4
+/obj/structure/mirror{
+	pixel_y = 28
 	},
-/turf/open/floor/mineral/titanium/white,
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/turf/open/floor/plasteel/freezer,
 /area/centcom/evac)
 "Ti" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -20922,16 +20958,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
-"Uo" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium/white,
-/area/centcom/evac)
 "Up" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien14";
@@ -21027,6 +21053,12 @@
 	},
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/plasteel,
+/area/centcom/evac)
+"UG" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Bathroom"
+	},
+/turf/open/floor/plasteel/freezer,
 /area/centcom/evac)
 "UH" = (
 /obj/machinery/light{
@@ -22559,6 +22591,19 @@
 /obj/item/reagent_containers/glass/beaker,
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
+"YR" = (
+/obj/machinery/door/window/eastleft{
+	name = "bar counter door"
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "YS" = (
 /obj/structure/destructible/cult/talisman,
 /obj/item/sharpener/cult,
@@ -22999,12 +23044,6 @@
 /obj/item/gun/magic/staff/spellblade,
 /turf/open/floor/wood,
 /area/centcom/testchamber)
-"ZS" = (
-/obj/structure/sink{
-	pixel_y = 20
-	},
-/turf/open/floor/carpet/blue,
-/area/centcom/evac)
 "ZT" = (
 /mob/living/simple_animal/cow,
 /turf/open/floor/grass,
@@ -49504,7 +49543,7 @@ MJ
 QF
 WR
 KQ
-KQ
+Bu
 KH
 SO
 Tt
@@ -49764,7 +49803,7 @@ Xj
 KH
 KH
 KH
-KP
+YR
 KX
 CU
 Oy
@@ -50532,7 +50571,7 @@ wT
 Sl
 KV
 KV
-KV
+Sm
 XU
 rY
 KV
@@ -50788,8 +50827,8 @@ aa
 aa
 KH
 YW
-Lb
 KV
+OO
 SQ
 tv
 KV
@@ -51045,20 +51084,20 @@ aa
 aa
 xC
 xA
-Lb
+KV
 KV
 KV
 KM
 Yj
 KH
-zY
-zY
+KH
+KH
 XA
 KV
 KV
 WP
 KV
-Lw
+Sf
 LP
 Im
 aa
@@ -51302,15 +51341,15 @@ aa
 aa
 KH
 Rl
-Lb
 KV
+Sm
 XU
 rY
 KV
 Lk
-Th
+La
 yL
-Uo
+GA
 KV
 Lb
 KH
@@ -51560,7 +51599,7 @@ Bw
 Sl
 KV
 KV
-KV
+OO
 SQ
 tv
 KV
@@ -52590,10 +52629,10 @@ Gt
 KQ
 KQ
 KH
-ZS
+Th
+UG
 ta
 TF
-ta
 ta
 KV
 KH
@@ -52847,8 +52886,8 @@ KQ
 KQ
 Ry
 KH
-Ld
-zS
+RH
+KH
 zS
 zS
 zS
@@ -53105,10 +53144,10 @@ jA
 KH
 KH
 KH
-RL
-RL
-RL
 KH
+RL
+RL
+RL
 KH
 aa
 aa

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6915,6 +6915,18 @@
 /obj/machinery/firealarm,
 /turf/closed/indestructible/riveted,
 /area/centcom/ferry)
+"pC" = (
+/obj/structure/mirror{
+	pixel_y = 28
+	},
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/freezer,
+/area/centcom/evac)
 "pD" = (
 /obj/structure/destructible/cult/tome,
 /obj/item/shuttle_curse,
@@ -12627,11 +12639,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
-"Bu" = (
-/obj/item/reagent_containers/food/snacks/deadmouse,
-/obj/effect/decal/cleanable/blood/gibs/core,
-/turf/open/floor/plating,
-/area/centcom/evac)
 "Bv" = (
 /obj/machinery/computer/card/centcom{
 	dir = 1
@@ -15228,14 +15235,6 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
-"Gt" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/eight,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/centcom/evac)
 "Gu" = (
 /obj/machinery/door/airlock/silver{
 	name = "Shower"
@@ -15274,16 +15273,6 @@
 	},
 /turf/open/lava/airless,
 /area/wizard_station)
-"GA" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/fire,
-/obj/machinery/door/firedoor/border_only,
-/obj/item/storage/firstaid/advanced{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/centcom/evac)
 "GB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/grille/ratvar,
@@ -17656,10 +17645,6 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
-"KU" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
 "KV" = (
 /turf/open/floor/mineral/titanium,
 /area/centcom/evac)
@@ -17951,6 +17936,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
+"Ml" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/eight,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/centcom/evac)
 "Mm" = (
 /turf/open/floor/grass,
 /area/centcom/holding)
@@ -18529,6 +18523,10 @@
 "NO" = (
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
+"NP" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/centcom/evac)
 "NQ" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -19228,6 +19226,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
+"PJ" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "PK" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -19934,10 +19939,6 @@
 /obj/machinery/door/window/westleft,
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
-"Ry" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
-/area/centcom/evac)
 "RA" = (
 /obj/structure/lattice/catwalk/swarmer_catwalk,
 /mob/living/simple_animal/hostile/retaliate/goat/king,
@@ -20205,10 +20206,6 @@
 	},
 /turf/open/floor/bluespace,
 /area/centcom/testchamber)
-"Sh" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/centcom/evac)
 "Si" = (
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/two)
@@ -20474,6 +20471,12 @@
 /obj/machinery/portable_atmospherics/canister/nob,
 /turf/open/floor/plasteel/dark,
 /area/centcom/testchamber)
+"Ta" = (
+/obj/effect/decal/cleanable/blood/gibs/core,
+/obj/item/reagent_containers/food/snacks/deadmouse,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/centcom/evac)
 "Tb" = (
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/wood,
@@ -20523,15 +20526,6 @@
 /obj/item/gun/ballistic/automatic/tommygun,
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
-"Th" = (
-/obj/structure/mirror{
-	pixel_y = 28
-	},
-/obj/structure/sink{
-	pixel_y = 20
-	},
-/turf/open/floor/plasteel/freezer,
-/area/centcom/evac)
 "Ti" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -20890,6 +20884,16 @@
 /obj/effect/landmark/holding_facility,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Uf" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/fire,
+/obj/machinery/door/firedoor/border_only,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/centcom/evac)
 "Ug" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -21326,6 +21330,11 @@
 /obj/machinery/vending/medical/syndicate_access,
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
+"Vt" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/centcom/evac)
 "Vu" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -21606,6 +21615,11 @@
 	},
 /turf/open/floor/plasteel/bluespace,
 /area/centcom/evac)
+"Wi" = (
+/obj/machinery/space_heater,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/centcom/evac)
 "Wj" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -21865,14 +21879,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
-"WR" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/eight,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/centcom/evac)
 "WS" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -22396,6 +22402,15 @@
 /obj/item/reagent_containers/food/snacks/chawanmushi,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Yg" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/eight,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/centcom/evac)
 "Yh" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -49284,9 +49299,9 @@ aa
 aa
 Cj
 QF
-Sh
+Wi
 KQ
-Ry
+Vt
 KH
 KL
 KO
@@ -49541,9 +49556,9 @@ aa
 aa
 MJ
 QF
-WR
+Yg
 KQ
-Bu
+NP
 KH
 SO
 Tt
@@ -50312,7 +50327,7 @@ aa
 aa
 aa
 KH
-KU
+PJ
 KV
 KV
 KV
@@ -51349,7 +51364,7 @@ KV
 Lk
 La
 yL
-GA
+Uf
 KV
 Lb
 KH
@@ -51854,7 +51869,7 @@ aa
 aa
 aa
 KH
-KU
+PJ
 KV
 KV
 KV
@@ -52625,11 +52640,11 @@ aa
 aa
 MJ
 QF
-Gt
+Ml
 KQ
-KQ
+NP
 KH
-Th
+pC
 UG
 ta
 TF
@@ -52882,9 +52897,9 @@ aa
 aa
 Nz
 QF
+Ta
 KQ
-KQ
-Ry
+Vt
 KH
 RH
 KH

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -19862,12 +19862,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
-"Rl" = (
-/obj/machinery/vending/toyliberationstation{
-	pixel_x = -1
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
 "Rm" = (
 /obj/structure/chair/wood/wings{
 	dir = 3
@@ -21046,6 +21040,13 @@
 /obj/structure/table/wood/fancy,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
+"UD" = (
+/obj/machinery/vending/toyliberationstation{
+	age_restrictions = 0;
+	extended_inventory = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "UE" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood,
@@ -21899,6 +21900,14 @@
 /obj/item/desynchronizer,
 /turf/open/floor/wood,
 /area/centcom/testchamber)
+"WW" = (
+/obj/machinery/vending/toyliberationstation{
+	age_restrictions = 0;
+	extended_inventory = 1;
+	pixel_x = -1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "WY" = (
 /obj/structure/mineral_door/paperframe{
 	name = "Arcade"
@@ -22678,10 +22687,6 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
-"YW" = (
-/obj/machinery/vending/toyliberationstation,
-/turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
 "YX" = (
 /obj/machinery/airalarm/directional/west{
 	pixel_x = -24
@@ -50841,7 +50846,7 @@ aa
 aa
 aa
 KH
-YW
+UD
 KV
 OO
 SQ
@@ -51355,7 +51360,7 @@ aa
 aa
 aa
 KH
-Rl
+WW
 KV
 Sm
 XU


### PR DESCRIPTION
At the request of one of the Yog Discord users, I added a (loaded) mounted defibrillator to the medbay of the CentCom recovery ship. However, while I was at it, I decided to make the following additions:

* A proper bathroom in the "living quarters" area at the cost of a bed and a dresser.
* A non-patrolling cleanbot in the cockpit, named "Captain Cleanbot".
* Four additional seats.
* Additional lighting towards the "rear" of the ship.
* A dead mouse in the port escape pod dock. Gross.
* Some additional grime in the port and starboard escape pod docks. That's what you get for taking the plebeian pods. 

#### Changelog

:cl:  
rscadd: Adds a mounted defibrillator to the CentCom recovery ship.
rscadd: Adds a bathroom to the CentCom recovery ship.
rscadd: Adds additional seating, lighting, and "grime" to the CentCom recovery ship.
/:cl:
