### PR TITLE
Theos MASSIVELY BUFFS his FAVORITE POWERGAME GUN the DRAGNET by reducing the TELEPORT OFFSET of targetted teleports by ONE TILE

### DIFF
--- a/code/modules/projectiles/projectile/energy/net_snare.dm
+++ b/code/modules/projectiles/projectile/energy/net_snare.dm
@@ -37,7 +37,7 @@
 /obj/effect/nettingportal/proc/pop(obj/item/beacon/destination)
 	if(destination)
 		for(var/mob/living/L in get_turf(src))
-			do_teleport(L, get_turf(destination), 2, channel = TELEPORT_CHANNEL_BLUESPACE)//teleport what's in the tile to the beacon
+			do_teleport(L, get_turf(destination), 1, channel = TELEPORT_CHANNEL_BLUESPACE)//teleport what's in the tile to the beacon
 	else
 		for(var/mob/living/L in get_turf(src))
 			do_teleport(L, L, 15, channel = TELEPORT_CHANNEL_BLUESPACE) //Otherwise it just warps you off somewhere.


### PR DESCRIPTION

### Intent of your Pull Request

makes dragnet teleports slightly more accurate

### Why is this good for the game?

increases RP

#### Changelog

:cl:  
tweak: the dragnet's targetted teleport setting now has a potential offset of 1 tile down from 2
/:cl:
