### PR TITLE
Makes hostile AI ever so slightly faster

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -137,7 +137,7 @@
 			if(can_see(targets_from, HM, vision_range))
 				. += HM
 	else
-		. = list() // The following code is only very slightly slower than just returning oview(vision_range, targets_from), but it saves us much more work down the line, particularly when bees are involved
+		. = list()
 		for (var/atom/movable/A in oview(vision_range, targets_from))
 			. += A
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -140,7 +140,7 @@
 		. = list() // The following code is only very slightly slower than just returning oview(vision_range, targets_from), but it saves us much more work down the line, particularly when bees are involved
 		for (var/obj/A in oview(vision_range, targets_from))
 			. += A
-		for (var/mob/A in oview(vision_range, targets_from))
+		for (var/mob/living/A in oview(vision_range, targets_from))
 			. += A
 
 /mob/living/simple_animal/hostile/proc/FindTarget(var/list/possible_targets, var/HasTargetsList = 0)//Step 2, filter down possible targets to things we actually care about

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -138,9 +138,7 @@
 				. += HM
 	else
 		. = list() // The following code is only very slightly slower than just returning oview(vision_range, targets_from), but it saves us much more work down the line, particularly when bees are involved
-		for (var/obj/A in oview(vision_range, targets_from))
-			. += A
-		for (var/mob/living/A in oview(vision_range, targets_from))
+		for (var/atom/movable/A in oview(vision_range, targets_from))
 			. += A
 
 /mob/living/simple_animal/hostile/proc/FindTarget(var/list/possible_targets, var/HasTargetsList = 0)//Step 2, filter down possible targets to things we actually care about


### PR DESCRIPTION
This is a very minor change, just makes it so that ListTargets(), a proc which finds a first batch of possible targets, only calls oview once, and only on ``/atom/movable``s.

## Changelog

:cl: Altoids
bugfix: Hostile mobs are now like 2% faster at finding a target.
/:cl:
