### PR TITLE
Fixes Misaligned Random Maintenance Door in Starboard Quarter Boxstation Maint

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -37661,10 +37661,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"dBH" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
 "dBV" = (
 /obj/machinery/camera{
 	c_tag = "Central Hallway West";
@@ -50257,6 +50253,11 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
+"nHa" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "nHr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -113344,8 +113345,8 @@ iKq
 iKq
 iKq
 cNW
-bNA
-cOe
+cOT
+cOT
 vJS
 cNW
 aaa
@@ -113600,9 +113601,9 @@ iKq
 iKq
 iKq
 iKq
-cNW
-cOT
-cOT
+nHa
+axl
+uxT
 vJS
 cNW
 cNW
@@ -113857,12 +113858,12 @@ iKq
 iKq
 iKq
 iKq
-dBH
-axl
-uxT
+cNW
+cOe
+cNW
 vJS
 ciL
-cOe
+bNA
 cOe
 cae
 bPp

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -50253,11 +50253,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
-"nHa" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "nHr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -52128,6 +52123,15 @@
 /obj/effect/spawner/lootdrop/aimodule_harmful,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"phB" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "phT" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -113601,7 +113605,7 @@ iKq
 iKq
 iKq
 iKq
-nHa
+phB
 axl
 uxT
 vJS


### PR DESCRIPTION
![bpng](https://user-images.githubusercontent.com/62276730/97770366-fb048d80-1b08-11eb-9a62-c0d97d54cfe3.png)
This PR intends to realign a maintenance door and subsequent affected maintenance.
![cpng](https://user-images.githubusercontent.com/62276730/97770367-ffc94180-1b08-11eb-91ba-bf2221ae2bba.png)
also I think that door had a wall in it

### Changelog
:cl:  
tweak: realigned maintenance door. 
/:cl:
