### PR TITLE
Takes out eclipse from rotation due to being a crashfest. It is still forcable by admins but shouldnt be forced outside of testing

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -38,7 +38,6 @@ map icebox
 endmap
 
 map eclipsestation
-	votable
 	minplayers 60
 endmap
 


### PR DESCRIPTION
Takes out eclipse from rotation due to being a crashfest. It is still forcable by admins but shouldnt be forced outside of testing