### PR TITLE
Stasis bed rotation

### DIFF
--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -155,6 +155,10 @@
 	. = default_deconstruction_screwdriver(user, "stasis_maintenance", "stasis", I)
 	update_icon()
 
+/obj/machinery/stasis/wrench_act(mob/living/user, obj/item/I)
+	if(default_change_direction_wrench(user, I))
+		return TRUE
+
 /obj/machinery/stasis/crowbar_act(mob/living/user, obj/item/I)
 	return default_deconstruction_crowbar(I)
 


### PR DESCRIPTION
The stasis beds can be rotated by opening the maintenance hatch and using a wrench, just like the sleepers. 

:cl:  
rscadd: You can now rotate stasis beds
/:cl:
