### PR TITLE
Increase TGUI Timeout in a vain attempt to fix load failures

### DIFF
--- a/code/modules/tgui_panel/tgui_panel.dm
+++ b/code/modules/tgui_panel/tgui_panel.dm
@@ -46,7 +46,7 @@
 	window.send_asset(get_asset_datum(/datum/asset/simple/namespaced/fontawesome))
 	window.send_asset(get_asset_datum(/datum/asset/spritesheet/chat))
 	request_telemetry()
-	addtimer(CALLBACK(src, .proc/on_initialize_timed_out), 2 SECONDS)
+	addtimer(CALLBACK(src, .proc/on_initialize_timed_out), 10 SECONDS)
 
 /**
  * private


### PR DESCRIPTION
### Intent of your Pull Request

_Hopefully_(but probably not) fixes TG chat timing out by allowing it to load for 10 seconds instead of 2

### Why is this good for the game?

If we're gonna have tg chat atleast have it load correctly

#### Changelog

:cl:  
experimental: TGChat might work better?
/:cl:
