### PR TITLE
Fixes #9873

### DIFF
--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -161,6 +161,7 @@
 				item_state = initial(G.item_state)
 				icon_state = initial(G.icon_state)
 				item_color = wash_color
+				name = initial(G.name)
 				desc = "The colors are a bit dodgy." 
 
 /obj/item/clothing/shoes/sneakers/machine_wash(obj/machinery/washing_machine/WM)

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -162,7 +162,7 @@
 				icon_state = initial(G.icon_state)
 				item_color = wash_color
 				name = "washed gloves"
-				desc = "The colors are a bit dodgy." // removed break here, it should use the last item in the list for its color. See black gloves.
+				desc = "The colors are a bit dodgy." 
 
 /obj/item/clothing/shoes/sneakers/machine_wash(obj/machinery/washing_machine/WM)
 	if(chained)

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -162,8 +162,7 @@
 				icon_state = initial(G.icon_state)
 				item_color = wash_color
 				name = "washed gloves"
-				desc = "The colors are a bit dodgy."
-				break
+				desc = "The colors are a bit dodgy." // removed break here, it should use the last item in the list for its color. See black gloves.
 
 /obj/item/clothing/shoes/sneakers/machine_wash(obj/machinery/washing_machine/WM)
 	if(chained)

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -161,7 +161,6 @@
 				item_state = initial(G.item_state)
 				icon_state = initial(G.icon_state)
 				item_color = wash_color
-				name = "washed gloves"
 				desc = "The colors are a bit dodgy." 
 
 /obj/item/clothing/shoes/sneakers/machine_wash(obj/machinery/washing_machine/WM)


### PR DESCRIPTION
due to how it was written, it would stop right after the first G.item_color equaled wash_color in term screwing over whenever there was more than one subtype of glove.
By removing a break statement, we take a minimal loss of performance but end up with the right glove sprite.

Fixes #9873 
#### Changelog

:cl:  
bugfix: fixed washing gloves with a black crayon = forensic sprite
/:cl:
