### PR TITLE
Adds cheese culture and wheel crates.

### DIFF
--- a/yogstation/code/modules/cargo/cargo_packs.dm
+++ b/yogstation/code/modules/cargo/cargo_packs.dm
@@ -54,7 +54,7 @@
 /datum/supply_pack/organic/cheeseculture
 	name = "Cheese Culture Crate"
 	desc = "Contains a variety of advanced cheese bacteria cultures."
-	cost = 1500
+	cost = 800
 	contains = list(/obj/item/storage/box/cheese)
 	crate_name = "cheese culture crate"
 	

--- a/yogstation/code/modules/cargo/cargo_packs.dm
+++ b/yogstation/code/modules/cargo/cargo_packs.dm
@@ -51,12 +51,33 @@
 	crate_name = "Advanced Crate Container"
 	crate_type = /obj/structure/closet/crate/large
 
-/datum/supply_pack/organic/cheese
+/datum/supply_pack/organic/cheeseculture
 	name = "Cheese Culture Crate"
-	desc = "A crate containing a variety of advanced cheese bacteria cultures."
+	desc = "Contains a variety of advanced cheese bacteria cultures."
 	cost = 1500
 	contains = list(/obj/item/storage/box/cheese)
-	crate_name = "cheese crate"
+	crate_name = "cheese culture crate"
+	
+/datum/supply_pack/organic/randomized/cheesewheel
+	name = "Cheese Wheel Crate"
+	desc = "Contains 6 various cheese wheels, for stations that don't have a chef or work ethic."
+	cost = 1000
+	contains = list(/obj/item/reagent_containers/food/snacks/cheesewedge/parmesan,
+					/obj/item/reagent_containers/food/snacks/store/cheesewheel/swiss,
+					/obj/item/reagent_containers/food/snacks/store/cheesewheel/mozzarella,
+					/obj/item/reagent_containers/food/snacks/store/cheesewheel/halloumi,
+					/obj/item/reagent_containers/food/snacks/store/cheesewheel/goat,
+					/obj/item/reagent_containers/food/snacks/store/cheesewheel/feta,
+					/obj/item/reagent_containers/food/snacks/store/cheesewheel/cheddar,
+					/obj/item/reagent_containers/food/snacks/store/cheesewheel/brie,
+					/obj/item/reagent_containers/food/snacks/store/cheesewheel/blue,
+					/obj/item/reagent_containers/food/snacks/store/cheesewheel/american)
+	crate_name = "cheese wheel crate"
+
+/datum/supply_pack/organic/randomized/cheesewheel/fill(obj/structure/closet/crate/C)
+	for(var/i in 1 to 6)
+		var/item = pick(contains)
+		new item(C)
 
 /datum/supply_pack/critter/exoticgoat
 	name = "Exotic Goat Crate"

--- a/yogstation/code/modules/cargo/cargo_packs.dm
+++ b/yogstation/code/modules/cargo/cargo_packs.dm
@@ -51,6 +51,13 @@
 	crate_name = "Advanced Crate Container"
 	crate_type = /obj/structure/closet/crate/large
 
+/datum/supply_pack/organic/cheese
+	name = "Cheese Culture Crate"
+	desc = "A crate containing a variety of advanced cheese bacteria cultures."
+	cost = 1500
+	contains = list(/obj/item/storage/box/cheese)
+	crate_name = "cheese crate"
+
 /datum/supply_pack/critter/exoticgoat
 	name = "Exotic Goat Crate"
 	desc = "Contains a bunch of genetically altered goats from Goat Tech Industries. Try to collect them all!"


### PR DESCRIPTION
Cheese wasn't orderable from cargo before. Now, there's two cheese-related crates.

- **Cheese Culture Crate** - 800 credits - Contains the advanced cheese bacteria box found in the chef's refrigerator (freezer? I don't remember the specific name of it).
- **Cheese Wheel Crate** - 1,000 credits - Contains 6 random cheese wheels. An arguably far worse deal in exchange for being ready-made.

#### Changelog

:cl:  
rscadd: Allows the advanced cheese bacteria box to be purchased from cargo for 1,500 credits under the name of "Cheese Culture Crate". Don't want to make cheese? Get 6 random cheese wheels, ready-made, for only 1,000 credits.
/:cl:
