### PR TITLE
Matches the frequency of the torture device in the oldAIset ruin

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
@@ -621,11 +621,6 @@
 /obj/item/storage/toolbox/syndicate,
 /turf/open/floor/plasteel/airless,
 /area/tcommsat/oldaisat)
-"ce" = (
-/obj/structure/table,
-/obj/item/electropack,
-/turf/open/floor/plating/airless,
-/area/tcommsat/oldaisat)
 "cf" = (
 /obj/structure/table,
 /obj/item/hemostat,
@@ -912,6 +907,13 @@
 	frequency = 1449
 	},
 /turf/open/floor/plasteel/airless/dark,
+/area/tcommsat/oldaisat)
+"Pu" = (
+/obj/structure/table,
+/obj/item/electropack{
+	code = 30
+	},
+/turf/open/floor/plating/airless,
 /area/tcommsat/oldaisat)
 
 (1,1,1) = {"
@@ -2653,7 +2655,7 @@ ac
 ac
 bU
 bZ
-ce
+Pu
 bw
 ac
 ag

--- a/_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
@@ -603,11 +603,6 @@
 /obj/item/cigbutt,
 /turf/open/floor/plating/airless,
 /area/tcommsat/oldaisat)
-"ca" = (
-/obj/effect/decal/cleanable/blood,
-/obj/item/assembly/signaler,
-/turf/open/floor/plasteel/airless/dark,
-/area/tcommsat/oldaisat)
 "cb" = (
 /obj/structure/table,
 /obj/item/reagent_containers/syringe/lethal/choral,
@@ -910,6 +905,13 @@
 "da" = (
 /obj/machinery/teleport/hub,
 /turf/open/floor/plating,
+/area/tcommsat/oldaisat)
+"pZ" = (
+/obj/effect/decal/cleanable/blood,
+/obj/item/assembly/signaler{
+	frequency = 1449
+	},
+/turf/open/floor/plasteel/airless/dark,
 /area/tcommsat/oldaisat)
 
 (1,1,1) = {"
@@ -2709,7 +2711,7 @@ bw
 bw
 bw
 ac
-ca
+pZ
 cf
 bw
 ac


### PR DESCRIPTION
The frequency on the remote doesn't match the electropack in the room meaning it won't work as intended.

![8lu18f14de](https://user-images.githubusercontent.com/24533979/102025129-79388e80-3d5b-11eb-96e9-94d9db8f545a.png)
![image](https://user-images.githubusercontent.com/24533979/102025123-7473da80-3d5b-11eb-937d-53593f3df390.png)


#### Changelog

:cl:  Hopek
bugfix: fixed the frequency of the torture device in the oldAIset ruin to make it work.
/:cl:
