### PR TITLE
some ninja changes

### DIFF
--- a/code/datums/actions/ninja.dm
+++ b/code/datums/actions/ninja.dm
@@ -21,13 +21,13 @@
 	icon_icon = 'icons/mob/actions/actions_spells.dmi'
 
 /datum/action/item_action/ninjastar
-	name = "Create Throwing Stars (1E)"
+	name = "Create Throwing Stars (3E)"
 	desc = "Creates some throwing stars"
 	button_icon_state = "throwingstar"
 	icon_icon = 'icons/obj/items_and_weapons.dmi'
 
 /datum/action/item_action/ninjanet
-	name = "Energy Net (20E)"
+	name = "Energy Net (25E)"
 	desc = "Captures a fallen opponent in a net of energy. Will teleport them to a holding facility after 30 seconds."
 	button_icon_state = "energynet"
 	icon_icon = 'icons/effects/effects.dmi'

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -686,7 +686,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	name = "capture"
 
 /datum/objective/capture/proc/gen_amount_goal()
-	target_amount = rand(5,10)
+	target_amount = rand(3,5)
 	update_explanation_text()
 	return target_amount
 

--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -1,3 +1,15 @@
+/**
+ * # Energy Katana
+ *
+ * The space ninja's katana.
+ *
+ * The katana that only space ninja spawns with.  Comes with 30 force and throwforce, along with a signature special jaunting system.
+ * Upon clicking on a tile with the dash on, the user will teleport to that tile.
+ * The katana has 5 dashes stored at maximum, and upon using the dash, it will return 20 seconds after it was used.
+ * It also has a special feature where if it is tossed at a space ninja who owns it (determined by the ninja suit), the ninja will catch the katana instead of being hit by it.
+ *
+ */
+
 /obj/item/energy_katana
 	name = "energy katana"
 	desc = "A katana infused with strong energy."
@@ -5,8 +17,8 @@
 	item_state = "energy_katana"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
-	force = 40
-	throwforce = 20
+	force = 30
+	throwforce = 30
 	block_chance = 50
 	armour_penetration = 50
 	w_class = WEIGHT_CLASS_NORMAL
@@ -99,8 +111,8 @@
 	QDEL_NULL(spark_system)
 	return ..()
 
-/datum/action/innate/dash/ninja
-	current_charges = 3
-	max_charges = 3
-	charge_rate = 30
+/datum/action/innate/dash/ninja //Holds a good amount of charges, but charges them slowly. Use them wisely.
+	current_charges = 5
+	max_charges = 5
+	charge_rate = 200
 	recharge_sound = null

--- a/code/modules/ninja/suit/head.dm
+++ b/code/modules/ninja/suit/head.dm
@@ -5,7 +5,7 @@
 	name = "ninja hood"
 	icon_state = "s-ninja"
 	item_state = "s-ninja_mask"
-	armor = list("melee" = 60, "bullet" = 50, "laser" = 30,"energy" = 15, "bomb" = 30, "bio" = 30, "rad" = 25, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 50, "bullet" = 40, "laser" = 30,"energy" = 15, "bomb" = 30, "bio" = 30, "rad" = 25, "fire" = 100, "acid" = 100)
 	strip_delay = 12
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	blockTracking = 1//Roughly the only unique thing about this helmet.

--- a/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
@@ -14,7 +14,7 @@ It is possible to destroy the net by the occupant or someone else.
 	mouse_opacity = MOUSE_OPACITY_ICON//So you can hit it with stuff.
 	anchored = TRUE//Can't drag/grab the net.
 	layer = ABOVE_ALL_MOB_LAYER
-	max_integrity = 25 //How much health it has.
+	max_integrity = 40 //How much health it has.
 	can_buckle = 1
 	buckle_lying = 0
 	buckle_prevents_pull = TRUE

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_net.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_net.dm
@@ -20,7 +20,7 @@
 	if(istype(C, /mob/dead/observer))
 		to_chat(H, "<span class='warning'>You may not use an energy net on ghosts!</span>")
 		return
-	if(!ninjacost(200,N_STEALTH_CANCEL))
+	if(!ninjacost(250,N_STEALTH_CANCEL)) //25 energy, 25% of base cell.
 		H.Beam(C,"n_beam",time=15)
 		H.say("Get over here!", forced = "ninja net")
 		var/obj/structure/energy_net/E = new /obj/structure/energy_net(C.drop_location())

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_stars.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_stars.dm
@@ -1,8 +1,8 @@
 
 
-//Creates a throwing star
+//Creates a throwing star for 3 energy, 3% of the base power cell.
 /obj/item/clothing/suit/space/space_ninja/proc/ninjastar()
-	if(!ninjacost(10))
+	if(!ninjacost(30))
 		var/mob/living/carbon/human/H = affecting
 		var/obj/item/throwing_star/ninja/N = new(H)
 		if(H.put_in_hands(N))
@@ -12,7 +12,19 @@
 		H.throw_mode_on() //So they can quickly throw it.
 
 
-/obj/item/throwing_star/ninja
+/obj/item/throwing_star/ninja //while not the most important item in the codebase, it is still neat.
 	name = "ninja throwing star"
-	throwforce = 30
-	embedding = list("embedded_pain_multiplier" = 6, "embed_chance" = 100, "embedded_fall_chance" = 0)
+	desc = "A small throwing star with incapacitating poison laced onto the edges."
+	throwforce = 10
+	embedding = list("embedded_pain_multiplier" = 1, "embed_chance" = 100, "embedded_fall_chance" = 20, "embedded_fall_pain_multiplier" = 1, "embedded_impact_pain_multiplier" = 1)
+
+/obj/item/throwing_star/ninja/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
+	if(!..())
+		if(iscarbon(hit_atom))
+			var/mob/living/carbon/L = hit_atom
+			L.apply_damage(25, STAMINA)
+			L.reagents.add_reagent(/datum/reagent/toxin/ninjatoxin, 5)
+			return
+
+	..()
+

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_stealth.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_stealth.dm
@@ -18,7 +18,7 @@ Contents:
 			to_chat(U, "<span class='warning'>You don't have enough power to enable Stealth!</span>")
 			return
 		stealth = !stealth
-		animate(U, alpha = 50,time = 15)
+		animate(U, alpha = 20,time = 15)
 		U.visible_message("<span class='warning'>[U.name] vanishes into thin air!</span>", \
 						"<span class='notice'>You are now mostly invisible to normal detection.</span>")
 

--- a/code/modules/ninja/suit/ninjaDrainAct.dm
+++ b/code/modules/ninja/suit/ninjaDrainAct.dm
@@ -261,4 +261,4 @@ They *could* go in their appropriate files, but this is supposed to be modular
 		spark_system.set_up(5, 0, loc)
 		playsound(src, "sparks", 50, 1)
 		visible_message("<span class='danger'>[H] electrocutes [src] with [H.p_their()] touch!</span>", "<span class='userdanger'>[H] electrocutes you with [H.p_their()] touch!</span>")
-		electrocute_act(25, H)
+		electrocute_act(15, H)

--- a/code/modules/ninja/suit/shoes.dm
+++ b/code/modules/ninja/suit/shoes.dm
@@ -7,7 +7,7 @@
 	permeability_coefficient = 0.01
 	clothing_flags = NOSLIP
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
-	armor = list("melee" = 60, "bullet" = 50, "laser" = 30,"energy" = 15, "bomb" = 30, "bio" = 30, "rad" = 30, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 50, "bullet" = 40, "laser" = 30,"energy" = 15, "bomb" = 30, "bio" = 30, "rad" = 30, "fire" = 100, "acid" = 100)
 	strip_delay = 120
 	cold_protection = FEET
 	min_cold_protection_temperature = SHOES_MIN_TEMP_PROTECT

--- a/code/modules/ninja/suit/suit.dm
+++ b/code/modules/ninja/suit/suit.dm
@@ -19,7 +19,7 @@ Contents:
 	allowed = list(/obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/tank/internals, /obj/item/stock_parts/cell)
 	slowdown = 1
 	resistance_flags = LAVA_PROOF | ACID_PROOF
-	armor = list("melee" = 60, "bullet" = 50, "laser" = 30,"energy" = 15, "bomb" = 30, "bio" = 30, "rad" = 30, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 50, "bullet" = 40, "laser" = 30,"energy" = 15, "bomb" = 30, "bio" = 30, "rad" = 30, "fire" = 100, "acid" = 100)
 	strip_delay = 12
 
 	actions_types = list(/datum/action/item_action/initialize_ninja_suit, /datum/action/item_action/ninjasmoke, /datum/action/item_action/ninjaboost, /datum/action/item_action/ninjapulse, /datum/action/item_action/ninjastar, /datum/action/item_action/ninjanet, /datum/action/item_action/ninja_sword_recall, /datum/action/item_action/ninja_stealth, /datum/action/item_action/toggle_glove)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -946,3 +946,15 @@
 				to_chat(M, "<span class='warning'>Your missing arm aches from wherever you left it.</span>")
 				M.emote("sigh")
 	return ..()
+
+/datum/reagent/toxin/ninjatoxin //toxin applied by ninja throwing stars
+	name = "Spider Toxin"
+	description = "A weak poison that is supposedly manufactured by the spider clan that causes fatigue in victims."
+	silent_toxin = TRUE
+	color = "#6E2828"
+	toxpwr = 0.1
+	metabolization_rate = 2 * REAGENTS_METABOLISM
+
+/datum/reagent/toxin/ninjatoxin/on_mob_life(mob/living/carbon/M)
+	M.adjustStaminaLoss(3)
+	..()


### PR DESCRIPTION
This PR changes a few ninja things to try to make him slightly less strong in head to head combat and better suited for stealth, hit and runs, and capturing.

this pr changes the following-
throwing stars cost 3 energy instead of 1
energy net costs 25 energy instead of 20
katana throw force and force is now 30 instead of 40 force and 20 throw force
max jaunt charges increased to 5 and cooldown is upped to 20 seconds per jaunt
net has 40 health instead of 25
ninja stars deal far less damage but now deal some stamina damage and inject some stamina damage inducing toxin
stealth is far more effective (makes you more invisible)
shocking someone with your hands deals 15 damage instead of 25
the ninja suit's armor now has 50 melee and 40 bullet resistance instead of 60 melee and 50 bullet resistance.

This PR tries to make ninjas less of a killing machine but better at sneaking around and capturing people. This is likely more of a nerf than a buff to the ninja overall, which is fine, he is quite powerful anyhow. It is good for the game since ninjas are generally supposed to be sneaky assassins rather than one man army's. I tested it all and it seems fairly balanced but I may be wrong.

#### Changelog

:cl:  
tweak: tweaks ninja stats, such as the ninja stars, sword, stealth, and armor, plus more.
/:cl:
