### PR TITLE
Shadowling empowered thralls now get veil

### DIFF
--- a/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
@@ -1,4 +1,4 @@
-#define EMPOWERED_THRALL_LIMIT 5
+#define EMPOWERED_THRALL_LIMIT 3
 
 /obj/effect/proc_holder/spell/proc/shadowling_check(var/mob/living/carbon/human/H)
 	if(!H || !istype(H)) return
@@ -601,6 +601,7 @@
 				thrallToRevive.set_species(/datum/species/shadow/ling/lesser)
 				thrallToRevive.mind.RemoveSpell(/obj/effect/proc_holder/spell/targeted/lesser_glare)
 				thrallToRevive.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/sling/glare(null))
+				thrallToRevive.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/veil(null))
 			if("Revive")
 				if(!is_thrall(thrallToRevive))
 					to_chat(user, "<span class='warning'>[thrallToRevive] is not a thrall.</span>")

--- a/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
@@ -597,7 +597,7 @@
 					return
 				thrallToRevive.visible_message("<span class='warning'>[thrallToRevive] slowly rises, no longer recognizable as human.</span>", \
 											   "<span class='shadowling'><b>You feel new power flow into you. You have been gifted by your masters. You now closely resemble them. You are empowered in \
-											    darkness but wither slowly in light. In addition, Lesser Glare has been upgraded into it's true form.</b></span>")
+											    darkness but wither slowly in light. In addition, Lesser Glare has been upgraded into it's true form, and you've been given the ability to turn off nearby lights.</b></span>")
 				thrallToRevive.set_species(/datum/species/shadow/ling/lesser)
 				thrallToRevive.mind.RemoveSpell(/obj/effect/proc_holder/spell/targeted/lesser_glare)
 				thrallToRevive.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/sling/glare(null))


### PR DESCRIPTION
Empowered thralls still aren't really worth it, considering one of the main advantages of thralls is that they can blend in pretty well and don't have to die to lights, but empowered thralls lose both of these advantages, while supposedly being a 'upgrade'. This changes that to make them a viable upgrade since they now get veil, and an actual reason to empower thralls. However, to balance it, the maximum number of empowered thralls is now only 3 instead of 5, so each shadowling can basically have one empowered thrall if they distribute fairly.

#### Changelog

:cl:  
rscadd: Empowered thralls now get the veil (lights) ability.
tweak: max amount of empowered thralls is now 3 rather than 5
/:cl:
