### PR TITLE
Gives the AI one(1) shell if there are no roundstart cyborgs

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -363,26 +363,24 @@ SUBSYSTEM_DEF(ticker)
 			SSticker.minds += P.new_character.mind
 		CHECK_TICK
 
-
 /**
   * Equips people that are readied up when the round starts
   *
   * In addition, responsible for spawning the cyborg shell if there are no roundstart cyborgs and announcing if there ISN'T a Captain present
   */
 /datum/controller/subsystem/ticker/proc/equip_characters()
-	var/captainless=1
-
+	var/captainless = TRUE
 	var/no_cyborgs = TRUE
 
 	for(var/mob/dead/new_player/N in GLOB.player_list)
 		var/mob/living/carbon/human/player = N.new_character
 		if(istype(player) && player.mind && player.mind.assigned_role)
 			if(player.mind.assigned_role == "Captain")
-				captainless=0
+				captainless = FALSE
 			if(player.mind.assigned_role == "Cyborg")
 				no_cyborgs = FALSE
 			if(player.mind.assigned_role != player.mind.special_role)
-				SSjob.EquipRank(N, player.mind.assigned_role, 0)
+				SSjob.EquipRank(N, player.mind.assigned_role, FALSE)
 				if(CONFIG_GET(flag/roundstart_traits) && ishuman(N.new_character))
 					SSquirks.AssignQuirks(N.new_character, N.client, TRUE)
 		CHECK_TICK

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -364,18 +364,42 @@ SUBSYSTEM_DEF(ticker)
 		CHECK_TICK
 
 
+/**
+  * Equips people that are readied up when the round starts
+  *
+  * In addition, responsible for spawning the cyborg shell if there are no roundstart cyborgs and announcing if there ISN'T a Captain present
+  */
 /datum/controller/subsystem/ticker/proc/equip_characters()
 	var/captainless=1
+
+	var/no_cyborgs = TRUE
+
 	for(var/mob/dead/new_player/N in GLOB.player_list)
 		var/mob/living/carbon/human/player = N.new_character
 		if(istype(player) && player.mind && player.mind.assigned_role)
 			if(player.mind.assigned_role == "Captain")
 				captainless=0
+			if(player.mind.assigned_role == "Cyborg")
+				no_cyborgs = FALSE
 			if(player.mind.assigned_role != player.mind.special_role)
 				SSjob.EquipRank(N, player.mind.assigned_role, 0)
 				if(CONFIG_GET(flag/roundstart_traits) && ishuman(N.new_character))
 					SSquirks.AssignQuirks(N.new_character, N.client, TRUE)
 		CHECK_TICK
+	if(no_cyborgs)
+		var/obj/S = null
+		for(var/obj/effect/landmark/start/sloc in GLOB.start_landmarks_list)
+			if(sloc.name != "Cyborg")
+				S = sloc //so we can revert to spawning them on top of eachother if something goes wrong
+				continue
+			if(locate(/mob/living) in sloc.loc)
+				continue
+			S = sloc
+			sloc.used = TRUE
+			break
+		if(S)
+			new /mob/living/silicon/robot/shell(get_turf(S))
+
 	if(captainless)
 		for(var/mob/dead/new_player/N in GLOB.player_list)
 			if(N.new_character)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1249,3 +1249,7 @@
 		old_ai.connected_robots -= src
 	if(connected_ai)
 		connected_ai.connected_robots |= src
+
+
+/mob/living/silicon/robot/shell
+	shell = TRUE

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1250,6 +1250,5 @@
 	if(connected_ai)
 		connected_ai.connected_robots |= src
 
-
 /mob/living/silicon/robot/shell
 	shell = TRUE


### PR DESCRIPTION
### Intent of your Pull Request
Bounty.

See title. 

### Why is this good for the game?
Gives AI's, especially traitor AI's, some way to interact with the outside world. They're not as good as a regular borg so this is balanced enough in my opinion


#### Changelog

:cl:  
experimental: If there are no roundstart cyborgs the AI gets a complementary shell! Courtesy of NanoTrasen Data Mining Division
/:cl:

Obligatory Jamie bad x2