### PR TITLE
TEMPORARILY removes the stock exchange machines from cargo

### DIFF
--- a/_maps/map_files/EclipseStation/EclipseStation.dmm
+++ b/_maps/map_files/EclipseStation/EclipseStation.dmm
@@ -67409,20 +67409,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"cIC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/machinery/computer/stockexchange,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "cID" = (
 /obj/structure/chair/stool,
 /obj/structure/disposalpipe/segment{
@@ -77999,12 +77985,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"dec" = (
-/obj/structure/table,
-/obj/machinery/computer/stockexchange,
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "ded" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -85160,6 +85140,19 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"moP" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "mpw" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -88499,6 +88492,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"use" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "usI" = (
 /obj/structure/cable{
 	icon_state = "1-2";
@@ -121718,7 +121716,7 @@ fRe
 ddR
 cHf
 agh
-cIC
+moP
 den
 cdQ
 bNK
@@ -122746,7 +122744,7 @@ jVV
 ddV
 ddX
 ddX
-dec
+use
 der
 aez
 bNN

--- a/_maps/map_files/IceBox/IceBox.dmm
+++ b/_maps/map_files/IceBox/IceBox.dmm
@@ -29934,11 +29934,6 @@
 /obj/item/clothing/head/soft,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"bjn" = (
-/obj/structure/table,
-/obj/machinery/computer/stockexchange,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "bjo" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Bay North"
@@ -59631,6 +59626,10 @@
 /obj/structure/transit_tube_pod,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/lounge)
+"ltP" = (
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "luw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -85180,7 +85179,7 @@ aPA
 aSg
 bcb
 aZE
-bjn
+ltP
 bjr
 bjh
 bmh

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -21268,11 +21268,6 @@
 /obj/item/clothing/head/soft,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"bjn" = (
-/obj/structure/table,
-/obj/machinery/computer/stockexchange,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "bjo" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Bay North"
@@ -51901,6 +51896,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"pDH" = (
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "pEf" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -85170,7 +85169,7 @@ aPA
 gJt
 bcb
 aZE
-bjn
+pDH
 bjr
 bjh
 bmh

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -21255,19 +21255,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"bjm" = (
-/obj/structure/table,
-/obj/item/hand_labeler,
-/obj/item/hand_labeler,
-/obj/machinery/requests_console{
-	department = "Cargo Bay";
-	departmentType = 2;
-	pixel_y = 30
-	},
-/obj/item/clothing/head/soft,
-/obj/item/clothing/head/soft,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "bjo" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Bay North"
@@ -24353,19 +24340,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"btt" = (
-/obj/structure/table,
-/obj/item/folder/yellow,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 6;
-	pixel_y = -5
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "btu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -25215,11 +25189,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"bvZ" = (
-/obj/structure/table,
-/obj/machinery/computer/stockexchange,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "bwa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -34419,6 +34388,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"cOW" = (
+/obj/structure/table,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "cPo" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/darkblue{
@@ -48721,6 +48699,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"nrf" = (
+/obj/structure/table,
+/obj/item/folder/yellow,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "nrj" = (
 /obj/structure/rack,
 /obj/item/storage/briefcase,
@@ -51896,10 +51879,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"pDH" = (
-/obj/structure/table,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "pEf" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -57986,6 +57965,17 @@
 "tSz" = (
 /turf/open/floor/plasteel,
 /area/science/nanite)
+"tSG" = (
+/obj/structure/table,
+/obj/machinery/requests_console{
+	department = "Cargo Bay";
+	departmentType = 2;
+	pixel_y = 30
+	},
+/obj/item/clothing/head/soft,
+/obj/item/clothing/head/soft,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "tSO" = (
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/carpet,
@@ -59660,6 +59650,12 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"vdA" = (
+/obj/structure/table,
+/obj/item/hand_labeler,
+/obj/item/hand_labeler,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "vdI" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
@@ -85169,7 +85165,7 @@ aPA
 gJt
 bcb
 aZE
-pDH
+vdA
 bjr
 bjh
 bmh
@@ -85426,7 +85422,7 @@ bcu
 bfe
 fRZ
 aZE
-bjm
+tSG
 bjr
 bjh
 bmh
@@ -87489,8 +87485,8 @@ bmt
 boN
 bqo
 brO
-btt
-bvZ
+cOW
+nrf
 hxY
 bxu
 bxx

--- a/yogstation/code/modules/research/designs/comp_board_designs.dm
+++ b/yogstation/code/modules/research/designs/comp_board_designs.dm
@@ -1,11 +1,3 @@
-/datum/design/board/stockexchange
-	name = "Computer Design (Stock Exchange Console)"
-	desc = "Allows for the construction of circuit boards used to build a Stock Exchange Console."
-	id = "stockexchange"
-	build_path = /obj/item/circuitboard/computer/stockexchange
-	category = list("Computer Boards")
-	departmental_flags = DEPARTMENTAL_FLAG_CARGO
-
 /datum/design/board/minesweeper
 	name = "Computer Design (Minesweeper)"
 	desc = "Allows for the construction of circuit boards used to build a new Minesweeper machine."


### PR DESCRIPTION
steals cargos money; makes them broke

### Intent of your Pull Request

Removing the stock exchange machines from the maps that they are on because the current stock system is shit and makes balancing cargo a pain in the rear. Gamer is gonna rework it and re-add it in, I promise. 

### Why is this change good for the game?

Cargo having some money is good. Cargo having three hundred thousand credits and buying a shuttle's worth of riot shotguns is not. 

# Wiki Documentation

Could alter/remove mentions of the stock machine but it's going to get re-added so probably just a note that says it's currently removed so we don't get 50 mhelps about where the stock machine went

### Briefly describe your PR and the impacts of it, in layman's terms. 
stock machine go sleepy time for a second

### What should players be aware of when it comes to the changes your PR is implementing?
no stocks

### What general grouping does this PR fall under? 
Cargo balancing

### Are there any aspects of the PR that you would like us not to mention on the Wiki?
no

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
no

# Changelog



:cl:  
rscdel: Temporarily removing stock machines from maps that have them
/:cl:
