### PR TITLE
Fixes several bugs with Goldgrubs, allows them to eat titanium and have more ore in their tummy

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
@@ -44,10 +44,11 @@
 /mob/living/simple_animal/hostile/asteroid/goldgrub/GiveTarget(new_target)
 	target = new_target
 	if(target != null)
-			visible_message("<span class='notice'>The [name] looks at [target.name] with hungry eyes.</span>")
 		else if(isliving(target))
+		if(istype(target, /obj/item/stack/ore) && loot.len < max_loot)
+			visible_message("<span class='notice'>\The [name] looks at \the [target.name] with hungry eyes.</span>")
 			Aggro()
-			visible_message("<span class='danger'>The [name] tries to flee from [target.name]!</span>")
+			visible_message("<span class='danger'>\The [name] tries to flee from \the [target.name]!</span>")
 			retreat_distance = 10
 			minimum_distance = 10
 			if(will_burrow)
@@ -60,21 +61,29 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/proc/EatOre(atom/targeted_ore)
+	var/vored = TRUE
 	for(var/obj/item/stack/ore/O in get_turf(targeted_ore))
 		if(length(loot) < max_loot)
 			var/using = min(10 - length(loot), O.amount)
 			for(var/i in 1 to using)
 				loot += O.type
 			O.use(using)
-	visible_message("<span class='notice'>The ore was swallowed whole!</span>")
+		else // We are now full! We will consume no more ore ever again.
+			search_objects = 0
+			vored = FALSE
+			break
+	if(vored)
+		visible_message("<span class='notice'>\The ore was swallowed whole by \the [name]!</span>")
+	else
+		visible_message("<span class='notice'>\The [name] nibbles some of the ore and then stops. \She seems to be full!</span>")
 
-		visible_message("<span class='danger'>The [name] buries into the ground, vanishing from sight!</span>")
 /mob/living/simple_animal/hostile/asteroid/goldgrub/proc/Burrow()//You failed the chase to kill the goldgrub in time!
 	if(stat == CONSCIOUS)
+		visible_message("<span class='danger'>\The [name] buries into the ground, vanishing from sight!</span>")
 		qdel(src)
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/bullet_act(obj/item/projectile/P)
-	visible_message("<span class='danger'>The [P.name] was repelled by [name]'s girth!</span>")
+	visible_message("<span class='danger'>\The [P.name] was repelled by [name]'s blubberous girth!</span>")
 	return BULLET_ACT_BLOCK
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/adjustHealth(amount, updating_health = TRUE, forced = FALSE)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
@@ -32,6 +32,7 @@
 
 	var/chase_time = 100
 	var/will_burrow = TRUE
+	var/max_loot = 15 // The maximum amount of ore that can be stored in this thing's gut
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/Initialize()
 	. = ..()
@@ -43,7 +44,6 @@
 /mob/living/simple_animal/hostile/asteroid/goldgrub/GiveTarget(new_target)
 	target = new_target
 	if(target != null)
-		if(istype(target, /obj/item/stack/ore) && loot.len < 10)
 			visible_message("<span class='notice'>The [name] looks at [target.name] with hungry eyes.</span>")
 		else if(isliving(target))
 			Aggro()
@@ -61,7 +61,7 @@
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/proc/EatOre(atom/targeted_ore)
 	for(var/obj/item/stack/ore/O in get_turf(targeted_ore))
-		if(length(loot) < 10)
+		if(length(loot) < max_loot)
 			var/using = min(10 - length(loot), O.amount)
 			for(var/i in 1 to using)
 				loot += O.type

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
@@ -28,7 +28,7 @@
 	status_flags = CANPUSH
 	search_objects = 1
 	wanted_objects = list(/obj/item/stack/ore/diamond, /obj/item/stack/ore/gold, /obj/item/stack/ore/silver,
-						  /obj/item/stack/ore/uranium) // Eventually becomes a typecache
+						  /obj/item/stack/ore/uranium, /obj/item/stack/ore/titanium) // Eventually becomes a typecache
 
 	var/chase_time = 100
 	var/will_burrow = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
@@ -36,9 +36,9 @@
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/Initialize()
 	. = ..()
-	var/i = rand(1,length(initial(wanted_objects)) - 1)
+	var/i = rand(1,3)
 	while(i)
-		loot += pick(initial(wanted_objects))
+		loot += pick(wanted_objects)
 		i--
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/GiveTarget(new_target)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
@@ -28,7 +28,7 @@
 	status_flags = CANPUSH
 	search_objects = 1
 	wanted_objects = list(/obj/item/stack/ore/diamond, /obj/item/stack/ore/gold, /obj/item/stack/ore/silver,
-						  /obj/item/stack/ore/uranium)
+						  /obj/item/stack/ore/uranium) // Eventually becomes a typecache
 
 	var/chase_time = 100
 	var/will_burrow = TRUE
@@ -44,8 +44,8 @@
 /mob/living/simple_animal/hostile/asteroid/goldgrub/GiveTarget(new_target)
 	target = new_target
 	if(target != null)
-		if(istype(target, /obj/item/stack/ore) && loot.len < max_loot)
-			visible_message("<span class='notice'>\The [name] looks at \the [target.name] with hungry eyes.</span>")
+		if(wanted_objects[target.type] && loot.len < max_loot)
+			visible_message("<span class='notice'>\The [name] looks at \the [target.name] with \his hungry eyes.</span>")
 		else if(iscarbon(target) || issilicon(target))
 			Aggro()
 			visible_message("<span class='danger'>\The [name] tries to flee from \the [target.name]!</span>")
@@ -55,26 +55,21 @@
 				addtimer(CALLBACK(src, .proc/Burrow), chase_time)
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/AttackingTarget()
-	if(istype(target, /obj/item/stack/ore))
+	if(wanted_objects[target.type])
 		EatOre(target)
 		return
 	return ..()
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/proc/EatOre(atom/targeted_ore)
-	var/vored = TRUE
-	for(var/obj/item/stack/ore/O in get_turf(targeted_ore))
-		if(length(loot) < max_loot)
-			var/using = min(10 - length(loot), O.amount)
-			for(var/i in 1 to using)
-				loot += O.type
-			O.use(using)
-		else // We are now full! We will consume no more ore ever again.
-			search_objects = 0
-			vored = FALSE
-			break
-	if(vored)
+	var/obj/item/stack/ore/O = targeted_ore
+	if(length(loot) < max_loot)
+		var/using = min(max_loot - length(loot), O.amount)
+		for(var/i in 1 to using)
+			loot += O.type
+		O.use(using)
 		visible_message("<span class='notice'>\The ore was swallowed whole by \the [name]!</span>")
-	else
+	else // We are now full! We will consume no more ore ever again.
+		search_objects = 0
 		visible_message("<span class='notice'>\The [name] nibbles some of the ore and then stops. \She seems to be full!</span>")
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/proc/Burrow()//You failed the chase to kill the goldgrub in time!

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
@@ -36,9 +36,9 @@
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/Initialize()
 	. = ..()
-	var/i = rand(1,3)
+	var/i = rand(1,length(initial(wanted_objects)) - 1)
 	while(i)
-		loot += pick(/obj/item/stack/ore/silver, /obj/item/stack/ore/gold, /obj/item/stack/ore/uranium, /obj/item/stack/ore/diamond)
+		loot += pick(initial(wanted_objects))
 		i--
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/GiveTarget(new_target)
@@ -68,9 +68,9 @@
 			O.use(using)
 	visible_message("<span class='notice'>The ore was swallowed whole!</span>")
 
-/mob/living/simple_animal/hostile/asteroid/goldgrub/proc/Burrow()//Begin the chase to kill the goldgrub in time
-	if(!stat)
 		visible_message("<span class='danger'>The [name] buries into the ground, vanishing from sight!</span>")
+/mob/living/simple_animal/hostile/asteroid/goldgrub/proc/Burrow()//You failed the chase to kill the goldgrub in time!
+	if(stat == CONSCIOUS)
 		qdel(src)
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/bullet_act(obj/item/projectile/P)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
@@ -44,9 +44,9 @@
 /mob/living/simple_animal/hostile/asteroid/goldgrub/GiveTarget(new_target)
 	target = new_target
 	if(target != null)
-		else if(isliving(target))
 		if(istype(target, /obj/item/stack/ore) && loot.len < max_loot)
 			visible_message("<span class='notice'>\The [name] looks at \the [target.name] with hungry eyes.</span>")
+		else if(iscarbon(target) || issilicon(target))
 			Aggro()
 			visible_message("<span class='danger'>\The [name] tries to flee from \the [target.name]!</span>")
 			retreat_distance = 10


### PR DESCRIPTION
Fixes #10190 

![image](https://user-images.githubusercontent.com/29939414/101165108-b5514e00-35fb-11eb-8e40-87f02113f262.png)

## ROCK AND STONE TO THE BONE

Goldgrub code is really one of those things where you can tell nobody has really bothered to edit it in like 5 years. While the main goal was to fix the issue listed above, I bothered to actually improve the quality of the code somewhat and give goldgrubs a half-hearted polish. In the end, the changelog speaks for itself.

## Coder Warning

I bothered to clean up the code surrounding goldgrubs, as well. Once their bellies are full, their AI stops even looking for new ore, which improves performance. Making them no longer huff plasma also means they no longer scan an entire turf just to look for something the ``../simple_animal/hostile`` code has already found for the grub.

I also removed a few magic numbers/lists in the code, which is nice.

## Changelog

:cl: Altoids
tweak: Goldgrubs are now able to eat titanium.
tweak: Goldgrubs are now able to store up to 15 units of ore in their bellies, up from 10. This includes the 1-3 ore that spawns in their bellies when they first appear.
tweak: Goldgrubs are now only scared by carbons and silicons.
bugfix: Goldgrubs no longer eat any ore possible on the turf that contains the ore they actually want to eat.
bugfix: Goldgrubs no longer look longingly at ores they are far too picky to eat.
bugfix: Goldgrubs no longer spam their eating message near ores despite not being able to eat them.
bugfix: Goldgrubs no longer search around for ore when they are far too full to eat anything.
spellcheck: The text responses of the Goldgrub now have better grammar, and better articulate what it is doing.
/:cl:
