### PR TITLE
Fixes Anti-magic sometimes not working, fixes Runic Bombs double-exploding sometimes

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -996,10 +996,16 @@
 
 	apply_effect((amount*RAD_MOB_COEFFICIENT)/max(1, (radiation**2)*RAD_OVERDOSE_REDUCTION), EFFECT_IRRADIATE, blocked)
 
-/mob/living/anti_magic_check(magic = TRUE, holy = FALSE, tinfoil = FALSE, chargecost = 1, self = FALSE)
-	. = ..()
-	if(.)
+///Return any anti magic atom on this mob that matches the magic type
+/mob/living/proc/anti_magic_check(magic = TRUE, holy = FALSE, tinfoil = FALSE, chargecost = 1, self = FALSE)
+	if(!magic && !holy && !tinfoil)
 		return
+	var/list/protection_sources = list()
+	if(SEND_SIGNAL(src, COMSIG_MOB_RECEIVE_MAGIC, src, magic, holy, tinfoil, chargecost, self, protection_sources) & COMPONENT_BLOCK_MAGIC)
+		if(protection_sources.len)
+			return pick(protection_sources)
+		else
+			return src
 	if((magic && HAS_TRAIT(src, TRAIT_ANTIMAGIC)) || (holy && HAS_TRAIT(src, TRAIT_HOLY)))
 		return src
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -997,7 +997,7 @@
 	apply_effect((amount*RAD_MOB_COEFFICIENT)/max(1, (radiation**2)*RAD_OVERDOSE_REDUCTION), EFFECT_IRRADIATE, blocked)
 
 ///Return any anti magic atom on this mob that matches the magic type
-/mob/living/proc/anti_magic_check(magic = TRUE, holy = FALSE, tinfoil = FALSE, chargecost = 1, self = FALSE)
+/mob/living/anti_magic_check(magic = TRUE, holy = FALSE, tinfoil = FALSE, chargecost = 1, self = FALSE)
 	if(!magic && !holy && !tinfoil)
 		return
 	var/list/protection_sources = list()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -899,16 +899,7 @@
 
 ///Return any anti magic atom on this mob that matches the magic type
 /mob/proc/anti_magic_check(magic = TRUE, holy = FALSE, tinfoil = FALSE, chargecost = 1, self = FALSE)
-	if(!magic && !holy && !tinfoil)
-		return
-	var/list/protection_sources = list()
-	if(SEND_SIGNAL(src, COMSIG_MOB_RECEIVE_MAGIC, src, magic, holy, tinfoil, chargecost, self, protection_sources) & COMPONENT_BLOCK_MAGIC)
-		if(protection_sources.len)
-			return pick(protection_sources)
-		else
-			return src
-	if((magic && HAS_TRAIT(src, TRAIT_ANTIMAGIC)) || (holy && HAS_TRAIT(src, TRAIT_HOLY)))
-		return src
+	return
 
 /**
   * Buckle to another mob

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -751,9 +751,6 @@
 	var/boom = 1
 
 /obj/item/projectile/magic/runic_bomb/on_hit(target)
-	if(ismob(target))
-		var/mob/M = target
-		explosion(M, -1, 0, boom, 0, 0)
 	if(iscarbon(target))
 		var/mob/living/carbon/X = target
 		ADD_TRAIT(X, TRAIT_NODISMEMBER, type)
@@ -764,7 +761,9 @@
 			REMOVE_TRAIT(X, TRAIT_SLEEPIMMUNE, type)
 			REMOVE_TRAIT(X, TRAIT_STUNIMMUNE, type)
 			X.adjustBruteLoss(-120)
-		explosion(X, -1, 0, boom, 0, 0)
+	if(ismob(target))
+		var/mob/M = target
+		explosion(M, -1, 0, boom, 0, 0)
 
 /obj/item/projectile/magic/runic_toxin
 	name = "Runic Toxin"

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -9,6 +9,17 @@
 	var/tile_dropoff = 0
 	var/tile_dropoff_s = 0
 
+	var/antimagic_affected = TRUE // Marks whether antimagic will cause this projectile to vanish on contact.
+
+/obj/item/projectile/magic/prehit(atom/target)
+	. = ..()
+	if(isliving(target))
+		var/mob/living/L = target
+		if(L.anti_magic_check())
+			L.visible_message("<span class='warning'>[src] vanishes on contact with [target]!</span>")
+			qdel(src)
+			return FALSE
+
 /obj/item/projectile/magic/death
 	name = "bolt of death"
 	icon_state = "pulse1_bl"
@@ -17,9 +28,6 @@
 	. = ..()
 	if(ismob(target))
 		var/mob/M = target
-		if(M.anti_magic_check())
-			M.visible_message("<span class='warning'>[src] vanishes on contact with [target]!</span>")
-			return BULLET_ACT_BLOCK
 		M.death(0)
 
 /obj/item/projectile/magic/resurrection
@@ -33,9 +41,6 @@
 	. = ..()
 	if(isliving(target))
 		if(target.hellbound)
-			return BULLET_ACT_BLOCK
-		if(target.anti_magic_check())
-			target.visible_message("<span class='warning'>[src] vanishes on contact with [target]!</span>")
 			return BULLET_ACT_BLOCK
 		if(iscarbon(target))
 			var/mob/living/carbon/C = target
@@ -58,11 +63,6 @@
 
 /obj/item/projectile/magic/teleport/on_hit(mob/target)
 	. = ..()
-	if(ismob(target))
-		var/mob/M = target
-		if(M.anti_magic_check())
-			M.visible_message("<span class='warning'>[src] fizzles on contact with [target]!</span>")
-			return BULLET_ACT_BLOCK
 	var/teleammount = 0
 	var/teleloc = target
 	if(!isturf(target))
@@ -84,11 +84,6 @@
 
 /obj/item/projectile/magic/safety/on_hit(atom/target)
 	. = ..()
-	if(ismob(target))
-		var/mob/M = target
-		if(M.anti_magic_check())
-			M.visible_message("<span class='warning'>[src] fizzles on contact with [target]!</span>")
-			return BULLET_ACT_BLOCK
 	if(isturf(target))
 		return BULLET_ACT_HIT
 
@@ -139,12 +134,6 @@
 
 /obj/item/projectile/magic/change/on_hit(atom/change)
 	. = ..()
-	if(ismob(change))
-		var/mob/M = change
-		if(M.anti_magic_check())
-			M.visible_message("<span class='warning'>[src] fizzles on contact with [M]!</span>")
-			qdel(src)
-			return BULLET_ACT_BLOCK
 	wabbajack(change)
 	qdel(src)
 
@@ -298,11 +287,6 @@
 
 /obj/item/projectile/magic/cheese/on_hit(mob/living/target)
 	. = ..()
-	if(ismob(target))
-		var/mob/M = target
-		if(M.anti_magic_check())
-			M.visible_message("<span class='warning'>[src] fizzles on contact with [target]!</span>")
-			return BULLET_ACT_BLOCK
 	if(!istype(target) || target.stat == DEAD || target.notransform || (GODMODE & target.status_flags))
 		return
 	if(istype(target) && target.mind)
@@ -372,15 +356,6 @@
 	dismemberment = 50
 	nodamage = FALSE
 
-/obj/item/projectile/magic/spellblade/on_hit(target)
-	if(ismob(target))
-		var/mob/M = target
-		if(M.anti_magic_check())
-			M.visible_message("<span class='warning'>[src] vanishes on contact with [target]!</span>")
-			qdel(src)
-			return BULLET_ACT_BLOCK
-	. = ..()
-
 /obj/item/projectile/magic/arcane_barrage
 	name = "arcane bolt"
 	icon_state = "arcane_barrage"
@@ -390,16 +365,6 @@
 	armour_penetration = 0
 	flag = "magic"
 	hitsound = 'sound/weapons/barragespellhit.ogg'
-
-/obj/item/projectile/magic/arcane_barrage/on_hit(target)
-	if(ismob(target))
-		var/mob/M = target
-		if(M.anti_magic_check())
-			M.visible_message("<span class='warning'>[src] vanishes on contact with [target]!</span>")
-			qdel(src)
-			return
-	. = ..()
-
 
 /obj/item/projectile/magic/locker
 	name = "locker bolt"
@@ -413,10 +378,6 @@
 /obj/item/projectile/magic/locker/prehit(atom/A)
 	if(ismob(A) && locker_suck)
 		var/mob/M = A
-		if(M.anti_magic_check())
-			M.visible_message("<span class='warning'>[src] vanishes on contact with [A]!</span>")
-			qdel(src)
-			return
 		if(M.anchored)
 			return ..()
 		M.forceMove(src)
@@ -490,9 +451,6 @@
 	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target
-		if(L.anti_magic_check())
-			L.visible_message("<span class='warning'>[src] vanishes on contact with [target]!</span>")
-			return BULLET_ACT_BLOCK
 		var/atom/throw_target = get_edge_target_turf(L, angle2dir(Angle))
 		L.throw_at(throw_target, 200, 4)
 
@@ -504,9 +462,6 @@
 	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target
-		if(L.anti_magic_check() || !firer)
-			L.visible_message("<span class='warning'>[src] vanishes on contact with [target]!</span>")
-			return BULLET_ACT_BLOCK
 		L.apply_status_effect(STATUS_EFFECT_BOUNTY, firer)
 
 /obj/item/projectile/magic/antimagic
@@ -517,9 +472,6 @@
 	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target
-		if(L.anti_magic_check())
-			L.visible_message("<span class='warning'>[src] vanishes on contact with [target]!</span>")
-			return BULLET_ACT_BLOCK
 		L.apply_status_effect(STATUS_EFFECT_ANTIMAGIC)
 
 /obj/item/projectile/magic/fetch
@@ -544,9 +496,6 @@
 	. = ..()
 	if(ismob(target))
 		var/mob/M = target
-		if(M.anti_magic_check())
-			M.visible_message("<span class='warning'>[src] vanishes on contact with [target]!</span>")
-			return BULLET_ACT_BLOCK
 		SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, src, /datum/mood_event/sapped)
 
 /obj/item/projectile/magic/necropotence
@@ -579,9 +528,6 @@
 	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
-		if(M.anti_magic_check())
-			M.visible_message("<span class='warning'>[src] vanishes on contact with [target]!</span>")
-			return BULLET_ACT_BLOCK
 		for(var/x in M.get_traumas())//checks to see if the victim is already going through possession
 			if(istype(x, /datum/brain_trauma/special/imaginary_friend/trapped_owner))
 				M.visible_message("<span class='warning'>[src] vanishes on contact with [target]!</span>")
@@ -654,12 +600,6 @@
 
 /obj/item/projectile/magic/aoe/lightning/on_hit(target)
 	. = ..()
-	if(ismob(target))
-		var/mob/M = target
-		if(M.anti_magic_check())
-			visible_message("<span class='warning'>[src] fizzles on contact with [target]!</span>")
-			qdel(src)
-			return BULLET_ACT_BLOCK
 	tesla_zap(src, tesla_range, tesla_power, tesla_flags)
 	qdel(src)
 
@@ -684,9 +624,6 @@
 	. = ..()
 	if(ismob(target))
 		var/mob/living/M = target
-		if(M.anti_magic_check())
-			visible_message("<span class='warning'>[src] vanishes into smoke on contact with [target]!</span>")
-			return BULLET_ACT_BLOCK
 		M.take_overall_damage(0,10) //between this 10 burn, the 10 brute, the explosion brute, and the onfire burn, your at about 65 damage if you stop drop and roll immediately
 	var/turf/T = get_turf(target)
 	explosion(T, -1, exp_heavy, exp_light, exp_flash, 0, flame_range = exp_fire)
@@ -700,10 +637,6 @@
 
 /obj/item/projectile/magic/aoe/fireball/infernal/on_hit(target)
 	. = ..()
-	if(ismob(target))
-		var/mob/living/M = target
-		if(M.anti_magic_check())
-			return BULLET_ACT_BLOCK
 	var/turf/T = get_turf(target)
 	for(var/i=0, i<50, i+=10)
 		addtimer(CALLBACK(GLOBAL_PROC, .proc/explosion, T, -1, exp_heavy, exp_light, exp_flash, FALSE, FALSE, exp_fire), i)
@@ -731,10 +664,6 @@
 /obj/item/projectile/temp/runic_icycle/on_hit(target)
 	if(ismob(target))
 		var/mob/M = target
-		if(M.anti_magic_check())
-			M.visible_message("<span class='warning'>[src] vanishes on contact with [target]!</span>")
-			qdel(src)
-			return BULLET_ACT_BLOCK
 	.=..()
 	if(iscarbon(target))
 		var/mob/living/carbon/X = target
@@ -750,10 +679,6 @@
 /obj/item/projectile/magic/runic_tentacle/on_hit(target)
 	if(ismob(target))
 		var/mob/M = target
-		if(M.anti_magic_check())
-			M.visible_message("<span class='warning'>[src] vanishes on contact with [target]!</span>")
-			qdel(src)
-			return BULLET_ACT_BLOCK
 		new /obj/effect/temp_visual/goliath_tentacle/original(target)
 	.=..()
 	if(iscarbon(target))
@@ -769,12 +694,6 @@
 	flag = "magic"
 	nodamage = TRUE
 /obj/item/projectile/magic/runic_heal/on_hit(target)
-	if(ismob(target))
-		var/mob/M = target
-		if(M.anti_magic_check())
-			M.visible_message("<span class='warning'>[src] vanishes on contact with [target]!</span>")
-			qdel(src)
-			return BULLET_ACT_BLOCK
 	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/X = target
@@ -799,12 +718,6 @@
 	nodamage = FALSE
 
 /obj/item/projectile/magic/runic_fire/on_hit(target)
-	if(ismob(target))
-		var/mob/M = target
-		if(M.anti_magic_check())
-			M.visible_message("<span class='warning'>[src] vanishes on contact with [target]!</span>")
-			qdel(src)
-			return BULLET_ACT_BLOCK
 	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/X = target
@@ -823,12 +736,6 @@
 	ricochets_max = 66
 
 /obj/item/projectile/magic/runic_honk/on_hit(target)
-	if(ismob(target))
-		var/mob/M = target
-		if(M.anti_magic_check())
-			M.visible_message("<span class='warning'>[src] vanishes on contact with [target]!</span>")
-			qdel(src)
-			return BULLET_ACT_BLOCK
 	. = ..()
 	var/mob/X = target
 	if(istype(X))
@@ -846,12 +753,7 @@
 /obj/item/projectile/magic/runic_bomb/on_hit(target)
 	if(ismob(target))
 		var/mob/M = target
-		if(M.anti_magic_check())
-			M.visible_message("<span class='warning'>[src] vanishes on contact with [target]!</span>")
-			qdel(src)
-			return BULLET_ACT_BLOCK
-		else
-			explosion(M, -1, 0, boom, 0, 0)
+		explosion(M, -1, 0, boom, 0, 0)
 	if(iscarbon(target))
 		var/mob/living/carbon/X = target
 		ADD_TRAIT(X, TRAIT_NODISMEMBER, type)
@@ -874,12 +776,6 @@
 	eyeblur = 10
 
 /obj/item/projectile/magic/runic_toxin/on_hit(target)
-	if(ismob(target))
-		var/mob/M = target
-		if(M.anti_magic_check())
-			M.visible_message("<span class='warning'>[src] vanishes on contact with [target]!</span>")
-			qdel(src)
-			return BULLET_ACT_BLOCK
 	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/X = target
@@ -905,12 +801,6 @@
 	impact_effect_type = /obj/effect/temp_visual/dir_setting/bloodsplatter
 
 /obj/item/projectile/magic/runic_death/on_hit(mob/living/target)
-	if(ismob(target))
-		var/mob/M = target
-		if(M.anti_magic_check())
-			M.visible_message("<span class='warning'>[src] vanishes on contact with [target]!</span>")
-			qdel(src)
-			return BULLET_ACT_BLOCK
 	. = ..()
 	if(iszombie(target))
 		target.gib()
@@ -927,12 +817,6 @@
 	flag = "magic"
 
 /obj/item/projectile/magic/shotgun_slug/on_hit(target)
-	if(ismob(target))
-		var/mob/M = target
-		if(M.anti_magic_check())
-			M.visible_message("<span class='warning'>[src] vanishes on contact with [target]!</span>")
-			qdel(src)
-			return BULLET_ACT_BLOCK
 	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/X = target
@@ -946,12 +830,6 @@
 
 
 /obj/item/projectile/magic/incediary_slug/on_hit(target)
-	if(ismob(target))
-		var/mob/M = target
-		if(M.anti_magic_check())
-			M.visible_message("<span class='warning'>[src] vanishes on contact with [target]!</span>")
-			qdel(src)
-			return BULLET_ACT_BLOCK
 	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/X = target
@@ -966,12 +844,6 @@
 	irradiate = 12
 
 /obj/item/projectile/magic/runic_mutation/on_hit(target)
-	if(ismob(target))
-		var/mob/M = target
-		if(M.anti_magic_check())
-			M.visible_message("<span class='warning'>[src] vanishes on contact with [target]!</span>")
-			qdel(src)
-			return BULLET_ACT_BLOCK
 	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/X = target
@@ -989,12 +861,6 @@
 
 
 /obj/item/projectile/magic/runic_resizement/on_hit(target)
-	if(ismob(target))
-		var/mob/M = target
-		if(M.anti_magic_check())
-			M.visible_message("<span class='warning'>[src] vanishes on contact with [target]!</span>")
-			qdel(src)
-			return BULLET_ACT_BLOCK
 	. = ..()
 	if(isliving(target))
 		var/mob/living/X = target

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -662,8 +662,6 @@
 	temperature = 80
 
 /obj/item/projectile/temp/runic_icycle/on_hit(target)
-	if(ismob(target))
-		var/mob/M = target
 	.=..()
 	if(iscarbon(target))
 		var/mob/living/carbon/X = target
@@ -678,7 +676,6 @@
 
 /obj/item/projectile/magic/runic_tentacle/on_hit(target)
 	if(ismob(target))
-		var/mob/M = target
 		new /obj/effect/temp_visual/goliath_tentacle/original(target)
 	.=..()
 	if(iscarbon(target))


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/29939414/101080202-1599ae80-356e-11eb-9643-2abac5d1b255.png)


### The Conspiracy

So it turns out, that every singular ../projectile/magic has an onhit override that contains the same 5-ish lines of code. Some versions even forget to call ``qdel(src)`` or call crappy versions of the ``anti_magic_check()`` proc. No more!

As well, all of it is now handled in ``prehit`` instead of ``on_hit``, which should fix some issues regarding spells ignoring antimagic.

### Runic Bombs

Something I found while doing this was a poor bit of code that causes runic bombs to explode twice:
```dm
    if(ismob(target))
        var/mob/M = target
        if(M.anti_magic_check())
            M.visible_message("<span class='warning'>[src] vanishes on contact with [target]!</span>")
            qdel(src)
            return BULLET_ACT_BLOCK
        else
            explosion(M, -1, 0, boom, 0, 0)
    if(iscarbon(target))
        var/mob/living/carbon/X = target
        ADD_TRAIT(X, TRAIT_NODISMEMBER, type)
        ADD_TRAIT(X, TRAIT_SLEEPIMMUNE, type)
        ADD_TRAIT(X, TRAIT_STUNIMMUNE, type)
        spawn(5)
            REMOVE_TRAIT(X, TRAIT_NODISMEMBER, type)
            REMOVE_TRAIT(X, TRAIT_SLEEPIMMUNE, type)
            REMOVE_TRAIT(X, TRAIT_STUNIMMUNE, type)
            X.adjustBruteLoss(-120)
        explosion(X, -1, 0, boom, 0, 0)
```
So that's been fixed, too, as a treat. This might result in these bombs doing less damage, for what that's worth.


# Changelog

:cl: Altoids
bugfix: Anti-magic now works correctly against arcane barrage, spellblade, and more!
bugfix: Runic bombs no longer double-explode when the target is a carbon.
/:cl:
