### PR TITLE
Removes slaughter demon heart from wizard academy

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/Academy.dmm
+++ b/_maps/RandomRuins/SpaceRuins/Academy.dmm
@@ -1577,6 +1577,7 @@
 /mob/living/simple_animal/slaughter{
 	desc = "A radioactive being made of condensed fusion material";
 	name = "Radioactive Prat Demon"
+	loot = list(list(/obj/effect/decal/cleanable/blood, /obj/effect/decal/cleanable/blood/innards)
 	},
 /turf/open/floor/plating,
 /area/awaymission/academy/academycellar)

--- a/_maps/RandomRuins/SpaceRuins/Academy.dmm
+++ b/_maps/RandomRuins/SpaceRuins/Academy.dmm
@@ -1577,7 +1577,7 @@
 /mob/living/simple_animal/slaughter{
 	desc = "A radioactive being made of condensed fusion material";
 	name = "Radioactive Prat Demon"
-	loot = list(list(/obj/effect/decal/cleanable/blood, /obj/effect/decal/cleanable/blood/innards)
+	loot = list(/obj/effect/decal/cleanable/blood, /obj/effect/decal/cleanable/blood/innards)
 	},
 /turf/open/floor/plating,
 /area/awaymission/academy/academycellar)

--- a/_maps/RandomRuins/SpaceRuins/Academy.dmm
+++ b/_maps/RandomRuins/SpaceRuins/Academy.dmm
@@ -1576,7 +1576,7 @@
 "rD" = (
 /mob/living/simple_animal/slaughter{
 	desc = "A radioactive being made of condensed fusion material";
-	name = "Radioactive Prat Demon"
+	name = "Radioactive Prat Demon";
 	loot = list(/obj/effect/decal/cleanable/blood, /obj/effect/decal/cleanable/blood/innards)
 	},
 /turf/open/floor/plating,


### PR DESCRIPTION

:cl:  
rscdel: Slaughter demon with no AI in wizard academy no longer drops bloodcrawl ability button
/:cl:
