### PR TITLE
Places an Air Fan at the entrance of the Paper Ruin

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/originalcontent.dmm
+++ b/_maps/RandomRuins/SpaceRuins/originalcontent.dmm
@@ -44,20 +44,6 @@
 	},
 /turf/template_noop,
 /area/template_noop)
-"aj" = (
-/obj/machinery/door/airlock/freezer{
-	name = "airlock";
-	opacity = 0
-	},
-/obj/structure/fluff/paper{
-	dir = 8
-	},
-/obj/structure/fluff/paper{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
 "ak" = (
 /obj/structure/fluff/paper{
 	dir = 9
@@ -894,6 +880,21 @@
 	dir = 1
 	},
 /mob/living/simple_animal/hostile/stickman/ranged,
+/turf/open/indestructible/paper,
+/area/ruin/powered)
+"fR" = (
+/obj/machinery/door/airlock/freezer{
+	name = "airlock";
+	opacity = 0
+	},
+/obj/structure/fluff/paper{
+	dir = 8
+	},
+/obj/structure/fluff/paper{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/fans/tiny,
 /turf/open/indestructible/paper,
 /area/ruin/powered)
 "wr" = (
@@ -2540,7 +2541,7 @@ aa
 (37,1,1) = {"
 aa
 ah
-aj
+fR
 an
 wr
 av


### PR DESCRIPTION
Places an air fan at the entrance of the Paper Ruin (originalcontent.dmm) so it doesn't just vent whenever you enter it.
![bpng](https://user-images.githubusercontent.com/62276730/97791999-f7c3dd00-1bae-11eb-9aad-d0773ebdd077.png)
# Changelog
:cl:  
rscadd: Adds an Air Fan at the entrance of the Paper Ruin  
/:cl:
