### PR TITLE
Removes Xray from the genetics powers pool

### DIFF
--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -57,15 +57,6 @@
 	REMOVE_TRAIT(owner, visionflag, GENETIC_MUTATION)
 	owner.update_sight()
 
-//X-ray Vision lets you see through walls.
-/datum/mutation/human/thermal/x_ray
-	name = "X Ray Vision"
-	desc = "A strange genome that allows the user to see between the spaces of walls." //actual x-ray would mean you'd constantly be blasting rads, wich might be fun for later //hmb
-	text_gain_indication = "<span class='notice'>The walls suddenly disappear!</span>"
-	instability = 35
-	locked = TRUE
-	visionflag = TRAIT_XRAY_VISION
-
 //Laser Eyes lets you shoot lasers from your eyes!
 /datum/mutation/human/laser_eyes
 	name = "Laser Eyes"


### PR DESCRIPTION
Four simple reasons:
1. If any singular thing enables powergaming in a way that directly breaks the rules and causes massive issues it's this power
2. There's not a lot more unfun than to be a traitor who has literally no way of detecting whether or not he's been spotted by the 3 validhunting assistants who have alerted the validhunting horde about his antics he had no way of knowing where detected
3. Xray isn't a power that benefits the game at all by being mass distributed in any form to anyone. I have never seen a round improved by everyone running around with xray. 
4. Xray will still exist in the game, it's just behind the research protected xray implant, which goes completely unused because the xray power is vastly superior. 