### PR TITLE
NTSL Nerf: I Hate Xenomorphs Edition

### DIFF
--- a/yogstation/code/modules/scripting/Implementations/Telecomms.dm
+++ b/yogstation/code/modules/scripting/Implementations/Telecomms.dm
@@ -441,9 +441,7 @@ GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/common,/datum/languag
 #undef MAX_MEM_VARS
 #undef HUMAN
 #undef MONKEY
-#undef ALIEN
 #undef ROBOT
-#undef SLIME
 #undef DRONE
 #undef DRACONIC
 #undef BEACHTONGUE

--- a/yogstation/code/modules/scripting/Implementations/Telecomms.dm
+++ b/yogstation/code/modules/scripting/Implementations/Telecomms.dm
@@ -7,10 +7,10 @@
 #define HUMAN 1
 #define MONKEY 2
 #define ROBOT 4
-#define DRONE 8
-#define DRACONIC 16
-#define BEACHTONGUE 32
+#define DRACONIC 8
+#define BEACHTONGUE 16
 GLOBAL_LIST_INIT(allowed_custom_spans,list(SPAN_ROBOT,SPAN_YELL,SPAN_ITALICS,SPAN_SANS,SPAN_COMMAND,SPAN_CLOWN))//Span classes that players are allowed to set in a radio transmission.
+//WHY DOESNT THIS LIST WORK AAAAAA
 GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/common,/datum/language/machine,/datum/language/draconic))// language datums that players are allowed to translate to in a radio transmission.
 
 /n_Interpreter/TCS_Interpreter
@@ -112,7 +112,6 @@ GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/common,/datum/languag
 		"human" = HUMAN,
 		"monkey" = MONKEY,
 		"robot" = ROBOT,
-		"drone" = DRONE,
 		"draconic" = DRACONIC,
 		"beachtounge" = BEACHTONGUE
 	)))
@@ -146,8 +145,6 @@ GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/common,/datum/languag
 		oldlang = MONKEY
 	else if(oldlang == /datum/language/machine)
 		oldlang = ROBOT
-	else if(oldlang == /datum/language/drone)
-		oldlang = DRONE
 	else if(oldlang == /datum/language/draconic)
 		oldlang = DRACONIC
 	else if(oldlang == /datum/language/beachbum)
@@ -272,8 +269,6 @@ GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/common,/datum/languag
 			return /datum/language/monkey
 		if(ROBOT)
 			return /datum/language/machine
-		if(DRONE)
-			return /datum/language/drone
 		if(DRACONIC)
 			return /datum/language/draconic
 		if(BEACHTONGUE)
@@ -442,6 +437,5 @@ GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/common,/datum/languag
 #undef HUMAN
 #undef MONKEY
 #undef ROBOT
-#undef DRONE
 #undef DRACONIC
 #undef BEACHTONGUE

--- a/yogstation/code/modules/scripting/Implementations/Telecomms.dm
+++ b/yogstation/code/modules/scripting/Implementations/Telecomms.dm
@@ -6,12 +6,11 @@
 
 #define HUMAN 1
 #define MONKEY 2
-#define ALIEN 4
-#define ROBOT 8
-#define SLIME 16
-#define DRONE 32
-#define DRACONIC 64
-#define BEACHTONGUE 128
+#define ROBOT 4
+#define SLIME 8
+#define DRONE 16
+#define DRACONIC 32
+#define BEACHTONGUE 64
 GLOBAL_LIST_INIT(allowed_custom_spans,list(SPAN_ROBOT,SPAN_YELL,SPAN_ITALICS,SPAN_SANS,SPAN_COMMAND,SPAN_CLOWN))//Span classes that players are allowed to set in a radio transmission.
 GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/common,/datum/language/machine,/datum/language/draconic))// language datums that players are allowed to translate to in a radio transmission.
 
@@ -113,7 +112,6 @@ GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/common,/datum/languag
 	interpreter.SetVar("languages", new /datum/n_enum(list(
 		"human" = HUMAN,
 		"monkey" = MONKEY,
-		"alien" = ALIEN,
 		"robot" = ROBOT,
 		"slime" = SLIME,
 		"drone" = DRONE,
@@ -148,8 +146,6 @@ GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/common,/datum/languag
 		oldlang = HUMAN
 	else if(oldlang == /datum/language/monkey)
 		oldlang = MONKEY
-	else if(oldlang == /datum/language/xenocommon)
-		oldlang = ALIEN
 	else if(oldlang == /datum/language/machine)
 		oldlang = ROBOT
 	else if(oldlang == /datum/language/slime)
@@ -278,8 +274,6 @@ GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/common,/datum/languag
 			return /datum/language/common
 		if(MONKEY)
 			return /datum/language/monkey
-		if(ALIEN)
-			return /datum/language/xenocommon
 		if(ROBOT)
 			return /datum/language/machine
 		if(SLIME)

--- a/yogstation/code/modules/scripting/Implementations/Telecomms.dm
+++ b/yogstation/code/modules/scripting/Implementations/Telecomms.dm
@@ -7,10 +7,9 @@
 #define HUMAN 1
 #define MONKEY 2
 #define ROBOT 4
-#define SLIME 8
-#define DRONE 16
-#define DRACONIC 32
-#define BEACHTONGUE 64
+#define DRONE 8
+#define DRACONIC 16
+#define BEACHTONGUE 32
 GLOBAL_LIST_INIT(allowed_custom_spans,list(SPAN_ROBOT,SPAN_YELL,SPAN_ITALICS,SPAN_SANS,SPAN_COMMAND,SPAN_CLOWN))//Span classes that players are allowed to set in a radio transmission.
 GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/common,/datum/language/machine,/datum/language/draconic))// language datums that players are allowed to translate to in a radio transmission.
 
@@ -113,7 +112,6 @@ GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/common,/datum/languag
 		"human" = HUMAN,
 		"monkey" = MONKEY,
 		"robot" = ROBOT,
-		"slime" = SLIME,
 		"drone" = DRONE,
 		"draconic" = DRACONIC,
 		"beachtounge" = BEACHTONGUE
@@ -148,8 +146,6 @@ GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/common,/datum/languag
 		oldlang = MONKEY
 	else if(oldlang == /datum/language/machine)
 		oldlang = ROBOT
-	else if(oldlang == /datum/language/slime)
-		oldlang = SLIME
 	else if(oldlang == /datum/language/drone)
 		oldlang = DRONE
 	else if(oldlang == /datum/language/draconic)
@@ -276,8 +272,6 @@ GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/common,/datum/languag
 			return /datum/language/monkey
 		if(ROBOT)
 			return /datum/language/machine
-		if(SLIME)
-			return /datum/language/slime
 		if(DRONE)
 			return /datum/language/drone
 		if(DRACONIC)


### PR DESCRIPTION
Polymorphs should NOT be able to be translated by an NTSL script and neither should slimes. It breaks the point of having a language barrier.

New NTSL flags are as so:
Common Language is 1
Monkey Language is 2
Encoded Audio Language is 4
DRACONIC is 8
Beachbum is 16

:cl: 
rscdel: NTSL no longer translates slimes or xenocommon.
/:cl:
