### PR TITLE
Deletes firelocks on destruction

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -284,13 +284,9 @@
 		close()
 
 /obj/machinery/door/firedoor/deconstruct(disassembled = TRUE)
-	if(!(flags_1 & NODECONSTRUCT_1))
+	if(!(flags_1 & NODECONSTRUCT_1) && disassembled)
 		var/obj/structure/firelock_frame/F = new assemblytype(get_turf(src))
-		if(disassembled)
-			F.constructionStep = CONSTRUCTION_PANEL_OPEN
-		else
-			F.constructionStep = CONSTRUCTION_WIRES_EXPOSED
-			F.obj_integrity = F.max_integrity * 0.5
+		F.constructionStep = CONSTRUCTION_PANEL_OPEN
 		F.update_icon()
 	qdel(src)
 


### PR DESCRIPTION
### Intent of your Pull Request

No one bothers to deconstruct broken firelocks and they just clutter the area when explosions happen
![image](https://user-images.githubusercontent.com/28408322/97770270-191dbe00-1b08-11eb-9cc6-63952810939a.png)

#### Changelog

:cl:  
tweak: Firelocks now delete when destroyed
/:cl:
