### PR TITLE
bo staff damage is directed at the head, increasing its effectiveness…

### DIFF
--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -226,7 +226,7 @@
 
 		log_combat(user, H, "Bo Staffed", src.name, "((DAMTYPE: STAMINA)")
 		add_fingerprint(user)
-		H.adjustStaminaLoss(rand(28,33))
+		H.apply_damage(rand(28,33), STAMINA, BODY_ZONE_HEAD)
 		if(H.staminaloss && !H.IsSleeping())
 			var/total_health = (H.health - H.staminaloss)
 			if(total_health <= HEALTH_THRESHOLD_CRIT && !H.stat)


### PR DESCRIPTION
current hit amount is roughly 4-5 which is more than the 3-4 that was intended so it'd be competitive with the esword damagewise
:cl:  
tweak: bo staff deals directed damage to the head instead of distributed damage, increasing effectiveness by 20%
/:cl:
