### PR TITLE
Fixes a runtime with sending UI assets too early

### DIFF
--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -157,9 +157,8 @@
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui && tgui_id)
 		ui = new(user, src, tgui_id, filedesc)
-		ui.send_asset(get_asset_datum(/datum/asset/simple/headers))
 		ui.open()
-
+		ui.send_asset(get_asset_datum(/datum/asset/simple/headers))
 // CONVENTIONS, READ THIS WHEN CREATING NEW PROGRAM AND OVERRIDING THIS PROC:
 // Topic calls are automagically forwarded from NanoModule this program contains.
 // Calls beginning with "PRG_" are reserved for programs handling.


### PR DESCRIPTION
### Intent of your Pull Request

Runtime in tgui.dm, line 159: send_asset() can only be called after open().

Gets rid of that

### Why is this good for the game?

Runtimes bad
