### PR TITLE
fix oversight that makes pockets not get checked for heretic sacrifices

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -499,7 +499,7 @@
 
 //GetAllContents that is reasonable and not stupid
 /mob/living/carbon/proc/get_all_gear()
-	var/list/processing_list = get_equipped_items() + held_items
+	var/list/processing_list = get_equipped_items(TRUE) + held_items
 	listclearnulls(processing_list) // handles empty hands
 	var/i = 0
 	while(i < length(processing_list) )


### PR DESCRIPTION

:cl:  
bugfix: heretics now have their pockets checked for their book when they sacrifice someone and need to get a charge
/:cl:
