### PR TITLE
Adds the Shuttle Catastrophe Event

### DIFF
--- a/code/__DEFINES/shuttles.dm
+++ b/code/__DEFINES/shuttles.dm
@@ -31,6 +31,11 @@
 #define EARLY_LAUNCHED 2
 #define ENDGAME_TRANSIT 3
 
+//positive value = cannot purchase
+#define SHUTTLEPURCHASE_PURCHASABLE 0 //station can buy a shuttle
+#define SHUTTLEPURCHASE_PURCHASED 1 //station has already bought a shuttle, so cannot
+#define SHUTTLEPURCHASE_FORCED 2 //station was given a new shuttle through events or other shenanigans
+
 // Ripples, effects that signal a shuttle's arrival
 #define SHUTTLE_RIPPLE_TIME 100
 

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -46,7 +46,7 @@ SUBSYSTEM_DEF(shuttle)
 
 	var/datum/round_event/shuttle_loan/shuttle_loan
 
-	var/shuttle_purchased = FALSE //If the station has purchased a replacement escape shuttle this round
+	var/shuttle_purchased = SHUTTLEPURCHASE_PURCHASABLE //If the station has purchased a replacement escape shuttle this round
 	var/emag_shuttle_purchased = FALSE //If the traitors have purchased a replacement escape shuttle this round
 
 	var/lockdown = FALSE	//disallow transit after nuke goes off

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -152,8 +152,10 @@
 					if(SSshuttle.emergency.mode != SHUTTLE_RECALL && SSshuttle.emergency.mode != SHUTTLE_IDLE)
 						to_chat(usr, "It's a bit late to buy a new shuttle, don't you think?")
 						return
-					if(SSshuttle.shuttle_purchased && (SSshuttle.emag_shuttle_purchased || !(obj_flags & EMAGGED)))
+					if(SSshuttle.shuttle_purchased == SHUTTLEPURCHASE_PURCHASED && (SSshuttle.emag_shuttle_purchased || !(obj_flags & EMAGGED)))
 						to_chat(usr, "A replacement shuttle has already been purchased.")
+					else if(SSshuttle.shuttle_purchased == SHUTTLEPURCHASE_FORCED)
+						to_chat(usr, "<span class='alert'>Due to unforseen circumstances, shuttle purchasing is no longer available.</span>")
 					else if(!S.prerequisites_met())
 						to_chat(usr, "You have not met the requirements for purchasing this shuttle.")
 					else if(S.emag_buy && !(obj_flags & EMAGGED))
@@ -166,7 +168,7 @@
 						if(points_to_check >= S.credit_cost)
 							SSshuttle.shuttle_purchased = TRUE
 							if(obj_flags & EMAGGED)
-								SSshuttle.emag_shuttle_purchased = TRUE
+								SSshuttle.emag_shuttle_purchased = SHUTTLEPURCHASE_PURCHASED
 							SSshuttle.unload_preview()
 							SSshuttle.load_template(S)
 							SSshuttle.existing_shuttle = SSshuttle.emergency

--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -1,0 +1,37 @@
+/datum/round_event_control/shuttle_catastrophe
+	name = "Shuttle Catastrophe"
+	typepath = /datum/round_event/shuttle_catastrophe
+	weight = 10
+	max_occurrences = 1
+
+/datum/round_event_control/shuttle_catastrophe/canSpawnEvent(players, gamemode)
+	if(SSshuttle.emergency.name == "Build your own shuttle kit")
+		return FALSE //don't undo manual player engineering, it also would unload people and ghost them, there's just a lot of problems
+	return ..()
+
+
+/datum/round_event/shuttle_catastrophe
+	var/datum/map_template/shuttle/new_shuttle
+
+/datum/round_event/shuttle_catastrophe/announce(fake)
+	var/cause = pick("was attacked by [syndicate_name()] Operatives", "mysteriously teleported away", "had its refuelling crew mutiny",
+		"was found with its engines stolen", "\[REDACTED\]", "flew into the sunset, and melted", "learned something from a very wise cow, and left on its own",
+		"had cloning devices on it", "had its shuttle inspector put the shuttle in reverse instead of park, causing the shuttle to crash into the hangar")
+
+	priority_announce("Your emergency shuttle [cause]. Your replacement shuttle will be the [new_shuttle.name] until further notice.", "CentCom Spacecraft Engineering")
+
+/datum/round_event/shuttle_catastrophe/setup()
+	var/list/valid_shuttle_templates = list()
+	for(var/shuttle_id in SSmapping.shuttle_templates)
+		var/datum/map_template/shuttle/template = SSmapping.shuttle_templates[shuttle_id]
+		if(template.can_be_bought && template.credit_cost < INFINITY) //if we could get it from the communications console, it's cool for us to get it here
+			valid_shuttle_templates += template
+	new_shuttle = pick(valid_shuttle_templates)
+
+/datum/round_event/shuttle_catastrophe/start()
+	SSshuttle.shuttle_purchased = SHUTTLEPURCHASE_FORCED
+	SSshuttle.unload_preview()
+	SSshuttle.load_template(new_shuttle)
+	SSshuttle.existing_shuttle = SSshuttle.emergency
+	SSshuttle.action_load(new_shuttle)
+	log_shuttle("Shuttle Catastrophe set a new shuttle, [new_shuttle.name].")

--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -24,7 +24,7 @@
 	var/list/valid_shuttle_templates = list()
 	for(var/shuttle_id in SSmapping.shuttle_templates)
 		var/datum/map_template/shuttle/template = SSmapping.shuttle_templates[shuttle_id]
-		if(template.can_be_bought && template.credit_cost < INFINITY) //if we could get it from the communications console, it's cool for us to get it here
+		if(!template.emag_buy && template.credit_cost < INFINITY) //if we could get it from the communications console, it's cool for us to get it here
 			valid_shuttle_templates += template
 	new_shuttle = pick(valid_shuttle_templates)
 
@@ -34,4 +34,4 @@
 	SSshuttle.load_template(new_shuttle)
 	SSshuttle.existing_shuttle = SSshuttle.emergency
 	SSshuttle.action_load(new_shuttle)
-	log_shuttle("Shuttle Catastrophe set a new shuttle, [new_shuttle.name].")
+	log_game("Shuttle Catastrophe set a new shuttle, [new_shuttle.name].")

--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -15,7 +15,7 @@
 
 /datum/round_event/shuttle_catastrophe/announce(fake)
 	var/cause = pick("was attacked by [syndicate_name()] Operatives", "mysteriously teleported away", "had its refuelling crew mutiny",
-		"was found with its engines stolen", "\[REDACTED\]", "flew into the sunset, and melted", "learned something from a very wise cow, and left on its own",
+		"was found with its engines stolen", "\[REDACTED\]", "flew into the sunset, and melted", "fell into a black hole",
 		"had cloning devices on it", "had its shuttle inspector put the shuttle in reverse instead of park, causing the shuttle to crash into the hangar")
 
 	priority_announce("Your emergency shuttle [cause]. Your replacement shuttle will be the [new_shuttle.name] until further notice.", "CentCom Spacecraft Engineering")

--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -16,7 +16,7 @@
 /datum/round_event/shuttle_catastrophe/announce(fake)
 	var/cause = pick("was attacked by [syndicate_name()] Operatives", "mysteriously teleported away", "had its refuelling crew mutiny",
 		"was found with its engines stolen", "\[REDACTED\]", "flew into the sunset, and melted", "fell into a black hole",
-		"had cloning devices on it", "had its shuttle inspector put the shuttle in reverse instead of park, causing the shuttle to crash into the hangar")
+		"was stolen by the Clown Planet", "had its shuttle inspector put the shuttle in reverse instead of park, causing the shuttle to crash into the hangar")
 
 	priority_announce("Your emergency shuttle [cause]. Your replacement shuttle will be the [new_shuttle.name] until further notice.", "CentCom Spacecraft Engineering")
 

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -1765,6 +1765,7 @@
 #include "code\modules\events\processor_overload.dm"
 #include "code\modules\events\radiation_storm.dm"
 #include "code\modules\events\sentience.dm"
+#include "code\modules\events\shuttle_catastrophe.dm"
 #include "code\modules\events\shuttle_loan.dm"
 #include "code\modules\events\space_dragon.dm"
 #include "code\modules\events\spacevine.dm"


### PR DESCRIPTION
Port https://github.com/tgstation/tgstation/pull/53003

The shuttle runs into some kind of horrible event, and is no longer servicable. The station is given a new one!

Only pulls from ones in the console, none of the crazy weird ones like the Supermatter Shuttle.

Allows for variety and unexpectancy to happen, should be rare enough that it isn't a constant problem however.

#### Changelog

:cl:  
rscadd: Adds Shuttle Catastrophe
/:cl:
