### PR TITLE
Adds cheese staff to CentCom loot room

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -17623,6 +17623,19 @@
 /obj/effect/spawner/structure/window/reinforced/indestructable,
 /turf/open/floor/plating,
 /area/centcom/testchamber)
+"KK" = (
+/obj/structure/glowshroom/single,
+/obj/structure/table/wood,
+/obj/item/gun/magic/wand/death,
+/obj/item/gun/magic/wand/door,
+/obj/item/gun/magic/wand/fireball,
+/obj/item/gun/magic/wand/polymorph,
+/obj/item/gun/magic/wand/resurrection/debug,
+/obj/item/gun/magic/wand/safety,
+/obj/item/gun/magic/wand/teleport,
+/obj/item/gun/magic/staff/cheese,
+/turf/open/floor/wood,
+/area/centcom/testchamber)
 "KL" = (
 /obj/item/storage/box/donkpockets,
 /obj/effect/turf_decal/tile/bar{
@@ -19445,18 +19458,6 @@
 /obj/singularity/wizard/mapped,
 /turf/open/indestructible/binary,
 /area/fabric_of_reality)
-"Qn" = (
-/obj/structure/glowshroom/single,
-/obj/structure/table/wood,
-/obj/item/gun/magic/wand/death,
-/obj/item/gun/magic/wand/door,
-/obj/item/gun/magic/wand/fireball,
-/obj/item/gun/magic/wand/polymorph,
-/obj/item/gun/magic/wand/resurrection/debug,
-/obj/item/gun/magic/wand/safety,
-/obj/item/gun/magic/wand/teleport,
-/turf/open/floor/wood,
-/area/centcom/testchamber)
 "Qo" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -70136,7 +70137,7 @@ Wx
 Vi
 wS
 Tv
-Qn
+KK
 ND
 vq
 wS


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/24533979/98391489-53adbc00-201c-11eb-9737-681c827066c7.png)

![GEYXT5YSgA](https://user-images.githubusercontent.com/24533979/98391455-4b558100-201c-11eb-8fe0-c0d892dab060.png)



#### Changelog

:cl:  Hopek
rscadd: The almighty cheese staff has been added to the CentCom loot room.
/:cl:
