### PR TITLE
ashwalkers can actually use the blowgun now

### DIFF
--- a/code/modules/projectiles/guns/misc/syringe_gun.dm
+++ b/code/modules/projectiles/guns/misc/syringe_gun.dm
@@ -114,6 +114,7 @@
 	icon_state = "blowgun"
 	item_state = "blowgun"
 	fire_sound = 'sound/items/syringeproj.ogg'
+	trigger_guard = TRIGGER_GUARD_ALLOW_ALL //it's a fucking blowgun it shouldn't even have a triggerguard
 
 /obj/item/gun/syringe/blowgun/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
 	visible_message("<span class='danger'>[user] starts aiming with a blowgun!</span>")


### PR DESCRIPTION
ashwalkers previously couldn't use the blowgun since their 'fingers didn't fit the trigger guard'
that doesn't happen anymore

Also, that means golems can also use blowguns if they want

#### Changelog

:cl:  
rscadd: Ashwalkers can use the blowgun
/:cl:
