### PR TITLE
Moves the seclathe into the armory

### DIFF
--- a/_maps/map_files/EclipseStation/EclipseStation.dmm
+++ b/_maps/map_files/EclipseStation/EclipseStation.dmm
@@ -3489,8 +3489,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ahu" = (
-/obj/structure/table,
-/obj/machinery/recharger,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -3501,6 +3499,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/rnd/production/techfab/department/security,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ahv" = (
@@ -3699,7 +3698,9 @@
 	icon_state = "0-8"
 	},
 /obj/structure/table,
-/obj/machinery/recharger,
+/obj/machinery/recharger{
+	pixel_x = -6
+	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -3709,6 +3710,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/recharger{
+	pixel_x = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -11376,7 +11380,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "axU" = (
-/obj/machinery/rnd/production/techfab/department/security,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8

--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -6366,16 +6366,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig)
-"aiV" = (
-/obj/machinery/rnd/production/techfab/department/security,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aiW" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/maintenance/port/central";
@@ -28280,22 +28270,13 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "glM" = (
-/obj/item/storage/box/teargas{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/flashbangs{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/rnd/production/techfab/department/security,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "gni" = (
@@ -31154,6 +31135,15 @@
 /obj/item/camera,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
+"jhz" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "jik" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -44451,7 +44441,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
-/mob/living/simple_animal/parrot/Poly,
 /obj/machinery/camera{
 	c_tag = "Chief Engineer's Office";
 	dir = 2
@@ -44459,6 +44448,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/mob/living/simple_animal/parrot/Poly,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "vHJ" = (
@@ -45470,6 +45460,15 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26
+	},
+/obj/item/storage/box/teargas{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/flashbangs{
+	pixel_x = -3;
+	pixel_y = -3
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -81145,8 +81144,8 @@ aCB
 agF
 aFm
 agF
-aiV
 ajV
+jhz
 akW
 alN
 amK

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -2466,7 +2466,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/space)
 "afL" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
@@ -4743,7 +4743,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area)
 "akr" = (
 /obj/structure/table,
 /obj/item/folder/red,
@@ -4938,7 +4938,7 @@
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/security/brig)
+/area/space)
 "akN" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -4948,7 +4948,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/security/brig)
+/area/space)
 "akO" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	id = "Cell 1";
@@ -4964,7 +4964,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/space)
 "akP" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
@@ -4976,7 +4976,7 @@
 	icon_state = "4-8"
 	},
 /turf/closed/wall,
-/area/security/brig)
+/area/space)
 "akR" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	id = "Cell 2";
@@ -4992,7 +4992,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/space)
 "akS" = (
 /obj/machinery/computer/security/telescreen{
 	dir = 8;
@@ -5021,7 +5021,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area)
 "akU" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig Desk";
@@ -5038,7 +5038,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/space)
 "akV" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -5048,7 +5048,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/security/brig)
+/area/space)
 "akW" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/security/glass{
@@ -5071,7 +5071,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/space)
 "akX" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/security/glass{
@@ -5096,7 +5096,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/space)
 "akY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -5321,7 +5321,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/space)
 "alB" = (
 /obj/machinery/computer/secure_data,
 /turf/open/floor/plasteel/dark,
@@ -5578,7 +5578,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area)
 "amj" = (
 /obj/structure/bed,
 /obj/machinery/flasher{
@@ -5621,7 +5621,7 @@
 	req_access_txt = "63"
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/space)
 "amm" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -5641,13 +5641,13 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/space)
 "amn" = (
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/space)
 "amo" = (
 /obj/machinery/flasher{
 	id = "brigentry";
@@ -5991,7 +5991,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/space)
 "amU" = (
 /obj/machinery/button/flasher{
 	id = "cell4";
@@ -6019,7 +6019,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/space)
 "amW" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "testlab";
@@ -6067,7 +6067,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area)
 "ana" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -7965,7 +7965,7 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
-/area/security/brig)
+/area/space)
 "arZ" = (
 /obj/structure/filingcabinet,
 /obj/structure/disposalpipe/segment,
@@ -8135,7 +8135,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/space)
 "asv" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -8474,7 +8474,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/space)
 "atp" = (
 /obj/machinery/door/airlock/external{
 	name = "Construction Zone"
@@ -12665,8 +12665,21 @@
 "aEs" = (
 /obj/effect/turf_decal/bot_white,
 /obj/structure/rack,
-/obj/item/storage/box/firingpins,
-/obj/item/storage/box/firingpins,
+/obj/item/storage/box/firingpins{
+	pixel_x = -8
+	},
+/obj/item/storage/box/firingpins{
+	pixel_x = -8
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = 8
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = 8
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aEt" = (
@@ -12674,10 +12687,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/structure/rack,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
+/obj/machinery/rnd/production/techfab/department/security,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aEu" = (
@@ -37505,14 +37515,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"clS" = (
-/obj/machinery/rnd/production/techfab/department/security,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "clZ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -40348,7 +40350,6 @@
 	dir = 8
 	},
 /obj/structure/bed/dogbed/runtime,
-/mob/living/simple_animal/pet/cat/Runtime,
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/cmo";
 	dir = 4;
@@ -40358,6 +40359,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/mob/living/simple_animal/pet/cat/Runtime,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "dBa" = (
@@ -41093,12 +41095,12 @@
 /area/science/xenobiology)
 "ehJ" = (
 /obj/structure/flora/ausbushes/grassybush,
-/mob/living/carbon/monkey,
 /obj/machinery/door/window/westleft{
 	dir = 2;
 	name = "Monkey Pen";
 	req_access_txt = "9"
 	},
+/mob/living/carbon/monkey,
 /turf/open/floor/grass,
 /area/medical/genetics)
 "ehN" = (
@@ -43110,6 +43112,13 @@
 	},
 /turf/open/floor/plating,
 /area/medical/virology)
+"fVm" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "fVQ" = (
 /obj/structure/table,
 /obj/item/analyzer,
@@ -44291,6 +44300,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/fore)
+"gXh" = (
+/turf/closed/wall,
+/area/space)
 "gXs" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -44443,6 +44455,20 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
+"hiz" = (
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = -25;
+	pixel_y = -2;
+	prison_radio = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area)
 "hky" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/yellow{
@@ -46228,6 +46254,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"iGx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area)
 "iHb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -46711,6 +46746,10 @@
 /obj/effect/turf_decal/tile/slightlydarkerblue,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"jbF" = (
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area)
 "jbI" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -47768,6 +47807,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"jTS" = (
+/turf/open/floor/plasteel,
+/area/space)
 "jUt" = (
 /obj/structure/altar_of_gods,
 /turf/open/floor/plasteel/dark,
@@ -48127,6 +48169,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/fore)
+"kfc" = (
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "kfB" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -48414,6 +48465,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"kuC" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "kvW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -49144,6 +49201,15 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"lax" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area)
 "laH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -49244,9 +49310,9 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "leK" = (
-/mob/living/carbon/monkey,
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/leafybush,
+/mob/living/carbon/monkey,
 /turf/open/floor/grass,
 /area/medical/genetics)
 "lgx" = (
@@ -53087,6 +53153,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"okV" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/closed/wall/r_wall,
+/area/space)
 "olh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/sustenance{
@@ -54026,6 +54098,29 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"oWU" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area)
+"oXa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area)
 "oXp" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -58590,9 +58685,9 @@
 /area/crew_quarters/toilet/locker)
 "sMx" = (
 /obj/structure/window/reinforced,
-/mob/living/carbon/monkey,
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
+/mob/living/carbon/monkey,
 /turf/open/floor/grass,
 /area/medical/genetics)
 "sNe" = (
@@ -58903,6 +58998,18 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
+"tdg" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "tdr" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel/white,
@@ -59306,6 +59413,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"tsd" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area)
 "tsI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60230,6 +60344,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"ukZ" = (
+/turf/closed/wall,
+/area)
 "ulD" = (
 /obj/structure/tank_dispenser,
 /obj/effect/turf_decal/bot{
@@ -61453,6 +61570,12 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"voV" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area)
 "vpp" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -62030,6 +62153,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/fore)
+"vOR" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area)
 "vPm" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment{
@@ -63697,6 +63830,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"xtv" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "xtG" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -92358,7 +92501,7 @@ aiE
 acd
 ahZ
 akg
-agj
+gXh
 adL
 ahr
 aih
@@ -92615,7 +92758,7 @@ ajv
 agl
 ajx
 akj
-agj
+gXh
 agj
 agj
 aiX
@@ -94417,8 +94560,8 @@ akk
 akN
 aqn
 ami
-amR
-anw
+oWU
+voV
 anz
 aov
 api
@@ -94672,8 +94815,8 @@ aiI
 ajH
 ako
 akQ
-agj
-agj
+ukZ
+ukZ
 amS
 any
 anz
@@ -94928,8 +95071,8 @@ agR
 ajd
 ajB
 akm
-akV
-aqa
+vOR
+hiz
 amj
 amR
 anw
@@ -95184,13 +95327,13 @@ ahS
 aiK
 ajc
 apo
-akl
+oXa
 akT
 amZ
 alx
 amR
-anw
-anz
+kuC
+jTS
 aov
 apk
 anw
@@ -95440,13 +95583,13 @@ agL
 anq
 aiJ
 ajc
-ajH
-akk
-akV
+iGx
+jbF
+vOR
 aqn
 amk
 amR
-anw
+kuC
 anr
 avi
 avm
@@ -95696,14 +95839,14 @@ aoK
 ayd
 ahX
 aiL
-ajc
-ajH
+lax
+iGx
 akq
 akQ
 agj
 agj
-amS
-anx
+okV
+kfc
 anv
 aoz
 apm
@@ -95954,8 +96097,8 @@ ahy
 aie
 aiN
 ajc
-ajH
-akp
+iGx
+tsd
 akU
 alz
 aml
@@ -96211,7 +96354,7 @@ cxk
 agt
 aiM
 ajc
-ajH
+iGx
 akp
 akV
 alB
@@ -96467,8 +96610,8 @@ agt
 ahA
 aHp
 aIF
-ajc
-ajH
+lax
+iGx
 akp
 akQ
 alA
@@ -96728,8 +96871,8 @@ agf
 ajH
 alC
 akX
-alC
-alC
+tdg
+tdg
 amI
 anz
 anv
@@ -96985,7 +97128,7 @@ anS
 akc
 aiG
 akW
-aiG
+xtv
 amo
 amJ
 anz
@@ -97242,7 +97385,7 @@ aiQ
 ajH
 amq
 akQ
-agj
+gXh
 agj
 aiX
 anB
@@ -98521,7 +98664,7 @@ afT
 agz
 ahb
 ahI
-bHT
+fVm
 abp
 ajh
 ajn
@@ -98778,7 +98921,7 @@ afV
 agB
 ahd
 ahI
-clS
+bHT
 abp
 ajj
 ajP

--- a/_maps/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/map_files/YogsDelta/YogsDelta.dmm
@@ -38771,7 +38771,6 @@
 /obj/machinery/newscaster/security_unit{
 	pixel_y = 32
 	},
-/obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -38784,14 +38783,13 @@
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/stripes/box,
-/obj/machinery/rnd/production/techfab/department/security,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/security/main)
 "biM" = (
@@ -39630,20 +39628,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"bjP" = (
-/obj/effect/turf_decal/loading_area,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "bjQ" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -41994,11 +41978,10 @@
 /turf/closed/wall/r_wall,
 /area/security/execution/transfer)
 "bnH" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/rnd/production/techfab/department/security,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "bnI" = (
@@ -65202,7 +65185,9 @@
 /area/crew_quarters/dorms)
 "bVl" = (
 /obj/structure/table/reinforced,
-/obj/machinery/recharger,
+/obj/machinery/recharger{
+	pixel_x = -6
+	},
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -32
 	},
@@ -65211,6 +65196,9 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/recharger{
+	pixel_x = 6
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
@@ -181108,7 +181096,7 @@ aFm
 aaa
 bnc
 biL
-bjP
+bkw
 bkw
 aKk
 bbD

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -3475,6 +3475,13 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/storage/box/teargas{
+	pixel_x = 1;
+	pixel_y = -2
+	},
+/obj/item/storage/box/flashes{
+	pixel_x = 3
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aga" = (
@@ -4287,13 +4294,6 @@
 	icon_state = "2-4"
 	},
 /obj/structure/rack,
-/obj/item/storage/box/flashes{
-	pixel_x = 3
-	},
-/obj/item/storage/box/teargas{
-	pixel_x = 1;
-	pixel_y = -2
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -4304,6 +4304,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/storage/box/breacherslug,
+/obj/item/storage/box/breacherslug,
+/obj/item/gun/ballistic/shotgun/automatic/breaching,
+/obj/item/gun/ballistic/shotgun/automatic/breaching,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ahF" = (
@@ -7788,12 +7792,8 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
 "anq" = (
-/obj/structure/rack,
 /obj/effect/turf_decal/bot,
-/obj/item/storage/box/breacherslug,
-/obj/item/storage/box/breacherslug,
-/obj/item/gun/ballistic/shotgun/automatic/breaching,
-/obj/item/gun/ballistic/shotgun/automatic/breaching,
+/obj/machinery/rnd/production/techfab/department/security,
 /turf/open/floor/plasteel,
 /area/security/warden)
 "anr" = (
@@ -10814,7 +10814,6 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "asL" = (
-/obj/machinery/rnd/production/techfab/department/security,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -10822,6 +10821,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/security/main)
 "asM" = (


### PR DESCRIPTION
The seclathe can print guns, guns should be located in the armory, not the security office.

#### Changelog

:cl:  
tweak: The seclathe is now located in the armory
/:cl:
