### PR TITLE
Adds Stand arrow as necropolis chest loot

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -13,7 +13,7 @@
 	desc = "It's watching you suspiciously."
 
 /obj/structure/closet/crate/necropolis/tendril/PopulateContents()
-	var/loot = rand(1,26)
+	var/loot = rand(1,27)
 	switch(loot)
 		if(1)
 			new /obj/item/shared_storage/red(src)
@@ -75,6 +75,8 @@
 			new /obj/item/rune_scimmy(src)
 		if(26)
 			new /obj/item/reagent_containers/glass/bottle/necropolis_seed(src)
+		if(27)
+			new /obj/item/stand_arrow(src)
 
 //KA modkit design discs
 /obj/item/disk/design_disk/modkit_disc


### PR DESCRIPTION
adds the stand arrow as necropolis chest loot
more balanced then tarots because it can instantly kill you
#### Changelog

:cl:  
rscadd: Added stand arrow to necropolis chest
/:cl:
