### PR TITLE
Fixes "Spawn on Centcom" breaking Assassination Objectives

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1266,16 +1266,26 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	set name = "Spawn on Centcom"
 	if(!check_rights(R_ADMIN))
 		return
-	var/turf/T = locate(196,82,1)
+	var/turf/T = locate(196,82,1) // Magic number alert!
 	if(ismob(usr))
 		var/mob/M = usr
 		if(isobserver(M))
-			M.forceMove(T)
-			var/mob/living/carbon/human/newmob = M.change_mob_type( /mob/living/carbon/human , null, null, TRUE)
-			newmob.equipOutfit(/datum/outfit/centcom/official)
+			var/mob/living/carbon/human/H = new(pick(spawn_locs))
+			var/datum/preferences/A = new
+			A.copy_to(H)
+			H.dna.update_dna_identity()
+			H.equipOutfit(/datum/outfit/centcom/official)
+			
+			var/datum/mind/Mind = new /datum/mind(M.key) // Reusing the mob's original mind actually breaks objectives for any antag who had this person as their target.
+			// For that reason, we're making a new one. This mimics the behavior of, say, lone operatives, and I believe other ghostroles.
+			Mind.active = 1
+			Mind.transfer_to(H)
+			
 			var/msg = "[key_name_admin(usr)] has spawned in at centcom [ADMIN_VERBOSEJMP(usr)]."
 			message_admins(msg)
 			log_admin(msg)
+			return
+	to_chat(usr,"<span class='warning'>Only observers can use this command!</span>")
 
 /datum/admins/proc/cmd_admin_fuckrads()
 	set category = "Admin.Round Interaction"

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1270,7 +1270,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(ismob(usr))
 		var/mob/M = usr
 		if(isobserver(M))
-			var/mob/living/carbon/human/H = new(pick(spawn_locs))
+			var/mob/living/carbon/human/H = new(T)
 			var/datum/preferences/A = new
 			A.copy_to(H)
 			H.dna.update_dna_identity()

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1281,7 +1281,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 			Mind.active = 1
 			Mind.transfer_to(H)
 			
-			var/msg = "[key_name_admin(usr)] has spawned in at centcom [ADMIN_VERBOSEJMP(usr)]."
+			var/msg = "[key_name_admin(H)] has spawned in at centcom [ADMIN_VERBOSEJMP(H)]."
 			message_admins(msg)
 			log_admin(msg)
 			return


### PR DESCRIPTION
### Badmin Begone
![image](https://user-images.githubusercontent.com/29939414/101042333-b1152a00-3542-11eb-98da-42e7bd83a9be.png)

I ended up re-using the logic used by the Lone Operatives event to create the human used by this verb.

## Changelog

:cl: Altoids
bugfix: The Spawn On Centcom command no longer causes assassination objectives targeting the user to redtext.
/:cl:
