### PR TITLE
Syndicate Brainwashing Denial Kits (Syndicate Mindshield Implants) now show up on the sechud.

### DIFF
--- a/code/game/objects/items/implants/implant_mindshieldtot.dm
+++ b/code/game/objects/items/implants/implant_mindshieldtot.dm
@@ -21,7 +21,7 @@
 		if(!target.mind)
 			ADD_TRAIT(target, TRAIT_MINDSHIELD, "implant")
 			target.sec_hud_set_implants()
-			return FALSE
+			return TRUE
 
 		if(target.mind.has_antag_datum(/datum/antagonist/brainwashed))
 			target.mind.remove_antag_datum(/datum/antagonist/brainwashed)


### PR DESCRIPTION
I wanted to see if this would be used more often if I toggled the visibility for it, this would usually be used for a dynamic round, or similar strange scenarios, but I'm wondering if I toggle it, people may use it more for stealth.

:cl:  Xoxeyos
tweak: SBDK's are now visible on the sechud.
/:cl:
