### PR TITLE
Attempting to speak an invalid radio prefix (such as ...) will no longer cause you to whisper and play a radio noise

### DIFF
--- a/_maps/RandomRuins/StationRuins/maint/10x10/10x10_junction.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/10x10/10x10_junction.dmm
@@ -12,8 +12,7 @@
 	id = "junctionshutter";
 	name = "Shutters Control";
 	pixel_x = 26;
-	pixel_y = 4;
-	sync_doors = 0
+	pixel_y = 4
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -27,8 +26,7 @@
 	id = "junctionshutter";
 	name = "Shutters Control";
 	pixel_x = -4;
-	pixel_y = 26;
-	sync_doors = 0
+	pixel_y = 26
 	},
 /obj/machinery/light{
 	dir = 2
@@ -53,7 +51,8 @@
 /area/template_noop)
 "v" = (
 /obj/machinery/door/poddoor/shutters/preopen{
-	id = "junctionshutter"
+	id = "junctionshutter";
+	state_open = 1
 	},
 /turf/open/floor/plating,
 /area/template_noop)
@@ -62,8 +61,7 @@
 	id = "junctionshutter";
 	name = "Shutters Control";
 	pixel_x = -4;
-	pixel_y = -26;
-	sync_doors = 0
+	pixel_y = -26
 	},
 /obj/machinery/light{
 	dir = 1
@@ -96,8 +94,7 @@
 	id = "junctionshutter";
 	name = "Shutters Control";
 	pixel_x = -26;
-	pixel_y = 4;
-	sync_doors = 0
+	pixel_y = 4
 	},
 /obj/machinery/light{
 	dir = 4;

--- a/_maps/RandomRuins/StationRuins/maint/10x10/10x10_junction.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/10x10/10x10_junction.dmm
@@ -51,7 +51,8 @@
 /area/template_noop)
 "v" = (
 /obj/machinery/door/poddoor/shutters/preopen{
-	id = "junctionshutter"
+	id = "junctionshutter";
+	state_open = 1
 	},
 /turf/open/floor/plating,
 /area/template_noop)

--- a/_maps/RandomRuins/StationRuins/maint/10x10/10x10_junction.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/10x10/10x10_junction.dmm
@@ -12,7 +12,8 @@
 	id = "junctionshutter";
 	name = "Shutters Control";
 	pixel_x = 26;
-	pixel_y = 4
+	pixel_y = 4;
+	sync_doors = 0
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -26,7 +27,8 @@
 	id = "junctionshutter";
 	name = "Shutters Control";
 	pixel_x = -4;
-	pixel_y = 26
+	pixel_y = 26;
+	sync_doors = 0
 	},
 /obj/machinery/light{
 	dir = 2
@@ -51,8 +53,7 @@
 /area/template_noop)
 "v" = (
 /obj/machinery/door/poddoor/shutters/preopen{
-	id = "junctionshutter";
-	state_open = 1
+	id = "junctionshutter"
 	},
 /turf/open/floor/plating,
 /area/template_noop)
@@ -61,7 +62,8 @@
 	id = "junctionshutter";
 	name = "Shutters Control";
 	pixel_x = -4;
-	pixel_y = -26
+	pixel_y = -26;
+	sync_doors = 0
 	},
 /obj/machinery/light{
 	dir = 1
@@ -94,7 +96,8 @@
 	id = "junctionshutter";
 	name = "Shutters Control";
 	pixel_x = -26;
-	pixel_y = 4
+	pixel_y = 4;
+	sync_doors = 0
 	},
 /obj/machinery/light{
 	dir = 4;

--- a/_maps/RandomRuins/StationRuins/maint/10x10/10x10_junction.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/10x10/10x10_junction.dmm
@@ -51,8 +51,7 @@
 /area/template_noop)
 "v" = (
 /obj/machinery/door/poddoor/shutters/preopen{
-	id = "junctionshutter";
-	state_open = 1
+	id = "junctionshutter"
 	},
 /turf/open/floor/plating,
 /area/template_noop)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -142,7 +142,7 @@
 			mods[MODE_SING] = TRUE
 		else if(key == ";" && !mods[MODE_HEADSET])
 			mods[MODE_HEADSET] = TRUE
-		else if((key in GLOB.department_radio_prefixes) && length(message) > length(key) + 1 && !mods[RADIO_EXTENSION])
+		else if((key in GLOB.department_radio_prefixes) && length(message) > length(key) + 1 && !mods[RADIO_EXTENSION] && (lowertext(message[1 + length(key)]) in GLOB.department_radio_keys))
 			mods[RADIO_KEY] = lowertext(message[1 + length(key)])
 			mods[RADIO_EXTENSION] = GLOB.department_radio_keys[mods[RADIO_KEY]]
 			chop_to = length(key) + 2


### PR DESCRIPTION

### Intent of your Pull Request
As title. 
Tested!
![image](https://user-images.githubusercontent.com/40673387/99198198-fc6ac280-2764-11eb-9c90-3f41db9a3530.png)

### Why is this good for the game?

Darkstick cried a lot so this will make him stop crying.

Also allows you to be like "...really"  which improves rp, I guess?

#### Changelog

:cl:  
bugfix: you no longer can whisper into phantom radios 
bugfix: you can now say ... again without talking into a radio channel that doesn't exist
/:cl:
