### PR TITLE
Fixed bug that made it so Adult Slimes couldnt damage basic stuff like windows.

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -144,7 +144,7 @@
 /obj/attack_slime(mob/living/simple_animal/slime/user)
 	if(!user.is_adult)
 		return
-	attack_generic(user, rand(10, 15), "melee", 1)
+	attack_generic(user, rand(10, 15), BRUTE, "melee", 1)
 
 /obj/mech_melee_attack(obj/mecha/M)
 	M.do_attack_animation(src)


### PR DESCRIPTION
### Intent of your Pull Request

Explain what the purpose of your PR is.
apparently adult slimes were supposed to be able to break things the whole time it just was broken.
This is a port of https://github.com/tgstation/tgstation/pull/46718 which I was aware of since it existed but never bothered porting


#### Changelog

:cl:  
bugfix: slimes now put more weight behind there body slaps
/:cl:
