### PR TITLE
nuka cola nerf: fuck powergaming edition

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -475,7 +475,7 @@
 	M.drowsyness = 0
 	M.AdjustSleeping(-40, FALSE)
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)
-	M.apply_effect(5,EFFECT_IRRADIATE,0)
+	M.apply_effect(10,EFFECT_IRRADIATE,0)
 	..()
 	. = 1
 


### PR DESCRIPTION
nuka cola does more rad damage per sip.
1 sip (5u) appears to bring the rads up to 122-130 rads so uh, have fun trying to chug it now

#### Changelog

:cl:  
tweak: nukacola does more rad damage
/:cl:
