### PR TITLE
Amber task force gets airlock Jimmys vs jaws of life

### DIFF
--- a/code/modules/clothing/outfits/amber.dm
+++ b/code/modules/clothing/outfits/amber.dm
@@ -24,7 +24,7 @@
 	new /obj/item/flashlight/flare(src)
 	new /obj/item/flashlight/flare(src)
 	new /obj/item/restraints/handcuffs/cable/zipties(src)
-	new /obj/item/jawsoflife(src)
+	new /obj/item/jawsoflife/jimmy(src)
 
 
 /obj/item/storage/belt/military/amber_commander/ComponentInitialize() // Amber Commander
@@ -35,7 +35,7 @@
 	new /obj/item/melee/classic_baton/telescopic(src)
 	new /obj/item/megaphone(src)
 	new /obj/item/restraints/handcuffs/cable/zipties(src)
-	new /obj/item/jawsoflife(src)
+	new /obj/item/jawsoflife/jimmy(src)
 
 /obj/item/storage/belt/military/amber_medic/ComponentInitialize() // Amber Medic
 	. = ..()
@@ -45,7 +45,7 @@
 	new /obj/item/reagent_containers/hypospray/medipen/survival(src)
 	new /obj/item/reagent_containers/hypospray/medipen/survival(src)
 	new /obj/item/reagent_containers/hypospray/combat(src)
-	new /obj/item/jawsoflife(src)
+	new /obj/item/jawsoflife/jimmy(src)
 
 
 /datum/outfit/amber

--- a/code/modules/clothing/outfits/amber.dm
+++ b/code/modules/clothing/outfits/amber.dm
@@ -24,7 +24,7 @@
 	new /obj/item/flashlight/flare(src)
 	new /obj/item/flashlight/flare(src)
 	new /obj/item/restraints/handcuffs/cable/zipties(src)
-	new /obj/item/jawsoflife/jimmy(src)
+	new /obj/item/jawsoflife/jimmy(src) 
 
 
 /obj/item/storage/belt/military/amber_commander/ComponentInitialize() // Amber Commander

--- a/code/modules/clothing/outfits/amber.dm
+++ b/code/modules/clothing/outfits/amber.dm
@@ -24,7 +24,7 @@
 	new /obj/item/flashlight/flare(src)
 	new /obj/item/flashlight/flare(src)
 	new /obj/item/restraints/handcuffs/cable/zipties(src)
-	new /obj/item/jawsoflife/jimmy(src) 
+	new /obj/item/jawsoflife/jimmy(src)
 
 
 /obj/item/storage/belt/military/amber_commander/ComponentInitialize() // Amber Commander


### PR DESCRIPTION
**Why:**
I was originally going to release the airlock Jimmy with the Amber Task Force but due to me not finishing the Jimmy in time and atomization I gave them jaws of life.

The airlock Jimmy is a device that feels "cool" to use for opening airlocks, so it really gives you that "breaking in" soldier feel, in my opinion.

As far as balance, this isn't really a nerf or buff in my opinion since I don't think this will really affect the Amber task force's effectiveness but further separates them as something unique.

Also, the jaws of life look like a very bulky device vs the Jimmy which looks like something you'd carry in a vest.

#### Changelog

:cl:  Hopek
tweak: Amber task force gets airlock Jimmys vs jaws of life just like the peacekeeper ERT.
/:cl:
