### PR TITLE
adds clockcult anchors

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -325,7 +325,7 @@ Credit where due:
 	<li><b>Ark Chamber:</b> Houses the Ark in the very center.</li>\
 	<li><b>Listening Station:</b> (Bottom Left Corner of Circle) Contains intercoms, a telecomms relay, and a list of frequencies.</li>\
 	<li><b>Observation Room:</b> (Bottom Right Corner of Circle) Contains six camera observers. These can be used to watch the station through its cameras, as well as to teleport down \
-	to most areas. To do this, use the Warp action while hovering over the tile you want to warp to.</li>\
+	to maintenance. To do this, use the Warp action while using the console, and you will be transported to the station.</li>\
 	<li><b>Infirmary:</b> (Uper Right Corner of Circle) Contains sleepers and basic medical supplies for superficial wounds. The sleepers can consume Vitality to heal any occupants. \
 	This room is generally more useful during the preparation phase; when defending the Ark, scripture is more useful.</li>\
 	<li><b>Summoning Room:</b> (Uper Left Corner of Circle) Holds two scarabs as well as extra clockwork slabs. Also houses the eminence spire to pick an eminence as well has the herald's beacon which alows the clock cult to declare war.</li>\

--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -1,4 +1,5 @@
 GLOBAL_VAR_INIT(servants_active, FALSE) //This var controls whether or not a lot of the cult's structures work or not
+GLOBAL_LIST_EMPTY(clockcult_free_absconds)
 
 /*
 
@@ -325,7 +326,7 @@ Credit where due:
 	<li><b>Ark Chamber:</b> Houses the Ark in the very center.</li>\
 	<li><b>Listening Station:</b> (Bottom Left Corner of Circle) Contains intercoms, a telecomms relay, and a list of frequencies.</li>\
 	<li><b>Observation Room:</b> (Bottom Right Corner of Circle) Contains six camera observers. These can be used to watch the station through its cameras, as well as to teleport down \
-	to maintenance. To do this, use the Warp action while using the console, and you will be transported to the station.</li>\
+	to the station. To do this, use the Warp action while using the console, and you will be transported to the station.</li>\
 	<li><b>Infirmary:</b> (Uper Right Corner of Circle) Contains sleepers and basic medical supplies for superficial wounds. The sleepers can consume Vitality to heal any occupants. \
 	This room is generally more useful during the preparation phase; when defending the Ark, scripture is more useful.</li>\
 	<li><b>Summoning Room:</b> (Uper Left Corner of Circle) Holds two scarabs as well as extra clockwork slabs. Also houses the eminence spire to pick an eminence as well has the herald's beacon which alows the clock cult to declare war.</li>\

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -362,6 +362,8 @@
 				continue
 			else if(locate(/obj/effect/blessing, T2))
 				continue
+			else if(locate(/obj/structure/destructible/clockwork/anchor, T2))
+				continue
 			var/area/AR = get_area(T2)
 			if(!AR.clockwork_warp_allowed || !istype(AR, /area/maintenance))
 				continue
@@ -387,6 +389,8 @@
 					else if(T2.flags_1 & NOJAUNT_1)
 						continue
 					else if(locate(/obj/effect/blessing, T2))
+						continue
+					else if(locate(/obj/structure/destructible/clockwork/anchor, T2))
 						continue
 					if(!AR.clockwork_warp_allowed)
 						continue

--- a/code/modules/antagonists/clockcult/clock_scriptures/scripture_drivers.dm
+++ b/code/modules/antagonists/clockcult/clock_scriptures/scripture_drivers.dm
@@ -171,7 +171,7 @@
 /datum/clockwork_scripture/abscond
 	descname = "Return to Reebe"
 	name = "Abscond"
-	desc = "Yanks you through space, returning you to home base."
+	desc = "Yanks you through space, returning you to home base. Requires you to be next to your anchor."
 	invocations = list("As we bid farewell, and return to the stars...", "...we shall find our way home.")
 	whispered = TRUE
 	channel_time = 50
@@ -185,12 +185,21 @@
 	important = TRUE
 	quickbind = TRUE
 	quickbind_desc = "Returns you to Reebe."
+	var/obj/structure/destructible/clockwork/anchor/anchor
 	var/client_color
 
 /datum/clockwork_scripture/abscond/check_special_requirements()
 	if(is_reebe(invoker.z))
 		to_chat(invoker, "<span class='danger'>You're already at Reebe.</span>")
-		return
+		return FALSE
+	var/obj/structure/destructible/clockwork/anchor/anchor
+	for(var/obj/structure/destructible/clockwork/anchor/a in orange(1, invoker))
+		if(a.owner == invoker.mind)
+			anchor = a
+			break
+	if(!anchor)
+		to_chat(invoker, "<span class='danger'>You need to be next to your anchor.</span>") // remind me to give them a pointer to it at this point.
+		return FALSE
 	return TRUE
 
 /datum/clockwork_scripture/abscond/recital()
@@ -212,6 +221,9 @@
 		adjust_clockwork_power(-special_power_cost)
 		invoker.pulling.forceMove(T)
 	invoker.forceMove(T)
+	for(var/obj/structure/destructible/clockwork/anchor/a in GLOB.all_clockwork_objects)
+		if(a.owner == invoker.mind)
+			a.disable()
 	if(invoker.client)
 		animate(invoker.client, color = client_color, time = 25)
 

--- a/code/modules/antagonists/clockcult/clock_scriptures/scripture_drivers.dm
+++ b/code/modules/antagonists/clockcult/clock_scriptures/scripture_drivers.dm
@@ -171,7 +171,7 @@
 /datum/clockwork_scripture/abscond
 	descname = "Return to Reebe"
 	name = "Abscond"
-	desc = "Yanks you through space, returning you to home base. Requires you to be next to your anchor."
+	desc = "Yanks you through space, returning you to home base. Requires you to be next to your anchor if there are 8 servants or more."
 	invocations = list("As we bid farewell, and return to the stars...", "...we shall find our way home.")
 	whispered = TRUE
 	channel_time = 50
@@ -197,7 +197,7 @@
 		if(a.owner == invoker.mind)
 			anchor = a
 			break
-	if(!anchor)
+	if(!anchor && !GLOB.clockcult_free_absconds[invoker.mind])
 		to_chat(invoker, "<span class='danger'>You need to be next to your anchor.</span>") // remind me to give them a pointer to it at this point.
 		return FALSE
 	return TRUE
@@ -219,7 +219,11 @@
 	do_sparks(5, TRUE, T)
 	if(take_pulling)
 		adjust_clockwork_power(-special_power_cost)
+		if(istype(invoker.pulling, /mob/living))
+			var/mob/living/l = invoker.pulling
+			GLOB.clockcult_free_absconds -= l.mind
 		invoker.pulling.forceMove(T)
+	GLOB.clockcult_free_absconds -= invoker.mind
 	invoker.forceMove(T)
 	for(var/obj/structure/destructible/clockwork/anchor/a in GLOB.all_clockwork_objects)
 		if(a.owner == invoker.mind)

--- a/code/modules/antagonists/clockcult/clock_structures/teleport_anchors.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/teleport_anchors.dm
@@ -1,0 +1,33 @@
+/obj/structure/destructible/clockwork/anchor
+	name = "Anchor"
+	desc = "" //A aaaaaaaaaaaaaa
+	clockwork_desc = "Abscond next to this or hit it with your slab to warp back to Reebe."
+	icon_state = "mania_motor"
+	break_message = "<span class='warning'>The antenna break off, leaving a pile of shards!</span>"
+	max_integrity = 100
+	light_color = "#AF0AAF"
+
+	var/datum/mind/owner
+
+/obj/structure/destructible/clockwork/anchor/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/clockwork/slab) && is_servant_of_ratvar(user))
+		if(owner != user.mind)
+			to_chat(user, "<span class='danger'>You need to use your own anchor.</span>") // Remind me to make a pointer to their anchor
+			return FALSE
+		var/obj/item/clockwork/slab/s = I
+		return s.recite_scripture(/datum/clockwork_scripture/abscond, user)
+	return ..()
+
+/obj/structure/destructible/clockwork/anchor/proc/disable() // Called when our owner is deconverted
+	animate(src, alpha = 0, 50)
+	QDEL_IN(src, 50)
+	for(var/mob/m in view(7, src))
+		if(is_servant_of_ratvar(m))
+			to_chat(m, "<span class='notice'>The anchor fades out of existence, as its connection to its owner has been severed.</span>")
+		else
+			to_chat(m, "<span class='notice'>The anchor fades out of existence.</span>")
+
+/obj/structure/destructible/clockwork/anchor/CanPass(atom/movable/mover, turf/target)
+	if(istype(mover, /mob/living) && is_servant_of_ratvar(mover))
+		return TRUE
+	return ..()

--- a/code/modules/antagonists/clockcult/clockcult.dm
+++ b/code/modules/antagonists/clockcult/clockcult.dm
@@ -164,6 +164,11 @@
 	owner.special_role = null
 	if(iscyborg(owner.current))
 		to_chat(owner.current, "<span class='warning'>Despite your freedom from Ratvar's influence, you are still irreparably damaged and no longer possess certain functions such as AI linking.</span>")
+	for(var/obj/o in GLOB.all_clockwork_objects)
+		if(istype(o, /obj/structure/destructible/clockwork/anchor))
+			var/obj/structure/destructible/clockwork/anchor/a = o
+			if(a.owner == owner)
+				a.disable()
 	. = ..()
 
 

--- a/strings/clockwork_cult_changelog.txt
+++ b/strings/clockwork_cult_changelog.txt
@@ -1,1 +1,2 @@
 Stargazers have been removed. Integration cogs are now the primary way of creating power.
+When warping to the station, you will be warped to a random tile in maint, with an anchor created in that location. You will need to abscond next to the anchor to go back to Reebe.

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -1376,6 +1376,7 @@
 #include "code\modules\antagonists\clockcult\clock_structures\ocular_warden.dm"
 #include "code\modules\antagonists\clockcult\clock_structures\ratvar_the_clockwork_justicar.dm"
 #include "code\modules\antagonists\clockcult\clock_structures\taunting_trail.dm"
+#include "code\modules\antagonists\clockcult\clock_structures\teleport_anchors.dm"
 #include "code\modules\antagonists\clockcult\clock_structures\wall_gear.dm"
 #include "code\modules\antagonists\clockcult\clock_structures\trap_triggers\lever.dm"
 #include "code\modules\antagonists\clockcult\clock_structures\trap_triggers\pressure_sensor.dm"


### PR DESCRIPTION
Requested by @alexkar598, not fully done yet

Adds clock cult anchors. When you warp to the station, instead of warping to any tile you want, you'll instead be warping to a randomly chosen tile in maintenance (initially picking from xeno/blobstarts, then widening out if none of them are acceptable).

The anchors are passthrough for clock cultists.

To get back to the station, you'll need to either abscond next to the anchor, hit the anchor with your slab, or have someone else teleport you back using their anchor.

I'll leave arguing why this is a good thing for @alexkar598 since I just wanted something to code and he was gonna make this anyways.

:cl:
tweak: Warping to the station as a clock cultist now spawns an anchor which you need to teleport out with again, making clock cultists significantly less mobile
/:cl: