### PR TITLE
Aliens can attack firedoors on harm intent

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -196,7 +196,10 @@
 	if(welded)
 		to_chat(user, "<span class='warning'>[src] refuses to budge!</span>")
 		return
-	open()
+	if(user.a_intent == INTENT_HARM)
+		return ..()
+	else
+		open()
 
 /obj/machinery/door/firedoor/do_animate(animation)
 	switch(animation)


### PR DESCRIPTION
### Intent of your Pull Request

This is incredibly annoying since it's very easy for you to become stuck which is just, not fun. Still can't open them normally while welded, but barely anyone welds firedoors anyhow.

#### Changelog

:cl:  
tweak: Xenos can attack firedoors on harm intent
/:cl:
