### PR TITLE
bloodcult teleport spell costs 50 health up from 7 if used to teleport yourself

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -149,7 +149,7 @@
 	desc = "Empowers your hand to teleport yourself or another cultist to a teleport rune on contact."
 	button_icon_state = "tele"
 	magic_path = "/obj/item/melee/blood_magic/teleport"
-	health_cost = 7
+	health_cost = 50
 
 /datum/action/innate/cult/blood_spell/emp
 	name = "Electromagnetic Pulse"
@@ -494,6 +494,8 @@
 			to_chat(user, "<span class='warning'>The target rune is blocked. You cannot teleport there.</span>")
 			return
 		uses--
+		if(!(target == user))
+			health_cost = 7
 		var/turf/origin = get_turf(user)
 		var/mob/living/L = target
 		if(do_teleport(L, dest, channel = TELEPORT_CHANNEL_CULT))
@@ -501,6 +503,7 @@
 				"<span class='cultitalic'>You speak the words of the talisman and find yourself somewhere else!</span>", "<i>You hear a sharp crack.</i>")
 			dest.visible_message("<span class='warning'>There is a boom of outrushing air as something appears above the rune!</span>", null, "<i>You hear a boom.</i>")
 		..()
+		health_cost = initial(health_cost)
 
 //Shackles
 /obj/item/melee/blood_magic/shackles

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -146,7 +146,7 @@
 
 /datum/action/innate/cult/blood_spell/teleport
 	name = "Teleport"
-	desc = "Empowers your hand to teleport yourself or another cultist to a teleport rune on contact."
+	desc = "Empowers your hand to teleport yourself or another cultist to a teleport rune on contact. This will deal heavy damage to your arm if you use it to teleport yourself."
 	button_icon_state = "tele"
 	magic_path = "/obj/item/melee/blood_magic/teleport"
 	health_cost = 50
@@ -460,7 +460,7 @@
 /obj/item/melee/blood_magic/teleport
 	name = "Teleporting Aura"
 	color = RUNE_COLOR_TELEPORT
-	desc = "Will teleport a cultist to a teleport rune on contact."
+	desc = "Will teleport a cultist to a teleport rune on contact. This will deal heavy damage to your arm if you use it on yourself."
 	invocation = "Sas'so c'arta forbici!"
 
 /obj/item/melee/blood_magic/teleport/afterattack(atom/target, mob/living/carbon/user, proximity)
@@ -496,6 +496,8 @@
 		uses--
 		if(!(target == user))
 			health_cost = 7
+		else if(user.health < 38) //at this point 50 damage to an arm will crit
+			health_cost = abs(user.health) //but since we're dealing damage to an arm, this won't
 		var/turf/origin = get_turf(user)
 		var/mob/living/L = target
 		if(do_teleport(L, dest, channel = TELEPORT_CHANNEL_CULT))


### PR DESCRIPTION
solidifies it as an escape spell by increasing the damage caused when it's cast so downtime is slightly increased

:cl:  
tweak: bloodcult teleport spell will cripple the arm it's used on if used to self teleport
/:cl:
