### PR TITLE
Adds Syndicate uniforms that have suit sensors

### DIFF
--- a/code/modules/clothing/under/syndicate.dm
+++ b/code/modules/clothing/under/syndicate.dm
@@ -56,3 +56,29 @@
 	can_adjust = FALSE
 	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	resistance_flags = NONE
+
+/obj/item/clothing/under/syndicate/crew
+	name = "syndicate uniform"
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 40)
+	has_sensor = HAS_SENSORS
+
+/obj/item/clothing/under/syndicate/crew/security
+	name = "syndicate security uniform"
+	desc = "With a suit lined with this many pockets, you are ready to secure."
+	icon_state = "syndicate_combat"
+	item_color = "syndicate_combat"
+	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 40)
+	strip_delay = 50
+	alt_covers_chest = TRUE
+	sensor_mode = SENSOR_COORDS
+	can_adjust = FALSE
+
+/obj/item/clothing/under/syndicate/crew/command
+	name = "syndicate command uniform"
+	desc = "With a suit lined with this many pockets, you are ready to command."
+	icon_state = "syndicate_combat"
+	item_color = "syndicate_combat"
+	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 40)
+	alt_covers_chest = TRUE
+	sensor_mode = SENSOR_COORDS
+	can_adjust = FALSE

--- a/code/modules/clothing/under/syndicate.dm
+++ b/code/modules/clothing/under/syndicate.dm
@@ -74,12 +74,6 @@
 	sensor_mode = SENSOR_COORDS
 	can_adjust = FALSE
 
-/obj/item/clothing/under/syndicate/crew/command
+/obj/item/clothing/under/syndicate/crew/security/command
 	name = "syndicate command uniform"
 	desc = "With a suit lined with this many pockets, you are ready to command."
-	icon_state = "syndicate_combat"
-	item_color = "syndicate_combat"
-	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 40)
-	alt_covers_chest = TRUE
-	sensor_mode = SENSOR_COORDS
-	can_adjust = FALSE

--- a/code/modules/clothing/under/syndicate.dm
+++ b/code/modules/clothing/under/syndicate.dm
@@ -57,6 +57,7 @@
 	armor = list("melee" = 5, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	resistance_flags = NONE
 
+// SYNDICATE STATION
 /obj/item/clothing/under/syndicate/crew
 	name = "syndicate uniform"
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 40)


### PR DESCRIPTION
One of the complaints of the last Syndicate Station round was that the Syndicate uniforms don't have sensors. While someone suggested that the admins could varedit them to have sensors, it seems like this would be very inefficient, especially for spawning them in quantities sufficient for an entire crew. Thus, I have decided to make some new uniforms specifically for use in events like these. These are:

- **Syndicate uniform**: A generic, armorless (aside from fire and acid resistance) tactical turtleneck, intended for general crewmembers.
- **Syndicate security uniform**: Intended for security, this adds 10 melee armor and comes with pockets/the combat uniform sprite.
- **Syndicate command uniform**: Obviously intended for command, this is almost identical to the security uniform.

#### Changelog

:cl:  
rscadd: Added the Syndicate crew, security, and command uniforms to code.
/:cl:
