### PR TITLE
[admin] Ticket based activity tracker

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -2,6 +2,7 @@ GLOBAL_LIST_EMPTY(clients)							//all clients
 GLOBAL_LIST_EMPTY(admins)							//all clients whom are admins
 GLOBAL_PROTECT(admins)
 GLOBAL_LIST_EMPTY(deadmins)							//all ckeys who have used the de-admin verb.
+GLOBAL_LIST_EMPTY(ticket_logout_admins)				//all ckeys who have been marked as inactive by the ticket activity checker
 
 GLOBAL_LIST_EMPTY(directory)							//all ckeys with associated client
 GLOBAL_LIST_EMPTY(stealthminID)						//reference list with IDs that store ckeys, for stealthmins

--- a/yogstation/code/controllers/subsystem/yogs.dm
+++ b/yogstation/code/controllers/subsystem/yogs.dm
@@ -1,5 +1,4 @@
 #define ROUND_END_ANNOUNCEMENT_TIME 105 //the time at which the game will announce that the shuttle can be called, in minutes.
-#define REBWOINK_TIME 50 // Number of seconds before unclaimed tickets bwoink again and yell about being unclaimed
 
 SUBSYSTEM_DEF(Yogs)
 	name = "Yog Features"
@@ -143,13 +142,6 @@ SUBSYSTEM_DEF(Yogs)
 	if(world.time > (ROUND_END_ANNOUNCEMENT_TIME*600) && !endedshift && !(EMERGENCY_AT_LEAST_DOCKED))
 		priority_announce("Crew, your shift has come to an end. \n You may call the shuttle whenever you find it appropriate.", "End of shift announcement", 'sound/ai/commandreport.ogg')
 		endedshift = TRUE
-	
-	//UNCLAIMED TICKET BWOINKER
-	if(world.time - last_rebwoink > REBWOINK_TIME*10)
-		last_rebwoink = world.time
-		for(var/datum/admin_help/bwoink in GLOB.unclaimed_tickets)
-			if(bwoink.check_owner())
-				GLOB.unclaimed_tickets -= bwoink
 	
 	// Department goal checker
 	if(department_goals.len && SSticker.current_state == GAME_STATE_PLAYING)

--- a/yogstation/code/modules/admin/verbs/adminhelp.dm
+++ b/yogstation/code/modules/admin/verbs/adminhelp.dm
@@ -1,4 +1,4 @@
-#define REBWOINK_TIME 60 // Number of seconds before unclaimed tickets bwoink again and yell about being unclaimed
+#define REBWOINK_TIME 60 SECONDS // Number of seconds before unclaimed tickets bwoink again and yell about being unclaimed
 
 /client/var/adminhelptimerid = 0	//a timer id for returning the ahelp verb
 /client/var/datum/admin_help/current_ticket	//the current ticket the (usually) not-admin client is dealing with
@@ -172,7 +172,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	GLOB.ahelp_tickets.tickets_list += src
 	GLOB.ahelp_tickets.ticketAmount += 1
 
-	addtimer(CALLBACK(src, .proc/resend_bwoink), REBWOINK_TIME*10) //Callback used for resending adminhelp alert
+	addtimer(CALLBACK(src, .proc/resend_bwoink), REBWOINK_TIME) //Callback used for resending adminhelp alert
 
 
 /datum/admin_help/Destroy()
@@ -193,7 +193,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 				SEND_SOUND(X, sound('sound/effects/adminhelp.ogg'))
 				world.sync_logout_with_db(X.connection_number)	//"log" them out
 				GLOB.ticket_logout_admins += X
-		addtimer(CALLBACK(src, .proc/resend_bwoink), REBWOINK_TIME*10) //uh oh recursion
+		addtimer(CALLBACK(src, .proc/resend_bwoink), REBWOINK_TIME) //uh oh recursion
 		return FALSE
 	if(handling_admin in GLOB.ticket_logout_admins && state == AHELP_ACTIVE) //an inactive admin is handling a ticket, log them back in
 		handling_admin.sync_login_with_db()


### PR DESCRIPTION
# Intent of your Pull Request

Implements a ticket based activity tracker.

Basically, whenever a ticket is left unclaimed it will log any admins who do not have a ticket assigned to them as inactive so that they do not receive tracked hours. This ensures that hours are being fairly tracked for admins who handle ticket, and punishes people who prioritize playing instead of handling tickets.

An additional benefit of this system is that it does not discriminate based on rank. Council, admins, retmins and host are all treated the same way by the code.

**I am aware that there are ways to game this system. I have had a thunk about how to improve this system, but I really can't be fucked to do anything about it now, and this is better than nothing.**

Additionally I also refactored how the 'rebwoink' system works. Basically before it would spam you with a notification every 50 seconds regardless of whether or not you had 4 active tickets already. Now it sends individual notifications for every unclaimed ticket, so you don't get like 10 bwoinks at the same time, instead they get spread out in accordance as to when the tickets came in.

Additionally, it will only send you an audio bwoink if you do not have any unclaimed tickets.

:cl:  
rscadd: New admin ticket based activity checker
/:cl: