### PR TITLE
Fixes a few typos in some of the Antag objective explanation texts

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -213,7 +213,7 @@ GLOBAL_LIST_EMPTY(objectives)
 /datum/objective/assassinate/internal/update_explanation_text()
 	..()
 	if(target && !target.current)
-		explanation_text = "Assassinate [target.name], who was obliterated"
+		explanation_text = "Assassinate [target.name], who was obliterated."
 
 /datum/objective/mutiny
 	name = "mutiny"
@@ -863,7 +863,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 		var/mob/new_target = input(admin,"Select target:", "Objective target") as null|anything in possible_targets
 		target = new_target.mind
 	else
-		to_chat(admin, "No active AIs with minds")
+		to_chat(admin, "<span class='warning'>No active AIs with minds!</span>")
 	update_explanation_text()
 
 /datum/objective/destroy/internal
@@ -900,7 +900,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 //Picks as many people as it can from a department (Security,Engineer,Medical,Science)
 //and tasks the lings with killing and replacing them
 /datum/objective/changeling_team_objective/impersonate_department
-	explanation_text = "Ensure X department are killed, impersonated, and replaced by Changelings"
+	explanation_text = "Ensure X department are killed, impersonated, and replaced by Changelings."
 	var/command_staff_only = FALSE //if this is true, it picks command staff instead
 	var/list/department_minds = list()
 	var/list/department_real_names = list()
@@ -1050,7 +1050,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 //This subtype always picks as many command staff as it can (HoS,HoP,Cap,CE,CMO,RD)
 //and tasks the lings with killing and replacing them
 /datum/objective/changeling_team_objective/impersonate_department/impersonate_heads
-	explanation_text = "Have X or more heads of staff escape on the shuttle disguised as heads, while the real heads are dead"
+	explanation_text = "Have X or more heads of staff escape on the shuttle disguised as heads, while the real heads are dead."
 	command_staff_only = TRUE
 
 ////////////////////////////////
@@ -1222,7 +1222,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 
 	target = pick(heads)
 	name = "Photograph [target.name]."
-	explanation_text = "Extract with a photograph [target.name], the [target.assigned_role]."
+	explanation_text = "Extract with a photograph of [target.name], the [target.assigned_role]."
 	return TRUE
 
 /**


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/29939414/96174720-51f64a00-0eef-11eb-97da-439af802c061.png)


Also adds a span to an admin alert message within ``objective.dm``.

#### Changelog

:cl:  Altoids
spellcheck: It's now made clear that you have to extract a photograph OF the person you're targeting, when you have that objective.
/:cl:
