### PR TITLE
bag of holding can no longer hold bulky or larger items

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -57,8 +57,6 @@
 /obj/item/storage/backpack/holding/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.allow_big_nesting = TRUE
-	STR.max_w_class = WEIGHT_CLASS_GIGANTIC
 	STR.max_combined_w_class = 35
 
 /obj/item/storage/backpack/holding/suicide_act(mob/living/user)


### PR DESCRIPTION
The bag of holding makes adding weight to an item completely worthless since with a bag of holding you can take like 10 of whatever the huge item is i.e. full sized shotgun and not have to worry about how much of a pain in the ass it'd be to move it otherwise. Each bag at the base price only costs a diamond, two gold, a small amount of uranium and a single bluespace crystal (which is decreased with parts the lathe has been upgraded with by then), meaning basically anyone can get one.
it's either this or making them super ass to get if we don't want to pretend being able to run around with a hidden shotgun or ten is ok

:cl:  
tweak: bluespace bags are unable to hold items of the bulky or gigantic size
/:cl:
