### PR TITLE
Tritium is more dangerous/useful by reducing o2 output by 10x

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -501,10 +501,10 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 		if(antinoblium_attached)
 			removed.adjust_moles(/datum/gas/plasma, max(((device_energy * dynamic_heat_modifier) / PLASMA_RELEASE_MODIFIER) * (1+(100-support_integrity)/25), 0))
-			removed.adjust_moles(/datum/gas/oxygen, max((((device_energy + removed.return_temperature() * dynamic_heat_modifier) - T0C) / (OXYGEN_RELEASE_MODIFIER/(TRITIUM_OXYGEN_MODIFIER*tritiumcomp))) * (1+(100-support_integrity)/25), 0))
+			removed.adjust_moles(/datum/gas/oxygen, max((((device_energy + removed.return_temperature() * dynamic_heat_modifier) - T0C) / (OXYGEN_RELEASE_MODIFIER/max(TRITIUM_OXYGEN_MODIFIER*tritiumcomp), 1)) * (1+(100-support_integrity)/25), 0))
 		else
 			removed.adjust_moles(/datum/gas/plasma, max((device_energy * dynamic_heat_modifier) / PLASMA_RELEASE_MODIFIER, 0))
-			removed.adjust_moles(/datum/gas/oxygen, max(((device_energy + removed.return_temperature() * dynamic_heat_modifier) - T0C) / (OXYGEN_RELEASE_MODIFIER/(TRITIUM_OXYGEN_MODIFIER*tritiumcomp)), 0))
+			removed.adjust_moles(/datum/gas/oxygen, max(((device_energy + removed.return_temperature() * dynamic_heat_modifier) - T0C) / (OXYGEN_RELEASE_MODIFIER/max(TRITIUM_OXYGEN_MODIFIER*tritiumcomp), 1), 0))
 
 		if(produces_gas)
 			env.merge(removed)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -501,10 +501,10 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 		if(antinoblium_attached)
 			removed.adjust_moles(/datum/gas/plasma, max(((device_energy * dynamic_heat_modifier) / PLASMA_RELEASE_MODIFIER) * (1+(100-support_integrity)/25), 0))
-			removed.adjust_moles(/datum/gas/oxygen, max((((device_energy + removed.return_temperature() * dynamic_heat_modifier) - T0C) / (OXYGEN_RELEASE_MODIFIER/TRITIUM_OXYGEN_MODIFIER) * (1+(100-support_integrity)/25), 0))
+			removed.adjust_moles(/datum/gas/oxygen, max((((device_energy + removed.return_temperature() * dynamic_heat_modifier) - T0C) / (OXYGEN_RELEASE_MODIFIER/(TRITIUM_OXYGEN_MODIFIER*tritiumcomp)) * (1+(100-support_integrity)/25), 0))
 		else
 			removed.adjust_moles(/datum/gas/plasma, max((device_energy * dynamic_heat_modifier) / PLASMA_RELEASE_MODIFIER, 0))
-			removed.adjust_moles(/datum/gas/oxygen, max(((device_energy + removed.return_temperature() * dynamic_heat_modifier) - T0C) / (OXYGEN_RELEASE_MODIFIER/TRITIUM_OXYGEN_MODIFIER), 0))
+			removed.adjust_moles(/datum/gas/oxygen, max(((device_energy + removed.return_temperature() * dynamic_heat_modifier) - T0C) / (OXYGEN_RELEASE_MODIFIER/(TRITIUM_OXYGEN_MODIFIER*tritiumcomp)), 0))
 
 		if(produces_gas)
 			env.merge(removed)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -501,10 +501,10 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 		if(antinoblium_attached)
 			removed.adjust_moles(/datum/gas/plasma, max(((device_energy * dynamic_heat_modifier) / PLASMA_RELEASE_MODIFIER) * (1+(100-support_integrity)/25), 0))
-			removed.adjust_moles(/datum/gas/oxygen, max((((device_energy + removed.return_temperature() * dynamic_heat_modifier) - T0C) / (OXYGEN_RELEASE_MODIFIER/max(TRITIUM_OXYGEN_MODIFIER*tritiumcomp), 1)) * (1+(100-support_integrity)/25), 0))
+			removed.adjust_moles(/datum/gas/oxygen, max((((device_energy + removed.return_temperature() * dynamic_heat_modifier) - T0C) / (OXYGEN_RELEASE_MODIFIER/max(TRITIUM_OXYGEN_MODIFIER*tritiumcomp, 1))) * (1+(100-support_integrity)/25), 0))
 		else
 			removed.adjust_moles(/datum/gas/plasma, max((device_energy * dynamic_heat_modifier) / PLASMA_RELEASE_MODIFIER, 0))
-			removed.adjust_moles(/datum/gas/oxygen, max(((device_energy + removed.return_temperature() * dynamic_heat_modifier) - T0C) / (OXYGEN_RELEASE_MODIFIER/max(TRITIUM_OXYGEN_MODIFIER*tritiumcomp), 1), 0))
+			removed.adjust_moles(/datum/gas/oxygen, max(((device_energy + removed.return_temperature() * dynamic_heat_modifier) - T0C) / (OXYGEN_RELEASE_MODIFIER/max(TRITIUM_OXYGEN_MODIFIER*tritiumcomp, 1)), 0))
 
 		if(produces_gas)
 			env.merge(removed)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -32,7 +32,7 @@
 #define HYDROGEN_HEAT_RESISTANCE 2 // just a bit of heat resistance to spice it up
 #define PLUONIUM_HEAT_RESISTANCE 5
 
-#define TRITIUM_OXYGEN_MODIFIER 5 // How much to divide oxygen output
+#define TRITIUM_OXYGEN_MODIFIER 10 // How much to divide oxygen output
 
 #define POWERLOSS_INHIBITION_GAS_THRESHOLD 0.20         //Higher == Higher percentage of inhibitor gas needed before the charge inertia chain reaction effect starts.
 #define POWERLOSS_INHIBITION_MOLE_THRESHOLD 20        //Higher == More moles of the gas are needed before the charge inertia chain reaction effect starts.        //Scales powerloss inhibition down until this amount of moles is reached

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -32,6 +32,8 @@
 #define HYDROGEN_HEAT_RESISTANCE 2 // just a bit of heat resistance to spice it up
 #define PLUONIUM_HEAT_RESISTANCE 5
 
+#define TRITIUM_OXYGEN_MODIFIER 5 // How much to divide oxygen output
+
 #define POWERLOSS_INHIBITION_GAS_THRESHOLD 0.20         //Higher == Higher percentage of inhibitor gas needed before the charge inertia chain reaction effect starts.
 #define POWERLOSS_INHIBITION_MOLE_THRESHOLD 20        //Higher == More moles of the gas are needed before the charge inertia chain reaction effect starts.        //Scales powerloss inhibition down until this amount of moles is reached
 #define POWERLOSS_INHIBITION_MOLE_BOOST_THRESHOLD 500  //bonus powerloss inhibition boost if this amount of moles is reached
@@ -499,10 +501,10 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 		if(antinoblium_attached)
 			removed.adjust_moles(/datum/gas/plasma, max(((device_energy * dynamic_heat_modifier) / PLASMA_RELEASE_MODIFIER) * (1+(100-support_integrity)/25), 0))
-			removed.adjust_moles(/datum/gas/oxygen, max((((device_energy + removed.return_temperature() * dynamic_heat_modifier) - T0C) / OXYGEN_RELEASE_MODIFIER) * (1+(100-support_integrity)/25), 0))
+			removed.adjust_moles(/datum/gas/oxygen, max((((device_energy + removed.return_temperature() * dynamic_heat_modifier) - T0C) / (OXYGEN_RELEASE_MODIFIER/TRITIUM_OXYGEN_MODIFIER) * (1+(100-support_integrity)/25), 0))
 		else
 			removed.adjust_moles(/datum/gas/plasma, max((device_energy * dynamic_heat_modifier) / PLASMA_RELEASE_MODIFIER, 0))
-			removed.adjust_moles(/datum/gas/oxygen, max(((device_energy + removed.return_temperature() * dynamic_heat_modifier) - T0C) / OXYGEN_RELEASE_MODIFIER, 0))
+			removed.adjust_moles(/datum/gas/oxygen, max(((device_energy + removed.return_temperature() * dynamic_heat_modifier) - T0C) / (OXYGEN_RELEASE_MODIFIER/TRITIUM_OXYGEN_MODIFIER), 0))
 
 		if(produces_gas)
 			env.merge(removed)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -501,7 +501,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 		if(antinoblium_attached)
 			removed.adjust_moles(/datum/gas/plasma, max(((device_energy * dynamic_heat_modifier) / PLASMA_RELEASE_MODIFIER) * (1+(100-support_integrity)/25), 0))
-			removed.adjust_moles(/datum/gas/oxygen, max((((device_energy + removed.return_temperature() * dynamic_heat_modifier) - T0C) / (OXYGEN_RELEASE_MODIFIER/(TRITIUM_OXYGEN_MODIFIER*tritiumcomp)) * (1+(100-support_integrity)/25), 0))
+			removed.adjust_moles(/datum/gas/oxygen, max((((device_energy + removed.return_temperature() * dynamic_heat_modifier) - T0C) / (OXYGEN_RELEASE_MODIFIER/(TRITIUM_OXYGEN_MODIFIER*tritiumcomp))) * (1+(100-support_integrity)/25), 0))
 		else
 			removed.adjust_moles(/datum/gas/plasma, max((device_energy * dynamic_heat_modifier) / PLASMA_RELEASE_MODIFIER, 0))
 			removed.adjust_moles(/datum/gas/oxygen, max(((device_energy + removed.return_temperature() * dynamic_heat_modifier) - T0C) / (OXYGEN_RELEASE_MODIFIER/(TRITIUM_OXYGEN_MODIFIER*tritiumcomp)), 0))


### PR DESCRIPTION
### Intent of your Pull Request

Reduce the amount of o2 released from the sm(at 100% tritium) by 10x

### Why is this good for the game?

Makes tritium more spooky and also useful instead of burning instantly

~~will fix commit in sec~~

#### Changelog

:cl:  
tweak: Tritium now reduces o2 output by up to 10x
/:cl:
