### PR TITLE
fixes rounding error in growthstages

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -282,7 +282,7 @@
 		else
 			plant_overlay.icon_state = myseed.icon_harvest
 	else
-		var/t_growthstate = min(round((age / myseed.maturation) * myseed.growthstages), myseed.growthstages)
+		var/t_growthstate = clamp(round((age / myseed.maturation) * myseed.growthstages), 1, myseed.growthstages)
 		plant_overlay.icon_state = "[myseed.icon_grow][t_growthstate]"
 	add_overlay(plant_overlay)
 


### PR DESCRIPTION
### Intent of your Pull Request

It fixes a rounding error that breaks certain plants growthstages and iconstates, fixes for example the growth bug when you get growth speeds on a plant way too low.

My real intent is to speedrun that t-shirt, so pretty please tag your repo with hacktoberfest? 😳 

#### Changelog

:cl:  
bugfix: fixed botany rounding error that caused grass and other plants to misbehave
/:cl:
