### PR TITLE
Fixes Ragin/Bullshit Mages Preferences not working, Uncorrupts save files

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -11,7 +11,7 @@
 #define ROLE_OPERATIVE			"Operative"
 #define ROLE_CHANGELING			"Changeling"
 #define ROLE_WIZARD				"Wizard"
-#define ROLE_RAGINMAGES			"Ragin' Mages"
+#define ROLE_RAGINMAGES			"Ragin Mages"
 #define ROLE_BULLSHITMAGES		"Bullshit Mages"
 #define ROLE_MALF				"Malf AI"
 #define ROLE_REV				"Revolutionary"

--- a/code/game/gamemodes/wizard/raginmages.dm
+++ b/code/game/gamemodes/wizard/raginmages.dm
@@ -95,9 +95,10 @@
 								if("No")
 									continue
 
-			sleep(300)
+			sleep(310) // Slightly longer so as to ensure late-senders still get counted in
 		if(!candidates.len)
 			message_admins("This is awkward, sleeping until another mage check...")
+			notify_ghosts("There was an attempt to spawn in another ragin' mage, but none of you qualified!")
 			making_mage = 0
 			mages_made--
 			return

--- a/code/game/gamemodes/wizard/raginmages.dm
+++ b/code/game/gamemodes/wizard/raginmages.dm
@@ -75,15 +75,16 @@
 	spawn(rand(spawn_delay_min, spawn_delay_max))
 		message_admins("SWF is still pissed, sending another wizard - [max_mages - mages_made] left.")
 		for(var/mob/dead/observer/G in GLOB.player_list)
-			if(G.client && !G.client.holder && !G.client.is_afk() && (ROLE_WIZARD in G.client.prefs.be_special))
-				if(!is_banned_from(G.ckey, list(ROLE_WIZARD, ROLE_SYNDICATE)))
-					if(age_check(G.client))
-						candidates += G
+			if(G.client && !G.client.holder && !G.client.is_afk()) // If they're active and available
+				if((!bullshit_mode && (ROLE_RAGINMAGES in G.client.prefs.be_special)) || (bullshit_mode && (ROLE_BULLSHITMAGES in G.client.prefs.be_special))) // If they have preference towards this
+					if(!is_banned_from(G.ckey, list(ROLE_WIZARD, ROLE_SYNDICATE, ROLE_RAGINMAGES, ROLE_BULLSHITMAGES))) // If they're not banned
+						if(age_check(G.client))
+							candidates += G
 		if(!candidates.len)
 			message_admins("No applicable ghosts for the next ragin' mage, asking ghosts instead.")
 			var/time_passed = world.time
 			for(var/mob/dead/observer/G in GLOB.player_list)
-				if(!is_banned_from(G.ckey, list(ROLE_WIZARD, ROLE_SYNDICATE)))
+				if(!is_banned_from(G.ckey, list(ROLE_WIZARD, ROLE_SYNDICATE, ROLE_RAGINMAGES, ROLE_BULLSHITMAGES)))
 					if(age_check(G.client))
 						spawn(0)
 							switch(alert(G, "Do you wish to be considered for the position of Space Wizard Foundation 'diplomat'?","Please answer in 30 seconds!","Yes","No"))

--- a/code/game/gamemodes/wizard/raginmages.dm
+++ b/code/game/gamemodes/wizard/raginmages.dm
@@ -12,7 +12,7 @@
 	var/making_mage = 0
 	var/mages_made = 1
 	var/time_checked = 0
-	var/bullshit_mode = 0 // requested by hornygranny
+	var/bullshit_mode = FALSE // requested by hornygranny
 	var/time_check = 1500
 	var/spawn_delay_min = 500
 	var/spawn_delay_max = 700
@@ -135,7 +135,7 @@
 	antag_datum = /datum/antagonist/wizard/
 	antag_flag = ROLE_BULLSHITMAGES
 	required_players = 40
-	bullshit_mode = 1
+	bullshit_mode = TRUE
 	time_check = 250
 	spawn_delay_min = 50
 	spawn_delay_max = 150

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -5,7 +5,7 @@
 //	You do not need to raise this if you are adding new values that have sane defaults.
 //	Only raise this value when changing the meaning/format/name/layout of an existing value
 //	where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX	24
+#define SAVEFILE_VERSION_MAX	25
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -42,6 +42,12 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 //if your savefile is 3 months out of date, then 'tough shit'.
 
 /datum/preferences/proc/update_preferences(current_version, savefile/S)
+	// Fixes savefile corruption caused by https://github.com/yogstation13/Yogstation/pull/9767
+	if(current_version < 25) // This is the only thing that makes V25 different.
+		if(LAZYFIND(be_special,"Ragin")) 
+			be_special -= "Ragin"
+			be_special += "Ragin Mages"
+	//
 	return
 
 /datum/preferences/proc/update_character(current_version, savefile/S)


### PR DESCRIPTION
### Uh oh savefile corruptio
![image](https://user-images.githubusercontent.com/29939414/96082602-23418a80-0e81-11eb-965e-d95a3c980b75.png)
This fixes #9844, which was caused by #9767. Both of these were made by the same person.

In addition, this PR fixes Ragin/Bullshit preferences not working for ghosts, whenever the gamemode fishes for new mages from those who are dead.

As well, it is now theoretically possible to ban someone from being a Ragin or Bullshit Mage. I don't.. really know _why_ you'd need to do that specifically instead of a blanket Wizard ban, but, there it is.

### **Fixing this required incrementing the savefile version to 25.**

# Changelog

:cl:  Altoids
bugfix: It is now possible to enable the Ragin Mages antag preference from the Game Preferences menu.
bugfix: Antag Preferences for Ragin and Bullshit Mages now actually work for ghosts.
bugfix: Ragin and Bullshit job bans now actually function.
/:cl:
