### PR TITLE
shadowlings get nightmare jaunt

### DIFF
--- a/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
@@ -710,8 +710,8 @@
 	range = -1
 	include_user = TRUE
 	overlay = null
-	action_icon = 'yogstation/icons/mob/actions.dmi'
-	action_icon_state = "shadow_walk"
+	action_icon = 'icons/mob/actions/actions_spells.dmi'
+	action_icon_state = "jaunt"
 
 	var/apply_damage = TRUE
 

--- a/yogstation/code/modules/antagonists/shadowling/special_shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/special_shadowling_abilities.dm
@@ -103,6 +103,7 @@
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/sling/glare(null))
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/veil(null))
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/void_jaunt(null))
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadowwalk(null))
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/flashfreeze(null))
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/collective_mind(null))
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/shadowling_regenarmor(null))


### PR DESCRIPTION
This gives shadowlings nightmare jaunt so that they're able to enter lit departments in order to disable them, and it also allows them to be invisible in the dark if they so choose. This is so that slings can actually be more mobile than nightmares, their weaker armblade wielding cousins. This also changes the void jaunt icon to ethereal jaunt so that it isn't the same as nightmare jaunt. I have tested it, and it works fine.

#### Changelog

:cl:  
rscadd: adds nightmare jaunt to slings
tweak: edits void jaunt icon to ethereal jaunt
/:cl:
