### PR TITLE
Removes t-posing

### DIFF
--- a/yogstation/code/modules/mob/living/emote.dm
+++ b/yogstation/code/modules/mob/living/emote.dm
@@ -24,12 +24,6 @@
 	message = "strikes a menacing pose!"
 	restraint_check = TRUE
 
-/datum/emote/living/tpose
-	key = "tpose"
-	key_third_person = "tposes"
-	message = "strikes a T-pose!"
-	restraint_check = TRUE
-
 /datum/emote/living/vpose
 	key = "vpose"
 	key_third_person = "vposes"


### PR DESCRIPTION
### Intent of your Pull Request
See #9733 which has a similar rationale.

T posing is not as meta/ooc as dabbing since it does not cause you brain damage but it is still a 21st century meme in a 26th century game. And it's not even like, a good meme either

If you like T posing don't worry, things do get better in high school

#### Changelog

:cl:  
rscdel: Removed the T pose emote
/:cl:
