### PR TITLE
reduces effectiveness of several nanite programs

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -953,6 +953,25 @@
 		. = 1
 	..()
 
+/datum/reagent/medicine/stimulants/nanite
+	name = "Nano-Stimulants"
+	description = "Nanite synthesized muscle stimulation mix that temporarily increases speed and stun resistance slightly. Overdose causes weakness and toxin damage."
+
+/datum/reagent/medicine/stimulants/nanite/on_mob_metabolize(mob/living/L)
+	..()
+	L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=-0.25, blacklisted_movetypes=(FLYING|FLOATING))
+
+/datum/reagent/medicine/stimulants/nanite/on_mob_life(mob/living/carbon/M)
+	if(M.health < 50 && M.health > 0)
+		M.adjustOxyLoss(-1*REM, 0)
+		M.adjustToxLoss(-1*REM, 0)
+		M.adjustBruteLoss(-1*REM, 0)
+		M.adjustFireLoss(-1*REM, 0)
+	M.AdjustAllImmobility(-20, FALSE)
+	M.adjustStaminaLoss(-15*REM, 0)
+	..()
+	. = 1
+
 /datum/reagent/medicine/insulin
 	name = "Insulin"
 	description = "Increases sugar depletion rates."

--- a/code/modules/research/nanites/nanite_programs/buffing.dm
+++ b/code/modules/research/nanites/nanite_programs/buffing.dm
@@ -10,13 +10,13 @@
 	. = ..()
 	if(ishuman(host_mob))
 		var/mob/living/carbon/human/H = host_mob
-		H.physiology.stun_mod *= 0.5
+		H.physiology.stun_mod *= 0.75
 
 /datum/nanite_program/nervous/disable_passive_effect()
 	. = ..()
 	if(ishuman(host_mob))
 		var/mob/living/carbon/human/H = host_mob
-		H.physiology.stun_mod *= 2
+		H.physiology.stun_mod /= 0.75
 
 /datum/nanite_program/triggered/adrenaline
 	name = "Adrenaline Burst"
@@ -47,15 +47,15 @@
 	. = ..()
 	if(ishuman(host_mob))
 		var/mob/living/carbon/human/H = host_mob
-		H.physiology.armor.melee += 50
-		H.physiology.armor.bullet += 35
+		H.physiology.armor.melee += 30
+		H.physiology.armor.bullet += 25
 
 /datum/nanite_program/hardening/disable_passive_effect()
 	. = ..()
 	if(ishuman(host_mob))
 		var/mob/living/carbon/human/H = host_mob
-		H.physiology.armor.melee -= 50
-		H.physiology.armor.bullet -= 35
+		H.physiology.armor.melee -= 30
+		H.physiology.armor.bullet -= 25
 
 /datum/nanite_program/refractive
 	name = "Dermal Refractive Surface"
@@ -67,15 +67,15 @@
 	. = ..()
 	if(ishuman(host_mob))
 		var/mob/living/carbon/human/H = host_mob
-		H.physiology.armor.laser += 50
-		H.physiology.armor.energy += 35
+		H.physiology.armor.laser += 30
+		H.physiology.armor.energy += 25
 
 /datum/nanite_program/refractive/disable_passive_effect()
 	. = ..()
 	if(ishuman(host_mob))
 		var/mob/living/carbon/human/H = host_mob
-		H.physiology.armor.laser -= 50
-		H.physiology.armor.energy -= 35
+		H.physiology.armor.laser -= 30
+		H.physiology.armor.energy -= 25
 
 /datum/nanite_program/coagulating
 	name = "Rapid Coagulation"

--- a/code/modules/research/nanites/nanite_programs/buffing.dm
+++ b/code/modules/research/nanites/nanite_programs/buffing.dm
@@ -33,7 +33,7 @@
 	host_mob.adjustStaminaLoss(-75)
 	host_mob.set_resting(FALSE)
 	host_mob.update_mobility()
-	host_mob.reagents.add_reagent(/datum/reagent/medicine/stimulants, 1.5)
+	host_mob.reagents.add_reagent(/datum/reagent/medicine/stimulants/nanite, 1.5)
 
 /datum/nanite_program/hardening
 	name = "Dermal Hardening"


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

reduces the effectiveness of nerve support from 50% stun resist to 25% stun resist
reduces armor from both armor programs to 30 primary 25 secondary
nanite stimulants now only heal 15 stamina per cycle down from 30 and provide a movespeed buff of -0.25 down(?) from -1

### Why is this change good for the game?
passive  buffs with very little downside in the form of "someone MIGHT blow you up once in 200 rounds" are bad

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
This will be the basis of the Wiki entry for your PR, and more information / detail is better for Wiki editors to integrate.

### What should players be aware of when it comes to the changes your PR is implementing?

### What general grouping does this PR fall under? 
nanites

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
For example, "This new chem will heal X brute damage". 
reduces the effectiveness of nerve support from 50% stun resist to 25% stun resist
reduces armor from both armor programs to 30 primary 25 secondary
new chemical: nanite stimulants which function similarly to normal stimulants but only provide 25% of the movespeed and 50% less stamina healing, injected  by the stimulant nanite program
# Changelog


:cl:  
tweak: nerve support nanites are 50% less effective at reducing stuns
tweak: armor nanites have had their armor values reduced from 50/35 to 30/25 melee/laser and ballistic/energy
tweak: nanite stimulants are now 50% weaker for stamina healing and have a 0.25 speed boost down from 1
/:cl:
