### PR TITLE
a different nuka cola nerf - SEAN UPDATE NEEDED

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -462,7 +462,7 @@
 
 /datum/reagent/consumable/nuka_cola/on_mob_metabolize(mob/living/L)
 	..()
-	L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=-0.75, blacklisted_movetypes=(FLYING|FLOATING))
+	L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=-0.50, blacklisted_movetypes=(FLYING|FLOATING))
 
 /datum/reagent/consumable/nuka_cola/on_mob_end_metabolize(mob/living/L)
 	L.remove_movespeed_modifier(type)
@@ -476,6 +476,7 @@
 	M.AdjustSleeping(-40, FALSE)
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)
 	M.apply_effect(5,EFFECT_IRRADIATE,0)
+	M.adjustStaminaLoss(1)
 	..()
 	. = 1
 


### PR DESCRIPTION
disclaimer, this should not be combined with Redd's PR, do not merge both.

This reduces nuka cola's speed buff by 33% and makes it deal a slight amount of stamina damage that is largely unnoticeable so long as you don't drink more than 25 units in a sitting or are getting shot by disablers and it stops your stamina regeneration. Reinforces the idea of nuka cola being a cheap and only mildly effective getaway drug rather than a combat drug since now it can hamper you when fighting against people with stamina draining weapons. Radiation amount is kept untouched.

#### Changelog

:cl:  
tweak: nuka cola speedbuff isn't as good, and it deals slight amounts of stamina damage
/:cl:


Jamie Edit: 
Alternative to #10621
Alternative to #10629
Alternative to #10629

THEOS SORT THIS OUT