### PR TITLE
lets the quartermaster make desk announcements with their console

### DIFF
--- a/_maps/map_files/EclipseStation/EclipseStation.dmm
+++ b/_maps/map_files/EclipseStation/EclipseStation.dmm
@@ -72868,15 +72868,6 @@
 "cQn" = (
 /turf/open/floor/carpet/orange,
 /area/quartermaster/qm)
-"cQo" = (
-/obj/structure/table,
-/obj/item/clipboard,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/carpet/orange,
-/area/quartermaster/qm)
 "cQp" = (
 /obj/machinery/light,
 /obj/machinery/status_display/supply{
@@ -79458,23 +79449,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"deI" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/table,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "deJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -79565,18 +79539,6 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"deR" = (
-/obj/machinery/camera{
-	c_tag = "Cargo Fabrication";
-	dir = 1;
-	network = list("ss13","Cargo")
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "deS" = (
@@ -82638,6 +82600,22 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/teleporter/hub/security)
+"dXO" = (
+/obj/machinery/camera{
+	c_tag = "Cargo Fabrication";
+	dir = 1;
+	network = list("ss13","Cargo")
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "dYX" = (
 /turf/closed/wall,
 /area/solar/port/aft)
@@ -83389,6 +83367,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"ggq" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "gje" = (
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
@@ -89248,6 +89239,21 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"wBh" = (
+/obj/structure/table,
+/obj/item/clipboard,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Quartermaster's Desk";
+	departmentType = 2;
+	pixel_x = 30
+	},
+/turf/open/floor/carpet/orange,
+/area/quartermaster/qm)
 "wCA" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -118930,7 +118936,7 @@ cIx
 cIO
 ags
 cJd
-cQo
+wBh
 bYX
 cQu
 ags
@@ -119444,7 +119450,7 @@ cHo
 bVy
 agb
 dey
-deI
+ggq
 bPK
 deQ
 agb
@@ -119703,7 +119709,7 @@ agb
 dez
 bOI
 agh
-deR
+dXO
 agb
 bUm
 bSl

--- a/_maps/map_files/IceBox/IceBox.dmm
+++ b/_maps/map_files/IceBox/IceBox.dmm
@@ -37344,26 +37344,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"bvF" = (
-/obj/machinery/requests_console{
-	department = "Cargo Bay";
-	departmentType = 2;
-	pixel_x = -30
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/machinery/computer/bounty{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "bvG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58159,6 +58139,27 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"fpk" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/computer/bounty{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Quartermaster's Desk";
+	departmentType = 2;
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "fql" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/cryopod{
@@ -86197,7 +86198,7 @@ bjr
 bjr
 bub
 bxu
-bvF
+fpk
 bzP
 bAS
 bxu

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -28379,26 +28379,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"bvF" = (
-/obj/machinery/requests_console{
-	department = "Cargo Bay";
-	departmentType = 2;
-	pixel_x = -30
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/machinery/computer/bounty{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "bvG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58922,6 +58902,27 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"ten" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Quartermaster's Desk";
+	departmentType = 2;
+	pixel_x = -30
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/computer/bounty{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "tes" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -86759,7 +86760,7 @@ tJW
 bjr
 bub
 bxu
-bvF
+ten
 bzP
 bAS
 bxu

--- a/_maps/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/map_files/YogsDelta/YogsDelta.dmm
@@ -15582,25 +15582,6 @@
 "aAb" = (
 /turf/closed/wall,
 /area/hydroponics/garden/abandoned)
-"aAc" = (
-/obj/machinery/requests_console{
-	department = "Quartermaster's Desk";
-	name = "Quartermaster RC";
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/obj/machinery/light_switch{
-	pixel_x = 23
-	},
-/obj/machinery/computer/bounty{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "aAd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -127009,6 +126990,26 @@
 /obj/machinery/vending/gifts,
 /turf/open/floor/wood,
 /area/clerk)
+"oUR" = (
+/obj/machinery/light_switch{
+	pixel_x = 23
+	},
+/obj/machinery/computer/bounty{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Quartermaster's Desk";
+	departmentType = 2;
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "oYI" = (
 /obj/machinery/igniter/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
@@ -174418,7 +174419,7 @@ aQV
 aSy
 axU
 doI
-aAc
+oUR
 cbK
 aQV
 aad

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -21308,21 +21308,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"aPk" = (
-/obj/structure/table,
-/obj/item/folder/yellow,
-/obj/item/pen{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/pen/red,
-/obj/machinery/requests_console{
-	department = "Cargo Bay";
-	departmentType = 2;
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "aPl" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -84937,6 +84922,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
+"tVL" = (
+/obj/structure/table,
+/obj/item/folder/yellow,
+/obj/item/pen{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/pen/red,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Quartermaster's Desk";
+	departmentType = 2;
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "tXK" = (
 /obj/machinery/air_sensor/atmos/toxins_mixing_tank,
 /turf/open/floor/engine/vacuum,
@@ -107115,7 +107116,7 @@ dne
 aBe
 dne
 aNR
-aPk
+tVL
 aQt
 aRN
 aSX


### PR DESCRIPTION
### Intent of your Pull Request

The fucking signal tech gets it, but the QM doesn't.

Okay.

Applies to all maps, including Eclipse, which didn't originally have a quartermaster RC.

#### Changelog

:cl:  
rscadd: announcementConsole = 1 instead of 0 on all the quartermaster request consoles
/:cl:
