### PR TITLE
poppy the safety possum is resistant to lasers on the SM engine

### DIFF
--- a/_maps/RandomRuins/StationRuins/BoxStation/engine_sm.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/engine_sm.dmm
@@ -2026,8 +2026,10 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"Jj" = (
-/mob/living/simple_animal/opossum/poppy,
+"IP" = (
+/mob/living/simple_animal/opossum/poppy{
+	damage_coeff = list("brute" = 1, "fire" = 1, "tox" = 1, "clone" = 1, "stamina" = 0, "oxy" = 1, "laser" = 0)
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "Pb" = (
@@ -2401,7 +2403,7 @@ dl
 dB
 ad
 dT
-Jj
+IP
 eg
 bN
 ev


### PR DESCRIPTION
title, it hurts my soul to see poppy get fuggen blasted every round. i may have done a shitcode moment, just let me know. i wanted to move poppy, but there was no better area so i decided to go this route. plus, its funny to see a possum be completely laser proof.
🆑
tweak: poppy is immune to lasers in sm engine
/🆑