### PR TITLE
Replaces Feweh in the wizard academy 

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/Academy.dmm
+++ b/_maps/RandomRuins/SpaceRuins/Academy.dmm
@@ -1090,8 +1090,8 @@
 /area/awaymission/academy/academycellar)
 "lC" = (
 /mob/living/simple_animal/hostile/wizard{
-	desc = "Currently on the run from NanoTrasen for committing War Crimes";
-	name = "Alexander The Fugitive"
+	desc = "The leader of a small team of hard working archivists.";
+	name = "Anvil The Archivist"
 	},
 /turf/open/floor/wood,
 /area/awaymission/academy/academycellar)

--- a/_maps/RandomRuins/SpaceRuins/Academy.dmm
+++ b/_maps/RandomRuins/SpaceRuins/Academy.dmm
@@ -1090,8 +1090,8 @@
 /area/awaymission/academy/academycellar)
 "lC" = (
 /mob/living/simple_animal/hostile/wizard{
-	desc = "Exiled from his old academy when he casted a illusion spell to make 16 clones of himself then claimed they were not his";
-	name = "Feweh The Replicator"
+	desc = "Currently on the run from NanoTrasen for committing War Crimes";
+	name = "Alexander The Fugitive"
 	},
 /turf/open/floor/wood,
 /area/awaymission/academy/academycellar)


### PR DESCRIPTION
Feweh's not even associated with Yogs
Anvil's a great member of our community and very popular

:cl:  
tweak: Feweh the Replicator has been expelled from the wizard academy! In his place, Anvil the Archivist has transferred in.
/:cl:
