### PR TITLE
Makes the wooden mug description more succinct

### DIFF
--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -423,7 +423,7 @@
 
 /obj/item/reagent_containers/glass/woodmug
 	name = "wooden mug"
-	desc = "Style is everything, whether it be an ashtray or a keychain or a kitchen timer, we’re living in an age of design, where the physical contours of an object are paramount. Look at this wooden mug, for instance, and see how much it deviates, in its conception, from the ordinary mug. Not much. It is round, tallish, has a handle just like any coffee mug. But it’s not an ordinary coffee mug. First of all its form is totally different; it’s made of wood, not ceramic or plastic. It’s an object that cannot be used casually and put it away, you would love to possess it."
+	desc = "A stout mug made of wood."
 	icon_state = "woodenmug"
 	icon = 'icons/obj/drinks.dmi'
 	volume = 30


### PR DESCRIPTION
Why the FUCK was it so long?

#### Changelog

:cl:  
tweak: Made the wooden mug description shorter.
/:cl:
