### PR TITLE
Disables Darkspawn for dynamic because it's a bit broken.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -972,7 +972,7 @@
 	restricted_roles = list("AI", "Cyborg")
 	required_candidates = 3
 	weight = 1
-	cost = 30
+	cost = 101
 	scaling_cost = 20
 	antag_cap = list(3,3,3,3,3,3,3,3,4,5)
 	requirements = list(80,75,70,65,50,30,30,30,25,20)


### PR DESCRIPTION
You can't talk with your fellow darkspawn using .k, and when you remove the antagonist status in the traitor panel the psi and divulge actions likes to stick around.

:cl:  
tweak: Darkspawn is disabled until these bugs are fixed.
/:cl:
