### PR TITLE
fixed version of #10597

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -289,7 +289,7 @@
 	
 /datum/disease/transformation/ghost
 	name = "Spectral Curse"
-	cure_text = /datum/reagent/water/holywater
+	cure_text = "Holy Water"
 	cures = list(/datum/reagent/water/holywater)
 	agent = "Spectral Curse"
 	desc = "A 'gift' from the spectral realm"


### PR DESCRIPTION
closes #10597

:cl:  
bugfix: spectral curse's cure as shown on a health analyzer is no longer a type path
/:cl:
