### PR TITLE
cult stun hand stuns less powerfully as the cult becomes stronger

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -417,6 +417,8 @@
 	var/mob/living/L = target
 	if(iscultist(target))
 		return
+	var/datum/antagonist/cult/C = user.mind.has_antag_datum(datum/antagonist/cult)
+	var/datum/team/cult/cult = C.get_team
 	if(iscultist(user))
 		user.visible_message("<span class='warning'>[user] holds up [user.p_their()] hand, which explodes in a flash of red light!</span>", \
 							"<span class='cultitalic'>You attempt to stun [L] with the spell!</span>")
@@ -439,20 +441,52 @@
 				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
 									   "<span class='userdanger'>A feeling of warmth washes over you, rays of holy light surround your body and protect you from the flash of light!</span>")
 		else
-			to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
-			L.Paralyze(160)
-			L.flash_act(1,1)
-			if(issilicon(target))
-				var/mob/living/silicon/S = L
-				S.emp_act(EMP_HEAVY)
-			else if(iscarbon(target))
-				var/mob/living/carbon/C = L
-				C.silent += 6
-				C.stuttering += 15
-				C.cultslurring += 15
-				C.Jitter(15)
-			if(is_servant_of_ratvar(L))
-				L.adjustBruteLoss(15)
+			if(cult.cult_ascendent)
+				to_chat(user, "<span class='cultitalic'>[L] is thrown away in a flash of red light!</span>")
+				L.Knockdown(100)
+				L.apply_damage(50), STAMINA, BODY_ZONE_HEAD)
+				var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
+				target.throw_at(throw_target, 5, 4)
+				L.flash_act(1,1)
+				if(issilicon(target))
+					var/mob/living/silicon/S = L
+					S.emp_act(EMP_HEAVY)
+				else if(iscarbon(target))
+					var/mob/living/carbon/C = L
+					C.cultslurring += 10
+					C.Jitter(15)
+				if(is_servant_of_ratvar(L))
+					L.adjustBruteLoss(30)
+			else if(cult.cult_risen)
+				to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
+				L.Paralyze(80)
+				L.flash_act(1,1)
+				if(issilicon(target))
+					var/mob/living/silicon/S = L
+					S.emp_act(EMP_LIGHT)
+				else if(iscarbon(target))
+					var/mob/living/carbon/C = L
+					C.silent += 3
+					C.stuttering += 7
+					C.cultslurring += 7
+					C.Jitter(7)
+				if(is_servant_of_ratvar(L))
+					L.adjustBruteLoss(20)
+			else
+				to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
+				L.Paralyze(160)
+				L.flash_act(1,1)
+				if(issilicon(target))
+					var/mob/living/silicon/S = L
+					S.emp_act(EMP_HEAVY)
+				else if(iscarbon(target))
+					var/mob/living/carbon/C = L
+					C.silent += 6
+					C.stuttering += 15
+					C.cultslurring += 15
+					C.Jitter(15)
+				if(is_servant_of_ratvar(L))
+					L.adjustBruteLoss(15)
 		uses--
 	..()
 

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -139,7 +139,7 @@
 //Cult Blood Spells
 /datum/action/innate/cult/blood_spell/stun
 	name = "Stun"
-	desc = "Empowers your hand to stun and mute a victim on contact."
+	desc = "Empowers your hand to stun and mute a victim on contact. Effects become weaker as the cult grows in size."
 	button_icon_state = "hand"
 	magic_path = "/obj/item/melee/blood_magic/stun"
 	health_cost = 10
@@ -407,7 +407,7 @@
 //Stun
 /obj/item/melee/blood_magic/stun
 	name = "Stunning Aura"
-	desc = "Will stun and mute a victim on contact."
+	desc = "Will stun and mute a victim on contact. Effects become weaker as the cult grows."
 	color = RUNE_COLOR_RED
 	invocation = "Fuu ma'jin!"
 
@@ -458,7 +458,7 @@
 				if(is_servant_of_ratvar(L))
 					L.adjustBruteLoss(30)
 			else if(cult.cult_risen)
-				to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
+				to_chat(user, "<span class='cultitalic'>In a dull flash of red, [L] falls to the ground!</span>")
 				L.Paralyze(80)
 				L.flash_act(1,1)
 				if(issilicon(target))

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -444,7 +444,7 @@
 			if(cult.cult_ascendent)
 				to_chat(user, "<span class='cultitalic'>[L] is thrown away in a flash of red light!</span>")
 				L.Knockdown(100)
-				L.apply_damage(50), STAMINA, BODY_ZONE_HEAD)
+				L.apply_damage(50, STAMINA, BODY_ZONE_HEAD)
 				var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
 				target.throw_at(throw_target, 5, 4)
 				L.flash_act(1,1)

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -417,8 +417,8 @@
 	var/mob/living/L = target
 	if(iscultist(target))
 		return
-	var/datum/antagonist/cult/C = user.mind.has_antag_datum(datum/antagonist/cult)
-	var/datum/team/cult/cult = C.get_team
+	var/datum/antagonist/cult/cultist = user.mind.has_antag_datum(/datum/antagonist/cult)
+	var/datum/team/cult/cult = cultist.get_team()
 	if(iscultist(user))
 		user.visible_message("<span class='warning'>[user] holds up [user.p_their()] hand, which explodes in a flash of red light!</span>", \
 							"<span class='cultitalic'>You attempt to stun [L] with the spell!</span>")
@@ -446,7 +446,7 @@
 				L.Knockdown(100)
 				L.apply_damage(50, STAMINA, BODY_ZONE_HEAD)
 				var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
-				target.throw_at(throw_target, 5, 4)
+				L.throw_at(throw_target, 5, 4)
 				L.flash_act(1,1)
 				if(issilicon(target))
 					var/mob/living/silicon/S = L

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -442,11 +442,9 @@
 									   "<span class='userdanger'>A feeling of warmth washes over you, rays of holy light surround your body and protect you from the flash of light!</span>")
 		else
 			if(cult.cult_ascendent)
-				to_chat(user, "<span class='cultitalic'>[L] is thrown away in a flash of red light!</span>")
+				to_chat(user, "<span class='cultitalic'>[L] is dazed by a flash of red light!</span>")
 				L.Knockdown(100)
 				L.apply_damage(50, STAMINA, BODY_ZONE_HEAD)
-				var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
-				L.throw_at(throw_target, 5, 4)
 				L.flash_act(1,1)
 				if(issilicon(target))
 					var/mob/living/silicon/S = L


### PR DESCRIPTION
effects:
cult below red eyes/halos: no change
cult at red eyes: effects are halved
cult at halos: throws target 5 tiles away, knocks them down for 10 seconds, and deals 50 stamina damage


Should make the stun less useful in open combat lategame so it's not an easy win in melee combat as if you don't have a stunbaton already ANYWAYS

:cl:  
tweak: cult stun hand stuns weaker as the cult increases in power, with effects being halved on entering risen (red eyes) and dealing heavy stamina damage and knockdown while throwing the target when in ascendent (halos)
/:cl:
