### PR TITLE
meteors not effected by floating since they already move hella fast

### DIFF
--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -121,6 +121,9 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 		if(prob(10) && !isspaceturf(T))//randomly takes a 'hit' from ramming
 			get_hit()
 
+/obj/effect/meteor/Process_Spacemove(movement_dir = 0)
+	return TRUE
+
 /obj/effect/meteor/Destroy()
 	if (timerid)
 		deltimer(timerid)


### PR DESCRIPTION
doesn't effect much since most meteors already move super fast but it does make the meatball man actually incredibly slow
also means meteor speed is an accurate representation of the meteor's speed

:cl:  
tweak: meteors are no longer effected by 0g floating
/:cl:
