### PR TITLE
Adds security body camera to security officer lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -111,6 +111,7 @@
 	new /obj/item/flashlight/seclite(src)
 	new /obj/item/radio/security(src)
 	new /obj/item/clipboard/yog/paperwork/security(src)
+	new /obj/item/clothing/neck/bodycam(src)
 
 /obj/structure/closet/secure_closet/security/sec
 


### PR DESCRIPTION
#### Why It's Good For The Game
When I've played HoS or even Warden (surprisingly often as acting HoS), I like to have my officers use body cameras, mostly so I don't have to become another officer as well. However, they're often researched so late into the shift that either too much is going on for them to go back to the office and get one or they just plain don't want to.

Also, miners start with body cameras in their lockers, and it's rarely seemed to be a problem.

#### Changelog

:cl:  
rscadd: Added body cameras to the security officer's lockers.
/:cl:
