### PR TITLE
allows you to get insulated gloves from electrical toolboxes again but at a reduced chance

### DIFF
--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -137,8 +137,8 @@
 	new /obj/item/crowbar(src)
 	new /obj/item/stack/cable_coil(src,MAXCOIL,pickedcolor)
 	new /obj/item/stack/cable_coil(src,MAXCOIL,pickedcolor)
-	if(prob(50))
-		new /obj/item/clothing/gloves/color/fyellow(src)
+	if(prob(10))
+		new /obj/item/clothing/gloves/color/yellow(src)
 	else
 		new /obj/item/stack/cable_coil(src,MAXCOIL,pickedcolor)
 


### PR DESCRIPTION
there is a 10% any electrical toolbox has a insulated glove 
#### Changelog

:cl:  
tweak: gave back electrical toolboxes the chance to spawn insulateds at a reduced chance
/:cl:
