### PR TITLE
Fixes minor variations executing over itself

### DIFF
--- a/code/game/objects/effects/spawners/minor_variation.dm
+++ b/code/game/objects/effects/spawners/minor_variation.dm
@@ -21,7 +21,7 @@ This is mainly to prevent creating new map files when creating smaller variation
 	placement()
 
 /obj/effect/variation/proc/placement()
-	..()
+	return
 
 /obj/effect/variation/proc/place(x = 0, y = 0 , item , direction)
 	if(!x)

--- a/code/game/objects/effects/spawners/minor_variation.dm
+++ b/code/game/objects/effects/spawners/minor_variation.dm
@@ -18,6 +18,10 @@ This is mainly to prevent creating new map files when creating smaller variation
 /obj/effect/variation/Initialize()
 	. = ..()
 	chosen = FALSE
+	placement()
+
+/obj/effect/variation/proc/placement()
+	..()
 
 /obj/effect/variation/proc/place(x = 0, y = 0 , item , direction)
 	if(!x)

--- a/code/game/objects/effects/spawners/minor_variation_templates.dm
+++ b/code/game/objects/effects/spawners/minor_variation_templates.dm
@@ -8,8 +8,7 @@ obj/effects/variation/sec
 	name = "Brig cell variation"
 	variations = 2
 
-/obj/effect/variation/box/sec/brig_cell/Initialize()
-	. = ..()
+/obj/effect/variation/box/sec/brig_cell/placement()
 	// chooses between two basic cell variations
 
 	var/list/bed = list(
@@ -34,8 +33,7 @@ obj/effects/variation/sec
 	name = "perma cell variation"
 	variations = 4
 
-/obj/effect/variation/box/sec/brig_cell/perma/Initialize()
-	. = ..()
+/obj/effect/variation/box/sec/brig_cell/perma/placement()
 	// chooses between four perma cell variations
 
 	var/list/bed = list(


### PR DESCRIPTION
Fixes this by moving execution code out of initialize so it isn't forced to execute again
![image](https://user-images.githubusercontent.com/24533979/103236253-02c68f80-490a-11eb-98d6-920a64c1c979.png)


I had to add a parent call to fix Travis in my previous PR when I should have just moved it to its own proc in the first place.

Result: 
![0eq6YE2tU7](https://user-images.githubusercontent.com/24533979/103236301-2d184d00-490a-11eb-96c9-e502533c0bad.png)


#### Changelog

:cl:  Hopek
bugfix: Fixes minor variations executing over itself
/:cl:
