### PR TITLE
Darkspawns can now use their psiweb

### DIFF
--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn.dm
@@ -381,6 +381,9 @@
 
 // Psi Web code //
 
+/datum/antagonist/darkspawn/ui_state(mob/user)
+	return GLOB.always_state
+
 /datum/antagonist/darkspawn/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Fixes a issue because some person was too lazy to fix bugs from their bounty pr

### Why is this change good for the game?

bugs are bad

# Changelog

:cl:  
bugfix: Darkspawn can use their psiweb
/:cl:
