### PR TITLE
Adds the Build Your Own Shuttle, Jr. / Adds emergency shuttle consoles to the build shuttles

### DIFF
--- a/_maps/shuttles/emergency_construction.dmm
+++ b/_maps/shuttles/emergency_construction.dmm
@@ -219,6 +219,12 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
+"L" = (
+/obj/machinery/computer/emergency_shuttle{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "O" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/firedoor/border_only,
@@ -460,7 +466,7 @@ f
 f
 f
 f
-f
+L
 O
 "}
 (9,1,1) = {"

--- a/_maps/shuttles/emergency_construction_small.dmm
+++ b/_maps/shuttles/emergency_construction_small.dmm
@@ -1,0 +1,469 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/template_noop,
+/area/template_noop)
+"d" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency/shuttle_build{
+	dwidth = 9;
+	height = 15;
+	name = "Shuttle Under Construction";
+	port_direction = 4;
+	preferred_direction = 2;
+	width = 26
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"e" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"f" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty{
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/obj/item/stack/rods/fifty,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"i" = (
+/obj/structure/table,
+/obj/item/storage/box/lights/mixed{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/electronics/airalarm{
+	pixel_x = 8
+	},
+/obj/item/electronics/airalarm{
+	pixel_x = 8
+	},
+/obj/item/electronics/airalarm{
+	pixel_x = 8
+	},
+/obj/item/electronics/airalarm{
+	pixel_x = 8
+	},
+/obj/item/electronics/airlock{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/electronics/airlock{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/electronics/airlock{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/electronics/airlock{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/electronics/airlock{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/electronics/airlock{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/electronics/airlock{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/electronics/airlock{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"j" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"l" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"n" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/item/airlock_painter,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"s" = (
+/obj/structure/shuttle/engine/propulsion,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"t" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"w" = (
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"B" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical,
+/obj/item/clothing/gloves/color/yellow{
+	pixel_y = 8
+	},
+/obj/item/storage/toolbox/electrical,
+/obj/item/multitool{
+	pixel_x = 2;
+	pixel_y = -4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"E" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"F" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"M" = (
+/turf/closed/wall/mineral/titanium/interior,
+/area/shuttle/escape)
+"P" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/shuttle/engine/heater,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"Q" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/shuttle/escape)
+"U" = (
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/titaniumglass{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"X" = (
+/obj/structure/table,
+/obj/item/stack/sheet/mineral/titanium/fifty{
+	pixel_x = 1;
+	pixel_y = 2
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Z" = (
+/obj/machinery/computer/emergency_shuttle,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+
+(1,1,1) = {"
+a
+a
+a
+a
+t
+t
+t
+E
+t
+d
+t
+t
+F
+t
+t
+l
+t
+l
+t
+t
+Q
+a
+"}
+(2,1,1) = {"
+a
+t
+t
+t
+t
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+Q
+Q
+"}
+(3,1,1) = {"
+t
+M
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+P
+s
+"}
+(4,1,1) = {"
+e
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+P
+s
+"}
+(5,1,1) = {"
+e
+w
+w
+w
+w
+w
+w
+w
+w
+w
+n
+f
+w
+w
+w
+w
+w
+w
+w
+w
+P
+s
+"}
+(6,1,1) = {"
+e
+Z
+w
+w
+w
+w
+w
+w
+w
+w
+B
+X
+w
+w
+w
+w
+w
+w
+w
+w
+P
+s
+"}
+(7,1,1) = {"
+e
+w
+w
+w
+w
+w
+w
+w
+w
+w
+i
+U
+w
+w
+w
+w
+w
+w
+w
+w
+P
+s
+"}
+(8,1,1) = {"
+e
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+P
+s
+"}
+(9,1,1) = {"
+t
+M
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+P
+s
+"}
+(10,1,1) = {"
+a
+t
+t
+t
+t
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+Q
+Q
+"}
+(11,1,1) = {"
+a
+a
+a
+a
+t
+t
+t
+t
+j
+t
+t
+t
+j
+t
+t
+t
+j
+t
+t
+t
+Q
+a
+"}

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -161,10 +161,17 @@
 
 /datum/map_template/shuttle/emergency/construction
 	suffix = "construction"
-	name = "Build your own shuttle kit"
+	name = "Build Your Own Shuttle"
 	description = "For the enterprising shuttle engineer! The chassis will dock upon purchase, but launch will have to be authorized as usual via shuttle call. Comes stocked with construction materials."
-	admin_notes = "No brig, no medical facilities, no shuttle console."
+	admin_notes = "No brig and no medical facilities. Build YOUR own."
 	credit_cost = 5000
+
+/datum/map_template/shuttle/emergency/construction_small
+	suffix = "construction_small"
+	name = "Build Your Own Shuttle, Jr."
+	description = "The full-size BYOS too big for your taste? Aside from the reduced size and cost, this has the all same (lack of) amenities as its full-sized sibling."
+	admin_notes = "No brig and no medical facilities. Build YOUR own."
+	credit_cost = 2000
 
 /datum/map_template/shuttle/emergency/airless/prerequisites_met()
 	// first 10 minutes only


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29339701/93659552-6d675580-fa14-11ea-99e4-a7e5547df66c.png)

A smaller version of the Build Your Own Shuttle for those that don't need as much space. Particularly useful for when nobody really wants to contribute, but you don't want it to look utterly empty.

Also, I have added an emergency shuttle console to both of them, as there is apparently no way to create them on said shuttles short of divine intervention.

#### Changelog

:cl:  
rscadd: Added the "Build Your Own Shuttle, Jr.", a smaller alternative to the full-sized Build Your Own Shuttle for a correspondingly lower price.  
rscadd: Added emergency shuttle console to the Build Your Own Shuttles.
spellcheck: Capitalized the "build your own shuttle kit" and removed "kit" from name.
/:cl:
