### PR TITLE
Fixes nullspaced GPSes breaking all the GPSes

### DIFF
--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -99,6 +99,8 @@ GLOBAL_LIST_EMPTY(GPS_list)
 		if(G.emped || !G.tracking || G == src)
 			continue
 		var/turf/pos = get_turf_global(G) // yogs - get_turf_global instead of get_turf
+		if(!pos)
+			continue
 		if(!global_mode && pos.z != curr.z)
 			continue
 		var/list/signal = list()


### PR DESCRIPTION
This happened during 31502, and this PR should fix it

:cl: monster860
fix: GPSes in nullspace no longer cause all GPSes to break
/:cl: