### PR TITLE
Removes greentext from traitors

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -362,35 +362,20 @@
 
 	var/objectives_text = ""
 	if(objectives.len)//If the traitor had no objectives, don't need to process this.
-		var/count = 1
 		for(var/datum/objective/objective in objectives)
-			if(objective.check_completion())
-				objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <span class='greentext'>Success!</span>"
-			else
-				objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <span class='redtext'>Fail.</span>"
+			if(!objective.check_completion())
 				traitorwin = FALSE
-			count++
 
 	if(uplink_true)
 		var/uplink_text = "(used [TC_uses] TC) [purchases]"
 		if(TC_uses==0 && traitorwin)
-			var/static/icon/badass = icon('icons/badass.dmi', "badass")
-			uplink_text += "<BIG>[icon2html(badass, world)]</BIG>"
 			SSachievements.unlock_achievement(/datum/achievement/badass, owner.current.client)
 		result += uplink_text
 
 	result += objectives_text
 
-	var/special_role_text = lowertext(name)
-
 	if (contractor_hub)
 		result += contractor_round_end()
-
-	if(traitorwin)
-		result += "<span class='greentext'>The [special_role_text] was successful!</span>"
-	else
-		result += "<span class='redtext'>The [special_role_text] has failed!</span>"
-		SEND_SOUND(owner.current, 'sound/ambience/ambifailure.ogg')
 
 	return result.Join("<br>")
 

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -362,9 +362,14 @@
 
 	var/objectives_text = ""
 	if(objectives.len)//If the traitor had no objectives, don't need to process this.
+		var/count = 1
 		for(var/datum/objective/objective in objectives)
-			if(!objective.check_completion())
+			if(objective.check_completion())
+				objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text]"
+			else
+				objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text]"
 				traitorwin = FALSE
+			count++
 
 	if(uplink_true)
 		var/uplink_text = "(used [TC_uses] TC) [purchases]"


### PR DESCRIPTION
### Intent of your Pull Request

Discourages the 'win' and gloating mindset
Discourages the validhunt/murderbone to 'win' and 'must redtext the traitor' mindsets
Encourages the addition of more creative and liberal objectives without worrying about how possible it is to track within code
Tested in private server, working with no runtimes
Avant-garde
requesting test merge

#### Changelog

:cl:  
experimental: Removed greentext from traitors 
/:cl:
