### PR TITLE
Removes cloning (WAIT!, read the PR before downvoting!)

### DIFF
--- a/_maps/map_files/EclipseStation/EclipseStation.dmm
+++ b/_maps/map_files/EclipseStation/EclipseStation.dmm
@@ -81688,16 +81688,6 @@
 /obj/item/dice,
 /turf/open/floor/wood,
 /area/maintenance/department/chapel)
-"ePD" = (
-/obj/machinery/camera{
-	c_tag = "Cloning";
-	dir = 1;
-	network = list("ss13","Medbay")
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/genetics/cloning)
 "eQh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -83524,6 +83514,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/teleporter/hub/science)
+"iGz" = (
+/obj/item/paper/fluff/cloning,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/genetics/cloning)
 "iKX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -84186,15 +84182,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"kok" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/genetics/cloning)
 "kpO" = (
 /obj/structure/cable{
 	icon_state = "4-8";
@@ -85891,12 +85878,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/chapel)
-"oce" = (
-/obj/item/paper/fluff/cloning,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/genetics/cloning)
 "odq" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=PPH2";
@@ -86581,6 +86562,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"pRp" = (
+/obj/machinery/camera{
+	c_tag = "Cloning Lab";
+	dir = 1;
+	network = list("ss13","rd","Medbay")
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/genetics/cloning)
 "pRI" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
@@ -87351,6 +87342,15 @@
 /mob/living/simple_animal/hostile/retaliate/goose/vomit,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"rKd" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/genetics/cloning)
 "rKm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -88542,6 +88542,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"uBx" = (
+/obj/machinery/camera{
+	c_tag = "Cloning";
+	dir = 1;
+	network = list("ss13","Medbay")
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/genetics/cloning)
 "uCs" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -89933,16 +89943,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"xFh" = (
-/obj/machinery/camera{
-	c_tag = "Cloning Lab";
-	dir = 1;
-	network = list("ss13","rd","Medbay")
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/genetics/cloning)
 "xGo" = (
 /obj/machinery/light{
 	dir = 8;
@@ -101913,7 +101913,7 @@ bKM
 bLl
 bNm
 bEx
-oce
+iGz
 aun
 cdh
 kaT
@@ -102170,7 +102170,7 @@ aun
 bBT
 bPg
 bEy
-ePD
+uBx
 aun
 ciq
 cqn
@@ -102427,7 +102427,7 @@ aun
 bBU
 bSE
 bEy
-xFh
+pRp
 aun
 clD
 hXw
@@ -102684,7 +102684,7 @@ aun
 bBV
 bTj
 bEz
-oce
+iGz
 aun
 clE
 cqn
@@ -102941,7 +102941,7 @@ aun
 bLQ
 bTK
 bEy
-kok
+rKd
 aun
 cat
 cqp

--- a/_maps/map_files/EclipseStation/EclipseStation.dmm
+++ b/_maps/map_files/EclipseStation/EclipseStation.dmm
@@ -81706,15 +81706,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"eRs" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/genetics/cloning)
 "eTM" = (
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/quantumpad{
@@ -83582,6 +83573,12 @@
 /obj/item/bedsheet/dorms,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"iSo" = (
+/obj/item/paper/fluff/cloning,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/genetics/cloning)
 "iTN" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -84105,16 +84102,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
-"keT" = (
-/obj/machinery/camera{
-	c_tag = "Cloning";
-	dir = 1;
-	network = list("ss13","Medbay")
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/genetics/cloning)
 "keX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -84360,6 +84347,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"kHw" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/genetics/cloning)
 "kIl" = (
 /obj/structure/cable{
 	icon_state = "4-8";
@@ -86700,6 +86696,16 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/department/chapel)
+"qpA" = (
+/obj/machinery/camera{
+	c_tag = "Cloning";
+	dir = 1;
+	network = list("ss13","Medbay")
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/genetics/cloning)
 "qqa" = (
 /obj/machinery/bounty_board,
 /turf/closed/wall,
@@ -87655,12 +87661,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
-"svG" = (
-/obj/item/paper/fluff/cloning,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/genetics/cloning)
 "szL" = (
 /obj/structure/light_construct/small,
 /turf/open/floor/wood,
@@ -89843,6 +89843,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"xrn" = (
+/obj/machinery/camera{
+	c_tag = "Cloning Lab";
+	dir = 1;
+	network = list("ss13","rd","Medbay")
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/genetics/cloning)
 "xsd" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plating,
@@ -89933,16 +89943,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"xDD" = (
-/obj/machinery/camera{
-	c_tag = "Cloning Lab";
-	dir = 1;
-	network = list("ss13","rd","Medbay")
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/genetics/cloning)
 "xGo" = (
 /obj/machinery/light{
 	dir = 8;
@@ -101913,7 +101913,7 @@ bKM
 bLl
 bNm
 bEx
-svG
+iSo
 aun
 cdh
 kaT
@@ -102170,7 +102170,7 @@ aun
 bBT
 bPg
 bEy
-keT
+qpA
 aun
 ciq
 cqn
@@ -102427,7 +102427,7 @@ aun
 bBU
 bSE
 bEy
-xDD
+xrn
 aun
 clD
 hXw
@@ -102684,7 +102684,7 @@ aun
 bBV
 bTj
 bEz
-svG
+iSo
 aun
 clE
 cqn
@@ -102941,7 +102941,7 @@ aun
 bLQ
 bTK
 bEy
-eRs
+kHw
 aun
 cat
 cqp

--- a/_maps/map_files/EclipseStation/EclipseStation.dmm
+++ b/_maps/map_files/EclipseStation/EclipseStation.dmm
@@ -81706,6 +81706,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"eRs" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/genetics/cloning)
 "eTM" = (
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/quantumpad{
@@ -83514,12 +83523,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/teleporter/hub/science)
-"iGz" = (
-/obj/item/paper/fluff/cloning,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/genetics/cloning)
 "iKX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -84102,6 +84105,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
+"keT" = (
+/obj/machinery/camera{
+	c_tag = "Cloning";
+	dir = 1;
+	network = list("ss13","Medbay")
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/genetics/cloning)
 "keX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -86562,16 +86575,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
-"pRp" = (
-/obj/machinery/camera{
-	c_tag = "Cloning Lab";
-	dir = 1;
-	network = list("ss13","rd","Medbay")
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/genetics/cloning)
 "pRI" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
@@ -87342,15 +87345,6 @@
 /mob/living/simple_animal/hostile/retaliate/goose/vomit,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"rKd" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/genetics/cloning)
 "rKm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -87661,6 +87655,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
+"svG" = (
+/obj/item/paper/fluff/cloning,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/genetics/cloning)
 "szL" = (
 /obj/structure/light_construct/small,
 /turf/open/floor/wood,
@@ -88542,16 +88542,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"uBx" = (
-/obj/machinery/camera{
-	c_tag = "Cloning";
-	dir = 1;
-	network = list("ss13","Medbay")
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/genetics/cloning)
 "uCs" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -89943,6 +89933,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"xDD" = (
+/obj/machinery/camera{
+	c_tag = "Cloning Lab";
+	dir = 1;
+	network = list("ss13","rd","Medbay")
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/genetics/cloning)
 "xGo" = (
 /obj/machinery/light{
 	dir = 8;
@@ -101913,7 +101913,7 @@ bKM
 bLl
 bNm
 bEx
-iGz
+svG
 aun
 cdh
 kaT
@@ -102170,7 +102170,7 @@ aun
 bBT
 bPg
 bEy
-uBx
+keT
 aun
 ciq
 cqn
@@ -102427,7 +102427,7 @@ aun
 bBU
 bSE
 bEy
-pRp
+xDD
 aun
 clD
 hXw
@@ -102684,7 +102684,7 @@ aun
 bBV
 bTj
 bEz
-iGz
+svG
 aun
 clE
 cqn
@@ -102941,7 +102941,7 @@ aun
 bLQ
 bTK
 bEy
-rKd
+eRs
 aun
 cat
 cqp

--- a/_maps/map_files/EclipseStation/EclipseStation.dmm
+++ b/_maps/map_files/EclipseStation/EclipseStation.dmm
@@ -40367,14 +40367,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
-"bFE" = (
-/obj/machinery/computer/cloning{
-	dir = 1
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/genetics/cloning)
 "bFF" = (
 /obj/machinery/light/small,
 /obj/machinery/disposal/bin,
@@ -40383,22 +40375,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"bFG" = (
-/obj/machinery/dna_scannernew,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/genetics/cloning)
-"bFH" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/clonepod,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/genetics/cloning)
 "bFI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -48020,17 +47996,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"bUS" = (
-/obj/machinery/clonepod,
-/obj/machinery/camera{
-	c_tag = "Cloning";
-	dir = 1;
-	network = list("ss13","Medbay")
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/genetics/cloning)
 "bUT" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -70719,17 +70684,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
-"cOi" = (
-/obj/machinery/dna_scannernew,
-/obj/machinery/camera{
-	c_tag = "Cloning Lab";
-	dir = 1;
-	network = list("ss13","rd","Medbay")
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/genetics/cloning)
 "cOj" = (
 /turf/open/floor/wood,
 /area/crew_quarters/dorms/b)
@@ -81634,6 +81588,15 @@
 "eza" = (
 /turf/closed/wall/mineral/bronze,
 /area/maintenance/port/fore)
+"ezr" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/genetics/cloning)
 "ezJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -82023,6 +81986,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"fzn" = (
+/obj/item/paper/fluff/cloning,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/genetics/cloning)
 "fzE" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -83980,6 +83949,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"jNq" = (
+/obj/machinery/camera{
+	c_tag = "Cloning Lab";
+	dir = 1;
+	network = list("ss13","rd","Medbay")
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/genetics/cloning)
 "jPi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -85995,6 +85974,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"opZ" = (
+/obj/machinery/camera{
+	c_tag = "Cloning";
+	dir = 1;
+	network = list("ss13","Medbay")
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/genetics/cloning)
 "orq" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -101667,7 +101656,7 @@ aun
 bBP
 bEw
 bEy
-bFG
+bEy
 aun
 cdf
 cqn
@@ -101924,7 +101913,7 @@ bKM
 bLl
 bNm
 bEx
-bFE
+fzn
 aun
 cdh
 kaT
@@ -102181,7 +102170,7 @@ aun
 bBT
 bPg
 bEy
-bUS
+opZ
 aun
 ciq
 cqn
@@ -102438,7 +102427,7 @@ aun
 bBU
 bSE
 bEy
-cOi
+jNq
 aun
 clD
 hXw
@@ -102695,7 +102684,7 @@ aun
 bBV
 bTj
 bEz
-bFE
+fzn
 aun
 clE
 cqn
@@ -102952,7 +102941,7 @@ aun
 bLQ
 bTK
 bEy
-bFH
+ezr
 aun
 cat
 cqp

--- a/_maps/map_files/EclipseStation/EclipseStation.dmm
+++ b/_maps/map_files/EclipseStation/EclipseStation.dmm
@@ -81588,15 +81588,6 @@
 "eza" = (
 /turf/closed/wall/mineral/bronze,
 /area/maintenance/port/fore)
-"ezr" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/genetics/cloning)
 "ezJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -81697,6 +81688,16 @@
 /obj/item/dice,
 /turf/open/floor/wood,
 /area/maintenance/department/chapel)
+"ePD" = (
+/obj/machinery/camera{
+	c_tag = "Cloning";
+	dir = 1;
+	network = list("ss13","Medbay")
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/genetics/cloning)
 "eQh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -81986,12 +81987,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"fzn" = (
-/obj/item/paper/fluff/cloning,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/genetics/cloning)
 "fzE" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -83949,16 +83944,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"jNq" = (
-/obj/machinery/camera{
-	c_tag = "Cloning Lab";
-	dir = 1;
-	network = list("ss13","rd","Medbay")
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/genetics/cloning)
 "jPi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -84201,6 +84186,15 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"kok" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/genetics/cloning)
 "kpO" = (
 /obj/structure/cable{
 	icon_state = "4-8";
@@ -85897,6 +85891,12 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/chapel)
+"oce" = (
+/obj/item/paper/fluff/cloning,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/genetics/cloning)
 "odq" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=PPH2";
@@ -85974,16 +85974,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"opZ" = (
-/obj/machinery/camera{
-	c_tag = "Cloning";
-	dir = 1;
-	network = list("ss13","Medbay")
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/genetics/cloning)
 "orq" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -89943,6 +89933,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"xFh" = (
+/obj/machinery/camera{
+	c_tag = "Cloning Lab";
+	dir = 1;
+	network = list("ss13","rd","Medbay")
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/genetics/cloning)
 "xGo" = (
 /obj/machinery/light{
 	dir = 8;
@@ -101913,7 +101913,7 @@ bKM
 bLl
 bNm
 bEx
-fzn
+oce
 aun
 cdh
 kaT
@@ -102170,7 +102170,7 @@ aun
 bBT
 bPg
 bEy
-opZ
+ePD
 aun
 ciq
 cqn
@@ -102427,7 +102427,7 @@ aun
 bBU
 bSE
 bEy
-jNq
+xFh
 aun
 clD
 hXw
@@ -102684,7 +102684,7 @@ aun
 bBV
 bTj
 bEz
-fzn
+oce
 aun
 clE
 cqn
@@ -102941,7 +102941,7 @@ aun
 bLQ
 bTK
 bEy
-ezr
+kok
 aun
 cat
 cqp

--- a/_maps/map_files/IceBox/IceBox.dmm
+++ b/_maps/map_files/IceBox/IceBox.dmm
@@ -57247,6 +57247,16 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"eAc" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "eBF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -59302,6 +59312,18 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
+"kFb" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/item/paper/fluff/cloning,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "kFK" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -59727,19 +59749,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"lQs" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/shower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "lQG" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -62065,18 +62074,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"sEy" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/item/paper/fluff/cloning,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "sHQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -62343,6 +62340,19 @@
 /obj/effect/turf_decal/bot_white/right,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
+"tpy" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "tqk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -63135,16 +63145,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"vSf" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "vSD" = (
 /obj/machinery/pipedispenser,
 /obj/structure/extinguisher_cabinet{
@@ -104976,7 +104976,7 @@ bsu
 fzU
 aWX
 bnW
-vSf
+eAc
 bua
 bzd
 bhh
@@ -105233,7 +105233,7 @@ bpE
 btk
 aCH
 bnX
-sEy
+kFb
 bua
 bBL
 bhh
@@ -105490,7 +105490,7 @@ bpE
 bti
 bsL
 bnY
-lQs
+tpy
 bua
 bBK
 bwz

--- a/_maps/map_files/IceBox/IceBox.dmm
+++ b/_maps/map_files/IceBox/IceBox.dmm
@@ -57247,16 +57247,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"eAc" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "eBF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -59005,6 +58995,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"jEH" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/item/paper/fluff/cloning,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "jKc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -59312,18 +59314,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
-"kFb" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/item/paper/fluff/cloning,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "kFK" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -60290,6 +60280,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"nEe" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "nFF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -62303,6 +62303,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"tme" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "tpq" = (
 /obj/item/coin/silver{
 	pixel_x = 7;
@@ -62340,19 +62353,6 @@
 /obj/effect/turf_decal/bot_white/right,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
-"tpy" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/shower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "tqk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -104976,7 +104976,7 @@ bsu
 fzU
 aWX
 bnW
-eAc
+nEe
 bua
 bzd
 bhh
@@ -105233,7 +105233,7 @@ bpE
 btk
 aCH
 bnX
-kFb
+jEH
 bua
 bBL
 bhh
@@ -105490,7 +105490,7 @@ bpE
 bti
 bsL
 bnY
-tpy
+tme
 bua
 bBK
 bwz

--- a/_maps/map_files/IceBox/IceBox.dmm
+++ b/_maps/map_files/IceBox/IceBox.dmm
@@ -57565,16 +57565,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"fqd" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "frE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -57983,19 +57973,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"gve" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/shower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "gvw" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Mix Pump"
@@ -58666,18 +58643,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"iGi" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/item/paper/fluff/cloning,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "iGw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -59762,6 +59727,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"lQs" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "lQG" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -62087,6 +62065,18 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"sEy" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/item/paper/fluff/cloning,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "sHQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -63145,6 +63135,16 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"vSf" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "vSD" = (
 /obj/machinery/pipedispenser,
 /obj/structure/extinguisher_cabinet{
@@ -104976,7 +104976,7 @@ bsu
 fzU
 aWX
 bnW
-fqd
+vSf
 bua
 bzd
 bhh
@@ -105233,7 +105233,7 @@ bpE
 btk
 aCH
 bnX
-iGi
+sEy
 bua
 bBL
 bhh
@@ -105490,7 +105490,7 @@ bpE
 bti
 bsL
 bnY
-gve
+lQs
 bua
 bBK
 bwz

--- a/_maps/map_files/IceBox/IceBox.dmm
+++ b/_maps/map_files/IceBox/IceBox.dmm
@@ -38554,45 +38554,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"bzl" = (
-/obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
-"bzm" = (
-/obj/machinery/clonepod,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/shower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
-"bzn" = (
-/obj/machinery/computer/cloning{
-	dir = 1
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "bzo" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -57604,6 +57565,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"fqd" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "frE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -58012,6 +57983,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"gve" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "gvw" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Mix Pump"
@@ -58682,6 +58666,18 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"iGi" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/item/paper/fluff/cloning,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "iGw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -104980,7 +104976,7 @@ bsu
 fzU
 aWX
 bnW
-bzl
+fqd
 bua
 bzd
 bhh
@@ -105237,7 +105233,7 @@ bpE
 btk
 aCH
 bnX
-bzn
+iGi
 bua
 bBL
 bhh
@@ -105494,7 +105490,7 @@ bpE
 bti
 bsL
 bnY
-bzm
+gve
 bua
 bBK
 bwz

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -36219,12 +36219,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"dWD" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics/cloning)
 "dXk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -45783,13 +45777,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"lhI" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/obj/item/paper/fluff/cloning,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics/cloning)
 "lhO" = (
 /obj/structure/window/reinforced{
 	pixel_y = 2
@@ -56417,6 +56404,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"sQa" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics/cloning)
 "sQI" = (
 /turf/closed/wall,
 /area/security/execution/transfer)
@@ -62013,6 +62009,13 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
+"wNa" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/item/paper/fluff/cloning,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics/cloning)
 "wNL" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera{
@@ -63500,15 +63503,6 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/rec_center)
-"xYg" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics/cloning)
 "xYQ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -63887,6 +63881,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"ykh" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics/cloning)
 "ykC" = (
 /obj/machinery/flasher{
 	id = "AI";
@@ -107025,9 +107025,9 @@ pHz
 mZG
 uac
 omX
-xYg
-lhI
-dWD
+sQa
+wNa
+ykh
 kYK
 kYK
 kYK

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -33521,6 +33521,15 @@
 "czK" = (
 /turf/closed/wall,
 /area/vacant_room)
+"cAe" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics/cloning)
 "cAf" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -36194,15 +36203,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"dVR" = (
-/obj/machinery/computer/cloning{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics/cloning)
 "dWr" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -42067,16 +42067,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"ixQ" = (
-/obj/machinery/clonepod,
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics/cloning)
 "iyN" = (
 /obj/machinery/camera{
 	c_tag = "Prison Cell 3";
@@ -52534,6 +52524,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"pXL" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/item/paper/fluff/cloning,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics/cloning)
 "pXS" = (
 /obj/structure/transit_tube/crossing,
 /obj/structure/lattice,
@@ -54334,13 +54331,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"rlV" = (
-/obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics/cloning)
 "rne" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -58190,6 +58180,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"tZZ" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics/cloning)
 "uab" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -107029,9 +107025,9 @@ pHz
 mZG
 uac
 omX
-ixQ
-dVR
-rlV
+cAe
+pXL
+tZZ
 kYK
 kYK
 kYK

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -33521,15 +33521,6 @@
 "czK" = (
 /turf/closed/wall,
 /area/vacant_room)
-"cAe" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics/cloning)
 "cAf" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -36228,6 +36219,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"dWD" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics/cloning)
 "dXk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -45786,6 +45783,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
+"lhI" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/item/paper/fluff/cloning,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics/cloning)
 "lhO" = (
 /obj/structure/window/reinforced{
 	pixel_y = 2
@@ -52524,13 +52528,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"pXL" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/obj/item/paper/fluff/cloning,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics/cloning)
 "pXS" = (
 /obj/structure/transit_tube/crossing,
 /obj/structure/lattice,
@@ -58180,12 +58177,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"tZZ" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics/cloning)
 "uab" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -63509,6 +63500,15 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/rec_center)
+"xYg" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics/cloning)
 "xYQ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -107025,9 +107025,9 @@ pHz
 mZG
 uac
 omX
-cAe
-pXL
-tZZ
+xYg
+lhI
+dWD
 kYK
 kYK
 kYK

--- a/_maps/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/map_files/YogsDelta/YogsDelta.dmm
@@ -124871,25 +124871,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"fFp" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/genetics/cloning)
 "fJO" = (
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access";
@@ -125519,19 +125500,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"jnn" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/item/paper/fluff/cloning,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics/cloning)
 "juf" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /obj/effect/turf_decal/stripes/line{
@@ -125771,15 +125739,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
-"kUm" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics/cloning)
 "kXP" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -126177,6 +126136,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/morgue)
+"mLe" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/item/paper/fluff/cloning,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics/cloning)
 "mMY" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/vending/snack/random,
@@ -126208,6 +126180,25 @@
 /obj/machinery/bounty_board,
 /turf/closed/wall/r_wall,
 /area/security/execution/transfer)
+"mYp" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/status_display/evac{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics/cloning)
 "mZp" = (
 /obj/machinery/camera{
 	c_tag = "Medbay - Morgue";
@@ -127757,6 +127748,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"wmY" = (
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics/cloning)
 "wsq" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/water_vapor,
@@ -169409,7 +169409,7 @@ dit
 cma
 cfl
 dlV
-fFp
+mYp
 dpm
 dqZ
 dst
@@ -169666,7 +169666,7 @@ ccQ
 cmj
 cfm
 dlV
-jnn
+mLe
 dpn
 dra
 dsu
@@ -169923,7 +169923,7 @@ ccR
 cml
 cfn
 dlV
-kUm
+wmY
 dpo
 dpo
 dsv

--- a/_maps/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/map_files/YogsDelta/YogsDelta.dmm
@@ -111444,49 +111444,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/science/lab)
-"dnl" = (
-/obj/machinery/clonepod,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/genetics/cloning)
-"dnm" = (
-/obj/machinery/computer/cloning,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics/cloning)
-"dnn" = (
-/obj/machinery/dna_scannernew,
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics/cloning)
 "dno" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/tile/purple{
@@ -124914,6 +124871,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"fFp" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/status_display/evac{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics/cloning)
 "fJO" = (
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access";
@@ -125543,6 +125519,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"jnn" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/item/paper/fluff/cloning,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics/cloning)
 "juf" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /obj/effect/turf_decal/stripes/line{
@@ -125782,6 +125771,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
+"kUm" = (
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics/cloning)
 "kXP" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -169411,7 +169409,7 @@ dit
 cma
 cfl
 dlV
-dnl
+fFp
 dpm
 dqZ
 dst
@@ -169668,7 +169666,7 @@ ccQ
 cmj
 cfm
 dlV
-dnm
+jnn
 dpn
 dra
 dsu
@@ -169925,7 +169923,7 @@ ccR
 cml
 cfn
 dlV
-dnn
+kUm
 dpo
 dpo
 dsv

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -44676,22 +44676,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
-"bIr" = (
-/obj/machinery/computer/cloning{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics/cloning)
 "bIs" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -44844,14 +44828,6 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics/cloning)
-"bIN" = (
-/obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
@@ -65134,26 +65110,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
-"cvw" = (
-/obj/machinery/clonepod{
-	pixel_y = 2
-	},
-/obj/item/radio/intercom{
-	pixel_x = 29
-	},
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/genetics/cloning)
 "cvx" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 4
@@ -76871,6 +76827,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"iaI" = (
+/obj/item/radio/intercom{
+	pixel_x = 29
+	},
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics/cloning)
 "ibf" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -80615,6 +80588,20 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"rKm" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/item/paper/fluff/cloning,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics/cloning)
 "rLy" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -81878,6 +81865,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"uyq" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics/cloning)
 "uGb" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -107443,9 +107437,9 @@ bFe
 csz
 ctz
 cmu
-cvw
-bIr
-bIN
+iaI
+rKm
+uyq
 cqo
 bKt
 czZ

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -331,14 +331,11 @@
 /obj/effect/spawner/lootdrop/techstorage/medical
 	name = "medical circuit board spawner"
 	loot = list(
-				/obj/item/circuitboard/computer/cloning,
-				/obj/item/circuitboard/machine/clonepod,
 				/obj/item/circuitboard/machine/chem_dispenser,
 				/obj/item/circuitboard/computer/scan_consolenew,
 				/obj/item/circuitboard/computer/med_data,
 				/obj/item/circuitboard/machine/smoke_machine,
 				/obj/item/circuitboard/machine/chem_master,
-				/obj/item/circuitboard/machine/clonescanner,
 				/obj/item/circuitboard/computer/pandemic
 				)
 

--- a/code/modules/paperwork/paper_premade.dm
+++ b/code/modules/paperwork/paper_premade.dm
@@ -10,6 +10,11 @@
 /obj/item/paper/fluff/shuttles/daniel
 	info = "i love daniel<br>daniel is my best friend<br><br>you are tearing me apart elise"
 	infolang = /datum/language/aphasia
+	
+/obj/item/paper/fluff/cloning
+	name = "notice- 'IMPORTANT'"
+	info = "<b>IMPORTANT NOTICE:</b><br>\nHey there Nanotrasen station! Due to budget cuts, we had to uninstall your cloning pod and sell it to shady aliens. Result: You have no cloning pod.<br>\n<br>\n<small><i>PS: You can still research and build a cloning pod yourself unlike your peers at GeeTea station.</i></small><hr><br>\n<small><i>PPS: Tell us if you spot any army of mutant insect clones. It turned out those shady aliens were doing shady business.</i></small>"
+	infolang = /datum/language/common
 
 ////////////	Job guides n' fluff
 


### PR DESCRIPTION
> What the actual fuck alex are you cra- 

okay okay shut up for a second mr. contributor. Im not removing cloning fully, just from roundstart.
> THIS IS STUPID IM GOING TO DOWNVO-

calm down for a minute. Read the PR in its entirety then downvote it, ok?

# Please read the PR and my rational for the change before downvoting( or upvoting :) )/sending me colorful messages

### Let's start with the facts. This is what this PR does:
- On all maps but omega(omega is so small anyways lol, they need the cloner), the cloning pod, cloning scanner and cloning computer no longer spawn on roundstart
- On all maps, the cloning boards no longer spawn in tech storage
- Wherever there used to be a cloning setup, there is this now:

<details>
  <summary>Click here to see the in game paper detailing removal of cloning
</summary>

![img](https://user-images.githubusercontent.com/25136265/103728703-c26fad00-4fac-11eb-9b9f-b61754d8ed22.png)

</details>

### Now, the why behind the how
This PR was created to solve several issues cloning introduces
- Doctors generally giving up easily on patients and simply throwing them into the clone pod
- Low skill cap in medical partly due to last point. This PR won't solve that issue but its a step in the right direction
- Death isn't really impactful when even if the traitor decapitated you and left your brain on the floor, you can easily be brought back to life within a few minutes at the cost of pretty much all your belongings.
- People simply dragging bodies to cloning and screaming at doctors when they try to do anything else with the body such as defibbing.

As for the benefits this PR brings to the table outside of current issues solved or partly solved:
- Actual meaningful interaction between departments, between medical and science for the research and while I'd love to say between medical and engineering, I don't have much hope for any significant cooperation between medical and engineering. Its probably going to be a lone bored med building a cloning setup by himself. Medically is really cooped up in their department and outside the one time upgrade to T4s, they dont get much interacting with the rest of the station outside healing the wounded.
- Gives the medical system slightly more depth. Its not much but its a step in the right direction.

Now this PR I think is great but it does come at downsides which cannot be overlooked:
- Due to the low skillcap and the resulting low attraction of players to medical. MDs are pretty incompetent overall. The removal of cloning certainly won't help getting players revived when they die and noone in the medical staff knows how to operate a defib without setting their johnson on fire. Unfortunatly, its a viscious circle, low depth in the medical system repel players from medical roles which in turn create a need for low depth medical systems. The loop has to be broken somewhere and this PR is part of the process of breaking the loop
- On lowpop box rounds, this is going to hurt. However, pod cloning and to a lesser extent, borging still exists and are viable revival methods. Hopefully we will be able to get more competant med players in the future which will make this point moot.

What I would like to see in future PRs altho I have little weight on what will or will not get accepted:
- Giving more depth to the medical system, perhaps with the concept of breaking bones, perhaps some other way
- Tying into the last point, making self serve medbay not a viable option for a quick complete recovery as individuals stealing items from vendors to heal themselves is a major issue while playing as MD.
- Making cloning more expensive to make it less viable to treat everyone using it and instead more a last resort when nothing else works and theyre FUBAR/theres 50 people everyone is dying oh god we need the HOS back alive ASAP. Perhaps using human meat alongside chemical additives as "fuel" for the cloner?
- Giving more reasons for departments to interact with each other instead of staying cooped up in their departments with their techfabs and catgirls.
- If this PR is merged and once it settles down, maybe remap things a bit to remove the empty room lol

I gave my best shot at giving a rational why removing cloning from the start of the round while still allowing it as an auxiliary option that can be built later on in the round but if that did not convince you, I suppose you will put a downvote on this PR.

:cl:  
rscdel: The station no longer starts with a functional cloning setup
/:cl:
