### PR TITLE
[Box] Public teleporter access

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -26877,6 +26877,16 @@
 /obj/machinery/vending/cart,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
+"bsd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 5;
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bsf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28695,12 +28705,6 @@
 	},
 /turf/open/floor/plating,
 /area/teleporter)
-"bws" = (
-/obj/structure/rack,
-/obj/item/tank/internals/oxygen,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plating,
-/area/teleporter)
 "bwt" = (
 /obj/machinery/teleport/hub,
 /turf/open/floor/plating,
@@ -29665,16 +29669,6 @@
 /area/security/checkpoint/supply)
 "byU" = (
 /obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"byW" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = -32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "byZ" = (
@@ -44560,6 +44554,12 @@
 "hoc" = (
 /turf/closed/wall,
 /area/security/checkpoint/service)
+"hoA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hoP" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -46719,6 +46719,19 @@
 /obj/item/clothing/gloves/color/fyellow,
 /turf/open/floor/plasteel,
 /area/storage/tools)
+"jdH" = (
+/obj/structure/rack,
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/gas,
+/obj/machinery/button/door{
+	id = "tele";
+	name = "Public Teleporter Access Control";
+	pixel_x = -6;
+	pixel_y = -24;
+	req_access_txt = "17"
+	},
+/turf/open/floor/plating,
+/area/teleporter)
 "jdO" = (
 /turf/closed/wall,
 /area/medical/storage)
@@ -56958,6 +56971,19 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"rrL" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "tele";
+	name = "Public Teleporter Access Control";
+	pixel_x = -6;
+	pixel_y = 24;
+	req_access_txt = "17"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "rsV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -57709,6 +57735,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/nanite)
+"sbf" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor{
+	id = "tele";
+	name = "Public Teleporter Access"
+	},
+/turf/open/floor/plating,
+/area/teleporter)
 "sdg" = (
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor";
@@ -97519,7 +97553,7 @@ blZ
 aNO
 bwq
 bqH
-aJq
+mUt
 aJq
 aXf
 bCv
@@ -97775,10 +97809,10 @@ bsl
 bmb
 buW
 bwt
-bqH
-aLY
-aLY
-bBx
+sbf
+hoA
+aJq
+bsd
 bCv
 apG
 bFk
@@ -98031,11 +98065,11 @@ bqH
 bpX
 bmc
 buV
-bws
+jdH
 bqH
+rrL
 aJq
-aJq
-byW
+aXf
 bCv
 bAV
 bCv
@@ -98290,9 +98324,9 @@ bmf
 asD
 asD
 bqH
-aJq
-aJq
-aXf
+aLY
+aLY
+bBx
 bCv
 bDP
 bCv


### PR DESCRIPTION
### Intent of your Pull Request
Anyone with teleporter access can press the button and open it to general public, should help with making underused ruins like space bar or game room more populated.
![chrome_pTJ2ltE1bI](https://user-images.githubusercontent.com/48154165/93666342-bacbdd00-fa7d-11ea-9f13-4fa6f4d8d72e.png)


#### Changelog

:cl:  
rscadd: teleporter now has a blast door for public use
/:cl:
