### PR TITLE
makes it so heads of staff can't be roundstart antag

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -12,7 +12,7 @@ GLOBAL_VAR(changeling_team_objective_type) //If this is not null, we hand our th
 	antag_flag = ROLE_CHANGELING
 	false_report_weight = 10
 	restricted_jobs = list("AI", "Cyborg")
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel") //YOGS - added hop
+	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Research Director", "Chief Engineer", "Chief Medical Officer") //YOGS - added hop
 	required_players = 15
 	required_enemies = 1
 	recommended_enemies = 4
@@ -162,4 +162,4 @@ GLOBAL_VAR(changeling_team_objective_type) //If this is not null, we hand our th
 	round_credits += "<br>"
 
 	round_credits += ..()
-	return round_credits 
+	return round_credits

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -40,7 +40,7 @@
 	report_type = "cult"
 	antag_flag = ROLE_CULTIST
 	false_report_weight = 10
-	restricted_jobs = list("Chaplain","AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel")
+	restricted_jobs = list("Chaplain","AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Research Director", "Chief Engineer", "Chief Medical Officer")
 	protected_jobs = list()
 	required_players = 29
 	required_enemies = 4
@@ -267,7 +267,7 @@
 			L.maxHealth = initial(L.maxHealth)
 			to_chat(L, "<span class='cult'>Your form regains its original durability!</span>")
 	//send message to cultists saying they can do stuff again
-	
+
 /datum/game_mode/cult/generate_credit_text()
 	var/list/round_credits = list()
 	var/len_before_addition

--- a/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
+++ b/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
@@ -4,7 +4,7 @@
 	report_type = "heresy"
 	antag_flag = ROLE_HERETIC
 	false_report_weight = 5
-	protected_jobs = list("Prisoner","Security Officer", "Warden", "Detective", "Head of Security", "Captain")
+	protected_jobs = list("Chaplain","Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Research Director", "Chief Engineer", "Chief Medical Officer")
 	restricted_jobs = list("AI", "Cyborg")
 	required_players = 0
 	required_enemies = 1

--- a/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
+++ b/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
@@ -4,7 +4,7 @@
 	report_type = "heresy"
 	antag_flag = ROLE_HERETIC
 	false_report_weight = 5
-	protected_jobs = list("Chaplain","Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Research Director", "Chief Engineer", "Chief Medical Officer")
+	protected_jobs = list("Prisoner","Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Research Director", "Chief Engineer", "Chief Medical Officer")
 	restricted_jobs = list("AI", "Cyborg")
 	required_players = 0
 	required_enemies = 1

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -12,7 +12,7 @@
 	antag_flag = ROLE_TRAITOR
 	false_report_weight = 20 //Reports of traitors are pretty common.
 	restricted_jobs = list("Cyborg")//They are part of the AI if he is traitor so are they, they use to get double chances
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel") //YOGS -  added the hop
+	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Research Director", "Chief Engineer", "Chief Medical Officer") //YOGS -  added the hop
 	required_players = 0
 	required_enemies = 1
 	recommended_enemies = 4
@@ -43,7 +43,7 @@
 
 	if(CONFIG_GET(flag/protect_assistant_from_antagonist))
 		restricted_jobs += "Assistant"
-		
+
 	if(CONFIG_GET(flag/protect_AI_from_traitor))
 		restricted_jobs += "AI"
 

--- a/yogstation/code/game/gamemodes/darkspawn/darkspawn.dm
+++ b/yogstation/code/game/gamemodes/darkspawn/darkspawn.dm
@@ -14,7 +14,7 @@
 	recommended_enemies = 3
 	enemy_minimum_age = 15
 	restricted_jobs = list("AI", "Cyborg")
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel")
+	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Research Director", "Chief Engineer", "Chief Medical Officer")
 	title_icon = "ss13"
 
 /datum/game_mode/darkspawn/announce()
@@ -128,7 +128,7 @@
 	if(!istype(mind))
 		return FALSE
 	return mind.remove_antag_datum(/datum/antagonist/veil)
-	
+
 /datum/game_mode/darkspawn/generate_credit_text()
 	var/list/round_credits = list()
 	var/len_before_addition

--- a/yogstation/code/game/gamemodes/shadowling/shadowling.dm
+++ b/yogstation/code/game/gamemodes/shadowling/shadowling.dm
@@ -56,7 +56,7 @@ Made by Xhuis
 	recommended_enemies = 3
 	enemy_minimum_age = 14
 	restricted_jobs = list("AI", "Cyborg")
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer")
+	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Research Director", "Chief Engineer", "Chief Medical Officer")
 	title_icon = "ss13"
 
 /datum/game_mode/shadowling/announce()

--- a/yogstation/code/game/gamemodes/vampire/vampire.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire.dm
@@ -21,7 +21,7 @@
 	antag_flag = ROLE_VAMPIRE
 	false_report_weight = 1
 	restricted_jobs = list("AI", "Cyborg")
-	protected_jobs = list("Head of Security", "Captain", "Security Officer", "Chaplain", "Detective", "Warden", "Head of Personnel")
+	protected_jobs = list("Head of Security", "Captain", "Head of Personnel", "Research Director", "Chief Engineer", "Chief Medical Officer", "Security Officer", "Chaplain", "Detective", "Warden")
 	required_players = 15
 	required_enemies = 1
 	recommended_enemies = 3
@@ -106,7 +106,7 @@
 	return "The Wizard Federation has created a new being based off ancient mythology. \
 	These beings are known as vampires and are capable of sucking blood from crew members. \
 	No further information is known at this time."
-	
+
 /datum/game_mode/vampire/generate_credit_text()
 	var/list/round_credits = list()
 	var/len_before_addition


### PR DESCRIPTION
closes #10008
heads are supposed to be trustworthy and have access to the resources of an entire department, making them valuable in group antagonists and can basically be easy mode in solo antagonist roles. Converting a head of staff should be something risky for how much reward there is to it, not something attained at roundstart

keep in mind this doesn't mean you won't roll antag if you are trying to roll head roles, you'll just get assigned another job
:cl:  
tweak: heads of staff can no longer be antagonists
/:cl:
