### PR TITLE
Gives ashwalkers a pair of science goggles and a hand labeler

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -464,20 +464,6 @@
 /obj/item/construction/rcd/loaded,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
-"bn" = (
-/obj/structure/closet/crate/radiation,
-/obj/item/flashlight/lantern,
-/obj/item/flashlight/lantern,
-/obj/item/flashlight/lantern,
-/obj/item/flashlight/flare,
-/obj/structure/stone_tile/block/cracked{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
 "bo" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -1381,7 +1367,7 @@
 /obj/item/seeds/bamboo,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"ZT" = (
+"ST" = (
 /obj/structure/stone_tile{
 	dir = 4
 	},
@@ -1391,6 +1377,23 @@
 /obj/item/reagent_containers/blood/lizard,
 /obj/item/stack/sheet/cloth/ten,
 /obj/item/healthanalyzer,
+/obj/item/clothing/glasses/science,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"Vq" = (
+/obj/structure/closet/crate/radiation,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/flare,
+/obj/structure/stone_tile/block/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
+/obj/item/hand_labeler,
+/obj/item/hand_labeler_refill,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 
@@ -1553,10 +1556,10 @@ aa
 aa
 ae
 as
-ZT
+ST
 aQ
 am
-bn
+Vq
 bz
 ak
 cb


### PR DESCRIPTION
They don't fit into the tribal theme of ashwalkers but the organization these things provide is very nice.

intent: Gives ashwalkers a better way to organize

Purpose: Lets ashwalkers organize their stuff better. I did not specifically test it but it is a very simple change so there is no reason for it not to work.

Why is it good for the game?: Lets ashwalkers organize their stuff better.

Why is it beneficial?: Lets ashwalkers organize their stuff better, what more can I say? Ashwalkers can't organize their things well, so this lets them do it.

#### Changelog

:cl:  
rscadd: Gives ashwalkers a pair of science goggles and a hand labeler
/:cl:
