### PR TITLE
Makes the free miner R&D kit better.

### DIFF
--- a/_maps/yogstation/shuttles/whiteship_miner.dmm
+++ b/_maps/yogstation/shuttles/whiteship_miner.dmm
@@ -958,6 +958,10 @@
 /obj/item/stock_parts/manipulator,
 /obj/item/stock_parts/matter_bin,
 /obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/manipulator,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
 "wj" = (

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1074,6 +1074,17 @@
 	new /obj/item/circuitboard/machine/circuit_imprinter(src)
 	new /obj/item/circuitboard/computer/rdconsole(src)
 
+/obj/item/storage/box/rndboards/miner
+	name = "\proper Morokha Heavy Industries Research and Development Kit"
+	desc = "A box containing the essential circuit boards for research and development. Materials, stock parts, and intelligence not included."
+
+/obj/item/storage/box/rndboards/miner/PopulateContents()
+	new /obj/item/circuitboard/machine/autolathe(src)
+	new /obj/item/circuitboard/machine/protolathe(src)
+	new /obj/item/circuitboard/machine/destructive_analyzer(src)
+	new /obj/item/circuitboard/machine/circuit_imprinter(src)
+	new /obj/item/circuitboard/computer/rdconsole(src)
+
 /obj/item/storage/box/silver_sulf
 	name = "box of silver sulfadiazine patches"
 	desc = "Contains patches used to treat burns."

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -261,7 +261,7 @@
 
 /obj/machinery/mineral/equipment_vendor/free_miner
 	name = "free miner ship equipment vendor"
-	desc = "a vendor sold by nanotrasen to profit off small mining contractors."
+	desc = "A vendor sold by NanoTrasen to profit off small mining contractors."
 	prize_list = list(
 		new /datum/data/mining_equipment("Kinetic Accelerator", 		/obj/item/gun/energy/kinetic_accelerator,						750, VENDING_WEAPON),
 		new /datum/data/mining_equipment("Resonator",          			/obj/item/resonator,											800, VENDING_WEAPON),
@@ -301,7 +301,7 @@
 		new /datum/data/mining_equipment("Stimpack Bundle",				/obj/item/storage/box/medipens/utility,							200, VENDING_MEDS),
 		new /datum/data/mining_equipment("Point Transfer Card", 		/obj/item/card/mining_point_card,								500, VENDING_MISC),
 		new /datum/data/mining_equipment("Space Cash",    				/obj/item/stack/spacecash/c1000,								2000, VENDING_MISC),
-		new /datum/data/mining_equipment("Nanotrasen Brand Circuitry Kit",  	/obj/item/storage/box/rndboards,								2000, VENDING_TOOL)
+		new /datum/data/mining_equipment("R&D Starter Kit",  			/obj/item/storage/box/rndboards/miner,							2500, VENDING_TOOL)
 		)
 
 /obj/machinery/mineral/equipment_vendor/free_miner/New()


### PR DESCRIPTION
This PR is to somewhat improve upon the free miners' R&D kit for lore-friendliness and playability.

It replaces the Liberator's Legacy (an item that only the free golems should have) with the **Morokha Heavy Industries Research and Development Kit** (shortened to "R&D Starter Kit" in the vendor), created by a subsidiary of NanoTrasen. In addition to the protolathe, destructive analyzer, circuit imprinter, and R&D console boards, it includes an autolathe board since the free miners don't have one. <sub>Or at least, not yet, but that's a separate PR.</sub>

#### Changelog

:cl:  
rscadd: Adds enough additional stock parts to the free miner ship to build an autolathe. (except glass)
rscadd: Gives the free miner equipment vendor a new R&D kit, with new flavor text and an autolathe board.
tweak: R&D kit from free miner vendor costs 2,500 points, compared to 2,000 points.
spellcheck: Fixed the capitalization of the free miner equipment vendor description.
/:cl:
