### PR TITLE
Replaces Rotciv with Colton in wizard academy

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/Academy.dmm
+++ b/_maps/RandomRuins/SpaceRuins/Academy.dmm
@@ -1090,8 +1090,8 @@
 /area/awaymission/academy/academycellar)
 "lC" = (
 /mob/living/simple_animal/hostile/wizard{
-	desc = "Found leading several other scribes, one of which was prone to rage";
-	name = "Anvil the Archiver"
+	desc = "Found leading several other archivists, one of which was prone to rage";
+	name = "Anvil the Archivist"
 	},
 /turf/open/floor/wood,
 /area/awaymission/academy/academycellar)

--- a/_maps/RandomRuins/SpaceRuins/Academy.dmm
+++ b/_maps/RandomRuins/SpaceRuins/Academy.dmm
@@ -1090,8 +1090,8 @@
 /area/awaymission/academy/academycellar)
 "lC" = (
 /mob/living/simple_animal/hostile/wizard{
-	desc = "Exiled from his old academy when he casted a illusion spell to make 16 clones of himself then claimed they were not his";
-	name = "Feweh The Replicator"
+	desc = "Found stranded on a remote island surrounded by cheese";
+	name = "Tessa the Fromager"
 	},
 /turf/open/floor/wood,
 /area/awaymission/academy/academycellar)

--- a/_maps/RandomRuins/SpaceRuins/Academy.dmm
+++ b/_maps/RandomRuins/SpaceRuins/Academy.dmm
@@ -970,7 +970,7 @@
 /area/awaymission/academy/academyaft)
 "kV" = (
 /mob/living/simple_animal/hostile/wizard{
-	name = "Rotciv The Dented"
+	name = "Colton the Afterburner"
 	},
 /turf/open/floor/carpet,
 /area/awaymission/academy/academyaft)

--- a/_maps/RandomRuins/SpaceRuins/Academy.dmm
+++ b/_maps/RandomRuins/SpaceRuins/Academy.dmm
@@ -1090,8 +1090,8 @@
 /area/awaymission/academy/academycellar)
 "lC" = (
 /mob/living/simple_animal/hostile/wizard{
-	desc = "Found stranded on a remote island surrounded by cheese";
-	name = "Tessa the Fromager"
+	desc = "Found leading several other scribes, one of which was prone to rage";
+	name = "Anvil the Archiver"
 	},
 /turf/open/floor/wood,
 /area/awaymission/academy/academycellar)


### PR DESCRIPTION
Self explanatory title

Oh yeah and adds Anvilman as a wizard because people kept complaining about Feweh not being a yogs reference, so instead of replacing Feweh with Colton I added another person because golly me do I fucking hate retards

:cl:  
tweak: Rotciv the Dented and Feweh the Replicator have been expelled from the wizard academy! In their place, Colton the Afterburner and Anvil the Archivist have transferred in.
/:cl: