### PR TITLE
Moves Plasma Cutters to mining vendors, also makes the gigadrill slower

### DIFF
--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -5602,9 +5602,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aiz" = (
 /obj/structure/cable/white{
@@ -5615,9 +5613,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aiA" = (
 /obj/structure/cable/white{
@@ -5633,9 +5629,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aiB" = (
 /obj/structure/cable/white{
@@ -5648,9 +5642,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aiC" = (
 /obj/structure/cable/white{
@@ -5666,9 +5658,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aiD" = (
 /obj/structure/sign/warning/electricshock{
@@ -5683,9 +5673,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aiE" = (
 /obj/structure/cable/white{
@@ -6062,9 +6050,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aje" = (
 /obj/structure/cable/white{
@@ -6077,9 +6063,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "ajf" = (
 /obj/structure/cable/white{
@@ -6095,9 +6079,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "ajg" = (
 /obj/structure/cable/white{
@@ -6575,9 +6557,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "ajO" = (
 /obj/structure/cable/white{
@@ -6938,9 +6918,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "akq" = (
 /obj/structure/cable/white{
@@ -6979,9 +6957,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "akt" = (
 /obj/structure/cable/white{
@@ -7122,9 +7098,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "akE" = (
 /obj/structure/cable/white{
@@ -7187,9 +7161,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "akJ" = (
 /obj/machinery/airalarm{
@@ -7210,9 +7182,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "akL" = (
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
@@ -7319,9 +7289,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "akT" = (
 /obj/structure/cable/white{
@@ -7460,9 +7428,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "alc" = (
 /obj/machinery/light{
@@ -7472,9 +7438,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "ald" = (
 /obj/structure/sign/nanotrasen,
@@ -7947,9 +7911,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "alS" = (
 /obj/machinery/vending/cola/random,
@@ -8138,9 +8100,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "amh" = (
 /obj/structure/cable/white{
@@ -8150,9 +8110,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "ami" = (
 /obj/machinery/holopad,
@@ -9466,9 +9424,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aog" = (
 /obj/structure/cable/white{
@@ -10654,9 +10610,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/bar/atrium)
 "apV" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -13874,9 +13828,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "auu" = (
 /obj/structure/table/glass,
@@ -20198,9 +20150,7 @@
 	icon_state = "vent_map_on-1"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "aEa" = (
 /obj/structure/table,
@@ -21364,9 +21314,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aFJ" = (
 /obj/structure/cable/white{
@@ -21385,9 +21333,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aFK" = (
 /obj/machinery/camera{
@@ -21821,9 +21767,7 @@
 	dir = 4;
 	icon_state = "scrub_map_on-3"
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aGx" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -22497,9 +22441,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aHD" = (
 /obj/structure/cable/white{
@@ -27269,9 +27211,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aPt" = (
 /obj/machinery/navbeacon{
@@ -27284,9 +27224,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aPu" = (
 /obj/structure/cable/white{
@@ -27299,9 +27237,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aPv" = (
 /obj/machinery/light{
@@ -27323,18 +27259,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aPx" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aPy" = (
 /obj/structure/table,
@@ -27677,9 +27609,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aQh" = (
 /obj/structure/chair/wood/normal{
@@ -27713,9 +27643,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aQk" = (
 /obj/machinery/firealarm{
@@ -27726,9 +27654,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aQl" = (
 /obj/effect/landmark/event_spawn,
@@ -27738,9 +27664,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aQm" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -27963,9 +27887,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aQI" = (
 /obj/structure/cable/white{
@@ -28010,9 +27932,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aQL" = (
 /obj/machinery/firealarm{
@@ -28080,9 +28000,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aQW" = (
 /turf/closed/wall,
@@ -28263,9 +28181,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aRm" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -28278,9 +28194,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aRn" = (
 /obj/effect/turf_decal/tile/blue{
@@ -28303,9 +28217,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aRp" = (
 /obj/structure/bed,
@@ -30372,9 +30284,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "aVq" = (
 /obj/machinery/holopad,
@@ -30400,9 +30310,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "aVt" = (
 /obj/machinery/computer/rdconsole/core{
@@ -30743,9 +30651,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "aWc" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -30760,9 +30666,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "aWd" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -30909,9 +30813,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "aWq" = (
 /obj/structure/cable/white{
@@ -31916,9 +31818,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "aXZ" = (
 /obj/structure/cable/white{
@@ -31929,9 +31829,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "aYa" = (
 /obj/structure/cable/white{
@@ -31972,9 +31870,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aYd" = (
 /obj/structure/cable/white{
@@ -34126,9 +34022,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bby" = (
 /obj/machinery/newscaster{
@@ -34279,9 +34173,7 @@
 	pixel_x = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bbJ" = (
 /obj/structure/closet/crate/bin,
@@ -38616,9 +38508,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "bZq" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
@@ -40876,9 +40766,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "mae" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -42190,9 +42078,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "sqz" = (
 /turf/closed/wall,

--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -5602,7 +5602,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/fore)
 "aiz" = (
 /obj/structure/cable/white{
@@ -5613,7 +5615,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/fore)
 "aiA" = (
 /obj/structure/cable/white{
@@ -5629,7 +5633,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/fore)
 "aiB" = (
 /obj/structure/cable/white{
@@ -5642,7 +5648,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/fore)
 "aiC" = (
 /obj/structure/cable/white{
@@ -5658,7 +5666,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/fore)
 "aiD" = (
 /obj/structure/sign/warning/electricshock{
@@ -5673,7 +5683,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/fore)
 "aiE" = (
 /obj/structure/cable/white{
@@ -6050,7 +6062,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/fore)
 "aje" = (
 /obj/structure/cable/white{
@@ -6063,7 +6077,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/fore)
 "ajf" = (
 /obj/structure/cable/white{
@@ -6079,7 +6095,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/fore)
 "ajg" = (
 /obj/structure/cable/white{
@@ -6557,7 +6575,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/starboard)
 "ajO" = (
 /obj/structure/cable/white{
@@ -6918,7 +6938,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/starboard)
 "akq" = (
 /obj/structure/cable/white{
@@ -6957,7 +6979,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/starboard)
 "akt" = (
 /obj/structure/cable/white{
@@ -7098,7 +7122,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/starboard)
 "akE" = (
 /obj/structure/cable/white{
@@ -7161,7 +7187,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/starboard)
 "akJ" = (
 /obj/machinery/airalarm{
@@ -7182,7 +7210,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/starboard)
 "akL" = (
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
@@ -7289,7 +7319,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/starboard)
 "akT" = (
 /obj/structure/cable/white{
@@ -7428,7 +7460,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/starboard)
 "alc" = (
 /obj/machinery/light{
@@ -7438,7 +7472,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/starboard)
 "ald" = (
 /obj/structure/sign/nanotrasen,
@@ -7911,7 +7947,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/starboard)
 "alS" = (
 /obj/machinery/vending/cola/random,
@@ -8100,7 +8138,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/central)
 "amh" = (
 /obj/structure/cable/white{
@@ -8110,7 +8150,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/fore)
 "ami" = (
 /obj/machinery/holopad,
@@ -9424,7 +9466,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/central)
 "aog" = (
 /obj/structure/cable/white{
@@ -10610,7 +10654,9 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/crew_quarters/bar/atrium)
 "apV" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -13828,7 +13874,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/central)
 "auu" = (
 /obj/structure/table/glass,
@@ -20150,7 +20198,9 @@
 	icon_state = "vent_map_on-1"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/starboard)
 "aEa" = (
 /obj/structure/table,
@@ -21314,7 +21364,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/port)
 "aFJ" = (
 /obj/structure/cable/white{
@@ -21333,7 +21385,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/port)
 "aFK" = (
 /obj/machinery/camera{
@@ -21767,7 +21821,9 @@
 	dir = 4;
 	icon_state = "scrub_map_on-3"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/port)
 "aGx" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -22441,7 +22497,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/port)
 "aHD" = (
 /obj/structure/cable/white{
@@ -27211,7 +27269,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/central)
 "aPt" = (
 /obj/machinery/navbeacon{
@@ -27224,7 +27284,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/central)
 "aPu" = (
 /obj/structure/cable/white{
@@ -27237,7 +27299,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/central)
 "aPv" = (
 /obj/machinery/light{
@@ -27259,14 +27323,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/central)
 "aPx" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/central)
 "aPy" = (
 /obj/structure/table,
@@ -27609,7 +27677,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/central)
 "aQh" = (
 /obj/structure/chair/wood/normal{
@@ -27643,7 +27713,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/central)
 "aQk" = (
 /obj/machinery/firealarm{
@@ -27654,7 +27726,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/central)
 "aQl" = (
 /obj/effect/landmark/event_spawn,
@@ -27664,7 +27738,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/central)
 "aQm" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -27887,7 +27963,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/secondary/entry)
 "aQI" = (
 /obj/structure/cable/white{
@@ -27932,7 +28010,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/secondary/entry)
 "aQL" = (
 /obj/machinery/firealarm{
@@ -28000,7 +28080,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/secondary/entry)
 "aQW" = (
 /turf/closed/wall,
@@ -28181,7 +28263,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/secondary/entry)
 "aRm" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -28194,7 +28278,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/secondary/entry)
 "aRn" = (
 /obj/effect/turf_decal/tile/blue{
@@ -28217,7 +28303,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/secondary/entry)
 "aRp" = (
 /obj/structure/bed,
@@ -30284,7 +30372,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/aft)
 "aVq" = (
 /obj/machinery/holopad,
@@ -30310,7 +30400,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/aft)
 "aVt" = (
 /obj/machinery/computer/rdconsole/core{
@@ -30651,7 +30743,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/aft)
 "aWc" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -30666,7 +30760,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/aft)
 "aWd" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -30813,7 +30909,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/aft)
 "aWq" = (
 /obj/structure/cable/white{
@@ -31818,7 +31916,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/aft)
 "aXZ" = (
 /obj/structure/cable/white{
@@ -31829,7 +31929,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/aft)
 "aYa" = (
 /obj/structure/cable/white{
@@ -31870,7 +31972,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/secondary/entry)
 "aYd" = (
 /obj/structure/cable/white{
@@ -34022,7 +34126,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/port)
 "bby" = (
 /obj/machinery/newscaster{
@@ -34173,7 +34279,9 @@
 	pixel_x = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/starboard)
 "bbJ" = (
 /obj/structure/closet/crate/bin,
@@ -38508,7 +38616,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/crew_quarters/dorms)
 "bZq" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
@@ -40766,7 +40876,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/hallway/primary/fore)
 "mae" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -42078,7 +42190,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
 /area/crew_quarters/dorms)
 "sqz" = (
 /turf/closed/wall,

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -26,6 +26,8 @@
 		new /datum/data/mining_equipment("Super Resonator",				/obj/item/resonator/upgraded,										2500, VENDING_WEAPON),
 		new /datum/data/mining_equipment("Silver Pickaxe",				/obj/item/pickaxe/silver,											1000, VENDING_WEAPON),
 		new /datum/data/mining_equipment("Diamond Pickaxe",				/obj/item/pickaxe/diamond,											2000, VENDING_WEAPON),
+		new /datum/data/mining_equipment("Plasma Cutter",				/obj/item/gun/energy/plasmacutter,									2500, VENDING_WEAPON),
+		new /datum/data/mining_equipment("Advanced Plasma Cutter",		/obj/item/gun/energy/plasmacutter/adv,								7500, VENDING_WEAPON),
 		new /datum/data/mining_equipment("KA Minebot Passthrough",		/obj/item/borg/upgrade/modkit/minebot_passthrough,					100, VENDING_UPGRADE),
 		new /datum/data/mining_equipment("KA White Tracer Rounds",		/obj/item/borg/upgrade/modkit/tracer,								100, VENDING_UPGRADE),
 		new /datum/data/mining_equipment("KA Adjustable Tracer Rounds",	/obj/item/borg/upgrade/modkit/tracer/adjustable,					150, VENDING_UPGRADE),

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -271,6 +271,7 @@
 		new /datum/data/mining_equipment("Silver Pickaxe",				/obj/item/pickaxe/silver,										750, VENDING_WEAPON),
 		new /datum/data/mining_equipment("Diamond Pickaxe",				/obj/item/pickaxe/diamond,										1500, VENDING_WEAPON),
 		new /datum/data/mining_equipment("Plasma Cutter" ,				/obj/item/gun/energy/plasmacutter,								2500, VENDING_WEAPON),
+		new /datum/data/mining_equipment("Advanced Plasma Cutter",		/obj/item/gun/energy/plasmacutter/adv,							7500, VENDING_WEAPON),
 		new /datum/data/mining_equipment("KA Minebot Passthrough",		/obj/item/borg/upgrade/modkit/minebot_passthrough,				100, VENDING_UPGRADE),
 		new /datum/data/mining_equipment("KA White Tracer Rounds",		/obj/item/borg/upgrade/modkit/tracer,							100, VENDING_UPGRADE),
 		new /datum/data/mining_equipment("KA Adjustable Tracer Rounds",	/obj/item/borg/upgrade/modkit/tracer/adjustable,				150, VENDING_UPGRADE),

--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -6,7 +6,7 @@
 	range = 4
 	dismemberment = 20
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
-	var/mine_range = 3 //mines this many additional tiles of rock
+	var/mine_range = 0 //mines this many additional tiles of rock
 	tracer_type = /obj/effect/projectile/tracer/plasma_cutter
 	muzzle_type = /obj/effect/projectile/muzzle/plasma_cutter
 	impact_type = /obj/effect/projectile/impact/plasma_cutter
@@ -23,9 +23,9 @@
 			return BULLET_ACT_FORCE_PIERCE
 
 /obj/item/projectile/plasma/adv
-	damage = 7
-	range = 5
-	mine_range = 5
+	damage = 10
+	range = 4
+	mine_range = 2
 
 /obj/item/projectile/plasma/adv/mech
 	damage = 10

--- a/code/modules/research/designs/mining_designs.dm
+++ b/code/modules/research/designs/mining_designs.dm
@@ -42,26 +42,6 @@
 	category = list("Mining Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO
 
-/datum/design/plasmacutter
-	name = "Plasma Cutter"
-	desc = "You could use it to cut limbs off of xenos! Or, you know, mine stuff."
-	id = "plasmacutter"
-	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 1500, MAT_GLASS = 500, MAT_PLASMA = 1000, MAT_SILVER = 1000, MAT_URANIUM = 800)
-	build_path = /obj/item/gun/energy/plasmacutter
-	category = list("Mining Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_CARGO
-
-/datum/design/plasmacutter_adv
-	name = "Advanced Plasma Cutter"
-	desc = "It's an advanced plasma cutter, oh my god."
-	id = "plasmacutter_adv"
-	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 3000, MAT_GLASS = 1000, MAT_PLASMA = 2000, MAT_GOLD = 2000, MAT_URANIUM = 3000, MAT_DIAMOND = 2000)
-	build_path = /obj/item/gun/energy/plasmacutter/adv
-	category = list("Mining Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_CARGO
-
 /datum/design/jackhammer
 	name = "Sonic Jackhammer"
 	desc = "Essentially a handheld planet-cracker. Can drill through walls with ease as well."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -507,7 +507,7 @@
 	display_name = "Mining Technology"
 	description = "Better than Efficiency V."
 	prereq_ids = list("engineering", "basic_plasma")
-	design_ids = list("drill", "superresonator", "triggermod", "damagemod", "cooldownmod", "rangemod", "ore_redemption", "mining_equipment_vendor", "cargoexpress", "plasmacutter")//e a r l y    g a  m e)
+	design_ids = list("drill", "superresonator", "triggermod", "damagemod", "cooldownmod", "rangemod", "ore_redemption", "mining_equipment_vendor", "cargoexpress")//e a r l y    g a  m e)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
@@ -516,7 +516,7 @@
 	display_name = "Advanced Mining Technology"
 	description = "Efficiency Level 127"	//dumb mc references
 	prereq_ids = list("basic_mining", "adv_engi", "adv_power", "adv_plasma")
-	design_ids = list("drill_diamond", "jackhammer", "hypermod", "plasmacutter_adv", "borg_upgrade_plasmacutter")
+	design_ids = list("drill_diamond", "jackhammer", "hypermod", "borg_upgrade_plasmacutter")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 

--- a/yogstation/code/modules/xenoarch/loot/gigadrill.dm
+++ b/yogstation/code/modules/xenoarch/loot/gigadrill.dm
@@ -29,7 +29,7 @@
 /obj/vehicle/ridden/gigadrill/Initialize()
 	. = ..()
 	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
-	D.vehicle_move_delay = 1
+	D.vehicle_move_delay = 4
 	D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 7), TEXT_SOUTH = list(0, 18), TEXT_EAST = list(-18, 9), TEXT_WEST = list( 18, 9)))
 	D.set_vehicle_dir_layer(SOUTH, ABOVE_MOB_LAYER)
 	D.set_vehicle_dir_layer(NORTH, ABOVE_MOB_LAYER)


### PR DESCRIPTION
### Intent of your Pull Request

Plasma Cutters & Adv Plasma Cutters have been removed from the protolathe/research and moved to the mining vendor

Regular Cutters(2500 points) are now:  5 Damage, 4 Range, 0 Extra Range || OLD: 5 Damage, 4 Range, 3 Extra Range

Adv Cutters are now(7500 points): 10 Damage, 4 Range, 2 Extra Range || OLD: 7 Damage, 5 Range, 5 Extra Range

Gigadrill is now 4x slower (it's not really slow and is still pretty fast)

#### Changelog

:cl:  
tweak: Plasma cutters are now only buyable from vendors
tweak: Plasma cutters have been nerfed a little
tweak: The gigadrill is slower
/:cl:
