### PR TITLE
removes self destruct from free miner ship

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -36,8 +36,8 @@
 "ag" = (
 /obj/machinery/porta_turret{
 	dir = 8;
-	set_obj_flags = "EMAGGED";
-	installation = /obj/item/gun/energy/lasercannon
+	installation = /obj/item/gun/energy/lasercannon;
+	set_obj_flags = "EMAGGED"
 	},
 /turf/open/floor/engine,
 /area/awaymission/BMPship/Aft)
@@ -2126,8 +2126,8 @@
 "gl" = (
 /obj/machinery/porta_turret{
 	dir = 8;
-	set_obj_flags = "EMAGGED";
-	installation = /obj/item/gun/energy/lasercannon
+	installation = /obj/item/gun/energy/lasercannon;
+	set_obj_flags = "EMAGGED"
 	},
 /turf/open/floor/engine,
 /area/awaymission/BMPship/Fore)

--- a/_maps/RandomRuins/SpaceRuins/shuttlerelic.dmm
+++ b/_maps/RandomRuins/SpaceRuins/shuttlerelic.dmm
@@ -54,15 +54,15 @@
 /area/ruin/powered)
 "m" = (
 /obj/structure/chair/old{
-	icon_state = "chairold";
-	dir = 1
+	dir = 1;
+	icon_state = "chairold"
 	},
 /turf/open/floor/oldshuttle,
 /area/ruin/powered)
 "n" = (
 /obj/structure/chair/old{
-	icon_state = "chairold";
-	dir = 1
+	dir = 1;
+	icon_state = "chairold"
 	},
 /obj/item/crowbar/large{
 	desc = "It's a big crowbar. It doesn't fit in your pockets, because it's big. It feels oddly heavy..";
@@ -73,8 +73,8 @@
 /area/ruin/powered)
 "o" = (
 /obj/structure/chair/old{
-	icon_state = "chairold";
-	dir = 1
+	dir = 1;
+	icon_state = "chairold"
 	},
 /mob/living/simple_animal/hostile/retaliate/spaceman,
 /turf/open/floor/oldshuttle,

--- a/_maps/yogstation/shuttles/whiteship_miner.dmm
+++ b/_maps/yogstation/shuttles/whiteship_miner.dmm
@@ -683,14 +683,6 @@
 /obj/item/storage/photo_album,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/abandoned)
-"gv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/syndicatebomb/training{
-	desc = "A sticky note on the side says 'DO NOT TOUCH, VERY DANGEROUS'.";
-	name = "self-destruct device"
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
 "gP" = (
 /obj/effect/decal/cleanable/xenoblood,
 /obj/machinery/iv_drip{
@@ -1487,7 +1479,7 @@ ax
 YW
 JR
 JR
-gv
+bx
 JR
 JR
 pa


### PR DESCRIPTION
the only time its ever used is by new players trying to grief i literally see no reason at all to have it
#### Changelog

:cl:  
rscdel: Removed the self destruct from free miners
/:cl:
