### PR TITLE
fix minor bug that would prevent people from getting the lavaland speed boost if they were inside something on z level transfer

### DIFF
--- a/yogstation/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/human_movement.dm
@@ -6,7 +6,7 @@
 
 /mob/living/carbon/human/update_move_intent_slowdown()
 	var/turf/T = get_turf(src)
-	if(!is_mining_level(T.z))
+	if(T && !is_mining_level(T.z))
 		return ..()
 
 	var/mod = 0

--- a/yogstation/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/human_movement.dm
@@ -5,7 +5,8 @@
 		update_movespeed()
 
 /mob/living/carbon/human/update_move_intent_slowdown()
-	if(!is_mining_level(z))
+	var/turf/T = get_turf(src)
+	if(!is_mining_level(T.z))
 		return ..()
 
 	var/mod = 0


### PR DESCRIPTION
:cl:  
bugfix: hiding in a locker will not prevent you from moving faster on lavaland
/:cl:
