### PR TITLE
No more revolutionary provocateurs from dynamic.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -85,7 +85,7 @@
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 1
 	weight = 1
-	cost = 20
+	cost = 101
 	requirements = list(80,75,60,60,55,50,40,30,20,20)
 	high_population_requirement = 50
 	flags = HIGHLANDER_RULESET


### PR DESCRIPTION
The revolution gamemode is currently problematic with dynamic, there will be a code solution created soon, however this will keep it from spawning in at all for now.

:cl:  
tweak: Provocateurs are now impossible to spawn.
/:cl:
