### PR TITLE
Paper ruin less cheeseable

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/originalcontent.dmm
+++ b/_maps/RandomRuins/SpaceRuins/originalcontent.dmm
@@ -882,19 +882,14 @@
 /mob/living/simple_animal/hostile/stickman/ranged,
 /turf/open/indestructible/paper,
 /area/ruin/powered)
-"fR" = (
-/obj/machinery/door/airlock/freezer{
-	name = "airlock";
-	opacity = 0
+"gJ" = (
+/obj/structure/fluff/paper{
+	dir = 4
 	},
 /obj/structure/fluff/paper{
 	dir = 8
 	},
-/obj/structure/fluff/paper{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/fans/tiny,
+/obj/structure/fans/tiny/invisible,
 /turf/open/indestructible/paper,
 /area/ruin/powered)
 "wr" = (
@@ -911,6 +906,20 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/turf/open/indestructible/paper,
+/area/ruin/powered)
+"zE" = (
+/obj/machinery/door/airlock/freezer{
+	name = "airlock";
+	opacity = 0
+	},
+/obj/structure/fluff/paper{
+	dir = 8
+	},
+/obj/structure/fluff/paper{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/indestructible/paper,
 /area/ruin/powered)
 "Ns" = (
@@ -2541,8 +2550,8 @@ aa
 (37,1,1) = {"
 aa
 ah
-fR
-an
+zE
+gJ
 wr
 av
 ap

--- a/_maps/RandomRuins/SpaceRuins/originalcontent.dmm
+++ b/_maps/RandomRuins/SpaceRuins/originalcontent.dmm
@@ -44,78 +44,7 @@
 	},
 /turf/template_noop,
 /area/template_noop)
-"ak" = (
-/obj/structure/fluff/paper{
-	dir = 9
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"al" = (
-/obj/structure/fluff/paper{
-	dir = 1
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"am" = (
-/obj/structure/fluff/paper{
-	dir = 5
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"an" = (
-/obj/structure/fluff/paper{
-	dir = 4
-	},
-/obj/structure/fluff/paper{
-	dir = 8
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"ao" = (
-/obj/structure/fluff/paper/corner{
-	dir = 4
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
 "ap" = (
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"aq" = (
-/obj/structure/fluff/paper{
-	dir = 4
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"ar" = (
-/obj/structure/fluff/paper{
-	dir = 8
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"as" = (
-/obj/item/paper/crumpled/ruins/originalcontent,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"at" = (
-/mob/living/simple_animal/hostile/stickman,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"au" = (
-/obj/structure/fluff/paper/stack{
-	dir = 4
-	},
-/obj/structure/fluff/paper/corner{
-	dir = 1
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"av" = (
-/obj/structure/fluff/paper/corner{
-	dir = 1
-	},
-/obj/structure/fluff/paper/corner{
-	dir = 4
-	},
 /turf/open/indestructible/paper,
 /area/ruin/powered)
 "aw" = (
@@ -124,237 +53,40 @@
 	},
 /turf/template_noop,
 /area/template_noop)
-"ax" = (
-/obj/structure/fluff/paper/corner{
-	dir = 1
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"ay" = (
-/obj/structure/fluff/paper{
-	dir = 10
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"az" = (
-/obj/structure/fluff/paper,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
 "aA" = (
-/obj/structure/fluff/paper/corner{
-	dir = 8
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"aB" = (
-/obj/structure/fluff/paper/stack,
-/obj/structure/fluff/paper/stack{
-	dir = 1
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"aC" = (
-/obj/structure/fluff/paper{
-	dir = 5
-	},
-/obj/structure/fluff/paper{
-	dir = 9
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"aD" = (
-/obj/structure/fluff/paper/corner{
-	dir = 8
-	},
-/obj/structure/fluff/paper/corner,
-/mob/living/simple_animal/hostile/stickman,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"aE" = (
-/obj/structure/fluff/paper{
-	dir = 8
-	},
-/obj/structure/fluff/paper/corner{
-	dir = 1
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"aF" = (
-/obj/structure/fluff/paper{
-	dir = 8
-	},
 /obj/structure/fluff/paper{
 	dir = 4
 	},
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"aG" = (
-/obj/structure/fluff/paper{
-	dir = 10
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/obj/structure/fluff/paper/corner{
-	dir = 1
-	},
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"aH" = (
-/obj/structure/fluff/paper/corner{
-	dir = 8
-	},
-/obj/structure/fluff/paper{
-	dir = 5
-	},
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"aI" = (
-/obj/structure/fluff/paper/stack{
-	dir = 1
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"aJ" = (
-/obj/structure/fluff/paper/corner{
-	dir = 1
-	},
-/obj/structure/fluff/paper/corner,
-/turf/open/indestructible/paper,
 /area/ruin/powered)
 "aK" = (
-/obj/structure/fluff/paper{
-	dir = 1
-	},
-/obj/structure/fluff/paper,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"aL" = (
-/obj/structure/fluff/paper{
-	dir = 1
-	},
-/obj/structure/fluff/paper/corner{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/stickman,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"aM" = (
 /obj/structure/fluff/paper/stack{
-	dir = 10
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"aN" = (
-/obj/structure/fluff/paper/corner{
-	dir = 8
-	},
-/obj/structure/fluff/paper{
-	dir = 4
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"aO" = (
-/obj/structure/fluff/paper,
-/mob/living/simple_animal/hostile/stickman/dog,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"aP" = (
-/obj/structure/fluff/paper{
-	dir = 8
-	},
-/obj/structure/fluff/paper{
-	dir = 4
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"aQ" = (
-/obj/structure/fluff/paper{
-	dir = 10
-	},
-/obj/structure/fluff/paper/corner{
-	dir = 1
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"aR" = (
-/obj/structure/fluff/paper{
-	dir = 1
-	},
-/obj/structure/fluff/paper/corner{
-	dir = 8
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"aS" = (
-/obj/structure/fluff/paper/corner,
-/mob/living/simple_animal/hostile/stickman/dog,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"aT" = (
-/obj/structure/fluff/paper{
-	dir = 6
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"aU" = (
-/obj/structure/fluff/paper/corner{
-	dir = 1
+	dir = 9
 	},
 /obj/structure/fluff/paper,
-/turf/open/indestructible/paper,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
 /area/ruin/powered)
 "aV" = (
-/obj/structure/fluff/paper{
-	dir = 6
-	},
 /obj/structure/fluff/paper/corner{
-	dir = 4
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"aW" = (
-/obj/structure/fluff/paper{
 	dir = 1
 	},
-/obj/structure/fluff/paper/stack,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"aX" = (
-/obj/structure/fluff/paper/stack,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"aY" = (
-/obj/structure/fluff/paper/corner,
-/obj/structure/fluff/paper/corner{
-	dir = 4
+/obj/structure/fluff/paper,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/turf/open/indestructible/paper,
 /area/ruin/powered)
 "aZ" = (
-/obj/structure/fluff/paper/corner{
-	dir = 8
-	},
-/obj/structure/fluff/paper/corner{
-	dir = 1
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"ba" = (
 /obj/structure/fluff/paper{
-	dir = 1
-	},
-/mob/living/simple_animal/hostile/stickman/dog,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bb" = (
-/obj/structure/fluff/paper/corner{
-	dir = 1
-	},
-/obj/structure/fluff/paper/corner{
 	dir = 8
 	},
-/turf/open/indestructible/paper,
+/obj/item/toy/crayon/yellow,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
 /area/ruin/powered)
 "bc" = (
 /obj/structure/fluff/paper{
@@ -376,61 +108,13 @@
 /area/template_noop)
 "bf" = (
 /obj/structure/fluff/paper{
-	dir = 4
+	dir = 10
 	},
-/obj/structure/fluff/paper/stack{
-	dir = 9
+/obj/structure/table/wood,
+/obj/item/storage/crayons,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bg" = (
-/obj/structure/fluff/paper{
-	dir = 8
-	},
-/obj/item/toy/crayon/yellow,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bh" = (
-/obj/structure/fluff/paper{
-	dir = 1
-	},
-/obj/item/toy/crayon/red,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bi" = (
-/obj/structure/fluff/paper{
-	dir = 1
-	},
-/obj/structure/fluff/paper/corner,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bj" = (
-/obj/structure/fluff/paper,
-/obj/structure/fluff/paper/corner{
-	dir = 4
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bk" = (
-/obj/structure/fluff/paper/corner{
-	dir = 8
-	},
-/obj/structure/fluff/paper/corner{
-	dir = 1
-	},
-/mob/living/simple_animal/hostile/stickman,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bl" = (
-/obj/structure/fluff/paper/stack{
-	dir = 9
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bm" = (
-/obj/structure/fluff/paper,
-/mob/living/simple_animal/hostile/stickman,
-/turf/open/indestructible/paper,
 /area/ruin/powered)
 "bn" = (
 /obj/structure/fluff/paper{
@@ -450,55 +134,6 @@
 	},
 /turf/template_noop,
 /area/template_noop)
-"bp" = (
-/obj/structure/fluff/paper{
-	dir = 8
-	},
-/obj/item/toy/crayon/rainbow,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bq" = (
-/obj/structure/fluff/paper{
-	dir = 4
-	},
-/obj/structure/fluff/paper/stack{
-	dir = 4
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"br" = (
-/obj/structure/fluff/paper{
-	dir = 8
-	},
-/obj/structure/fluff/paper/stack{
-	dir = 4
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bs" = (
-/obj/item/toy/crayon/spraycan,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bt" = (
-/obj/item/storage/crayons,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bu" = (
-/mob/living/simple_animal/hostile/stickman/ranged,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bv" = (
-/obj/structure/fluff/paper/corner{
-	dir = 8
-	},
-/obj/structure/fluff/paper{
-	dir = 4
-	},
-/obj/structure/fluff/paper/stack{
-	dir = 1
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
 "bw" = (
 /obj/structure/fluff/paper/corner{
 	dir = 1
@@ -511,118 +146,215 @@
 	},
 /turf/template_noop,
 /area/template_noop)
-"by" = (
-/obj/structure/fluff/paper/corner,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bz" = (
-/obj/structure/fluff/paper/stack{
-	dir = 9
-	},
-/obj/structure/fluff/paper,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
 "bA" = (
 /obj/item/toner,
 /turf/open/indestructible/paper,
 /area/ruin/powered)
-"bB" = (
-/obj/structure/easel,
-/obj/item/paper/pamphlet/ruin/originalcontent/stickman,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bC" = (
-/obj/item/toy/crayon/yellow,
-/obj/structure/fluff/paper{
-	dir = 8
+"bI" = (
+/obj/structure/fluff/paper/corner{
+	dir = 1
 	},
-/turf/open/indestructible/paper,
+/obj/structure/fluff/paper/corner,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
 /area/ruin/powered)
-"bD" = (
+"cr" = (
 /obj/structure/fluff/paper{
 	dir = 4
 	},
-/obj/structure/fluff/paper/corner{
+/obj/structure/fluff/paper{
 	dir = 8
 	},
-/turf/open/indestructible/paper,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
 /area/ruin/powered)
-"bE" = (
-/mob/living/simple_animal/hostile/stickman/dog,
-/turf/open/indestructible/paper,
+"dm" = (
+/obj/structure/fluff/paper,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
 /area/ruin/powered)
-"bF" = (
+"ds" = (
+/obj/item/toy/crayon/blue,
+/mob/living/simple_animal/hostile/stickman/ranged,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"ey" = (
+/obj/structure/fluff/paper/stack,
 /obj/structure/fluff/paper/stack{
 	dir = 1
 	},
-/obj/structure/fluff/paper/stack,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"eH" = (
 /obj/structure/fluff/paper/corner{
 	dir = 1
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bG" = (
-/obj/item/toy/crayon/blue,
-/mob/living/simple_animal/hostile/stickman/ranged,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bH" = (
-/obj/structure/fluff/paper{
-	dir = 4
-	},
-/obj/item/toy/crayon/yellow,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bI" = (
-/obj/structure/fluff/paper{
-	dir = 9
-	},
-/obj/structure/closet/crate/bin,
-/obj/item/paper/crumpled/ruins/originalcontent,
-/obj/item/paper/crumpled/ruins/originalcontent,
-/obj/item/paper/crumpled/ruins/originalcontent,
-/obj/item/gps{
-	gpstag = "Pulpy Signal"
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bJ" = (
-/obj/structure/fluff/paper{
-	dir = 1
-	},
-/obj/structure/easel,
-/obj/item/paper/pamphlet/ruin/originalcontent/treeside,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bK" = (
-/obj/structure/fluff/paper{
-	dir = 5
-	},
-/obj/structure/table/wood,
-/obj/item/storage/crayons,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bL" = (
-/obj/structure/fluff/paper{
-	dir = 4
 	},
 /obj/structure/fluff/paper/stack{
 	dir = 6
 	},
-/turf/open/indestructible/paper,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
 /area/ruin/powered)
-"bM" = (
-/obj/item/toy/crayon/purple,
-/turf/open/indestructible/paper,
+"fh" = (
+/obj/structure/fluff/paper/stack{
+	dir = 9
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
 /area/ruin/powered)
-"bN" = (
-/obj/structure/fluff/paper/corner,
+"fj" = (
+/obj/structure/fluff/paper{
+	dir = 8
+	},
+/obj/structure/fluff/paper/stack{
+	dir = 6
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"fw" = (
+/obj/structure/fluff/paper,
+/mob/living/simple_animal/hostile/stickman/dog,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"fK" = (
+/obj/structure/fluff/paper{
+	dir = 1
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"fU" = (
+/obj/structure/fluff/paper/corner{
+	dir = 4
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"ga" = (
+/obj/structure/fluff/paper/stack{
+	dir = 1
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"gH" = (
+/obj/structure/fluff/paper{
+	dir = 4
+	},
+/obj/structure/fluff/paper/corner{
+	dir = 8
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"he" = (
+/obj/structure/fluff/paper{
+	dir = 1
+	},
+/obj/structure/fluff/paper/corner{
+	dir = 8
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"jw" = (
+/obj/structure/fluff/paper/corner{
+	dir = 8
+	},
+/obj/structure/fluff/paper{
+	dir = 4
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"jO" = (
+/mob/living/simple_animal/hostile/stickman/ranged,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"kw" = (
+/obj/structure/fluff/paper/corner{
+	dir = 8
+	},
 /obj/structure/fluff/paper/corner{
 	dir = 1
 	},
-/turf/open/indestructible/paper,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
 /area/ruin/powered)
-"bO" = (
+"kD" = (
+/obj/structure/fluff/paper/corner,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"kW" = (
+/obj/structure/fluff/paper/stack{
+	dir = 9
+	},
+/obj/item/toy/crayon/purple,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"kY" = (
+/obj/structure/fluff/paper/stack{
+	dir = 4
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"lK" = (
+/obj/structure/fluff/paper{
+	dir = 8
+	},
+/obj/structure/fluff/paper{
+	dir = 4
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"lU" = (
+/obj/structure/fluff/paper{
+	dir = 6
+	},
+/obj/structure/fluff/paper{
+	dir = 5
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"mg" = (
+/obj/item/toy/crayon/spraycan,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"nB" = (
 /obj/machinery/door/airlock/freezer{
 	name = "airlock";
 	opacity = 0
@@ -631,268 +363,28 @@
 	dir = 1
 	},
 /obj/structure/fluff/paper,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bP" = (
-/obj/structure/fluff/paper{
-	dir = 1
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/obj/structure/fluff/paper/corner{
-	dir = 8
-	},
-/obj/structure/fluff/paper/stack{
-	dir = 4
-	},
-/turf/open/indestructible/paper,
 /area/ruin/powered)
-"bQ" = (
-/obj/structure/fluff/paper{
-	dir = 1
-	},
-/obj/structure/fluff/paper/stack,
-/obj/structure/fluff/paper/stack{
-	dir = 1
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bR" = (
-/obj/structure/fluff/paper/stack{
-	dir = 4
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bS" = (
-/obj/structure/fluff/paper/stack{
-	dir = 1
-	},
-/obj/structure/fluff/paper/stack,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bT" = (
-/obj/structure/fluff/paper/corner{
-	dir = 1
-	},
-/obj/structure/fluff/paper/stack{
-	dir = 6
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bU" = (
-/obj/structure/fluff/paper{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/stickman,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bV" = (
-/obj/item/toy/crayon/yellow,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bW" = (
-/obj/structure/fluff/paper{
-	dir = 8
-	},
-/obj/structure/easel,
-/obj/item/paper/pamphlet/ruin/originalcontent/pennywise,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bX" = (
-/obj/item/toy/crayon/blue,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bY" = (
-/obj/item/toy/crayon/red,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"bZ" = (
-/obj/structure/fluff/paper{
-	dir = 4
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/rainbow,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"ca" = (
-/obj/structure/fluff/paper{
-	dir = 10
-	},
-/obj/structure/table/wood,
-/obj/item/storage/crayons,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"cb" = (
-/obj/structure/fluff/paper/stack{
-	dir = 9
-	},
-/obj/item/toy/crayon/purple,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"cc" = (
-/mob/living/simple_animal/hostile/boss/paper_wizard,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"cd" = (
-/obj/structure/fluff/paper{
-	dir = 4
-	},
-/obj/structure/table/wood,
-/obj/item/toy/crayon/rainbow,
-/obj/item/toy/crayon/spraycan,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"ce" = (
-/obj/structure/fluff/paper{
-	dir = 4
-	},
-/obj/structure/fluff/paper/corner{
-	dir = 4
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"cf" = (
-/obj/structure/fluff/paper{
-	dir = 8
-	},
-/obj/structure/fluff/paper/stack,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"cg" = (
-/obj/structure/fluff/paper{
-	dir = 4
-	},
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"ch" = (
-/obj/structure/fluff/paper,
-/obj/item/paper/crumpled/ruins/originalcontent,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"ci" = (
-/obj/structure/fluff/paper,
-/obj/structure/fluff/paper/corner{
-	dir = 1
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"cj" = (
-/obj/structure/fluff/paper{
-	dir = 1
-	},
-/mob/living/simple_animal/hostile/stickman,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"ck" = (
-/obj/structure/fluff/paper{
-	dir = 6
-	},
-/obj/structure/fluff/paper{
-	dir = 5
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"cl" = (
-/obj/structure/fluff/paper/corner,
-/obj/structure/fluff/paper/stack{
-	dir = 4
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"cm" = (
-/obj/structure/fluff/paper,
-/obj/structure/table/wood,
-/obj/item/storage/crayons,
-/obj/item/storage/crayons,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"cn" = (
-/obj/structure/fluff/paper{
-	dir = 6
-	},
-/obj/structure/table/wood,
-/obj/item/canvas/twentythreeXtwentythree,
-/obj/item/canvas,
-/obj/item/canvas/nineteenXnineteen,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"co" = (
-/obj/structure/fluff/paper,
-/obj/structure/fluff/paper/stack{
-	dir = 9
-	},
-/obj/item/toy/crayon/blue,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"cp" = (
-/obj/structure/fluff/paper{
-	dir = 10
-	},
-/obj/machinery/photocopier,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"cq" = (
-/obj/structure/fluff/paper,
-/obj/structure/table/wood,
-/obj/item/storage/crayons,
-/obj/item/pen/fourcolor,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"cr" = (
+"ok" = (
 /obj/structure/fluff/paper,
 /obj/structure/easel,
 /obj/item/paper/pamphlet/ruin/originalcontent/yelling,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"cs" = (
-/obj/structure/fluff/paper,
-/obj/structure/fluff/paper{
-	dir = 1
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/mob/living/simple_animal/hostile/stickman/dog,
-/turf/open/indestructible/paper,
 /area/ruin/powered)
-"ct" = (
-/obj/structure/fluff/paper,
-/obj/structure/fluff/paper{
-	dir = 1
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"cu" = (
-/obj/structure/fluff/paper{
-	dir = 8
-	},
+"oJ" = (
 /obj/structure/fluff/paper/stack{
-	dir = 6
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"cv" = (
-/obj/structure/fluff/paper,
-/obj/structure/fluff/paper/stack{
-	dir = 6
-	},
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"cw" = (
-/obj/structure/fluff/paper{
 	dir = 1
 	},
-/mob/living/simple_animal/hostile/stickman/ranged,
-/turf/open/indestructible/paper,
-/area/ruin/powered)
-"gJ" = (
-/obj/structure/fluff/paper{
-	dir = 4
+/obj/structure/fluff/paper/stack,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
-/obj/structure/fluff/paper{
-	dir = 8
-	},
-/obj/structure/fans/tiny/invisible,
-/turf/open/indestructible/paper,
 /area/ruin/powered)
-"wr" = (
+"pQ" = (
 /obj/machinery/door/airlock/freezer{
 	name = "airlock";
 	opacity = 0
@@ -906,9 +398,741 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/turf/open/indestructible/paper,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
 /area/ruin/powered)
-"zE" = (
+"qJ" = (
+/obj/structure/fluff/paper{
+	dir = 10
+	},
+/obj/structure/fluff/paper/corner{
+	dir = 1
+	},
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"qZ" = (
+/obj/structure/fluff/paper{
+	dir = 8
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"rr" = (
+/obj/item/toy/crayon/yellow,
+/obj/structure/fluff/paper{
+	dir = 8
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"rx" = (
+/obj/structure/easel,
+/obj/item/paper/pamphlet/ruin/originalcontent/stickman,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"rJ" = (
+/obj/structure/fluff/paper/corner{
+	dir = 8
+	},
+/obj/structure/fluff/paper/corner{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/stickman,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"rU" = (
+/obj/structure/fluff/paper{
+	dir = 10
+	},
+/obj/structure/fluff/paper/corner{
+	dir = 1
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"sk" = (
+/obj/structure/fluff/paper,
+/mob/living/simple_animal/hostile/stickman,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"sw" = (
+/obj/structure/fluff/paper{
+	dir = 6
+	},
+/obj/structure/fluff/paper/corner{
+	dir = 4
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"sF" = (
+/obj/item/toy/crayon/red,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"tb" = (
+/obj/structure/fluff/paper/stack{
+	dir = 1
+	},
+/obj/structure/fluff/paper/stack,
+/obj/structure/fluff/paper/corner{
+	dir = 1
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"tn" = (
+/obj/structure/fluff/paper{
+	dir = 4
+	},
+/obj/structure/fluff/paper/corner{
+	dir = 4
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"tP" = (
+/obj/item/storage/crayons,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"tR" = (
+/obj/structure/fluff/paper{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/stickman,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"tU" = (
+/obj/structure/fluff/paper{
+	dir = 1
+	},
+/obj/structure/fluff/paper/stack,
+/obj/structure/fluff/paper/stack{
+	dir = 1
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"ui" = (
+/obj/structure/fluff/paper{
+	dir = 4
+	},
+/obj/structure/fluff/paper{
+	dir = 8
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"ur" = (
+/obj/structure/fluff/paper,
+/obj/structure/fluff/paper/stack{
+	dir = 6
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"uu" = (
+/obj/structure/fluff/paper/corner,
+/obj/structure/fluff/paper/corner{
+	dir = 4
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"uT" = (
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"vc" = (
+/obj/structure/fluff/paper{
+	dir = 9
+	},
+/obj/structure/closet/crate/bin,
+/obj/item/paper/crumpled/ruins/originalcontent,
+/obj/item/paper/crumpled/ruins/originalcontent,
+/obj/item/paper/crumpled/ruins/originalcontent,
+/obj/item/gps{
+	gpstag = "Pulpy Signal"
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"vf" = (
+/mob/living/simple_animal/hostile/stickman/dog,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"vs" = (
+/obj/structure/fluff/paper{
+	dir = 4
+	},
+/obj/item/toy/crayon/yellow,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"wp" = (
+/obj/structure/fluff/paper,
+/obj/structure/table/wood,
+/obj/item/storage/crayons,
+/obj/item/storage/crayons,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"xB" = (
+/obj/structure/fluff/paper{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/stickman/dog,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"xY" = (
+/obj/structure/fluff/paper{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/stickman/ranged,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"yd" = (
+/obj/structure/fluff/paper{
+	dir = 5
+	},
+/obj/structure/fluff/paper{
+	dir = 9
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"yF" = (
+/obj/structure/fluff/paper{
+	dir = 8
+	},
+/obj/item/toy/crayon/rainbow,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"zM" = (
+/obj/structure/fluff/paper,
+/obj/structure/fluff/paper/corner{
+	dir = 1
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"zN" = (
+/obj/structure/fluff/paper{
+	dir = 4
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/rainbow,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"Ap" = (
+/obj/structure/fluff/paper{
+	dir = 4
+	},
+/obj/structure/fluff/paper/stack{
+	dir = 4
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"AR" = (
+/obj/item/paper/secretrecipe,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"Bq" = (
+/obj/structure/fluff/paper/stack{
+	dir = 10
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"BB" = (
+/obj/structure/fluff/paper{
+	dir = 1
+	},
+/obj/item/toy/crayon/red,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"Cb" = (
+/obj/structure/fluff/paper/corner,
+/obj/structure/fluff/paper/corner{
+	dir = 1
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"Ce" = (
+/obj/structure/fluff/paper,
+/obj/structure/table/wood,
+/obj/item/storage/crayons,
+/obj/item/pen/fourcolor,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"CL" = (
+/obj/structure/fluff/paper/corner{
+	dir = 8
+	},
+/obj/structure/fluff/paper{
+	dir = 5
+	},
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"DC" = (
+/obj/structure/fluff/paper{
+	dir = 10
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"DY" = (
+/obj/structure/fluff/paper{
+	dir = 4
+	},
+/obj/structure/fluff/paper/stack{
+	dir = 9
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"Er" = (
+/obj/structure/fluff/paper,
+/obj/structure/fluff/paper/stack{
+	dir = 9
+	},
+/obj/item/toy/crayon/blue,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"Ew" = (
+/obj/structure/fluff/paper{
+	dir = 1
+	},
+/obj/structure/easel,
+/obj/item/paper/pamphlet/ruin/originalcontent/treeside,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"EU" = (
+/obj/structure/fluff/paper{
+	dir = 6
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"Fn" = (
+/obj/structure/fluff/paper{
+	dir = 6
+	},
+/obj/structure/table/wood,
+/obj/item/canvas/twentythreeXtwentythree,
+/obj/item/canvas,
+/obj/item/canvas/nineteenXnineteen,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"Fp" = (
+/obj/item/toy/crayon/yellow,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"Fw" = (
+/obj/structure/fluff/paper/corner{
+	dir = 1
+	},
+/obj/structure/fluff/paper/corner{
+	dir = 4
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"FA" = (
+/obj/structure/fluff/paper/stack{
+	dir = 4
+	},
+/obj/structure/fluff/paper/corner{
+	dir = 1
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"Hp" = (
+/obj/structure/fluff/paper{
+	dir = 1
+	},
+/obj/structure/fluff/paper/stack,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"IL" = (
+/obj/structure/fluff/paper{
+	dir = 5
+	},
+/obj/structure/table/wood,
+/obj/item/storage/crayons,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"IU" = (
+/mob/living/simple_animal/hostile/stickman,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"Jv" = (
+/obj/structure/fluff/paper{
+	dir = 8
+	},
+/obj/structure/fluff/paper/stack,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"JM" = (
+/obj/structure/fluff/paper{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/item/toy/crayon/rainbow,
+/obj/item/toy/crayon/spraycan,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"KE" = (
+/obj/structure/fluff/paper{
+	dir = 8
+	},
+/obj/structure/fluff/paper{
+	dir = 4
+	},
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"Lh" = (
+/obj/structure/fluff/paper{
+	dir = 1
+	},
+/obj/structure/fluff/paper/corner{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/stickman,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"LA" = (
+/obj/structure/fluff/paper/corner,
+/mob/living/simple_animal/hostile/stickman/dog,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"LL" = (
+/obj/structure/fluff/paper{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/stickman,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"LT" = (
+/obj/structure/fluff/paper/corner{
+	dir = 1
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"NS" = (
+/obj/structure/fluff/paper{
+	dir = 8
+	},
+/obj/structure/fluff/paper/stack{
+	dir = 4
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"Oi" = (
+/obj/item/toy/crayon/blue,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"Ok" = (
+/obj/structure/fluff/paper/stack,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"OA" = (
+/obj/structure/fluff/paper{
+	dir = 8
+	},
+/obj/structure/easel,
+/obj/item/paper/pamphlet/ruin/originalcontent/pennywise,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"OO" = (
+/obj/structure/fluff/paper{
+	dir = 1
+	},
+/obj/structure/fluff/paper,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"PL" = (
+/obj/structure/fluff/paper{
+	dir = 8
+	},
+/obj/structure/fluff/paper/corner{
+	dir = 1
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"PO" = (
+/mob/living/simple_animal/hostile/boss/paper_wizard,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"PZ" = (
+/obj/structure/fluff/paper{
+	dir = 10
+	},
+/obj/machinery/photocopier,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"QB" = (
+/obj/structure/fluff/paper,
+/obj/structure/fluff/paper{
+	dir = 1
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"Ra" = (
+/obj/structure/fluff/paper{
+	dir = 1
+	},
+/obj/structure/fluff/paper/corner,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"Rd" = (
+/obj/structure/fluff/paper{
+	dir = 9
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"Ro" = (
+/obj/item/toy/crayon/purple,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"Si" = (
+/obj/structure/fluff/paper,
+/obj/structure/fluff/paper/corner{
+	dir = 4
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"SB" = (
+/obj/structure/fluff/paper/corner{
+	dir = 8
+	},
+/obj/structure/fluff/paper/corner,
+/mob/living/simple_animal/hostile/stickman,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"TM" = (
+/obj/structure/fluff/paper/corner,
+/obj/structure/fluff/paper/stack{
+	dir = 4
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"Uk" = (
+/obj/structure/fluff/paper{
+	dir = 5
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"Vj" = (
+/obj/item/toner,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"WZ" = (
+/obj/structure/fluff/paper,
+/obj/item/paper/crumpled/ruins/originalcontent,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"Xi" = (
+/obj/structure/fluff/paper,
+/obj/structure/fluff/paper{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/stickman/dog,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"Xn" = (
+/obj/structure/fluff/paper{
+	dir = 1
+	},
+/obj/structure/fluff/paper/corner{
+	dir = 8
+	},
+/obj/structure/fluff/paper/stack{
+	dir = 4
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"Xv" = (
+/obj/structure/fluff/paper{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"Yf" = (
+/obj/item/paper/crumpled/ruins/originalcontent,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"Yh" = (
+/obj/structure/fluff/paper/corner{
+	dir = 1
+	},
+/obj/structure/fluff/paper/corner{
+	dir = 8
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"Zb" = (
+/obj/structure/fluff/paper/corner{
+	dir = 8
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"Zy" = (
+/obj/structure/fluff/paper/corner{
+	dir = 8
+	},
+/obj/structure/fluff/paper{
+	dir = 4
+	},
+/obj/structure/fluff/paper/stack{
+	dir = 1
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/powered)
+"ZA" = (
 /obj/machinery/door/airlock/freezer{
 	name = "airlock";
 	opacity = 0
@@ -920,11 +1144,20 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/indestructible/paper,
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
 /area/ruin/powered)
-"Ns" = (
-/obj/item/paper/secretrecipe,
-/turf/open/indestructible/paper,
+"ZS" = (
+/obj/structure/fluff/paper{
+	dir = 4
+	},
+/obj/structure/fluff/paper/stack{
+	dir = 6
+	},
+/turf/open/indestructible/paper{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
 /area/ruin/powered)
 
 (1,1,1) = {"
@@ -1394,22 +1627,22 @@ af
 af
 af
 af
-ak
-ar
-ar
-ay
+Rd
+qZ
+qZ
+DC
 af
-ak
-ar
-ar
-ar
-ar
-ar
-ar
-ar
-ar
-ar
-ay
+Rd
+qZ
+qZ
+qZ
+qZ
+qZ
+qZ
+qZ
+qZ
+qZ
+DC
 af
 af
 af
@@ -1438,23 +1671,23 @@ af
 af
 af
 af
-ak
-aY
-aq
-aq
-bk
-bp
-aY
-aq
-aq
-aq
-aq
-bL
-aq
-bU
-ax
-ap
-ch
+Rd
+uu
+aA
+aA
+rJ
+yF
+uu
+aA
+aA
+aA
+aA
+ZS
+aA
+LL
+LT
+uT
+WZ
 af
 af
 af
@@ -1483,23 +1716,23 @@ af
 af
 af
 af
-al
-az
+fK
+dm
 af
 af
-am
-bq
-aT
-af
-af
-af
+Uk
+Ap
+EU
 af
 af
 af
 af
-am
-aq
-ci
+af
+af
+af
+Uk
+aA
+zM
 af
 af
 af
@@ -1528,8 +1761,8 @@ af
 af
 af
 af
-aW
-az
+Hp
+dm
 af
 af
 af
@@ -1544,8 +1777,8 @@ af
 af
 af
 af
-aR
-ay
+he
+DC
 af
 af
 af
@@ -1573,24 +1806,24 @@ af
 af
 af
 af
-al
-az
+fK
+dm
 af
 af
 af
 af
-ak
-ar
-ar
-ar
-ay
+Rd
+qZ
+qZ
+qZ
+DC
 af
 af
 af
 af
 af
-cj
-co
+tR
+Er
 af
 af
 af
@@ -1618,24 +1851,24 @@ af
 af
 af
 af
-am
-aZ
-ay
+Uk
+kw
+DC
 af
 af
 af
-al
-ap
-ap
-ap
-aA
-ar
-ay
+fK
+uT
+uT
+uT
+Zb
+qZ
+DC
 af
 af
 af
-al
-az
+fK
+dm
 af
 af
 af
@@ -1664,24 +1897,24 @@ af
 af
 af
 af
-al
-az
+fK
+dm
 af
 af
-ak
-ao
-ap
-ap
-ap
-ap
-ap
-az
+Rd
+fU
+uT
+uT
+uT
+uT
+uT
+dm
 af
 af
 af
-am
-aZ
-ay
+Uk
+kw
+DC
 af
 af
 bd
@@ -1703,30 +1936,30 @@ af
 af
 af
 af
-ak
-ay
+Rd
+DC
 af
 af
 af
 af
-ba
-aA
-bg
-ar
-ao
-bl
-ap
-bu
-ap
-ap
-aM
-az
+xB
+Zb
+aZ
+qZ
+fU
+fh
+uT
+jO
+uT
+uT
+Bq
+dm
 af
 af
 af
 af
-al
-az
+fK
+dm
 af
 af
 bd
@@ -1748,30 +1981,30 @@ af
 af
 af
 af
-al
-az
+fK
+dm
 af
 af
 af
 af
-am
-aq
-ax
-ap
-ap
-ap
-ap
+Uk
+aA
+LT
+uT
+uT
+uT
+uT
 ap
 bA
-bE
-ap
-aA
-ar
-ay
+vf
+uT
+Zb
+qZ
+DC
 af
 af
-al
-az
+fK
+dm
 af
 af
 bd
@@ -1793,31 +2026,31 @@ af
 af
 af
 af
-al
-aA
-ay
+fK
+Zb
+DC
 af
 af
 af
 af
 af
-al
-bl
-ap
-bt
-ap
-ap
-ap
+fK
+fh
+uT
+tP
+uT
 ap
 ap
-ap
-ap
-az
+uT
+uT
+uT
+uT
+dm
 af
 af
-am
-aZ
-ay
+Uk
+kw
+DC
 af
 bx
 ae
@@ -1836,33 +2069,33 @@ af
 af
 af
 af
-aC
-aE
-ao
-aI
-az
+yd
+PL
+fU
+ga
+dm
 af
 af
 af
 af
 af
-am
-ax
-ap
-ap
-ap
-ap
-bB
-ap
-ap
-ap
-bu
-az
+Uk
+LT
+uT
+uT
+uT
+uT
+rx
+uT
+uT
+uT
+jO
+dm
 af
 af
 af
-al
-az
+fK
+dm
 af
 af
 af
@@ -1882,32 +2115,32 @@ af
 af
 af
 af
-am
-aq
-aJ
-aN
-aP
-aE
-ar
-ay
+Uk
+aA
+bI
+jw
+lK
+PL
+qZ
+DC
 af
 af
-am
-ax
-bu
-by
-aq
-aq
-bF
-ap
-ap
-bt
-az
+Uk
+LT
+jO
+kD
+aA
+aA
+tb
+uT
+uT
+tP
+dm
 af
 af
 af
-al
-az
+fK
+dm
 af
 af
 af
@@ -1929,30 +2162,30 @@ af
 af
 af
 af
-aK
+OO
 af
 af
-al
-aX
-az
-af
-af
-af
-am
-ax
-az
-af
-af
-al
-as
-bR
-ap
-az
+fK
+Ok
+dm
 af
 af
 af
-al
-cv
+Uk
+LT
+dm
+af
+af
+fK
+Yf
+kY
+uT
+dm
+af
+af
+af
+fK
+ur
 af
 af
 af
@@ -1974,30 +2207,30 @@ af
 af
 af
 af
-aL
-ay
+Lh
+DC
 af
-am
-aq
-bb
-ar
-ay
-af
-af
-al
-bz
-af
-af
-al
-bM
-ap
-ap
+Uk
 aA
-ay
+Yh
+qZ
+DC
 af
 af
-bi
-aT
+fK
+aK
+af
+af
+fK
+Ro
+uT
+uT
+Zb
+DC
+af
+af
+Ra
+EU
 af
 af
 af
@@ -2019,29 +2252,29 @@ af
 af
 af
 af
-al
-az
+fK
+dm
 af
 af
 af
-al
-ap
-az
+fK
+uT
+dm
 af
 af
-al
-aA
-ar
-bC
-ao
-ap
-ap
-bV
-ap
-az
+fK
+Zb
+qZ
+rr
+fU
+uT
+uT
+Fp
+uT
+dm
 af
 af
-cs
+Xi
 af
 af
 af
@@ -2057,36 +2290,36 @@ ac
 af
 af
 af
-ak
-ar
-ar
-ay
+Rd
+qZ
+qZ
+DC
 af
 af
 af
-al
-aO
+fK
+fw
 af
 af
 af
-am
-bf
-aZ
-ay
+Uk
+DY
+kw
+DC
 af
-al
-ap
-ap
-ap
-bG
-ap
-bM
-ap
-ap
-az
+fK
+uT
+uT
+uT
+ds
+uT
+Ro
+uT
+uT
+dm
 af
 af
-ct
+QB
 af
 af
 af
@@ -2102,36 +2335,36 @@ ac
 af
 af
 af
-al
-ap
-ap
-az
+fK
+uT
+uT
+dm
 af
 af
 af
-am
-aN
-aQ
+Uk
+jw
+rU
 af
 af
 af
 af
-bh
-az
+BB
+dm
 af
-al
-ap
-aI
-by
-bH
-bN
-aq
-aq
-ax
-az
+fK
+uT
+ga
+kD
+vs
+Cb
+aA
+aA
+LT
+dm
 af
 af
-ct
+QB
 af
 af
 af
@@ -2147,37 +2380,37 @@ ac
 af
 af
 af
-al
-as
-ap
-az
+fK
+Yf
+uT
+dm
 af
 af
 af
 af
 af
-aR
-ay
+he
+DC
 af
 af
 af
-al
-bm
+fK
+sk
 af
-al
-ap
-ap
-az
+fK
+uT
+uT
+dm
 af
-bO
+nB
 af
 af
-am
-aN
-aQ
+Uk
+jw
+rU
 af
-aR
-ay
+he
+DC
 af
 af
 af
@@ -2192,37 +2425,37 @@ ac
 af
 af
 af
-al
-ap
-ap
-aA
-ay
+fK
+uT
+uT
+Zb
+DC
 af
 af
 af
 af
-am
-aU
+Uk
+aV
 af
 af
 af
-bi
-aT
+Ra
+EU
 af
-al
-aX
-ap
-az
+fK
+Ok
+uT
+dm
 af
-bP
-ay
+Xn
+DC
 af
 af
 af
-ck
+lU
 af
-am
-ci
+Uk
+zM
 af
 af
 af
@@ -2236,39 +2469,39 @@ aa
 ac
 af
 af
-ak
-ao
-ap
-ap
-aB
-aD
-aF
-aG
+Rd
+fU
+uT
+uT
+ey
+SB
+KE
+qJ
 af
 af
 af
-aK
+OO
 af
 af
-ak
-bj
+Rd
+Si
 af
 af
-al
-ap
-ap
-az
+fK
+uT
+uT
+dm
 af
-al
-Ns
-bW
-ca
-af
-af
+fK
+AR
+OA
+bf
 af
 af
-aR
-ay
+af
+af
+he
+DC
 af
 af
 bd
@@ -2281,39 +2514,39 @@ aa
 ac
 af
 af
-al
-ap
-ap
-ap
-ap
-az
+fK
+uT
+uT
+uT
+uT
+dm
 af
-aH
-an
-an
-an
-aV
-af
-af
-al
-az
+CL
+cr
+cr
+cr
+sw
 af
 af
-am
-aq
-aq
-aT
+fK
+dm
 af
-bQ
-ap
-ap
+af
+Uk
 aA
-cf
-ar
-cp
+aA
+EU
 af
-al
-az
+tU
+uT
+uT
+Zb
+Jv
+qZ
+PZ
+af
+fK
+dm
 af
 af
 bd
@@ -2326,12 +2559,12 @@ aa
 ad
 ag
 af
-al
-ap
-at
-ap
-ap
-az
+fK
+uT
+IU
+uT
+uT
+dm
 af
 af
 af
@@ -2340,8 +2573,8 @@ af
 af
 af
 af
-al
-az
+fK
+dm
 af
 af
 af
@@ -2349,17 +2582,17 @@ af
 af
 af
 af
-al
-bS
-bX
-ap
-bR
-ap
-cq
+fK
+oJ
+Oi
+uT
+kY
+uT
+Ce
 af
-am
-aZ
-ay
+Uk
+kw
+DC
 af
 bd
 aa
@@ -2371,13 +2604,13 @@ aa
 aa
 ac
 af
-al
-ap
-ap
-ap
-ap
-aA
-ay
+fK
+uT
+uT
+uT
+uT
+Zb
+DC
 af
 af
 af
@@ -2385,26 +2618,26 @@ af
 af
 af
 af
-al
-az
+fK
+dm
 af
 af
 af
 af
 af
 af
-bI
-ao
-bM
-bt
-cb
-ap
-ap
-cr
+vc
+fU
+Ro
+tP
+kW
+uT
+uT
+ok
 af
 af
-al
-az
+fK
+dm
 af
 bx
 bw
@@ -2416,40 +2649,40 @@ aa
 aa
 ac
 af
-al
-ap
-ap
-ap
-ap
-ap
-aA
-ar
-ay
+fK
+uT
+uT
+uT
+uT
+uT
+Zb
+qZ
+DC
 af
 af
 af
 af
 af
-am
-bb
-ay
+Uk
+Yh
+DC
 af
 af
 af
 af
 af
-bJ
-bA
-ap
-bY
-cc
-ap
-cl
-aT
+Ew
+Vj
+uT
+sF
+PO
+uT
+TM
+EU
 af
 af
-al
-az
+fK
+dm
 af
 af
 bd
@@ -2461,40 +2694,40 @@ aa
 aa
 ac
 af
-am
-aq
-au
-ap
-ap
-ap
-ap
-ap
-az
+Uk
+aA
+FA
+uT
+uT
+uT
+uT
+uT
+dm
 af
 af
 af
 af
 af
 af
-al
-az
+fK
+dm
 af
 af
 af
 af
 af
-bK
-aq
-bT
-ap
-ap
-ap
-cm
+IL
+aA
+eH
+uT
+uT
+uT
+wp
 af
 af
-ak
-ao
-az
+Rd
+fU
+dm
 af
 af
 bd
@@ -2508,38 +2741,38 @@ ac
 af
 af
 af
-al
-ap
-ap
-at
-as
-ap
-aA
-ay
+fK
+uT
+uT
+IU
+Yf
+uT
+Zb
+DC
 af
 af
 af
 af
 af
-am
-bb
-br
-ay
+Uk
+Yh
+NS
+DC
 af
 af
 af
 af
 af
-am
-bZ
-cd
-cg
-cn
+Uk
+zN
+JM
+Xv
+Fn
 af
 af
-al
-ap
-az
+fK
+uT
+dm
 af
 af
 bd
@@ -2550,31 +2783,26 @@ aa
 (37,1,1) = {"
 aa
 ah
-zE
-gJ
-wr
-av
-ap
-ap
-ap
-ap
-ap
-ap
-aA
-ar
-ay
+ZA
+ui
+pQ
+Fw
+uT
+uT
+uT
+uT
+uT
+uT
+Zb
+qZ
+DC
 af
 af
 af
 af
-al
-bs
-az
-af
-af
-af
-af
-af
+fK
+mg
+dm
 af
 af
 af
@@ -2582,9 +2810,14 @@ af
 af
 af
 af
-cw
-ap
-az
+af
+af
+af
+af
+af
+xY
+uT
+dm
 af
 af
 bd
@@ -2598,26 +2831,26 @@ ac
 af
 af
 af
-am
-ax
-ap
-ap
-ap
-ap
-aM
-ap
-ap
-az
+Uk
+LT
+uT
+uT
+uT
+uT
+Bq
+uT
+uT
+dm
 af
 af
 af
 af
-am
-aq
-bv
-aE
-ar
-ay
+Uk
+aA
+Zy
+PL
+qZ
+DC
 af
 af
 af
@@ -2625,11 +2858,11 @@ af
 af
 af
 af
-ak
-cu
-aY
-aq
-aT
+Rd
+fj
+uu
+aA
+EU
 af
 af
 bd
@@ -2644,15 +2877,15 @@ ag
 af
 af
 af
-am
-aq
-aq
-ax
-ap
-ap
-ap
-aS
-aT
+Uk
+aA
+aA
+LT
+uT
+uT
+uT
+LA
+EU
 af
 af
 af
@@ -2660,19 +2893,19 @@ af
 af
 af
 af
-al
-bu
-az
+fK
+jO
+dm
 af
 af
 af
 af
-ak
-ar
-ar
-aY
-aq
-aT
+Rd
+qZ
+qZ
+uu
+aA
+EU
 af
 af
 af
@@ -2692,11 +2925,11 @@ af
 af
 af
 af
-am
-aq
-aq
-ax
-az
+Uk
+aA
+aA
+LT
+dm
 af
 af
 af
@@ -2705,17 +2938,17 @@ af
 af
 af
 af
-am
-aq
-bD
-an
-an
-an
-an
-ce
-bq
-aq
-aT
+Uk
+aA
+gH
+cr
+cr
+cr
+cr
+tn
+Ap
+aA
+EU
 af
 af
 af
@@ -2740,8 +2973,8 @@ af
 af
 af
 af
-am
-aT
+Uk
+EU
 af
 af
 af


### PR DESCRIPTION
### Intent of your Pull Request
Makes the tinyfan invisible so you can't smash it and vent all gas out
Also makes the gas inside it lavaland atmos so kpa works

### Why is this good for the game?
Cheese is good and all but not in this context


#### Changelog

:cl:  
tweak: tinyfan in paper ruin goes invisible and atmos inside is now lavaland atmos
/:cl:
