### PR TITLE
Fixes the link pretty-filter, somewhat

### DIFF
--- a/config/pretty_filter.txt
+++ b/config/pretty_filter.txt
@@ -43,4 +43,4 @@ n[i1!\\\/]+g(?:g|l+[e3]+t)=BAN ME ADMINS!
 One day while Andy was masturbating=BAN ME ADMINS!
 XEzwgBD=BAN ME ADMINS!
 
-\b(?:https:\/\/)?(?:www\.)?(?!yogstation\.net|github\.com)\w{4,128}\.\w{3}\b\S*=[Link Removed]
+\b(?:https:\/\/)?(?:www\.)?(?!yogstation\.net|github\.com)\w{4,128}\.\w{2}\.?\w{0,2}\b\S*=[Link Removed]

--- a/config/pretty_filter.txt
+++ b/config/pretty_filter.txt
@@ -43,4 +43,4 @@ n[i1!\\\/]+g(?:g|l+[e3]+t)=BAN ME ADMINS!
 One day while Andy was masturbating=BAN ME ADMINS!
 XEzwgBD=BAN ME ADMINS!
 
-(\b|^)(https?:\/\/)?(?!\w*\.?yogstation.net)(https?:\/\/)?(?!\w*\.?github.com)[-a-zA-Z0-9@:%._\+~#]{5,256}\.(com|net|gg|org|ly|at|co|ink|im|nl)\b([-a-zA-Z0-9()@:%_\+.~#?&//]*)=$1[Link Censored]
+\b(?:https:\/\/)?(?:www\.)?(?!yogstation\.net|github\.com)\w{4,128}\.\w{3}\b\S*=[Link Removed]

--- a/config/pretty_filter.txt
+++ b/config/pretty_filter.txt
@@ -43,4 +43,4 @@ n[i1!\\\/]+g(?:g|l+[e3]+t)=BAN ME ADMINS!
 One day while Andy was masturbating=BAN ME ADMINS!
 XEzwgBD=BAN ME ADMINS!
 
-\b(?:https:\/\/)?(?:www\.)?(?!yogstation\.net|github\.com)\w{4,128}\.\w{2}\.?\w{0,2}\b\S*=[Link Removed]
+\b(?:https?:\/\/)?(?:www|i)?\.?(?!yogstation\.net|github\.com)\w{4,128}\.\w{2}\.?\w{0,2}\b\S*=[Link Removed]


### PR DESCRIPTION
Jamie asked me to help him fix up a regex in the pretty filter that captures on bad links, but does not capture on links to Yogstation or Github. I've done so.

Here's an example of what the old regex did (and alarmingly did not!) capture on **(Warning: NSFW links used to test the regex!)**: https://regex101.com/r/ouQpdX/1

And now my new regex (Again, NSFW links used to test it): https://regex101.com/r/KwBR7K/2

## Changelog

:cl:  Altoids
bugfix: It is no longer possible to spam OOC with links to your favorite furry website.
/:cl:
