### PR TITLE
bibby is refusing to tell me how to fix darkspawn so instead of learning tgui I had to fix the clockwork slab since I can do that without it

### DIFF
--- a/code/modules/antagonists/clockcult/clock_items/clockwork_slab.dm
+++ b/code/modules/antagonists/clockcult/clock_items/clockwork_slab.dm
@@ -172,6 +172,7 @@
 	return TRUE
 
 /obj/item/clockwork/slab/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "ClockworkSlab", name)
 		ui.set_autoupdate(FALSE) //we'll update this occasionally, but not as often as possible


### PR DESCRIPTION
clockwork slab won't open a menu every time it is used in hand or whatever have fun

:cl:  
bugfix: clock slab won't open new windows if it can update an already open one
/:cl:
