### PR TITLE
The Revenant Malfunction ability can now damage and destroy window shutters.

### DIFF
--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -318,6 +318,9 @@
 		new /obj/effect/temp_visual/revenant(S.loc)
 		S.spark_system.start()
 		S.emp_act(EMP_HEAVY)
+	for(var/obj/machinery/door/firedoor/window/W in T) // Fuck you atmos-locks
+		W.take_damage(rand(5,20))
+		to_chat(user,"<span class='notice'>The shutter mechanism starts to grind its gears.</span>")
 
 //Blight: Infects nearby humans and in general messes living stuff up.
 /obj/effect/proc_holder/spell/aoe_turf/revenant/blight


### PR DESCRIPTION
Revenants can now destroy window shutters, it picks a random number between 5 and 20, and applies it to the window shutter.

:cl:  Xoxeyos
rscadd: You can now vent rooms again as a revenant, by destroying window shutters with the malfunction ability.
/:cl:
