### PR TITLE
17 year olds can no longer exist upon Nanotrasen Property, or in the entire universe for that matter

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -277,7 +277,7 @@
 #define OFFSET_NECK "neck"
 
 //MINOR TWEAKS/MISC
-#define AGE_MIN				17	//youngest a character can be
+#define AGE_MIN				18	//youngest a character can be
 #define AGE_MAX				85	//oldest a character can be
 #define AGE_MINOR			21  //legal age of space drinking and smoking
 #define WIZARD_AGE_MIN		30	//youngest a wizard can be


### PR DESCRIPTION
### Intent of your Pull Request

Raises minimum age of a character to be 18, an intergalactically agreed age of an adult. Agreed on by both the Syndicate and Nanotrasen, so now you know even the Syndicate doesn't support child predators.

Also unironically why would you hire someone under 18, especially for a Head role

#### Changelog

:cl:  
tweak: Changes AGE_MIN from 17 to 18
/:cl:
