### PR TITLE
Increase amount of roundstart cyborgs

### DIFF
--- a/code/modules/jobs/job_types/cyborg.dm
+++ b/code/modules/jobs/job_types/cyborg.dm
@@ -5,7 +5,7 @@
 	department_flag = ENGSEC
 	faction = "Station"
 	total_positions = 0
-	spawn_positions = 1
+	spawn_positions = 2
 	supervisors = "your laws and the AI"	//Nodrak
 	selection_color = "#ddffdd"
 	minimal_player_age = 21
@@ -14,10 +14,13 @@
 
 	display_order = JOB_DISPLAY_ORDER_CYBORG
 
-	changed_maps = list("EclipseStation")
+	changed_maps = list("EclipseStation", "OmegaStation")
 
 /datum/job/cyborg/proc/EclipseStationChanges()
-	spawn_positions = 2
+	spawn_positions = 3
+
+/datum/job/cyborg/proc/OmegaStationChanges()
+	spawn_positions = 1
 
 /datum/job/cyborg/equip(mob/living/carbon/human/H, visualsOnly = FALSE, announce = TRUE, latejoin = FALSE, datum/outfit/outfit_override = null, client/preference_source = null)
 	if(visualsOnly)


### PR DESCRIPTION
### Intent of your Pull Request

All maps beside Eclipse(3 Cyborgs) & Omega(1 Cyborg) now get 2 roundstart Cyborgs


#### Changelog

:cl:  
tweak: Increase Roundstart Cyborgs to 2
/:cl:
