### PR TITLE
revive rune takes 7 sacrifices up from 3

### DIFF
--- a/code/__DEFINES/cult.dm
+++ b/code/__DEFINES/cult.dm
@@ -25,5 +25,5 @@
 #define DEFAULT_BLOODTIP "14:6,14:27"
 #define DEFAULT_TOOLTIP "6:-29,5:-2"
 //misc
-#define SOULS_TO_REVIVE 3
+#define SOULS_TO_REVIVE 7
 #define BLOODCULT_EYE "f00"


### PR DESCRIPTION
cult already can use basically any body they get living or dead and sacrificing stuff is already a net gain this makes it slightly less of a net gain since they can use constructs/summon ghosts/converting more people to easily make up for losses

:cl:  
tweak: revive rune requires 7 sacrifices up from 3
/:cl:
