### PR TITLE
Fix chat now fixes chat

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -107,6 +107,8 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	// Tgui Topic middleware
 	if(tgui_Topic(href_list))
 		return
+	if(href_list["reload_tguipanel"])
+		nuke_chat()
 	if(href_list["reload_statbrowser"])
 		src << browse(file('html/statbrowser.html'), "window=statbrowser")
 	// Log all hrefs

--- a/code/modules/tgui_panel/external.dm
+++ b/code/modules/tgui_panel/external.dm
@@ -12,19 +12,21 @@
 	set name = "Fix chat"
 	set category = "OOC"
 	var/action
-	log_tgui(src, "Started fixing.",
-		context = "verb/fix_tgui_panel")
-	// Not ready
-	if(!tgui_panel?.is_ready())
-		log_tgui(src, "Panel is not ready",
-			context = "verb/fix_tgui_panel")
-		tgui_panel.window.send_message("ping", force = TRUE)
-		action = alert(src, "Method: Pinging the panel.\nWait a bit and tell me if it's fixed", "", "Fixed", "Nope")
-		if(action == "Fixed")
-			log_tgui(src, "Fixed by sending a ping",
-				context = "verb/fix_tgui_panel")
-			return
-	// Catch all solution
+	log_tgui(src, "Started fixing.", context = "verb/fix_tgui_panel")
+
+	nuke_chat()
+
+	// Failed to fix
+	action = alert(src, "Did that work?", "", "Yes", "No, switch to old ui")
+	if (action == "No, switch to old ui")
+		winset(src, "output", "on-show=&is-disabled=0&is-visible=1")
+		winset(src, "browseroutput", "is-disabled=1;is-visible=0")
+		log_tgui(src, "Failed to fix.", context = "verb/fix_tgui_panel")
+
+/client/proc/nuke_chat()
+	// Catch all solution (kick the whole thing in the pants)
+	winset(src, "output", "on-show=&is-disabled=0&is-visible=1")
+	winset(src, "browseroutput", "is-disabled=1;is-visible=0")
 	if(!tgui_panel || !istype(tgui_panel))
 		log_tgui(src, "tgui_panel datum is missing",
 			context = "verb/fix_tgui_panel")
@@ -33,15 +35,3 @@
 	// Force show the panel to see if there are any errors
 	winset(src, "output", "is-disabled=1&is-visible=0")
 	winset(src, "browseroutput", "is-disabled=0;is-visible=1")
-	action = alert(src, "Method: Reinitializing the panel.\nWait a bit and tell me if it's fixed", "", "Fixed", "Nope")
-	if(action == "Fixed")
-		log_tgui(src, "Fixed by calling 'initialize'",
-			context = "verb/fix_tgui_panel")
-		return
-	// Failed to fix
-	action = alert(src, "Welp, I'm all out of ideas. Try closing BYOND and reconnecting.\nWe could also disable tgui_panel and re-enable the old UI", "", "Thanks anyways", "Switch to old UI")
-	if (action == "Switch to old UI")
-		winset(src, "output", "on-show=&is-disabled=0&is-visible=1")
-		winset(src, "browseroutput", "is-disabled=1;is-visible=0")
-	log_tgui(src, "Failed to fix.",
-		context = "verb/fix_tgui_panel")

--- a/code/modules/tgui_panel/tgui_panel.dm
+++ b/code/modules/tgui_panel/tgui_panel.dm
@@ -55,7 +55,7 @@
  */
 /datum/tgui_panel/proc/on_initialize_timed_out()
 	// Currently does nothing but sending a message to old chat.
-	SEND_TEXT(client, "<span class=\"userdanger\">Failed to load fancy chat, reverting to old chat. Certain features won't work.</span>")
+	SEND_TEXT(client, "<span class=\"userdanger\">Failed to load fancy chat, click <a href='?src=[REF(src)];reload_tguipanel=1'>HERE</a> to attempt to reload it.</span>")
 
 /**
  * private


### PR DESCRIPTION
### Intent of your Pull Request

Ports: https://github.com/tgstation/tgstation/pull/54517

Makes fix chat do the switch to old UI trick and reload tgchat making it work on first click

### Why is this good for the game?

Making button button better is good
Also makes switch to old UI 
Also puts a thing you can click on in chat to reload the output

#### Changelog

:cl:  
tweak: Fix chat now fixes chat
/:cl:
