### PR TITLE
Makes space pods not require /client/MouseMove by polling client.mouseParams on process()

### DIFF
--- a/yogstation/code/modules/spacepods/physics.dm
+++ b/yogstation/code/modules/spacepods/physics.dm
@@ -1,4 +1,7 @@
 /obj/spacepod/process(time)
+	if(pilot.client)
+		onMouseMove(pilot.client.mouseParams)
+		
 	time /= 10 // fuck off with your deciseconds
 
 	if(world.time > last_slowprocess + 15)

--- a/yogstation/code/modules/spacepods/physics.dm
+++ b/yogstation/code/modules/spacepods/physics.dm
@@ -1,6 +1,5 @@
 /obj/spacepod/process(time)
-	if(pilot.client)
-		onMouseMove(pilot.client.mouseParams)
+	onMouseMove()
 		
 	time /= 10 // fuck off with your deciseconds
 

--- a/yogstation/code/modules/spacepods/spacepod.dm
+++ b/yogstation/code/modules/spacepods/spacepod.dm
@@ -663,7 +663,7 @@ GLOBAL_LIST_INIT(spacepods_list, list())
 /obj/spacepod/onMouseMove(params)
 	if(!pilot || !pilot.client || pilot.incapacitated())
 		return // I don't know what's going on.
-	var/list/params_list = params2list(params)
+	var/list/params_list = params2list(pilot.client.mouseParams)
 	var/sl_list = splittext(params_list["screen-loc"],",")
 	var/sl_x_list = splittext(sl_list[1], ":")
 	var/sl_y_list = splittext(sl_list[2], ":")

--- a/yogstation/code/modules/spacepods/spacepod.dm
+++ b/yogstation/code/modules/spacepods/spacepod.dm
@@ -631,7 +631,6 @@ GLOBAL_LIST_INIT(spacepods_list, list())
 		return FALSE
 	if(!pilot && allow_pilot)
 		pilot = M
-		LAZYOR(M.mousemove_intercept_objects, src)
 		M.click_intercept = src
 	else if(passengers.len < max_passengers)
 		passengers += M
@@ -647,7 +646,6 @@ GLOBAL_LIST_INIT(spacepods_list, list())
 		return
 	if(M == pilot)
 		pilot = null
-		LAZYREMOVE(M.mousemove_intercept_objects, src)
 		if(M.click_intercept == src)
 			M.click_intercept = null
 		desired_angle = null // since there's no pilot there's no one aiming it.
@@ -662,7 +660,7 @@ GLOBAL_LIST_INIT(spacepods_list, list())
 		M.client.pixel_y = 0
 	return TRUE
 
-/obj/spacepod/onMouseMove(object,location,control,params)
+/obj/spacepod/onMouseMove(params)
 	if(!pilot || !pilot.client || pilot.incapacitated())
 		return // I don't know what's going on.
 	var/list/params_list = params2list(params)

--- a/yogstation/code/modules/spacepods/spacepod.dm
+++ b/yogstation/code/modules/spacepods/spacepod.dm
@@ -660,7 +660,7 @@ GLOBAL_LIST_INIT(spacepods_list, list())
 		M.client.pixel_y = 0
 	return TRUE
 
-/obj/spacepod/onMouseMove(params)
+/obj/spacepod/onMouseMove()
 	if(!pilot || !pilot.client || pilot.incapacitated())
 		return // I don't know what's going on.
 	var/list/params_list = params2list(pilot.client.mouseParams)


### PR DESCRIPTION
See title, should make it work despite #9582 