### PR TITLE
Nerfs free miner placement weight

### DIFF
--- a/yogstation/code/datums/ruins/free_miners.dm
+++ b/yogstation/code/datums/ruins/free_miners.dm
@@ -6,7 +6,6 @@
 	description = "Some space miners still cling to the old way of getting that \
 		sweet, sweet plasma - painstakingly digging it out of free-floating asteroids\
 		instead of flying down to the hellscape of lavaland."
-	placement_weight = 2
 	allow_duplicates = FALSE
 	always_spawn_with = list(/datum/map_template/ruin/space/whiteshipdock = PLACE_SPACE_RUIN)
 


### PR DESCRIPTION
It was part of my attempt at "fixing" free miners due to the issues caused by the dynamic white ship PR--which got reverted, so I no longer see a need to have it at the literally one-of-a-kind level it is.

### Why is this good for the game?

Free miners are now somewhat rarer than before.

#### Changelog

:cl:  
tweak: Free miner placement weight has been reduced to 1, from 2. I don't know what exactly it means, but it should mean they show up less.
/:cl:
