### PR TITLE
[PORT] Orbit menu checks ghosts recursively, ghosts have orbit counters

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1102,3 +1102,21 @@
   */
 /atom/proc/rust_heretic_act()
 	return
+/**
+  * Recursive getter method to return a list of all ghosts orbitting this atom
+  * 
+  * This will work fine without manually passing arguments.
+  */
+/atom/proc/get_all_orbiters(list/processed, source = TRUE)
+	var/list/output = list()
+	if (!processed)
+		processed = list()
+	if (src in processed)
+		return output
+	if (!source)
+		output += src
+	processed += src
+	for (var/o in orbiters?.orbiters)
+		var/atom/atom_orbiter = o
+		output += atom_orbiter.get_all_orbiters(processed, source = FALSE)
+	return output

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -24,37 +24,36 @@
 
 /datum/orbit_menu/ui_data(mob/user)
 	var/list/data = list()
-
 	var/list/alive = list()
 	var/list/antagonists = list()
 	var/list/dead = list()
 	var/list/ghosts = list()
 	var/list/misc = list()
 	var/list/npcs = list()
-
 	var/list/pois = getpois(skip_mindless = 1)
 	for (var/name in pois)
 		var/list/serialized = list()
 		serialized["name"] = name
-
 		var/poi = pois[name]
-
+		serialized["ref"] = REF(poi)
 		var/mob/M = poi
 		if (istype(M))
 			if (isobserver(M))
+				var/number_of_orbiters = length(M.get_all_orbiters())
+				if (number_of_orbiters)
+					serialized["orbiters"] = number_of_orbiters
 				ghosts += list(serialized)
 			else if (M.stat == DEAD)
 				dead += list(serialized)
 			else if (M.mind == null)
 				npcs += list(serialized)
 			else
-				var/number_of_orbiters = M.orbiters?.orbiters?.len
+				var/number_of_orbiters = length(M.get_all_orbiters())
 				if (number_of_orbiters)
 					serialized["orbiters"] = number_of_orbiters
 
 				var/datum/mind/mind = M.mind
 				var/was_antagonist = FALSE
-
 				for (var/_A in mind.antag_datums)
 					var/datum/antagonist/A = _A
 					if (A.show_to_ghosts)
@@ -62,17 +61,14 @@
 						serialized["antag"] = A.name
 						antagonists += list(serialized)
 						break
-
 				if (!was_antagonist)
 					alive += list(serialized)
 		else
 			misc += list(serialized)
-
 	data["alive"] = alive
 	data["antagonists"] = antagonists
 	data["dead"] = dead
 	data["ghosts"] = ghosts
 	data["misc"] = misc
 	data["npcs"] = npcs
-
 	return data

--- a/tgui/packages/tgui/interfaces/Orbit.js
+++ b/tgui/packages/tgui/interfaces/Orbit.js
@@ -160,11 +160,17 @@ export const Orbit = (props, context) => {
             ))}
         </Section>
 
-        <BasicSection
-          title="Ghosts"
-          source={ghosts}
-          searchText={searchText}
-        />
+        <Section title="Ghosts">
+          {ghosts
+            .filter(searchFor(searchText))
+            .sort(compareNumberedText)
+            .map(thing => (
+              <OrbitedButton
+                key={thing.name}
+                color="grey"
+                thing={thing} />
+            ))}
+        </Section>
 
         <BasicSection
           title="Dead"


### PR DESCRIPTION
### Intent of your Pull Request

Ports: https://github.com/tgstation/tgstation/pull/53826

About The Pull Request

The orbit-counter of the orbit menu only showed the number of ghosts directly orbiting someone. That means if 100 ghosts were orbiting me, and I was orbiting a living player, the orbit menu would only show that 1 person is orbiting that player.

Secondly, the orbit menu now displays the number of people orbiting a ghost. This is because sometimes everyone is orbiting a single observer, who in turn is following all the action or whatever. This makes it easier to figure out who that is
Why It's Good For The Game

Makes the orbit menu more clear and usable
Changelog

🆑MrDoomBringer, Redmoogle
add: The orbit menu now shows the total number of ghosts orbiting something
/🆑