### PR TITLE
adds a quick search button for heretic rituals

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -33,7 +33,7 @@
 		gain_knowledge(/datum/eldritch_knowledge/spell/basic)
 		gain_knowledge(/datum/eldritch_knowledge/living_heart)
 		gain_knowledge(/datum/eldritch_knowledge/codex_cicatrix)
-		gain_knowledge(/datum/eldritch_knowledge/clippy)
+		gain_knowledge(/datum/eldritch_knowledge/recall)
 	current.log_message("has been converted to the cult of the forgotten ones!", LOG_ATTACK, color="#960000")
 	GLOB.reality_smash_track.AddMind(owner)
 	START_PROCESSING(SSprocessing,src)

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -33,6 +33,7 @@
 		gain_knowledge(/datum/eldritch_knowledge/spell/basic)
 		gain_knowledge(/datum/eldritch_knowledge/living_heart)
 		gain_knowledge(/datum/eldritch_knowledge/codex_cicatrix)
+		gain_knowledge(/datum/eldritch_knowledge/clippy)
 	current.log_message("has been converted to the cult of the forgotten ones!", LOG_ATTACK, color="#960000")
 	GLOB.reality_smash_track.AddMind(owner)
 	START_PROCESSING(SSprocessing,src)
@@ -222,7 +223,7 @@
 	var/timer = 5 MINUTES
 
 /datum/objective/stalk/process()
-	if(owner?.current.stat != DEAD && target?.current.stat != DEAD && (target.current in view(5,owner.current)))
+	if(owner?.current.stat != DEAD && target && target.current.stat != DEAD && (target.current in view(5,owner.current)))
 		timer -= 1 SECONDS
 	///we don't want to process after the counter reaches 0, otherwise it is wasted processing
 	if(timer <= 0)

--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -25,6 +25,8 @@
 	var/list/result_atoms = list()
 	///What path is this on defaults to "Side"
 	var/route = PATH_SIDE
+	///string that quickly describes the required atoms
+	var/required_shit_list
 
 /datum/eldritch_knowledge/New()
 	. = ..()
@@ -219,7 +221,7 @@
 ///////////////
 
 /datum/eldritch_knowledge/spell/basic
-	name = "Break of dawn"
+	name = "Break of Dawn"
 	desc = "Starts your journey in the mansus. Allows you to select a target using a living heart on a transmutation rune."
 	gain_text = "Gates of mansus open up to your mind."
 	next_knowledge = list(/datum/eldritch_knowledge/base_rust,/datum/eldritch_knowledge/base_ash,/datum/eldritch_knowledge/base_flesh)
@@ -227,6 +229,7 @@
 	spell_to_add = /obj/effect/proc_holder/spell/targeted/touch/mansus_grasp
 	required_atoms = list(/obj/item/living_heart)
 	route = "Start"
+	required_shit_list = "A living heart, which will be given a target for sacrifice or sacrifice its target if their corpse is on the rune."
 
 /datum/eldritch_knowledge/spell/basic/recipe_snowflake_check(list/atoms, loc)
 	. = ..()
@@ -272,7 +275,7 @@
 				to_chat(user,"<span class='warning'>Your new target has been selected, go and sacrifice [LH.target.real_name]!</span>")
 
 			else
-				to_chat(user,"<span class='warning'>target could not be found for living heart.</span>")
+				to_chat(user,"<span class='warning'>A target could not be found for the living heart.</span>")
 
 /datum/eldritch_knowledge/spell/basic/cleanup_atoms(list/atoms)
 	return
@@ -285,6 +288,7 @@
 	required_atoms = list(/obj/item/organ/heart,/obj/effect/decal/cleanable/blood,/obj/item/reagent_containers/food/snacks/grown/poppy)
 	result_atoms = list(/obj/item/living_heart)
 	route = "Start"
+	required_shit_list = "A pool of blood, a poppy, and a heart."
 
 /datum/eldritch_knowledge/codex_cicatrix
 	name = "Codex Cicatrix"
@@ -294,3 +298,29 @@
 	required_atoms = list(/obj/item/organ/eyes,/obj/item/stack/sheet/animalhide/human,/obj/item/storage/book/bible,/obj/item/pen)
 	result_atoms = list(/obj/item/forbidden_book)
 	route = "Start"
+	required_shit_list = "A bible, a sheet of human skin, a pen, and a pair of eyes."
+
+/datum/eldritch_knowledge/clippy
+	name = "Recall Ritual"
+	desc = "Activate a transmutation rune after placing your Codex Cicatrix on it to recall a compact list of your known rituals, selecting one will show its required objects."
+	gain_text = "FUCK"
+	cost = 0
+	route = "Start"
+	required_atoms = list(/obj/item/forbidden_book)
+
+/datum/eldritch_knowledge/clippy/on_finished_recipe(mob/living/user,list/atoms,loc)
+	var/list/datum/eldritch_knowledge/clippy_list = list()
+	var/datum/antagonist/heretic/cultie = user.mind.has_antag_datum(/datum/antagonist/heretic)
+	var/list/knowledge = cultie.get_all_knowledge()
+	for(var/X in knowledge)
+		var/datum/eldritch_knowledge/EK = knowledge[X]
+		if(!EK.required_shit_list)
+			continue
+		clippy_list[EK.name] = EK.required_shit_list
+	var/ctrlf = input(user, "Select a ritual to recall its reagents.", "Clippy") as null | anything in clippy_list
+	if(ctrlf)
+		to_chat(user, "<span class='cult'>Transmutation requirements for [ctrlf]: [clippy_list[ctrlf]]</span>")
+	return TRUE
+
+/datum/eldritch_knowledge/clippy/cleanup_atoms(list/atoms)
+	return

--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -303,7 +303,7 @@
 /datum/eldritch_knowledge/recall
 	name = "Recall Ritual"
 	desc = "Activate a transmutation rune after placing your Codex Cicatrix on it to recall a compact list of your known rituals, selecting one will show its required objects."
-	gain_text = "FUCK"
+	gain_text = "Your thoughts begin to echo inside your head."
 	cost = 0
 	route = "Start"
 	required_atoms = list(/obj/item/forbidden_book)

--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -300,7 +300,7 @@
 	route = "Start"
 	required_shit_list = "A bible, a sheet of human skin, a pen, and a pair of eyes."
 
-/datum/eldritch_knowledge/clippy
+/datum/eldritch_knowledge/recall
 	name = "Recall Ritual"
 	desc = "Activate a transmutation rune after placing your Codex Cicatrix on it to recall a compact list of your known rituals, selecting one will show its required objects."
 	gain_text = "FUCK"
@@ -308,19 +308,19 @@
 	route = "Start"
 	required_atoms = list(/obj/item/forbidden_book)
 
-/datum/eldritch_knowledge/clippy/on_finished_recipe(mob/living/user,list/atoms,loc)
-	var/list/datum/eldritch_knowledge/clippy_list = list()
+/datum/eldritch_knowledge/recall/on_finished_recipe(mob/living/user,list/atoms,loc)
+	var/list/datum/eldritch_knowledge/recall_list = list()
 	var/datum/antagonist/heretic/cultie = user.mind.has_antag_datum(/datum/antagonist/heretic)
 	var/list/knowledge = cultie.get_all_knowledge()
 	for(var/X in knowledge)
 		var/datum/eldritch_knowledge/EK = knowledge[X]
 		if(!EK.required_shit_list)
 			continue
-		clippy_list[EK.name] = EK.required_shit_list
-	var/ctrlf = input(user, "Select a ritual to recall its reagents.", "Clippy") as null | anything in clippy_list
+		recall_list[EK.name] = EK.required_shit_list
+	var/ctrlf = input(user, "Select a ritual to recall its reagents.", "Recall Knowledge") as null | anything in recall_list
 	if(ctrlf)
-		to_chat(user, "<span class='cult'>Transmutation requirements for [ctrlf]: [clippy_list[ctrlf]]</span>")
+		to_chat(user, "<span class='cult'>Transmutation requirements for [ctrlf]: [recall_list[ctrlf]]</span>")
 	return TRUE
 
-/datum/eldritch_knowledge/clippy/cleanup_atoms(list/atoms)
+/datum/eldritch_knowledge/recall/cleanup_atoms(list/atoms)
 	return

--- a/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
@@ -8,6 +8,7 @@
 	result_atoms = list(/obj/item/melee/sickly_blade/ash)
 	cost = 1
 	route = PATH_ASH
+	required_shit_list = "A pile of ash and a knife."
 
 /datum/eldritch_knowledge/spell/ashen_shift
 	name = "Ashen Shift"
@@ -55,6 +56,7 @@
 	next_knowledge = list(/datum/eldritch_knowledge/spell/ashen_shift,/datum/eldritch_knowledge/flesh_ghoul)
 	required_atoms = list(/obj/item/organ/eyes,/obj/item/shard)
 	result_atoms = list(/obj/item/clothing/neck/eldritch_amulet)
+	required_shit_list = "A glass shard and a pair of eyes."
 
 /datum/eldritch_knowledge/ash_mark
 	name = "Mark of ash"
@@ -80,6 +82,7 @@
 	next_knowledge = list(/datum/eldritch_knowledge/curse/corrosion,/datum/eldritch_knowledge/ash_blade_upgrade,/datum/eldritch_knowledge/curse/paralysis)
 	timer = 2 MINUTES
 	route = PATH_ASH
+	required_shit_list = "A pair of eyes, a screwdriver, and a pool of blood. Requires an item touched by the to-be victim."
 
 /datum/eldritch_knowledge/curse/blindness/curse(mob/living/chosen_mob)
 	. = ..()
@@ -122,6 +125,7 @@
 	required_atoms = list(/obj/item/wirecutters,/obj/effect/decal/cleanable/blood,/obj/item/organ/heart,/obj/item/bodypart/l_arm,/obj/item/bodypart/r_arm)
 	next_knowledge = list(/datum/eldritch_knowledge/curse/blindness,/datum/eldritch_knowledge/spell/area_conversion)
 	timer = 2 MINUTES
+	required_shit_list = "Wirecutters, a pool of blood, a heart, and a left and right arm. Requires an item touched by the to-be victim."
 
 /datum/eldritch_knowledge/curse/corrosion/curse(mob/living/chosen_mob)
 	. = ..()
@@ -139,6 +143,7 @@
 	required_atoms = list(/obj/item/kitchen/knife,/obj/effect/decal/cleanable/blood,/obj/item/bodypart/l_leg,/obj/item/bodypart/r_leg,/obj/item/hatchet)
 	next_knowledge = list(/datum/eldritch_knowledge/curse/blindness,/datum/eldritch_knowledge/summon/raw_prophet)
 	timer = 5 MINUTES
+	required_shit_list = "A knife, a pool of blood, a left and right leg, and a hatchet. Requires an item touched by the to-be victim."
 
 /datum/eldritch_knowledge/curse/paralysis/curse(mob/living/chosen_mob)
 	. = ..()
@@ -168,6 +173,7 @@
 	cost = 3
 	route = PATH_ASH
 	var/list/trait_list = list(TRAIT_RESISTHEAT,TRAIT_NOBREATH,TRAIT_RESISTCOLD,TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE,TRAIT_NOFIRE,TRAIT_RADIMMUNE,TRAIT_GENELESS,TRAIT_PIERCEIMMUNE,TRAIT_NODISMEMBER,TRAIT_BOMBIMMUNE)
+	required_shit_list = "Three dead bodies."
 
 /datum/eldritch_knowledge/final/ash_final/on_finished_recipe(mob/living/user, list/atoms, loc)
 	priority_announce("$^@&#*$^@(#&$(@&#^$&#^@# Fear The Blaze, for Ashbringer [user.real_name] has come! $^@&#*$^@(#&$(@&#^$&#^@#","#$^@&#*$^@(#&$(@&#^$&#^@#", 'sound/ai/spanomalies.ogg')

--- a/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
@@ -8,6 +8,7 @@
 	result_atoms = list(/obj/item/melee/sickly_blade/flesh)
 	cost = 1
 	route = PATH_FLESH
+	required_shit_list = "A pool of blood and a knife."
 
 /datum/eldritch_knowledge/flesh_ghoul
 	name = "Imperfect Ritual"
@@ -20,6 +21,7 @@
 	var/max_amt = 2
 	var/current_amt = 0
 	var/list/ghouls = list()
+	required_shit_list = "A poppy and your deceased to rise."
 
 /datum/eldritch_knowledge/flesh_ghoul/on_finished_recipe(mob/living/user,list/atoms,loc)
 	var/mob/living/carbon/human/humie = locate() in atoms
@@ -172,6 +174,7 @@
 	mob_to_summon = /mob/living/simple_animal/hostile/eldritch/raw_prophet
 	next_knowledge = list(/datum/eldritch_knowledge/flesh_blade_upgrade,/datum/eldritch_knowledge/spell/blood_siphon,/datum/eldritch_knowledge/curse/paralysis)
 	route = PATH_FLESH
+	required_shit_list = "A pair of eyes and a left and right arm."
 
 /datum/eldritch_knowledge/summon/stalker
 	name = "Lonely Ritual"
@@ -182,6 +185,7 @@
 	mob_to_summon = /mob/living/simple_animal/hostile/eldritch/stalker
 	next_knowledge = list(/datum/eldritch_knowledge/summon/ashy,/datum/eldritch_knowledge/summon/rusty,/datum/eldritch_knowledge/final/flesh_final)
 	route = PATH_FLESH
+	required_shit_list = "A knife, a candle, a pen, and a piece of paper."
 
 /datum/eldritch_knowledge/summon/ashy
 	name = "Ashen Ritual"
@@ -191,6 +195,7 @@
 	required_atoms = list(/obj/effect/decal/cleanable/ash,/obj/item/bodypart/head,/obj/item/book)
 	mob_to_summon = /mob/living/simple_animal/hostile/eldritch/ash_spirit
 	next_knowledge = list(/datum/eldritch_knowledge/summon/stalker,/datum/eldritch_knowledge/spell/flame_birth)
+	required_shit_list = "A pile of ash, a head and a book."
 
 /datum/eldritch_knowledge/summon/rusty
 	name = "Rusted Ritual"
@@ -200,6 +205,7 @@
 	required_atoms = list(/obj/effect/decal/cleanable/vomit,,/obj/item/book)
 	mob_to_summon = /mob/living/simple_animal/hostile/eldritch/rust_spirit
 	next_knowledge = list(/datum/eldritch_knowledge/summon/stalker,/datum/eldritch_knowledge/spell/entropic_plume)
+	required_shit_list = "A pool of vomit and a book"
 
 /datum/eldritch_knowledge/spell/blood_siphon
 	name = "Blood Siphon"
@@ -216,6 +222,7 @@
 	required_atoms = list(/mob/living/carbon/human)
 	cost = 3
 	route = PATH_FLESH
+	required_shit_list = "Three dead bodies."
 
 /datum/eldritch_knowledge/final/flesh_final/on_finished_recipe(mob/living/user, list/atoms, loc)
 	var/alert_ = alert(user,"Do you want to ascend as the Lord of the Night or empower yourself and summon a Terror of the Night?","...","Yes","No")

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -8,6 +8,7 @@
 	result_atoms = list(/obj/item/melee/sickly_blade/rust)
 	cost = 1
 	route = PATH_RUST
+	required_shit_list = "A piece of trash and a knife."
 
 /datum/eldritch_knowledge/rust_fist
 	name = "Grasp of rust"
@@ -106,6 +107,7 @@
 	next_knowledge = list(/datum/eldritch_knowledge/rust_regen,/datum/eldritch_knowledge/flesh_ghoul)
 	required_atoms = list(/obj/structure/table,/obj/item/clothing/mask/gas)
 	result_atoms = list(/obj/item/clothing/suit/hooded/cultrobes/eldritch)
+	required_shit_list = "A table and a gas mask."
 
 /datum/eldritch_knowledge/essence
 	name = "Priest's ritual"
@@ -115,6 +117,7 @@
 	next_knowledge = list(/datum/eldritch_knowledge/rust_regen,/datum/eldritch_knowledge/spell/ashen_shift)
 	required_atoms = list(/obj/structure/reagent_dispensers/watertank)
 	result_atoms = list(/obj/item/reagent_containers/glass/beaker/eldritch)
+	required_shit_list = "A tank of water."
 
 /datum/eldritch_knowledge/final/rust_final
 	name = "Rustbringer's Oath"
@@ -123,6 +126,7 @@
 	cost = 3
 	required_atoms = list(/mob/living/carbon/human)
 	route = PATH_RUST
+	required_shit_list = "Three dead bodies."
 
 /datum/eldritch_knowledge/final/rust_final/on_finished_recipe(mob/living/user, list/atoms, loc)
 	var/mob/living/carbon/human/H = user


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

adds a quick search ritual using the eldritch book thing with a transmutation rune that shows you all your known rituals and lets you check the reagents for one
also runtime fix for freespace stalk objective
### Why is this change good for the game?
faster and accessible access to game information in game GOOD
# Wiki Documentation

Heretic transmutation rune ritual: recall ritual that shows a list of current usable rituals and their requirements accessible by transmuting the codex cicatrix

# Changelog

:cl:  
rscadd: new ritual for heretics: use a transmutation rune on your codex cicatrix to see what current rituals you have access to and the required items for each one
/:cl:
