### PR TITLE
fixes airlock shitcode

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -151,7 +151,7 @@
 				here.PlaceOnTop(/turf/closed/wall)
 				qdel(src)
 				return
-			if(9 to 11)
+			if(10 to 11)
 				lights = FALSE
 				locked = TRUE
 			if(12 to 15)


### PR DESCRIPTION


### Intent of your Pull Request

Basically, if any airlock is considered "abandoned" by mapping, it would roll a number between 1 and 100, triggering various effects ranging from the door being completely replaced by a wall, or stuff like the door being bolted.

To poorly explain: if it rolls a 9, its in range to trigger MULTIPLE effects, though only one works because it runs first and completely overrides the entire switch case.

This has no effect on gameplay or server performance. I just want the code to look nice.

#### Changelog

:cl:  
bugfix: fixes airlock shitcode
/:cl:
