### PR TITLE
Moves Clownbug to Hostile gold slime pool instead of Passive

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/cockroach.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cockroach.dm
@@ -59,6 +59,7 @@
 	desc = "Absolutely disgusting... almost as horrid as that one green clown."
 	icon_state = "clowngoblin"
 	icon_dead = "clowngoblin"
+	gold_core_spawnable = NO_SPAWN
 	verb_say = "honks"
 	verb_ask = "honks inquisitively"
 	verb_exclaim = "honks loudly"

--- a/code/modules/mob/living/simple_animal/friendly/cockroach.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cockroach.dm
@@ -59,7 +59,7 @@
 	desc = "Absolutely disgusting... almost as horrid as that one green clown."
 	icon_state = "clowngoblin"
 	icon_dead = "clowngoblin"
-	gold_core_spawnable = NO_SPAWN
+	gold_core_spawnable = HOSTILE_SPAWN
 	verb_say = "honks"
 	verb_ask = "honks inquisitively"
 	verb_exclaim = "honks loudly"


### PR DESCRIPTION
### Intent of your Pull Request
Fixes issue #10092 

It's a funny meme, but it can easily crash the server. 

This is unfortunately a kind of hacky workaround, and it adds yet _more_ things to the hostile gold spawn pool, but now it can't be made with the stabilized gold core, and thus won't crash the server. 

#### Changelog

:cl:  
rscdel: Clown bug has been retired from passive gold slime pool and moved to hostile. He knows what he did.
/:cl:
