### PR TITLE
Uniform Bar Variants: Added Drink Showcases, Christmas Tree Spawners, and more.

### DIFF
--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_box.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_box.dmm
@@ -1124,19 +1124,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"cH" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
-	},
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "cI" = (
 /obj/effect/landmark/start/cook,
 /turf/open/floor/plasteel/cafeteria,
@@ -1328,6 +1315,35 @@
 "dh" = (
 /obj/structure/sign/barsign,
 /turf/closed/wall,
+/area/crew_quarters/bar)
+"fQ" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/item/reagent_containers/glass/rag,
+/obj/item/book/manual/wiki/barman_recipes,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"gP" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"jF" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/smartfridge/drinks,
+/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "jO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -1607,7 +1623,7 @@ bx
 bx
 cp
 bx
-cb
+fQ
 cN
 dc
 ag
@@ -1639,9 +1655,9 @@ bJ
 bx
 cq
 bx
-cH
+jF
 bx
-bx
+gP
 ag
 "}
 (16,1,1) = {"

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_box.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_box.dmm
@@ -1316,35 +1316,6 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"fQ" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/item/reagent_containers/glass/rag,
-/obj/item/book/manual/wiki/barman_recipes,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"gP" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"jF" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/smartfridge/drinks,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "jO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
@@ -1354,6 +1325,15 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"mg" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/smartfridge/drinks,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "sb" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets{
@@ -1403,6 +1383,16 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"OA" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/item/reagent_containers/glass/rag,
+/obj/item/book/manual/wiki/barman_recipes,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "QH" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin{
@@ -1419,6 +1409,16 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"SG" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 
 (1,1,1) = {"
 aa
@@ -1623,7 +1623,7 @@ bx
 bx
 cp
 bx
-fQ
+OA
 cN
 dc
 ag
@@ -1655,9 +1655,9 @@ bJ
 bx
 cq
 bx
-jF
+mg
 bx
-gP
+SG
 ag
 "}
 (16,1,1) = {"

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_casino.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_casino.dmm
@@ -911,10 +911,6 @@
 	icon_state = "r_wall"
 	},
 /area/crew_quarters/bar)
-"nY" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet,
-/area/crew_quarters/bar)
 "pr" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -925,7 +921,11 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
-"yt" = (
+"qe" = (
+/obj/effect/spawner/xmastree,
+/turf/open/floor/carpet,
+/area/crew_quarters/bar)
+"zc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8;
 	icon_state = "vent_map_on-1"
@@ -934,8 +934,8 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
-"HQ" = (
-/obj/effect/spawner/xmastree,
+"Gp" = (
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
 "JA" = (
@@ -948,10 +948,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
-"OZ" = (
-/obj/effect/landmark/event_spawn,
-/turf/closed/wall,
-/area/crew_quarters/bar)
 "Qz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -973,6 +969,10 @@
 	},
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/kitchen)
+"Sl" = (
+/obj/effect/landmark/event_spawn,
+/turf/closed/wall,
+/area/crew_quarters/bar)
 "SW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
@@ -1002,7 +1002,7 @@ ac
 ab
 ac
 ab
-OZ
+Sl
 ab
 ac
 ac
@@ -1126,7 +1126,7 @@ ac
 (9,1,1) = {"
 ac
 ap
-HQ
+qe
 ap
 aD
 aD
@@ -1199,7 +1199,7 @@ cm
 bZ
 cm
 bR
-nY
+Gp
 bJ
 ac
 "}
@@ -1293,7 +1293,7 @@ am
 bA
 bQ
 cf
-cq
+co
 co
 co
 bK
@@ -1320,7 +1320,7 @@ am
 am
 aP
 aZ
-yt
+zc
 am
 bC
 bS
@@ -1341,7 +1341,7 @@ am
 aU
 bT
 Sc
-cq
+co
 co
 co
 bN

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_casino.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_casino.dmm
@@ -494,16 +494,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
-"bk" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/crew_quarters/kitchen)
 "bl" = (
 /obj/machinery/gibber,
 /turf/open/floor/plasteel{
@@ -921,6 +911,10 @@
 	icon_state = "r_wall"
 	},
 /area/crew_quarters/bar)
+"nY" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/carpet,
+/area/crew_quarters/bar)
 "pr" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -931,6 +925,19 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
+"yt" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8;
+	icon_state = "vent_map_on-1"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/crew_quarters/kitchen)
+"HQ" = (
+/obj/effect/spawner/xmastree,
+/turf/open/floor/carpet,
+/area/crew_quarters/bar)
 "JA" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet,
@@ -941,6 +948,10 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
+"OZ" = (
+/obj/effect/landmark/event_spawn,
+/turf/closed/wall,
+/area/crew_quarters/bar)
 "Qz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -991,7 +1002,7 @@ ac
 ab
 ac
 ab
-ac
+OZ
 ab
 ac
 ac
@@ -1115,7 +1126,7 @@ ac
 (9,1,1) = {"
 ac
 ap
-ap
+HQ
 ap
 aD
 aD
@@ -1188,7 +1199,7 @@ cm
 bZ
 cm
 bR
-ap
+nY
 bJ
 ac
 "}
@@ -1309,7 +1320,7 @@ am
 am
 aP
 aZ
-bk
+yt
 am
 bC
 bS

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_cheese.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_cheese.dmm
@@ -904,85 +904,7 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"dF" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/icecream_vat,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
-"ih" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
-	},
-/obj/machinery/reagentgrinder,
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"jQ" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/enzyme{
-	layer = 5
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"mD" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/obj/machinery/vending/dinnerware,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"nf" = (
-/obj/machinery/food_cart,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"nC" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"oE" = (
-/obj/machinery/smartfridge/drinks,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"rh" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"rk" = (
-/obj/structure/table,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26
-	},
-/obj/machinery/reagentgrinder/kitchen{
-	pixel_y = 10
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"vO" = (
-/obj/machinery/vending/boozeomat,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"zX" = (
+"dI" = (
 /obj/machinery/light{
 	dir = 4
 	},
@@ -1002,7 +924,29 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"Ar" = (
+"hk" = (
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"jQ" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	layer = 5
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"kC" = (
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"oC" = (
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/cable_coil,
@@ -1011,33 +955,72 @@
 /obj/structure/closet/secure_closet/bartender,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"Le" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/spawner/xmastree,
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
+"rk" = (
+/obj/structure/table,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
-/area/crew_quarters/bar)
-"RM" = (
+/obj/machinery/reagentgrinder/kitchen{
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"rA" = (
 /obj/effect/landmark/blobstart,
 /obj/item/reagent_containers/food/snacks/store/cheesewheel/cheddar,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
-"Tw" = (
+"rW" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"tG" = (
+/obj/machinery/food_cart,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"ul" = (
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"we" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"Ux" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/table,
-/obj/item/reagent_containers/glass/mixbowl{
-	pixel_x = 1;
-	pixel_y = 4
+"BJ" = (
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"Ew" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/machinery/reagentgrinder,
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"Fb" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/icecream_vat,
+/turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"UF" = (
+"Ra" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/wine{
 	pixel_x = -4
@@ -1048,11 +1031,20 @@
 /obj/item/reagent_containers/food/drinks/bottle/lizardwine,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"VB" = (
-/obj/effect/landmark/xeno_spawn,
+"RF" = (
+/obj/machinery/smartfridge/drinks,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"XG" = (
+"Ux" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/table,
+/obj/item/reagent_containers/glass/mixbowl{
+	pixel_x = 1;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"UZ" = (
 /obj/machinery/camera{
 	c_tag = "Bar Storage"
 	},
@@ -1064,6 +1056,14 @@
 	pixel_y = 28
 	},
 /turf/open/floor/wood,
+/area/crew_quarters/bar)
+"ZP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/spawner/xmastree,
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
 /area/crew_quarters/bar)
 
 (1,1,1) = {"
@@ -1198,7 +1198,7 @@ ag
 ag
 aB
 aI
-Le
+ZP
 bj
 bC
 am
@@ -1251,7 +1251,7 @@ bk
 aB
 au
 aE
-UF
+Ra
 aY
 aB
 aX
@@ -1264,7 +1264,7 @@ aK
 ag
 ag
 ag
-vO
+ul
 cD
 cK
 bX
@@ -1277,7 +1277,7 @@ cC
 (14,1,1) = {"
 ah
 at
-ih
+Ew
 ba
 ag
 aV
@@ -1291,9 +1291,9 @@ cz
 ag
 "}
 (15,1,1) = {"
-Ar
+oC
 au
-VB
+hk
 aB
 bl
 aB
@@ -1308,14 +1308,14 @@ ag
 "}
 (16,1,1) = {"
 ag
-XG
+UZ
 aM
 ag
 ag
 ag
-zX
-nC
-oE
+dI
+kC
+RF
 cd
 aB
 cr
@@ -1324,10 +1324,10 @@ ag
 "}
 (17,1,1) = {"
 ak
-rh
+BJ
 aN
 ag
-RM
+rA
 al
 al
 al
@@ -1345,10 +1345,10 @@ al
 al
 al
 al
-mD
+rW
 ce
-Tw
-Tw
+we
+we
 ce
 cs
 al
@@ -1357,7 +1357,7 @@ aa
 (19,1,1) = {"
 al
 bc
-dF
+Fb
 bq
 bq
 al
@@ -1393,7 +1393,7 @@ aQ
 bf
 bt
 al
-nf
+tG
 bQ
 ce
 ce

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_cheese.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_cheese.dmm
@@ -30,12 +30,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"af" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "ag" = (
 /turf/closed/wall,
 /area/crew_quarters/bar)
@@ -166,32 +160,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"av" = (
-/obj/machinery/camera{
-	c_tag = "Bar Storage"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"aw" = (
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/cable_coil,
-/obj/item/flashlight/lamp,
-/obj/item/flashlight/lamp/green,
-/obj/structure/closet/secure_closet/bartender,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"ax" = (
-/obj/machinery/food_cart,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
 "ay" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -288,20 +256,6 @@
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"aL" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "aM" = (
 /obj/structure/chair/stool,
 /turf/open/floor/wood,
@@ -321,13 +275,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"aO" = (
-/obj/machinery/icecream_vat,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
 "aP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -380,13 +327,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"aW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
-	},
-/area/crew_quarters/bar)
 "aX" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
@@ -415,11 +355,6 @@
 /area/crew_quarters/bar)
 "ba" = (
 /obj/structure/fermenting_barrel,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"bb" = (
-/obj/structure/table/wood,
-/obj/machinery/reagentgrinder,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "bc" = (
@@ -498,36 +433,12 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"bp" = (
-/obj/structure/sign/warning/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
-	pixel_x = 4;
-	pixel_y = 28
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "bq" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "br" = (
 /mob/living/carbon/monkey/punpun,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"bs" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26
-	},
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "bt" = (
@@ -599,13 +510,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"bD" = (
-/obj/machinery/vending/boozeomat,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "bE" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 28
@@ -664,22 +568,6 @@
 	dir = 8
 	},
 /obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"bL" = (
-/obj/machinery/vending/dinnerware,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"bM" = (
-/turf/open/floor/wood{
-	icon_state = "wood-broken4"
-	},
-/area/crew_quarters/bar)
-"bN" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 8
-	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "bO" = (
@@ -804,14 +692,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "ce" = (
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"cf" = (
-/obj/machinery/deepfryer,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "ci" = (
@@ -943,17 +823,6 @@
 /obj/machinery/computer/arcade,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"cA" = (
-/obj/item/reagent_containers/food/drinks/bottle/wine{
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/food/drinks/bottle/lizardwine,
-/obj/item/reagent_containers/food/drinks/bottle/wine{
-	pixel_x = 4
-	},
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "cB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -1035,6 +904,29 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/crew_quarters/bar)
+"dF" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/icecream_vat,
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen)
+"ih" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/machinery/reagentgrinder,
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "jQ" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/enzyme{
@@ -1042,6 +934,39 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"mD" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"nf" = (
+/obj/machinery/food_cart,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"nC" = (
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"oE" = (
+/obj/machinery/smartfridge/drinks,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"rh" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "rk" = (
 /obj/structure/table,
 /obj/machinery/firealarm{
@@ -1053,6 +978,56 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"vO" = (
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"zX" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/sign/warning/securearea{
+	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
+	icon_state = "monkey_painting";
+	name = "Mr. Deempisi portrait";
+	pixel_x = 28;
+	pixel_y = -4
+	},
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/radio/intercom{
+	pixel_y = 25
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"Ar" = (
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/cable_coil,
+/obj/item/flashlight/lamp,
+/obj/item/flashlight/lamp/green,
+/obj/structure/closet/secure_closet/bartender,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"Le" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/spawner/xmastree,
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
+/area/crew_quarters/bar)
+"RM" = (
+/obj/effect/landmark/blobstart,
+/obj/item/reagent_containers/food/snacks/store/cheesewheel/cheddar,
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
+"Tw" = (
+/obj/machinery/deepfryer,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "Ux" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table,
@@ -1062,6 +1037,34 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"UF" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/food/drinks/bottle/lizardwine,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"VB" = (
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"XG" = (
+/obj/machinery/camera{
+	c_tag = "Bar Storage"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8;
+	icon_state = "vent_map_on-1"
+	},
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 
 (1,1,1) = {"
 aa
@@ -1195,7 +1198,7 @@ ag
 ag
 aB
 aI
-aW
+Le
 bj
 bC
 am
@@ -1248,7 +1251,7 @@ bk
 aB
 au
 aE
-bk
+UF
 aY
 aB
 aX
@@ -1261,7 +1264,7 @@ aK
 ag
 ag
 ag
-bp
+vO
 cD
 cK
 bX
@@ -1274,7 +1277,7 @@ cC
 (14,1,1) = {"
 ah
 at
-aL
+ih
 ba
 ag
 aV
@@ -1288,9 +1291,9 @@ cz
 ag
 "}
 (15,1,1) = {"
-af
+Ar
 au
-aB
+VB
 aB
 bl
 aB
@@ -1305,14 +1308,14 @@ ag
 "}
 (16,1,1) = {"
 ag
-av
-aM
+XG
 aM
 ag
-aB
-aB
-bM
-cA
+ag
+ag
+zX
+nC
+oE
 cd
 aB
 cr
@@ -1321,13 +1324,13 @@ ag
 "}
 (17,1,1) = {"
 ak
-aw
+rh
 aN
-bb
 ag
-bs
-bD
-bN
+RM
+al
+al
+al
 al
 al
 cl
@@ -1342,10 +1345,10 @@ al
 al
 al
 al
-al
-al
-al
-cf
+mD
+ce
+Tw
+Tw
 ce
 cs
 al
@@ -1353,12 +1356,12 @@ aa
 "}
 (19,1,1) = {"
 al
-ax
-aO
 bc
+dF
+bq
 bq
 al
-bL
+bE
 ce
 bP
 jQ
@@ -1390,7 +1393,7 @@ aQ
 bf
 bt
 al
-bE
+nf
 bQ
 ce
 ce

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_citadel.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_citadel.dmm
@@ -284,20 +284,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"dd" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
-	},
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/item/reagent_containers/glass/rag,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "dP" = (
 /obj/structure/chair/sofa/left,
 /obj/structure/window{
@@ -327,15 +313,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"fh" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "ft" = (
 /obj/effect/landmark/event_spawn,
 /turf/closed/wall,
@@ -449,6 +426,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"kq" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "kK" = (
 /obj/machinery/camera{
 	c_tag = "Bar Storage"
@@ -560,6 +544,12 @@
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair/sofa/right{
 	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"qv" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 32
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -1119,6 +1109,17 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"KN" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "La" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -1242,6 +1243,15 @@
 	},
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/wood,
+/area/crew_quarters/bar)
+"RX" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/smartfridge/drinks,
+/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "RZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -1654,8 +1664,8 @@ kk
 Pe
 cK
 Pe
-fh
-sC
+KN
+kq
 xa
 OC
 "}
@@ -1686,9 +1696,9 @@ ac
 Pe
 IO
 Pe
-dd
+RX
 wZ
-wZ
+qv
 OC
 "}
 (16,1,1) = {"

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_citadel.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_citadel.dmm
@@ -284,6 +284,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"dl" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 32
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "dP" = (
 /obj/structure/chair/sofa/left,
 /obj/structure/window{
@@ -313,6 +319,17 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"fm" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "ft" = (
 /obj/effect/landmark/event_spawn,
 /turf/closed/wall,
@@ -426,13 +443,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"kq" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "kK" = (
 /obj/machinery/camera{
 	c_tag = "Bar Storage"
@@ -544,12 +554,6 @@
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair/sofa/right{
 	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"qv" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -790,13 +794,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"BK" = (
-/obj/effect/landmark/start/assistant,
-/obj/structure/chair/sofa/right{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "BR" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
@@ -942,12 +939,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"Hb" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "He" = (
 /obj/machinery/light,
 /turf/open/floor/wood,
@@ -1109,17 +1100,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"KN" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "La" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -1217,6 +1197,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"Qa" = (
+/obj/structure/chair/sofa/right{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "QW" = (
 /obj/effect/landmark/blobstart,
 /obj/item/toy/beach_ball/holoball,
@@ -1243,15 +1229,6 @@
 	},
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/wood,
-/area/crew_quarters/bar)
-"RX" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/smartfridge/drinks,
-/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "RZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -1294,14 +1271,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"Tb" = (
-/obj/structure/chair/sofa,
-/obj/structure/window{
-	dir = 1
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "Tn" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -1330,6 +1299,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"TU" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "Ue" = (
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/glass/fifty,
@@ -1374,6 +1350,15 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"WZ" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/smartfridge/drinks,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "Xf" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood,
@@ -1440,6 +1425,13 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"YC" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "Zr" = (
 /obj/structure/piano{
 	icon_state = "piano"
@@ -1490,7 +1482,7 @@ wZ
 bf
 zU
 Fi
-BK
+Qa
 OC
 "}
 (3,1,1) = {"
@@ -1504,7 +1496,7 @@ VE
 zJ
 wZ
 Zr
-Tb
+To
 HN
 nv
 oj
@@ -1519,7 +1511,7 @@ hD
 Dr
 sZ
 wZ
-Hb
+YC
 dP
 bk
 ad
@@ -1664,8 +1656,8 @@ kk
 Pe
 cK
 Pe
-KN
-kq
+fm
+TU
 xa
 OC
 "}
@@ -1696,9 +1688,9 @@ ac
 Pe
 IO
 Pe
-RX
+WZ
 wZ
-qv
+dl
 OC
 "}
 (16,1,1) = {"

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_clock.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_clock.dmm
@@ -244,13 +244,6 @@
 "eu" = (
 /turf/open/floor/bronze,
 /area/crew_quarters/kitchen)
-"eI" = (
-/obj/item/clockwork/alloy_shards,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
-	},
-/turf/open/floor/bronze,
-/area/crew_quarters/bar)
 "eP" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/bronze,
@@ -307,10 +300,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
-"hv" = (
-/obj/machinery/smartfridge/drinks,
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
 "ia" = (
 /obj/machinery/light_switch{
 	pixel_y = -25
@@ -335,6 +324,16 @@
 	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
+"js" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/mob/living/simple_animal/bot/honkbot,
+/turf/open/floor/bronze,
+/area/crew_quarters/theatre)
 "jy" = (
 /obj/structure/chair/bronze{
 	dir = 1
@@ -689,6 +688,12 @@
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
+"Cw" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/effect/landmark/event_spawn,
+/obj/effect/spawner/xmastree,
+/turf/open/floor/bronze,
+/area/crew_quarters/bar)
 "Cz" = (
 /obj/item/kitchen/rollingpin{
 	pixel_x = 3
@@ -732,12 +737,6 @@
 "Ej" = (
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"Er" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/obj/effect/landmark/event_spawn,
-/obj/effect/spawner/xmastree,
-/turf/open/floor/bronze,
-/area/crew_quarters/bar)
 "EX" = (
 /obj/structure/chair/bronze{
 	dir = 4
@@ -767,10 +766,8 @@
 	},
 /turf/open/floor/bronze,
 /area/crew_quarters/kitchen)
-"Gl" = (
-/obj/structure/table/bronze,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
+"Gs" = (
+/obj/machinery/smartfridge/drinks,
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
 "Gv" = (
@@ -933,6 +930,13 @@
 /obj/effect/landmark/start/cook,
 /turf/open/floor/bronze,
 /area/crew_quarters/kitchen)
+"MA" = (
+/obj/item/clockwork/alloy_shards,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 32
+	},
+/turf/open/floor/bronze,
+/area/crew_quarters/bar)
 "Nc" = (
 /obj/item/clockwork/component/geis_capacitor/fallen_armor,
 /turf/open/floor/bronze,
@@ -945,16 +949,6 @@
 /obj/structure/table/bronze,
 /turf/open/floor/bronze,
 /area/crew_quarters/kitchen)
-"NC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/mob/living/simple_animal/bot/honkbot,
-/turf/open/floor/bronze,
-/area/crew_quarters/theatre)
 "Oy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4;
@@ -1033,6 +1027,12 @@
 	pixel_y = 2
 	},
 /obj/structure/table/bronze,
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
+"Sf" = (
+/obj/structure/table/bronze,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
 "SD" = (
@@ -1130,6 +1130,16 @@
 	},
 /turf/open/floor/bronze,
 /area/crew_quarters/bar)
+"Wq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/bronze,
+/area/crew_quarters/theatre)
 "Ws" = (
 /turf/closed/wall/mineral/bronze,
 /area/crew_quarters/bar)
@@ -1166,16 +1176,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
-"Yk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/bronze,
-/area/crew_quarters/theatre)
 "YH" = (
 /obj/item/clockwork/alloy_shards/small,
 /turf/open/floor/bronze/reebe,
@@ -1255,7 +1255,7 @@ Ws
 ab
 wa
 rB
-NC
+js
 fz
 Wx
 AD
@@ -1271,12 +1271,12 @@ Ws
 nF
 xV
 ya
-Yk
+Wq
 fz
 Wx
 Wx
 Wx
-Er
+Cw
 Vt
 Vl
 Wx
@@ -1390,7 +1390,7 @@ AD
 AD
 zN
 AD
-Gl
+Sf
 yQ
 Rh
 Ws
@@ -1422,9 +1422,9 @@ BM
 AD
 BH
 AD
-hv
+Gs
 AD
-eI
+MA
 Ws
 "}
 (16,1,1) = {"

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_clock.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_clock.dmm
@@ -244,6 +244,13 @@
 "eu" = (
 /turf/open/floor/bronze,
 /area/crew_quarters/kitchen)
+"eI" = (
+/obj/item/clockwork/alloy_shards,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 32
+	},
+/turf/open/floor/bronze,
+/area/crew_quarters/bar)
 "eP" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/bronze,
@@ -299,6 +306,10 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
+/area/crew_quarters/bar)
+"hv" = (
+/obj/machinery/smartfridge/drinks,
+/turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
 "ia" = (
 /obj/machinery/light_switch{
@@ -367,10 +378,6 @@
 /obj/item/toy/plush/plushvar,
 /obj/structure/table/bronze,
 /turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
-"nu" = (
-/obj/item/clockwork/alloy_shards,
-/turf/open/floor/bronze,
 /area/crew_quarters/bar)
 "nC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -725,6 +732,12 @@
 "Ej" = (
 /turf/closed/wall,
 /area/crew_quarters/bar)
+"Er" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/effect/landmark/event_spawn,
+/obj/effect/spawner/xmastree,
+/turf/open/floor/bronze,
+/area/crew_quarters/bar)
 "EX" = (
 /obj/structure/chair/bronze{
 	dir = 4
@@ -754,6 +767,12 @@
 	},
 /turf/open/floor/bronze,
 /area/crew_quarters/kitchen)
+"Gl" = (
+/obj/structure/table/bronze,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
 "Gv" = (
 /obj/machinery/chem_dispenser/drinks/beer{
 	dir = 8
@@ -811,19 +830,6 @@
 /obj/structure/table/bronze,
 /turf/open/floor/bronze,
 /area/crew_quarters/kitchen)
-"HX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/bronze,
-/area/crew_quarters/bar)
-"Ia" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/turf/open/floor/bronze,
-/area/crew_quarters/theatre)
 "Iq" = (
 /obj/machinery/disposal/bin,
 /obj/structure/sign/warning/securearea{
@@ -927,15 +933,6 @@
 /obj/effect/landmark/start/cook,
 /turf/open/floor/bronze,
 /area/crew_quarters/kitchen)
-"ML" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
-	},
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/structure/table/bronze,
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
 "Nc" = (
 /obj/item/clockwork/component/geis_capacitor/fallen_armor,
 /turf/open/floor/bronze,
@@ -948,6 +945,16 @@
 /obj/structure/table/bronze,
 /turf/open/floor/bronze,
 /area/crew_quarters/kitchen)
+"NC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/mob/living/simple_animal/bot/honkbot,
+/turf/open/floor/bronze,
+/area/crew_quarters/theatre)
 "Oy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4;
@@ -1159,6 +1166,16 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
+"Yk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/bronze,
+/area/crew_quarters/theatre)
 "YH" = (
 /obj/item/clockwork/alloy_shards/small,
 /turf/open/floor/bronze/reebe,
@@ -1238,7 +1255,7 @@ Ws
 ab
 wa
 rB
-Ia
+NC
 fz
 Wx
 AD
@@ -1254,12 +1271,12 @@ Ws
 nF
 xV
 ya
-CO
+Yk
 fz
 Wx
 Wx
 Wx
-HX
+Er
 Vt
 Vl
 Wx
@@ -1373,7 +1390,7 @@ AD
 AD
 zN
 AD
-BA
+Gl
 yQ
 Rh
 Ws
@@ -1405,9 +1422,9 @@ BM
 AD
 BH
 AD
-ML
+hv
 AD
-nu
+eI
 Ws
 "}
 (16,1,1) = {"

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_conveyor.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_conveyor.dmm
@@ -1005,6 +1005,15 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
+"cS" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8;
+	icon_state = "vent_map_on-1"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/crew_quarters/kitchen)
 "cV" = (
 /obj/machinery/conveyor{
 	dir = 9;
@@ -1082,10 +1091,22 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
-"nk" = (
+"ht" = (
+/obj/effect/landmark/event_spawn,
+/turf/closed/wall,
+/area/crew_quarters/bar)
+"jj" = (
 /obj/machinery/computer/slot_machine,
 /obj/machinery/light{
 	dir = 1
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
+"jX" = (
+/obj/structure/chair/americandiner{
+	dir = 1;
+	icon_state = "americhair";
+	tag = ""
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
@@ -1100,6 +1121,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
+"rA" = (
+/obj/machinery/camera{
+	c_tag = "Theatre Stage";
+	dir = 2
+	},
+/obj/structure/table,
+/obj/item/clothing/head/hardhat/cakehat,
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
 "up" = (
@@ -1120,8 +1150,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"HO" = (
+"BP" = (
 /obj/effect/spawner/xmastree,
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
+"EC" = (
+/obj/structure/chair/stool,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
 "KY" = (
@@ -1131,22 +1166,10 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
-"MH" = (
-/obj/structure/chair/americandiner{
-	dir = 1;
-	icon_state = "americhair";
-	tag = ""
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
-"UH" = (
-/obj/machinery/camera{
-	c_tag = "Theatre Stage";
-	dir = 2
-	},
-/obj/structure/table,
-/obj/item/clothing/head/hardhat/cakehat,
-/turf/open/floor/plasteel/vaporwave,
+"SA" = (
+/obj/effect/landmark/blobstart,
+/obj/item/clothing/mask/cigarette/rollie/cannabis,
+/turf/open/floor/plating,
 /area/crew_quarters/bar)
 "VM" = (
 /obj/structure/table,
@@ -1156,15 +1179,6 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/kitchen)
-"VV" = (
-/obj/effect/landmark/blobstart,
-/obj/item/clothing/mask/cigarette/rollie/cannabis,
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
-"Wr" = (
-/obj/effect/landmark/event_spawn,
-/turf/closed/wall,
-/area/crew_quarters/bar)
 "XW" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only,
@@ -1178,20 +1192,6 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/kitchen)
-"YP" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
-"Zl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/crew_quarters/kitchen)
 
 (1,1,1) = {"
 aa
@@ -1200,7 +1200,7 @@ ab
 ab
 ab
 nw
-Wr
+ht
 nw
 ab
 nw
@@ -1253,7 +1253,7 @@ bs
 bs
 bs
 cV
-YP
+EC
 dq
 ab
 "}
@@ -1291,8 +1291,8 @@ cF
 "}
 (7,1,1) = {"
 ae
-UH
-MH
+rA
+jX
 aP
 bd
 bv
@@ -1307,7 +1307,7 @@ nw
 "}
 (8,1,1) = {"
 ac
-HO
+BP
 ao
 aP
 bg
@@ -1323,7 +1323,7 @@ cF
 "}
 (9,1,1) = {"
 ab
-nk
+jj
 ao
 ao
 ao
@@ -1454,7 +1454,7 @@ ak
 bk
 aF
 ab
-VV
+SA
 al
 bi
 bN
@@ -1491,7 +1491,7 @@ al
 bl
 bO
 bU
-cf
+bN
 bN
 bN
 ct
@@ -1518,7 +1518,7 @@ al
 al
 aN
 aZ
-Zl
+cS
 al
 bA
 bQ
@@ -1539,7 +1539,7 @@ al
 bC
 bR
 VM
-cf
+bN
 bN
 bN
 XW

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_conveyor.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_conveyor.dmm
@@ -118,25 +118,6 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
-"ar" = (
-/obj/machinery/camera{
-	c_tag = "Theatre Stage";
-	dir = 2
-	},
-/obj/structure/chair/americandiner{
-	dir = 4;
-	icon_state = "americhair"
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
-"as" = (
-/obj/structure/table,
-/obj/item/clothing/head/hardhat/cakehat,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
 "at" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -459,10 +440,6 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/kitchen)
-"bm" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "bn" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/plasteel{
@@ -474,16 +451,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
-	},
-/turf/open/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/crew_quarters/kitchen)
-"bp" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
 	},
 /turf/open/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -849,10 +816,6 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/kitchen)
-"co" = (
-/obj/machinery/computer/slot_machine,
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
 "cp" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1119,6 +1082,13 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
+"nk" = (
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
 "nw" = (
 /obj/effect/spawner/structure/window/plasma,
 /turf/open/floor/plating,
@@ -1150,11 +1120,32 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"HO" = (
+/obj/effect/spawner/xmastree,
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
 "KY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4;
 	icon_state = "scrub_map_on-3"
 	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
+"MH" = (
+/obj/structure/chair/americandiner{
+	dir = 1;
+	icon_state = "americhair";
+	tag = ""
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
+"UH" = (
+/obj/machinery/camera{
+	c_tag = "Theatre Stage";
+	dir = 2
+	},
+/obj/structure/table,
+/obj/item/clothing/head/hardhat/cakehat,
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
 "VM" = (
@@ -1165,6 +1156,15 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/kitchen)
+"VV" = (
+/obj/effect/landmark/blobstart,
+/obj/item/clothing/mask/cigarette/rollie/cannabis,
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
+"Wr" = (
+/obj/effect/landmark/event_spawn,
+/turf/closed/wall,
+/area/crew_quarters/bar)
 "XW" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only,
@@ -1178,6 +1178,20 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/kitchen)
+"YP" = (
+/obj/structure/chair/stool,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
+"Zl" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8;
+	icon_state = "vent_map_on-1"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/crew_quarters/kitchen)
 
 (1,1,1) = {"
 aa
@@ -1186,7 +1200,7 @@ ab
 ab
 ab
 nw
-ab
+Wr
 nw
 ab
 nw
@@ -1228,7 +1242,7 @@ bb
 ab
 "}
 (4,1,1) = {"
-ac
+ab
 gz
 KY
 aP
@@ -1239,7 +1253,7 @@ bs
 bs
 bs
 cV
-aP
+YP
 dq
 ab
 "}
@@ -1277,8 +1291,8 @@ cF
 "}
 (7,1,1) = {"
 ae
-ar
-ao
+UH
+MH
 aP
 bd
 bv
@@ -1292,8 +1306,8 @@ ao
 nw
 "}
 (8,1,1) = {"
-ab
-as
+ac
+HO
 ao
 aP
 bg
@@ -1309,7 +1323,7 @@ cF
 "}
 (9,1,1) = {"
 ab
-co
+nk
 ao
 ao
 ao
@@ -1440,7 +1454,7 @@ ak
 bk
 aF
 ab
-bm
+VV
 al
 bi
 bN
@@ -1504,7 +1518,7 @@ al
 al
 aN
 aZ
-bp
+Zl
 al
 bA
 bQ

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_diner.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_diner.dmm
@@ -473,10 +473,6 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
-"bh" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "bi" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/plasteel{
@@ -488,16 +484,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
-	},
-/turf/open/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/crew_quarters/kitchen)
-"bk" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
 	},
 /turf/open/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -1067,6 +1053,11 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/crew_quarters/bar)
+"ka" = (
+/obj/effect/turf_decal/ameritard,
+/obj/effect/spawner/xmastree,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "ko" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/burger/baseball{
@@ -1125,6 +1116,20 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
+"Bu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8;
+	icon_state = "vent_map_on-1"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/crew_quarters/kitchen)
+"Ca" = (
+/obj/effect/landmark/blobstart,
+/obj/item/reagent_containers/food/snacks/burger/plain,
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "Dn" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only,
@@ -1147,6 +1152,11 @@
 /obj/structure/chair/americandiner/booth/end_left,
 /obj/effect/turf_decal/ameritard,
 /turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"Jm" = (
+/obj/effect/spawner/structure/window,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
 /area/crew_quarters/bar)
 "Ns" = (
 /obj/structure/disposalpipe/segment,
@@ -1185,7 +1195,7 @@ ab
 ab
 ab
 ab
-mc
+Jm
 ab
 mc
 ab
@@ -1232,7 +1242,7 @@ aB
 aO
 aO
 bS
-az
+ka
 az
 ca
 HO
@@ -1438,7 +1448,7 @@ ai
 bK
 bP
 ab
-bh
+Ca
 aj
 bg
 bD
@@ -1502,7 +1512,7 @@ aj
 aj
 aL
 aY
-bk
+Bu
 aj
 br
 bG

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_diner.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_diner.dmm
@@ -985,6 +985,11 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/bar)
+"cK" = (
+/obj/effect/spawner/structure/window,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "cQ" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/ameritard,
@@ -1053,11 +1058,6 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"ka" = (
-/obj/effect/turf_decal/ameritard,
-/obj/effect/spawner/xmastree,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "ko" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/burger/baseball{
@@ -1070,6 +1070,15 @@
 	},
 /turf/open/floor/plasteel{
 	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
+"lT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8;
+	icon_state = "vent_map_on-1"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
 "mc" = (
@@ -1088,6 +1097,11 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
+"sL" = (
+/obj/effect/turf_decal/ameritard,
+/obj/effect/spawner/xmastree,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "vO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -1101,6 +1115,11 @@
 "xx" = (
 /obj/structure/sign/plaques/deempisi,
 /turf/closed/wall,
+/area/crew_quarters/bar)
+"yv" = (
+/obj/effect/landmark/blobstart,
+/obj/item/reagent_containers/food/snacks/burger/plain,
+/turf/open/floor/plating,
 /area/crew_quarters/bar)
 "Aw" = (
 /obj/structure/table,
@@ -1116,20 +1135,6 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
-"Bu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/crew_quarters/kitchen)
-"Ca" = (
-/obj/effect/landmark/blobstart,
-/obj/item/reagent_containers/food/snacks/burger/plain,
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "Dn" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only,
@@ -1153,10 +1158,13 @@
 /obj/effect/turf_decal/ameritard,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"Jm" = (
-/obj/effect/spawner/structure/window,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
+"JN" = (
+/mob/living/carbon/monkey{
+	name = "Pun Pun"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
 /area/crew_quarters/bar)
 "Ns" = (
 /obj/structure/disposalpipe/segment,
@@ -1195,7 +1203,7 @@ ab
 ab
 ab
 ab
-Jm
+cK
 ab
 mc
 ab
@@ -1242,7 +1250,7 @@ aB
 aO
 aO
 bS
-ka
+sL
 az
 ca
 HO
@@ -1403,7 +1411,7 @@ ag
 bf
 aU
 bx
-cv
+JN
 cv
 cv
 bY
@@ -1448,7 +1456,7 @@ ai
 bK
 bP
 ab
-Ca
+yv
 aj
 bg
 bD
@@ -1512,7 +1520,7 @@ aj
 aj
 aL
 aY
-Bu
+lT
 aj
 br
 bG

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_disco.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_disco.dmm
@@ -463,10 +463,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"bi" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "bj" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/plasteel{
@@ -479,16 +475,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/crew_quarters/kitchen)
-"bl" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
-	},
 /turf/open/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -889,6 +875,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"da" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8;
+	icon_state = "vent_map_on-1"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/crew_quarters/kitchen)
 "db" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
@@ -939,6 +934,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"kj" = (
+/obj/effect/spawner/xmastree,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
+"rB" = (
+/obj/effect/landmark/blobstart,
+/obj/item/toy/beach_ball/holoball,
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "uB" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/mixbowl{
@@ -976,6 +980,11 @@
 /obj/structure/sign/plaques/deempisi,
 /turf/closed/wall,
 /area/crew_quarters/bar)
+"Oy" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "RL" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only,
@@ -998,7 +1007,7 @@ ai
 ai
 ai
 ai
-bM
+Oy
 ai
 bM
 ai
@@ -1121,7 +1130,7 @@ bC
 (9,1,1) = {"
 ai
 an
-an
+kj
 an
 bc
 bc
@@ -1251,7 +1260,7 @@ aj
 aQ
 bg
 ai
-bi
+rB
 bt
 bE
 cy
@@ -1315,7 +1324,7 @@ ak
 ak
 aM
 aZ
-bl
+da
 ak
 bI
 cb

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_disco.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_disco.dmm
@@ -330,15 +330,6 @@
 	},
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/bar)
-"aR" = (
-/obj/structure/chair/americandiner/booth/end_left{
-	dir = 8;
-	icon_state = "ameribooth-end1";
-	tag = ""
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "aS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -875,15 +866,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"da" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/crew_quarters/kitchen)
 "db" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
@@ -934,14 +916,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"kj" = (
+"lg" = (
 /obj/effect/spawner/xmastree,
 /turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
-"rB" = (
-/obj/effect/landmark/blobstart,
-/obj/item/toy/beach_ball/holoball,
-/turf/open/floor/plating,
 /area/crew_quarters/bar)
 "uB" = (
 /obj/structure/table,
@@ -962,6 +939,11 @@
 	},
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/kitchen)
+"wS" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "Gv" = (
 /obj/machinery/light_switch,
 /turf/closed/wall,
@@ -980,11 +962,15 @@
 /obj/structure/sign/plaques/deempisi,
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"Oy" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
+"OT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8;
+	icon_state = "vent_map_on-1"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/crew_quarters/kitchen)
 "RL" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only,
@@ -998,6 +984,11 @@
 	},
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/kitchen)
+"VI" = (
+/obj/effect/landmark/blobstart,
+/obj/item/toy/beach_ball/holoball,
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 
 (1,1,1) = {"
 aa
@@ -1007,7 +998,7 @@ ai
 ai
 ai
 ai
-Oy
+wS
 ai
 bM
 ai
@@ -1115,7 +1106,7 @@ bM
 ai
 an
 aF
-aR
+aP
 bc
 bc
 bc
@@ -1130,7 +1121,7 @@ bC
 (9,1,1) = {"
 ai
 an
-kj
+lg
 an
 bc
 bc
@@ -1260,7 +1251,7 @@ aj
 aQ
 bg
 ai
-rB
+VI
 bt
 bE
 cy
@@ -1297,7 +1288,7 @@ ak
 bG
 bZ
 co
-cA
+cy
 cy
 cy
 bx
@@ -1324,7 +1315,7 @@ ak
 ak
 aM
 aZ
-da
+OT
 ak
 bI
 cb
@@ -1345,7 +1336,7 @@ ak
 bJ
 cc
 uB
-cA
+cy
 cy
 cy
 RL

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_irish.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_irish.dmm
@@ -1438,26 +1438,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"cD" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
-	},
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/darkgreen,
-/obj/effect/turf_decal/tile/darkgreen{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "cE" = (
 /obj/effect/landmark/start/cook,
 /turf/open/floor/plasteel/cafeteria,
@@ -1747,6 +1727,23 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/crew_quarters/bar)
+"dF" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkgreen,
+/obj/effect/turf_decal/tile/darkgreen{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "hD" = (
 /obj/structure/table,
 /obj/machinery/requests_console{
@@ -1774,6 +1771,38 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"ve" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkgreen,
+/obj/effect/turf_decal/tile/darkgreen{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"Lo" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkgreen,
+/obj/effect/turf_decal/tile/darkgreen{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/machinery/smartfridge/drinks,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "MM" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin{
@@ -1994,7 +2023,7 @@ aI
 aI
 ci
 aI
-bU
+ve
 cI
 cX
 ad
@@ -2026,9 +2055,9 @@ bF
 aI
 cj
 aI
-cD
+Lo
 aI
-aI
+dF
 ad
 "}
 (16,1,1) = {"

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_irish.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_irish.dmm
@@ -1727,7 +1727,7 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"dF" = (
+"dd" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
@@ -1739,9 +1739,7 @@
 	dir = 1;
 	icon_state = "tile_corner"
 	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
-	},
+/obj/machinery/smartfridge/drinks,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "hD" = (
@@ -1771,7 +1769,7 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"ve" = (
+"qV" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -1786,21 +1784,6 @@
 	},
 /obj/item/book/manual/wiki/barman_recipes,
 /obj/item/reagent_containers/glass/rag,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"Lo" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/darkgreen,
-/obj/effect/turf_decal/tile/darkgreen{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/obj/machinery/smartfridge/drinks,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "MM" = (
@@ -1819,6 +1802,23 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"PQ" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkgreen,
+/obj/effect/turf_decal/tile/darkgreen{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 
 (1,1,1) = {"
 aa
@@ -2023,7 +2023,7 @@ aI
 aI
 ci
 aI
-ve
+qV
 cI
 cX
 ad
@@ -2055,9 +2055,9 @@ bF
 aI
 cj
 aI
-Lo
+dd
 aI
-dF
+PQ
 ad
 "}
 (16,1,1) = {"

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_purple.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_purple.dmm
@@ -234,13 +234,6 @@
 /obj/structure/piano,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"aC" = (
-/obj/structure/chair/stool/bar{
-	color = "purple"
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "aD" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8;
@@ -1363,12 +1356,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"mU" = (
+"kV" = (
+/obj/structure/table/reinforced{
+	color = "purple"
+	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1;
 	icon_state = "tile_corner"
 	},
-/obj/machinery/smartfridge/drinks,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/item/toy/crayon/purple,
+/obj/item/toy/crayon/purple,
+/obj/item/toy/crayon/purple,
+/obj/item/toy/crayon/purple,
+/obj/item/toy/crayon/purple,
+/obj/item/toy/cards/deck,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "rs" = (
@@ -1382,23 +1387,13 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"Aj" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+"xW" = (
+/obj/structure/chair/stool/bar{
+	color = "purple"
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/spawner/xmastree,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
-"AR" = (
-/obj/structure/chair/comfy/brown{
-	buildstackamount = 0;
-	color = "purple";
-	dir = 1
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/mineral/titanium/purple,
 /area/crew_quarters/bar)
 "BD" = (
 /obj/machinery/light{
@@ -1422,6 +1417,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"Eq" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8;
+	icon_state = "vent_map_on-1"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/crew_quarters/kitchen)
 "ER" = (
 /obj/structure/table,
 /obj/machinery/requests_console{
@@ -1452,12 +1456,29 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
-"FV" = (
+"IV" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/machinery/smartfridge/drinks,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
+"Px" = (
 /obj/effect/landmark/blobstart,
 /obj/item/toy/crayon/purple,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
-"Ls" = (
+"SV" = (
+/obj/structure/chair/comfy/brown{
+	buildstackamount = 0;
+	color = "purple";
+	dir = 1
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/mineral/titanium/purple,
+/area/crew_quarters/bar)
+"Tj" = (
 /obj/structure/table/reinforced{
 	color = "purple"
 	},
@@ -1475,35 +1496,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"MP" = (
-/obj/structure/table/reinforced{
-	color = "purple"
-	},
+"UJ" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 1;
+	dir = 4;
 	icon_state = "tile_corner"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
-	},
-/obj/item/toy/crayon/purple,
-/obj/item/toy/crayon/purple,
-/obj/item/toy/crayon/purple,
-/obj/item/toy/crayon/purple,
-/obj/item/toy/crayon/purple,
-/obj/item/toy/cards/deck,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/spawner/xmastree,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"Ow" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/crew_quarters/kitchen)
 
 (1,1,1) = {"
 aa
@@ -1540,14 +1541,14 @@ ab
 (3,1,1) = {"
 ab
 ab
-aC
+xW
 aT
 aT
 aT
 aT
 aT
 aT
-Aj
+UJ
 aT
 di
 du
@@ -1594,7 +1595,7 @@ bh
 bx
 bh
 ca
-AR
+SV
 bx
 bh
 df
@@ -1671,13 +1672,13 @@ at
 cd
 cf
 aW
-MP
+kV
 cJ
-Ls
+Tj
 cJ
 cY
 cY
-mU
+IV
 bF
 ab
 "}
@@ -1766,7 +1767,7 @@ aj
 aJ
 as
 ab
-FV
+Px
 ak
 bP
 cN
@@ -1830,7 +1831,7 @@ ak
 ak
 aP
 be
-Ow
+Eq
 ak
 bT
 co

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_purple.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_purple.dmm
@@ -633,10 +633,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
-"bq" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "br" = (
 /obj/structure/kitchenspike,
 /obj/effect/turf_decal/tile/purple,
@@ -659,16 +655,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
-	},
-/turf/open/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/crew_quarters/kitchen)
-"bt" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
 	},
 /turf/open/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -736,25 +722,6 @@
 	color = "purple"
 	},
 /turf/open/floor/mineral/titanium/purple,
-/area/crew_quarters/bar)
-"bA" = (
-/obj/structure/table/reinforced{
-	color = "purple"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
-	},
-/obj/item/toy/crayon/purple,
-/obj/item/toy/crayon/purple,
-/obj/item/toy/crayon/purple,
-/obj/item/toy/crayon/purple,
-/obj/item/toy/crayon/purple,
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bB" = (
 /obj/machinery/disposal/bin,
@@ -837,21 +804,6 @@
 	},
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/mineral/titanium/purple,
-/area/crew_quarters/bar)
-"bK" = (
-/obj/item/toy/cards/deck,
-/obj/structure/table/reinforced{
-	color = "purple"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bL" = (
 /obj/structure/chair/stool/bar{
@@ -1185,24 +1137,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"cv" = (
-/obj/item/clothing/head/that{
-	throwforce = 1;
-	throwing = 1
-	},
-/obj/structure/table/reinforced{
-	color = "purple"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "cx" = (
 /obj/effect/landmark/start/bartender,
 /turf/open/floor/mineral/titanium/purple,
@@ -1294,17 +1228,6 @@
 	dir = 1;
 	icon_state = "tile_corner"
 	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
-"dh" = (
-/obj/structure/table/reinforced{
-	color = "purple"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/obj/item/gun/ballistic/revolver/russian,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "di" = (
@@ -1440,6 +1363,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"mU" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/machinery/smartfridge/drinks,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "rs" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/mixbowl{
@@ -1450,6 +1381,24 @@
 "vE" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
+"Aj" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/spawner/xmastree,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
+"AR" = (
+/obj/structure/chair/comfy/brown{
+	buildstackamount = 0;
+	color = "purple";
+	dir = 1
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/mineral/titanium/purple,
 /area/crew_quarters/bar)
 "BD" = (
 /obj/machinery/light{
@@ -1503,6 +1452,58 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
+"FV" = (
+/obj/effect/landmark/blobstart,
+/obj/item/toy/crayon/purple,
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
+"Ls" = (
+/obj/structure/table/reinforced{
+	color = "purple"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/item/clothing/head/that{
+	throwforce = 1;
+	throwing = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
+"MP" = (
+/obj/structure/table/reinforced{
+	color = "purple"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/item/toy/crayon/purple,
+/obj/item/toy/crayon/purple,
+/obj/item/toy/crayon/purple,
+/obj/item/toy/crayon/purple,
+/obj/item/toy/crayon/purple,
+/obj/item/toy/cards/deck,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
+"Ow" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8;
+	icon_state = "vent_map_on-1"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/crew_quarters/kitchen)
 
 (1,1,1) = {"
 aa
@@ -1546,7 +1547,7 @@ aT
 aT
 aT
 aT
-aT
+Aj
 aT
 di
 du
@@ -1593,7 +1594,7 @@ bh
 bx
 bh
 ca
-bh
+AR
 bx
 bh
 df
@@ -1670,13 +1671,13 @@ at
 cd
 cf
 aW
-bA
-bK
+MP
 cJ
-cv
+Ls
 cJ
 cY
-dh
+cY
+mU
 bF
 ab
 "}
@@ -1765,7 +1766,7 @@ aj
 aJ
 as
 ab
-bq
+FV
 ak
 bP
 cN
@@ -1829,7 +1830,7 @@ ak
 ak
 aP
 be
-bt
+Ow
 ak
 bT
 co

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_spacious.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_spacious.dmm
@@ -1004,6 +1004,15 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"lI" = (
+/obj/structure/chair/stool/bar,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "nP" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin{
@@ -1037,6 +1046,10 @@
 /obj/machinery/door/window/westright,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"Eu" = (
+/obj/structure/sign/plaques/deempisi,
+/turf/closed/wall,
+/area/crew_quarters/bar)
 "EC" = (
 /obj/structure/table,
 /obj/machinery/requests_console{
@@ -1060,10 +1073,6 @@
 "Lp" = (
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"RJ" = (
-/obj/structure/sign/plaques/deempisi,
-/turf/closed/wall,
-/area/crew_quarters/bar)
 "Sp" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -1153,7 +1162,7 @@ cT
 ba
 ba
 cI
-cI
+lI
 cI
 cI
 ba
@@ -1188,7 +1197,7 @@ bz
 bj
 bj
 bz
-cI
+lI
 ba
 bw
 "}
@@ -1236,7 +1245,7 @@ bz
 bj
 bj
 bz
-cI
+lI
 cm
 ab
 "}
@@ -1261,7 +1270,7 @@ ab
 ab
 ab
 ab
-RJ
+Eu
 bk
 cA
 cy

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_spacious.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_spacious.dmm
@@ -1060,6 +1060,10 @@
 "Lp" = (
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"RJ" = (
+/obj/structure/sign/plaques/deempisi,
+/turf/closed/wall,
+/area/crew_quarters/bar)
 "Sp" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -1257,7 +1261,7 @@ ab
 ab
 ab
 ab
-ab
+RJ
 bk
 cA
 cy

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_trek.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_trek.dmm
@@ -738,23 +738,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/mineral/titanium/white,
 /area/crew_quarters/bar)
-"by" = (
-/obj/effect/landmark/start/bartender,
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/crew_quarters/bar)
 "bz" = (
 /obj/machinery/light{
 	dir = 4
@@ -1156,23 +1139,6 @@
 /obj/machinery/processor,
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
-"cs" = (
-/obj/effect/landmark/start/assistant,
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/crew_quarters/bar)
 "ct" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/chair/comfy/shuttle{
@@ -1485,6 +1451,10 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/crew_quarters/kitchen)
+"Rz" = (
+/obj/structure/sign/plaques/deempisi,
+/turf/closed/wall,
+/area/crew_quarters/bar)
 "Sd" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -1498,10 +1468,6 @@
 	},
 /obj/item/twohanded/required/kirbyplants/photosynthetic,
 /turf/open/floor/mineral/titanium/white,
-/area/crew_quarters/bar)
-"SI" = (
-/obj/structure/sign/plaques/deempisi,
-/turf/closed/wall,
 /area/crew_quarters/bar)
 "ST" = (
 /obj/structure/table,
@@ -1683,7 +1649,7 @@ bN
 bN
 bN
 bN
-cs
+aL
 cD
 ag
 "}
@@ -1692,7 +1658,7 @@ ag
 ag
 ag
 ag
-SI
+Rz
 bp
 aL
 aM
@@ -1710,7 +1676,7 @@ aP
 aZ
 ag
 bt
-by
+aL
 aM
 bX
 aM

--- a/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_trek.dmm
+++ b/_maps/yogstation/RandomRuins/StationRuins/BoxStation/bar_trek.dmm
@@ -185,10 +185,6 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/crew_quarters/bar)
-"ar" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/mineral/titanium/blue,
-/area/crew_quarters/bar)
 "as" = (
 /obj/effect/spawner/xmastree,
 /turf/open/floor/mineral/titanium/blue,
@@ -1503,6 +1499,10 @@
 /obj/item/twohanded/required/kirbyplants/photosynthetic,
 /turf/open/floor/mineral/titanium/white,
 /area/crew_quarters/bar)
+"SI" = (
+/obj/structure/sign/plaques/deempisi,
+/turf/closed/wall,
+/area/crew_quarters/bar)
 "ST" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder/kitchen{
@@ -1595,7 +1595,7 @@ ag
 ag
 am
 aK
-ar
+aI
 cH
 ca
 aI
@@ -1692,7 +1692,7 @@ ag
 ag
 ag
 ag
-ag
+SI
 bp
 aL
 aM


### PR DESCRIPTION
The intent of this PR is to have all bar variants be more uniform. All bars now have 3 Generic Event spawners (Another for the theater), xeno_spawn in their backrooms, a Drink Showcase, a Blob Start surrounded by walls (bar_cheese is the most affected by this), a Christmas Tree Spawner (as much as I'm weary of the items), 2 Chef starts, 3 Assistant starts, 1 Bartender starts, Pun Pun, a Honkbot in the theater (should one exist) and an image of Mr Deempisi. 

Ontop of this, the Generic Event spawner has been removed from the Kitchen Backrooms, as is unform with bar_box.

#### Changelog

:cl:  
rscadd: Added several starts, Pun Pun to bar_diner, added xeno_spawns to bars that did not have it, added blob starts to bars that did not have it, added drink showcases to all bars that did not have it, added a honkbot to all existing theaters, added christmas tree spawners,
rscdel: Removed generic event spawners in kitchen backrooms that had them, removed extra chef starters.  
/:cl:
