### PR TITLE
Fix: Candle boxes don't lose their icon on self attack

### DIFF
--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -113,6 +113,10 @@
 	spawn_type = /obj/item/candle
 	fancy_open = TRUE
 
+/obj/item/storage/box/fancy/candle_box/attack_self(mob_user)
+	. = ..()
+	update_icon()
+
 /obj/item/storage/box/fancy/candle_box/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)


### PR DESCRIPTION
:cl:  Hopek
bugfix: Candle boxes now don't lose their icon on self-attack
/:cl:

Fixes : #9846 