### PR TITLE
Mining-only Bombcap Multiplier adjustment

### DIFF
--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -75,19 +75,19 @@ require only minor tweaks.
     ZTRAIT_MINING = TRUE, \
     ZTRAIT_ASHSTORM = TRUE, \
     ZTRAIT_LAVA_RUINS = TRUE, \
-    ZTRAIT_BOMBCAP_MULTIPLIER = 4, \
+    ZTRAIT_BOMBCAP_MULTIPLIER = 5, \
     ZTRAIT_BASETURF = /turf/open/lava/smooth/lava_land_surface)
 #define ZTRAITS_ICEMOON list(\
     ZTRAIT_MINING = TRUE, \
     ZTRAIT_ICE_RUINS = TRUE, \
-    ZTRAIT_BOMBCAP_MULTIPLIER = 4, \
+    ZTRAIT_BOMBCAP_MULTIPLIER = 5, \
     ZTRAIT_UP = -1, \
     ZTRAIT_DOWN = 1, \
     ZTRAIT_BASETURF = /turf/open/floor/plating/asteroid/snow/icemoon)
 #define ZTRAITS_ICEMOON_UNDERGROUND list(\
     ZTRAIT_MINING = TRUE, \
     ZTRAIT_ICE_RUINS_UNDERGROUND = TRUE, \
-    ZTRAIT_BOMBCAP_MULTIPLIER = 4, \
+    ZTRAIT_BOMBCAP_MULTIPLIER = 5, \
     ZTRAIT_UP = -1, \
     ZTRAIT_BASETURF = /turf/open/lava/plasma/ice_moon)
 #define ZTRAITS_REEBE list(ZTRAIT_REEBE = TRUE, ZTRAIT_BOMBCAP_MULTIPLIER = 0.60)

--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -75,19 +75,19 @@ require only minor tweaks.
     ZTRAIT_MINING = TRUE, \
     ZTRAIT_ASHSTORM = TRUE, \
     ZTRAIT_LAVA_RUINS = TRUE, \
-    ZTRAIT_BOMBCAP_MULTIPLIER = 2, \
+    ZTRAIT_BOMBCAP_MULTIPLIER = 4, \
     ZTRAIT_BASETURF = /turf/open/lava/smooth/lava_land_surface)
 #define ZTRAITS_ICEMOON list(\
     ZTRAIT_MINING = TRUE, \
     ZTRAIT_ICE_RUINS = TRUE, \
-    ZTRAIT_BOMBCAP_MULTIPLIER = 2, \
+    ZTRAIT_BOMBCAP_MULTIPLIER = 4, \
     ZTRAIT_UP = -1, \
     ZTRAIT_DOWN = 1, \
     ZTRAIT_BASETURF = /turf/open/floor/plating/asteroid/snow/icemoon)
 #define ZTRAITS_ICEMOON_UNDERGROUND list(\
     ZTRAIT_MINING = TRUE, \
     ZTRAIT_ICE_RUINS_UNDERGROUND = TRUE, \
-    ZTRAIT_BOMBCAP_MULTIPLIER = 2, \
+    ZTRAIT_BOMBCAP_MULTIPLIER = 4, \
     ZTRAIT_UP = -1, \
     ZTRAIT_BASETURF = /turf/open/lava/plasma/ice_moon)
 #define ZTRAITS_REEBE list(ZTRAIT_REEBE = TRUE, ZTRAIT_BOMBCAP_MULTIPLIER = 0.60)


### PR DESCRIPTION
### Intent of your Pull Request

**Edit: This PR is to adjust the Bombcap for Lavaland/Mining worlds, due to the changes made not too long ago with the default Maxcap settings and changes made some time ago to the cap as well.**

**The intent is to further shine a light on the Toxins department to its primary roles: making a Science Bomb for points, or making Mining Bombs for the Mining Team.**


Follow-up PR from my other one about the new Toxins machine, L.A.M.: https://github.com/yogstation13/Yogstation/pull/9608

Back in 2018, the Lavaland Bombcap was also reduced from 3x to 2x to reduce lag: https://github.com/yogstation13/Yogstation/commit/c4fd8715a5f5e9c3c0446072a5d526ee3e82c8f6

The current Maxcap is 3/6/12, down from its old default of 5/10/20. 

This means that the Maxcaps on Lavaland, for example, went from 15/30/60 to 6/12/24.

This 5x adjustment will give us bombs on Mining worlds that are 15/30/60 again.

## Why it's good for the game

Returning the bombcap to normal provides an alternative mining process to the Mining team very early on in the game, as well as the mid-game, to request bombing aid from Toxins, whether or not the other PR goes thru. Because all bosses are relatively bomb-immune, it remains strictly a tool for helping clear out large chunks of rock and tunnels.


#### Changelog

:cl:  
tweak: Bombs triggered on lavaland and other mining worlds can be as large as they used to be.
/:cl: