### PR TITLE
prevents chaplain from being a heretic

### DIFF
--- a/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
+++ b/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
@@ -4,7 +4,7 @@
 	report_type = "heresy"
 	antag_flag = ROLE_HERETIC
 	false_report_weight = 5
-	protected_jobs = list("Prisoner","Security Officer", "Warden", "Detective", "Head of Security", "Captain")
+	protected_jobs = list("Chaplain","Security Officer", "Warden", "Detective", "Head of Security", "Captain")
 	restricted_jobs = list("AI", "Cyborg")
 	required_players = 0
 	required_enemies = 1


### PR DESCRIPTION
they get antimagic tools and shouldn't be in service of subversive powers since theyre the one role that tends to have powers to combat them

:cl:  
tweak: chaplains can't be heretics to their own religion
/:cl:
