### PR TITLE
Zombies own 2021

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1272,15 +1272,15 @@
 
 		if(welded && !locked)
 			to_chat(user, "<span class='warning'>It's welded, this will take a while...</span>")
-			time_to_open = 120 * door_time_multiplier
+			time_to_open = 100 * door_time_multiplier
 
 		if(locked && !welded)
 			to_chat(user, "<span class='warning'>The bolts are down, it won't budge! Forcing the bolts will take a while...</span>")
-			time_to_open = 100 * door_time_multiplier
+			time_to_open = 80 * door_time_multiplier
 
 		if(locked && welded)
 			to_chat(user, "<span class='warning'>The bolts are down, and it's welded.Forcing the bolts and breaking the seal will take a long while...</span>")
-			time_to_open = 240 * door_time_multiplier
+			time_to_open = 200 * door_time_multiplier
 
 
 		if(hasPower())

--- a/code/modules/antagonists/zombie/abilities/adrenaline.dm
+++ b/code/modules/antagonists/zombie/abilities/adrenaline.dm
@@ -3,8 +3,8 @@
 	desc = "Makes you able to sprint for a second or two!"
 	action_icon = 'icons/mob/actions/actions_changeling.dmi'
 	action_icon_state = "adrenaline"
-	cooldown_time = 7.5 MINUTES
-	var/reagent_amount = 2
+	cooldown_time = 3 MINUTES
+	var/reagent_amount = 3
 
 
 /obj/effect/proc_holder/zombie/adrenaline/proc/add_reagent(mob/living/carbon/user)

--- a/code/modules/antagonists/zombie/abilities/tank.dm
+++ b/code/modules/antagonists/zombie/abilities/tank.dm
@@ -3,10 +3,10 @@
 	desc = "Gives you a moderate armor boost for a few seconds. Heals 75% of your brute and fire damage."
 	action_icon = 'icons/mob/actions/actions_changeling.dmi'
 	action_icon_state = "fake_death"
-	cooldown_time = 7.5 MINUTES
+	cooldown_time = 2.5 MINUTES
 	var/duration = 30 SECONDS
-	var/armor_boost = 15
-	var/heal = 0.75
+	var/armor_boost = 12.5
+	var/heal = 0.6
 
 
 /obj/effect/proc_holder/zombie/tank/proc/run_ability(mob/living/carbon/human/user)

--- a/code/modules/antagonists/zombie/abilities/tank.dm
+++ b/code/modules/antagonists/zombie/abilities/tank.dm
@@ -1,6 +1,6 @@
 /obj/effect/proc_holder/zombie/tank
 	name = "Tank"
-	desc = "Gives you a moderate armor boost for a few seconds. Heals 75% of your brute and fire damage."
+	desc = "Gives you a moderate armor boost for a few seconds. Heals 60% of your brute and fire damage."
 	action_icon = 'icons/mob/actions/actions_changeling.dmi'
 	action_icon_state = "fake_death"
 	cooldown_time = 2.5 MINUTES

--- a/code/modules/antagonists/zombie/zombie.dm
+++ b/code/modules/antagonists/zombie/zombie.dm
@@ -1,4 +1,4 @@
-#define TIER_2_TIME 9000
+#define TIER_2_TIME 4500
 
 /datum/antagonist/zombie
 	name = "Zombie"

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -99,7 +99,7 @@
 	burnmod = 0.925
 	speedmod = 1.45
 	mutanthands = /obj/item/zombie_hand/gamemode
-	inherent_traits = list(TRAIT_RESISTCOLD, TRAIT_RESISTHIGHPRESSURE, TRAIT_RESISTLOWPRESSURE,
+	inherent_traits = list(TRAIT_RESISTCOLD, TRAIT_RESISTHIGHPRESSURE, TRAIT_RESISTLOWPRESSURE, TRAIT_RESISTDAMAGESLOWDOWN, TRAIT_STABLELIVER, TRAIT_STABLEHEART,
 	TRAIT_RADIMMUNE, TRAIT_LIMBATTACHMENT, TRAIT_NOBREATH, TRAIT_NODEATH, TRAIT_FAKEDEATH, TRAIT_NOHUNGER, TRAIT_RESISTHEAT, TRAIT_SHOCKIMMUNE, TRAIT_PUSHIMMUNE, TRAIT_STUNIMMUNE, TRAIT_BADDNA)
 	no_equip = list(SLOT_WEAR_MASK, SLOT_GLASSES, SLOT_HEAD)
 
@@ -110,13 +110,14 @@
 	brutemod = 1
 
 /datum/species/zombie/infectious/gamemode/juggernaut
+	mutanthands = /obj/item/zombie_hand/gamemode/tank
 	armor = 30 // 135 damage to KO a zombie, which kills it
-	brutemod = 0.8
-	speedmod = 1.75
-	heal_rate = 1.15
+	brutemod = 0.75
+	speedmod = 1.3
+	heal_rate = 1.20
 
 /datum/species/zombie/infectious/gamemode/spitter
-	armor = 10 // 110 damage to KO a zombie, which kills it
+	armor = 5 // 110 damage to KO a zombie, which kills it
 	brutemod = 1
 	burnmod = 1
 

--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -45,7 +45,7 @@
 			var/flesh_wound = ran_zone(user.zone_selected)
 			if(scaled_infect_chance)
 				var/mob/living/mob_target = target
-				var/total_damage = mob_target.get_damage_amount(BRUTE) + mob_target.get_damage_amount(BURN) + mob_target.get_damage_amount(TOX) + mob_target.get_damage_amount(OXY) + mob_target.get_damage_amount(CLONE)
+				var/total_damage = mob_target.get_damage_amount(BRUTE)
 
 				var/infect_modifier = (total_damage ** 2) / 100
 
@@ -110,7 +110,10 @@
 /obj/item/zombie_hand/gamemode/runner
 	force = 10
 	infect_chance = 35
-	door_open_modifier = 1.5
+	door_open_modifier = 1.1
+
+/obj/item/zombie_hand/gamemode/tank
+	door_open_modifier = 0.8
 
 /obj/item/zombie_hand/gamemode/necro
 	force = 7

--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -99,7 +99,7 @@
 	causes_damage = FALSE
 
 /obj/item/organ/zombie_infection/gamemode
-	damage_caused = 2.5
+	damage_caused = 3
 
 /obj/item/organ/zombie_infection/gamemode/zombify()
 	timer_id = null


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request
Makes zombies less shit. Can't die when organs fall out, ignores damage slow down to a certain degree
Ability cooldowns nerfed.

### Why is this change good for the game?

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
100 seconds to open welded door
80 to open bolted door
200 to open welded & bolted door

3 minute cooldown on adrenaline for runners
2.5 minute cooldown on tank
tier 2 time halved
Infect chance only based on brute damage now
Increase damage of being infected

### What should players be aware of when it comes to the changes your PR is implementing?

### What general grouping does this PR fall under? 
Zombie balancing

### Are there any aspects of the PR that you would like us not to mention on the Wiki?
no

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
see above

# Changelog

:cl:  
tweak: Tweaked zombie values, probably still dogshit, but less so now
/:cl:
