### PR TITLE
unblacklists the abandoned zoo space ruin

### DIFF
--- a/config/spaceruinblacklist.txt
+++ b/config/spaceruinblacklist.txt
@@ -4,7 +4,7 @@
 #SPECIFYING AN INVALID MAP WILL RESULT IN RUNTIMES ON GAME START
 
 #_maps/RandomRuins/SpaceRuins/abandonedteleporter.dmm
-_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
+#_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
 #_maps/RandomRuins/SpaceRuins/asteroid1.dmm
 #_maps/RandomRuins/SpaceRuins/asteroid2.dmm
 #_maps/RandomRuins/SpaceRuins/asteroid3.dmm


### PR DESCRIPTION
i cant find any reason why this should be blacklisted its also a neat ruin
#### Changelog

:cl:  

tweak: re enables abandoned zoo as a possible space ruin
/:cl:
