### PR TITLE
WT rifle gets 2 round burst

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -90,7 +90,6 @@
 	fire_delay = 2
 	can_suppress = FALSE
 	burst_size = 2
-	actions_types = list(/datum/action/item_action/toggle_firemode)
 	can_bayonet = TRUE
 	knife_x_offset = 25
 	knife_y_offset = 12

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -89,8 +89,8 @@
 	mag_type = /obj/item/ammo_box/magazine/wt550m9
 	fire_delay = 2
 	can_suppress = FALSE
-	burst_size = 0
-	actions_types = list()
+	burst_size = 2
+	actions_types = list(/datum/action/item_action/toggle_firemode)
 	can_bayonet = TRUE
 	knife_x_offset = 25
 	knife_y_offset = 12


### PR DESCRIPTION
bullets deal 15-20 damage per shot depending on AP (40 AP for AP rounds) meaning it'd deal 30-40 damage per burst putting it on par with other ballistic weapons and making it slightly more viable compared to shotguns
:cl:  
rscadd: WT autorifle can now fire in 2 round bursts
/:cl:
