### PR TITLE
Adds an error on BYOND build 513.1537 as it cannot compile the code due to a bug

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -57,3 +57,11 @@
 #endif
 
 #define EXTOOLS (world.system_type == MS_WINDOWS ? "byond-extools.dll" : "libbyond-extools.so")
+
+#if (DM_VERSION == 513) && (DM_BUILD == 1537)
+#error ============WARNING===============
+#error BYOND version 513.1537 contains a bug that prevents the codebase from compiling properly. Please upgrade/downgrade your BYOND version
+#error BYOND version 513.1537 contains a bug that prevents the codebase from compiling properly. Please upgrade/downgrade your BYOND version
+#error BYOND version 513.1537 contains a bug that prevents the codebase from compiling properly. Please upgrade/downgrade your BYOND version
+#error ==================================
+#endif


### PR DESCRIPTION
Known issue, lummox is working on a fix but BYOND version 513.1537 is broken at the time of this post and cannot be used to compile the code.

