### PR TITLE
darkspawn abilities are reapplied when lost also monkeys can't divulge

### DIFF
--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -21,3 +21,7 @@
 	var/datum/antagonist/changeling/changeling = mind.has_antag_datum(/datum/antagonist/changeling)
 	if(changeling)
 		changeling.regain_powers()
+
+	var/datum/antagonist/darkspawn/darkspawn = mind.has_antag_datum(/datum/antagonist/darkspawn)
+	if(darkspawn)
+		darkspawn.regain_abilities()

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn.dm
@@ -255,6 +255,13 @@
 	var/obj/screen/counter = owner.current.hud_used.psi_counter
 	counter.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font color='#7264FF'>[psi]</font></div>"
 
+/datum/antagonist/darkspawn/proc/regain_abilities()
+	for(var/A in abilities)
+		var/datum/action/innate/darkspawn/ability = abilities[A]
+		if(ability)
+			ability.Remove(ability.owner)
+			ability.Grant(owner.current)
+
 /datum/antagonist/darkspawn/proc/has_ability(id)
 	if(isnull(abilities[id]))
 		return
@@ -313,7 +320,12 @@
 /datum/antagonist/darkspawn/proc/force_divulge()
 	if(darkspawn_state != MUNDANE)
 		return
+	var/mob/living/carbon/C = owner.current
+	if(C && !ishuman(C))
+		C.humanize()
 	var/mob/living/carbon/human/H = owner.current
+	if(!H)
+		owner.current.gib(TRUE)
 	H.visible_message("<span class='boldwarning'>[H]'s skin begins to slough off in sheets!</span>", \
 	"<span class='userdanger'>You can't maintain your disguise any more! It begins sloughing off!</span>")
 	playsound(H, 'yogstation/sound/creatures/darkspawn_force_divulge.ogg', 50, FALSE)

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/_divulge.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/_divulge.dm
@@ -11,6 +11,9 @@
 	set waitfor = FALSE
 	var/mob/living/carbon/human/user = usr
 	var/turf/spot = get_turf(user)
+	if(!ishuman(user))
+		to_chat(user, "<span class='warning'>You need to be human-er to do that!</span>")
+		return
 	if(spot.get_lumcount() > DARKSPAWN_DIM_LIGHT)
 		to_chat(user, "<span class='warning'>You are only able to divulge in darkness!</span>")
 		return


### PR DESCRIPTION
big fix
:cl:  
bugfix: darkspawn now regenerate their abilities when swapping bodies instead of losing them
tweak: darkspawn who somehow become monkies can not divulge as monkies
/:cl:
