### PR TITLE
decrease airlock skip delay default from 30 seconds to 10 seconds

### DIFF
--- a/code/game/machinery/airlock_cycle_control.dm
+++ b/code/game/machinery/airlock_cycle_control.dm
@@ -77,7 +77,7 @@
 	var/depressurization_margin = 10 // use a lower value to reduce cross-contamination
 	var/depressurization_target = 0 // What to target - should be lower than the depressurization margin
 	var/overlays_hash = null
-	var/skip_delay = 300
+	var/skip_delay = 100
 	var/skip_timer = 0
 	var/is_skipping = FALSE
 


### PR DESCRIPTION
if an airlock needs to be cycling for over 10 seconds naturally something has probably gone terribly wrong, if it needs to be cycling for 30 then it is not working

:cl:  
tweak: airlock cycles can be manually skipped in 10 seconds down from 30
/:cl:
