### PR TITLE
Places Proper Reinforced Walls on Execution Room (Transfer Center)

### DIFF
--- a/_maps/RandomRuins/StationRuins/BoxStation/transfer1.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/transfer1.dmm
@@ -87,6 +87,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"p" = (
+/turf/closed/wall/r_wall,
+/area/security/execution/transfer)
 "q" = (
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
@@ -317,12 +320,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
-"P" = (
-/turf/closed/wall{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall"
-	},
-/area/security/execution/transfer)
 "Q" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -405,33 +402,33 @@ a
 a
 a
 a
-P
-P
-P
-P
-P
+p
+p
+p
+p
+p
 "}
 (2,1,1) = {"
 a
 a
 a
 a
-P
+p
 s
 U
 O
-P
+p
 "}
 (3,1,1) = {"
-P
-P
-P
+p
+p
+p
 d
-P
+p
 H
 z
 k
-P
+p
 "}
 (4,1,1) = {"
 Z

--- a/_maps/RandomRuins/StationRuins/BoxStation/transfer2.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/transfer2.dmm
@@ -82,6 +82,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
+"j" = (
+/turf/closed/wall/r_wall,
+/area/security/execution/transfer)
 "k" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -308,12 +311,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"J" = (
-/turf/closed/wall{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall"
-	},
-/area/security/execution/transfer)
 "L" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -420,33 +417,33 @@ a
 a
 a
 a
-J
-J
-J
-J
-J
+j
+j
+j
+j
+j
 "}
 (2,1,1) = {"
 a
 a
 a
 a
-J
+j
 s
 i
 Z
-J
+j
 "}
 (3,1,1) = {"
-J
-J
-J
+j
+j
+j
 d
-J
+j
 x
 w
 k
-J
+j
 "}
 (4,1,1) = {"
 u

--- a/_maps/RandomRuins/StationRuins/BoxStation/transfer3.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/transfer3.dmm
@@ -72,12 +72,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"o" = (
-/turf/closed/wall{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall"
-	},
-/area/security/execution/transfer)
 "p" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -434,39 +428,42 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"Y" = (
+/turf/closed/wall/r_wall,
+/area/security/execution/transfer)
 
 (1,1,1) = {"
 a
 a
 a
 a
-o
-o
-o
-o
-o
+Y
+Y
+Y
+Y
+Y
 "}
 (2,1,1) = {"
 a
 a
 a
 a
-o
+Y
 s
 W
 V
-o
+Y
 "}
 (3,1,1) = {"
 n
 n
-o
+Y
 d
-o
+Y
 p
 A
 J
-o
+Y
 "}
 (4,1,1) = {"
 b

--- a/_maps/RandomRuins/StationRuins/BoxStation/transfer4.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/transfer4.dmm
@@ -231,12 +231,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"w" = (
-/turf/closed/wall{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall"
-	},
-/area/security/execution/transfer)
 "y" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast";
@@ -284,6 +278,9 @@
 "D" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
+"E" = (
+/turf/closed/wall/r_wall,
 /area/security/execution/transfer)
 "F" = (
 /obj/effect/turf_decal/tile/red{
@@ -444,33 +441,33 @@ a
 a
 a
 a
-w
-w
-w
-w
-w
+E
+E
+E
+E
+E
 "}
 (2,1,1) = {"
 a
 a
 a
 a
-w
+E
 s
 g
 l
-w
+E
 "}
 (3,1,1) = {"
-w
-w
-w
+E
+E
+E
 d
-w
+E
 F
 b
 u
-w
+E
 "}
 (4,1,1) = {"
 Z

--- a/_maps/RandomRuins/StationRuins/BoxStation/transfer5.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/transfer5.dmm
@@ -101,12 +101,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"p" = (
-/turf/closed/wall{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall"
-	},
-/area/security/execution/transfer)
 "q" = (
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
@@ -232,6 +226,9 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
+"C" = (
+/turf/closed/wall/r_wall,
 /area/security/execution/transfer)
 "D" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -418,33 +415,33 @@ a
 a
 a
 a
-p
-p
-p
-p
-p
+C
+C
+C
+C
+C
 "}
 (2,1,1) = {"
 a
 a
 a
 a
-p
+C
 s
 l
 j
-p
+C
 "}
 (3,1,1) = {"
-p
-p
-p
+C
+C
+C
 d
-p
+C
 w
 Y
 P
-p
+C
 "}
 (4,1,1) = {"
 Z

--- a/_maps/RandomRuins/StationRuins/BoxStation/transfer6.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/transfer6.dmm
@@ -149,6 +149,9 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/execution/transfer)
+"x" = (
+/turf/closed/wall/r_wall,
+/area/security/execution/transfer)
 "y" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast";
@@ -322,12 +325,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"R" = (
-/turf/closed/wall{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall"
-	},
-/area/security/execution/transfer)
 "S" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -423,33 +420,33 @@ a
 a
 a
 a
-R
-R
-R
-R
-R
+x
+x
+x
+x
+x
 "}
 (2,1,1) = {"
 a
 a
 a
 a
-R
+x
 s
 H
 Z
-R
+x
 "}
 (3,1,1) = {"
-R
-R
-R
+x
+x
+x
 d
-R
+x
 P
 n
 j
-R
+x
 "}
 (4,1,1) = {"
 w

--- a/_maps/RandomRuins/StationRuins/BoxStation/transfer7.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/transfer7.dmm
@@ -399,12 +399,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
-"N" = (
-/turf/closed/wall{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall"
-	},
-/area/security/execution/transfer)
 "O" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -466,6 +460,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"U" = (
+/turf/closed/wall/r_wall,
+/area/security/execution/transfer)
 "W" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -478,33 +475,33 @@ a
 a
 a
 a
-N
-N
-N
-N
-N
+U
+U
+U
+U
+U
 "}
 (2,1,1) = {"
 a
 a
 a
 a
-N
+U
 s
 b
 S
-N
+U
 "}
 (3,1,1) = {"
 u
 u
-N
+U
 d
-N
+U
 L
 k
 j
-N
+U
 "}
 (4,1,1) = {"
 P

--- a/_maps/RandomRuins/StationRuins/BoxStation/transfer8.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/transfer8.dmm
@@ -279,12 +279,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"H" = (
-/turf/closed/wall{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall"
-	},
-/area/security/execution/transfer)
 "I" = (
 /obj/structure/table,
 /obj/item/folder/red{
@@ -393,6 +387,9 @@
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/security/execution/transfer)
+"X" = (
+/turf/closed/wall/r_wall,
+/area/security/execution/transfer)
 "Y" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -412,33 +409,33 @@ a
 a
 a
 a
-H
-H
-H
-H
-H
+X
+X
+X
+X
+X
 "}
 (2,1,1) = {"
 a
 a
 a
 a
-H
+X
 s
 i
 n
-H
+X
 "}
 (3,1,1) = {"
-H
-H
-H
+X
+X
+X
 d
-H
+X
 z
 O
 m
-H
+X
 "}
 (4,1,1) = {"
 p

--- a/_maps/RandomRuins/StationRuins/BoxStation/transfer9.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/transfer9.dmm
@@ -2,12 +2,6 @@
 "a" = (
 /turf/template_noop,
 /area/space)
-"b" = (
-/turf/closed/wall{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall"
-	},
-/area/security/execution/transfer)
 "c" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -222,6 +216,9 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"z" = (
+/turf/closed/wall/r_wall,
+/area/security/execution/transfer)
 "B" = (
 /obj/structure/chair{
 	dir = 1
@@ -414,33 +411,33 @@ a
 a
 a
 a
-b
-b
-b
-b
-b
+z
+z
+z
+z
+z
 "}
 (2,1,1) = {"
 a
 a
 a
 a
-b
+z
 s
 t
 W
-b
+z
 "}
 (3,1,1) = {"
-b
-b
-b
+z
+z
+z
 d
-b
+z
 J
 l
 K
-b
+z
 "}
 (4,1,1) = {"
 O


### PR DESCRIPTION
Places proper reinforced walls on the various Execution Room variants. This changes was made in lieu of bug report.
![image](https://user-images.githubusercontent.com/62276730/103273683-e10eec00-498d-11eb-909d-a83f6abce91c.png)
I honest to god cannot puzzle how this could've been done without malice or intent. We ought to find the guy who did this.

#### Changelog

:cl:  
bugfix: Fixes incorrect walls in the Execution Room (Transfer Center) variant  
/:cl:
