### PR TITLE
Adds Mime mech to Clownops 

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1117,6 +1117,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 80
 	include_modes = list(/datum/game_mode/nuclear/clown_ops)
 
+/datum/uplink_item/support/reticence
+	name = "Reticence"
+	desc = "A silent, fast, and nigh-invisible miming exosuit. Popular among mimes and mime assassins."
+	item = /obj/mecha/combat/reticence/loaded
+	cost = 45
+	include_modes = list(/datum/game_mode/nuclear/clown_ops)
+
 /datum/uplink_item/support/mauler
 	name = "Mauler Exosuit"
 	desc = "A massive and incredibly deadly military-grade exosuit. Features long-range targeting, thrust vectoring \


### PR DESCRIPTION
### Intent of your Pull Request

For 45TC, up for discussion

# Reticence Stats:

## Movement speed: 2
#### Ripley APLU has 1.5 speed
#### Gygax & Phazon & Odysseus has 2 speed
#### Durand has 4 speed

## Armor: 25 melee, 20 bullet, 30 laser, 15 energy. 15.000°K max temperature.
#### Odysseus has 20 melee, 10 bullet. 25.000°K max temperature
#### Ripley APLU has 40 melee, 20 bullet, 10 laser, 20 energy, 40 bomb. 20.000°K max temperature
#### Gygax has 25 melee, 20 bullet, 30 laser, 15 energy. 25.000°K max temperature
#### Durand has 40 melee, 35 bullet, 15 laser, 10 energy, 20 bomb. 30.000°K max temperature

## Integrity: 100
#### Odysseus has 120 integrity
#### Ripley APLU has 200 integrity
#### Gygax has 250 integrity
#### Durand has 400 integrity

## Equipped with
#### S.H.H. "Quietus" Carbine, injects you with mute toxin when hit
#### Mounted RCD
#### Stun punch (like Gygax and Durand)
#### Incredibly low opacity (see below)

![image](https://user-images.githubusercontent.com/28408322/96674882-b2461b00-1337-11eb-8a52-680418003b4d.png)

:cl:  
rscadd: Added Reticence to Clownops 
/:cl:
