### PR TITLE
fakedeathed lings can now be empty cloned to prevent ling checking with cloning

### DIFF
--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -468,6 +468,9 @@
 	else if (href_list["clone"])
 		var/datum/data/record/C = find_record("id", href_list["clone"], records)
 		var/empty = href_list["empty"]
+		var/datum/mind/M = C.fields["mindref"]
+		if(M?.has_antag_datum(/datum/antagonist/changeling) && HAS_TRAIT(M, TRAIT_FAKEDEATH))
+			empty = TRUE
 		//Look for that player! They better be dead!
 		if(C)
 			if(C.fields["body_only"] && !empty)

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -468,7 +468,7 @@
 	else if (href_list["clone"])
 		var/datum/data/record/C = find_record("id", href_list["clone"], records)
 		var/empty = href_list["empty"]
-		var/datum/mind/M = C.fields["mindref"]
+		var/datum/mind/M = locate(C.fields["mindref"])
 		if(M?.has_antag_datum(/datum/antagonist/changeling) && HAS_TRAIT(M, TRAIT_FAKEDEATH))
 			empty = TRUE
 		//Look for that player! They better be dead!


### PR DESCRIPTION
## Why is this good for the game?

ling checking is unanimously retarded and if you try it you will be gibbed

## Intent of your Pull Request

im trying to save players from being gibbed


#### Changelog

:cl:  
rscadd: Added cloning for fakedeath lings
/:cl: