### PR TITLE
adds the comment list showing all reaction priorities and moves around a few gas priorities so there aren't any empty spaces

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -1,4 +1,30 @@
 //All defines used in reactions are located in ..\__DEFINES\reactions.dm
+/*priority so far, check this list to see what are the numbers used. Please use a different priority for each reaction(higher number are done first)
+miaster = -10 (this should always be under all other fires)
+freonfire = -5
+plasmafire = -4
+h2fire = -3
+tritfire = -2
+halon_o2removal = -1
+nitrous_decomp = 0
+water_vapor = 1
+fusion = 2
+nitrylformation = 3
+bzformation = 4
+freonformation = 5
+stimformation = 6
+stim_ball = 7
+zauker_decomp = 8
+healium_formation = 9
+pluonium_formation = 10
+zauker_formation = 11
+halon_formation = 12
+hexane_formation = 13
+pluonium_response = 14 - 16
+metalhydrogen = 17
+nobliumsuppression = 1000
+nobliumformation = 1001
+*/
 
 /proc/init_gas_reactions()
 	. = list()
@@ -371,7 +397,7 @@
 		return REACTING
 
 /datum/gas_reaction/stimformation //Stimulum formation follows a strange pattern of how effective it will be at a given temperature, having some multiple peaks and some large dropoffs. Exo and endo thermic.
-	priority = 5
+	priority = 6
 	name = "Stimulum formation"
 	id = "stimformation"
 
@@ -603,7 +629,7 @@
 	
 	
 /datum/gas_reaction/hexane_formation
-	priority = 14
+	priority = 13
 	name = "Hexane formation"
 	id = "hexane_formation"
 
@@ -633,7 +659,7 @@
 	return REACTING
 
 /datum/gas_reaction/metalhydrogen
-	priority = 20
+	priority = 17
 	name = "Metal Hydrogen formation"
 	id = "metalhydrogen"
 
@@ -886,7 +912,7 @@
 	return NO_REACTION
 
 /datum/gas_reaction/pluonium_bz_response
-	priority = 13
+	priority = 14
 	name = "Pluonium bz response"
 	id = "pluonium_bz_response"
 
@@ -926,7 +952,7 @@
 	return REACTING
 
 /datum/gas_reaction/pluonium_tritium_response
-	priority = 16
+	priority = 15
 	name = "Pluonium tritium response"
 	id = "pluonium_tritium_response"
 
@@ -958,7 +984,7 @@
 	return REACTING
 
 /datum/gas_reaction/pluonium_hydrogen_response
-	priority = 17
+	priority = 16
 	name = "Pluonium hydrogen response"
 	id = "pluonium_hydrogen_response"
 


### PR DESCRIPTION
### Intent of your Pull Request

adds a list of gas reactions with their rough names to keep track of what exists and has what priority

### Why is this good for the game?

documentation

#### Changelog

:cl:  
tweak: some gas reactions have had their priorities moved, shouldn't change anything
/:cl:
