### PR TITLE
remove knockdown from hand teleport

### DIFF
--- a/yogstation/code/modules/guardian/abilities/major/hand.dm
+++ b/yogstation/code/modules/guardian/abilities/major/hand.dm
@@ -16,7 +16,6 @@
 		AM.forceMove(hand_turf)
 		if(isliving(AM))
 			var/mob/living/L = AM
-			L.Knockdown(10)
 	guardian.face_atom(hand_turf)
 	return ..()
 

--- a/yogstation/code/modules/guardian/abilities/major/hand.dm
+++ b/yogstation/code/modules/guardian/abilities/major/hand.dm
@@ -14,8 +14,6 @@
 		if(AM.anchored)
 			continue
 		AM.forceMove(hand_turf)
-		if(isliving(AM))
-			var/mob/living/L = AM
 	guardian.face_atom(hand_turf)
 	return ..()
 


### PR DESCRIPTION
literally everyone uses this since it moves people next to you and forces them to drop whatever they're holding

:cl:  
tweak: the hand holoparasite ability no longer knocks down
/:cl:
