### PR TITLE
makes it so that armblades cannot be melted with acid

### DIFF
--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -144,7 +144,6 @@
 	req_human = 1
 	weapon_type = /obj/item/melee/arm_blade
 	weapon_name_simple = "blade"
-	resistance_flags = ACID_PROOF
 
 /obj/item/melee/arm_blade
 	name = "arm blade"
@@ -165,6 +164,7 @@
 	sharpness = IS_SHARP
 	var/can_drop = FALSE
 	var/fake = FALSE
+	resistance_flags = ACID_PROOF
 
 /obj/item/melee/arm_blade/Initialize(mapload,silent,synthetic)
 	. = ..()

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -144,6 +144,7 @@
 	req_human = 1
 	weapon_type = /obj/item/melee/arm_blade
 	weapon_name_simple = "blade"
+	resistance_flags = ACID_PROOF
 
 /obj/item/melee/arm_blade
 	name = "arm blade"

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -170,6 +170,7 @@
 	item_flags = ABSTRACT | DROPDEL
 	w_class = WEIGHT_CLASS_HUGE
 	sharpness = IS_SHARP
+	resistance_flags = ACID_PROOF
 
 /obj/item/light_eater/Initialize()
 	. = ..()


### PR DESCRIPTION
### Intent of your Pull Request

this was an oversight i discovered: you could melt both changeling armblades and most notably nightmare armblades with just some acid. for nightmares, this fucks them over very seriously, as they cannot get it back and essentially are just broken

### Why is this good for the game?

oversight bad for the most part, fucking over antags with little to no effort can be pretty dumb

#### Changelog

:cl:  
tweak: changeling and nightmare armblades are now acidproof 
/:cl:
