### PR TITLE
[box] Makes robotics entry airlock cycle

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -37205,6 +37205,7 @@
 	req_access_txt = "16"
 	},
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
@@ -37217,6 +37218,7 @@
 	pixel_y = 21
 	},
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -37439,7 +37441,9 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "dzD" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plating,
 /area/storage/tech)
 "dzR" = (
@@ -41996,9 +42000,7 @@
 	id = "commissaryshutter";
 	name = "Vacant Commissary Shutter"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -56304,9 +56306,7 @@
 	id = "commissaryshutter";
 	name = "Vacant Commissary Shutter"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -31643,6 +31643,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm{
+	dir = 2;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -41995,7 +41996,9 @@
 	id = "commissaryshutter";
 	name = "Vacant Commissary Shutter"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -43244,7 +43247,7 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Aft";
-	dir = 2
+	dir = 2;
 	network = list("minisat","ss13")
 	},
 /turf/open/space/basic,
@@ -45604,7 +45607,6 @@
 	pixel_y = -13
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	name = "Common Channel";
 	pixel_y = -27
@@ -49417,6 +49419,7 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/ai_monitored/storage/satellite";
+	dir = 2;
 	name = "MiniSat Maint APC";
 	pixel_y = -24
 	},
@@ -56438,7 +56441,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -21152,6 +21152,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_target{
+	dirx = -1;
+	diry = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "bgn" = (
@@ -21496,6 +21500,10 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_target{
+	dirx = 1;
+	diry = -1
+	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "bhu" = (
@@ -31635,7 +31643,6 @@
 	dir = 4
 	},
 /obj/machinery/airalarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -37197,7 +37204,6 @@
 	req_access_txt = "16"
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
@@ -37210,7 +37216,6 @@
 	pixel_y = 21
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -37433,9 +37438,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "dzD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/storage/tech)
 "dzR" = (
@@ -40343,9 +40346,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/vending/autodrobe{
-	req_access_txt = "0"
-	},
+/obj/machinery/vending/autodrobe,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -42926,9 +42927,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/storage/tech)
 "ias" = (
@@ -43241,7 +43240,6 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Aft";
-	dir = 2;
 	network = list("minisat","ss13")
 	},
 /turf/open/space/basic,
@@ -44873,11 +44871,8 @@
 	},
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
-	enabled = 1;
-	icon_state = "control_standby";
 	name = "Antechamber Turret Control";
 	pixel_x = 32;
-	pixel_y = 0;
 	req_access_txt = "19"
 	},
 /obj/effect/turf_decal/tile/darkblue{
@@ -45545,9 +45540,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
@@ -45593,7 +45586,6 @@
 	req_access_txt = "16"
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -45606,7 +45598,6 @@
 	pixel_y = -27
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
@@ -46023,7 +46014,6 @@
 	},
 /obj/effect/landmark/start/ai,
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
@@ -46037,7 +46027,6 @@
 	pixel_y = -27
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -46400,9 +46389,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/storage/tech)
 "kMZ" = (
@@ -49413,7 +49400,6 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/ai_monitored/storage/satellite";
-	dir = 2;
 	name = "MiniSat Maint APC";
 	pixel_y = -24
 	},
@@ -51271,9 +51257,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/sign/warning/radiation/rad_area{
 	pixel_y = -32
 	},
@@ -51580,9 +51564,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/door/window/westleft{
-	base_state = "left";
 	dir = 1;
-	icon_state = "left";
 	layer = 3.1;
 	name = "Cyborg Upload Console Window";
 	req_access_txt = "16"
@@ -55334,9 +55316,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
@@ -55919,9 +55899,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/sign/warning/radiation/rad_area{
 	pixel_y = -32
 	},
@@ -56433,9 +56411,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
@@ -57852,9 +57828,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel{
-	name = "floor"
-	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "tSz" = (
 /turf/open/floor/plasteel,
@@ -62320,7 +62294,6 @@
 "xHn" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/beakers{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/storage/box/syringes{

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -40346,7 +40346,9 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/vending/autodrobe,
+/obj/machinery/vending/autodrobe{
+	req_access_txt = "0"
+	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -42927,7 +42929,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plating,
 /area/storage/tech)
 "ias" = (
@@ -43240,6 +43244,7 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Aft";
+	dir = 2
 	network = list("minisat","ss13")
 	},
 /turf/open/space/basic,
@@ -44871,8 +44876,11 @@
 	},
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
+	enabled = 1;
+	icon_state = "control_standby";
 	name = "Antechamber Turret Control";
 	pixel_x = 32;
+	pixel_y = 0;
 	req_access_txt = "19"
 	},
 /obj/effect/turf_decal/tile/darkblue{
@@ -45540,7 +45548,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
@@ -45586,6 +45596,7 @@
 	req_access_txt = "16"
 	},
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -45593,11 +45604,13 @@
 	pixel_y = -13
 	},
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	name = "Common Channel";
 	pixel_y = -27
 	},
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
@@ -46014,6 +46027,7 @@
 	},
 /obj/effect/landmark/start/ai,
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
@@ -46027,6 +46041,7 @@
 	pixel_y = -27
 	},
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -46389,7 +46404,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plating,
 /area/storage/tech)
 "kMZ" = (
@@ -51257,7 +51274,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/structure/sign/warning/radiation/rad_area{
 	pixel_y = -32
 	},
@@ -51564,7 +51583,9 @@
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/door/window/westleft{
+	base_state = "left";
 	dir = 1;
+	icon_state = "left";
 	layer = 3.1;
 	name = "Cyborg Upload Console Window";
 	req_access_txt = "16"
@@ -55316,7 +55337,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
@@ -55899,7 +55922,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/structure/sign/warning/radiation/rad_area{
 	pixel_y = -32
 	},
@@ -56276,7 +56301,9 @@
 	id = "commissaryshutter";
 	name = "Vacant Commissary Shutter"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -57828,7 +57855,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	name = "floor"
+	},
 /area/engine/engineering)
 "tSz" = (
 /turf/open/floor/plasteel,
@@ -62294,6 +62323,7 @@
 "xHn" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/beakers{
+	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/storage/box/syringes{


### PR DESCRIPTION
### Intent of your Pull Request

This should make the external robotics doors act like the security entrance doors. (IE: close one when the other is opened.) If it doesn't, yell at Mooogle since he was the one guiding me.

### Why is this good for the game?

A lot of roboticists already close the outer mechbay doors manually to prevent the stray assistant or clown from sprinting in for a spare toolbelt or welding goggles. This just makes life easier for most of them without taking anything away in my opinion.

#### Changelog

:cl:  
tweak: [box] Makes robotics entry airlock cycle
/:cl:
