### PR TITLE
Disallows use of most darkspawn abilities while using crawling shadows

### DIFF
--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/creep.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/creep.dm
@@ -9,6 +9,11 @@
 	psi_addendum = " to activate and per second"
 	lucidity_price = 2
 
+/datum/action/innate/darkspawn/creep/IsAvailable()
+	if(istype(owner, /mob/living/simple_animal/hostile/crawling_shadows))
+		return
+	return ..()
+
 /datum/action/innate/darkspawn/creep/process()
 	var/mob/living/L = owner
 	active = L.has_status_effect(STATUS_EFFECT_CREEP)

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/demented_outburst.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/demented_outburst.dm
@@ -17,6 +17,11 @@
 	addtimer(CALLBACK(src, .proc/reset), 50)
 	return TRUE
 
+/datum/action/innate/darkspawn/demented_outburst/IsAvailable()
+	if(istype(owner, /mob/living/simple_animal/hostile/crawling_shadows))
+		return
+	return ..()
+
 /datum/action/innate/darkspawn/demented_outburst/proc/outburst()
 	in_use = FALSE
 	if(!owner || owner.stat)

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/devour_will.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/devour_will.dm
@@ -16,7 +16,7 @@
 	victims = list()
 
 /datum/action/innate/darkspawn/devour_will/IsAvailable()
-	if(!owner || !owner.get_empty_held_indexes())
+	if(!owner || istype(owner, /mob/living/simple_animal/hostile/crawling_shadows) ||istype(owner, /mob/living/simple_animal/hostile/darkspawn_progenitor) || !owner.get_empty_held_indexes())
 		return
 	return ..()
 

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/tagalong.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/tagalong.dm
@@ -10,6 +10,11 @@
 	lucidity_price = 2
 	var/datum/status_effect/tagalong/tagalong
 
+/datum/action/innate/darkspawn/tagalong/IsAvailable()
+	if(istype(owner, /mob/living/simple_animal/hostile/crawling_shadows))
+		return
+	return ..()
+
 /datum/action/innate/darkspawn/tagalong/process()
 	psi_cost = 30 * isnull(tagalong)
 

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/time_dilation.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/time_dilation.dm
@@ -9,7 +9,7 @@
 	lucidity_price = 3
 
 /datum/action/innate/darkspawn/time_dilation/IsAvailable()
-	if(..())
+	if(..() && !istype(owner, /mob/living/simple_animal/hostile/crawling_shadows))
 		var/mob/living/L = owner
 		return !L.has_status_effect(STATUS_EFFECT_TIME_DILATION)
 


### PR DESCRIPTION

:cl:    
tweak: darkspawn in crawling shadows are not able to use most abilities
/:cl:
