### PR TITLE
King Goat Plushie for Traitor Clerk

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1891,6 +1891,12 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/hierophant_antenna
 	restricted_roles = list("Shaft Miner")
 
+/datum/uplink_item/role_restricted/king_goat_plushie
+	name = "King Goat Plushie"
+	desc = "This plushie contains an inkling of the King Goat's Power."
+	item = /obj/item/toy/plush/goatplushie/angry/kinggoat
+	cost = 10
+	restricted_roles = list("Clerk")
 // Pointless
 /datum/uplink_item/badass
 	category = "(Pointless) Badassery"


### PR DESCRIPTION
### Intent of your Pull Request

Adds the King Goat plushie to the clerk's uplink at 10 TC. 

### Why is this good for the game?

The Clerk currently has no role-restricted traitor items unlike many of the other jobs on the station and lacks important accesses making them essentially a glorified assistant with better starting gear and costumes. The King Goat Plushie is only currently obtainable from mass buying plushie crates or finding them in the starting presents in your shop which is exceptionally rare. 
By adding the King Goat Plushie as a traitor item purchasable from the uplink we get to see the item being used more often for hilarious effect and buff the Clerk's uplink options.

It comparison to its closest competition the Esword the King Goat Plushie fares like this:
+Deals more damage when it eats cabbage and becoming an Ascended King Goat plushie.
+Is inconspicuous in sec searches so its unlikely for it to removed from your inventory or for you to be called a traitor. 
+Does not have to be sheathed nor does it make the esword's distinctive sound. The goat sounds when used may be as loud as a esword though.
+Everyone will respect you for holding the One True King in your hands. 
=Is the same size at small as the Esword allowing it to be stored in boxes.
=Crits in 4 hits the same as an esword.
-Does less damage than an esword in base form.
-Does not have the ability to delimb so you will be unable to cut heads off to prevent revivals. 
-When dropped it will jump and attack others including yourself could have niche uses but is more likely to screw you over.


#### Changelog

:cl:  
rscadd: Added new things  
/:cl:
