### PR TITLE
Adds variable profiling for initializations

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -156,6 +156,12 @@
 	if (canSmoothWith)
 		canSmoothWith = typelist("canSmoothWith", canSmoothWith)
 
+	world.log << " -------------------"
+	world.log << "Variables for [src]:"
+	for(var/i in vars)
+		world.log << i
+	world.log << " -------------------"
+
 	ComponentInitialize()
 
 	return INITIALIZE_HINT_NORMAL


### PR DESCRIPTION
Allows us to profile atoms' variables at Initialization through the DD log

:cl:
tweak: Makes lives easier for maintainers by adding variable profiling
/:cl: