### PR TITLE
Changes the description of the stabilized light pink extract to match the change Adam made like a year ago because the lack of a speed boost is what the actual intended behavior is

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/stabilized.dm
+++ b/code/modules/research/xenobiology/crossbreeding/stabilized.dm
@@ -169,7 +169,7 @@ Stabilized extracts:
 
 /obj/item/slimecross/stabilized/lightpink
 	colour = "light pink"
-	effect_desc = "The owner moves at high speeds while holding this extract, also stabilizes anyone in critical condition around you using Epinephrine and Regenerative Jelly."
+	effect_desc = "The owner stabilizes anyone in critical condition around them using Epinephrine and Regenerative Jelly."
 
 /obj/item/slimecross/stabilized/adamantine
 	colour = "adamantine"


### PR DESCRIPTION
Alternative to #10486 because light pink extracts aren't supposed to give you a speed boost and buffing xenobio to give them the funny methspeed again is objectively bad and goes against the kind of behavior that's desired on this server.
Fuck you, xenobio mains

:cl:   
tweak: The description of Stabilized Light Pink Extracts now match what they do
/:cl:
