### PR TITLE
Make events fire slightly more often

### DIFF
--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -9,7 +9,7 @@ SUBSYSTEM_DEF(events)
 
 	var/scheduled = 0			//The next world.time that a naturally occuring random event can be selected.
 	var/frequency_lower = 1200	//2 minutes lower bound.
-	var/frequency_upper = 5400	//9 minutes upper bound. Basically an event will happen every 2 to 9 minutes.
+	var/frequency_upper = 9 MINUTES //9 minutes upper bound. Basically an event will happen every 2 to 9 minutes.
 
 	var/list/holidays			//List of all holidays occuring today or null if no holidays
 	var/wizardmode = FALSE

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -8,8 +8,8 @@ SUBSYSTEM_DEF(events)
 	var/list/currentrun = list()
 
 	var/scheduled = 0			//The next world.time that a naturally occuring random event can be selected.
-	var/frequency_lower = 1800	//3 minutes lower bound.
-	var/frequency_upper = 6000	//10 minutes upper bound. Basically an event will happen every 3 to 10 minutes.
+	var/frequency_lower = 1200	//2 minutes lower bound.
+	var/frequency_upper = 5400	//9 minutes upper bound. Basically an event will happen every 2 to 9 minutes.
 
 	var/list/holidays			//List of all holidays occuring today or null if no holidays
 	var/wizardmode = FALSE

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -8,7 +8,7 @@ SUBSYSTEM_DEF(events)
 	var/list/currentrun = list()
 
 	var/scheduled = 0			//The next world.time that a naturally occuring random event can be selected.
-	var/frequency_lower = 1200	//2 minutes lower bound.
+	var/frequency_lower = 2 MINUTES //2 minutes lower bound.
 	var/frequency_upper = 9 MINUTES //9 minutes upper bound. Basically an event will happen every 2 to 9 minutes.
 
 	var/list/holidays			//List of all holidays occuring today or null if no holidays


### PR DESCRIPTION
### Intent of your Pull Request

Events now fire between 2-9 minutes instead of 3-10

Makes the game slightly funner and chaotic

### Why is this good for the game?

Slightly more chaotic rounds, more fun

#### Changelog

:cl:  
tweak: Events now happen more often
/:cl:
