### PR TITLE
Expands Secure Tech Storage, moves "Problematic" Boards to Secure Tech Storage.

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -30652,6 +30652,16 @@
 "bQZ" = (
 /turf/closed/wall/r_wall,
 /area/science/misc_lab)
+"bRf" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "bRh" = (
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 3;
@@ -34351,6 +34361,10 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"cKl" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cKI" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -34451,6 +34465,10 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
+"cMm" = (
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cMs" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -37476,6 +37494,18 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
+"ePd" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "ePT" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -37488,6 +37518,16 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"eQe" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "eQk" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/wood,
@@ -39111,10 +39151,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"ggl" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "ggw" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Tanks and Filtration";
@@ -41437,6 +41473,21 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port)
+"hVz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "hVC" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/machinery/door/firedoor/border_only{
@@ -42345,6 +42396,18 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
+"iBL" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8;
+	sortType = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/port/aft)
 "iBS" = (
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/door/firedoor/border_only,
@@ -42986,15 +43049,6 @@
 /obj/item/folder/documents,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
-"iVT" = (
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "iWE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -43066,18 +43120,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/fore)
-"iYc" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	sortType = 4
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/port/aft)
 "iYd" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/firedoor/border_only{
@@ -45393,14 +45435,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"kQi" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/item/clothing/neck/stethoscope,
-/obj/item/hand_labeler_refill,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "kQW" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Starboard Quarter Solar Access";
@@ -45595,6 +45629,21 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"kVS" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "kVU" = (
 /turf/closed/wall,
 /area/vacant_room/commissary)
@@ -45852,18 +45901,6 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/floor/grass,
 /area/medical/genetics)
-"lfg" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "lgl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 10
@@ -46186,6 +46223,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"lrA" = (
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "lsn" = (
 /obj/machinery/light,
 /turf/open/floor/engine,
@@ -47000,16 +47046,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"mcZ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "mdx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -47730,21 +47766,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/tcoms)
-"mEd" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "mEh" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -47893,21 +47914,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"mKE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "mKN" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -54314,6 +54320,12 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"rhW" = (
+/obj/structure/closet,
+/obj/item/storage/box/donkpockets,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "rig" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -57010,16 +57022,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"thR" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "tiN" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -58472,6 +58474,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"umG" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/clothing/neck/stethoscope,
+/obj/item/hand_labeler_refill,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "umU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -59182,21 +59192,6 @@
 /obj/structure/transit_tube/curved,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"uLj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/coin/silver,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "uLA" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -59515,11 +59510,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"uYM" = (
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "uZg" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -62990,12 +62980,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"xCF" = (
-/obj/structure/closet,
-/obj/item/storage/box/donkpockets,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "xCV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -63803,6 +63787,21 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"yhe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/coin/silver,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "yhk" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -85973,9 +85972,9 @@ bCq
 gZD
 gZD
 gZD
-iVT
-uYM
-cda
+lrA
+cMm
+bHE
 bQa
 cdW
 ceW
@@ -86234,8 +86233,8 @@ bCq
 cAA
 bHE
 bHE
-mcZ
-bHE
+bRf
+bJf
 bCq
 hmG
 cdb
@@ -86493,8 +86492,8 @@ eUx
 ceY
 cpY
 cqy
-thR
-mEd
+eQe
+kVS
 cwD
 kRv
 rEb
@@ -88034,7 +88033,7 @@ gZD
 gZD
 gZD
 bCq
-bHE
+cda
 bHE
 ejx
 bPr
@@ -89321,7 +89320,7 @@ gZD
 bCq
 bJZ
 wfd
-uLj
+yhe
 bPr
 aaf
 cjJ
@@ -90079,11 +90078,11 @@ bPr
 bPr
 bPr
 bCq
-mKE
+hVz
 bCq
-xCF
+rhW
 bHE
-kQi
+umG
 bCq
 cAA
 bHE
@@ -90606,8 +90605,8 @@ gXs
 gXs
 bCq
 bHE
-iYc
-ggl
+iBL
+cKl
 bCe
 bQa
 xLY
@@ -90863,7 +90862,7 @@ oRr
 gXs
 bCq
 caz
-lfg
+ePd
 cqy
 cdv
 cem

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -36511,13 +36511,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"dXz" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/rnd{
-	loot = list(/obj/item/circuitboard/computer/aifixer,/obj/item/circuitboard/machine/rdserver,/obj/item/circuitboard/machine/mechfab,/obj/item/circuitboard/machine/circuit_imprinter/department,/obj/item/circuitboard/machine/destructive_analyzer,/obj/item/circuitboard/computer/rdconsole,/obj/item/circuitboard/computer/nanite_chamber_control,/obj/item/circuitboard/computer/nanite_cloud_controller,/obj/item/circuitboard/machine/nanite_chamber,/obj/item/circuitboard/machine/nanite_programmer,/obj/item/circuitboard/machine/nanite_program_hub)
-	},
-/turf/open/floor/plasteel/white,
-/area/storage/tech)
 "dXW" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -38803,6 +38796,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"fPN" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/service{
+	loot = list(/obj/item/circuitboard/computer/arcade/battle,/obj/item/circuitboard/computer/arcade/orion_trail,/obj/item/circuitboard/machine/autolathe,/obj/item/circuitboard/computer/mining,/obj/item/circuitboard/machine/ore_redemption,/obj/item/circuitboard/machine/mining_equipment_vendor,/obj/item/circuitboard/machine/microwave,/obj/item/circuitboard/machine/chem_dispenser/drinks,/obj/item/circuitboard/machine/chem_dispenser/drinks/beer,/obj/item/circuitboard/computer/slot_machine)
+	},
+/turf/open/floor/plasteel/white,
+/area/storage/tech)
 "fQz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cloth_curtain{
@@ -46037,6 +46037,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"lks" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/rnd{
+	loot = list(/obj/item/circuitboard/computer/aifixer,/obj/item/circuitboard/machine/rdserver,/obj/item/circuitboard/machine/mechfab,/obj/item/circuitboard/machine/circuit_imprinter/department,/obj/item/circuitboard/machine/destructive_analyzer,/obj/item/circuitboard/computer/rdconsole,/obj/item/circuitboard/machine/monkey_recycler)
+	},
+/turf/open/floor/plasteel/white,
+/area/storage/tech)
 "lkF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -46578,6 +46585,38 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
+"lGI" = (
+/obj/structure/rack,
+/obj/item/circuitboard/computer/med_data{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/circuitboard/computer/teleporter{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/circuitboard/machine/nanite_program_hub{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/circuitboard/machine/nanite_chamber{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/circuitboard/computer/nanite_chamber_control{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/circuitboard/machine/nanite_programmer{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/circuitboard/computer/nanite_cloud_controller{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/turf/open/floor/plasteel/white,
+/area/storage/tech)
 "lIg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46892,15 +46931,6 @@
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
-"lWC" = (
-/obj/structure/rack,
-/obj/item/circuitboard/computer/med_data{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/circuitboard/computer/teleporter,
-/turf/open/floor/plasteel/white,
-/area/storage/tech)
 "lYh" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -58078,11 +58108,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"tVM" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/service,
-/turf/open/floor/plasteel/white,
-/area/storage/tech)
 "tVZ" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "robotics";
@@ -91096,7 +91121,7 @@ aaf
 oZY
 iJL
 irW
-lWC
+lGI
 oZY
 aaf
 bCq
@@ -93151,7 +93176,7 @@ bCs
 juo
 oYv
 dzD
-dXz
+lks
 pfl
 dzD
 xZE
@@ -93668,7 +93693,7 @@ wYJ
 fyA
 gRh
 hZA
-tVM
+fPN
 bCs
 cay
 ccw

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -31288,28 +31288,6 @@
 "bYN" = (
 /turf/closed/wall,
 /area/security/checkpoint/engineering)
-"bYZ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Tech Storage";
-	req_access_txt = "23"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/storage/tech)
 "bZg" = (
 /obj/machinery/computer/secure_data{
 	dir = 1
@@ -34153,6 +34131,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
+"cET" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/techstorage/command,
+/obj/structure/rack,
+/turf/open/floor/plasteel/white,
+/area/storage/tech)
 "cFl" = (
 /turf/closed/wall,
 /area/maintenance/solars/port/aft)
@@ -34364,22 +34350,6 @@
 	dir = 4
 	},
 /area/crew_quarters/theatre)
-"cIZ" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/storage/tech)
 "cJt" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -35092,6 +35062,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"cWK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating,
+/area/storage/tech)
 "cWT" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/white,
@@ -35834,6 +35815,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"dBt" = (
+/obj/structure/closet,
+/obj/item/storage/box/donkpockets,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "dBV" = (
 /obj/machinery/camera{
 	c_tag = "Central Hallway West";
@@ -36523,6 +36511,13 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"dXz" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/rnd{
+	loot = list(/obj/item/circuitboard/computer/aifixer,/obj/item/circuitboard/machine/rdserver,/obj/item/circuitboard/machine/mechfab,/obj/item/circuitboard/machine/circuit_imprinter/department,/obj/item/circuitboard/machine/destructive_analyzer,/obj/item/circuitboard/computer/rdconsole,/obj/item/circuitboard/computer/nanite_chamber_control,/obj/item/circuitboard/computer/nanite_cloud_controller,/obj/item/circuitboard/machine/nanite_chamber,/obj/item/circuitboard/machine/nanite_programmer,/obj/item/circuitboard/machine/nanite_program_hub)
+	},
+/turf/open/floor/plasteel/white,
+/area/storage/tech)
 "dXW" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -37035,11 +37030,6 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/wood,
 /area/library)
-"exY" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/rnd,
-/turf/open/floor/plasteel/white,
-/area/storage/tech)
 "eyp" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -37181,28 +37171,6 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"eCt" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/storage/tech)
 "eCX" = (
 /obj/machinery/airalarm/mixingchamber{
 	dir = 4;
@@ -38499,6 +38467,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"fAl" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/port/aft)
 "fAv" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/wood,
@@ -38625,19 +38599,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"fId" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/camera/motion{
-	c_tag = "Secure Tech Storage";
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/storage/tech)
 "fIy" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/machinery/door/firedoor/border_only,
@@ -38946,16 +38907,6 @@
 /obj/item/t_scanner,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"fXn" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/storage/tech)
 "fXp" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -39262,6 +39213,17 @@
 "gjl" = (
 /turf/closed/wall,
 /area/quartermaster/warehouse)
+"gjq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/dark,
+/area/storage/tech)
 "gjN" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
@@ -39288,15 +39250,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"gmQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/storage/tech)
 "gnb" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -40540,15 +40493,6 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"hqB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/storage/tech)
 "hrn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -41052,6 +40996,12 @@
 	},
 /turf/open/floor/plating,
 /area/clerk)
+"hDH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/storage/tech)
 "hDX" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -42127,6 +42077,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"irW" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/storage/tech)
 "isa" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -42663,6 +42623,11 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
+"iJL" = (
+/obj/effect/spawner/lootdrop/techstorage/RnD_secure,
+/obj/structure/rack,
+/turf/open/floor/plasteel/white,
+/area/storage/tech)
 "iJP" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -43988,6 +43953,15 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
+"jGT" = (
+/obj/structure/table,
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/white,
+/area/storage/tech)
 "jHx" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -44141,14 +44115,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
-"jNW" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/command,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/storage/tech)
 "jOm" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -44468,22 +44434,6 @@
 /obj/machinery/vending/wardrobe/viro_wardrobe,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"kaj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/storage/tech)
 "kar" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/plating,
@@ -44623,20 +44573,6 @@
 /obj/effect/turf_decal/tile/slightlydarkerblue,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"kie" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plating,
-/area/storage/tech)
 "kig" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -45309,6 +45245,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"kGG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/clothing/neck/stethoscope,
+/obj/item/hand_labeler_refill,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "kHj" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/small{
@@ -45868,15 +45815,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"lcb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/storage/tech)
 "lcC" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload";
@@ -46433,14 +46371,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"lyB" = (
-/obj/machinery/light_switch{
-	pixel_x = 27
-	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/medical,
-/turf/open/floor/plasteel/white,
-/area/storage/tech)
 "lza" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -46858,6 +46788,22 @@
 /obj/machinery/telecomms/bus/preset_three,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
+"lPY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/storage/tech)
 "lQm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -46946,6 +46892,15 @@
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
+"lWC" = (
+/obj/structure/rack,
+/obj/item/circuitboard/computer/med_data{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/circuitboard/computer/teleporter,
+/turf/open/floor/plasteel/white,
+/area/storage/tech)
 "lYh" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -47958,6 +47913,28 @@
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"mLu" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Tech Storage";
+	req_access_txt = "23"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/storage/tech)
 "mLv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -48138,15 +48115,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
-"mSs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/storage/tech)
 "mTg" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -48617,6 +48585,16 @@
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"nfu" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/storage/tech)
 "nfK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -49898,12 +49876,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"ocD" = (
-/obj/structure/table,
-/obj/item/aicard,
-/obj/item/aiModule/reset,
-/turf/open/floor/plasteel/white,
-/area/storage/tech)
 "ody" = (
 /obj/structure/window/reinforced,
 /obj/structure/transit_tube/curved{
@@ -50816,6 +50788,24 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"oDx" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/storage/tech)
 "oDC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -51334,6 +51324,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"oYv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/storage/tech)
 "oZQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -53602,12 +53604,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"qKA" = (
-/obj/structure/closet,
-/obj/item/storage/box/donkpockets,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "qKK" = (
 /obj/effect/turf_decal/tile/darkblue{
 	dir = 8
@@ -53828,18 +53824,6 @@
 "qQV" = (
 /turf/template_noop,
 /area/template_noop)
-"qRN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/storage/tech)
 "qSp" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -55125,17 +55109,6 @@
 	},
 /turf/open/floor/plating,
 /area/vacant_room/commissary)
-"rPP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/storage/tech)
 "rRn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
@@ -56840,11 +56813,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"tbC" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/RnD_secure,
-/turf/open/floor/plasteel/white,
-/area/storage/tech)
 "tbW" = (
 /obj/machinery/blackbox_recorder,
 /obj/structure/cable/yellow{
@@ -57653,6 +57621,19 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
+"tFi" = (
+/obj/machinery/camera/motion{
+	c_tag = "Secure Tech Storage";
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/aicard,
+/obj/item/aiModule/reset,
+/obj/structure/rack,
+/turf/open/floor/plasteel/white,
+/area/storage/tech)
 "tFH" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
@@ -58141,14 +58122,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
-"tYm" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/item/clothing/neck/stethoscope,
-/obj/item/hand_labeler_refill,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "tYp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
@@ -58275,6 +58248,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"ucm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/storage/tech)
 "ucp" = (
 /obj/effect/landmark/stationroom/maint/threexthree,
 /turf/template_noop,
@@ -59581,6 +59563,15 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"vbn" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/storage/tech)
 "vbA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
 /turf/open/floor/plasteel,
@@ -60152,19 +60143,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"vzc" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/storage/tech)
 "vzs" = (
 /obj/machinery/meter,
 /obj/machinery/button/door{
@@ -60391,25 +60369,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"vHq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/storage/tech)
 "vHw" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical{
@@ -60647,6 +60606,19 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"vPQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/storage/tech)
 "vQq" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/machinery/door/firedoor/border_only{
@@ -61861,6 +61833,18 @@
 /obj/item/stock_parts/cell/high/plus,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"wHp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/storage/tech)
 "wHY" = (
 /obj/structure/cable/white{
 	icon_state = "1-8"
@@ -62189,6 +62173,16 @@
 /obj/effect/landmark/stationroom/maint/fivexthree,
 /turf/template_noop,
 /area/maintenance/port/aft)
+"wYJ" = (
+/obj/machinery/light_switch{
+	pixel_x = 27
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/medical{
+	loot = list(/obj/item/circuitboard/computer/cloning,/obj/item/circuitboard/machine/clonepod,/obj/item/circuitboard/machine/chem_dispenser,/obj/item/circuitboard/computer/scan_consolenew,/obj/item/circuitboard/machine/smoke_machine,/obj/item/circuitboard/machine/chem_master,/obj/item/circuitboard/machine/clonescanner,/obj/item/circuitboard/computer/pandemic)
+	},
+/turf/open/floor/plasteel/white,
+/area/storage/tech)
 "wYY" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
@@ -62645,6 +62639,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"xqR" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/storage/tech)
 "xrs" = (
 /obj/machinery/requests_console{
 	department = "AI";
@@ -87495,7 +87501,7 @@ gZD
 gZD
 gZD
 bCq
-bHE
+ibH
 bHE
 ejx
 bPr
@@ -88266,7 +88272,7 @@ gZD
 gZD
 gZD
 bCq
-bHE
+bJZ
 bHE
 ejx
 bPr
@@ -89037,7 +89043,7 @@ gZD
 gZD
 gZD
 bCq
-xLY
+fAl
 bHE
 lMq
 bPr
@@ -89294,7 +89300,7 @@ gZD
 gZD
 gZD
 bCq
-bHE
+ceW
 wfd
 tTI
 bPr
@@ -90312,17 +90318,17 @@ mjb
 bGq
 hQb
 qsH
-bCq
-qKA
 bHE
-tYm
+dBt
 bCq
-cAA
-bHE
-ceW
 bCq
-bSs
-bJZ
+bCq
+bPr
+bPr
+bPr
+bCq
+bCq
+bCq
 bHE
 bHE
 cdi
@@ -90570,15 +90576,15 @@ fOz
 bCq
 vAA
 bCq
-ibH
 bCq
 bCq
-bCq
-bPr
-bPr
-bPr
-bCq
-bCq
+aaa
+aaa
+aaa
+aaa
+aaa
+gXs
+gXs
 bCq
 bHE
 xLY
@@ -90827,14 +90833,14 @@ fOz
 ciT
 bqD
 bCq
-bCq
-bCq
+gXs
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+cHk
+vXl
+jOm
+cRb
+oRr
 gXs
 bCq
 caz
@@ -91087,11 +91093,11 @@ bCq
 gXs
 gXs
 aaf
-cHk
-vXl
-jOm
-cRb
-oRr
+oZY
+iJL
+irW
+lWC
+oZY
 aaf
 bCq
 cay
@@ -91336,7 +91342,7 @@ gXs
 gXs
 vWM
 clg
-bUs
+kGG
 bHE
 xLY
 bqD
@@ -91346,8 +91352,8 @@ bPr
 gXs
 oZY
 fMU
-jNW
-tbC
+gjq
+leu
 oZY
 aaa
 bCq
@@ -91602,9 +91608,9 @@ bHE
 bPr
 aaa
 oZY
-lcb
-fXn
-fId
+cET
+irW
+tFi
 oZY
 aaa
 bCq
@@ -92629,7 +92635,7 @@ bNI
 bHE
 bCs
 tzL
-ocD
+jGT
 pfl
 weR
 dzD
@@ -92886,11 +92892,11 @@ bNI
 bHE
 bCs
 cMh
-eCt
-kie
-cIZ
-hqB
-gmQ
+oDx
+cWK
+xqR
+vbn
+hDH
 vHw
 bCs
 cay
@@ -93143,11 +93149,11 @@ bNI
 xLY
 bCs
 juo
-kaj
-exY
-rPP
-leu
-hZA
+oYv
+dzD
+dXz
+pfl
+dzD
 xZE
 bCs
 cay
@@ -93400,11 +93406,11 @@ bNI
 bHE
 bCs
 gIE
-vHq
-mSs
-qRN
-mSs
-vzc
+lPY
+wHp
+vPQ
+ucm
+nfu
 kCd
 bCs
 cay
@@ -93658,7 +93664,7 @@ bHE
 bCs
 cRi
 sKA
-lyB
+wYJ
 fyA
 gRh
 hZA
@@ -94171,7 +94177,7 @@ bNI
 bTz
 bCs
 bCs
-bYZ
+mLu
 bCs
 pNb
 pIF

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -31697,34 +31697,12 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"cdh" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	sortType = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "cdi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"cdj" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -32203,13 +32181,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
-"cgF" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "cgO" = (
 /obj/structure/rack,
 /obj/item/lighter,
@@ -35815,13 +35786,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"dBt" = (
-/obj/structure/closet,
-/obj/item/storage/box/donkpockets,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "dBV" = (
 /obj/machinery/camera{
 	c_tag = "Central Hallway West";
@@ -38467,12 +38431,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"fAl" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/port/aft)
 "fAv" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/wood,
@@ -39153,6 +39111,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"ggl" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "ggw" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Tanks and Filtration";
@@ -39747,12 +39709,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"gDU" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/closet/crate,
-/obj/item/coin/silver,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "gEr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -41606,18 +41562,6 @@
 /obj/effect/landmark/stationroom/box/execution,
 /turf/template_noop,
 /area/template_noop)
-"iay" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "iaV" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -43042,6 +42986,15 @@
 /obj/item/folder/documents,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
+"iVT" = (
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "iWE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -43113,6 +43066,18 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/fore)
+"iYc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8;
+	sortType = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/port/aft)
 "iYd" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/firedoor/border_only{
@@ -44330,21 +44295,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jXF" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "jXG" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload Access";
@@ -45252,17 +45202,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"kGG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/item/clothing/neck/stethoscope,
-/obj/item/hand_labeler_refill,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "kHj" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/small{
@@ -45454,6 +45393,14 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"kQi" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/clothing/neck/stethoscope,
+/obj/item/hand_labeler_refill,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "kQW" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Starboard Quarter Solar Access";
@@ -45905,6 +45852,18 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/floor/grass,
 /area/medical/genetics)
+"lfg" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "lgl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 10
@@ -47041,6 +47000,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"mcZ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "mdx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -47761,6 +47730,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/tcoms)
+"mEd" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "mEh" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -47909,6 +47893,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"mKE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "mKN" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -52382,15 +52381,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/tcoms)
-"pOY" = (
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/maintenance_hatch,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "pPf" = (
 /obj/structure/table/wood,
 /obj/item/camera_film,
@@ -57020,6 +57010,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"thR" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "tiN" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -58035,18 +58035,6 @@
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/carpet,
 /area/medical/psych)
-"tTI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "tUE" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -59194,6 +59182,21 @@
 /obj/structure/transit_tube/curved,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"uLj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/coin/silver,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "uLA" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -59580,16 +59583,6 @@
 /obj/item/kitchen/rollingpin,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"vbh" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "vbn" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -61197,13 +61190,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"wil" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "wiA" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/loading_area{
@@ -63004,6 +62990,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"xCF" = (
+/obj/structure/closet,
+/obj/item/storage/box/donkpockets,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "xCV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -85206,10 +85198,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+bCq
+bPr
+bPr
+bCq
 bCq
 gZD
 gZD
@@ -85464,9 +85456,9 @@ aaa
 aaa
 aaa
 bCq
-bPr
-bPr
-bCq
+gZD
+gZD
+wXV
 bCq
 gZD
 gZD
@@ -85723,7 +85715,7 @@ aaa
 bCq
 gZD
 gZD
-wXV
+gZD
 bCq
 bCq
 bCq
@@ -85981,7 +85973,7 @@ bCq
 gZD
 gZD
 gZD
-bCq
+iVT
 uYM
 cda
 bQa
@@ -86225,8 +86217,8 @@ aaa
 bJc
 aaa
 aaa
-aaa
-aaa
+aoV
+aoV
 aaa
 aaa
 aaa
@@ -86238,12 +86230,12 @@ bCq
 gZD
 gZD
 gZD
-pOY
+bCq
+cAA
 bHE
-xLY
 bHE
-bUs
-ceY
+mcZ
+bHE
 bCq
 hmG
 cdb
@@ -86496,13 +86488,13 @@ gZD
 gZD
 gZD
 bCq
-cAA
-bHE
-bHE
-cgF
-bCq
-bCq
-iay
+ivM
+eUx
+ceY
+cpY
+cqy
+thR
+mEd
 cwD
 kRv
 rEb
@@ -86745,21 +86737,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 bCq
-gZD
-gZD
-gZD
 bCq
-ivM
-eUx
-bHE
-cpY
-vbh
-cqy
-jXF
+bCq
+bCq
+bCq
+fmF
+bCq
+bCq
+bCq
+bCq
+bCq
+bCq
+bCq
+bCq
+oUK
 bQa
 bHE
 xLY
@@ -86996,25 +86988,25 @@ mOm
 eiN
 bKj
 bGi
-aoV
-aoV
+aaf
+gXs
 aaa
 aaa
 aaa
 aaa
 bCq
+gZD
+gZD
+gZD
+gZD
+gZD
+gZD
+gZD
+gZD
+gZD
+nQi
 bCq
-bCq
-bCq
-bCq
-fmF
-bCq
-bCq
-bCq
-bCq
-bCq
-bCq
-bCq
+ceY
 bCq
 eam
 bCq
@@ -87253,12 +87245,12 @@ bxy
 iQY
 bKm
 bxy
-aaf
-gXs
-aaa
-aaa
-aaa
-aaa
+aaH
+bCq
+bCq
+bCq
+bCq
+bCq
 bCq
 gZD
 gZD
@@ -87269,9 +87261,9 @@ gZD
 gZD
 gZD
 gZD
-nQi
+gZD
 bCq
-ceY
+bHE
 bHE
 oUK
 bPr
@@ -87510,16 +87502,16 @@ bHA
 wqI
 bKl
 bxy
-aaH
-bCq
-bCq
-bCq
-bCq
-bCq
+aaf
 bCq
 gZD
 gZD
 gZD
+ocv
+bCq
+gZD
+gZD
+gZD
 gZD
 gZD
 gZD
@@ -87528,7 +87520,7 @@ gZD
 gZD
 gZD
 bCq
-ibH
+oME
 bHE
 ejx
 bPr
@@ -87767,26 +87759,26 @@ byE
 eSR
 eCn
 bGi
-aaf
+aoV
 bPr
 gZD
 gZD
 gZD
-ocv
-bCq
-gZD
-gZD
-gZD
-gZD
-gZD
-gZD
-gZD
-gZD
-gZD
 gZD
 bCq
-oME
-bHE
+gZD
+gZD
+gZD
+gZD
+gZD
+gZD
+gZD
+gZD
+gZD
+gZD
+bCq
+bCq
+cAA
 ejx
 bPr
 aaf
@@ -88024,13 +88016,13 @@ aDP
 eSR
 bKn
 bGi
-aoV
+aaf
 bPr
 gZD
 gZD
 gZD
 gZD
-bCq
+fIy
 gZD
 gZD
 gZD
@@ -88042,8 +88034,8 @@ gZD
 gZD
 gZD
 bCq
-bCq
-cAA
+bHE
+bHE
 ejx
 bPr
 aaa
@@ -88281,25 +88273,25 @@ rGe
 pSY
 bKp
 bGi
-aaf
+aaH
 bPr
 gZD
 gZD
 gZD
 gZD
-fIy
-gZD
-gZD
-gZD
-gZD
-gZD
-gZD
-gZD
-gZD
-gZD
-gZD
 bCq
-bJZ
+gZD
+gZD
+gZD
+gZD
+gZD
+gZD
+gZD
+gZD
+gZD
+gZD
+lmY
+bHE
 bHE
 ejx
 bPr
@@ -88538,7 +88530,7 @@ aPe
 byE
 bKo
 bxy
-aaH
+aaf
 bCq
 gZD
 gZD
@@ -88555,7 +88547,7 @@ gZD
 gZD
 gZD
 gZD
-lmY
+bCq
 bHE
 bHE
 ejx
@@ -88795,17 +88787,17 @@ bGn
 bGn
 bKq
 bxy
-aaf
+bPr
+bCq
+bCq
+fmF
+bCq
+bCq
 bCq
 gZD
 gZD
 gZD
 gZD
-bCq
-gZD
-gZD
-gZD
-gZD
 gZD
 gZD
 gZD
@@ -88813,7 +88805,7 @@ gZD
 gZD
 gZD
 bCq
-bHE
+xLY
 vwa
 ejx
 bPr
@@ -89052,13 +89044,13 @@ bxy
 bxy
 bxy
 bxy
+bLu
+bHE
+bHE
+bRh
 bPr
-bCq
-bCq
-fmF
-bCq
-bCq
-bCq
+aaf
+bPr
 gZD
 gZD
 gZD
@@ -89070,7 +89062,7 @@ gZD
 gZD
 gZD
 bCq
-fAl
+bHE
 bHE
 lMq
 bPr
@@ -89309,12 +89301,12 @@ gZD
 gZD
 vJk
 bCq
-bLu
-bHE
-bHE
-bRh
 bPr
-aaf
+bPr
+bHE
+bPr
+bPr
+aaa
 bPr
 gZD
 gZD
@@ -89327,9 +89319,9 @@ gZD
 gZD
 gZD
 bCq
-ceW
+bJZ
 wfd
-tTI
+uLj
 bPr
 aaf
 cjJ
@@ -89566,27 +89558,27 @@ gZD
 gZD
 gZD
 bCq
-bPr
+aaf
 bPr
 bHE
 bPr
-bPr
 aaa
-bPr
-gZD
-gZD
-gZD
-gZD
-gZD
-gZD
-gZD
-gZD
-gZD
-gZD
+aaa
 bCq
-bJZ
-lMq
-gDU
+bCq
+bCq
+bCq
+bCq
+jKG
+bCq
+bCq
+bCq
+bCq
+bCq
+bCq
+cOw
+nCr
+cOw
 bCq
 aaa
 aaf
@@ -89823,27 +89815,27 @@ gZD
 gZD
 gZD
 bCq
-aaf
+aaa
 bPr
 bHE
 bPr
 aaa
 aaa
 bCq
-bCq
-bCq
-bCq
-bCq
-jKG
-bCq
-bCq
-bCq
-bCq
-bCq
-bCq
-cOw
-nCr
-cOw
+lsV
+hBp
+mwF
+hBp
+hBp
+hBp
+hBp
+hBp
+hBp
+lZn
+eVD
+nMN
+bUv
+ccu
 bCq
 bCq
 bCq
@@ -90087,21 +90079,21 @@ bPr
 bPr
 bPr
 bCq
-lsV
-hBp
-mwF
-hBp
-hBp
-hBp
-hBp
-hBp
-hBp
-lZn
-eVD
-nMN
-bUv
-cem
-ccu
+mKE
+bCq
+xCF
+bHE
+kQi
+bCq
+cAA
+bHE
+ceW
+bCq
+bSs
+ceW
+bHE
+cay
+bHE
 ciT
 bCq
 bSs
@@ -90345,8 +90337,8 @@ mjb
 bGq
 hQb
 qsH
-bHE
-dBt
+bCq
+ibH
 bCq
 bCq
 bCq
@@ -90357,8 +90349,8 @@ bCq
 bCq
 bCq
 bHE
+cay
 bHE
-cdi
 bCq
 bCq
 bHE
@@ -90614,8 +90606,8 @@ gXs
 gXs
 bCq
 bHE
-xLY
-cdh
+iYc
+ggl
 bCe
 bQa
 xLY
@@ -90871,8 +90863,8 @@ oRr
 gXs
 bCq
 caz
-wil
-cdj
+lfg
+cqy
 cdv
 cem
 cem
@@ -91369,7 +91361,7 @@ gXs
 gXs
 vWM
 clg
-kGG
+bUs
 bHE
 xLY
 bqD

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -38042,6 +38042,13 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"fhw" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/service{
+	loot = list(/obj/item/circuitboard/computer/arcade/battle,/obj/item/circuitboard/computer/arcade/orion_trail,/obj/item/circuitboard/machine/autolathe,/obj/item/circuitboard/computer/mining,/obj/item/circuitboard/machine/ore_redemption,/obj/item/circuitboard/machine/mining_equipment_vendor,/obj/item/circuitboard/machine/microwave,/obj/item/circuitboard/machine/chem_dispenser/drinks,/obj/item/circuitboard/machine/chem_dispenser/drinks/beer,/obj/item/circuitboard/computer/slot_machine)
+	},
+/turf/open/floor/plasteel/white,
+/area/storage/tech)
 "fib" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/bot,
@@ -38619,6 +38626,13 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"fKg" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/rnd{
+	loot = list(/obj/item/circuitboard/computer/aifixer,/obj/item/circuitboard/machine/rdserver,/obj/item/circuitboard/machine/mechfab,/obj/item/circuitboard/machine/circuit_imprinter/department,/obj/item/circuitboard/machine/destructive_analyzer,/obj/item/circuitboard/computer/rdconsole,/obj/item/circuitboard/machine/monkey_recycler)
+	},
+/turf/open/floor/plasteel/white,
+/area/storage/tech)
 "fKl" = (
 /obj/machinery/computer/nanite_chamber_control{
 	dir = 8
@@ -38796,13 +38810,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"fPN" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/service{
-	loot = list(/obj/item/circuitboard/computer/arcade/battle,/obj/item/circuitboard/computer/arcade/orion_trail,/obj/item/circuitboard/machine/autolathe,/obj/item/circuitboard/computer/mining,/obj/item/circuitboard/machine/ore_redemption,/obj/item/circuitboard/machine/mining_equipment_vendor,/obj/item/circuitboard/machine/microwave,/obj/item/circuitboard/machine/chem_dispenser/drinks,/obj/item/circuitboard/machine/chem_dispenser/drinks/beer,/obj/item/circuitboard/computer/slot_machine)
-	},
-/turf/open/floor/plasteel/white,
-/area/storage/tech)
 "fQz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cloth_curtain{
@@ -45892,11 +45899,6 @@
 "ldW" = (
 /turf/template_noop,
 /area/maintenance/aft)
-"leu" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/security,
-/turf/open/floor/plasteel/white,
-/area/storage/tech)
 "leK" = (
 /mob/living/carbon/monkey,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -46037,13 +46039,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"lks" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/rnd{
-	loot = list(/obj/item/circuitboard/computer/aifixer,/obj/item/circuitboard/machine/rdserver,/obj/item/circuitboard/machine/mechfab,/obj/item/circuitboard/machine/circuit_imprinter/department,/obj/item/circuitboard/machine/destructive_analyzer,/obj/item/circuitboard/computer/rdconsole,/obj/item/circuitboard/machine/monkey_recycler)
-	},
-/turf/open/floor/plasteel/white,
-/area/storage/tech)
 "lkF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -46585,7 +46580,7 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
-"lGI" = (
+"lGH" = (
 /obj/structure/rack,
 /obj/item/circuitboard/computer/med_data{
 	pixel_x = 6;
@@ -59181,6 +59176,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"uJX" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/security{
+	loot = list(/obj/item/circuitboard/computer/secure_data,/obj/item/circuitboard/computer/security,/obj/item/circuitboard/computer/prisoner,/obj/item/circuitboard/computer/warrant)
+	},
+/turf/open/floor/plasteel/white,
+/area/storage/tech)
 "uKK" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -91121,7 +91123,7 @@ aaf
 oZY
 iJL
 irW
-lGI
+lGH
 oZY
 aaf
 bCq
@@ -91378,7 +91380,7 @@ gXs
 oZY
 fMU
 gjq
-leu
+uJX
 oZY
 aaa
 bCq
@@ -93176,7 +93178,7 @@ bCs
 juo
 oYv
 dzD
-lks
+fKg
 pfl
 dzD
 xZE
@@ -93693,7 +93695,7 @@ wYJ
 fyA
 gRh
 hZA
-fPN
+fhw
 bCs
 cay
 ccw


### PR DESCRIPTION
"might" isnt a strong word, but "This won't be merged" is

## Intent of your Pull Request

Revises Tech Storage and Secure Tech storage as per Jamie's request and definition of problematic boards. The Teleporter, Medical Record and all of Security's boards are now in the expanded tech storage. Intellicard and AI module reset is now in Secure Tech Storage too.
![cpng](https://user-images.githubusercontent.com/62276730/99593773-34ba0d00-29c0-11eb-925e-e0f59d600a11.png)

Ulterior changes, the following maint areas and their contents have been shifted:
![bpng](https://user-images.githubusercontent.com/62276730/99594314-07ba2a00-29c1-11eb-9255-1349be6e44c6.png)
![apng](https://user-images.githubusercontent.com/62276730/99594321-0983ed80-29c1-11eb-9373-ce91476ae9c5.png)

## Why its Good:

I'm not happy with this compromise at all. 
Does make sense ickwise though, so I'll just have to stick to manually wrecking maintforts.
### Changelog
sorry I couldnt add trimlines :_(
:cl:  
rscadd: Expanded Secure Tech Storage. Shifted boards and intellicard
rscdel: Teleporter Board and Medical Record board from their respective loot spawners. Removed pieces of maint that would have otherwise collided with the Secure Tech expansion.
/:cl:
