### PR TITLE
Fixes donators not being able to use the donation tab because kmc is a shitty coder and oh my fucking god why are you so bad i hate this i hate savefiles who came up with the idea of savefiles theres like 30 migrations in them because WHY THE FUCK NOT hi dad hi mom

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -5,7 +5,7 @@
 //	You do not need to raise this if you are adding new values that have sane defaults.
 //	Only raise this value when changing the meaning/format/name/layout of an existing value
 //	where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX	29
+#define SAVEFILE_VERSION_MAX	30
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -125,6 +125,11 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 			job_preferences = list()
 	if(current_version < 29)
 		purrbation = FALSE
+	if(current_version < 30) //Someone doesn't know how to code and make savefiles get corrupted
+		if(!ispath(donor_hat))
+			donor_hat = null
+		if(!ispath(donor_item))
+			donor_item = null
 
 /datum/preferences/proc/load_path(ckey,filename="preferences.sav")
 	if(!ckey)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -252,8 +252,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	// yogs start - Donor features & yogtoggles
 	yogtoggles		= sanitize_integer(yogtoggles, 0, (1 << 23), initial(yogtoggles))
 	donor_pda		= sanitize_integer(donor_pda, 1, GLOB.donor_pdas.len, 1)
-	donor_hat       = sanitize(donor_hat)
-	donor_item      = sanitize(donor_item)
 	purrbation      = sanitize_integer(purrbation, FALSE, TRUE, initial(purrbation))
 
 	accent			= sanitize_text(accent, initial(accent)) // Can't use sanitize_inlist since it doesn't support falsely default values.

--- a/yogstation/code/modules/client/preferences.dm
+++ b/yogstation/code/modules/client/preferences.dm
@@ -1,7 +1,7 @@
 /datum/preferences
 	var/donor_hat = 0
-	var/donor_item = 0
-	var/donor_pda = 1
+	var/donor_item = null
+	var/donor_pda = null
 	var/quiet_round = FALSE
 	var/yogtoggles = YOGTOGGLES_DEFAULT
 	var/purrbation = null


### PR DESCRIPTION
the things are set to "0" and "1" because old code made savefiles and they weren't valid. Hopefully the migration should fix it by resetting it for those who have bad values

:cl:  
bugfix: Probably fixes the issue where donators can't click the donator preferences tab because their item/hat selection is invalid
/:cl:
