### PR TITLE
Fixes funny annoucements

### DIFF
--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -263,7 +263,7 @@ GLOBAL_LIST_EMPTY(req_console_ckey_departments)
 		if(isliving(usr))
 			var/mob/living/L = usr
 			message = L.treat_message(message)
-		minor_announce(message, "[department] Announcement:")
+		minor_announce(html_decode(message), "[department] Announcement:")
 		GLOB.news_network.SubmitArticle(message, department, "Station Announcements", null)
 		usr.log_talk(message, LOG_SAY, tag="station announcement from [src]")
 		message_admins("[ADMIN_LOOKUPFLW(usr)] has made a station announcement from [src] at [AREACOORD(usr)].")


### PR DESCRIPTION
Fixes the weird characters showing up in request console annoucements

Examples of it being broken:
![](https://cdn.discordapp.com/attachments/484171651550806029/767038832868327444/XBF34LP.png)
![](https://cdn.discordapp.com/attachments/484171651550806029/767038833216061450/gR8IeZO.png)

Its due to being html_encode'd twice so i just decode it before announcing it which will then reencode it

Coderbus shamed me into fixing it