### PR TITLE
Undo my own work to make adminbus easier

### DIFF
--- a/code/modules/holodeck/area_copy.dm
+++ b/code/modules/holodeck/area_copy.dm
@@ -2,9 +2,8 @@
 GLOBAL_LIST_INIT(duplicate_forbidden_vars,list(
 	"tag", "datum_components", "area", "type", "loc", "locs", "vars", "parent", "parent_type", "verbs", "ckey", "key",
 	"power_supply", "contents", "reagents", "stat", "x", "y", "z", "group", "atmos_adjacent_turfs", "comp_lookup",
-	"client_mobs_in_contents", "bodyparts", "internal_organs", "hand_bodyparts", "overlays", "overlays_standing", "hud_list",
-	"actions", "AIStatus", "appearance", "managed_overlays", "managed_vis_overlays", "computer_id", "lastKnownIP", "implants",
-	"tgui_shared_states"
+	"client_mobs_in_contents", "bodyparts", "internal_organs", "hand_bodyparts", "hud_list",
+	"actions", "AIStatus", "computer_id", "lastKnownIP", "implants", "tgui_shared_states"
 	))
 
 /proc/DuplicateObject(atom/original, perfectcopy = TRUE, sameloc, atom/newloc = null, nerf, holoitem)
@@ -23,7 +22,7 @@ GLOBAL_LIST_INIT(duplicate_forbidden_vars,list(
 			if(islist(original.vars[V]))
 				var/list/L = original.vars[V]
 				O.vars[V] = L.Copy()
-			else if(istype(original.vars[V], /datum) || ismob(original.vars[V]))
+			else if(istype(original.vars[V], /datum))
 				continue	// this would reference the original's object, that will break when it is used or deleted.
 			else
 				O.vars[V] = original.vars[V]
@@ -52,10 +51,6 @@ GLOBAL_LIST_INIT(duplicate_forbidden_vars,list(
 				contained_atom.flags_1 |= HOLOGRAM_1
 			if(M.circuit)
 				M.circuit.flags_1 |= HOLOGRAM_1
-	if(ismob(O))	//Overlays are carried over despite disallowing them, if a fix is found remove this.
-		var/mob/M = O
-		M.cut_overlays()
-		M.regenerate_icons()
 	return O
 
 


### PR DESCRIPTION
### Intent of your Pull Request
Undoes some of the work in https://github.com/yogstation13/Yogstation/pull/10555 to make my brand of adminbus easier


### Why is this good for the game?

Allows easy copying of appearance of objects with one click, rather than manually VV'ing it.

#### Changelog

:cl:  
tweak: Tweaks an admin build mode tool
/:cl:
