### PR TITLE
Fixes Jamie's "solution" to the free miners infrequently spawning.

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -264,7 +264,7 @@
 	dwidth = 11
 	height = 22
 	width = 35
-	shuttlekeys = list("whiteship_salvage", "whiteship_construction", "whiteship_hospital", "whiteship_ufo", "whiteship_frigate", "whiteship_miner")
+	shuttlekeys = list("whiteship_salvage", "whiteship_construction", "whiteship_hospital", "whiteship_ufo", "whiteship_frigate")
 
 /obj/docking_port/mobile
 	name = "shuttle"

--- a/yogstation/code/datums/ruins/free_miners.dm
+++ b/yogstation/code/datums/ruins/free_miners.dm
@@ -6,6 +6,7 @@
 	description = "Some space miners still cling to the old way of getting that \
 		sweet, sweet plasma - painstakingly digging it out of free-floating asteroids\
 		instead of flying down to the hellscape of lavaland."
+	placement_weight = 2
 	allow_duplicates = FALSE
 	always_spawn_with = list(/datum/map_template/ruin/space/whiteshipdock = PLACE_SPACE_RUIN)
 


### PR DESCRIPTION
In one fix or another, Jamie decided to resolve the problem UselessTheremin brought up of the free miner ship not spawning as often due to my random white ship PR by putting it in with the random ships. This is a problem, primarily because the free miners are supposed to have the asteroid to spawn with, since space ruins with actual ores make up a rather small portion of the space ruins, let alone actual asteroids. Also, even though the actual free miner "ruin" invokes the whiteshipdock, I'd prefer it if they weren't stepping on each other's toes.

So my fix for this was to increase the placement weight of the free miners from 1 to 2. I've not been able to see this actually used in code elsewhere, but I figured we'll give it a shot.

#### Changelog

:cl:  
bugfix: The free miners no longer have a chance to spawn without an asteroid.
/:cl:
