### PR TITLE
holy water now actually blocks clockwork jaunts

### DIFF
--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -349,6 +349,9 @@
 		to_chat(user, "<span class='sevtug_small'>[prob(1) ? "Servant cannot into space." : "You can't teleport into space."]</span>")
 		return
 	else if(T.flags_1 & NOJAUNT_1)
+		to_chat(user, "<span class='sevtug_small'>This tile is blessed by strange energies and deflects the warp.</span>")
+		return
+	else if(locate(/obj/effect/blessing, T))
 		to_chat(user, "<span class='sevtug_small'>This tile is blessed by holy water and deflects the warp.</span>")
 		return
 	var/area/AR = get_area(T)


### PR DESCRIPTION
yes this is apparently a bug
:cl:  
bugfix: holy water will now block tiles from being teleported onto by clock cultists via observation consoles
/:cl:
