### PR TITLE
Revert "Gives us a bit of memory wiggle room"

### DIFF
--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -19,7 +19,7 @@
 	var/map_file = "YogStation.dmm"
 
 	var/traits = null
-	var/space_ruin_levels = 4
+	var/space_ruin_levels = 7
 	var/space_empty_levels = 1
 
 	var/minetype = "lavaland"
@@ -70,8 +70,8 @@
 	map_name = json["map_name"]
 	CHECK_EXISTS("map_path")
 	map_path = json["map_path"]
-	map_file = json["map_file"]
 
+	map_file = json["map_file"]
 	// "map_file": "BoxStation.dmm"
 	if (istext(map_file))
 		if (!fexists("_maps/[map_path]/[map_file]"))

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -147,6 +147,7 @@
 /datum/map_template/ruin/space/spacehotel
 	id = "spacehotel"
 	suffix = "spacehotel.dmm"
+	unpickable = TRUE
 	name = "The Twin-Nexus Hotel"
 	description = "An interstellar hotel, where the weary spaceman can rest their head and relax, assured that the residental staff will not murder them in their sleep. Probably."
 

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -147,7 +147,6 @@
 /datum/map_template/ruin/space/spacehotel
 	id = "spacehotel"
 	suffix = "spacehotel.dmm"
-	unpickable = TRUE
 	name = "The Twin-Nexus Hotel"
 	description = "An interstellar hotel, where the weary spaceman can rest their head and relax, assured that the residental staff will not murder them in their sleep. Probably."
 


### PR DESCRIPTION
we are having multiple rounds in a row where there is no space ruin spawners at all

this simply changes the ammount of space ruins that spawn back to what it originally was