### PR TITLE
Removes Xray from genetics PR #2

### DIFF
--- a/code/datums/mutations/_combined.dm
+++ b/code/datums/mutations/_combined.dm
@@ -17,10 +17,6 @@
 	required = "/datum/mutation/human/strong; /datum/mutation/human/radioactive"
 	result = HULK
 
-/datum/generecipe/x_ray
-	required = "/datum/mutation/human/thermal; /datum/mutation/human/radioactive"
-	result = /datum/mutation/human/thermal/x_ray
-
 /datum/generecipe/mindread
 	required = "/datum/mutation/human/antenna; /datum/mutation/human/paranoia"
 	result = MINDREAD
@@ -28,7 +24,7 @@
 /datum/generecipe/shock
 	required = "/datum/mutation/human/insulated; /datum/mutation/human/radioactive"
 	result = SHOCKTOUCH
-	
+
 /datum/generecipe/antiglow
 	required = "/datum/mutation/human/glow; /datum/mutation/human/void"
 	result = ANTIGLOWY


### PR DESCRIPTION
Four simple reasons:

1. If any singular thing enables powergaming in a way that directly breaks the rules and causes massive issues it's this power
2. There's not a lot more unfun than to be a traitor who has literally no way of detecting whether or not he's been spotted by the 3 validhunting assistants who have alerted the validhunting horde about his antics he had no way of knowing where detected
3. Xray isn't a power that benefits the game at all by being mass distributed in any form to anyone. I have never seen a round improved by everyone running around with xray.
4. Xray will still exist in the game, it's just behind the research protected xray implant, which goes completely unused because the xray power is vastly superior.

This PR doesn't nuke it from code, it is just not possible by genetics, also this actually compiles. 

🆑
rscdel: Removed the ability for Geneticists to acquire Xray
/🆑