### PR TITLE
You can now attack open supply closets

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -287,6 +287,8 @@ GLOBAL_LIST_EMPTY(lockers)
 /obj/structure/closet/proc/tool_interact(obj/item/W, mob/user)//returns TRUE if attackBy call shouldnt be continued (because tool was used/closet was of wrong type), FALSE if otherwise
 	. = TRUE
 	if(opened)
+		if(user.a_intent == INTENT_HARM)
+			return FALSE
 		if(istype(W, cutting_tool))
 			if(W.tool_behaviour == TOOL_WELDER)
 				if(!W.tool_start_check(user, amount=0))


### PR DESCRIPTION
### Intent of your Pull Request

Fixes: https://github.com/yogstation13/Yogstation/issues/9628

### Why is this good for the game?

Had a supplypod land in a door and I didnt have the tools, kept bashing it and putting the item in on harm intent this fixes that. Still does it open though. Need to figure out that

#### Changelog

:cl:  
bugfix: You can now attack open closets
/:cl:
