### PR TITLE
Increases the pipenet warning limit before muting itself

### DIFF
--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -53,7 +53,7 @@
 						if(!members.Find(item))
 
 							if(item.parent)
-								var/static/pipenetwarnings = 10
+								var/static/pipenetwarnings = 100
 								if(pipenetwarnings > 0)
 									log_mapping("build_pipeline(): [item.type] added to a pipenet while still having one. (pipes leading to the same spot stacking in one turf) around [AREACOORD(item)].")
 									pipenetwarnings--


### PR DESCRIPTION
### Intent of your Pull Request

Increase amount of errors it will log before muting itself

### Why is this good for the game?

It's easier to read a bunch of false positives than it is to restart
