### PR TITLE
Chemical heaters now scale from max_temprature not target temprerature 

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -66,7 +66,7 @@
 		return
 	if(on)
 		if(beaker && beaker.reagents.total_volume)
-			var/direction = (beaker.reagents.chem_temp > target_temperature) ? TRUE : FALSE // TRUE is cooling, used to allow it to snap to the target temp
+			var/direction = beaker.reagents.chem_temp > target_temperature // is it cooling? used to allow it to snap to the target temp
 			var/heating = (1000 - beaker.reagents.chem_temp) * heater_coefficient * (direction ? -1 : 1) // How much to increase the heat by
 			if(heating + beaker.reagents.chem_temp >= target_temperature && !direction) // Heat snapping condition
 				heating = target_temperature - beaker.reagents.chem_temp // Makes it snap to target temp

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -9,7 +9,7 @@
 	circuit = /obj/item/circuitboard/machine/chem_heater
 	var/obj/item/reagent_containers/beaker = null
 	var/target_temperature = 300
-	var/heater_coefficient = 0.025
+	var/heater_coefficient = 0.025 // Multiplier for heat
 	var/on = FALSE
 
 /obj/machinery/chem_heater/Destroy()
@@ -65,12 +65,12 @@
 		return
 	if(on)
 		if(beaker && beaker.reagents.total_volume)
-			var/direction = (beaker.reagents.chem_temp > target_temperature) ? TRUE : FALSE // TRUE is cooling
-			var/heating = (1000 - beaker.reagents.chem_temp) * heater_coefficient * (direction ? -1 : 1)
-			if(heating + beaker.reagents.chem_temp >= target_temperature && !direction)
-				heating = target_temperature - beaker.reagents.chem_temp // Stops it from overshooting
-			else if(heating + beaker.reagents.chem_temp <= target_temperature && direction)
-				heating = target_temperature - beaker.reagents.chem_temp // Allows it to work even while cooling
+			var/direction = (beaker.reagents.chem_temp > target_temperature) ? TRUE : FALSE // TRUE is cooling, used to allow it to snap to the target temp
+			var/heating = (1000 - beaker.reagents.chem_temp) * heater_coefficient * (direction ? -1 : 1) // How much to increase the heat by
+			if(heating + beaker.reagents.chem_temp >= target_temperature && !direction) // Heat snapping condition
+				heating = target_temperature - beaker.reagents.chem_temp // Makes it snap to target temp
+			else if(heating + beaker.reagents.chem_temp <= target_temperature && direction) // Cooling snapping condition
+				heating = target_temperature - beaker.reagents.chem_temp // Makes it snap to target temp
 
 			beaker.reagents.adjust_thermal_energy(heating * SPECIFIC_HEAT_DEFAULT * beaker.reagents.total_volume)
 			beaker.reagents.handle_reactions()

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -9,7 +9,8 @@
 	circuit = /obj/item/circuitboard/machine/chem_heater
 	var/obj/item/reagent_containers/beaker = null
 	var/target_temperature = 300
-	var/heater_coefficient = 0.025 // Multiplier for heat
+	/// Multiplier for heat
+	var/heater_coefficient = 0.025
 	var/on = FALSE
 
 /obj/machinery/chem_heater/Destroy()


### PR DESCRIPTION
### Intent of your Pull Request

Makes it so the equation isnt (target - current) and instead (1000 - current) * -1(or1)

Takes about ~8 seconds for a unupgraded heater to hit 380K
Should take about ~2 seconds at Tier 4

_Tested AND works backwards_

### Why is this good for the game?

Muh Realism. Also prevents just bypassing the need for heating by have chemicals be 1 tick
_also fixes a slight bug where it would never reach target temperature_

#### Changelog

:cl:  
tweak: Chem heaters now scale based on max temperature
/:cl:
