### PR TITLE
fixes polysmorphs not being able to wear lipstick properly

### DIFF
--- a/code/game/objects/items/cosmetics.dm
+++ b/code/game/objects/items/cosmetics.dm
@@ -52,6 +52,9 @@
 
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
+		if(ispolysmorph(M))//polysmorphs dont have sprites for lipstick
+			to_chat(user,"<span class='warning'>Where are the lips on that?</span>")
+			return
 		if(H.is_mouth_covered())
 			to_chat(user, "<span class='warning'>Remove [ H == user ? "your" : "[H.p_their()]" ] mask!</span>")
 			return


### PR DESCRIPTION
polysmorphs cannot apply lipstick anymore. There was no sprite for it, and it didnt change color. If someone else wants to fix this in the future be my guest.

closes #10646

:cl:  
tweak: polymorphs can no longer 'apply' lipstick
/:cl:
