### PR TITLE
Fixes the syndicate sleeping pen only working against syndicates

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -152,7 +152,7 @@
  */
 
 /obj/item/pen/sleepy/attack(mob/living/M, mob/user)
-	if(!is_syndicate(M)) // if non syndicate , it is just a regular pen as they don't know how to activate hidden payload.
+	if(!is_syndicate(user)) // if non syndicate , it is just a regular pen as they don't know how to activate hidden payload.
 		. = ..()
 		return
 	if(!istype(M))


### PR DESCRIPTION
During the original syndicate PR I tested the items against myself and since I was a syndicate during the test it worked perfectly.
There was a typo so it didn't work on anyone that is not a syndicate.

:cl:  Hopek
bugfix: Fixed the syndicate sleeping pen only working against other syndicates
/:cl:
