### PR TITLE
removes nuka cola from vendor

### DIFF
--- a/code/modules/vending/cola.dm
+++ b/code/modules/vending/cola.dm
@@ -18,8 +18,7 @@
 		              /obj/item/reagent_containers/food/drinks/soda_cans/shamblers = 6,
 					  /obj/item/reagent_containers/food/drinks/soda_cans/buzz_fuzz = 5,
 		              /obj/item/reagent_containers/food/drinks/soda_cans/sprited_cranberry = 2)
-	premium = list(/obj/item/reagent_containers/food/drinks/bottle/nukacola = 1,
-		           /obj/item/reagent_containers/food/drinks/soda_cans/air = 1,
+	premium = list(/obj/item/reagent_containers/food/drinks/soda_cans/air = 1,
 		           /obj/item/reagent_containers/food/drinks/soda_cans/monkey_energy = 1,
 		           /obj/item/reagent_containers/food/drinks/soda_cans/grey_bull = 1)
 	refill_canister = /obj/item/vending_refill/cola


### PR DESCRIPTION
everyone elses nuka prs are shit, what fucking issue has it caused, the only people who use it are assistants buying it from the soda machines nobody makes it ever
#### Changelog

:cl:    
rscdel: Removed nuka from vendor

/:cl:
