### PR TITLE
Fixed gun firing animation being triggered if the weapon did not actually fire

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -69,6 +69,7 @@
 	var/zoom_amt = 3 //Distance in TURFs to move the user's screen forward (the "zoom" effect)
 	var/zoom_out_amt = 0
 	var/datum/action/toggle_scope_zoom/azoom
+	var/recent_shoot = null //time of the last shot with the gun. Used to track if firing happened for feedback out of all things
 
 /obj/item/gun/Initialize()
 	. = ..()
@@ -303,7 +304,7 @@
 /obj/item/gun/proc/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
 	if(user)
 		SEND_SIGNAL(user, COMSIG_MOB_FIRED_GUN, user, target, params, zone_override)
-
+	
 	add_fingerprint(user)
 
 	if(semicd)
@@ -349,6 +350,7 @@
 	if(user)
 		user.update_inv_hands()
 	SSblackbox.record_feedback("tally", "gun_fired", 1, type)
+	recent_shoot = world.time
 	return TRUE
 
 /obj/item/gun/update_icon()

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -423,9 +423,8 @@
 
 /obj/item/gun/ballistic/afterattack()
 	prefire_empty_checks()
-	var/fired = chambered ? TRUE : FALSE
 	. = ..() //The gun actually firing
-	if(fired)
+	if(can_shoot() && recent_shoot + 5 > world.time)
 		feedback("fire")
 	postfire_empty_checks()
 


### PR DESCRIPTION
@SomeguyManperson 
![image](https://user-images.githubusercontent.com/24533979/94345559-5ca67900-ffec-11ea-99c5-00d5e1897b7b.png)
![image](https://user-images.githubusercontent.com/24533979/94345568-692ad180-ffec-11ea-98f2-620a9d82952b.png)

Also replaced fired with canshoot() for cleaner code.

#### Changelog

:cl:  Hopek
bugfix: Gun firing animation is no longer triggered if the weapon did not actually fire. This was triggered by hitting things with it or using it on other items.
/:cl:
