### PR TITLE
Gets rid of some runtimes

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -214,7 +214,7 @@ GLOBAL_LIST_INIT(heavyfootmob, typecacheof(list(
 
 #define ismecha(A) (istype(A, /obj/mecha))
 
-#define ismopable(A) (A.layer <= HIGH_SIGIL_LAYER) //If something can be cleaned by floor-cleaning devices such as mops or clean bots
+#define ismopable(A) (A.loc.layer <= HIGH_SIGIL_LAYER) //If something can be cleaned by floor-cleaning devices such as mops or clean bots
 
 #define isorgan(A) (istype(A, /obj/item/organ))
 

--- a/code/game/mecha/mecha_actions.dm
+++ b/code/game/mecha/mecha_actions.dm
@@ -191,7 +191,7 @@
 	button_icon_state = "mech_overload_off"
 
 /datum/action/innate/mecha/mech_overload_mode/Activate(forced_state = null)
-	if(chassis?.equipment_disabled) // If a EMP or something has messed a mech up return instead of activating
+	if(chassis?.equipment_disabled) // If a EMP or something has messed a mech up return instead of activating -- Moogle
 		return
 	if(!owner || !chassis || chassis.occupant != owner)
 		return

--- a/code/game/mecha/mecha_actions.dm
+++ b/code/game/mecha/mecha_actions.dm
@@ -191,7 +191,7 @@
 	button_icon_state = "mech_overload_off"
 
 /datum/action/innate/mecha/mech_overload_mode/Activate(forced_state = null)
-	if(chassis.equipment_disabled)
+	if(chassis?.equipment_disabled) // If a EMP or something has messed a mech up return instead of activating
 		return
 	if(!owner || !chassis || chassis.occupant != owner)
 		return

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -36,6 +36,7 @@
 	ui = SStgui.try_update_ui(user, src, ui)
 	if (!ui)
 		ui = new(user, src, "NtosMain")
+		ui.set_autoupdate(TRUE)
 		ui.open()
 		ui.send_asset(get_asset_datum(/datum/asset/simple/headers))
 

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -36,8 +36,8 @@
 	ui = SStgui.try_update_ui(user, src, ui)
 	if (!ui)
 		ui = new(user, src, "NtosMain")
-		ui.send_asset(get_asset_datum(/datum/asset/simple/headers))
 		ui.open()
+		ui.send_asset(get_asset_datum(/datum/asset/simple/headers))
 
 
 /obj/item/modular_computer/ui_data(mob/user)


### PR DESCRIPTION
### Intent of your Pull Request

Gets rid of runtimes and in the process probably makes the modular computer icons work properly

`Runtime in tgui.dm, line 159: send_asset() can only be called after open().`
`runtime error: Cannot read null.equipment_disabled`
`runtime error: Cannot execute null.wash().`

### Why is this good for the game?

Runtime and Issues are bad

#### Changelog

:cl:  
bugfix: Modular computers work more correctly
/:cl:
