### PR TITLE
Radium piles aren't as bright

### DIFF
--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -75,7 +75,7 @@
 	name = "glowing goo"
 	desc = "Jeez. I hope that's not for lunch."
 	icon_state = "greenglow"
-	light_power = 3
+	light_power = 1
 	light_range = 2
 	light_color = LIGHT_COLOR_GREEN
 


### PR DESCRIPTION
This is primarily to help slings not get cucked by radium piles, but also because they're too bright to begin with. Like, why are they so bright? This won't stop people from cucking slings by spamming this in maint still, but slings now can't take burn damage from standing on a pile of it unless another one or more is nearby, as it doesn't surpass the light threshold.

![gottem](https://user-images.githubusercontent.com/60946370/98506677-a99f8100-2221-11eb-8ff4-68e8b852d584.PNG)
In the picture, the sling is not going to take any burn damage, although it should still stop them from healing.

#### Changelog

:cl:  
tweak: radium piles are dimmer
/:cl:
