### PR TITLE
Adam told me to nerf the mirror shield like two months ago since it will almost always block attacks AND has no durability

### DIFF
--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -926,7 +926,7 @@ GLOBAL_VAR_INIT(curselimit, 0)
 	w_class = WEIGHT_CLASS_BULKY
 	attack_verb = list("bumped", "prodded")
 	hitsound = 'sound/weapons/smash.ogg'
-	var/illusions = 2
+	var/illusions = 5
 
 /obj/item/shield/mirror/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(iscultist(owner))
@@ -945,8 +945,8 @@ GLOBAL_VAR_INIT(curselimit, 0)
 				return FALSE //To avoid reflection chance double-dipping with block chance
 		. = ..()
 		if(.)
-			playsound(src, 'sound/weapons/parry.ogg', 100, 1)
 			if(illusions > 0)
+				playsound(src, 'sound/weapons/parry.ogg', 100, 1)
 				illusions--
 				addtimer(CALLBACK(src, /obj/item/shield/mirror.proc/readd), 450)
 				if(prob(60))
@@ -959,7 +959,13 @@ GLOBAL_VAR_INIT(curselimit, 0)
 					E.Copy_Parent(owner, 70, 10)
 					E.GiveTarget(owner)
 					E.Goto(owner, owner.movement_delay(), E.minimum_distance)
+			else
+				var/turf/T = get_turf(owner)
+				T.visible_message("<span class='warning'>[src] shatters as it blocks [hitby]!</span>")
+				new /obj/effect/temp_visual/cult/sparks(T)
+				qdel(src)
 			return TRUE
+				
 	else
 		if(prob(50))
 			var/mob/living/simple_animal/hostile/illusion/H = new(owner.loc)


### PR DESCRIPTION
### Intent of your Pull Request

Makes the mirror shield shatter harmlessly if it gets hit without having any hallucinations but boosts the number of hallucinations it gets to 5
might need to do some tweaking to make sure this can't be cheesed

### Why is this good for the game?

Just holding the damn thing made you nearly immune to almost all forms of attack and it doubles as a throwing weapon

#### Changelog

:cl:  
tweak: the mirror shield will now be destroyed if it blocks an attack without having any hallucinations ready
tweak: the mirror shield now has 5 hallucination charges up from 2
/:cl:
