### PR TITLE
Improves sloth ruin

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
@@ -23,6 +23,10 @@
 "g" = (
 /turf/closed/wall/mineral/wood,
 /area/ruin/powered)
+"n" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/ruin/powered)
 "q" = (
 /obj/item/coin/iron,
 /turf/open/floor/sepia{
@@ -54,8 +58,11 @@
 	},
 /area/ruin/powered)
 "M" = (
-/obj/structure/mineral_door/wood,
-/obj/structure/fans,
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/wood.dmi';
+	name = "sloth's house"
+	},
 /turf/open/floor/sepia{
 	blocks_air = 0;
 	slowdown = 10
@@ -65,7 +72,7 @@
 (1,1,1) = {"
 g
 g
-g
+n
 g
 g
 "}
@@ -93,7 +100,7 @@ g
 (5,1,1) = {"
 g
 g
-g
+n
 g
 g
 "}

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
@@ -1,644 +1,99 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
-/turf/closed/indestructible/riveted,
-/area/ruin/unpowered)
-"b" = (
-/turf/open/lava/smooth/lava_land_surface,
-/area/ruin/unpowered)
 "c" = (
-/obj/item/paper/fluff/stations/lavaland/sloth/note,
+/obj/machinery/computer/arcade,
 /turf/open/floor/sepia{
 	blocks_air = 0;
 	slowdown = 10
 	},
-/area/ruin/unpowered)
-"d" = (
-/turf/open/floor/sepia{
-	blocks_air = 0;
-	slowdown = 10
-	},
-/area/ruin/unpowered)
+/area/ruin/powered)
 "e" = (
-/obj/machinery/door/airlock/wood,
 /turf/open/floor/sepia{
 	blocks_air = 0;
 	slowdown = 10
 	},
-/area/ruin/unpowered)
+/area/ruin/powered)
 "f" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/grown/citrus/orange,
-/turf/open/floor/sepia{
-	blocks_air = 0;
-	slowdown = 10
-	},
-/area/ruin/unpowered)
-"g" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
 /turf/open/floor/sepia{
 	blocks_air = 0;
 	slowdown = 10
 	},
-/area/ruin/unpowered)
+/area/ruin/powered)
+"g" = (
+/turf/closed/wall/mineral/wood,
+/area/ruin/powered)
+"q" = (
+/obj/item/coin/iron,
+/turf/open/floor/sepia{
+	blocks_air = 0;
+	slowdown = 10
+	},
+/area/ruin/powered)
+"y" = (
+/obj/structure/table/wood,
+/obj/item/paper/fluff/stations/lavaland/sloth,
+/turf/open/floor/sepia{
+	blocks_air = 0;
+	slowdown = 10
+	},
+/area/ruin/powered)
+"E" = (
+/obj/item/trash/syndi_cakes,
+/obj/item/trash/chips{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/item/trash/can{
+	pixel_x = -8;
+	pixel_y = 10
+	},
+/turf/open/floor/sepia{
+	blocks_air = 0;
+	slowdown = 10
+	},
+/area/ruin/powered)
+"M" = (
+/obj/structure/mineral_door/wood,
+/obj/structure/fans,
+/turf/open/floor/sepia{
+	blocks_air = 0;
+	slowdown = 10
+	},
+/area/ruin/powered)
 
 (1,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+g
+g
+g
+g
+g
 "}
 (2,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-a
+g
+c
+q
+e
+g
 "}
 (3,1,1) = {"
-a
-b
-a
-a
-a
-a
-a
-a
-b
-a
+g
+e
+E
+e
+M
 "}
 (4,1,1) = {"
-a
-b
-a
-c
-d
-d
+g
 f
-a
-b
-a
+e
+y
+g
 "}
 (5,1,1) = {"
-a
-b
-a
-d
-d
-d
 g
-a
-b
-a
-"}
-(6,1,1) = {"
-a
-b
-a
-d
-a
-a
-a
-a
-b
-a
-"}
-(7,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(8,1,1) = {"
-a
-b
-a
-a
-a
-a
-d
-a
-b
-a
-"}
-(9,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(10,1,1) = {"
-a
-b
-a
-d
-a
-a
-a
-a
-b
-a
-"}
-(11,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(12,1,1) = {"
-a
-b
-a
-a
-a
-a
-d
-a
-b
-a
-"}
-(13,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(14,1,1) = {"
-a
-b
-a
-d
-a
-a
-a
-a
-b
-a
-"}
-(15,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(16,1,1) = {"
-a
-b
-a
-a
-a
-a
-d
-a
-b
-a
-"}
-(17,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(18,1,1) = {"
-a
-b
-a
-d
-a
-a
-a
-a
-b
-a
-"}
-(19,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(20,1,1) = {"
-a
-b
-a
-a
-a
-a
-d
-a
-b
-a
-"}
-(21,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(22,1,1) = {"
-a
-b
-a
-d
-a
-a
-a
-a
-b
-a
-"}
-(23,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(24,1,1) = {"
-a
-b
-a
-a
-a
-a
-d
-a
-b
-a
-"}
-(25,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(26,1,1) = {"
-a
-b
-a
-d
-a
-a
-a
-a
-b
-a
-"}
-(27,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(28,1,1) = {"
-a
-b
-a
-a
-a
-a
-d
-a
-b
-a
-"}
-(29,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(30,1,1) = {"
-a
-b
-a
-d
-a
-a
-a
-a
-b
-a
-"}
-(31,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(32,1,1) = {"
-a
-b
-a
-a
-a
-a
-d
-a
-b
-a
-"}
-(33,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(34,1,1) = {"
-a
-b
-a
-d
-a
-a
-a
-a
-b
-a
-"}
-(35,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(36,1,1) = {"
-a
-b
-a
-a
-a
-a
-d
-a
-b
-a
-"}
-(37,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(38,1,1) = {"
-a
-b
-a
-d
-a
-a
-a
-a
-b
-a
-"}
-(39,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(40,1,1) = {"
-a
-b
-a
-a
-a
-a
-d
-a
-b
-a
-"}
-(41,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(42,1,1) = {"
-a
-b
-a
-d
-a
-a
-a
-a
-b
-a
-"}
-(43,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(44,1,1) = {"
-a
-b
-a
-a
-a
-a
-d
-a
-b
-a
-"}
-(45,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(46,1,1) = {"
-a
-b
-a
-d
-a
-a
-a
-a
-b
-a
-"}
-(47,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(48,1,1) = {"
-a
-b
-a
-a
-a
-a
-d
-a
-b
-a
-"}
-(49,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(50,1,1) = {"
-a
-a
-a
-a
-e
-e
-a
-a
-a
-a
+g
+g
+g
+g
 "}

--- a/code/modules/ruins/lavalandruin_code/sloth.dm
+++ b/code/modules/ruins/lavalandruin_code/sloth.dm
@@ -1,5 +1,5 @@
 ///////////	lavaland slot ruin items
 
-/obj/item/paper/fluff/stations/lavaland/sloth/note
+/obj/item/paper/fluff/stations/lavaland/sloth
 	name = "note from sloth"
-	desc = "have not gotten around to finishing my cursed item yet sorry - sloth"
+	info = "sorry guys i'll have the temple ready soon<br>- sloth"


### PR DESCRIPTION
An alternative to #10225, simply reducing the size of the ruin from a 50x10 tunnel to a simple 5x5 house with an arcade machine, some trash, and a coin in it.

Old:
![image](https://user-images.githubusercontent.com/29339701/97510174-93a8db00-195a-11eb-9315-a194b524a6e9.png)

New:
![image](https://user-images.githubusercontent.com/29339701/97510537-4e38dd80-195b-11eb-88c6-94ee3e5bf05e.png)

#### Changelog

:cl:  
tweak: Vastly shrunk the sloth ruin due to how much space it takes up compared to its lack of usefulness. At least it has an arcade machine now.
/:cl:
