### PR TITLE
Radstorms no longer mutate radimmune species

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -72,6 +72,7 @@ GLOBAL_LIST_INIT(turfs_without_ground, typecacheof(list(
 #define iscatperson(A) (ishumanbasic(A) && istype(A.dna.species, /datum/species/human/felinid) )
 #define isethereal(A) (is_species(A, /datum/species/ethereal))
 #define isvampire(A) (is_species(A,/datum/species/vampire))
+#define ispreternis(A) (is_species(A,/datum/species/preternis))
 
 //more carbon mobs
 #define ismonkey(A) (istype(A, /mob/living/carbon/monkey))

--- a/code/__DEFINES/~yogs_defines/is_helpers.dm
+++ b/code/__DEFINES/~yogs_defines/is_helpers.dm
@@ -7,5 +7,3 @@
 #define is_darkspawn_or_veil(A) (A.mind && isdarkspawn(A) || isveil(A))
 
 #define isspacepod(A) (istype(A, /obj/spacepod))
-
-#define ispreternis(A) (is_species(A, /datum/species/preternis))

--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -48,7 +48,6 @@
 /datum/weather/rad_storm/end()
 	if(..())
 		return
-		
 	priority_announce("The radiation threat has passed. Please return to your workplaces.", "Anomaly Alert")
 	status_alarm(FALSE)
 

--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -32,16 +32,17 @@
 	var/resist = L.getarmor(null, "rad")
 	if(prob(40))
 		if(ishuman(L))
-			var/mob/living/carbon/human/H = L
-			if(H.dna && !HAS_TRAIT(H, TRAIT_GENELESS))
-				if(prob(max(0,100-resist)))
-					H.randmuti()
-					if(prob(50))
-						if(prob(90))
-							H.easy_randmut(NEGATIVE+MINOR_NEGATIVE)
-						else
-							H.easy_randmut(POSITIVE)
-						H.domutcheck()
+			if (!HAS_TRAIT(L,TRAIT_RADIMMUNE)) //if they dont have radimmune, continue
+				var/mob/living/carbon/human/H = L
+				if(H.dna && !HAS_TRAIT(H, TRAIT_GENELESS))
+					if(prob(max(0,100-resist)))
+						H.randmuti()
+						if(prob(50))
+							if(prob(90))
+								H.easy_randmut(NEGATIVE+MINOR_NEGATIVE)
+							else
+								H.easy_randmut(POSITIVE)
+							H.domutcheck()
 		L.rad_act(20)
 
 /datum/weather/rad_storm/end()

--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -48,6 +48,7 @@
 /datum/weather/rad_storm/end()
 	if(..())
 		return
+		
 	priority_announce("The radiation threat has passed. Please return to your workplaces.", "Anomaly Alert")
 	status_alarm(FALSE)
 


### PR DESCRIPTION
originally I started this to fix a reported bug, then I noticed I should check for rad immune instead of a species type.

Closes #10675 

:cl:  
bugfix: preternis and other rad immune species with dna no longer mutate in radstorms
/:cl:
