### PR TITLE
Preternis Changes

### DIFF
--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -10,7 +10,7 @@ adjust_charge - take a positive or negative value to adjust the charge level
 	id = "preternis"
 	default_color = "FFFFFF"
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
-	inherent_traits = list(TRAIT_NOHUNGER, TRAIT_MEDICALIGNORE, TRAIT_PIERCEIMMUNE, TRAIT_RESISTLOWPRESSURE) //Medical Ignore doesn't prevent basic treatment,only things that cannot help preternis,such as cryo and medbots
+	inherent_traits = list(TRAIT_NOHUNGER, TRAIT_MEDICALIGNORE, TRAIT_PIERCEIMMUNE) //Medical Ignore doesn't prevent basic treatment,only things that cannot help preternis,such as cryo and medbots
 	species_traits = list(EYECOLOR,HAIR,LIPS)
 	say_mod = "intones"
 	attack_verb = "assault"

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -10,19 +10,18 @@ adjust_charge - take a positive or negative value to adjust the charge level
 	id = "preternis"
 	default_color = "FFFFFF"
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
-	inherent_traits = list(TRAIT_NOHUNGER, TRAIT_RADIMMUNE, TRAIT_MEDICALIGNORE) //Medical Ignore doesn't prevent basic treatment,only things that cannot help preternis,such as cryo and medbots
+	inherent_traits = list(TRAIT_NOHUNGER, TRAIT_MEDICALIGNORE, TRAIT_PIERCEIMMUNE, TRAIT_RESISTLOWPRESSURE) //Medical Ignore doesn't prevent basic treatment,only things that cannot help preternis,such as cryo and medbots
 	species_traits = list(EYECOLOR,HAIR,LIPS)
 	say_mod = "intones"
 	attack_verb = "assault"
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/synthmeat
 	toxic_food = NONE
-	brutemod = 1.25
 	burnmod = 1.5
+	heatmod = 1.25 //Unlike other creatures, they only have simple fans in their system to cool them down.
 	yogs_draw_robot_hair = TRUE
 	mutanteyes = /obj/item/organ/eyes/preternis
 	mutantlungs = /obj/item/organ/lungs/preternis
 	yogs_virus_infect_chance = 20
-	virus_resistance_boost = 10 //YEOUTCH,good luck getting it out
 	var/charge = PRETERNIS_LEVEL_FULL
 	var/eating_msg_cooldown = FALSE
 	var/emag_lvl = 0
@@ -58,15 +57,13 @@ adjust_charge - take a positive or negative value to adjust the charge level
 	. = ..()
 	switch(severity)
 		if(EMP_HEAVY)
-			H.adjustBruteLoss(20)
-			H.adjustFireLoss(20)
+			H.adjustFireLoss(50)
 			H.Paralyze(50)
 			charge *= 0.4
 			H.visible_message("<span class='danger'>Electricity ripples over [H]'s subdermal implants, smoking profusely.</span>", \
 							"<span class='userdanger'>A surge of searing pain erupts throughout your very being! As the pain subsides, a terrible sensation of emptiness is left in its wake.</span>")
 		if(EMP_LIGHT)
-			H.adjustBruteLoss(10)
-			H.adjustFireLoss(10)
+			H.adjustFireLoss(25)
 			H.Paralyze(20)
 			charge *= 0.6
 			H.visible_message("<span class='danger'>A faint fizzling emanates from [H].</span>", \


### PR DESCRIPTION
This PR makes Preternis a little bit more robotlike, and changes the stats around.

Buffs-
Preternis no longer take 25% more brute damage
Viruses no longer are harder to get out of them

Neutral(?)-
They are now pierce immune due to being made out of metal. This means syringes can't be shot at them to inject stuff into their system. This can be a blessing or a curse, although it does mean chemists can't hit you with death mix syringes.
EMPs can't deal brute damage anymore, only burn. Brute damaging EMPs make no sense.

Nerfs-
Preternis get a 125% heat mod. Should mean they take more heat damage.
EMPs deal a bit more damage to them.
They are no longer rad immune, radiation can damage electronics too. Ethereals will be getting this soon instead.


This may be unbalanced, just tell me.

#### Changelog

:cl:  
tweak: Preternis are syringe immune, among other things.
/:cl:
