### PR TITLE
fix stunbatons stunning if they are caught

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -41,7 +41,8 @@
 	update_icon()
 
 /obj/item/melee/baton/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
-	..()
+	if(..())
+		return
 	//Only mob/living types have stun handling
 	if(status && prob(throw_hit_chance) && iscarbon(hit_atom))
 		baton_stun(hit_atom)


### PR DESCRIPTION
theos is mad
:cl:  
bugfix: stunbatons won't stun you if you catch them
/:cl:
