### PR TITLE
fix runtime when regenerating non-human-subtype carbons

### DIFF
--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -359,7 +359,7 @@
 		limb_list -= excluded_limbs
 	for(var/Z in limb_list)
 		. += regenerate_limb(Z, noheal)
-	if(("legs" in dna.species.mutant_bodyparts) && dna.features["legs"] == "Digitigrade Legs")
+	if(("legs" in dna?.species?.mutant_bodyparts) && dna.features["legs"] == "Digitigrade Legs")
 		Digitigrade_Leg_Swap(FALSE)
 
 /mob/living/proc/regenerate_limb(limb_zone, noheal)


### PR DESCRIPTION
or just xenos or whatever same thing
:cl:  
bugfix: inconsequential runtime deleted
/:cl:
