### PR TITLE
Spraycanpuncture

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -680,6 +680,26 @@
 		spray_overlay.color = paint_color
 		add_overlay(spray_overlay)
 
+/obj/item/toy/crayon/spraycan/attackby(obj/item/S) //1 light 2 flame
+	if(istype(S, /obj/item/screwdriver))
+		explosion(get_turf(src), 0, 0, 1, flame_range = 2)
+		log_bomber(user, "detonated a", src, "via screwdriver")
+		qdel(src)
+
+/obj/item/toy/crayon/spraycan/hellcan/attackby(obj/item/S) //2 light 5 flame
+	if(istype(S, /obj/item/screwdriver))
+		explosion(get_turf(src), 0, 0, 2, flame_range = 5)
+		log_bomber(user, "detonated a", src, "via screwdriver")
+		qdel(src)
+
+/obj/item/toy/crayon/spraycan/lubecan/attackby(obj/item/S) //lubecan makes big lube no explosion honk
+	if(istype(S, /obj/item/screwdriver))
+		chem_splash(loc, 5, list(reagents))
+		qdel(src)
+
+/obj/item/toy/crayon/spraycan/borg/attackby() //no
+	return
+
 /obj/item/toy/crayon/spraycan/borg
 	name = "cyborg spraycan"
 	desc = "A metallic container containing shiny synthesised paint."

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -682,21 +682,21 @@
 
 /obj/item/toy/crayon/spraycan/attackby(obj/item/S)
 	if(S.is_sharp() || istype(S, /obj/item/screwdriver) || istype(S, /obj/item/surgicaldrill))
-	
+
 		if(istype(src, /obj/item/toy/crayon/spraycan/hellcan))
 			explosion(get_turf(src), 0, 0, 2, flame_range = 5) //2 light 5 flame
 
 		else if(istype(src, /obj/item/toy/crayon/spraycan/lubecan))
 			chem_splash(loc, 5, list(reagents)) //lubecan makes big lube no explosion honk
 
+		else if(istype(src, /obj/item/toy/crayon/spraycan/borg))
+			return // are you fucking nuts
+			
 		else 
 			explosion(get_turf(src), 0, 0, 1, flame_range = 0) //1 light for default cans
 
 		log_bomber(usr, "detonated a", src, "via screwdriver")
 		qdel(src)
-
-/obj/item/toy/crayon/spraycan/borg/attackby() //no
-	return
 
 /obj/item/toy/crayon/spraycan/borg
 	name = "cyborg spraycan"

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -683,13 +683,13 @@
 /obj/item/toy/crayon/spraycan/attackby(obj/item/S) //1 light 2 flame
 	if(istype(S, /obj/item/screwdriver))
 		explosion(get_turf(src), 0, 0, 1, flame_range = 2)
-		log_bomber(user, "detonated a", src, "via screwdriver")
+		log_bomber(usr, "detonated a", src, "via screwdriver")
 		qdel(src)
 
 /obj/item/toy/crayon/spraycan/hellcan/attackby(obj/item/S) //2 light 5 flame
 	if(istype(S, /obj/item/screwdriver))
 		explosion(get_turf(src), 0, 0, 2, flame_range = 5)
-		log_bomber(user, "detonated a", src, "via screwdriver")
+		log_bomber(usr, "detonated a", src, "via screwdriver")
 		qdel(src)
 
 /obj/item/toy/crayon/spraycan/lubecan/attackby(obj/item/S) //lubecan makes big lube no explosion honk

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -680,7 +680,7 @@
 		spray_overlay.color = paint_color
 		add_overlay(spray_overlay)
 
-/obj/item/toy/crayon/spraycan/attackby(obj/item/S)
+/obj/item/toy/crayon/spraycan/attackby(obj/item/S,mob/user)
 	if(S.is_sharp() || istype(S, /obj/item/screwdriver) || istype(S, /obj/item/surgicaldrill))
 
 		if(istype(src, /obj/item/toy/crayon/spraycan/hellcan))
@@ -690,12 +690,13 @@
 			chem_splash(loc, 5, list(reagents)) //lubecan makes big lube no explosion honk
 
 		else if(istype(src, /obj/item/toy/crayon/spraycan/borg))
+			to_chat(user, "<span class='warning'>ERR ERR. ASIMOV SPRAYCAN FIRMWARE DOES NOT ALLOW THIS.</span>")
 			return // are you fucking nuts
-			
+
 		else 
 			explosion(get_turf(src), 0, 0, 1, flame_range = 0) //1 light for default cans
 
-		log_bomber(usr, "detonated a", src, "via screwdriver")
+		log_bomber(user, "detonated a", src, "via screwdriver")
 		qdel(src)
 
 /obj/item/toy/crayon/spraycan/borg

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -696,7 +696,7 @@
 		else 
 			explosion(get_turf(src), 0, 0, 1, flame_range = 0) //1 light for default cans
 
-		log_bomber(user, "detonated a", src, "via ", S)
+		log_bomber(user, "detonated a", src, "via [S.name]")
 		qdel(src)
 
 /obj/item/toy/crayon/spraycan/borg

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -680,21 +680,19 @@
 		spray_overlay.color = paint_color
 		add_overlay(spray_overlay)
 
-/obj/item/toy/crayon/spraycan/attackby(obj/item/S) //1 light
+/obj/item/toy/crayon/spraycan/attackby(obj/item/S)
 	if(S.is_sharp() || istype(S, /obj/item/screwdriver) || istype(S, /obj/item/surgicaldrill))
-		explosion(get_turf(src), 0, 0, 1, flame_range = 0)
-		log_bomber(usr, "detonated a", src, "via screwdriver")
-		qdel(src)
+	
+		if(istype(src, /obj/item/toy/crayon/spraycan/hellcan))
+			explosion(get_turf(src), 0, 0, 2, flame_range = 5) //2 light 5 flame
 
-/obj/item/toy/crayon/spraycan/hellcan/attackby(obj/item/S) //2 light 5 flame
-	if(S.is_sharp() || istype(S, /obj/item/screwdriver) || istype(S, /obj/item/surgicaldrill))
-		explosion(get_turf(src), 0, 0, 2, flame_range = 5)
-		log_bomber(usr, "detonated a", src, "via screwdriver")
-		qdel(src)
+		else if(istype(src, /obj/item/toy/crayon/spraycan/lubecan))
+			chem_splash(loc, 5, list(reagents)) //lubecan makes big lube no explosion honk
 
-/obj/item/toy/crayon/spraycan/lubecan/attackby(obj/item/S) //lubecan makes big lube no explosion honk
-	if(S.is_sharp() || istype(S, /obj/item/screwdriver) || istype(S, /obj/item/surgicaldrill))
-		chem_splash(loc, 5, list(reagents))
+		else 
+			explosion(get_turf(src), 0, 0, 1, flame_range = 0) //1 light for default cans
+
+		log_bomber(usr, "detonated a", src, "via screwdriver")
 		qdel(src)
 
 /obj/item/toy/crayon/spraycan/borg/attackby() //no

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -681,19 +681,19 @@
 		add_overlay(spray_overlay)
 
 /obj/item/toy/crayon/spraycan/attackby(obj/item/S) //1 light
-	if(istype(S, /obj/item/screwdriver))
+	if(S.is_sharp())
 		explosion(get_turf(src), 0, 0, 1, flame_range = 0)
 		log_bomber(usr, "detonated a", src, "via screwdriver")
 		qdel(src)
 
 /obj/item/toy/crayon/spraycan/hellcan/attackby(obj/item/S) //2 light 5 flame
-	if(istype(S, /obj/item/screwdriver))
+	if(S.is_sharp())
 		explosion(get_turf(src), 0, 0, 2, flame_range = 5)
 		log_bomber(usr, "detonated a", src, "via screwdriver")
 		qdel(src)
 
 /obj/item/toy/crayon/spraycan/lubecan/attackby(obj/item/S) //lubecan makes big lube no explosion honk
-	if(istype(S, /obj/item/screwdriver))
+	if(S.is_sharp())
 		chem_splash(loc, 5, list(reagents))
 		qdel(src)
 

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -681,19 +681,19 @@
 		add_overlay(spray_overlay)
 
 /obj/item/toy/crayon/spraycan/attackby(obj/item/S) //1 light
-	if(S.is_sharp())
+	if(S.is_sharp() || istype(S, /obj/item/screwdriver) || istype(S, /obj/item/surgicaldrill))
 		explosion(get_turf(src), 0, 0, 1, flame_range = 0)
 		log_bomber(usr, "detonated a", src, "via screwdriver")
 		qdel(src)
 
 /obj/item/toy/crayon/spraycan/hellcan/attackby(obj/item/S) //2 light 5 flame
-	if(S.is_sharp())
+	if(S.is_sharp() || istype(S, /obj/item/screwdriver) || istype(S, /obj/item/surgicaldrill))
 		explosion(get_turf(src), 0, 0, 2, flame_range = 5)
 		log_bomber(usr, "detonated a", src, "via screwdriver")
 		qdel(src)
 
 /obj/item/toy/crayon/spraycan/lubecan/attackby(obj/item/S) //lubecan makes big lube no explosion honk
-	if(S.is_sharp())
+	if(S.is_sharp() || istype(S, /obj/item/screwdriver) || istype(S, /obj/item/surgicaldrill))
 		chem_splash(loc, 5, list(reagents))
 		qdel(src)
 

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -696,7 +696,7 @@
 		else 
 			explosion(get_turf(src), 0, 0, 1, flame_range = 0) //1 light for default cans
 
-		log_bomber(user, "detonated a", src, "via screwdriver")
+		log_bomber(user, "detonated a", src, "via ", S)
 		qdel(src)
 
 /obj/item/toy/crayon/spraycan/borg

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -680,9 +680,9 @@
 		spray_overlay.color = paint_color
 		add_overlay(spray_overlay)
 
-/obj/item/toy/crayon/spraycan/attackby(obj/item/S) //1 light 2 flame
+/obj/item/toy/crayon/spraycan/attackby(obj/item/S) //1 light
 	if(istype(S, /obj/item/screwdriver))
-		explosion(get_turf(src), 0, 0, 1, flame_range = 2)
+		explosion(get_turf(src), 0, 0, 1, flame_range = 0)
 		log_bomber(usr, "detonated a", src, "via screwdriver")
 		qdel(src)
 


### PR DESCRIPTION
### Intent of your Pull Request

spraycans give off a very small light explosion if you puncture them with a sharp object or screwdriver or surgical drill
hellcans give off a slightly larger but still largely nonlethal explosion
lubecans spray the area with lube

spray can (0,0,1,0)
hell can (0,0,2,5)
lube can (0,0,0,0 but 5 radius of lube)

(note: spray cans no longer give off flame like image says; hellcans still do)
![](https://i.imgur.com/rtOGrJL.png)

### Why is this good for the game?

powrgamers can now telekinesis around spray cans and screwdrivers to deal negligible damage so they get distracted from welderbombing
![](https://i.imgur.com/5crIfAj.png)

#### Changelog

:cl:  
rscadd: Added spraycans exploding when you puncture them
/:cl:
