### PR TITLE
Overhauls the free golem base

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -104,14 +104,10 @@
 /turf/open/floor/plating,
 /area/ruin/powered/golem_ship)
 "jX" = (
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 4;
-	pixel_y = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
 /obj/effect/decal/cleanable/glass,
+/obj/item/storage/pill_bottle/charcoal,
 /turf/open/floor/pod/dark,
 /area/ruin/powered/golem_ship)
 "kD" = (
@@ -298,13 +294,9 @@
 /turf/open/floor/pod/dark,
 /area/ruin/powered/golem_ship)
 "zO" = (
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 4;
-	pixel_y = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
+/obj/item/storage/pill_bottle/bica,
 /turf/open/floor/pod/dark,
 /area/ruin/powered/golem_ship)
 "zV" = (
@@ -354,12 +346,8 @@
 /turf/open/floor/plating,
 /area/ruin/powered/golem_ship)
 "Ci" = (
-/obj/item/storage/firstaid/brute,
-/obj/item/storage/firstaid/brute{
-	pixel_x = 4;
-	pixel_y = 1
-	},
 /obj/structure/rack,
+/obj/item/storage/pill_bottle/kelo,
 /turf/open/floor/pod/dark,
 /area/ruin/powered/golem_ship)
 "CE" = (
@@ -522,7 +510,12 @@
 /area/ruin/powered/golem_ship)
 "Lh" = (
 /obj/structure/rack,
-/obj/item/seeds/tower,
+/obj/item/vending_refill/hydroseeds{
+	name = "MegaSeed resupply canister"
+	},
+/obj/item/vending_refill/hydronutrients{
+	name = "NutriMax resupply canister"
+	},
 /obj/item/storage/bag/plants/portaseeder,
 /obj/item/shovel/spade,
 /obj/item/cultivator,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -1,628 +1,1313 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
-/turf/template_noop,
-/area/template_noop)
-"b" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ruin/powered/golem_ship)
-"c" = (
-/obj/structure/closet/crate,
-/obj/item/shovel,
-/obj/item/shovel,
-/obj/item/shovel,
+"bN" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/structure/rack,
 /obj/item/pickaxe,
 /obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/obj/item/mining_scanner,
-/obj/item/flashlight/lantern,
-/obj/item/card/id/mining,
+/obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/ruin/powered/golem_ship)
-"d" = (
-/obj/structure/closet/crate,
-/obj/item/shovel,
-/obj/item/shovel,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/obj/item/mining_scanner,
-/obj/item/flashlight/lantern,
-/obj/item/card/id/mining,
-/turf/open/floor/plating,
-/area/ruin/powered/golem_ship)
-"e" = (
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/plating,
-/area/ruin/powered/golem_ship)
-"f" = (
-/turf/open/floor/plating,
-/area/ruin/powered/golem_ship)
-"g" = (
+"bQ" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/ruin/powered/golem_ship)
-"h" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
-/area/ruin/powered/golem_ship)
-"i" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8
-	},
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
-/area/ruin/powered/golem_ship)
-"j" = (
-/obj/machinery/door/airlock/titanium,
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"k" = (
-/obj/machinery/computer/arcade/battle,
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"l" = (
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"m" = (
-/obj/effect/mob_spawn/human/golem/adamantine,
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"n" = (
-/obj/machinery/mineral/equipment_vendor/golem,
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"o" = (
-/obj/item/resonator,
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"p" = (
-/obj/machinery/mineral/ore_redemption,
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"q" = (
-/obj/structure/statue/gold/rd,
-/obj/structure/window/reinforced{
+"bT" = (
+/obj/machinery/computer{
+	desc = "A computer long since rendered non-functional due to lack of maintenance. Spitting out error messages.";
 	dir = 4;
-	name = "shrine of the liberator"
+	name = "Broken Computer"
 	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/carpet/exoticpurple,
+/area/ruin/powered/golem_ship)
+"da" = (
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"dw" = (
+/obj/structure/rack,
+/obj/item/mining_scanner,
+/obj/item/mining_scanner,
+/obj/item/mining_scanner,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"fy" = (
+/turf/open/floor/carpet/exoticpurple,
+/area/ruin/powered/golem_ship)
+"gU" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium/purple,
+/turf/open/floor/pod/dark,
 /area/ruin/powered/golem_ship)
-"r" = (
-/obj/machinery/computer/shuttle,
-/turf/open/floor/mineral/titanium/purple,
+"hk" = (
+/obj/effect/mob_spawn/human/golem/adamantine,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/carpet/exoticpurple,
 /area/ruin/powered/golem_ship)
-"t" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
+"hy" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 4
 	},
-/turf/open/floor/mineral/titanium/purple,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
 /area/ruin/powered/golem_ship)
-"u" = (
-/obj/structure/table/wood,
+"hB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/pod,
+/area/ruin/powered/golem_ship)
+"hD" = (
+/obj/structure/closet{
+	anchored = 1;
+	name = "mining equipment"
+	},
+/obj/item/shovel,
+/obj/item/shovel,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/obj/item/mining_scanner,
+/obj/item/flashlight/lantern,
+/obj/item/card/id/mining,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"hQ" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"hV" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/stack/sheet/cloth/five,
+/obj/item/kitchen/knife/combat/survival,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"hY" = (
+/obj/machinery/mineral/equipment_vendor/golem,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"ig" = (
+/obj/machinery/shower,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"iU" = (
+/obj/effect/spawner/structure/window/hollow/survival_pod/directional{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"jX" = (
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"kD" = (
+/obj/machinery/door/airlock/survival_pod/glass,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"lu" = (
+/turf/template_noop,
+/area/space)
+"mL" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/template_noop,
+/area/ruin/powered/golem_ship)
+"mY" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/pod,
+/area/ruin/powered/golem_ship)
+"na" = (
+/obj/machinery/light/built,
+/obj/structure/frame/machine,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"nO" = (
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/survival_pod/glass,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"oz" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
+	},
+/turf/open/floor/pod,
+/area/ruin/powered/golem_ship)
+"pc" = (
+/obj/machinery/mineral/ore_redemption,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"pq" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/crown{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/item/clothing/head/crown{
+	pixel_x = -5
+	},
+/obj/item/clothing/head/beret/sci{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/item/clothing/head/beret/sci{
+	pixel_x = 4;
+	pixel_y = -1
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"pJ" = (
+/obj/structure/ore_box,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"pO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"pT" = (
+/obj/machinery/autolathe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"rh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/pod,
+/area/ruin/powered/golem_ship)
+"si" = (
+/obj/effect/spawner/structure/window/hollow/survival_pod/middle,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"sm" = (
+/turf/template_noop,
+/area/ruin/powered/golem_ship)
+"sJ" = (
+/obj/structure/ore_box,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"tx" = (
+/obj/structure/table/reinforced,
+/obj/item/cautery{
+	pixel_x = 4
+	},
+/obj/item/surgicaldrill,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"ty" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"uc" = (
+/obj/machinery/computer/operating{
+	dir = 4
+	},
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"uf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/robot_debris/old,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"uw" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/template_noop,
+/area/ruin/powered/golem_ship)
+"uB" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod,
+/area/ruin/powered/golem_ship)
+"vO" = (
+/obj/structure/frame/machine,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"wZ" = (
+/obj/effect/mob_spawn/human/golem/adamantine,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/carpet/exoticpurple,
+/area/ruin/powered/golem_ship)
+"xc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod,
+/area/ruin/powered/golem_ship)
+"xl" = (
+/obj/effect/spawner/structure/window/hollow/survival_pod/middle{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"xz" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/pod,
+/area/ruin/powered/golem_ship)
+"yp" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/pod,
+/area/ruin/powered/golem_ship)
+"yu" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/survival_pod/glass,
+/turf/open/floor/pod,
+/area/ruin/powered/golem_ship)
+"zE" = (
+/obj/structure/frame/computer{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"zO" = (
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/fire{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"zV" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light,
+/obj/item/surgical_drapes,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"Au" = (
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/survival_pod/glass,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"AH" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"AU" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"AY" = (
+/obj/structure/table/reinforced,
+/obj/item/scalpel{
+	pixel_y = 12
+	},
+/obj/item/retractor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"Bg" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/template_noop,
+/area/ruin/powered/golem_ship)
+"BF" = (
+/obj/structure/rack,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"Ci" = (
+/obj/item/storage/firstaid/brute,
+/obj/item/storage/firstaid/brute{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/obj/structure/rack,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"CE" = (
+/obj/structure/sign/mining,
+/turf/closed/wall/mineral/titanium/survival/pod,
+/area/ruin/powered/golem_ship)
+"CI" = (
+/obj/machinery/light/built{
+	dir = 4
+	},
+/turf/template_noop,
+/area/ruin/powered/golem_ship)
+"Do" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"Dq" = (
+/obj/effect/mob_spawn/human/golem/adamantine,
+/turf/open/floor/carpet/exoticpurple,
+/area/ruin/powered/golem_ship)
+"Dw" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/surgery,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"ER" = (
+/obj/structure/frame/machine,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"EV" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/item/shovel,
+/obj/item/shovel,
+/obj/item/shovel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"Fe" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/survival_pod/glass,
+/turf/open/floor/pod,
+/area/ruin/powered/golem_ship)
+"Ff" = (
+/obj/machinery/computer/arcade,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"FL" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/pod,
+/area/ruin/powered/golem_ship)
+"FM" = (
+/obj/structure/closet{
+	anchored = 1;
+	name = "mining equipment"
+	},
+/obj/item/shovel,
+/obj/item/shovel,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/obj/item/mining_scanner,
+/obj/item/flashlight/lantern,
+/obj/item/card/id/mining,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"FQ" = (
+/obj/structure/frame/computer{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"GD" = (
+/obj/structure/table/reinforced,
+/obj/item/areaeditor/blueprints{
+	desc = "Use to build new structures in the wastes.";
+	name = "land claim"
+	},
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"Hp" = (
+/turf/open/floor/pod,
+/area/ruin/powered/golem_ship)
+"Ht" = (
+/turf/closed/wall/mineral/titanium/survival/pod,
+/area/ruin/powered/golem_ship)
+"Hv" = (
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/survival_pod/glass,
+/turf/open/floor/pod,
+/area/ruin/powered/golem_ship)
+"HQ" = (
+/obj/machinery/computer/shuttle{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/exoticpurple,
+/area/ruin/powered/golem_ship)
+"Iu" = (
+/obj/structure/frame/computer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"ID" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"Jj" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod,
+/area/ruin/powered/golem_ship)
+"Jq" = (
+/obj/structure/shuttle/engine/huge{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered/golem_ship)
+"Kp" = (
+/obj/structure/table/optable,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"Ku" = (
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/template_noop,
+/area/ruin/powered/golem_ship)
+"KW" = (
+/obj/effect/spawner/structure/window/hollow/survival_pod/directional{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"Lh" = (
+/obj/structure/rack,
+/obj/item/seeds/tower,
+/obj/item/storage/bag/plants/portaseeder,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"Ls" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/exoticpurple,
+/area/ruin/powered/golem_ship)
+"LB" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"LI" = (
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"LU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"LX" = (
+/obj/machinery/computer{
+	desc = "A computer long since rendered non-functional due to lack of maintenance. Spitting out error messages.";
+	dir = 4;
+	name = "Broken Computer"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/carpet/exoticpurple,
+/area/ruin/powered/golem_ship)
+"MH" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"MQ" = (
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/survival_pod/glass,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/pod,
+/area/ruin/powered/golem_ship)
+"MR" = (
+/obj/structure/statue/gold/rd,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"MV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"Nj" = (
+/obj/structure/table_frame,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"Oj" = (
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/survival_pod/glass,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/pod,
+/area/ruin/powered/golem_ship)
+"Ol" = (
+/obj/item/resonator,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/carpet/exoticpurple,
+/area/ruin/powered/golem_ship)
+"Ox" = (
+/obj/structure/frame/machine,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"OL" = (
+/obj/item/resonator,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/exoticpurple,
+/area/ruin/powered/golem_ship)
+"OZ" = (
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"Ph" = (
+/obj/item/disk/design_disk/golem_shell,
+/obj/structure/table/reinforced,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"Pr" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/carpet/exoticpurple,
+/area/ruin/powered/golem_ship)
+"Pt" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/structure/chair/office/dark,
+/turf/open/floor/pod,
+/area/ruin/powered/golem_ship)
+"Pu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"Pz" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/template_noop,
+/area/ruin/powered/golem_ship)
+"PC" = (
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/survival_pod/glass,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/pod,
+/area/ruin/powered/golem_ship)
+"PN" = (
+/obj/machinery/door/airlock/survival_pod/glass,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"Qd" = (
+/obj/item/resonator,
+/turf/open/floor/carpet/exoticpurple,
+/area/ruin/powered/golem_ship)
+"Qu" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/survival_pod/glass,
+/turf/open/floor/pod,
+/area/ruin/powered/golem_ship)
+"Rk" = (
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"RO" = (
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/survival_pod/glass,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"Sb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"SR" = (
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/template_noop,
+/area/ruin/powered/golem_ship)
+"Ud" = (
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/survival_pod/glass,
+/turf/open/floor/pod,
+/area/ruin/powered/golem_ship)
+"UB" = (
+/obj/structure/table/reinforced,
+/obj/item/circular_saw,
+/obj/item/hemostat,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"UU" = (
+/obj/effect/spawner/structure/window/hollow/survival_pod/directional{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"UY" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/research_and_development{
+	name = "Sacred Text of the Liberator";
+	pixel_y = 3
+	},
 /obj/item/bedsheet/rd/royal_cape{
 	layer = 3;
 	pixel_x = 5;
 	pixel_y = 9
 	},
-/obj/item/book/manual/wiki/research_and_development{
-	name = "Sacred Text of the Liberator";
-	pixel_x = -4;
-	pixel_y = 3
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	name = "shrine of the liberator"
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"Vd" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"Vu" = (
+/obj/structure/rack,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"Wa" = (
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
-"v" = (
-/obj/item/resonator/upgraded,
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"w" = (
-/obj/machinery/autolathe,
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"x" = (
-/obj/structure/table/wood,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"y" = (
-/obj/machinery/computer/arcade/orion_trail,
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"z" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"A" = (
-/obj/structure/table/wood,
-/obj/item/surgical_drapes{
-	pixel_x = 15
-	},
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/fire,
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"B" = (
-/obj/item/storage/firstaid/fire,
-/obj/structure/table/wood,
-/obj/item/storage/firstaid/fire,
+"Wd" = (
+/obj/structure/table/reinforced,
 /obj/machinery/light,
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"C" = (
-/obj/item/storage/firstaid/brute,
-/obj/structure/table/wood,
-/obj/item/storage/firstaid/brute,
-/obj/item/areaeditor/blueprints{
-	desc = "Use to build new structures in the wastes.";
-	name = "land claim"
-	},
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"D" = (
-/obj/item/storage/firstaid/brute,
-/obj/structure/table/wood,
-/obj/item/storage/firstaid/brute,
-/obj/item/disk/design_disk/golem_shell,
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"E" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/item/storage/bag/trash,
+/obj/item/soap/nanotrasen,
+/obj/item/soap/nanotrasen,
 /turf/open/floor/plating,
 /area/ruin/powered/golem_ship)
-"F" = (
-/obj/structure/ore_box,
+"We" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/ruin/powered/golem_ship)
-"G" = (
-/turf/closed/wall/mineral/titanium,
-/area/ruin/powered/golem_ship)
-"H" = (
-/obj/machinery/door/airlock/titanium,
-/obj/structure/fans/tiny,
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"I" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/ruin/powered/golem_ship)
-"K" = (
-/obj/machinery/door/airlock/titanium,
-/obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"L" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"M" = (
-/obj/effect/mob_spawn/human/golem/adamantine,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"N" = (
+"WR" = (
 /obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"O" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"Q" = (
-/obj/machinery/light/small,
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"T" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/titanium,
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"U" = (
-/obj/effect/mob_spawn/human/golem/adamantine,
-/obj/machinery/light/small,
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/powered/golem_ship)
-"V" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/powered/golem_ship)
-"Y" = (
-/obj/machinery/door/airlock/titanium,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium/purple,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"Xc" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/template_noop,
+/area/ruin/powered/golem_ship)
+"Xr" = (
+/obj/effect/spawner/structure/window/hollow/survival_pod/directional{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"XR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"YA" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"YL" = (
+/obj/structure/sink{
+	pixel_y = 28
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"YP" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
 /area/ruin/powered/golem_ship)
 
 (1,1,1) = {"
-a
-a
-a
-a
-a
-a
-b
-b
-b
-b
-a
-a
-a
-a
-a
-a
+lu
+Ht
+Ht
+Ht
+Ht
+Ht
+lu
+lu
+lu
+lu
+lu
+lu
+lu
+Ht
+Ht
+Ht
+Ht
+Ht
+lu
 "}
 (2,1,1) = {"
-a
-a
-a
-a
-a
-a
-b
-q
-u
-G
-a
-a
-a
-a
-a
-a
+lu
+Ht
+UY
+YP
+Ff
+Ht
+lu
+lu
+lu
+lu
+lu
+lu
+lu
+Ht
+uc
+Kp
+zV
+Ht
+lu
 "}
 (3,1,1) = {"
-a
-a
-a
-b
-b
-H
-b
-r
-l
-G
-T
-b
-b
-a
-a
-a
+lu
+si
+Ph
+xc
+YP
+Ht
+Xc
+UU
+xl
+xl
+xl
+KW
+CI
+Ht
+MV
+Hp
+AY
+si
+lu
 "}
 (4,1,1) = {"
-a
-a
-a
-b
-k
-l
-j
-l
-l
-j
-l
-y
-b
-a
-a
-a
+lu
+si
+GD
+xc
+YP
+Ht
+Ht
+iU
+LX
+HQ
+bT
+Xr
+Ht
+Ht
+YL
+Hp
+UB
+si
+lu
 "}
 (5,1,1) = {"
-a
-a
-a
-b
-L
-l
-j
-l
-l
-j
-l
-l
-b
-a
-a
-a
+lu
+si
+MR
+MV
+Ff
+Ht
+Ox
+Hp
+Ls
+Pr
+Ls
+xc
+zE
+Ht
+Dw
+da
+tx
+si
+lu
 "}
 (6,1,1) = {"
-b
-b
-b
-b
-l
-l
-b
-l
-Q
-G
-l
-Q
-b
-b
-b
-b
+lu
+CE
+Ht
+kD
+Ht
+Ht
+Iu
+FL
+Ls
+fy
+Ls
+Pt
+vO
+Ht
+Ht
+PN
+Ht
+CE
+lu
 "}
 (7,1,1) = {"
-b
-c
-f
-j
-l
-l
-b
-l
-l
-G
-l
-l
-j
-f
-F
-b
+lu
+si
+FM
+da
+hD
+Ht
+Ht
+Ht
+Ht
+Qu
+Ht
+Ht
+Ht
+Ht
+zO
+YP
+da
+si
+lu
 "}
 (8,1,1) = {"
-b
-c
-f
-j
-l
-l
-b
-L
-l
-G
-l
-l
-j
-f
-F
-b
+lu
+si
+hD
+xc
+hD
+Ht
+hk
+Ol
+YP
+Hp
+LU
+Ol
+Dq
+Ht
+Ci
+hB
+da
+si
+lu
 "}
 (9,1,1) = {"
-b
-c
-I
-b
-M
-o
-b
-l
-l
-G
-o
-U
-b
-V
-F
-b
+lu
+si
+hD
+xc
+hD
+Ht
+wZ
+OL
+da
+xc
+YP
+Qd
+Dq
+Ht
+jX
+Hp
+YP
+si
+lu
 "}
 (10,1,1) = {"
-b
-c
-f
-b
-m
-o
-b
-l
-l
-G
-o
-m
-b
-f
-F
-b
+lu
+Ht
+hV
+YP
+hD
+Ht
+Ht
+Ht
+Ht
+Fe
+Ht
+Ht
+Ht
+Ht
+pO
+YP
+AH
+Ht
+lu
 "}
 (11,1,1) = {"
-b
-c
-f
-b
-b
-j
-b
-j
-j
-G
-j
-b
-b
-f
-F
-b
+lu
+Ht
+Ht
+yu
+Ht
+Ht
+XR
+Do
+YP
+YP
+YP
+gU
+OZ
+Ht
+Ht
+yu
+Ht
+Ht
+lu
 "}
 (12,1,1) = {"
-b
-c
-I
-b
-l
-l
-O
-l
-l
-O
-l
-z
-b
-V
-F
-b
+lu
+SR
+PC
+mY
+uB
+Hv
+da
+xc
+ER
+xc
+pT
+yp
+da
+Ud
+oz
+rh
+Oj
+uw
+lu
 "}
 (13,1,1) = {"
-b
-d
-f
-j
-l
-l
-l
-l
-l
-l
-l
-l
-j
-f
-F
-b
+lu
+mL
+Ud
+Hp
+Jj
+Hv
+YP
+xc
+Hp
+xc
+xc
+Hp
+YP
+MQ
+xz
+xc
+Hv
+Ku
+lu
 "}
 (14,1,1) = {"
-b
-d
-f
-j
-l
-l
-l
-l
-l
-l
-l
-l
-j
-f
-e
-b
+lu
+Ht
+Ht
+yu
+Ht
+Ht
+Pu
+xc
+LB
+xc
+ty
+Hp
+OZ
+Ht
+Ht
+yu
+Ht
+Ht
+lu
 "}
 (15,1,1) = {"
-b
-d
-f
-b
-l
-l
-l
-l
-l
-l
-l
-A
-b
-f
-f
-b
+Ht
+Ht
+ig
+OZ
+pq
+Ht
+YA
+Hp
+ID
+Hp
+ER
+Hp
+FQ
+Ht
+Vu
+OZ
+OZ
+Ht
+Ht
 "}
 (16,1,1) = {"
-T
-e
-I
-b
-N
-l
-l
-l
-l
-v
-l
-B
-b
-V
-f
-T
+Ht
+pJ
+OZ
+YA
+Wd
+Ht
+uf
+Hp
+hB
+xc
+xc
+Hp
+LB
+Ht
+bN
+XR
+YA
+bQ
+Ht
 "}
 (17,1,1) = {"
-T
-f
-f
-b
-l
-l
-p
-l
-l
-w
-l
-C
-b
-f
-f
-T
+CE
+pJ
+ID
+Rk
+Nj
+Ht
+YP
+Hp
+pc
+Hp
+OZ
+xc
+da
+Ht
+dw
+YA
+Rk
+bQ
+CE
 "}
 (18,1,1) = {"
-b
-g
-g
-b
-n
-l
-b
-Y
-Y
-b
-x
-D
-b
-E
-E
-b
+Ht
+pJ
+Sb
+OZ
+Vd
+Ht
+YP
+YP
+da
+WR
+YP
+da
+YP
+Ht
+BF
+OZ
+OZ
+We
+Ht
 "}
 (19,1,1) = {"
-b
-h
-h
-b
-h
-h
-b
-t
-Q
-b
-h
-h
-b
-h
-h
-b
+CE
+pJ
+YA
+LI
+na
+Ht
+hY
+Ht
+Au
+Ht
+Au
+Ht
+Sb
+Ht
+EV
+OZ
+YA
+AU
+CE
 "}
 (20,1,1) = {"
-b
-i
-i
-b
-i
-i
-b
-K
-K
-b
-i
-i
-b
-i
-i
-b
+Ht
+sJ
+OZ
+LB
+Vd
+Ht
+CE
+Ht
+MH
+hQ
+da
+Ht
+CE
+Ht
+Lh
+YA
+XR
+AU
+Ht
+"}
+(21,1,1) = {"
+Ht
+Ht
+hy
+hy
+hy
+Ht
+Pz
+Ht
+nO
+Ht
+RO
+Ht
+Bg
+Ht
+hy
+hy
+hy
+Ht
+Ht
+"}
+(22,1,1) = {"
+lu
+Ht
+Wa
+Wa
+Jq
+Ht
+lu
+lu
+lu
+lu
+lu
+lu
+lu
+Ht
+Wa
+Wa
+Jq
+Ht
+lu
+"}
+(23,1,1) = {"
+lu
+lu
+Wa
+Wa
+Wa
+lu
+lu
+lu
+lu
+lu
+lu
+lu
+lu
+lu
+Wa
+Wa
+Wa
+lu
+lu
+"}
+(24,1,1) = {"
+lu
+lu
+sm
+sm
+sm
+lu
+lu
+lu
+lu
+lu
+lu
+lu
+lu
+lu
+sm
+sm
+sm
+lu
+lu
 "}

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -175,15 +175,7 @@
 "pq" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/head/crown{
-	pixel_x = -5;
-	pixel_y = 7
-	},
-/obj/item/clothing/head/crown{
 	pixel_x = -5
-	},
-/obj/item/clothing/head/beret/sci{
-	pixel_x = 4;
-	pixel_y = 6
 	},
 /obj/item/clothing/head/beret/sci{
 	pixel_x = 4;

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -46,17 +46,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/carpet/exoticpurple,
 /area/ruin/powered/golem_ship)
-"hy" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 4
-	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 8
-	},
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
-/area/ruin/powered/golem_ship)
 "hB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
@@ -134,6 +123,9 @@
 "lu" = (
 /turf/template_noop,
 /area/space)
+"lK" = (
+/turf/open/floor/plating/lavaland_baseturf,
+/area/ruin/powered/golem_ship)
 "mL" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -171,6 +163,15 @@
 "pc" = (
 /obj/machinery/mineral/ore_redemption,
 /turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"po" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/turf/open/floor/plating/lavaland_baseturf,
 /area/ruin/powered/golem_ship)
 "pq" = (
 /obj/structure/table/reinforced,
@@ -416,6 +417,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
 /area/ruin/powered/golem_ship)
+"FC" = (
+/obj/structure/shuttle/engine/huge{
+	dir = 4
+	},
+/turf/open/floor/plating/lavaland_baseturf,
+/area/ruin/powered/golem_ship)
 "FL" = (
 /obj/machinery/light{
 	dir = 4
@@ -496,14 +503,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
-/area/ruin/powered/golem_ship)
-"Jq" = (
-/obj/structure/shuttle/engine/huge{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
 /area/ruin/powered/golem_ship)
 "Kp" = (
 /obj/structure/table/optable,
@@ -738,11 +737,6 @@
 /obj/item/flashlight/lantern,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/powered/golem_ship)
-"Wa" = (
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
 /area/ruin/powered/golem_ship)
 "Wd" = (
 /obj/structure/table/reinforced,
@@ -1222,9 +1216,9 @@ Ht
 (21,1,1) = {"
 Ht
 Ht
-hy
-hy
-hy
+po
+po
+po
 Ht
 Pz
 Ht
@@ -1234,18 +1228,18 @@ RO
 Ht
 Bg
 Ht
-hy
-hy
-hy
+po
+po
+po
 Ht
 Ht
 "}
 (22,1,1) = {"
 lu
 Ht
-Wa
-Wa
-Jq
+lK
+lK
+FC
 Ht
 lu
 lu
@@ -1255,18 +1249,18 @@ lu
 lu
 lu
 Ht
-Wa
-Wa
-Jq
+lK
+lK
+FC
 Ht
 lu
 "}
 (23,1,1) = {"
 lu
 lu
-Wa
-Wa
-Wa
+lK
+lK
+lK
 lu
 lu
 lu
@@ -1276,9 +1270,9 @@ lu
 lu
 lu
 lu
-Wa
-Wa
-Wa
+lK
+lK
+lK
 lu
 lu
 "}

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -356,3 +356,19 @@
 /obj/item/storage/pill_bottle/floorpill/full/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/reagent_containers/pill/floorpill(src)
+
+/obj/item/storage/pill_bottle/bica
+	name = "bottle of bicaridine pills"
+	desc = "Contains pills to treat bruises."
+
+/obj/item/storage/pill_bottle/bica/PopulateContents()
+	for(var/i in 1 to 7)
+		new /obj/item/reagent_containers/pill/bica(src)
+
+/obj/item/storage/pill_bottle/kelo
+	name = "bottle of kelotane pills"
+	desc = "Contains pills to treat burns."
+
+/obj/item/storage/pill_bottle/kelo/PopulateContents()
+	for(var/i in 1 to 7)
+		new /obj/item/reagent_containers/pill/kelo(src)

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -246,13 +246,15 @@
 /obj/machinery/mineral/equipment_vendor/golem/Initialize()
 	desc += "\nIt seems a few selections have been added."
 	prize_list += list(
+		new /datum/data/mining_equipment("Brute Pill Bottle",			/obj/item/storage/pill_bottle/bica,									600, VENDING_MEDS),
+		new /datum/data/mining_equipment("Burn Pill Bottle",			/obj/item/storage/pill_bottle/kelo,									600, VENDING_MEDS),
+		new /datum/data/mining_equipment("Toxin Pill Bottle",			/obj/item/storage/pill_bottle/charcoal,								600, VENDING_MEDS),
 		new /datum/data/mining_equipment("KA Trigger Guard Kit",    		/obj/item/borg/upgrade/modkit/trigger_guard,					1700, VENDING_UPGRADE),
 		new /datum/data/mining_equipment("Extra ID",       				/obj/item/card/id/mining, 				                   		250, VENDING_MISC),
 		new /datum/data/mining_equipment("Monkey Cube",					/obj/item/reagent_containers/food/snacks/monkeycube,        	300, VENDING_MISC),
 		new /datum/data/mining_equipment("Grey Slime Extract",			/obj/item/slime_extract/grey,									1000, VENDING_MISC),
 		new /datum/data/mining_equipment("Science Goggles",       		/obj/item/clothing/glasses/science,								250, VENDING_EQUIPMENT),
 		new /datum/data/mining_equipment("Toolbelt",					/obj/item/storage/belt/utility,	    							350, VENDING_EQUIPMENT),
-		new /datum/data/mining_equipment("Explorer Backpack",			/obj/item/storage/backpack/explorer,							500, VENDING_EQUIPMENT),
 		new /datum/data/mining_equipment("Random Poster",				/obj/item/poster/random_official,								100, VENDING_MISC),
 		new /datum/data/mining_equipment("Royal Cape of the Liberator", /obj/item/bedsheet/rd/royal_cape, 								500, VENDING_EQUIPMENT),
 		new /datum/data/mining_equipment("The Liberator's Legacy",  	/obj/item/storage/box/rndboards,								2000, VENDING_TOOL)

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -255,7 +255,7 @@
 		new /datum/data/mining_equipment("Grey Slime Extract",			/obj/item/slime_extract/grey,									1000, VENDING_MISC),
 		new /datum/data/mining_equipment("Science Goggles",       		/obj/item/clothing/glasses/science,								250, VENDING_EQUIPMENT),
 		new /datum/data/mining_equipment("Toolbelt",					/obj/item/storage/belt/utility,	    							350, VENDING_EQUIPMENT),
-		new /datum/data/mining_equipment("Random Poster",				/obj/item/poster/random_official,								100, VENDING_MISC),
+		new /datum/data/mining_equipment("Random Poster",				/obj/item/poster/random_official,								200, VENDING_MISC),
 		new /datum/data/mining_equipment("Royal Cape of the Liberator", /obj/item/bedsheet/rd/royal_cape, 								500, VENDING_EQUIPMENT),
 		new /datum/data/mining_equipment("The Liberator's Legacy",  	/obj/item/storage/box/rndboards,								2000, VENDING_TOOL)
 		)

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -246,14 +246,16 @@
 /obj/machinery/mineral/equipment_vendor/golem/Initialize()
 	desc += "\nIt seems a few selections have been added."
 	prize_list += list(
-		new /datum/data/mining_equipment("The Liberator's Legacy",  	/obj/item/storage/box/rndboards,								2000, VENDING_TOOL),
-		new /datum/data/mining_equipment("Modification Kit",    		/obj/item/borg/upgrade/modkit/trigger_guard,					1700, VENDING_UPGRADE),
-		new /datum/data/mining_equipment("Extra Id",       				/obj/item/card/id/mining, 				                   		250, VENDING_MISC),
+		new /datum/data/mining_equipment("KA Trigger Guard Kit",    		/obj/item/borg/upgrade/modkit/trigger_guard,					1700, VENDING_UPGRADE),
+		new /datum/data/mining_equipment("Extra ID",       				/obj/item/card/id/mining, 				                   		250, VENDING_MISC),
 		new /datum/data/mining_equipment("Monkey Cube",					/obj/item/reagent_containers/food/snacks/monkeycube,        	300, VENDING_MISC),
 		new /datum/data/mining_equipment("Grey Slime Extract",			/obj/item/slime_extract/grey,									1000, VENDING_MISC),
 		new /datum/data/mining_equipment("Science Goggles",       		/obj/item/clothing/glasses/science,								250, VENDING_EQUIPMENT),
 		new /datum/data/mining_equipment("Toolbelt",					/obj/item/storage/belt/utility,	    							350, VENDING_EQUIPMENT),
-		new /datum/data/mining_equipment("Royal Cape of the Liberator", /obj/item/bedsheet/rd/royal_cape, 								500, VENDING_EQUIPMENT)
+		new /datum/data/mining_equipment("Explorer Backpack",			/obj/item/storage/backpack/explorer,							500, VENDING_EQUIPMENT),
+		new /datum/data/mining_equipment("Random Poster",				/obj/item/poster/random_official,								100, VENDING_MISC),
+		new /datum/data/mining_equipment("Royal Cape of the Liberator", /obj/item/bedsheet/rd/royal_cape, 								500, VENDING_EQUIPMENT),
+		new /datum/data/mining_equipment("The Liberator's Legacy",  	/obj/item/storage/box/rndboards,								2000, VENDING_TOOL)
 		)
 	return ..()
 

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -145,7 +145,7 @@
 
 /obj/item/reagent_containers/pill/salicyclic
 	name = "salicylic acid pill"
-	desc = "Used to dull pain."
+	desc = "Used to stimulate bruise healing."
 	icon_state = "pill9"
 	list_reagents = list(/datum/reagent/medicine/sal_acid = 24)
 	rename_with_volume = TRUE
@@ -242,3 +242,14 @@
 	if(prob(20))
 		desc = pick(descs)
 
+/obj/item/reagent_containers/pill/bica
+	name = "bicaridine pill"
+	desc = "Used to stimulate burn healing."
+	icon_state = "pill10"
+	list_reagents = list(/datum/reagent/medicine/bicaridine = 14)
+
+/obj/item/reagent_containers/pill/kelo
+	name = "kelotane pill"
+	desc = "Used to heal burns."
+	icon_state = "pill12"
+	list_reagents = list(/datum/reagent/medicine/kelotane = 14)


### PR DESCRIPTION
Inspired by Azlan's free golem ship revamp at BeeStation/BeeStation-Hornet#893, I figured our free golem ship could use something of a revamp. With some modification from *that* (taking it down from "crashed, battle-scarred ship" to "crashed, dirty, old ship"), here it is.

<details>
<summary>Old</summary>

![image](https://user-images.githubusercontent.com/29339701/93687652-439e4500-fa8d-11ea-8856-00e4f33ecb60.png)

</details>

<details>
<summary>New</summary>

![image](https://user-images.githubusercontent.com/29339701/93687648-3da86400-fa8d-11ea-9cef-7e853286f9e3.png)

</details>

I decided to add random NanoTrasen posters for 200 points each because I think it'd be nice if the free golems were able to do some more decoration. In addition to this, I've also added bicaridine, kelotane, and charcoal pill bottles to the vendor, since most of the contents of proper first aid kits don't work on them, for 600 points each.

#### Changelog

:cl:  
rscadd: Praise to the Liberator! They have bequeathed a new ship unto the free golems, featuring more rooms, botanical supplies, and some hats!
rscadd: Added random posters and bicaridine, kelotane, and charcoal pill bottles to the free golem vendor.
tweak: Rearranged items and some grammar in the free golem vendor.
/:cl:
