### PR TITLE
Just blacklists the Lavaland prisoner

### DIFF
--- a/config/lavaruinblacklist.txt
+++ b/config/lavaruinblacklist.txt
@@ -14,6 +14,7 @@ _maps/RandomRuins/LavaRuins/lavaland_surface_cube.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+_maps/RandomRuins/LavaRuins/lavaland_surface_prisoner_crash.dmm
 
 ##SIN
 #_maps/RandomRuins/LavaRuins/lavaland_surface_envy.dmm


### PR DESCRIPTION
An alternative to #10170 as requested by Jamie. See that PR for reasoning.

#### Changelog

:cl:  
rscdel: Blacklisted the Lavaland prisoner spawn from spawning.
/:cl:
