### PR TITLE
Shadowling armor buff

### DIFF
--- a/yogstation/code/modules/antagonists/shadowling/shadowling_items.dm
+++ b/yogstation/code/modules/antagonists/shadowling/shadowling_items.dm
@@ -12,7 +12,7 @@
 	slowdown = 0
 	heat_protection = null //You didn't expect a light-sensitive creature to have heat resistance, did you?
 	max_heat_protection_temperature = null
-	armor = list("melee" = 25, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 25, "bio" = 100, "rad" = 100)
+	armor = list("melee" = 30, "bullet" = 30, "laser" = 0, "energy" = 0, "bomb" = 25, "bio" = 100, "rad" = 100)
 	item_flags = ABSTRACT | DROPDEL
 	clothing_flags = THICKMATERIAL | STOPSPRESSUREDAMAGE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
@@ -32,6 +32,7 @@
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
 	heat_protection = HEAD
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
+	armor = list("melee" = 30, "bullet" = 30, "laser" = 0, "energy" = 0, "bomb" = 25, "bio" = 100, "rad" = 100)
 	clothing_flags = STOPSPRESSUREDAMAGE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	item_flags = ABSTRACT | DROPDEL


### PR DESCRIPTION
The chitin armor and helmet shadowlings get now provide 30 melee and 30 bullet armor, instead of just 25 melee damage for the armor only. For reference, armor vests have 30 melee and 30 bullet armor. Note, chitin armor will still have 0 laser and energy armor, which means they'll still very effective, ballistics like shotgun spam will just be a bit less effective now.

#### Changelog

:cl:  
tweak: shadowling chitin now has 30 melee and bullet resistance.
/:cl:
