### PR TITLE
removes stupid mines from the stupid russian ruin

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_russianbunker.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_russianbunker.dmm
@@ -991,14 +991,6 @@
 	name = "\improper Russian Bunker";
 	noteleport = 1
 	})
-"MC" = (
-/obj/effect/mine/gas/plasma,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/pod,
-/area/ruin/unpowered{
-	name = "\improper Russian Bunker";
-	noteleport = 1
-	})
 "MU" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -1762,11 +1754,11 @@ hU
 ZP
 hU
 GM
-js
+aY
 YQ
 aY
 GM
-MC
+QJ
 Sw
 pP
 DQ


### PR DESCRIPTION
lyna completely fucked this ruin up
its not fun to tackle because of the turrets the 6 bears and the 20+ russians all with ranged weapons, all for a meh piece of armor which can be beaten by numerous other easilier obtainable things on lavaland
#### Changelog

:cl:  
rscdel: Removed some mines from russian lavaland ruin
/:cl:
