### PR TITLE
Adds hitscan laseser variants

### DIFF
--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -73,3 +73,23 @@
 	projectile_type = /obj/item/projectile/beam/mindflayer
 	select_name = "MINDFUCK"
 	fire_sound = 'sound/weapons/laser.ogg'
+
+/obj/item/ammo_casing/energy/laser/hitscan
+	projectile_type = /obj/item/projectile/beam/laser/hitscan
+	select_name = "hitscan"
+
+/obj/item/ammo_casing/energy/laser/hos/hitscan
+	projectile_type = /obj/item/projectile/beam/laser/hitscan
+	select_name = "hitscan"
+
+/obj/item/ammo_casing/energy/lasergun/hitscan
+	projectile_type = /obj/item/projectile/beam/laser/hitscan
+
+/obj/item/ammo_casing/energy/laser/practice/hitscan
+	projectile_type = /obj/item/projectile/beam/practice/hitscan
+
+/obj/item/ammo_casing/energy/laser/makeshiftlasrifle/hitscan
+	projectile_type = /obj/item/projectile/beam/laser/makeshiftlasrifle/hitscan
+
+/obj/item/ammo_casing/energy/laser/makeshiftlasrifle/weak/hitscan
+	projectile_type = /obj/item/projectile/beam/laser/makeshiftlasrifle/weak/hitscan

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -187,3 +187,15 @@
 				add_overlay("[icon_state]_fail_1")
 			if(151 to INFINITY)
 				add_overlay("[icon_state]_fail_2")
+
+/obj/item/gun/energy/e_gun/hitscan
+	ammo_type = list(/obj/item/ammo_casing/energy/disabler, /obj/item/ammo_casing/energy/laser/hitscan)
+
+/obj/item/gun/energy/e_gun/mini/hitscan
+	ammo_type = list(/obj/item/ammo_casing/energy/disabler, /obj/item/ammo_casing/energy/laser/hitscan)
+
+/obj/item/gun/energy/e_gun/hos/hitscan
+	ammo_type = list(/obj/item/ammo_casing/energy/disabler/hos, /obj/item/ammo_casing/energy/laser/hos/hitscan, /obj/item/ammo_casing/energy/ion/hos)
+
+/obj/item/gun/energy/e_gun/nuclear/hitscan
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/hitscan, /obj/item/ammo_casing/energy/disabler)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -174,3 +174,15 @@
 /obj/item/projectile/beam/laser/makeshiftlasrifle/weak
 	name = "weak laser"
 	damage = 5
+
+/obj/item/gun/energy/laser/hitscan
+	ammo_type = list(/obj/item/ammo_casing/energy/lasergun/hitscan)
+
+/obj/item/gun/energy/laser/practice/hitscan
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/practice/hitscan)
+
+/obj/item/gun/energy/laser/captain/hitscan
+	ammo_type = list(/obj/item/ammo_casing/energy/lasergun/hitscan)
+
+/obj/item/gun/energy/laser/makeshiftlasrifle/hitscan
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/makeshiftlasrifle/hitscan, /obj/item/ammo_casing/energy/laser/makeshiftlasrifle/weak/hitscan)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -185,3 +185,20 @@
 		var/mob/living/carbon/M = target
 		M.visible_message("<span class='danger'>[M] explodes into a shower of gibs!</span>")
 		M.gib()
+
+/obj/item/projectile/beam/laser/hitscan
+	damage = 15 // Reduced by 5 damage
+	hitscan = TRUE
+
+/obj/item/projectile/beam/weak/hitscan
+	damage = 10 // Reduced by 5. Also I think this is only used by raven shuttle.
+	hitscan = TRUE
+
+/obj/item/projectile/beam/practice/hitscan
+	hitscan = TRUE
+
+/obj/item/projectile/beam/laser/makeshiftlasrifle/hitscan
+	hitscan = TRUE
+
+/obj/item/projectile/beam/laser/makeshiftlasrifle/weak/hitscan
+	hitscan = TRUE


### PR DESCRIPTION
### Intent of your Pull Request

Adds hitscan variants to normal lasers.

### Why is this change good for the game?

because I want to see what its like

### What should players be aware of when it comes to the changes your PR is implementing?

lasers go pew

### What general grouping does this PR fall under? 

completely changes the balance of the game

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 

guns do less damage

# Changelog

:cl:  
rscadd: Added hitscan variants of laserguns
/:cl:
