### PR TITLE
Spellcard damage buff

### DIFF
--- a/code/modules/projectiles/projectile/magic/spellcard.dm
+++ b/code/modules/projectiles/projectile/magic/spellcard.dm
@@ -3,4 +3,4 @@
 	desc = "A piece of paper enchanted to give it extreme durability and stiffness, along with a very hot burn to anyone unfortunate enough to get hit by a charged one."
 	icon_state = "spellcard"
 	damage_type = BURN
-	damage = 2
+	damage = 3


### PR DESCRIPTION
This is a super simple buff to spell cards to hopefully make them a bit more viable. Right now spell cards cost 2 points, are robe less, have half the cooldown of fireball, and can deal up to 70 damage after clicking 5 times, and then you face a cooldown. There is almost no reason to pick spell cards over fireball, since fireball can instantly stun and deal a shit ton of damage to someone in one click, and most of the times leave them in critical due to fire damage. Fireball also can break down walls if you use it right just overall makes spell cards near useless.

TL;DR: Spell cards suck, damage buffed, they shouldn't suck anymore.

#### Changelog

:cl:  
tweak: Each spellcard now deals 3 damage instead of 2, letting each use of the spell deal up to 105 damage instead of 70.
/:cl:
