### PR TITLE
probably makes shelter capsules unable to breakwalls

### DIFF
--- a/code/modules/mining/shelters.dm
+++ b/code/modules/mining/shelters.dm
@@ -41,7 +41,7 @@
 
 /datum/map_template/shelter/alpha/New()
 	. = ..()
-	blacklisted_turfs = typecacheof(/turf/open/indestructible) //yogs added indestructible floors to the shelter black list
+	blacklisted_turfs += typecacheof(/turf/open/indestructible) //yogs added indestructible floors to the shelter black list
 	whitelisted_turfs = typecacheof(/turf/closed/mineral)
 	banned_objects = typecacheof(/obj/structure/stone_tile)
 
@@ -57,6 +57,6 @@
 
 /datum/map_template/shelter/beta/New()
 	. = ..()
-	blacklisted_turfs = typecacheof(/turf/open/indestructible) //yogs added indestructible floors to the shelter black list
+	blacklisted_turfs += typecacheof(/turf/open/indestructible) //yogs added indestructible floors to the shelter black list
 	whitelisted_turfs = typecacheof(/turf/closed/mineral)
 	banned_objects = typecacheof(/obj/structure/stone_tile)


### PR DESCRIPTION
thanks
also fixes #9314 I guess
note that this won't effect the destruction of rock walls since the whitelist overrides the blacklist
:cl:  
bugfix: shelter capsules can no longer delete normal walls
/:cl:
