### PR TITLE
make heretic monsters greentext by default

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_monster_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_monster_antag.dm
@@ -33,6 +33,7 @@
 	master_obj.owner = src
 	master_obj.explanation_text = "Assist your master in any way you can!"
 	objectives += master_obj
+	master_obj.completed = TRUE
 	owner.announce_objectives()
 	to_chat(owner, "<span class='boldannounce'>Your master is [master.owner.current.real_name]</span>")
 	return


### PR DESCRIPTION
less confusing than "the heretic monster has failed!" for no reason

:cl:  
bugfix: heretic monsters no longer always fail
/:cl:
