### PR TITLE
Reinstates #7906

### DIFF
--- a/code/game/machinery/airlock_cycle_control.dm
+++ b/code/game/machinery/airlock_cycle_control.dm
@@ -288,7 +288,6 @@
 		door.unbolt()
 
 /obj/machinery/advanced_airlock_controller/process()
-	. = ..()
 	process_atmos()
 
 /obj/machinery/advanced_airlock_controller/process_atmos()


### PR DESCRIPTION
### Intent of your Pull Request

I found (while doing Beestation/Beestation-Hornet#2962) and raised this issue on discord but no one actually did anything so I am doing this myself which isn't a very satisfactory situation considering I didn't even play a single second on Yogs but whatever. (Tho I did get logged in a few seconds ago and had an abysmal ping thanks to SK Broadband)

Okay, the thing is,
https://github.com/yogstation13/Yogstation/blob/839dd144559d9c4090a4b513234d4490607a563c/code/game/machinery/airlock_cycle_control.dm#L291
calls and sets the return value from this:
https://github.com/yogstation13/Yogstation/blob/65e3fe7465bc65581891620a5a0c17177b51f024/code/game/machinery/_machinery.dm#L170-L171
thereby it suicides on first process. I bet no one intended this.

### Why is this good for the game?

Reinstates #7906 so it can finally work

#### Changelog

:cl:  
bugfix: fixed a suicidal process()
/:cl:
