### PR TITLE
changes the nightmare's objective to something more thematic

### DIFF
--- a/code/modules/antagonists/nightmare/nightmare.dm
+++ b/code/modules/antagonists/nightmare/nightmare.dm
@@ -9,7 +9,7 @@
 	new_objective.owner = owner
 	new_objective.completed = TRUE
 	objectives += new_objective
-	new_objective.explanation_text = "<span class='userdanger'>Kill.</span>" // you can do whatever
+	new_objective.explanation_text = "This station is an insult to the void. Return it to darkness."
 	var/datum/objective/survive/survival = new
 	survival.owner = owner
 	objectives += survival // just dont die doing it


### PR DESCRIPTION
### Intent of your Pull Request

change the flavortext for the free objective nightmares get from "kill" to "return the station to darkness"

### Why is this good for the game?

it's not but an objective just saying to kill people is worse

#### Changelog

:cl:  
tweak: nightmare objective is now more T H E M A T I C
/:cl:
