### PR TITLE
Fixes improper name for gloves after washing

### DIFF
--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -161,7 +161,7 @@
 				item_state = initial(G.item_state)
 				icon_state = initial(G.icon_state)
 				item_color = wash_color
-				name = initial(G.name)
+				name = "washed gloves"
 				desc = "The colors are a bit dodgy."
 				break
 


### PR DESCRIPTION
Fixes #9667 

#### Changelog

:cl:   
bugfix: Fixes improper name for gloves after washing
/:cl:
