### PR TITLE
Fixes airlock jimmy messaging admins every pump

### DIFF
--- a/yogstation/code/game/objects/items/tools.dm
+++ b/yogstation/code/game/objects/items/tools.dm
@@ -175,10 +175,9 @@
 
 /obj/item/jawsoflife/jimmy/proc/show_gage(mob/user)
 	var/emag_givaway_flavor = ""
-	message_admins("pump charge is [pump_charge]")
 	if(pump_charge > 101)
-		emag_givaway_flavor = pick("somehow ","unironically ","ironically ","actually ","maybe ")
-	to_chat(user,"[src]'s pressure gage [emag_givaway_flavor]reads [pump_charge]%")
+		emag_givaway_flavor = pick("somehow","unironically","ironically","actually","maybe")
+	to_chat(user,"[src]'s pressure gage [emag_givaway_flavor] reads [pump_charge]%")
 
 /obj/item/jawsoflife/jimmy/proc/pump_cooldown()
 	is_pumping = FALSE


### PR DESCRIPTION
### Intent of your Pull Request

### I'm going to kill that pr creator

### Why is this good for the game?

### Admin sanity good

#### Changelog

:cl:  
tweak: Pumping airlock jimmy nolonger messages admins
/:cl:
