### PR TITLE
[I Ded] Reduces the charges and recharge rate of the Locker Staff

### DIFF
--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -116,7 +116,7 @@
 	icon_state = "locker"
 	item_state = "locker"
 	max_charges = 2
-	recharge_rate = 10
+	recharge_rate = 12
 
 //yes, they don't have sounds. they're admin staves, and their projectiles will play the chaos bolt sound anyway so why bother?
 

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -115,8 +115,8 @@
 	ammo_type = /obj/item/ammo_casing/magic/locker
 	icon_state = "locker"
 	item_state = "locker"
-	max_charges = 6
-	recharge_rate = 4
+	max_charges = 2
+	recharge_rate = 10
 
 //yes, they don't have sounds. they're admin staves, and their projectiles will play the chaos bolt sound anyway so why bother?
 


### PR DESCRIPTION
## What's wrong, Altoids?

![image](https://user-images.githubusercontent.com/29939414/96332826-e6fe5d80-102b-11eb-9b52-6116f5393338.png)
![image](https://user-images.githubusercontent.com/29939414/96332836-eebe0200-102b-11eb-9022-95965b7f7763.png)

So the thing about the staffs is that, their recharge rate is determined by how often SSobj calls process() on the staff.

It being ``4`` by default seems to imply that, since the server has a 20 tickrate, it takes a fifth of a second for a charge to return.
![image](https://user-images.githubusercontent.com/29939414/96332959-8d4a6300-102c-11eb-9c4d-f48bf09481d6.png)

This has resulted in the Locker staff being practically unlimited uses, which is silly considering it:
* Blocks incoming projectiles with the locker

* Can be used to stop enemies from moving through tight spaces, such as maint

* Incapacitates enemies in a way that cannot be negated by drugs, armor, etc

* Is a s t u n m e c h a n i c

## What'd you do?

Given all that, I've made it recharge at a third the previous speed, and reduced the max charges to two. You get two shots to easy-peasy bag a guy, and if you miss both shots, you're through. None of this, "I dodge five lockers and still get gatted" business.

This is very much an ``i ded`` PR, but the Wizard, the server, and Jamie all agree that this is dumb, so I'm doing it.

## Changelog
:cl:  Altoids
tweak: The Locker Staff now takes a measurable amount of time to recharge, and only has two charges maximum.
/:cl:
