### PR TITLE
Fixes Arrivals Airlocks never repressurizing ("hopek fucked up" edition)

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1317,11 +1317,11 @@
 	update_icon(AIRLOCK_CLOSING, 1)
 	layer = CLOSED_DOOR_LAYER
 	if(air_tight)
+		density = TRUE
 		air_update_turf(1)
 	sleep(1)
 	density = TRUE
 	if(!air_tight)
-		density = TRUE
 		air_update_turf(1)
 	sleep(4)
 	if(!safe)


### PR DESCRIPTION
So, while testing some extools-related code I decided to look into the arrivals airlock issue. After a bit I found out that the culprit was due to the air going through the airlock and into space causing the airlock to never repressurize. In effect, the airlock was leaking air.

So, looking into the code, guess what I found out?

~~IT WAS TG's FAULT. TG CODERS FUCKED IT 3 YEARS AGO.~~ Turns out it was actually hopek and Git Blame lied to me

That's right. There's a var called `air_tight`. It unfortunately due to shitty coding on the part of TG 3 years ago does the exact opposite, by making it so that the air_update_turf is never called. It makes the door not air tight. When a shuttle docks next to a door it's air_tight gets set to 1. 

:cl: monster860
fix: ARRIVALS AIRLOCKS CAN NOW REPRESSURIZE WOOHOO
/:cl: