### PR TITLE
Hexane no longer allows you to see dead chat and instead makes you immune to radiation

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1310,12 +1310,12 @@
 	. = ..()
 	L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=1.8, blacklisted_movetypes=(FLYING|FLOATING))
 	ADD_TRAIT(L, CHANGELING_HIVEMIND_MUTE, type)
-	ADD_TRAIT(L, TRAIT_SIXTHSENSE, type)
+	ADD_TRAIT(L, TRAIT_RADIMMUNE, type)
 
 /datum/reagent/hexane/on_mob_end_metabolize(mob/living/L)
 	L.remove_movespeed_modifier(type)
 	REMOVE_TRAIT(L, CHANGELING_HIVEMIND_MUTE, type)
-	REMOVE_TRAIT(L, TRAIT_SIXTHSENSE, type)
+	REMOVE_TRAIT(L, TRAIT_RADIMMUNE, type)
 	return ..()
 
 /////////////////////////Coloured Crayon Powder////////////////////////////


### PR DESCRIPTION
### Intent of your Pull Request

Quite simple, all there is to know is in the title

### Why is this good for the game?

Opening the dimensional portal to the realm of the salty isn't a good idea and can lead to quite the metagaming.

Obligatory improves RP.

#### Changelog

:cl:  alexkar598
rscadd: Hexane now makes you immune to radiation
rscdel: Hexane no longer allows you to see into the realm of the dead to hear the ghosts that sourrounds us
/:cl:
