### PR TITLE
slightly reduces the effectivity of healium

### DIFF
--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -303,10 +303,9 @@
 		if(healium_pp > gas_stimulation_min)
 			var/existing = H.reagents.get_reagent_amount(/datum/reagent/healium)
 			H.reagents.add_reagent(/datum/reagent/healium,max(0, 1 - existing))
-			H.adjustOxyLoss(-5)
 			H.adjustFireLoss(-7)
-			H.adjustToxLoss(-7)
-			H.adjustBruteLoss(-10)
+			H.adjustToxLoss(-5)
+			H.adjustBruteLoss(-5)
 		gas_breathed = breath.get_moles(/datum/gas/healium)
 		breath.adjust_moles(/datum/gas/healium, -gas_breathed)
 


### PR DESCRIPTION
### Intent of your Pull Request

should now be roughly on par with a pyroxadone mix at >600 kelvin minus the oxygen healing because you breathe faster when you are suffocating and making the healing gas heal suffocation on its own would mean not needing to actually add oxygen to internals using it

### Why is this good for the game?

Increases RP

#### Changelog

:cl:  
tweak: healium now heals 0 oxygen damage down from 5, 5 toxin damage down from 7, and 5 brute damage down from 10
/:cl:
