### PR TITLE
Adds the meat hook as blood-drunk miner loot

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -40,7 +40,7 @@ Difficulty: Medium
 	ranged_cooldown_time = 16
 	pixel_x = -16
 	crusher_loot = list(/obj/item/melee/transforming/cleaving_saw, /obj/item/gun/energy/kinetic_accelerator, /obj/item/crusher_trophy/miner_eye)
-	loot = list(/obj/item/melee/transforming/cleaving_saw, /obj/item/gun/energy/kinetic_accelerator)
+	loot = list(/obj/item/melee/transforming/cleaving_saw, /obj/item/gun/energy/kinetic_accelerator, /obj/item/gun/magic/hook)
 	wander = FALSE
 	del_on_death = TRUE
 	blood_volume = BLOOD_VOLUME_GENERIC


### PR DESCRIPTION
Since the meat hook is in a weird spot between being a bit too powerful to have in necropolis chests but not enough to have in other megafauna's loot, I got a suggestion to add it to the blood-drunk miner's loot. Which, considering the only other loot from the blood-drunk are a cleaving saw and a _kinetic accelerator_ (apparently, without any special modifications), seems reasonable.

#### Changelog

:cl:  
rscadd: Adds the meat hook to the blood-drunk miner's loot.
/:cl:
