### PR TITLE
theos does something really smart and prevents gibs from rotting if they are on a tile that has planetary atmos

### DIFF
--- a/code/datums/components/rot.dm
+++ b/code/datums/components/rot.dm
@@ -16,6 +16,9 @@
 	var/turf/open/T = get_turf(A)
 	if(!istype(T) || T.return_air().return_pressure() > (WARNING_HIGH_PRESSURE - 10))
 		return
+	var/area/A = get_area(T)
+	if(A.outdoors)
+		return
 
 	var/datum/gas_mixture/turf_air = T.return_air()
 	var/datum/gas_mixture/stank_breath = T.remove_air(1 / turf_air.return_volume() * turf_air.total_moles())

--- a/code/datums/components/rot.dm
+++ b/code/datums/components/rot.dm
@@ -16,8 +16,8 @@
 	var/turf/open/T = get_turf(A)
 	if(!istype(T) || T.return_air().return_pressure() > (WARNING_HIGH_PRESSURE - 10))
 		return
-	var/area/A = get_area(T)
-	if(A.outdoors)
+	var/area/area = get_area(T)
+	if(area.outdoors)
 		return
 
 	var/datum/gas_mixture/turf_air = T.return_air()


### PR DESCRIPTION
### Intent of your Pull Request

prevents gibs from rotting if they are outdoors, where the rotting just creates miasma on a tile that'd attempt to reassert it immediately after

### Why is this good for the game?

maybe less lag?

#### Changelog

:cl:  
tweak: gibs in outdoor tiles will no longer produce miasma
/:cl:
