### PR TITLE
all lavaland mushrooms have unique alcohol reagents

### DIFF
--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -157,7 +157,7 @@
 	resistance_flags = FLAMMABLE
 	max_integrity = 100
 	seed = /obj/item/seeds/lavaland/polypore
-	wine_power = 20
+	distill_reagent = /datum/reagent/consumable/ethanol/polyporepop
 
 /obj/item/reagent_containers/food/snacks/grown/ash_flora/Initialize()
 	. = ..()
@@ -171,21 +171,21 @@
 	desc = "A leaf, from a mushroom."
 	icon_state = "mushroom_leaf"
 	seed = /obj/item/seeds/lavaland/porcini
-	wine_power = 40
+	distill_reagent = /datum/reagent/consumable/ethanol/porcinisap
 
 /obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_cap
 	name = "mushroom cap"
 	desc = "The cap of a large mushroom."
 	icon_state = "mushroom_cap"
 	seed = /obj/item/seeds/lavaland/inocybe
-	wine_power = 70
+	distill_reagent = /datum/reagent/consumable/ethanol/inocybeshine
 
 /obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_stem
 	name = "mushroom stem"
 	desc = "A long mushroom stem. It's slightly glowing."
 	icon_state = "mushroom_stem"
 	seed = /obj/item/seeds/lavaland/ember
-	wine_power = 60
+	distill_reagent = /datum/reagent/consumable/ethanol/embershroomcream
 
 /obj/item/reagent_containers/food/snacks/grown/ash_flora/cactus_fruit
 	name = "cactus fruit"

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2127,11 +2127,10 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "The byproduct of fermenting a cactus. For those wanting a refreshing drink in a barren wasteland."
 
 /datum/reagent/consumable/ethanol/cactuscooler/on_mob_life(mob/living/carbon/M)
-	if(prob(80))
-		M.adjustBruteLoss(-1*REM, 0)
-		M.adjustFireLoss(-1*REM, 0)
-		. = TRUE
-	return ..()
+	if(M.getFireLoss() && prob(10))
+		M.heal_bodypart_damage(0, 1)
+		. = 1
+	return ..() || .
 
 /datum/reagent/consumable/ethanol/polyporepop
 	name = "Polypore Pop"

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -377,7 +377,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		M.heal_bodypart_damage(1,1)
 		. = 1
 	M.radiation = max(M.radiation-2, 0)
-	return ..()  || . 
+	return ..()  || .
 
 /datum/reagent/consumable/ethanol/ale
 	name = "Ale"
@@ -2127,10 +2127,73 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "The byproduct of fermenting a cactus. For those wanting a refreshing drink in a barren wasteland."
 
 /datum/reagent/consumable/ethanol/cactuscooler/on_mob_life(mob/living/carbon/M)
-	if(M.getFireLoss() && prob(10))
-		M.heal_bodypart_damage(0, 1)
-		. = 1
-	return ..() || .
+	if(prob(80))
+		M.adjustBruteLoss(-1*REM, 0)
+		M.adjustFireLoss(-1*REM, 0)
+		. = TRUE
+	return ..()
+
+/datum/reagent/consumable/ethanol/polyporepop
+	name = "Polypore Pop"
+	description = "A strong and fizzy alcoholic beverage made by fermenting polypore mushrooms."
+	color = "#664300" // rgb: 102, 67, 0
+	nutriment_factor = 2 * REAGENTS_METABOLISM
+	boozepwr = 50
+	taste_description = "fizzy alcohol"
+	glass_icon_state = "glass_brown2"
+	glass_name = "glass of polypore pop"
+	glass_desc = "Fizzy alcohol made from fermenting polypore mushrooms. Surprisingly good for being from a mushroom, and surprisingly strong."
+
+/datum/reagent/consumable/ethanol/porcinisap
+	name = "Porcini Sap"
+	description = "A soothing sap fermented from porcini leaves."
+	color = "#664300" // rgb: 102, 67, 0
+	nutriment_factor = 2 * REAGENTS_METABOLISM
+	boozepwr = 5
+	taste_description = "cough syrup"
+	glass_icon_state = "glass_brown2"
+	glass_name = "glass of porcini sap"
+	glass_desc = "Very weak alcohol that feels soothing as it goes down your throat and makes your stomach feel better."
+
+/datum/reagent/consumable/porcinisap/on_mob_life(mob/living/carbon/M)
+	M.adjust_disgust(-3)
+	..()
+
+/datum/reagent/consumable/ethanol/inocybeshine
+	name = "Inocybe Shine"
+	description = "A very strong, slightly toxic alcohol from fermented inocybe mycelium."
+	color = "#664300" // rgb: 102, 67, 0
+	nutriment_factor = 2 * REAGENTS_METABOLISM
+	boozepwr = 75
+	taste_description = "terrible bitterness"
+	glass_icon_state = "glass_brown2"
+	glass_name = "glass of inocybe shine"
+	glass_desc = "Very strong alcohol that tastes like shit and makes your liver feel weak."
+
+/datum/reagent/consumable/ethanol/inocybeshine/on_mob_life(mob/living/carbon/M)
+	if(prob(10))
+		M.adjustStaminaLoss(10,0)
+		M.blur_eyes(3)
+		M.adjust_disgust(1)
+		. = TRUE
+	return ..()
+
+/datum/reagent/consumable/ethanol/embershroomcream
+	name = "Embershroom Cream"
+	description = "Slightly bioluminescent smelly cream from fermented embershroom stems."
+	color = "#8CFF8C" // rgb: 140, 255, 140
+	nutriment_factor = 2 * REAGENTS_METABOLISM
+	boozepwr = 20
+	taste_description = "gross cream"
+	glass_icon_state = "booger"
+	glass_name = "glass of embershroom cream"
+	glass_desc = "Weak alcohol that makes your stomach feel like a disco party."
+
+/datum/reagent/consumable/embershroomcream/on_mob_metabolize(mob/living/M)
+	M.set_light(2)
+
+/datum/reagent/consumable/embershroomcream/on_mob_end_metabolize(mob/living/M)
+	M.set_light(-2)
 
 /datum/reagent/consumable/ethanol/painkiller
 	name = "Painkiller"
@@ -2164,7 +2227,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_icon_state = "flaming_moe2"
 	glass_name = "Flaming Moe"
 	glass_desc = "an amazing concoction of various different bar drinks and a secret ingredient"
-	
+
 /datum/reagent/consumable/ethanol/flaming_moe/on_mob_life(mob/living/carbon/M)
 	M.drowsyness = max(M.drowsyness-5, 0)
 	M.AdjustStun(-20, FALSE)


### PR DESCRIPTION
The title

the mushroom leaves drink helps reduce disgust, the poisonous caps one induces some stam damage and has a lot of alcohol content, the glowing stems one makes you glow a bit,  and the shavings one has medium alcohol content with no specific unique features.

#### Changelog

:cl:  
rscadd: all lavaland mushrooms now have unique alcohol reagents when fermented
/:cl:
