### PR TITLE
probably stops xenos from shooting themselves with neurospit

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -229,6 +229,7 @@ Doesn't work on other aliens/AI.*/
 
 	user.visible_message("<span class='danger'>[user] spits neurotoxin!", "<span class='alertalien'>You spit neurotoxin.</span>")
 	var/obj/item/projectile/bullet/neurotoxin/A = new /obj/item/projectile/bullet/neurotoxin(user.loc)
+	A.firer = user
 	A.preparePixelProjectile(target, user, params)
 	A.fire()
 	user.newtonian_move(get_dir(U, T))


### PR DESCRIPTION


### Intent of your Pull Request

yes

### Why is this good for the game?

yes

#### Changelog

:cl:  
bugfix: xenos will no longer shoot themselves with neurospit if they run into it
/:cl:
