### PR TITLE
probably fixes runtime in crafting.dm

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -216,7 +216,7 @@
 				var/datum/reagent/RGNT
 				while(amt > 0)
 					var/obj/item/reagent_containers/RC = locate() in surroundings
-					RG = RC.reagents.get_reagent(A)
+					RG = RC.reagents?.get_reagent(A)
 					if(RG)
 						if(!locate(RG.type) in Deletion)
 							Deletion += new RG.type()


### PR DESCRIPTION
no clue what causes it but there's a can't read null.reagents runtime that occurs sometimes during crafting
:cl:  
bugfix: crafting no longer sometimes doesn't expend its requirements
/:cl:
