### PR TITLE
Fixes synthflesh and changes slightly how it works

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -392,10 +392,10 @@
 /datum/reagent/medicine/synthflesh/reaction_mob(mob/living/M, method=TOUCH, reac_volume,show_message = 1)
 	var/can_heal = FALSE
 	if(iscarbon(M))
-		if (M.stat == DEAD && !overdosed)
+		if ((M.stat == DEAD) && !overdosed)
 			can_heal = TRUE
-		if(method in list(PATCH, TOUCH) && can_heal)
-			if(ishuman(M) && method == TOUCH)
+		if((method in list(PATCH, TOUCH)) && can_heal)
+			if(ishuman(M) && (method == TOUCH))
 				M.reagents.add_reagent(/datum/reagent/medicine/synthflesh, reac_volume)
 			M.adjustBruteLoss(-1.25 * reac_volume)
 			M.adjustFireLoss(-1.25 * reac_volume)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -384,21 +384,26 @@
 
 /datum/reagent/medicine/synthflesh
 	name = "Synthflesh"
-	description = "Has a 100% chance of instantly healing brute and burn damage on corpses. One unit of the chemical will heal 1.25 points of damage. Touch application only. Overdose will completely negate the effect of any additional synthflesh"
+	description = "Has a 100% chance of instantly healing brute and burn damage on corpses. The chemical wil heal up to 100 points of damage at 60 units applied. Touch application only. Overdose will completely negate the effect of any additional synthflesh"
 	reagent_state = LIQUID
 	color = "#FFEBEB"
-	overdose_threshold = 50
 
 /datum/reagent/medicine/synthflesh/reaction_mob(mob/living/M, method=TOUCH, reac_volume,show_message = 1)
 	var/can_heal = FALSE
 	if(iscarbon(M))
-		if ((M.stat == DEAD) && !overdosed)
+		if ((M.stat == DEAD))
 			can_heal = TRUE
 		if((method in list(PATCH, TOUCH)) && can_heal)
-			if(ishuman(M) && (method == TOUCH))
-				M.reagents.add_reagent(/datum/reagent/medicine/synthflesh, reac_volume)
-			M.adjustBruteLoss(-1.25 * reac_volume)
-			M.adjustFireLoss(-1.25 * reac_volume)
+			if(!ishuman(M))
+				M.adjustBruteLoss(-1.25 * reac_volume)
+				M.adjustFireLoss(-1.25 * reac_volume)
+			else
+				var/datum/reagent/S = M.reagents.get_reagent(/datum/reagent/medicine/synthflesh)
+				var/heal_amt = clamp(reac_volume, 0, 60 - S?.volume)
+				M.adjustBruteLoss(-2*heal_amt)
+				M.adjustFireLoss(-2*heal_amt)
+				if(method == TOUCH)
+					M.reagents.add_reagent(/datum/reagent/medicine/synthflesh, reac_volume)
 	..()
 
 /datum/reagent/medicine/charcoal

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -384,14 +384,14 @@
 
 /datum/reagent/medicine/synthflesh
 	name = "Synthflesh"
-	description = "Has a 100% chance of instantly healing brute and burn damage on corpses. The chemical wil heal up to 100 points of damage at 60 units applied. Touch application only. Overdose will completely negate the effect of any additional synthflesh"
+	description = "Has a 100% chance of instantly healing brute and burn damage on corpses. The chemical will heal up to 120 points of damage at 60 units applied. Touch application only."
 	reagent_state = LIQUID
 	color = "#FFEBEB"
 
 /datum/reagent/medicine/synthflesh/reaction_mob(mob/living/M, method=TOUCH, reac_volume,show_message = 1)
 	var/can_heal = FALSE
 	if(iscarbon(M))
-		if ((M.stat == DEAD))
+		if (M.stat == DEAD)
 			can_heal = TRUE
 		if((method in list(PATCH, TOUCH)) && can_heal)
 			if(!ishuman(M))


### PR DESCRIPTION
### Intent of your Pull Request

Synthflesh now heals 2 damage per unit, but can only heal when applied in doses up to 60 units, putting its effective healing amount at 120 health before needing to purge it

### Why is this good for the game?

Increases RP

#### Changelog

:cl:  
bugfix: synthflesh now works
tweak: synthflesh now has a healing cap at 60 units and heals 2 points of health up from 1.25 per unit 
/:cl:
