### PR TITLE
makes foods that require reagents to craft inherit those reagents

### DIFF
--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -196,6 +196,9 @@ All foods are distributed among various categories. Use common sense.
 	reagents.clear_reagents()
 	for(var/obj/item/reagent_containers/RC in contents)
 		RC.reagents.trans_to(reagents, RC.reagents.maximum_volume)
+	for(var/reagent in R.reqs)
+		if(ispath(reagent, /datum/reagent))
+			reagents.add_reagent(reagent, R.reqs[reagent])
 	if(istype(R))
 		contents_loop:
 			for(var/A in contents)


### PR DESCRIPTION

### Intent of your Pull Request

causes foods crafted with reagents to also have the reagents required to craft them with

### Why is this good for the game?

makes snowcones work as intended, probably doesn't break anything

#### Changelog

:cl:  
tweak: foods that have reagents required in their crafting now also have those reagents
/:cl:
