### PR TITLE
Enables Dynamic's continuous mode in the config (Experimental)

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -148,11 +148,7 @@ CONTINUOUS HIVEMIND
 CONTINUOUS MALF
 CONTINUOUS SHADOWLING
 CONTINUOUS VAMPIRE
-
-##Prevents the death of round-ending antagonist rulesets ending the round immediately.
-
 CONTINUOUS DYNAMIC
-
 ##Note: do not toggle continuous off for these modes, as they have no antagonists and would thus end immediately!
 
 CONTINUOUS METEOR

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -149,6 +149,10 @@ CONTINUOUS MALF
 CONTINUOUS SHADOWLING
 CONTINUOUS VAMPIRE
 
+##Prevents the death of round-ending antagonist rulesets ending the round immediately.
+
+CONTINUOUS DYNAMIC
+
 ##Note: do not toggle continuous off for these modes, as they have no antagonists and would thus end immediately!
 
 CONTINUOUS METEOR


### PR DESCRIPTION
Dynamic now shouldn't end due to any antagonist deaths, a port of https://github.com/BeeStation/BeeStation-Hornet/pull/2615

:cl:  
tweak: Dynamic is now continuous, for example, the round will not end when an antagonist dies.
experimental: This is experimental, and is up for change. A few test merges of this would be great.
/:cl:
