### PR TITLE
changes lanterns description

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -377,7 +377,7 @@
 	item_state = "lantern"
 	lefthand_file = 'icons/mob/inhands/equipment/mining_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/mining_righthand.dmi'
-	desc = "A mining lantern."
+	desc = "A mining lantern it seems to use kerosene as fuel."
 	brightness_on = 6			// luminosity when on
 
 /obj/item/flashlight/lantern/heirloom_moth

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -377,7 +377,7 @@
 	item_state = "lantern"
 	lefthand_file = 'icons/mob/inhands/equipment/mining_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/mining_righthand.dmi'
-	desc = "A mining lantern it seems to use kerosene as fuel."
+	desc = "A mining lantern. It seems to use kerosene as fuel."
 	brightness_on = 6			// luminosity when on
 
 /obj/item/flashlight/lantern/heirloom_moth


### PR DESCRIPTION
new description "A mining lantern it seems to use kerosene as fuel."
previously its description was "a mining lantern." which isnt a good description
#### Changelog

:cl:  
tweak: tweaked lanterns description
/:cl:
