### PR TITLE
Allows armbands, medals, and the bone talisman/codpiece to display over suits

### DIFF
--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -116,6 +116,7 @@
 	resistance_flags = FIRE_PROOF
 	var/medaltype = "medal" //Sprite used for medalbox
 	var/commended = FALSE
+	above_suit = TRUE
 
 //Pinning medals on people
 /obj/item/clothing/accessory/medal/attack(mob/living/carbon/human/M, mob/living/user)
@@ -244,6 +245,7 @@
 	icon_state = "redband"
 	item_color = "redband"
 	attachment_slot = null
+	above_suit = TRUE
 
 /obj/item/clothing/accessory/armband/deputy
 	name = "security deputy armband"
@@ -348,6 +350,7 @@
 	item_color = "talisman"
 	armor = list("melee" = 5, "bullet" = 5, "laser" = 5, "energy" = 5, "bomb" = 20, "bio" = 20, "rad" = 5, "fire" = 0, "acid" = 25)
 	attachment_slot = null
+	above_suit = TRUE
 
 /obj/item/clothing/accessory/skullcodpiece
 	name = "skull codpiece"
@@ -357,3 +360,4 @@
 	above_suit = TRUE
 	armor = list("melee" = 5, "bullet" = 5, "laser" = 5, "energy" = 5, "bomb" = 20, "bio" = 20, "rad" = 5, "fire" = 0, "acid" = 25)
 	attachment_slot = GROIN
+	above_suit = TRUE

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -360,4 +360,3 @@
 	above_suit = TRUE
 	armor = list("melee" = 5, "bullet" = 5, "laser" = 5, "energy" = 5, "bomb" = 20, "bio" = 20, "rad" = 5, "fire" = 0, "acid" = 25)
 	attachment_slot = GROIN
-	above_suit = TRUE


### PR DESCRIPTION
I was planning to make this part of my PR idea to (semi-)unlimit the number of accessories that a uniform can have, but since I'd probably be shouted at to atomize it anyway, I've decided to do it in this PR.

This is good for when you have a departmental armband, but also have to commonly (or just want to) wear a suit that obstructs it. I've tested it some and it only doesn't really look good on space suits, to which I'd be tempted to code some bit in that checks to see if the suit is one, but the difference is small enough that I can wait until a time that isn't midnight to do it.

#### Changelog

:cl:  
tweak: Allowed armbands, medals, and the bone talisman and codpiece to display over suits.
/:cl:
