### PR TITLE
Praetorian health buff

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/caste/praetorian.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/praetorian.dm
@@ -1,8 +1,8 @@
 /mob/living/carbon/alien/humanoid/royal/praetorian
 	name = "alien praetorian"
 	caste = "p"
-	maxHealth = 250
-	health = 250
+	maxHealth = 300
+	health = 300
 	icon_state = "alienp"
 
 /mob/living/carbon/alien/humanoid/royal/praetorian/Initialize()


### PR DESCRIPTION
I feel like praetorian isn't very good considering you lose the ability to ventcrawl and become far slower than standard humans. Tailwhip, and the ability to spit neurotoxin+build resin is pretty powerful, however one of the most powerful abilities in a xeno's arsenal is the ability to run away, and to ventcrawl, and the praetorian can't really do either of them, and doesn't get egg laying in compensation, so I am giving prae 50 more max health, bringing it to 300 health. (queen is 400 health). 

tl;dr praetorian gets 300 max hp instead of 250

#### Changelog

:cl:  
tweak: xeno praetorian gets +50 hp
/:cl:
