### PR TITLE
Adds the ability to baracade windows

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -14,6 +14,7 @@
 	anchored = TRUE
 	density = TRUE
 	max_integrity = 100
+	layer = ABOVE_WINDOW_LAYER // Barricades should probably be over windows especially if you can put them on windows
 	var/proj_pass_rate = 50 //How many projectiles will pass the cover. Lower means stronger cover
 	var/bar_material = METAL
 
@@ -94,6 +95,15 @@
 	drop_amount = 1
 	max_integrity = 50
 	proj_pass_rate = 65
+
+/obj/structure/barricade/wooden/crude/attackby(obj/item/I, mob/user) // Make it so you cant turn crude planks into walls
+	if(I.tool_behaviour == TOOL_CROWBAR && user.a_intent != INTENT_HARM)
+		user.visible_message("[user.name] starts prying [src.name] apart.", \
+							"<span class='notice'>You start prying the barricade apart</span>")
+		if(I.use_tool(src, user, 190, volume=50))
+			to_chat(user, "<span class='notice'>You disassemble the barricade.</span>")
+			new /obj/item/stack/sheet/mineral/wood(user.loc, 5)
+			qdel(src)
 
 /obj/structure/barricade/wooden/crude/snow
 	desc = "This space is blocked off by a crude assortment of planks. It seems to be covered in a layer of snow."

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -174,6 +174,18 @@
 
 	add_fingerprint(user)
 
+	if(istype(I,/obj/item/stack/sheet/mineral/wood))
+		var/obj/item/stack/sheet/mineral/wood/W = I
+		if(W.amount < 5)
+			to_chat(user, "<span class='warning'>You need at least five wooden planks to reinforce the window!</span>")
+			return
+		else
+			to_chat(user, "<span class='notice'>You start adding [I] to [src]...</span>")
+			if(do_after(user, 50, target=src))
+				W.use(5)
+				new /obj/structure/barricade/wooden/crude(get_turf(src))
+				return
+
 	if(I.tool_behaviour == TOOL_WELDER && user.a_intent == INTENT_HELP)
 		if(obj_integrity < max_integrity)
 			if(!I.tool_start_check(user, amount=0))

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -177,7 +177,7 @@
 	if(istype(I,/obj/item/stack/sheet/mineral/wood))
 		var/obj/item/stack/sheet/mineral/wood/W = I
 		if(W.amount < 5)
-			to_chat(user, "<span class='warning'>You need at least five wooden planks to reinforce the window!</span>")
+			to_chat(user, "<span class='warning'>You need at least five wooden planks to barricade the window!</span>")
 			return
 		else
 			to_chat(user, "<span class='notice'>You start adding [I] to [src]...</span>")


### PR DESCRIPTION
### Intent of your Pull Request

Add the ability to add 5 wood planks to barricade a window

Fun fact: Barricades block roughly ~45% or so of shots

![image](https://user-images.githubusercontent.com/20369082/100460350-065dc100-3095-11eb-80ce-14a6fda2dd16.png)

### Why is this good for the game?

Allows for slightly more indepth gameplay of 「Barricades and blocking shots」

#### Changelog

:cl:  
rscadd: Add the ability to reinforce windows with wood
/:cl:
