### PR TITLE
fix hyper healing guardian on hitting objects

### DIFF
--- a/yogstation/code/modules/guardian/abilities/major/healing.dm
+++ b/yogstation/code/modules/guardian/abilities/major/healing.dm
@@ -47,6 +47,7 @@
 			var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal(get_turf(O))
 			if(guardian.namedatum)
 				H.color = guardian.namedatum.colour
+			M.changeNext_move(CLICK_CD_MELEE)
 			return TRUE
 
 /datum/guardian_ability/major/healing/limited

--- a/yogstation/code/modules/guardian/abilities/major/healing.dm
+++ b/yogstation/code/modules/guardian/abilities/major/healing.dm
@@ -47,7 +47,7 @@
 			var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal(get_turf(O))
 			if(guardian.namedatum)
 				H.color = guardian.namedatum.colour
-			M.changeNext_move(CLICK_CD_MELEE)
+			guardian.changeNext_move(CLICK_CD_MELEE)
 			return TRUE
 
 /datum/guardian_ability/major/healing/limited


### PR DESCRIPTION
fixes #9735

:cl:  
bugfix: healing guardians now heal objects at a normal speed
/:cl:
