### PR TITLE
gives the bridge, ai upload, and tcomms reinforced plasma windows.

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -10538,6 +10538,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"aBf" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/tcommsat/server)
 "aBj" = (
 /obj/structure/rack,
 /obj/machinery/light{
@@ -15899,92 +15903,6 @@
 "aPR" = (
 /turf/closed/wall/r_wall,
 /area/bridge)
-"aPS" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/bridge)
-"aPT" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/bridge)
-"aPU" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/status_display/evac,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/bridge)
-"aPW" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/status_display/evac,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/bridge)
-"aPX" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/bridge)
 "aQi" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -18401,6 +18319,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"aXZ" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/bridge)
 "aYd" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/wood,
@@ -19726,20 +19659,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bbW" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "heads_meeting";
-	name = "privacy shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/bridge/meeting_room)
 "bbX" = (
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
@@ -20167,20 +20086,6 @@
 	},
 /turf/open/floor/carpet,
 /area/vacant_room)
-"bcX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "heads_meeting";
-	name = "privacy shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/bridge/meeting_room)
 "bcZ" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
@@ -24987,23 +24892,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bqx" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hop";
-	name = "Privacy Shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hop)
 "bqy" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -25337,24 +25225,6 @@
 /area/quartermaster/office)
 "brS" = (
 /turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
-"brU" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hop";
-	name = "Privacy Shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
 "brV" = (
 /obj/effect/decal/cleanable/oil,
@@ -32297,24 +32167,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"bPA" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plating,
-/area/bridge)
 "bPK" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -37024,10 +36876,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"dcc" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/open/floor/plating,
-/area/tcommsat/computer)
 "dch" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -37510,6 +37358,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"dwp" = (
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/bridge)
 "dwx" = (
 /obj/item/radio/intercom{
 	pixel_y = 30
@@ -37732,6 +37598,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"dDh" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/bridge)
 "dDm" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -37972,6 +37851,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"dMc" = (
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/bridge)
 "dNe" = (
 /obj/machinery/computer/prisoner,
 /turf/open/floor/plasteel/dark,
@@ -38231,6 +38125,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"dWV" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hop";
+	name = "Privacy Shutters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hop)
 "dXk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -38446,6 +38357,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"ekP" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hop";
+	name = "Privacy Shutters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hop)
 "ekT" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -41164,6 +41093,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"gxx" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/plasma/reinforced/shutter,
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/ai_upload)
 "gxK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -41280,6 +41214,14 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"gDF" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "tcomms";
+	name = "Telecommunications server shutters"
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/tcommsat/server)
 "gDG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41622,6 +41564,27 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"gTC" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/bridge)
 "gTU" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -43148,6 +43111,24 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"ihY" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/bridge)
 "ijm" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -44506,6 +44487,25 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"jhN" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/status_display/evac,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/bridge)
 "jhQ" = (
 /obj/structure/table/glass,
 /obj/machinery/door/window/northleft{
@@ -44763,21 +44763,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"jrE" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plating,
-/area/bridge)
 "jrI" = (
 /turf/closed/wall/r_wall,
 /area/medical/medbay/aft)
@@ -45937,6 +45922,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"knJ" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/bridge)
 "kob" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -46001,19 +46001,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
-"kpH" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plating,
-/area/bridge)
 "kpQ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -47254,14 +47241,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
-"lpR" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "tcomms";
-	name = "Telecommunications server shutters"
-	},
-/turf/open/floor/plating,
-/area/tcommsat/server)
 "lql" = (
 /obj/structure/table,
 /obj/item/stock_parts/subspace/filter,
@@ -49323,27 +49302,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"naT" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/bridge)
 "nbu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -50672,16 +50630,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"oaa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plating,
-/area/bridge)
 "oaW" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -51675,10 +51623,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"oJh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/tcommsat/server)
 "oKv" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
@@ -51778,6 +51722,20 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"oPF" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "heads_meeting";
+	name = "privacy shutters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/bridge/meeting_room)
 "oQi" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -52036,6 +51994,10 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
+"paM" = (
+/obj/effect/spawner/structure/window/plasma/reinforced/shutter,
+/turf/open/floor/plating,
+/area/tcommsat/computer)
 "pbM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/white,
@@ -54765,17 +54727,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"riH" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "tcomms_bridge";
-	name = "Telecommunications server shutters"
-	},
-/turf/open/floor/plating,
-/area/bridge)
 "rjA" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/slightlydarkerblue{
@@ -56889,11 +56840,6 @@
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
-"tcg" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/ai_upload)
 "tcL" = (
 /turf/open/floor/plasteel,
 /area/janitor)
@@ -57192,6 +57138,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"tow" = (
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/bridge)
 "toE" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -60979,6 +60935,25 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"wsx" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/status_display/evac,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/bridge)
 "wte" = (
 /obj/machinery/computer/crew,
 /obj/effect/turf_decal/tile/blue{
@@ -61570,6 +61545,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"wRM" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "tcomms_bridge";
+	name = "Telecommunications server shutters"
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/bridge)
 "wRR" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -90401,9 +90387,9 @@ bBi
 rEr
 dvH
 aZM
-bbW
-bcX
-bcX
+oPF
+oPF
+oPF
 aZM
 aZM
 aZM
@@ -90910,9 +90896,9 @@ bOS
 aaa
 aaa
 aTQ
-jrE
+dMc
 jqu
-oaa
+tow
 aZM
 aZq
 bbX
@@ -90926,8 +90912,8 @@ bqG
 bmr
 bmr
 boZ
-bqx
-brU
+dWV
+ekP
 bJX
 bmr
 bmr
@@ -91457,7 +91443,7 @@ aHj
 nma
 lYK
 oOH
-tcg
+gxx
 aaa
 lsK
 bRl
@@ -91971,7 +91957,7 @@ aHj
 pTL
 wdb
 gbM
-tcg
+gxx
 gXs
 lsK
 bNJ
@@ -92705,7 +92691,7 @@ bOS
 aJq
 aJq
 epq
-aPT
+knJ
 qmp
 izT
 pLS
@@ -92962,7 +92948,7 @@ bOS
 aJq
 aJq
 epq
-aPS
+ihY
 nEy
 jJD
 hRj
@@ -92977,14 +92963,14 @@ ekT
 cjW
 qwE
 ivT
-lpR
+gDF
 oSn
 eyT
 nUo
 yeb
 bVJ
-dcc
-dcc
+paM
+paM
 lFe
 aaa
 bOS
@@ -93219,13 +93205,13 @@ aKE
 aMa
 aNw
 epq
-aPU
+jhN
 dNe
 gjh
 hRj
 pRc
 nXa
-riH
+wRM
 tna
 sjp
 lPO
@@ -93234,7 +93220,7 @@ qee
 loF
 huI
 vAP
-lpR
+gDF
 tre
 eyT
 eyT
@@ -93476,7 +93462,7 @@ aJq
 aLZ
 aNv
 epq
-aPS
+ihY
 sAY
 bSP
 iof
@@ -93733,7 +93719,7 @@ aJq
 aMc
 aNy
 epq
-aPS
+ihY
 hZV
 bBj
 niM
@@ -93747,7 +93733,7 @@ qKK
 cPo
 qVN
 mFQ
-oJh
+aBf
 lhU
 yeb
 pOT
@@ -93990,7 +93976,7 @@ aJq
 aMb
 aNx
 epq
-aPS
+ihY
 rNu
 tfN
 hRj
@@ -94247,7 +94233,7 @@ aJq
 aMe
 aNA
 epq
-aPS
+ihY
 jWD
 jeK
 sAI
@@ -94261,7 +94247,7 @@ snD
 tEo
 uab
 hQm
-oJh
+aBf
 mZf
 yeb
 jgh
@@ -94504,7 +94490,7 @@ aJq
 aMd
 aNz
 epq
-aPS
+ihY
 obF
 dcM
 txp
@@ -94761,13 +94747,13 @@ aKF
 aMf
 aNB
 epq
-aPW
+wsx
 gax
 qgb
 iDN
 giN
 eTw
-riH
+wRM
 tbW
 kVQ
 xdg
@@ -94776,7 +94762,7 @@ pUK
 qEu
 gtE
 pBw
-lpR
+gDF
 uSQ
 oiA
 msT
@@ -95018,7 +95004,7 @@ bOS
 aJq
 aJq
 epq
-naT
+gTC
 pyD
 vAl
 rGJ
@@ -95033,14 +95019,14 @@ xYQ
 utm
 mCx
 diw
-lpR
+gDF
 ekU
 eDM
 nFx
 yeb
 bVJ
-dcc
-dcc
+paM
+paM
 lFe
 aaa
 bOS
@@ -95275,7 +95261,7 @@ bOS
 aJq
 aJq
 epq
-aPX
+aXZ
 gls
 nvJ
 tyN
@@ -97078,9 +97064,9 @@ bOS
 aaa
 aaa
 aTQ
-bPA
+dwp
 dIK
-kpH
+dDh
 aZV
 bbu
 bbw


### PR DESCRIPTION
in my opinion the windows are underused, and with the rwindow buff probably being changed, i thought that to add more security the bridge should have the strongest windows nanotrasen could pay for. they are nanotrasens finest on their new fancy research station, are they not?
🆑
tweak: rwindows on bridge and such
/🆑