### PR TITLE
smartmines no longer explode only for mindshielded people and normal mines don't explode when shot over

### DIFF
--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -109,10 +109,12 @@
 			if(!(MM.movement_type & FLYING))
 				checksmartmine(AM)
 		else
+			if(istype(AM, /obj/item/projectile))
+				return
 			triggermine(AM)
 
 /obj/effect/mine/proc/checksmartmine(mob/target)
-	if(smartmine && target && HAS_TRAIT(target, TRAIT_MINDSHIELD))
+	if(smartmine && target && !HAS_TRAIT(target, TRAIT_MINDSHIELD))
 		triggermine(target)
 	else if(!smartmine)
 		triggermine(target)


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

mines now work

### Why is this change good for the game?
mines will now function as intended and not detonate if you shoot something over your defensive mine line

# Changelog



:cl:  
bugfix: smartmines now detonate when stepped on by nonmindshielded people rather than ONLY mindshielded people
tweak: mines will no longer explode when passed by projectiles
/:cl:
