### PR TITLE
Replaces the nuka cola speed boost with a damage slowdown resistance

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -73,6 +73,7 @@
 #define TRAIT_PACIFISM			"pacifism"
 #define TRAIT_IGNORESLOWDOWN	"ignoreslow"
 #define TRAIT_IGNOREDAMAGESLOWDOWN "ignoredamageslowdown"
+#define TRAIT_RESISTDAMAGESLOWDOWN "resistdamageslowdown"
 #define TRAIT_DEATHCOMA			"deathcoma" //Causes death-like unconsciousness
 #define TRAIT_FAKEDEATH			"fakedeath" //Makes the owner appear as dead to most forms of medical examination
 #define TRAIT_DISFIGURED		"disfigured"

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1237,6 +1237,8 @@ GLOBAL_LIST_EMPTY(mentor_races)
 		if(!HAS_TRAIT(H, TRAIT_IGNOREDAMAGESLOWDOWN))
 			var/health_deficiency = max(H.maxHealth - H.health, H.staminaloss)
 			if(health_deficiency >= H.maxHealth * 0.4)
+				if(HAS_TRAIT(H, TRAIT_RESISTDAMAGESLOWDOWN)
+					health_deficiency *= 0.5
 				if(flight)
 					. += (health_deficiency / 75)
 				else

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1237,7 +1237,7 @@ GLOBAL_LIST_EMPTY(mentor_races)
 		if(!HAS_TRAIT(H, TRAIT_IGNOREDAMAGESLOWDOWN))
 			var/health_deficiency = max(H.maxHealth - H.health, H.staminaloss)
 			if(health_deficiency >= H.maxHealth * 0.4)
-				if(HAS_TRAIT(H, TRAIT_RESISTDAMAGESLOWDOWN)
+				if(HAS_TRAIT(H, TRAIT_RESISTDAMAGESLOWDOWN))
 					health_deficiency *= 0.5
 				if(flight)
 					. += (health_deficiency / 75)

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -462,10 +462,10 @@
 
 /datum/reagent/consumable/nuka_cola/on_mob_metabolize(mob/living/L)
 	..()
-	ADD_TRAIT(L, TRAIT_RESISTDAMAGESLOWDOWN)
+	ADD_TRAIT(L, TRAIT_RESISTDAMAGESLOWDOWN, type)
 
 /datum/reagent/consumable/nuka_cola/on_mob_end_metabolize(mob/living/L)
-	REMOVE_TRAIT(L, TRAIT_RESISTDAMAGESLOWDOWN)
+	REMOVE_TRAIT(L, TRAIT_RESISTDAMAGESLOWDOWN, type)
 	..()
 
 /datum/reagent/consumable/nuka_cola/on_mob_life(mob/living/carbon/M)

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -462,10 +462,10 @@
 
 /datum/reagent/consumable/nuka_cola/on_mob_metabolize(mob/living/L)
 	..()
-	L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=-0.75, blacklisted_movetypes=(FLYING|FLOATING))
+	ADD_TRAIT(L, TRAIT_RESISTDAMAGESLOWDOWN)
 
 /datum/reagent/consumable/nuka_cola/on_mob_end_metabolize(mob/living/L)
-	L.remove_movespeed_modifier(type)
+	REMOVE_TRAIT(L, TRAIT_RESISTDAMAGESLOWDOWN)
 	..()
 
 /datum/reagent/consumable/nuka_cola/on_mob_life(mob/living/carbon/M)


### PR DESCRIPTION
### Intent of your Pull Request

causes nuka cola to give you a 50% resistance to damage slowdown rather than a passive speed boost, making it more useful in protracted combat or for running away rather than just running

### Why is this good for the game?

Removes greytide speedboost drink also improves RP

#### Changelog

:cl:  
rscdel: nuka cola no longer gives a speed  boost when drank
tweak: nuka cola now gives a 50% resistance to damage slowdown
/:cl:
