### PR TITLE
Pepperspray is a lot more agonizing

### DIFF
--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -294,10 +294,10 @@
 			if(prob(30))
 				victim.emote("scream")
 			victim.blur_eyes(12)
-			victim.blind_eyes(6)
+			victim.blind_eyes(8)
 			victim.confused = max(M.confused, 10)
 			victim.damageoverlaytemp = 75
-			victim.Paralyze(75)
+			victim.Paralyze(80)
 			M.adjustStaminaLoss(3)
 			return
 		else if ( eyes_covered ) // Eye cover is better than mouth cover
@@ -309,10 +309,10 @@
 			if(prob(50))
 				victim.emote("scream")
 			victim.blur_eyes(12)
-			victim.blind_eyes(6)
+			victim.blind_eyes(8)
 			victim.confused = max(M.confused, 12)
 			victim.damageoverlaytemp = 100
-			victim.Paralyze(100)
+			victim.Paralyze(120)
 			M.adjustStaminaLoss(5)
 		victim.update_damage_hud()
 

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -293,9 +293,9 @@
 		else if ( mouth_covered )	// Reduced effects if partially protected
 			if(prob(30))
 				victim.emote("scream")
-			victim.blur_eyes(10)
+			victim.blur_eyes(12)
 			victim.blind_eyes(6)
-			victim.confused = max(M.confused, 8)
+			victim.confused = max(M.confused, 10)
 			victim.damageoverlaytemp = 75
 			victim.Paralyze(75)
 			M.adjustStaminaLoss(3)
@@ -308,9 +308,9 @@
 		else // Oh dear :D
 			if(prob(50))
 				victim.emote("scream")
-			victim.blur_eyes(10)
+			victim.blur_eyes(12)
 			victim.blind_eyes(6)
-			victim.confused = max(M.confused, 10)
+			victim.confused = max(M.confused, 12)
 			victim.damageoverlaytemp = 100
 			victim.Paralyze(100)
 			M.adjustStaminaLoss(5)

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -291,32 +291,35 @@
 		if ( eyes_covered && mouth_covered )
 			return
 		else if ( mouth_covered )	// Reduced effects if partially protected
-			if(prob(5))
+			if(prob(30))
 				victim.emote("scream")
-			victim.blur_eyes(3)
-			victim.blind_eyes(2)
-			victim.confused = max(M.confused, 3)
-			victim.damageoverlaytemp = 60
-			victim.Paralyze(60)
+			victim.blur_eyes(10)
+			victim.blind_eyes(6)
+			victim.confused = max(M.confused, 8)
+			victim.damageoverlaytemp = 75
+			victim.Paralyze(75)
+			M.adjustStaminaLoss(3)
 			return
 		else if ( eyes_covered ) // Eye cover is better than mouth cover
-			victim.blur_eyes(3)
+			victim.blur_eyes(4)
+			victim.confused = max(M.confused, 4)
 			victim.damageoverlaytemp = 30
 			return
 		else // Oh dear :D
-			if(prob(5))
+			if(prob(50))
 				victim.emote("scream")
-			victim.blur_eyes(5)
-			victim.blind_eyes(3)
-			victim.confused = max(M.confused, 6)
-			victim.damageoverlaytemp = 75
+			victim.blur_eyes(10)
+			victim.blind_eyes(6)
+			victim.confused = max(M.confused, 10)
+			victim.damageoverlaytemp = 100
 			victim.Paralyze(100)
+			M.adjustStaminaLoss(5)
 		victim.update_damage_hud()
 
 /datum/reagent/consumable/condensedcapsaicin/on_mob_life(mob/living/carbon/M)
-	if(prob(10))
-		M.visible_message("<span class='warning'>[M] [pick("dry heaves!","splutters!")]</span>")
 	if(prob(15))
+		M.visible_message("<span class='warning'>[M] [pick("dry heaves!","splutters!")]</span>")
+	if(prob(20))
 		M.emote("cough")
 
 	M.adjustStaminaLoss(3)
@@ -745,7 +748,7 @@
 	taste_mult = 2
 	taste_description = "bitter sweetness"
 	reagent_state = SOLID
-	
+
 /datum/reagent/consumable/mesophilicculture
 	name = "mesophilic culture"
 	description = "A mixture of mesophilic bacteria used to make most cheese."
@@ -769,7 +772,7 @@
 	description = "A special bacterium used to make blue cheese."
 	color = "#365E30" // rgb: 54, 94, 48
 	taste_description = "bitterness"
-	
+
 /datum/reagent/consumable/parmesan_delight
 	name = "Parmesan Delight"
 	description = "The time spent cultivating parmesan has produced this magical liquid."
@@ -800,4 +803,4 @@
 	color = "#75553a"
 	taste_mult = 1.5
 	taste_description = "gravy"
-	
+

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -275,7 +275,7 @@
 	description = "A chemical agent used for self-defense and in police work."
 	color = "#B31008" // rgb: 179, 16, 8
 	taste_description = "scorching agony"
-	metabolization_rate = 4 * REAGENTS_METABOLISM
+	metabolization_rate = 6 * REAGENTS_METABOLISM
 
 /datum/reagent/consumable/condensedcapsaicin/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	if(!ishuman(M) && !ismonkey(M))
@@ -301,9 +301,12 @@
 			M.adjustStaminaLoss(3)
 			return
 		else if ( eyes_covered ) // Eye cover is better than mouth cover
+			if(prob(20))
+				M.emote("cough")
 			victim.blur_eyes(4)
-			victim.confused = max(M.confused, 4)
-			victim.damageoverlaytemp = 30
+			victim.confused = max(M.confused, 6)
+			victim.damageoverlaytemp = 50
+			M.adjustStaminaLoss(3)
 			return
 		else // Oh dear :D
 			if(prob(50))


### PR DESCRIPTION
The title

Condensed capsaicin, and therefor pepperspray and tear gas grenades, is much more agonizing and painful. It blurs and blinds your eyes for longer, makes you scream more often, gives you a longer confused timer, and also causes stamina damage now. Tear gas grenades also make you cough more often. I've tested it, and it seems fairly balanced.  You can still almost completely nullify the effects of pepperspray with just eyeglasses, while glasses and a mask completely remove all it's effects. Having a mask on will still somewhat reduce the effects, although not as much as it used to.

#### Changelog

:cl:  
rscadd: Pepperspray stuns, confuses, and blinds you for longer, among other things.
/:cl:
