### PR TITLE
kinetic accelerator now works with damage multipliers from outside sources

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -136,6 +136,7 @@
 
 /obj/item/gun/energy/kinetic_accelerator/proc/reload()
 	cell.give(cell.maxcharge)
+	recharge_newshot(TRUE)
 	if(!suppressed)
 		playsound(src.loc, 'sound/weapons/kenetic_reload.ogg', 60, 1)
 	else


### PR DESCRIPTION
calls recharge_newshot() when fired so the gun has a BB reference when adding damage multipliers
technically the issue is present in any energy gun that has been recharged from 0 charge since a BB isn't loaded until it attempts to fire if it ran out of charge
:cl:  
bugfix: KA can now be effectively used with holdups and whatever
/:cl:
