### PR TITLE
Snappop shuttle now has a brig, now does not have a REAL giant pit or a "Greentext"

### DIFF
--- a/_maps/shuttles/emergency_clown.dmm
+++ b/_maps/shuttles/emergency_clown.dmm
@@ -113,11 +113,17 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "au" = (
-/turf/open/chasm,
+/obj/structure/chair/bananium,
+/turf/open/floor/mineral/plastitanium/red/brig/fakepit,
 /area/shuttle/escape)
 "av" = (
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/flasher{
+	id = "cockpit_flasher";
+	pixel_x = 6;
+	pixel_y = 24
 	},
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
@@ -139,14 +145,12 @@
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "az" = (
-/obj/item/greentext/quiet{
-	anchored = 1
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
+/turf/open/floor/mineral/plastitanium/red/brig/fakepit,
 /area/shuttle/escape)
 "aA" = (
 /obj/machinery/door/airlock/bananium/glass{
-	name = "Emergency Shuttle Greentext"
+	name = "Emergency Shuttle Brig";
+	req_access_txt = "2"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -407,12 +411,28 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
+"hx" = (
+/obj/item/toy/snappop/phoenix,
+/obj/machinery/light,
+/obj/machinery/button/flasher{
+	id = "cockpit_flasher";
+	pixel_x = 6;
+	pixel_y = -24
+	},
+/turf/open/floor/bluespace,
+/area/shuttle/escape)
 "ib" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /turf/open/floor/plating,
+/area/shuttle/escape)
+"jn" = (
+/obj/structure/chair/bananium{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red/brig/fakepit,
 /area/shuttle/escape)
 "kl" = (
 /obj/item/toy/snappop/phoenix,
@@ -448,6 +468,23 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
+"tr" = (
+/obj/machinery/flasher{
+	id = "shuttle_flasher";
+	pixel_x = -24;
+	pixel_y = 6
+	},
+/obj/machinery/button/flasher{
+	id = "shuttle_flasher";
+	pixel_x = -24;
+	pixel_y = -6
+	},
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red/brig/fakepit,
+/area/shuttle/escape)
 "Bq" = (
 /obj/item/toy/snappop/phoenix,
 /obj/machinery/door/firedoor/border_only{
@@ -470,6 +507,19 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
+/area/shuttle/escape)
+"IP" = (
+/obj/machinery/door/airlock/bananium/glass{
+	name = "Emergency Shuttle Brig";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/bluespace,
 /area/shuttle/escape)
 "Jj" = (
 /obj/structure/window/reinforced{
@@ -518,7 +568,7 @@ aa
 ab
 ab
 ab
-ab
+IP
 ab
 aI
 ab
@@ -541,8 +591,8 @@ ab
 ab
 ab
 au
-au
-au
+tr
+az
 ab
 aJ
 dp
@@ -566,7 +616,7 @@ an
 ab
 au
 az
-au
+jn
 ab
 aw
 Bq
@@ -589,8 +639,8 @@ aj
 ao
 ab
 au
-au
-au
+az
+jn
 ab
 ak
 XS
@@ -634,7 +684,7 @@ bg
 tc
 ag
 ak
-aq
+hx
 ab
 av
 ak

--- a/_maps/shuttles/emergency_clown.dmm
+++ b/_maps/shuttles/emergency_clown.dmm
@@ -428,7 +428,7 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "jn" = (
-/turf/open/floor/mineral/plastitanium/red/brig,
+/turf/open/floor/mineral/plastitanium/red/brig/fakepit,
 /area/shuttle/escape)
 "kl" = (
 /obj/item/toy/snappop/phoenix,
@@ -479,7 +479,7 @@
 	brightness = 3;
 	dir = 8
 	},
-/turf/open/floor/mineral/plastitanium/red/brig,
+/turf/open/floor/mineral/plastitanium/red/brig/fakepit,
 /area/shuttle/escape)
 "Bq" = (
 /obj/item/toy/snappop/phoenix,

--- a/_maps/shuttles/emergency_clown.dmm
+++ b/_maps/shuttles/emergency_clown.dmm
@@ -682,7 +682,7 @@ tc
 ag
 ak
 hx
-jn
+ab
 av
 ak
 aC

--- a/_maps/shuttles/emergency_clown.dmm
+++ b/_maps/shuttles/emergency_clown.dmm
@@ -142,7 +142,8 @@
 /area/shuttle/escape)
 "az" = (
 /obj/structure/chair/americandiner/black{
-	name = "The time-out chair"
+	desc = "If you're sitting here, you should be contemplating your life choices.";
+	name = "the time-out chair"
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
@@ -681,7 +682,7 @@ tc
 ag
 ak
 hx
-ab
+jn
 av
 ak
 aC

--- a/_maps/shuttles/emergency_clown.dmm
+++ b/_maps/shuttles/emergency_clown.dmm
@@ -141,7 +141,10 @@
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "az" = (
-/turf/open/floor/mineral/plastitanium/red/brig/ballpit,
+/obj/structure/chair/americandiner/black{
+	name = "The time-out chair"
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "aA" = (
 /obj/machinery/door/airlock/bananium/glass{
@@ -425,9 +428,7 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "jn" = (
-/obj/structure/bed,
-/obj/item/bedsheet/prisoner,
-/turf/open/floor/mineral/plastitanium/red/brig/ballpit,
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "kl" = (
 /obj/item/toy/snappop/phoenix,
@@ -478,7 +479,7 @@
 	brightness = 3;
 	dir = 8
 	},
-/turf/open/floor/mineral/plastitanium/red/brig/ballpit,
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "Bq" = (
 /obj/item/toy/snappop/phoenix,
@@ -514,7 +515,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/turf/open/floor/bluespace,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "Jj" = (
 /obj/structure/window/reinforced{
@@ -587,7 +588,7 @@ ab
 ab
 jn
 tr
-az
+jn
 ab
 aJ
 dp
@@ -634,7 +635,7 @@ aj
 ao
 ab
 jn
-az
+jn
 jn
 ab
 ak

--- a/_maps/shuttles/emergency_clown.dmm
+++ b/_maps/shuttles/emergency_clown.dmm
@@ -112,10 +112,6 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"au" = (
-/obj/structure/chair/bananium,
-/turf/open/floor/mineral/plastitanium/red/brig/fakepit,
-/area/shuttle/escape)
 "av" = (
 /obj/machinery/light{
 	dir = 1
@@ -145,7 +141,7 @@
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "az" = (
-/turf/open/floor/mineral/plastitanium/red/brig/fakepit,
+/turf/open/floor/mineral/plastitanium/red/brig/ballpit,
 /area/shuttle/escape)
 "aA" = (
 /obj/machinery/door/airlock/bananium/glass{
@@ -429,10 +425,9 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "jn" = (
-/obj/structure/chair/bananium{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium/red/brig/fakepit,
+/obj/structure/bed,
+/obj/item/bedsheet/prisoner,
+/turf/open/floor/mineral/plastitanium/red/brig/ballpit,
 /area/shuttle/escape)
 "kl" = (
 /obj/item/toy/snappop/phoenix,
@@ -483,7 +478,7 @@
 	brightness = 3;
 	dir = 8
 	},
-/turf/open/floor/mineral/plastitanium/red/brig/fakepit,
+/turf/open/floor/mineral/plastitanium/red/brig/ballpit,
 /area/shuttle/escape)
 "Bq" = (
 /obj/item/toy/snappop/phoenix,
@@ -590,7 +585,7 @@ ab
 ab
 ab
 ab
-au
+jn
 tr
 az
 ab
@@ -614,7 +609,7 @@ ad
 ai
 an
 ab
-au
+jn
 az
 jn
 ab
@@ -638,7 +633,7 @@ ae
 aj
 ao
 ab
-au
+jn
 az
 jn
 ab

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -69,7 +69,7 @@ GLOBAL_LIST_EMPTY(objectives)
 	if(SSshuttle.emergency.mode != SHUTTLE_ENDGAME)
 		return FALSE
 	var/turf/location = get_turf(M.current)
-	if(!location || istype(location, /turf/open/floor/plasteel/shuttle/red) || istype(location, /turf/open/floor/mineral/plastitanium/red/brig)) // Fails if they are in the shuttle brig
+	if(!location || istype(location, /turf/open/floor/plasteel/shuttle/red) || istype(location, /turf/open/floor/mineral/plastitanium/red/brig) || istype(location, /turf/open/floor/mineral/plastitanium/red/brig/fakepit)) // Fails if they are in the shuttle brig
 		return FALSE
 	return location.onCentCom() || location.onSyndieBase()
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -69,7 +69,7 @@ GLOBAL_LIST_EMPTY(objectives)
 	if(SSshuttle.emergency.mode != SHUTTLE_ENDGAME)
 		return FALSE
 	var/turf/location = get_turf(M.current)
-	if(!location || istype(location, /turf/open/floor/plasteel/shuttle/red) || istype(location, /turf/open/floor/mineral/plastitanium/red/brig) || istype(location, /turf/open/floor/mineral/plastitanium/red/brig/fakepit)) // Fails if they are in the shuttle brig
+	if(!location || istype(location, /turf/open/floor/plasteel/shuttle/red) || istype(location, /turf/open/floor/mineral/plastitanium/red/brig)) // Fails if they are in the shuttle brig
 		return FALSE
 	return location.onCentCom() || location.onSyndieBase()
 
@@ -1082,7 +1082,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	var/datum/data/record/record
 
 /**
-  * Search through all the security records, and find ours. 
+  * Search through all the security records, and find ours.
   */
 /datum/objective/minor/secrecords/finalize()
 	for(var/datum/data/record/s in GLOB.data_core.security)
@@ -1174,7 +1174,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	if(!A)
 		return FALSE
 	target = A.target
-	explanation_text = "Escape with a photo of the dead body of [target.name]."	
+	explanation_text = "Escape with a photo of the dead body of [target.name]."
 	return TRUE
 
 /**
@@ -1190,7 +1190,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 
 /**
   * # Mindshielding
-  * 
+  *
   * get mindshielded
   */
 /datum/objective/minor/mindshield
@@ -1219,11 +1219,11 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	var/list/datum/mind/heads = SSjob.get_living_heads()
 	if(!heads.len || (owner in heads))
 		return FALSE
-	
+
 	target = pick(heads)
 	name = "Photograph [target.name]."
 	explanation_text = "Extract with a photograph [target.name], the [target.assigned_role]."
-	return TRUE 
+	return TRUE
 
 /**
   * return true if we escape with a picture of the head of staff

--- a/code/game/turfs/simulated/floor/mineral_floor.dm
+++ b/code/game/turfs/simulated/floor/mineral_floor.dm
@@ -129,6 +129,15 @@
 /turf/open/floor/mineral/plastitanium/red/brig
 	name = "brig floor"
 
+/turf/open/floor/mineral/plastitanium/red/brig/fakepit
+	name = "chasm"
+	desc = "Watch your step."
+	smooth = SMOOTH_TRUE | SMOOTH_BORDER | SMOOTH_MORE
+	canSmoothWith = list(/turf/open/floor/mineral/plastitanium/red/brig/fakepit)
+	icon = 'icons/turf/floors/Chasms.dmi'
+	icon_state = "smooth"
+	tiled_dirt = FALSE
+
 //BANANIUM
 
 /turf/open/floor/mineral/bananium

--- a/code/game/turfs/simulated/floor/mineral_floor.dm
+++ b/code/game/turfs/simulated/floor/mineral_floor.dm
@@ -129,12 +129,12 @@
 /turf/open/floor/mineral/plastitanium/red/brig
 	name = "brig floor"
 
-/turf/open/floor/mineral/plastitanium/red/brig/ballpit
-	name = "deep ball pit"
-	desc = "A fun-looking ball pit for very naughy criminals."
+/turf/open/floor/mineral/plastitanium/red/brig/fakepit
+	name = "brig chasm"
+	desc = "A place for very naughy criminals."
 	smooth = SMOOTH_TRUE | SMOOTH_BORDER | SMOOTH_MORE
-	canSmoothWith = list(/turf/open/floor/mineral/plastitanium/red/brig/ballpit)
-	icon = 'yogstation/icons/turf/floors/ballpit_smooth.dmi'
+	canSmoothWith = list(/turf/open/floor/mineral/plastitanium/red/brig/fakepit)
+	icon = 'icons/turf/floors/Chasms.dmi'
 	icon_state = "smooth"
 	tiled_dirt = FALSE
 

--- a/code/game/turfs/simulated/floor/mineral_floor.dm
+++ b/code/game/turfs/simulated/floor/mineral_floor.dm
@@ -129,12 +129,12 @@
 /turf/open/floor/mineral/plastitanium/red/brig
 	name = "brig floor"
 
-/turf/open/floor/mineral/plastitanium/red/brig/fakepit
-	name = "chasm"
-	desc = "Watch your step."
+/turf/open/floor/mineral/plastitanium/red/brig/ballpit
+	name = "deep ball pit"
+	desc = "A fun-looking ball pit for very naughy criminals."
 	smooth = SMOOTH_TRUE | SMOOTH_BORDER | SMOOTH_MORE
-	canSmoothWith = list(/turf/open/floor/mineral/plastitanium/red/brig/fakepit)
-	icon = 'icons/turf/floors/Chasms.dmi'
+	canSmoothWith = list(/turf/open/floor/mineral/plastitanium/red/brig/ballpit)
+	icon = 'yogstation/icons/turf/floors/ballpit_smooth.dmi'
 	icon_state = "smooth"
 	tiled_dirt = FALSE
 


### PR DESCRIPTION

### Intent of your Pull Request
This shuttle is pretty cool EXCEPT for the big fucking pit and the haha xd greentext. So I fixed it.

Plus it's a personal pet peeve of mine to have shuttles that do not line up with ALL the airlocks. 

Also added: Flashers for both brig and cockpit

Compiled, not tested but I think the accesses on the airlocks are good? I hope? screm

And yes this is part of my mrp stuff. 
#### Changelog

:cl:  
rscadd: Added a proper brig to snappop, added a door, added flashers and a fake chasm brig tile  
rscdel: Removed the real chasm and the greentext book from the snappop shuttle
/:cl:
