### PR TITLE
makes minebots and goldgrubs actually mine and goldgrub on lavaland

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -553,7 +553,7 @@ mob/living/simple_animal/hostile/proc/DestroySurroundings() // for use with mega
 		toggle_ai(AI_Z_OFF)
 		return
 
-	var/cheap_search = isturf(T) && !is_station_level(T.z)
+	var/cheap_search = isturf(T) && !(is_station_level(T.z) || is_mining_level(T.z))
 	if (cheap_search)
 		tlist = ListTargetsLazy(T.z)
 	else


### PR DESCRIPTION
quick search used for non-station levels doesn't check for objects so they have to wait a way longer time than they should to check for items

:cl:  
tweak: goldgrubs and minebots on lavaland will now actually search for ores
/:cl:
