### PR TITLE
Autodoc for undocumented function and fixes passdoor flag

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -386,8 +386,9 @@
 /atom/proc/AllowDrop()
 	return FALSE
 
+/// Are you allowed to pass a sided object of the same dir
 /atom/proc/CheckExit()
-	return 1
+	return TRUE
 
 ///Is this atom within 1 tile of another atom
 /atom/proc/HasProximity(atom/movable/AM as mob|obj)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -127,12 +127,14 @@
 	return !density || (dir != to_dir) || (check_access(ID) && hasPower())
 
 /obj/machinery/door/window/CheckExit(atom/movable/mover as mob|obj, turf/target)
+	if(istype(mover) && (mover.pass_flags & PASSDOOR)) // Since it's a door, allow em through
+		return TRUE
 	if(istype(mover) && (mover.pass_flags & PASSGLASS))
-		return 1
+		return TRUE
 	if(get_dir(loc, target) == dir)
 		return !density
 	else
-		return 1
+		return TRUE
 
 /obj/machinery/door/window/open(forced=FALSE)
 	if (operating) //doors can still open when emag-disabled


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Fixes: https://github.com/yogstation13/Yogstation/issues/10377

### Why is this change good for the game?

Bug caused by _probably_ this undocumented function

Autodocuments are good and also bug fixes

# Changelog
:cl:  
bugfix: Mouses and drones can now pass on both sides of a windoor
/:cl:
