### PR TITLE
Makes Vampire not end on antag death and instead mulligan

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -147,6 +147,7 @@ CONTINUOUS WIZARD
 CONTINUOUS HIVEMIND
 CONTINUOUS MALF
 CONTINUOUS SHADOWLING
+CONTINUOUS VAMPIRE
 
 ##Note: do not toggle continuous off for these modes, as they have no antagonists and would thus end immediately!
 


### PR DESCRIPTION
Abrupt endings bad

#### Changelog

:cl:  
tweak: Makes Vampire not end on antag death and instead mulligan
/:cl:
