### PR TITLE
Removes Blob Starts and Generic Event Spawners from Random Maint

### DIFF
--- a/_maps/RandomRuins/StationRuins/maint/10x10/10x10_deltalibrary.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/10x10/10x10_deltalibrary.dmm
@@ -113,11 +113,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/template_noop)
-"az" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/template_noop)
 "aA" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -299,6 +294,10 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/grimy,
 /area/template_noop)
+"Gz" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/template_noop)
 "GX" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -410,7 +409,7 @@ aE
 ae
 aq
 av
-az
+Gz
 Ob
 ap
 aI

--- a/_maps/RandomRuins/StationRuins/maint/10x10/10x10_graffitiroom.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/10x10/10x10_graffitiroom.dmm
@@ -92,10 +92,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/template_noop)
-"q" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plasteel,
-/area/template_noop)
 "r" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -214,7 +210,7 @@ i
 l
 l
 v
-q
+l
 l
 l
 s

--- a/_maps/RandomRuins/StationRuins/maint/10x10/10x10_podrepairbay.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/10x10/10x10_podrepairbay.dmm
@@ -34,11 +34,6 @@
 	},
 /turf/closed/wall/mineral/titanium,
 /area/template_noop)
-"k" = (
-/obj/effect/decal/cleanable/oil/streak,
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/template_noop)
 "l" = (
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/plating,
@@ -97,10 +92,6 @@
 /obj/effect/decal/remains/robot,
 /turf/open/floor/plating,
 /area/template_noop)
-"C" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
-/area/template_noop)
 "E" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
@@ -148,6 +139,10 @@
 /area/template_noop)
 "S" = (
 /obj/structure/girder,
+/turf/open/floor/plating,
+/area/template_noop)
+"T" = (
+/obj/effect/decal/cleanable/oil/streak,
 /turf/open/floor/plating,
 /area/template_noop)
 "U" = (
@@ -217,7 +212,7 @@ f
 b
 u
 g
-C
+a
 B
 b
 "}
@@ -236,7 +231,7 @@ b
 (7,1,1) = {"
 c
 a
-k
+T
 b
 i
 S

--- a/_maps/RandomRuins/StationRuins/maint/5x4/5x4_boxsurgery.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/5x4/5x4_boxsurgery.dmm
@@ -57,10 +57,6 @@
 /obj/item/reagent_containers/blood/random,
 /turf/open/floor/plating,
 /area/template_noop)
-"v" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/template_noop)
 "y" = (
 /obj/machinery/sleeper{
 	dir = 4
@@ -98,7 +94,7 @@ f
 (3,1,1) = {"
 c
 h
-v
+f
 f
 "}
 (4,1,1) = {"


### PR DESCRIPTION
#### Intent of your Pull Request
Removes Blob Starts and Generic Event Spawners from Random Maints, specifically:
5x4 Box Surgery
10x10 Pod Repair Bay
10x10 Graffiti Room
10x10 Delta Library

###### Why is this good for the game?
Uniformity. We shouldn't let this be variable, and even if it isn't a problem on Boxstation, I don't want this to bite us in the ass when random maints are implemented on other maps. If people want generic event spawners and blob starts in random maints, it should be in all of them, or atleast all in a size category, but not some. This logic is in the same vein as #9633.

# Changelog
:cl:  
rscdel: Removed generic event spawners and blob starts in various random maint presets  
/:cl:
