### PR TITLE
Cryo pods now don't stop when cloning damage is present on MEDICALIGNORE

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -182,7 +182,7 @@
 		return
 	
 	/// Individuals with the MEDICALIGNORE trait will stop the cryo from functioning and display a unique warning unless there is clone damage on the body which cryo happens to be able to heal even with MEDICALIGNORE (oversight probably but one of the one ways to heal their clone damage atm). - Hopek
-	if(HAS_TRAIT(mob_occupant,TRAIT_MEDICALIGNORE) && mob_occupant.getCloneLoss())
+	if(HAS_TRAIT(mob_occupant,TRAIT_MEDICALIGNORE) && !mob_occupant.getCloneLoss())
 		src.visible_message("<span class='warning'>[src] is unable to treat [mob_occupant] as they cannot be treated with conventional medicine.</span>")
 		playsound(src,'sound/machines/cryo_warning_ignore.ogg',60,1)
 		on = FALSE

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -182,7 +182,7 @@
 		return
 	
 	/// Individuals with the MEDICALIGNORE trait will stop the cryo from functioning and display a unique warning unless there is clone damage on the body which cryo happens to be able to heal even with MEDICALIGNORE (oversight probably but one of the one ways to heal their clone damage atm). - Hopek
-	if(HAS_TRAIT(mob_occupant,TRAIT_MEDICALIGNORE) && (mob_occupant.getCloneLoss() < 1))
+	if(HAS_TRAIT(mob_occupant,TRAIT_MEDICALIGNORE) && mob_occupant.getCloneLoss())
 		src.visible_message("<span class='warning'>[src] is unable to treat [mob_occupant] as they cannot be treated with conventional medicine.</span>")
 		playsound(src,'sound/machines/cryo_warning_ignore.ogg',60,1)
 		on = FALSE

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -182,7 +182,7 @@
 		return
 	
 	/// Individuals with the MEDICALIGNORE trait will stop the cryo from functioning and display a unique warning unless there is clone damage on the body which cryo happens to be able to heal even with MEDICALIGNORE (oversight probably but one of the one ways to heal their clone damage atm). - Hopek
-	if(HAS_TRAIT(mob_occupant,TRAIT_MEDICALIGNORE) && (mob_occupant.getCloneLoss() > 1))
+	if(HAS_TRAIT(mob_occupant,TRAIT_MEDICALIGNORE) && (mob_occupant.getCloneLoss() < 1))
 		src.visible_message("<span class='warning'>[src] is unable to treat [mob_occupant] as they cannot be treated with conventional medicine.</span>")
 		playsound(src,'sound/machines/cryo_warning_ignore.ogg',60,1)
 		on = FALSE

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -181,7 +181,8 @@
 	if(mob_occupant.stat == DEAD) // We don't bother with dead people.
 		return
 	
-	if(HAS_TRAIT(mob_occupant,TRAIT_MEDICALIGNORE))
+	/// Individuals with the MEDICALIGNORE trait will stop the cryo from functioning and display a unique warning unless there is clone damage on the body which cryo happens to be able to heal even with MEDICALIGNORE (oversight probably but one of the one ways to heal their clone damage atm). - Hopek
+	if(HAS_TRAIT(mob_occupant,TRAIT_MEDICALIGNORE) && (mob_occupant.getCloneLoss() > 1))
 		src.visible_message("<span class='warning'>[src] is unable to treat [mob_occupant] as they cannot be treated with conventional medicine.</span>")
 		playsound(src,'sound/machines/cryo_warning_ignore.ogg',60,1)
 		on = FALSE


### PR DESCRIPTION
 This means that Preterni can now heal cloning damage from cryo pods again.

![image](https://user-images.githubusercontent.com/24533979/90021874-6c097700-dc77-11ea-85d5-6eea9d5e5876.png)
![image](https://user-images.githubusercontent.com/24533979/90021932-7f1c4700-dc77-11ea-9085-deb1b5fd19d5.png)



#### Changelog

:cl:  Hopek
tweak: Cryo pods don't stop when cloning damage is present on MEDICALIGNORE. This means that Preterni can now heal cloning damage in cryopods but will still not be trapped after they're healed even with brute or burn damage.
/:cl:
