### PR TITLE
Revert "Upgrade byond compiler version to fix some linux issues"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tgstation/byond:513.1533 as base
+FROM tgstation/byond:513.1519 as base
 
 FROM base as build_base
 


### PR DESCRIPTION
Reverts yogstation13/Yogstation#10684
I can't compile this(windows):
loading yogstation.dme
code\_compile_options.dm:62:error: #error ============WARNING===============
code\_compile_options.dm:63:error: #error BYOND version 513.1537 contains a bug that prevents the codebase from compiling properly. Please upgrade/downgrade your BYOND version
code\_compile_options.dm:64:error: #error BYOND version 513.1537 contains a bug that prevents the codebase from compiling properly. Please upgrade/downgrade your BYOND version
code\_compile_options.dm:65:error: #error BYOND version 513.1537 contains a bug that prevents the codebase from compiling properly. Please upgrade/downgrade your BYOND version
code\_compile_options.dm:66:error: #error ==================================
yogstation.dmb - 5 errors, 0 warnings (12/21/20 7:43 pm)
