### PR TITLE
[s] Fixes a major memory leak in shuttle code(#54245)

### DIFF
--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -72,7 +72,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 			// no warning though because this can happen naturaly as a result of it being built on top of
 			path = /turf/open/space
 
-	if(!GLOB.use_preloader && path == type && !(flags & CHANGETURF_FORCEOP)) // Don't no-op if the map loader requires it to be reconstructed
+	if(!GLOB.use_preloader && path == type && !(flags & CHANGETURF_FORCEOP) && (baseturfs == new_baseturfs)) // Don't no-op if the map loader requires it to be reconstructed, or if this is a new set of baseturfs
 		return src
 	if(flags & CHANGETURF_SKIP)
 		return new path(src)


### PR DESCRIPTION
Ports: https://github.com/tgstation/tgstation/pull/54245

### About The Pull Request

So uh, apparently the bug that killed kilo was a memory leak in shuttle base turfs that reoccured when a shuttle attempted to leave and it was landed on 2 turfs with the same path, since ChangeTurf() optimizes away changing to the same turf, base turfs didn't update, so we got a leaking list, and a crash on kilo when enough people took arrivals shuttle
Why It's Good For The Game

I have killed god
Oh also fixes #54240
Changelog

🆑 Orange man actually looked at the runtimes, Willox, Inept-At-Job figured out the symptoms, Kylerace owned a map editor, ActionNinja figured out why it was broken, and LemonInTheDark did a one line change
fix: Fixes a memory leak, there's a good chance that it's the same one that killed kilo.
/🆑
