### PR TITLE
Chem heaters now heat up linerarly

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -65,10 +65,9 @@
 	if(stat & NOPOWER)
 		return
 	if(on && beaker?.reagents.total_volume)
+		currentspeed = heater_speed
 		if((beaker.reagents.chem_temp + heater_speed) >= target_temperature)
 			currentspeed = target_temperature - beaker.reagents.chem_temp
-		else
-			currentspeed = heater_speed
 		beaker.reagents.adjust_thermal_energy(currentspeed * SPECIFIC_HEAT_DEFAULT * beaker.reagents.total_volume)
 		beaker.reagents.handle_reactions()
 

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -64,8 +64,7 @@
 	..()
 	if(stat & NOPOWER)
 		return
-		
-	if(on && beaker && beaker.reagents.total_volume)
+	if(on && beaker?.reagents.total_volume)
 		if((beaker.reagents.chem_temp + heater_speed) >= target_temperature)
 			currentspeed = target_temperature - beaker.reagents.chem_temp
 		else


### PR DESCRIPTION
### Intent of your Pull Request

Just https://github.com/yogstation13/Yogstation/pull/9590 but slightly redone

Chem heaters now heat up linearly instead of as a logarithmic curve, makes actual precision heating viable

Base Tier: 10K per cycle
Max Tier: 40K per cycle

Also no I will not consider but muh speed muh danger or whatever really invalid thing you have to say

#### Changelog

:cl:  
tweak: Chem heaters heat up linearly now
/:cl:
