### PR TITLE
Reinforced floors now say no to singularity pulls

### DIFF
--- a/code/game/turfs/simulated/floor/reinf_floor.dm
+++ b/code/game/turfs/simulated/floor/reinf_floor.dm
@@ -77,14 +77,7 @@
 				ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 
 /turf/open/floor/engine/singularity_pull(S, current_size)
-	..()
-	if(current_size >= STAGE_FIVE)
-		if(floor_tile)
-			if(prob(30))
-				new floor_tile(src)
-				make_plating()
-		else if(prob(30))
-			ReplaceWithLattice()
+	return
 
 /turf/open/floor/engine/attack_paw(mob/user)
 	return attack_hand(user)


### PR DESCRIPTION
### Intent of your Pull Request

Fixes infinite metal exploit by making reinforced floors ignore the singualrity(unless the singularity is on top of it)

_Tested_

### Why is this good for the game?

ngl infinite metal kinda bad

#### Changelog

:cl:  
tweak: NT have reinforced their reinforced floors against singularity
/:cl:
