### PR TITLE
Surrounds Tech Storage with Reinforced Walls

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -12783,13 +12783,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"aHO" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/storage/eva)
 "aHP" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -31285,28 +31278,6 @@
 "bYN" = (
 /turf/closed/wall,
 /area/security/checkpoint/engineering)
-"bYZ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Tech Storage";
-	req_access_txt = "23"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/storage/tech)
 "bZg" = (
 /obj/machinery/computer/secure_data{
 	dir = 1
@@ -38102,6 +38073,18 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"fjG" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "Secure Tech Storage";
+	req_access_txt = "19;23";
+	security_level = 6
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
 "fjY" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -52333,6 +52316,14 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"pNo" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Secure Tech Storage";
+	req_access_txt = "19;23";
+	security_level = 6
+	},
+/turf/closed/wall/r_wall,
+/area/ai_monitored/storage/eva)
 "pOw" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/port)
@@ -59734,6 +59725,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"vhJ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Tech Storage";
+	req_access_txt = "23";
+	security_level = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/storage/tech)
 "vhN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -92572,9 +92586,9 @@ aAb
 aBp
 aCc
 aDF
-ayL
+pNo
 aGq
-aHO
+fjG
 aJl
 ayW
 aJq
@@ -94171,7 +94185,7 @@ bNI
 bTz
 kfR
 kfR
-bYZ
+vhJ
 kfR
 pNb
 pIF

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -27632,9 +27632,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"bCs" = (
-/turf/closed/wall,
-/area/storage/tech)
 "bCu" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/public/glass{
@@ -44605,6 +44602,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"kfR" = (
+/turf/closed/wall/r_wall,
+/area/storage/tech)
 "kgS" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -91856,15 +91856,15 @@ bNI
 bNI
 bNI
 bHE
-bCs
-bCs
+kfR
+kfR
 ccA
 bGu
 gDG
 bJi
 ccA
-bCs
-bCs
+kfR
+kfR
 cay
 ccw
 ciZ
@@ -92113,7 +92113,7 @@ mMH
 cCf
 bNI
 bHE
-bCs
+kfR
 eVJ
 hcN
 jld
@@ -92121,7 +92121,7 @@ kMi
 uOe
 fQR
 lql
-bCs
+kfR
 cay
 ccw
 ccw
@@ -92370,7 +92370,7 @@ cCd
 cCe
 bNI
 bHE
-bCs
+kfR
 ojh
 mJy
 iWV
@@ -92378,7 +92378,7 @@ wPL
 wxB
 vsP
 qLd
-bCs
+kfR
 cay
 ccw
 bRq
@@ -92627,7 +92627,7 @@ bNJ
 cCe
 bNI
 bHE
-bCs
+kfR
 tzL
 ocD
 pfl
@@ -92635,7 +92635,7 @@ weR
 dzD
 sfV
 lwC
-bCs
+kfR
 lkF
 ccw
 pHO
@@ -92884,7 +92884,7 @@ xtS
 svR
 bNI
 bHE
-bCs
+kfR
 cMh
 eCt
 kie
@@ -92892,7 +92892,7 @@ cIZ
 hqB
 gmQ
 vHw
-bCs
+kfR
 cay
 ccw
 mqz
@@ -93141,7 +93141,7 @@ xPt
 juw
 bNI
 xLY
-bCs
+kfR
 juo
 kaj
 exY
@@ -93149,7 +93149,7 @@ rPP
 leu
 hZA
 xZE
-bCs
+kfR
 cay
 ccw
 hha
@@ -93398,7 +93398,7 @@ bNJ
 cCc
 bNI
 bHE
-bCs
+kfR
 gIE
 vHq
 mSs
@@ -93406,7 +93406,7 @@ qRN
 mSs
 vzc
 kCd
-bCs
+kfR
 cay
 ccw
 wTx
@@ -93655,7 +93655,7 @@ bNJ
 cCb
 bNI
 bHE
-bCs
+kfR
 cRi
 sKA
 lyB
@@ -93663,7 +93663,7 @@ fyA
 gRh
 hZA
 tVM
-bCs
+kfR
 cay
 ccw
 yly
@@ -93912,15 +93912,15 @@ bNJ
 bSz
 bNI
 bHE
-bCs
+kfR
 xLZ
 wMs
-bCs
-bCs
-bCs
-bCs
-bCs
-bCs
+kfR
+kfR
+kfR
+kfR
+kfR
+kfR
 cay
 ccw
 cig
@@ -94169,10 +94169,10 @@ bNI
 bNI
 bNI
 bTz
-bCs
-bCs
+kfR
+kfR
 bYZ
-bCs
+kfR
 pNb
 pIF
 huU


### PR DESCRIPTION
### Intent:
Tech storage is no surrounded by reinforced walls.

# Why is this good for the game?
You'd think there'd be more than a standard wall between Joe Antag and the R&D Server, Chem Dispenser, Camera Console, Smoke Machine, Cloning Boards, Microwave, etc.

############ Changelog

:cl:  
rscadd: [box] Adds reinforced walls around tech storage  
/:cl:
