### PR TITLE
Makes the chaplain's energy swords deal burn damage

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -417,6 +417,7 @@
 	item_state = "swordblue"
 	desc = "If you strike me down, I shall become more robust than you can possibly imagine."
 	slot_flags = ITEM_SLOT_BELT
+	damtype = BURN
 
 /obj/item/nullrod/claymore/saber/red
 	name = "dark energy sword"


### PR DESCRIPTION
They look and sound like normal energy swords, so why not make them deal burn damage, too?

Besides, the God Hand does an equal amount of burn damage, and I'd say trading disarm immunity for 30 block chance and the ability to use the hand slot for other things is fair.

#### Changelog

:cl:  
tweak: Made the chaplain's energy swords deal burn damage.
/:cl:
