### PR TITLE
Makes Path from Medbay to Morgue on Yogsdelta, Shortens Psychiatrist Office

### DIFF
--- a/_maps/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/map_files/YogsDelta/YogsDelta.dmm
@@ -1808,27 +1808,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"adl" = (
-/obj/structure/bookcase/random/nonfiction,
-/turf/open/floor/wood,
-/area/medical/medbay/central)
-"adm" = (
-/obj/structure/bookcase/manuals/medical,
-/turf/open/floor/wood,
-/area/medical/medbay/central)
-"adn" = (
-/turf/open/floor/wood,
-/area/medical/medbay/central)
-"ado" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/wood,
-/area/medical/medbay/central)
-"adp" = (
-/obj/structure/chair/comfy{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/medical/medbay/central)
 "adq" = (
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
@@ -1861,10 +1840,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"adu" = (
-/obj/structure/table/wood,
-/turf/open/floor/carpet,
-/area/medical/medbay/central)
 "adv" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -1878,9 +1853,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"adw" = (
-/turf/open/floor/carpet,
-/area/medical/medbay/central)
 "adx" = (
 /obj/structure/table/reinforced,
 /obj/item/analyzer{
@@ -1909,10 +1881,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"adA" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/carpet,
-/area/medical/medbay/central)
 "adB" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -1925,22 +1893,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/science)
-"adC" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/medical/medbay/central)
-"adD" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/carpet,
-/area/medical/medbay/central)
 "adE" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -1957,11 +1909,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
-"adF" = (
-/obj/structure/table/wood,
-/obj/item/taperecorder,
-/turf/open/floor/carpet,
-/area/medical/medbay/central)
 "adG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -79885,16 +79832,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"csi" = (
-/obj/structure/sign/poster/official/do_not_question{
-	pixel_y = -32
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "csj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
@@ -80664,21 +80601,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"ctl" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "ctm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -80786,23 +80708,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 26;
 	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
-"cty" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -82101,22 +82006,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
-"cvJ" = (
-/obj/machinery/door/airlock/wood{
-	name = "Psychiatrists office";
-	req_access_txt = "5"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/wood,
-/area/medical/medbay/central)
 "cvK" = (
 /obj/machinery/light{
 	dir = 8
@@ -82512,18 +82401,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet,
 /area/library)
-"cwn" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/medical/medbay/central)
 "cwo" = (
 /turf/closed/wall/r_wall,
 /area/engine/storage)
@@ -82931,14 +82808,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cwU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/medical/medbay/central)
 "cwV" = (
 /obj/machinery/door/airlock/command{
 	name = "Chief Medical Officer's Quarters";
@@ -85238,22 +85107,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/morgue)
-"cAA" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/med_data/laptop,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/turf/open/floor/carpet,
-/area/medical/medbay/central)
-"cAB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
-	},
-/turf/open/floor/carpet,
-/area/medical/medbay/central)
 "cAC" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -85908,21 +85761,6 @@
 	icon_state = "carpetsymbol"
 	},
 /area/clerk)
-"cBD" = (
-/obj/effect/landmark/start/yogs/psychiatrist,
-/obj/structure/chair/wood{
-	dir = 1;
-	icon_state = "wooden_chair"
-	},
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
-	},
-/turf/open/floor/carpet,
-/area/medical/medbay/central)
 "cBE" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -103876,12 +103714,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/abandoned)
-"dbR" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/turf/open/floor/carpet,
-/area/medical/medbay/central)
 "dbS" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -118673,14 +118505,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/morgue)
-"dDQ" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
-/area/medical/morgue)
 "dDW" = (
 /obj/structure/table/glass,
 /obj/item/folder/white,
@@ -125397,6 +125221,10 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"ehO" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/wood,
+/area/medical/psych)
 "ekV" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -125616,6 +125444,24 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
+"fRb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "fSb" = (
 /obj/effect/landmark/start/artist,
 /obj/structure/cable/white{
@@ -125680,6 +125526,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/science/research)
+"gcQ" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "geo" = (
 /obj/machinery/light,
 /turf/open/floor/engine{
@@ -125692,6 +125543,9 @@
 "gCK" = (
 /turf/closed/wall,
 /area/maintenance/department/science)
+"gDA" = (
+/turf/open/floor/carpet,
+/area/medical/psych)
 "gFZ" = (
 /obj/machinery/nanite_program_hub,
 /obj/effect/turf_decal/bot,
@@ -125749,6 +125603,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"gRX" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/wood,
+/area/medical/psych)
 "gSi" = (
 /turf/closed/wall/r_wall,
 /area/science/misc_lab)
@@ -125875,6 +125733,27 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"hQz" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/medical/medbay/central)
 "hSx" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -125939,6 +125818,24 @@
 /obj/machinery/cryopod,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"ikd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/medical/medbay/central)
 "iko" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -126053,6 +125950,9 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"jea" = (
+/turf/open/floor/wood,
+/area/medical/psych)
 "jmc" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/neutral{
@@ -126165,6 +126065,18 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"jRV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/light_switch{
+	pixel_x = 26;
+	pixel_y = 26
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "kam" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
@@ -126204,10 +126116,22 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"kzM" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "kEN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall,
 /area/vacant_room/commissary)
+"kEY" = (
+/turf/closed/wall,
+/area/medical/psych)
 "kGu" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -126355,6 +126279,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/vaporwave,
 /area/storage/art)
+"lRT" = (
+/obj/structure/chair/wood{
+	dir = 4;
+	icon_state = "wooden_chair"
+	},
+/obj/effect/landmark/start/yogs/psychiatrist,
+/turf/open/floor/carpet,
+/area/medical/psych)
 "lTo" = (
 /obj/docking_port/stationary{
 	area_type = /area/construction/mining/aux_base;
@@ -126763,6 +126695,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"oqD" = (
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/wood,
+/area/medical/psych)
 "oue" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/closed/wall/r_wall,
@@ -126823,6 +126759,15 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"oPz" = (
+/obj/structure/sign/poster/official/do_not_question{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "oRp" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/purple{
@@ -126905,11 +126850,32 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/theatre/abandoned)
+"pbO" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1;
+	icon_state = "vent_map_on-1"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/chair/comfy{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "pfG" = (
 /obj/effect/turf_decal/bot,
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"piM" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Morgue";
+	req_access_txt = "6"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/morgue)
 "pmQ" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -126951,6 +126917,13 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
+/area/medical/morgue)
+"psl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
 /area/medical/morgue)
 "pCm" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -127050,6 +127023,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/port)
+"qpG" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "qqz" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/bot,
@@ -127058,11 +127040,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
+"qAN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/wood{
+	name = "Psychiatrists office";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/wood,
+/area/medical/psych)
 "qFM" = (
 /obj/structure/table,
 /obj/item/camera_film,
 /turf/open/floor/plasteel/vaporwave,
 /area/storage/art)
+"qNg" = (
+/obj/machinery/light_switch{
+	pixel_x = 26;
+	pixel_y = 26
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "qTZ" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -127198,6 +127203,14 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/storage/art)
+"roE" = (
+/obj/structure/table/wood,
+/obj/machinery/light,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/taperecorder,
+/turf/open/floor/carpet,
+/area/medical/psych)
 "ryR" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4
@@ -127293,6 +127306,14 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/storage/art)
+"rZi" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/med_data/laptop{
+	dir = 8;
+	pixel_y = 1
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "saw" = (
 /turf/closed/wall/r_wall,
 /area/science/misc_lab/range)
@@ -127307,6 +127328,20 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
+"spB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 0
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "svv" = (
 /obj/machinery/door/poddoor/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
@@ -128089,6 +128124,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"ylj" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/bookcase/manuals/medical,
+/turf/open/floor/wood,
+/area/medical/psych)
 
 (1,1,1) = {"
 aaa
@@ -168619,7 +168665,7 @@ dfa
 dgY
 dAT
 dCy
-cty
+fRb
 cuc
 czd
 cBv
@@ -170418,7 +170464,7 @@ dfo
 csD
 dBa
 dCB
-dDQ
+psl
 dEY
 doG
 dqc
@@ -170675,7 +170721,7 @@ dgS
 dzY
 dBb
 dCB
-dCy
+piM
 dCy
 dCy
 dCy
@@ -170932,12 +170978,12 @@ dnt
 dzZ
 dBc
 abc
-adl
-adn
-adC
-adn
-adn
-cPy
+kzM
+kEY
+ylj
+oqD
+oqD
+kEY
 cyJ
 cAa
 dNS
@@ -171189,12 +171235,12 @@ dyu
 dwU
 dBd
 abc
-adm
-adn
-adp
-adp
-adp
-cPy
+kzM
+kEY
+qNg
+lRT
+gDA
+kEY
 cyK
 cAb
 dNS
@@ -171444,14 +171490,14 @@ dbo
 ckQ
 cin
 ckQ
-csi
-cPy
-adn
-adn
-adD
-adF
-adu
-cPy
+ckQ
+cXI
+oPz
+kEY
+gDA
+rZi
+roE
+kEY
 cyL
 cAc
 dto
@@ -171701,13 +171747,13 @@ dbq
 ddC
 cqC
 csy
-ctl
-cvJ
-cwn
-cwU
-cAA
-cBD
-dbR
+hQz
+ikd
+spB
+qAN
+jRV
+pbO
+qpG
 drB
 cyM
 czE
@@ -171959,13 +172005,13 @@ ddG
 cXO
 crG
 csk
-cPy
-ado
-adn
-cAB
-adw
-adA
-cPy
+gcQ
+cXO
+kEY
+jea
+ehO
+gRX
+kEY
 cyE
 czE
 dNS

--- a/_maps/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/map_files/YogsDelta/YogsDelta.dmm
@@ -126869,13 +126869,6 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"piM" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Morgue";
-	req_access_txt = "6"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/morgue)
 "pmQ" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -127447,6 +127440,25 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
+/area/medical/morgue)
+"tLu" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Morgue";
+	req_access_txt = "6"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/morgue)
 "tNc" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -170721,7 +170733,7 @@ dgS
 dzY
 dBb
 dCB
-piM
+tLu
 dCy
 dCy
 dCy


### PR DESCRIPTION
#Intent:

Adds a doorway to morgue from medbay, yknow, as there ought to be. Shortens psychiatrist office.

### Why is this good for the game?

You know every other medbay from Omega to Eclipse has a morgue connected to medbay? I'm not going to question why psych doesn't have his locker, or why morgue looks like a fucking maint room, or why the sleeper in maint is fair game, but no direct access to morgue from medbay is too far. 

If theres a psych main that's rightfully upset about the shortening of their office, feel free to PR another entrance.

# Changelog

:cl:  
rscadd: Psychiatrist area to psychiatrist area, A doorway to the Morgue from medbay
rscdel: Removed a small chunk of the Psychiatrist office  
/:cl:
