### PR TITLE
Add Mining Research Points and techgates mining research behind it

### DIFF
--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -67,13 +67,15 @@
 ///Techweb names for new point types. Can be used to define specific point values for specific types of research (science, security, engineering, etc.)
 #define TECHWEB_POINT_TYPE_GENERIC "General Research"
 #define TECHWEB_POINT_TYPE_NANITES "Nanite Research"
+#define TECHWEB_POINT_TYPE_MINING "Mining Research"
 
 #define TECHWEB_POINT_TYPE_DEFAULT TECHWEB_POINT_TYPE_GENERIC
 
 ///Associative names for techweb point values, see: [/modules/research/techweb/all_nodes][all_nodes]
 #define TECHWEB_POINT_TYPE_LIST_ASSOCIATIVE_NAMES list(\
 	TECHWEB_POINT_TYPE_GENERIC = "General Research",\
-	TECHWEB_POINT_TYPE_NANITES = "Nanite Research"\
+	TECHWEB_POINT_TYPE_NANITES = "Nanite Research",\
+	TECHWEB_POINT_TYPE_MINING = "Mining Research" \
 	)
 
 #define TECHWEB_BOMB_POINTCAP		50000 //Adjust as needed; Stops toxins from nullifying RND progression mechanics. Current Value Cap Radius: 100

--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -75,7 +75,7 @@
 #define TECHWEB_POINT_TYPE_LIST_ASSOCIATIVE_NAMES list(\
 	TECHWEB_POINT_TYPE_GENERIC = "General Research",\
 	TECHWEB_POINT_TYPE_NANITES = "Nanite Research",\
-	TECHWEB_POINT_TYPE_MINING = "Mining Research" \
+	TECHWEB_POINT_TYPE_MINING = "Mining Research"\
 	)
 
 #define TECHWEB_BOMB_POINTCAP		50000 //Adjust as needed; Stops toxins from nullifying RND progression mechanics. Current Value Cap Radius: 100

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -255,6 +255,7 @@
 			if(points)
 				if(I)
 					I.mining_points += points
+					SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_MINING = round(points/2)))
 					points = 0
 				else
 					to_chat(usr, "<span class='warning'>No valid ID detected.</span>")

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -522,8 +522,8 @@
 	display_name = "Mining Technology"
 	description = "Better than Efficiency V."
 	prereq_ids = list("engineering", "basic_plasma")
-	design_ids = list("drill", "superresonator", "triggermod", "damagemod", "cooldownmod", "rangemod", "ore_redemption", "mining_equipment_vendor", "cargoexpress", "plasmacutter")//e a r l y    g a  m e)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	design_ids = list("drill", "superresonator", "ore_redemption", "mining_equipment_vendor", "cargoexpress", "plasmacutter")//e a r l y    g a  m e)
+	research_costs = list(TECHWEB_POINT_TYPE_MINING = 1250)
 	export_price = 5000
 
 /datum/techweb_node/adv_mining
@@ -531,8 +531,17 @@
 	display_name = "Advanced Mining Technology"
 	description = "Efficiency Level 127"	//dumb mc references
 	prereq_ids = list("basic_mining", "adv_engi", "adv_power", "adv_plasma")
-	design_ids = list("drill_diamond", "jackhammer", "hypermod", "plasmacutter_adv", "borg_upgrade_plasmacutter")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	design_ids = list("drill_diamond", "jackhammer", "plasmacutter_adv", "borg_upgrade_plasmacutter")
+	research_costs = list(TECHWEB_POINT_TYPE_MINING = 4000)
+	export_price = 5000
+
+/datum/techweb_node/mining_mods
+	id = "mining_mods"
+	display_name = "Proto-Kinetic Accelerator Mods"
+	description = "Efficency Level Up"
+	prereq_ids = list("basic_mining")
+	design_ids = list("triggermod", "damagemod", "cooldownmod", "rangemod", "hypermod")
+	research_costs = list(TECHWEB_POINT_TYPE_MINING = 1500)
 	export_price = 5000
 
 /datum/techweb_node/camera_theory

--- a/code/modules/research/techweb/layout.dm
+++ b/code/modules/research/techweb/layout.dm
@@ -151,6 +151,10 @@
         ui_x = 96
         ui_y = -384
 
+/datum/techweb_node/mining_mods
+        ui_x = 96
+        ui_y = -416
+
 /datum/techweb_node/weaponry
         ui_x = -576
         ui_y = -416


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Kinda like #10790 but done differently

Instead of messing with cutters and all of that. It introduces a new point type `Mining Research` which is 1 Research Point per 2 Mining Points

To get the basic plasmacutter you spend 1250 points. which is 2500 MP which translate to ~2-3 loads of mining satchels
And also moves all of the pKa mods to their own semi-cheap node

### Why is this change good for the game?

Encourages a more friendly science/mining interaction as science has to research it but mining has to well. mine.

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
1 New technode, New research point gotten by mining

### What should players be aware of when it comes to the changes your PR is implementing?

### What general grouping does this PR fall under? 
Mining/Research Rebalance

### Are there any aspects of the PR that you would like us not to mention on the Wiki?

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
Normal mining node cost 1250 MRP:tm: points
Adv Mining Node costs 4000 MRP points
Proto-Kinetic Mods cost 1500 MRP points

# Changelog

:cl:  
rscadd: Add Mining Research Points
tweak: Techgate mining research behind it
/:cl:
