### PR TITLE
halloween roundstart skeleton nerf

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1132,6 +1132,9 @@
 /mob/living/carbon/human/species/skeleton
 	race = /datum/species/skeleton
 
+/mob/living/carbon/human/species/skeleton/lowcalcium
+	race = /datum/species/skeleton/lowcalcium
+
 /mob/living/carbon/human/species/synth
 	race = /datum/species/synth
 

--- a/code/modules/mob/living/carbon/human/species_types/skeletons.dm
+++ b/code/modules/mob/living/carbon/human/species_types/skeletons.dm
@@ -15,7 +15,15 @@
 	//They can technically be in an ERT
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | ERT_SPAWN
 
-/datum/species/skeleton/check_roundstart_eligible()
+/datum/species/skeleton/lowcalcium
+	// these are the ones players can be roundstart during halloween
+	name = "Lesser Spooky Scary Skeleton"
+	id = "weakskeleton"
+	brutemod = 1.5 // Their low calcium bones are much weaker to being smashed.
+	punchdamagehigh = 5 // their weak bones don't let them punch very well.
+	limbs_id = "skeleton" //they are just normal skeletons but weaker
+
+/datum/species/skeleton/lowcalcium/check_roundstart_eligible()
 	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
 		return TRUE
 	return ..()


### PR DESCRIPTION
this PR nerfs the skeletons you can play as during halloween. It doesn't nerf any other skeleton, like the ones you can get from botany or lich, instead it makes a new weak version of skeleton that replaces the roundstart eligibility in halloween. These weaker skeletons, which have low calcium, take 50% more brute damage and can only deal up to 5 damage per punch. They're still pretty damn powerful, but now they're not super OP.

#### Changelog

:cl:  
rscadd: adds low calcium skeletons for halloween roundstart
/:cl:
