### PR TITLE
Replaces the atmospheric burn test holodeck program by lava incinerator program. (Take two!)

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6904,9 +6904,6 @@
 	smooth = 1
 	},
 /area/centcom/holding)
-"pz" = (
-/turf/open/lava,
-/area/holodeck/rec_center/burn)
 "pB" = (
 /obj/machinery/firealarm,
 /turf/closed/indestructible/riveted,
@@ -23064,6 +23061,9 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/centcom/testchamber)
+"ZP" = (
+/turf/open/lava/smooth,
+/area/holodeck/rec_center/burn)
 "ZQ" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -85594,16 +85594,16 @@ aa
 "}
 (244,1,1) = {"
 ac
-pz
-pz
-pz
-pz
-pz
-pz
-pz
-pz
-pz
-pz
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
 bj
 bx
 bN
@@ -85851,16 +85851,16 @@ aa
 "}
 (245,1,1) = {"
 ac
-pz
-pz
-pz
-pz
-pz
-pz
-pz
-pz
-pz
-pz
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
 bj
 by
 bN
@@ -86108,16 +86108,16 @@ aa
 "}
 (246,1,1) = {"
 ac
-pz
-pz
-pz
-pz
-pz
-pz
-pz
-pz
-pz
-pz
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
 bj
 by
 bN
@@ -86365,16 +86365,16 @@ aa
 "}
 (247,1,1) = {"
 ac
-pz
-pz
-pz
-pz
-pz
-pz
-pz
-pz
-pz
-pz
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
 bj
 by
 bN
@@ -86622,16 +86622,16 @@ aa
 "}
 (248,1,1) = {"
 ac
-pz
-pz
-pz
-pz
-pz
-pz
-pz
-pz
-pz
-pz
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
+ZP
 bj
 bz
 bN

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -96,9 +96,6 @@
 "aq" = (
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/offline)
-"ar" = (
-/turf/open/floor/holofloor/plating/burnmix,
-/area/holodeck/rec_center/burn)
 "as" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -181,10 +178,6 @@
 /obj/effect/holodeck_effect/mobspawner,
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/wildlife)
-"aC" = (
-/obj/effect/holodeck_effect/sparks,
-/turf/open/floor/holofloor/plating/burnmix,
-/area/holodeck/rec_center/burn)
 "aD" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -6912,7 +6905,7 @@
 	},
 /area/centcom/holding)
 "pz" = (
-/turf/open/floor/holofloor/plating,
+/turf/open/lava,
 /area/holodeck/rec_center/burn)
 "pB" = (
 /obj/machinery/firealarm,
@@ -85859,14 +85852,14 @@ aa
 (245,1,1) = {"
 ac
 pz
-aC
-pz
-ar
 pz
 pz
-ar
 pz
-aC
+pz
+pz
+pz
+pz
+pz
 pz
 bj
 by
@@ -86116,14 +86109,14 @@ aa
 (246,1,1) = {"
 ac
 pz
-ar
-pz
-aC
 pz
 pz
-aC
 pz
-ar
+pz
+pz
+pz
+pz
+pz
 pz
 bj
 by
@@ -86373,14 +86366,14 @@ aa
 (247,1,1) = {"
 ac
 pz
-aC
-pz
-ar
 pz
 pz
-ar
 pz
-aC
+pz
+pz
+pz
+pz
+pz
 pz
 bj
 by

--- a/code/game/area/areas/holodeck.dm
+++ b/code/game/area/areas/holodeck.dm
@@ -107,7 +107,7 @@
 // Bad programs
 
 /area/holodeck/rec_center/burn
-	name = "Holodeck - Atmospheric Burn Test"
+	name = "Holodeck - Incinerator"
 	restricted = 1
 
 /area/holodeck/rec_center/wildlife


### PR DESCRIPTION
The atmospheric burn test holodeck program, AKA the one that fills the entire station with enormous pressure of plasma near instantaneously at the cost of two button presses, is overused, too easy to do, and far too effective for my liking. You should earn a proper plasmaflood, not get it as a freebie that comes with an emag.

With this PR, the EZ PLASMAFLOOD program will be replaced with a program that covers the holodeck in lava. Sweet sweet husking, evidence burning, sudden lava.

:cl:  
rscadd: lava holodeck
rscdel: plasmaflood holodeck
tweak: changed name of program accordingly
/:cl:
