### PR TITLE
Nuke ops ship gets sonic jackhammers for ice missions

### DIFF
--- a/_maps/shuttles/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator_basic.dmm
@@ -355,14 +355,6 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/syndicate/eva)
-"aO" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4;
-	name = "tactical chair"
-	},
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/dark,
-/area/shuttle/syndicate/airlock)
 "aP" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -1381,6 +1373,15 @@
 /obj/machinery/photocopier,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/syndicate/bridge)
+"UF" = (
+/obj/effect/turf_decal/bot_white,
+/obj/structure/closet/syndicate,
+/obj/item/pickaxe/drill/jackhammer,
+/obj/item/pickaxe/drill/jackhammer,
+/obj/item/pickaxe/drill/jackhammer,
+/obj/item/pickaxe/drill/jackhammer,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/syndicate/airlock)
 
 (1,1,1) = {"
 aa
@@ -1670,7 +1671,7 @@ aB
 tZ
 aX
 bc
-aO
+UF
 bm
 bx
 bG


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/24533979/100525732-aba59180-3188-11eb-92d8-f5d7ecef7a1e.png)

![image](https://user-images.githubusercontent.com/24533979/100525724-9a5c8500-3188-11eb-93ea-df2a11ee1361.png)

#### Changelog

:cl:  Hopek
rscadd: The Nuke ops ship has been given sonic jackhammers so that they may navigate the station on ice maps.
/:cl:
