### PR TITLE
Gets rid of invalid posters from maps

### DIFF
--- a/_maps/RandomRuins/StationRuins/maint/10x10/10x10_boxfactory.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/10x10/10x10_boxfactory.dmm
@@ -43,7 +43,7 @@
 /turf/open/floor/wood,
 /area/template_noop)
 "h" = (
-/obj/structure/sign/poster/official{
+/obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
 /turf/open/floor/plating,
@@ -96,7 +96,7 @@
 /turf/open/floor/wood,
 /area/template_noop)
 "p" = (
-/obj/structure/sign/poster/official{
+/obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel,

--- a/_maps/RandomRuins/StationRuins/maint/10x10/10x10_maze.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/10x10/10x10_maze.dmm
@@ -25,7 +25,7 @@
 /turf/open/floor/plating,
 /area/template_noop)
 "p" = (
-/obj/item/poster{
+/obj/item/poster/random_official{
 	pixel_y = 32
 	},
 /turf/open/floor/plating,

--- a/_maps/RandomRuins/StationRuins/maint/5x4/5x4_posterstore.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/5x4/5x4_posterstore.dmm
@@ -21,7 +21,7 @@
 /area/template_noop)
 "h" = (
 /obj/structure/table,
-/obj/structure/sign/poster/contraband{
+/obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
 	},
 /obj/item/poster/random_contraband{
@@ -47,7 +47,7 @@
 	pixel_y = 5
 	},
 /obj/item/poster/random_official,
-/obj/structure/sign/poster/official{
+/obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
 /turf/open/floor/plating,
@@ -58,7 +58,7 @@
 /area/template_noop)
 "w" = (
 /obj/structure/table,
-/obj/structure/sign/poster/contraband{
+/obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
 	},
 /obj/item/poster/random_contraband{
@@ -74,7 +74,7 @@
 "A" = (
 /obj/structure/rack,
 /obj/item/poster/random_official,
-/obj/structure/sign/poster/official{
+/obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
 /turf/open/floor/plating,
@@ -101,7 +101,7 @@
 /area/template_noop)
 "Y" = (
 /obj/structure/table,
-/obj/structure/sign/poster/contraband{
+/obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
 	},
 /obj/item/poster/random_contraband,


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Fixes: https://github.com/yogstation13/Yogstation/issues/10723

### Why is this change good for the game?

Muh immersion

# Changelog

Edit this changelog for changes that are noticeable by the players. Remove it if this isn't the case. If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. Prefix the PR title with [admin] if it's something admin related. Prefix the PR title with [s] if you are fixing an exploit so it is not announced on discord and the server.

:cl:  
bugfix: Invalid posters should nolonger show up
/:cl:
