### PR TITLE
Changes personal closet recipe to a generic secure closet

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -510,10 +510,11 @@
 	reqs = 	list(/obj/item/stack/sheet/cloth = 2, /obj/item/stack/rods = 1)
 	result = /obj/structure/cloth_curtain
 	category = CAT_MISC
-/datum/crafting_recipe/personal_closet
-	name = "Personal Closet"
+	
+/datum/crafting_recipe/secure_closet
+	name = "Secure Closet"
 	reqs = list(/obj/item/stack/sheet/metal = 5, /obj/item/stack/cable_coil = 10, /obj/item/electronics/airlock = 1)
-	result = /obj/structure/closet/secure_closet/personal
+	result = /obj/structure/closet/secure_closet
 	category = CAT_MISC
 
 /datum/crafting_recipe/chemical_payload


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29339701/98835269-3149e300-240e-11eb-94fc-48e882905bcc.png)

#### Changelog

:cl:  
bugfix: Crafted personal closets no longer spawn with bags and a radio.
tweak: Rebranded the personal closet recipe as a secure closet.
/:cl:
