### PR TITLE
Makes yellow toolboxes spawn with budget insuls 50% of the time instead of real gloves 10% of the time

### DIFF
--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -137,8 +137,8 @@
 	new /obj/item/crowbar(src)
 	new /obj/item/stack/cable_coil(src,MAXCOIL,pickedcolor)
 	new /obj/item/stack/cable_coil(src,MAXCOIL,pickedcolor)
-	if(prob(5))
-		new /obj/item/clothing/gloves/color/yellow(src)
+	if(prob(50))
+		new /obj/item/clothing/gloves/color/fyellow(src)
 	else
 		new /obj/item/stack/cable_coil(src,MAXCOIL,pickedcolor)
 


### PR DESCRIPTION
Imagine needing an admin meeting and 5 minutes of talking to figure this out

@JamieD1 