### PR TITLE
Removes the 'DNA' from abductors

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/abductors.dm
+++ b/code/modules/mob/living/carbon/human/species_types/abductors.dm
@@ -4,7 +4,7 @@
 	say_mod = "gibbers"
 	sexes = FALSE
 	species_traits = list(NOBLOOD,NOEYESPRITES)
-	inherent_traits = list(TRAIT_VIRUSIMMUNE,TRAIT_NOGUNS,TRAIT_NOHUNGER,TRAIT_NOBREATH)
+	inherent_traits = list(TRAIT_VIRUSIMMUNE,TRAIT_NOGUNS,TRAIT_NOHUNGER,TRAIT_NOBREATH,TRAIT_RADIMMUNE,TRAIT_GENELESS)
 	mutanttongue = /obj/item/organ/tongue/abductor
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 


### PR DESCRIPTION
### Intent of your Pull Request

~~inb4 salt~~

Makes it so abductors can not mutate, or take rad damage

### Why is this good for the game?

Fixes tourettes bug and probably a slew of other _'intended'_ features

#### Changelog

:cl:  
tweak: Abductors nolonger mutate
/:cl:
