### PR TITLE
Makes minebots ashproof

### DIFF
--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -11,6 +11,7 @@
 	icon_living = "mining_drone"
 	status_flags = CANSTUN|CANKNOCKDOWN|CANPUSH
 	mouse_opacity = MOUSE_OPACITY_ICON
+	weather_immunities = list("ash")
 	faction = list("neutral")
 	a_intent = INTENT_HARM
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)


### PR DESCRIPTION
### Intent of your Pull Request

Gives minebots the ash weather immunity

### Why is this good for the game?

Makes the already garbage minebot less of a garbage pick by making it not get itself killed if you forget about it or cant move it back inside

#### Changelog

:cl:  
Tweak: minebots are now ashproof
/:cl:
