### PR TITLE
NTSL Nerf: I hate slimes and drones edition

### DIFF
--- a/yogstation/code/modules/scripting/Implementations/Telecomms.dm
+++ b/yogstation/code/modules/scripting/Implementations/Telecomms.dm
@@ -8,11 +8,10 @@
 #define MONKEY 2
 #define ALIEN 4
 #define ROBOT 8
-#define SLIME 16
-#define DRONE 32
-#define DRACONIC 64
-#define BEACHTONGUE 128
+#define DRACONIC 16
+#define BEACHTONGUE 32
 GLOBAL_LIST_INIT(allowed_custom_spans,list(SPAN_ROBOT,SPAN_YELL,SPAN_ITALICS,SPAN_SANS,SPAN_COMMAND,SPAN_CLOWN))//Span classes that players are allowed to set in a radio transmission.
+//this is fucking broken
 GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/common,/datum/language/machine,/datum/language/draconic))// language datums that players are allowed to translate to in a radio transmission.
 
 /n_Interpreter/TCS_Interpreter
@@ -115,8 +114,6 @@ GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/common,/datum/languag
 		"monkey" = MONKEY,
 		"alien" = ALIEN,
 		"robot" = ROBOT,
-		"slime" = SLIME,
-		"drone" = DRONE,
 		"draconic" = DRACONIC,
 		"beachtounge" = BEACHTONGUE
 	)))
@@ -152,10 +149,6 @@ GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/common,/datum/languag
 		oldlang = ALIEN
 	else if(oldlang == /datum/language/machine)
 		oldlang = ROBOT
-	else if(oldlang == /datum/language/slime)
-		oldlang = SLIME
-	else if(oldlang == /datum/language/drone)
-		oldlang = DRONE
 	else if(oldlang == /datum/language/draconic)
 		oldlang = DRACONIC
 	else if(oldlang == /datum/language/beachbum)
@@ -282,10 +275,6 @@ GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/common,/datum/languag
 			return /datum/language/xenocommon
 		if(ROBOT)
 			return /datum/language/machine
-		if(SLIME)
-			return /datum/language/slime
-		if(DRONE)
-			return /datum/language/drone
 		if(DRACONIC)
 			return /datum/language/draconic
 		if(BEACHTONGUE)
@@ -455,7 +444,5 @@ GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/common,/datum/languag
 #undef MONKEY
 #undef ALIEN
 #undef ROBOT
-#undef SLIME
-#undef DRONE
 #undef DRACONIC
 #undef BEACHTONGUE


### PR DESCRIPTION
Drones and slimes should not be able to be translated.

Bitflags for NTSL are now:
Common - 1
Monkey - 2
Xenocommon - 4
Encoded Audio Lang - 8
Draconic - 16
Beachtongue - 32

#### Changelog

:cl:  
rscdel: Removes slimes and drones from translation
/:cl:
