### PR TITLE
Updates the day and greeting message of Oak Day

### DIFF
--- a/yogstation/code/modules/holidays/holidays.dm
+++ b/yogstation/code/modules/holidays/holidays.dm
@@ -33,7 +33,7 @@
 		)
 
 /datum/holiday/oakday
-	name = "Oak's Birthday"
+	name = "Oak Day"
 	begin_day = 14
 	begin_month = OCTOBER
 	drone_hat = /obj/item/clothing/head/hardhat/cakehat

--- a/yogstation/code/modules/holidays/holidays.dm
+++ b/yogstation/code/modules/holidays/holidays.dm
@@ -51,7 +51,7 @@
 	return pick("Gondola","Finnish","Council","Oakreich","Perkele")
 	
 /datum/holiday/oakday/greet()
-	return "</h4><span class=\"admin\"><span class=\"prefix\">ADMIN LOG:</span> <u><font color='#00ff00'>Xantam</font></u>/(Xantam) has created a permanent server ban for Oakboscage. Reason: Community Banned</span><h4>" // Honk if Oak is dead
+	return "</h4><span class=\"admin\"><span class=\"prefix\">ADMIN LOG:</span> <font color='#0000ff'><u>Xantam</u></font>/(Xantam) has created a permanent server ban for Oakboscage. Reason: Community Banned</span><h4>" // Honk if Oak is dead
 
 /datum/holiday/yogsday
 	name = "Yogstation Day"

--- a/yogstation/code/modules/holidays/holidays.dm
+++ b/yogstation/code/modules/holidays/holidays.dm
@@ -51,7 +51,7 @@
 	return pick("Gondola","Finnish","Council","Oakreich","Perkele")
 	
 /datum/holiday/oakday/greet()
-	return "Happy birthday to Oakboscage!"
+	return "</h4><span class=\"admin\"><span class=\"prefix\">ADMIN LOG:</span> <u><font color='#00ff00'>Xantam</font></u>/(Xantam) has created a permanent server ban for Oakboscage. Reason: Community Banned</span><h4>" // Honk if Oak is dead
 
 /datum/holiday/yogsday
 	name = "Yogstation Day"

--- a/yogstation/code/modules/holidays/holidays.dm
+++ b/yogstation/code/modules/holidays/holidays.dm
@@ -34,8 +34,8 @@
 
 /datum/holiday/oakday
 	name = "Oak's Birthday"
-	begin_day = 5
-	begin_month = JULY
+	begin_day = 14
+	begin_month = OCTOBER
 	drone_hat = /obj/item/clothing/head/hardhat/cakehat
 	lobby_music = list(
 		"https://www.youtube.com/watch?v=lM2Lr3NqUcg", // Maamme (Finnish Anthem)


### PR DESCRIPTION
### Honk if Oak is dead
![image](https://user-images.githubusercontent.com/29939414/96069069-0dbd6800-0e63-11eb-8be7-710451d05cc2.png)

This makes the greet() message for Oak day just be a rendering of Xantam's proudest moment.

In addition, it moves the time of Oak Day from his birthday, to the date of his removal.

## Changelog
:cl:  Altoids
rscdel: Removed Oakboscage
/:cl:
