### PR TITLE
wizards are technophobes now

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -96,6 +96,7 @@
 #define TRAIT_NODISMEMBER		"dismember_immunity"
 #define TRAIT_NOFIRE			"nonflammable"
 #define TRAIT_NOGUNS			"no_guns"
+#define TRAIT_TECHNOPHOBE		"technophobe" // Not allowed to use technology
 #define TRAIT_NOINTERACT		"no_interact" //Not allowed to touch anything (even with TK) or use things in hand
 #define TRAIT_NOHUNGER			"no_hunger"
 #define TRAIT_EASYDISMEMBER		"easy_dismember"

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -254,7 +254,7 @@ Class Procs:
 	else
 		if(interaction_flags_machine & INTERACT_MACHINE_REQUIRES_SILICON)
 			return FALSE
-		if(is_species(user, /datum/species/lizard/ashwalker))
+		if(HAS_TRAIT(user, TRAIT_TECHNOPHOBE))
 			return FALSE
 		if(!Adjacent(user))
 			var/mob/living/carbon/H = user

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -155,11 +155,13 @@
 	var/mob/living/M = mob_override || owner.current
 	update_wiz_icons_added(M, wiz_team ? TRUE : FALSE) //Don't bother showing the icon if you're solo wizard
 	M.faction |= ROLE_WIZARD
+	ADD_TRAIT(M, TRAIT_TECHNOPHOBE, MAGIC_TRAIT)
 
 /datum/antagonist/wizard/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/M = mob_override || owner.current
 	update_wiz_icons_removed(M)
 	M.faction -= ROLE_WIZARD
+	REMOVE_TRAIT(M, TRAIT_TECHNOPHOBE, MAGIC_TRAIT)
 
 
 /datum/antagonist/wizard/get_admin_commands()

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -46,7 +46,7 @@
 	id = "ashlizard"
 	limbs_id = "lizard"
 	species_traits = list(MUTCOLORS,EYECOLOR,LIPS,DIGITIGRADE)
-	inherent_traits = list(TRAIT_NOGUNS) //yogs start - ashwalkers have special lungs and actually breathe
+	inherent_traits = list(TRAIT_NOGUNS, TRAIT_TECHNOPHOBE) //yogs start - ashwalkers have special lungs and actually breathe
 	mutantlungs = /obj/item/organ/lungs/ashwalker
 	breathid = "n2" // yogs end
 	species_language_holder = /datum/language_holder/lizard/ash


### PR DESCRIPTION
Makes technophobia a trait instead of being a check for the ashwalker

Gives wizards technophobia

I'm not really that attached to this, it's just something that popped into my head when I was reading the goon wiki and it said in the gamemode description that wizards were technophobic.

:cl:
tweak: Wizards now can't use machinery
/:cl: