### PR TITLE
Fixes set-env depreciation for Turdis

### DIFF
--- a/.github/workflows/turdis.yml
+++ b/.github/workflows/turdis.yml
@@ -82,10 +82,10 @@ jobs:
           tools/travis/install_byond.sh
           cd $GITHUB_WORKSPACE
           printenv
-          echo "::set-env name=BYOND_SYSTEM::/home/runner/BYOND/byond"
-          echo "::set-env name=PATH::/home/runner/BYOND/byond/bin:$PATH"
-          echo "::set-env name=LD_LIBRARY_PATH::/home/runner/BYOND/byond/bin:$LD_LIBRARY_PATH"
-          echo "::set-env name=MANPATH::/home/runner/BYOND/byond/man:$MANPATH"
+          echo "BYOND_SYSTEM=/home/runner/BYOND/byond" >> $GITHUB_ENV
+          echo "/home/runner/BYOND/byond/bin" >> $GITHUB_PATH
+          echo "LD_LIBRARY_PATH=/home/runner/BYOND/byond/bin:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+          echo "MANPATH=/home/runner/BYOND/byond/man:$MANPATH" >> $GITHUB_ENV
           
       - name: Compile All Maps
         run: |
@@ -123,10 +123,10 @@ jobs:
       - name: Setup Environment
         run: |
           tools/travis/install_byond.sh
-          echo "::set-env name=BYOND_SYSTEM::/home/runner/BYOND/byond"
-          echo "::set-env name=PATH::/home/runner/BYOND/byond/bin:$PATH"
-          echo "::set-env name=LD_LIBRARY_PATH::/home/runner/BYOND/byond/bin:$LD_LIBRARY_PATH"
-          echo "::set-env name=MANPATH::/home/runner/BYOND/byond/man:$MANPATH"
+          echo "BYOND_SYSTEM=/home/runner/BYOND/byond" >> $GITHUB_ENV
+          echo "/home/runner/BYOND/byond/bin" >> $GITHUB_PATH
+          echo "LD_LIBRARY_PATH=/home/runner/BYOND/byond/bin:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+          echo "MANPATH=/home/runner/BYOND/byond/man:$MANPATH" >> $GITHUB_ENV
           cd $GITHUB_WORKSPACE
           tools/travis/install_rust_g.sh
           mysql -u root -h 127.0.0.1 -e 'CREATE DATABASE tg_travis;'


### PR DESCRIPTION
### Intent of your Pull Request

Fixes the GitHub depreciation warning for `set-env` in Turdis.
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

@alexkar598 

