### PR TITLE
fixes tesla zapping

### DIFF
--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -61,7 +61,7 @@
 		pixel_x = 0
 		pixel_y = 0
 
-		tesla_zap(src, 7, TESLA_DEFAULT_POWER, TRUE)
+		tesla_zap(src, 7, TESLA_DEFAULT_POWER)
 
 		pixel_x = -32
 		pixel_y = -32


### PR DESCRIPTION
Entirely unrelated to https://github.com/yogstation13/Yogstation/pull/10245

the TRUE variable is for the old explosion flag which isn't in the proc anymore, so it instead sets all but 1 of the flag (the 1st flag) to off. This fixes it so it just uses the default values.


