### PR TITLE
Fixes Singlo making infinite metal out of reinforced floors

### DIFF
--- a/code/game/turfs/simulated/floor/reinf_floor.dm
+++ b/code/game/turfs/simulated/floor/reinf_floor.dm
@@ -82,7 +82,7 @@
 		if(floor_tile)
 			if(prob(30))
 				new floor_tile(src)
-				make_plating()
+				make_plating(TRUE)
 		else if(prob(30))
 			ReplaceWithLattice()
 


### PR DESCRIPTION
### Intent of your Pull Request

TRUE :)

### Why is this good for the game?

It looks good, and infinite metal is bad.

#### Changelog

:cl:  
tweak: Can't make infinite rods out of reinforced plating
/:cl:
