### PR TITLE
the transit tube in 10x5_transit.dmm is now functional

### DIFF
--- a/_maps/RandomRuins/StationRuins/maint/10x5/10x5_transit.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/10x5/10x5_transit.dmm
@@ -47,7 +47,7 @@
 	dir = 1
 	},
 /obj/structure/transit_tube_pod{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,


### PR DESCRIPTION
It was facing the wrong direction

#### Changelog

:cl:  
bugfix: the transit tube in 10x5_transit.dmm is now functional
/:cl:
