### PR TITLE
walls are harder to slice through

### DIFF
--- a/code/game/turfs/simulated/wall/mineral_walls.dm
+++ b/code/game/turfs/simulated/wall/mineral_walls.dm
@@ -30,7 +30,7 @@
 	icon = 'icons/turf/walls/diamond_wall.dmi'
 	icon_state = "diamond"
 	sheet_type = /obj/item/stack/sheet/mineral/diamond
-	slicing_duration = 200   //diamond wall takes twice as much time to slice
+	slicing_duration = 400   //diamond wall takes twice as much time to slice
 	explosion_block = 3
 	canSmoothWith = list(/turf/closed/wall/mineral/diamond, /obj/structure/falsewall/diamond)
 
@@ -180,7 +180,7 @@
 	icon_state = "abductor"
 	smooth = SMOOTH_TRUE|SMOOTH_DIAGONAL
 	sheet_type = /obj/item/stack/sheet/mineral/abductor
-	slicing_duration = 200   //alien wall takes twice as much time to slice
+	slicing_duration = 400   //alien wall takes twice as much time to slice
 	explosion_block = 3
 	canSmoothWith = list(/turf/closed/wall/mineral/abductor, /obj/structure/falsewall/abductor)
 

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -16,8 +16,8 @@
 		pipe_astar_cost = 50 /* nich really doesn't like pipes that go through walls */\
 	)
 
-	var/hardness = 40 //lower numbers are harder. Used to determine the probability of a hulk smashing through.
-	var/slicing_duration = 100  //default time taken to slice the wall
+	var/hardness = 30 //lower numbers are harder. Used to determine the probability of a hulk smashing through.
+	var/slicing_duration = 200  //default time taken to slice the wall
 	var/sheet_type = /obj/item/stack/sheet/metal
 	var/sheet_amount = 2
 	var/girder_type = /obj/structure/girder


### PR DESCRIPTION
Walls now take twice as long to slice through and are a little bit more durable to hulk punches. It used to take 8 seconds to cut through a wall, now it takes 16 seconds. Feel free to say if it feels like too much. This also makes diamond and alien walls take 32 seconds to cut through, since both are normally twice as strong as normal walls, so they were buffed in comparison.

#### Changelog

:cl:  
tweak: Walls are tougher
/:cl:
