### PR TITLE
ORM can drop alloys again

### DIFF
--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -7,7 +7,7 @@
 	var/output_dir = SOUTH
 
 /obj/machinery/mineral/proc/unload_mineral(atom/movable/S)
-	if(!istype(S, /obj/item/stack/ore))
+	if(!istype(S, /obj/item/stack/ore) && !istype(S, /obj/item/stack/sheet)) // Realisticlly who is gonna shove a sheet into the loading machine --Redmoogle
 		return
 	S.forceMove(drop_location())
 	var/turf/T = get_step(src,output_dir)

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -7,7 +7,7 @@
 	var/output_dir = SOUTH
 
 /obj/machinery/mineral/proc/unload_mineral(atom/movable/S)
-	if(!istype(S, /obj/item/stack/ore) && !istype(S, /obj/item/stack/sheet)) // Realisticlly who is gonna shove a sheet into the loading machine --Redmoogle
+	if(!istype(S, /obj/item/stack/ore) && !istype(S, /obj/item/stack/sheet)) // Realistically who is gonna shove a sheet into the loading machine --Redmoogle
 		return
 	S.forceMove(drop_location())
 	var/turf/T = get_step(src,output_dir)


### PR DESCRIPTION
### Intent of your Pull Request

ORM can drop alloys again because alloys use a different proc to drop mats

Fixes: #9855 

#### Changelog

:cl:  
bugfix: ORM drops alloys again
/:cl:
