### PR TITLE
Removes the Goat Research Ship ruin

### DIFF
--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -318,6 +318,7 @@
 /datum/map_template/ruin/space/goat_transport
 	id = "goatresearch"
 	suffix = "goatresearch.dmm"
+	unpickable = TRUE
 	name= "Exotic Goat Transport Vessel"
 	description = "A ship transporting goats attacked by goats. How ironic..."
 


### PR DESCRIPTION
it is a total detriment to the quality of the game. Ugly as fuck, way too large, and a powergamer's dream. Cap headset, 2 rifles, laser rifle, and a cargo tech ID card to name a few. Oh yeah and there is barely any threat, I do not like this ruin one bit. 
🆑 
rscdel: the goat research ship is no longer pickable 
/🆑