### PR TITLE
Gives All Execution Variants Reinforced Walls (Boxstation)

### DIFF
--- a/_maps/RandomRuins/StationRuins/BoxStation/transfer1.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/transfer1.dmm
@@ -293,9 +293,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"M" = (
-/turf/closed/wall,
-/area/security/execution/transfer)
 "N" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/execution/transfer";
@@ -319,6 +316,12 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/white,
+/area/security/execution/transfer)
+"P" = (
+/turf/closed/wall{
+	icon = 'icons/turf/walls/reinforced_wall.dmi';
+	icon_state = "r_wall"
+	},
 /area/security/execution/transfer)
 "Q" = (
 /obj/structure/cable{
@@ -402,33 +405,33 @@ a
 a
 a
 a
-M
-M
-M
-M
-M
+P
+P
+P
+P
+P
 "}
 (2,1,1) = {"
 a
 a
 a
 a
-M
+P
 s
 U
 O
-M
+P
 "}
 (3,1,1) = {"
-M
-M
-M
+P
+P
+P
 d
-M
+P
 H
 z
 k
-M
+P
 "}
 (4,1,1) = {"
 Z

--- a/_maps/RandomRuins/StationRuins/BoxStation/transfer2.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/transfer2.dmm
@@ -308,15 +308,18 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"J" = (
+/turf/closed/wall{
+	icon = 'icons/turf/walls/reinforced_wall.dmi';
+	icon_state = "r_wall"
+	},
+/area/security/execution/transfer)
 "L" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/execution/transfer)
-"M" = (
-/turf/closed/wall,
 /area/security/execution/transfer)
 "N" = (
 /obj/machinery/power/apc{
@@ -417,33 +420,33 @@ a
 a
 a
 a
-M
-M
-M
-M
-M
+J
+J
+J
+J
+J
 "}
 (2,1,1) = {"
 a
 a
 a
 a
-M
+J
 s
 i
 Z
-M
+J
 "}
 (3,1,1) = {"
-M
-M
-M
+J
+J
+J
 d
-M
+J
 x
 w
 k
-M
+J
 "}
 (4,1,1) = {"
 u

--- a/_maps/RandomRuins/StationRuins/BoxStation/transfer3.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/transfer3.dmm
@@ -72,6 +72,12 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"o" = (
+/turf/closed/wall{
+	icon = 'icons/turf/walls/reinforced_wall.dmi';
+	icon_state = "r_wall"
+	},
+/area/security/execution/transfer)
 "p" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -327,9 +333,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"M" = (
-/turf/closed/wall,
-/area/security/execution/transfer)
 "N" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/execution/transfer";
@@ -437,33 +440,33 @@ a
 a
 a
 a
-M
-M
-M
-M
-M
+o
+o
+o
+o
+o
 "}
 (2,1,1) = {"
 a
 a
 a
 a
-M
+o
 s
 W
 V
-M
+o
 "}
 (3,1,1) = {"
 n
 n
-M
+o
 d
-M
+o
 p
 A
 J
-M
+o
 "}
 (4,1,1) = {"
 b

--- a/_maps/RandomRuins/StationRuins/BoxStation/transfer4.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/transfer4.dmm
@@ -231,6 +231,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"w" = (
+/turf/closed/wall{
+	icon = 'icons/turf/walls/reinforced_wall.dmi';
+	icon_state = "r_wall"
+	},
+/area/security/execution/transfer)
 "y" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast";
@@ -333,9 +339,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
-"M" = (
-/turf/closed/wall,
 /area/security/execution/transfer)
 "N" = (
 /obj/machinery/power/apc{
@@ -441,33 +444,33 @@ a
 a
 a
 a
-M
-M
-M
-M
-M
+w
+w
+w
+w
+w
 "}
 (2,1,1) = {"
 a
 a
 a
 a
-M
+w
 s
 g
 l
-M
+w
 "}
 (3,1,1) = {"
-M
-M
-M
+w
+w
+w
 d
-M
+w
 F
 b
 u
-M
+w
 "}
 (4,1,1) = {"
 Z

--- a/_maps/RandomRuins/StationRuins/BoxStation/transfer5.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/transfer5.dmm
@@ -101,6 +101,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"p" = (
+/turf/closed/wall{
+	icon = 'icons/turf/walls/reinforced_wall.dmi';
+	icon_state = "r_wall"
+	},
+/area/security/execution/transfer)
 "q" = (
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
@@ -298,9 +304,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"M" = (
-/turf/closed/wall,
-/area/security/execution/transfer)
 "N" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/execution/transfer";
@@ -415,33 +418,33 @@ a
 a
 a
 a
-M
-M
-M
-M
-M
+p
+p
+p
+p
+p
 "}
 (2,1,1) = {"
 a
 a
 a
 a
-M
+p
 s
 l
 j
-M
+p
 "}
 (3,1,1) = {"
-M
-M
-M
+p
+p
+p
 d
-M
+p
 w
 Y
 P
-M
+p
 "}
 (4,1,1) = {"
 Z

--- a/_maps/RandomRuins/StationRuins/BoxStation/transfer6.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/transfer6.dmm
@@ -282,9 +282,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/execution/transfer)
-"M" = (
-/turf/closed/wall,
-/area/security/execution/transfer)
 "N" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/execution/transfer";
@@ -324,6 +321,12 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
+"R" = (
+/turf/closed/wall{
+	icon = 'icons/turf/walls/reinforced_wall.dmi';
+	icon_state = "r_wall"
+	},
 /area/security/execution/transfer)
 "S" = (
 /obj/structure/cable{
@@ -420,33 +423,33 @@ a
 a
 a
 a
-M
-M
-M
-M
-M
+R
+R
+R
+R
+R
 "}
 (2,1,1) = {"
 a
 a
 a
 a
-M
+R
 s
 H
 Z
-M
+R
 "}
 (3,1,1) = {"
-M
-M
-M
+R
+R
+R
 d
-M
+R
 P
 n
 j
-M
+R
 "}
 (4,1,1) = {"
 w

--- a/_maps/RandomRuins/StationRuins/BoxStation/transfer7.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/transfer7.dmm
@@ -399,8 +399,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
-"M" = (
-/turf/closed/wall,
+"N" = (
+/turf/closed/wall{
+	icon = 'icons/turf/walls/reinforced_wall.dmi';
+	icon_state = "r_wall"
+	},
 /area/security/execution/transfer)
 "O" = (
 /obj/structure/cable{
@@ -475,33 +478,33 @@ a
 a
 a
 a
-M
-M
-M
-M
-M
+N
+N
+N
+N
+N
 "}
 (2,1,1) = {"
 a
 a
 a
 a
-M
+N
 s
 b
 S
-M
+N
 "}
 (3,1,1) = {"
 u
 u
-M
+N
 d
-M
+N
 L
 k
 j
-M
+N
 "}
 (4,1,1) = {"
 P

--- a/_maps/RandomRuins/StationRuins/BoxStation/transfer8.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/transfer8.dmm
@@ -279,6 +279,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"H" = (
+/turf/closed/wall{
+	icon = 'icons/turf/walls/reinforced_wall.dmi';
+	icon_state = "r_wall"
+	},
+/area/security/execution/transfer)
 "I" = (
 /obj/structure/table,
 /obj/item/folder/red{
@@ -302,9 +308,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/execution/transfer)
-"M" = (
-/turf/closed/wall,
 /area/security/execution/transfer)
 "N" = (
 /obj/machinery/power/apc{
@@ -409,33 +412,33 @@ a
 a
 a
 a
-M
-M
-M
-M
-M
+H
+H
+H
+H
+H
 "}
 (2,1,1) = {"
 a
 a
 a
 a
-M
+H
 s
 i
 n
-M
+H
 "}
 (3,1,1) = {"
-M
-M
-M
+H
+H
+H
 d
-M
+H
 z
 O
 m
-M
+H
 "}
 (4,1,1) = {"
 p

--- a/_maps/RandomRuins/StationRuins/BoxStation/transfer9.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/transfer9.dmm
@@ -2,6 +2,12 @@
 "a" = (
 /turf/template_noop,
 /area/space)
+"b" = (
+/turf/closed/wall{
+	icon = 'icons/turf/walls/reinforced_wall.dmi';
+	icon_state = "r_wall"
+	},
+/area/security/execution/transfer)
 "c" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -308,9 +314,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
-"M" = (
-/turf/closed/wall,
-/area/security/execution/transfer)
 "N" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/execution/transfer";
@@ -411,33 +414,33 @@ a
 a
 a
 a
-M
-M
-M
-M
-M
+b
+b
+b
+b
+b
 "}
 (2,1,1) = {"
 a
 a
 a
 a
-M
+b
 s
 t
 W
-M
+b
 "}
 (3,1,1) = {"
-M
-M
-M
+b
+b
+b
 d
-M
+b
 J
 l
 K
-M
+b
 "}
 (4,1,1) = {"
 O

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -411,9 +411,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"abc" = (
-/turf/closed/wall,
-/area/security/execution/transfer)
 "abd" = (
 /obj/machinery/bounty_board,
 /turf/closed/wall,
@@ -57346,6 +57343,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"tpl" = (
+/turf/closed/wall{
+	icon = 'icons/turf/walls/reinforced_wall.dmi';
+	icon_state = "r_wall"
+	},
+/area/security/execution/transfer)
 "tpq" = (
 /obj/item/coin/silver{
 	pixel_x = 7;
@@ -88590,7 +88593,7 @@ qQV
 qQV
 qQV
 qQV
-abc
+tpl
 aaf
 aaa
 aaf
@@ -88847,7 +88850,7 @@ qQV
 qQV
 qQV
 qQV
-abc
+tpl
 aaf
 aaa
 aaa
@@ -89104,7 +89107,7 @@ qQV
 qQV
 qQV
 qQV
-abc
+tpl
 aaf
 aaa
 aaf
@@ -89361,7 +89364,7 @@ qQV
 qQV
 qQV
 qQV
-abc
+tpl
 aaf
 aaa
 aaa

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -90909,7 +90909,7 @@ aej
 afy
 afD
 acd
-agJ
+agK
 ahp
 amb
 aiE
@@ -91166,7 +91166,7 @@ aei
 aeO
 afG
 acd
-agK
+agJ
 agK
 ail
 ajv

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -56772,6 +56772,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"sQI" = (
+/turf/closed/wall,
+/area/security/execution/transfer)
 "sQT" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
@@ -88840,7 +88843,7 @@ dxV
 uNu
 aat
 aUg
-afA
+sQI
 qQV
 qQV
 qQV
@@ -89097,7 +89100,7 @@ aat
 aat
 aat
 olh
-afA
+sQI
 qQV
 qQV
 qQV
@@ -89354,7 +89357,7 @@ aat
 aat
 aat
 sIN
-afA
+sQI
 qQV
 qQV
 qQV
@@ -89611,16 +89614,16 @@ aat
 aat
 hEn
 bab
-afA
-afA
-afA
-afA
-afA
-afA
-afA
+sQI
+sQI
+sQI
+sQI
+sQI
+sQI
+sQI
 aeT
-afA
-afA
+sQI
+sQI
 afA
 aaf
 aaa
@@ -89877,7 +89880,7 @@ acd
 aef
 aeU
 afz
-aai
+acd
 aai
 aai
 aai


### PR DESCRIPTION
This PR adds reinforced walls to all execution variants. This is inline with every outer area of Sec having reinforced walls, and it's honestly pretty easy to break in there and rescue your BB's corpse that they forgot to morgue once they execute them.

Should you have never seen the execution room before, this is what has changed:
![bpng](https://user-images.githubusercontent.com/62276730/96404615-56e62280-11a9-11eb-99ab-3385e2e7433a.png)
![cpng](https://user-images.githubusercontent.com/62276730/96404617-58afe600-11a9-11eb-801d-b2e39ba4130d.png)

:cl:  
rscadd: Added Reinforced walls to all Boxstation Execution variants.  
/:cl:
