### PR TITLE
Removes Gondola Hide from 3x3_tranquility Random Maint

### DIFF
--- a/_maps/RandomRuins/StationRuins/maint/3x3/3x3_tranquility.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/3x3/3x3_tranquility.dmm
@@ -7,13 +7,13 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
 /area/template_noop)
-"A" = (
-/obj/effect/decal/cleanable/blood/gibs,
+"t" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/plating,
 /area/template_noop)
-"D" = (
-/obj/item/stack/sheet/animalhide/gondola,
-/obj/effect/decal/cleanable/blood,
+"A" = (
+/obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plating,
 /area/template_noop)
 "E" = (
@@ -31,7 +31,7 @@ Q
 "}
 (2,1,1) = {"
 E
-D
+t
 f
 "}
 (3,1,1) = {"


### PR DESCRIPTION
# Intent of your Pull Request
Removes Gondole Hide from 3x3_tranquility.

### Why is this change good for the game?
![bpng](https://user-images.githubusercontent.com/62276730/103491736-2733d780-4df4-11eb-9508-b6a40704c10b.png)
Gonbolas are pretty strong.

##### Changelog

:cl:  
rscdel: Removed Gondola Hide from 3x3_tranquility
/:cl:
