### PR TITLE
makes space dragon as common as blob and allows it to start at 50 minutes instead of 70

### DIFF
--- a/code/modules/events/space_dragon.dm
+++ b/code/modules/events/space_dragon.dm
@@ -2,8 +2,8 @@
 	name = "Spawn Space Dragon"
 	typepath = /datum/round_event/ghost_role/space_dragon
 	max_occurrences = 1
-	weight = 8
-	earliest_start = 70 MINUTES
+	weight = 10
+	earliest_start = 50 MINUTES
 	min_players = 30
 
 /datum/round_event/ghost_role/space_dragon


### PR DESCRIPTION
its more common but still rare because of the ammount of time needed. its just as likely to roll at blob with 10 weight
#### Changelog

:cl:  
tweak: tweaked how often space dragon occurs
/:cl:
