### PR TITLE
makes the start of damage slowdown percent based

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1236,7 +1236,7 @@ GLOBAL_LIST_EMPTY(mentor_races)
 				. += I.slowdown
 		if(!HAS_TRAIT(H, TRAIT_IGNOREDAMAGESLOWDOWN))
 			var/health_deficiency = max(H.maxHealth - H.health, H.staminaloss)
-			if(health_deficiency >= maxHealth * 0.4)
+			if(health_deficiency >= H.maxHealth * 0.4)
 				if(flight)
 					. += (health_deficiency / 75)
 				else

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1236,7 +1236,7 @@ GLOBAL_LIST_EMPTY(mentor_races)
 				. += I.slowdown
 		if(!HAS_TRAIT(H, TRAIT_IGNOREDAMAGESLOWDOWN))
 			var/health_deficiency = max(H.maxHealth - H.health, H.staminaloss)
-			if(health_deficiency >= 40)
+			if(health_deficiency >= maxHealth * 0.4)
 				if(flight)
 					. += (health_deficiency / 75)
 				else


### PR DESCRIPTION
### Intent of your Pull Request

changes damage slowdown from being caused after taking 40 damage to being caused after taking 40% of your maximum health

### Why is this good for the game?

human mobs with higher health will take damage slowdown relative to how much health they actually have instead of how much health is the baseline

#### Changelog

:cl:  
tweak: damage slowdown now starts at 40% damage rather than 40 damage
/:cl:
