### PR TITLE
Ethereal Changes

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -11,11 +11,13 @@
 	exotic_blood = /datum/reagent/consumable/liquidelectricity //Liquid Electricity. fuck you think of something better gamer
 	siemens_coeff = 0.5 //They thrive on energy
 	brutemod = 1.25 //They're weak to punches
+	burnmod = 0.9 //They like heat and energy
+	coldmod = 1.25 //They don't really like the cold.
 	attack_type = BURN //burn bish
 	damage_overlay_type = "" //We are too cool for regular damage overlays
 	species_traits = list(DYNCOLORS, AGENDER, NO_UNDERWEAR)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
-	inherent_traits = list(TRAIT_NOHUNGER)
+	inherent_traits = list(TRAIT_NOHUNGER, TRAIT_RADIMMUNE) //They like energy and heat, which radiation basically is.
 	sexes = FALSE //no fetish content allowed
 	toxic_food = NONE
 	inert_mutation = SHOCKTOUCH
@@ -29,7 +31,6 @@
 	var/static/g2 = 164
 	var/static/b2 = 149
 	//this is shit but how do i fix it? no clue.
-
 
 /datum/species/ethereal/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
 	.=..()

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -9,7 +9,7 @@
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/ethereal
 	mutantstomach = /obj/item/organ/stomach/ethereal
 	exotic_blood = /datum/reagent/consumable/liquidelectricity //Liquid Electricity. fuck you think of something better gamer
-	siemens_coeff = 0.5 //They thrive on energy
+	siemens_coeff = 0.25 //They thrive on energy
 	brutemod = 1.25 //They're weak to punches
 	burnmod = 0.9 //They like heat and energy
 	coldmod = 1.25 //They don't really like the cold.
@@ -17,7 +17,7 @@
 	damage_overlay_type = "" //We are too cool for regular damage overlays
 	species_traits = list(DYNCOLORS, AGENDER, NO_UNDERWEAR)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
-	inherent_traits = list(TRAIT_NOHUNGER, TRAIT_RADIMMUNE) //They like energy and heat, which radiation basically is.
+	inherent_traits = list(TRAIT_NOHUNGER)
 	sexes = FALSE //no fetish content allowed
 	toxic_food = NONE
 	inert_mutation = SHOCKTOUCH


### PR DESCRIPTION
Buffs-
Ethereals are now rad immune, since they like heat and energy (and radiation is energy)
Ethereals now take 10% less burn damage than everyone else, since they like heat and are used to it.

Nerf-
Ethereals now take 25% more damage from the cold.

_Should_ be balanced. Previously their only real upside was taking less shock damage, while having to deal with 25% more brute damage (up to 75% more if they were starving)

edit: Ethereals no longer rad immune, instead they just get a shock resistance buff, making it so shocks only deal 25% their normal damage to ethereals.

#### Changelog

:cl:  
tweak: Ethereals are weaker to the cold, but are rad immune and take 10% less burn damage.
/:cl:
