### PR TITLE
fixes necropolis chests not dropping loot sometimes

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -56,7 +56,7 @@
 		if(17)
 			new /obj/item/warp_cube/red(src)
 		if(18)
-			new /obj/item/organ/heart/gland/heals
+			new /obj/item/organ/heart/gland/heals(src)
 		if(19)
 			new /obj/item/immortality_talisman(src)
 		if(20)


### PR DESCRIPTION
thanks adam

:cl:  
bugfix: necropolis chest healing gland drop now actually drops a healing gland instead of nothing
/:cl:
