### PR TITLE
Reverts seedling pr because it's causing over 2000 runtimes

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -97,6 +97,10 @@
 /mob/living/simple_animal/hostile/poison/bees,
 /turf/open/floor/grass,
 /area/ruin/space/has_grav/abandonedzoo)
+"ao" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/grass,
+/area/ruin/space/has_grav/abandonedzoo)
 "ap" = (
 /mob/living/simple_animal/hostile/asteroid/goldgrub{
 	will_burrow = 0
@@ -162,6 +166,10 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark/side,
+/area/ruin/space/has_grav/abandonedzoo)
+"aA" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
 /area/ruin/space/has_grav/abandonedzoo)
 "aB" = (
 /obj/machinery/light,
@@ -777,16 +785,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/abandonedzoo)
-"mc" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/mob/living/simple_animal/hostile/jungle/seedling,
-/turf/open/floor/grass,
-/area/ruin/space/has_grav/abandonedzoo)
-"ro" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/mob/living/simple_animal/hostile/jungle/seedling,
-/turf/open/floor/grass,
-/area/ruin/space/has_grav/abandonedzoo)
 "rI" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /mob/living/simple_animal/butterfly,
@@ -1087,7 +1085,7 @@ ac
 al
 an
 an
-ro
+aA
 ac
 at
 aZ
@@ -1147,7 +1145,7 @@ bW
 "}
 (17,1,1) = {"
 ac
-mc
+ao
 an
 Rw
 rI


### PR DESCRIPTION
### Intent of your Pull Request

Reverts: #10585 

### Why is this good for the game?

It causes over 2000 runtimes so I'd say this is a good revert

Changelog

🆑
rscdel: Removes seedlings from ruin
/🆑