### PR TITLE
Fixes the Crew Manifest modular computer app printing garbage manifests

### DIFF
--- a/code/modules/modular_computers/file_system/programs/crewmanifest.dm
+++ b/code/modules/modular_computers/file_system/programs/crewmanifest.dm
@@ -37,11 +37,17 @@
 	switch(action)
 		if("PRG_print")
 			if(computer && printer) //This option should never be called if there is no printer
-				var/contents = {"<h4>Crew Manifest</h4>
-								<br>
-								[GLOB.data_core ? GLOB.data_core.get_manifest_html(0) : ""]
-								"}
-				if(!printer.print_text(contents,text("crew manifest ([])", station_time_timestamp())))
+				var/contents = "<h2>Crew Manifest\n</h2>"
+				var/manifest = GLOB.data_core.get_manifest() // Keys are string names of departments, values are lists of lists. Each list therein has two elements: "name" and "rank"
+
+				for(var/dep in manifest) // For each department
+					contents += "<br><h3>[dep]</h34><br>"
+					for(var/person in manifest[dep]) // For each individual
+						var/n = person["name"]
+						var/r = person["rank"]
+						contents += "<b>[n]</b> - <i>[r]</i><br>"
+
+				if(!printer.print_text(contents,text("crew manifest ([])", station_time_timestamp()),FALSE))
 					to_chat(usr, "<span class='notice'>Hardware error: Printer was unable to print the file. It may be out of paper.</span>")
 					return
 				else

--- a/code/modules/modular_computers/hardware/printer.dm
+++ b/code/modules/modular_computers/hardware/printer.dm
@@ -17,14 +17,15 @@
 	. += "<span class='notice'>Paper level: [stored_paper]/[max_paper].</span>"
 
 
-/obj/item/computer_hardware/printer/proc/print_text(var/text_to_print, var/paper_title = "")
+/obj/item/computer_hardware/printer/proc/print_text(var/text_to_print, var/paper_title = "", var/do_encode = TRUE)
 	if(!stored_paper)
 		return FALSE
 	if(!check_functionality())
 		return FALSE
 	
-	text_to_print = html_encode(text_to_print)
-	paper_title = html_encode(paper_title)
+	if(do_encode)
+		text_to_print = html_encode(text_to_print)
+		paper_title = html_encode(paper_title)
 
 	var/obj/item/paper/P = new/obj/item/paper(holder.drop_location())
 


### PR DESCRIPTION

## Award for most useless bugfix goes to...
![image](https://user-images.githubusercontent.com/29939414/101066240-c185ce80-355b-11eb-8fa1-76f383d0a45d.png)

Turns out the manifest was getting put through ``html_encode()``. I've made it not do that anymore.

Fixes #9033.

## Changelog

:cl: Altoids
bugfix: The Crew Manifest app on modular computers no longer prints terrible-looking crew manifests.
/:cl:
