### PR TITLE
changes probabilty for legion to drop a necropolis chest to 10

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -164,7 +164,7 @@ Difficulty: Medium
 		if(last_legion)
 			loot = list(/obj/item/staff/storm)
 			elimination = FALSE
-		else if(prob(5))
+		else if(prob(10))
 			loot = list(/obj/structure/closet/crate/necropolis/tendril)
 		if(!true_spawn)
 			loot = null


### PR DESCRIPTION
its awful for it to be 5% especially because of its main drop not even working properly alot of the time
#### Changelog

:cl:  
tweak: tweaked necropolis chest drop rate
/:cl:
