### PR TITLE
Fixes typo in xmas.dm

### DIFF
--- a/code/modules/events/holiday/xmas.dm
+++ b/code/modules/events/holiday/xmas.dm
@@ -62,7 +62,7 @@
 	christmas_tree = null
 
 /datum/round_event_control/santa
-	name = "Vist by Santa"
+	name = "Visit by Santa"
 	holidayID = CHRISTMAS
 	typepath = /datum/round_event/santa
 	weight = 20


### PR DESCRIPTION
"Vist" is now "Visit".

:cl: Xoxeyos
spellcheck: Vist is now Visit.
/:cl:
