### PR TITLE
swarmers can eat stuff

### DIFF
--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -29,6 +29,7 @@
 
 /obj/item/integrate_amount() //returns the amount of resources gained when eating this item
 	var/list/mats = get_material_composition(ALL) // Ensures that items made from plasteel, and plas/titanium/plastitaniumglass get integrated correctly.
+	mats += materials
 	if(length(mats) && (mats[getmaterialref(/datum/material/iron)] || mats[getmaterialref(/datum/material/glass)]))
 		return 1
 	return ..()


### PR DESCRIPTION
fixes #10281

turns out the get material composition proc didn't check stuff aside from custom materials

#### Changelog

:cl:  
bugfix: swarmers can eat stuff
/:cl:
