### PR TITLE
[boring] Some mapping fixes from discord

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -5,6 +5,12 @@
 "b" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"c" = (
+/obj/machinery/vending/hydronutrients{
+	onstation = 0
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/seedvault)
 "d" = (
 /obj/structure/table/wood,
 /obj/item/lighter,
@@ -133,11 +139,9 @@
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "v" = (
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/plasteel/freezer,
-/area/ruin/powered/seedvault)
-"w" = (
-/obj/machinery/vending/hydroseeds,
+/obj/machinery/vending/hydroseeds{
+	onstation = 0
+	},
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "x" = (
@@ -436,7 +440,7 @@ h
 l
 h
 h
-v
+c
 h
 h
 B
@@ -480,7 +484,7 @@ h
 Q
 p
 h
-w
+v
 h
 h
 D

--- a/_maps/RandomRuins/StationRuins/maint/3x3/3x3_boxclutter5.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/3x3/3x3_boxclutter5.dmm
@@ -16,27 +16,22 @@
 /obj/item/stack/sheet/cardboard,
 /turf/open/floor/plating,
 /area/template_noop)
-"e" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/template_noop)
 "f" = (
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating,
 /area/template_noop)
-"i" = (
-/obj/structure/closet{
-	opened = 1
-	},
+"U" = (
+/obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/template_noop)
 
 (1,1,1) = {"
 a
 d
-e
+U
 "}
 (2,1,1) = {"
 b
@@ -45,6 +40,6 @@ b
 "}
 (3,1,1) = {"
 c
-i
+b
 f
 "}

--- a/_maps/RandomRuins/StationRuins/maint/3x3/3x3_pubbyclutter3.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/3x3/3x3_pubbyclutter3.dmm
@@ -24,13 +24,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/template_noop)
-"v" = (
-/obj/structure/closet{
-	opened = 1
-	},
+"B" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/item/kitchen/knife,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet,
 /turf/open/floor/plasteel,
 /area/template_noop)
 "N" = (
@@ -41,7 +39,7 @@
 
 (1,1,1) = {"
 a
-v
+b
 e
 "}
 (2,1,1) = {"
@@ -52,5 +50,5 @@ b
 (3,1,1) = {"
 b
 N
-b
+B
 "}

--- a/_maps/RandomRuins/StationRuins/maint/5x4/5x4_metarobotics.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/5x4/5x4_metarobotics.dmm
@@ -71,6 +71,10 @@
 	},
 /turf/open/floor/plating,
 /area/template_noop)
+"q" = (
+/obj/item/stack/sheet/metal/fifty,
+/turf/open/floor/plating,
+/area/template_noop)
 "C" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -79,21 +83,17 @@
 	},
 /turf/open/floor/plating,
 /area/template_noop)
+"N" = (
+/obj/item/extinguisher/mini,
+/turf/open/floor/circuit,
+/area/template_noop)
 "P" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/circuit,
 /area/template_noop)
-"T" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating,
-/area/template_noop)
 "X" = (
-/obj/structure/closet{
-	opened = 1
-	},
-/obj/item/extinguisher/mini,
+/obj/effect/decal/cleanable/blood/old,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plating,
 /area/template_noop)
 
@@ -106,13 +106,13 @@ j
 (2,1,1) = {"
 b
 P
-b
+N
 k
 "}
 (3,1,1) = {"
 c
-T
-c
+X
+q
 c
 "}
 (4,1,1) = {"
@@ -123,7 +123,7 @@ C
 "}
 (5,1,1) = {"
 e
-X
+c
 i
 n
 "}

--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -23002,20 +23002,6 @@
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/science/xenobiology)
-"bje" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 2;
-	external_pressure_bound = 120;
-	name = "server vent"
-	},
-/obj/machinery/camera{
-	c_tag = "Science - Server Room";
-	dir = 8;
-	name = "science camera";
-	network = list("ss13","rd")
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/science/xenobiology)
 "bjf" = (
 /obj/structure/dresser,
 /obj/structure/extinguisher_cabinet{
@@ -32685,6 +32671,19 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"kKr" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 2;
+	external_pressure_bound = 120;
+	name = "server vent"
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Kill Room";
+	dir = 8;
+	network = list("ss13","rd")
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/science/xenobiology)
 "kKQ" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/poddoor{
@@ -93265,7 +93264,7 @@ sKZ
 bfP
 bfP
 bfP
-bje
+kKr
 bjx
 bjI
 sKZ

--- a/_maps/shuttles/emergency_construction.dmm
+++ b/_maps/shuttles/emergency_construction.dmm
@@ -15,14 +15,8 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/escape)
 "d" = (
-/obj/structure/window/reinforced,
-/obj/structure/shuttle/engine/heater{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "e" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -40,10 +34,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"h" = (
-/obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "i" = (
@@ -187,37 +177,16 @@
 "p" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"q" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"r" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"s" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "t" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+/obj/structure/window/reinforced,
+/obj/structure/shuttle/engine/heater{
+	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "L" = (
 /obj/machinery/computer/emergency_shuttle{
@@ -225,23 +194,9 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"O" = (
+"X" = (
 /obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"W" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"Y" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 
@@ -250,7 +205,7 @@ a
 c
 e
 e
-W
+X
 e
 e
 g
@@ -258,7 +213,7 @@ e
 i
 e
 e
-W
+X
 e
 e
 g
@@ -275,7 +230,7 @@ a
 "}
 (2,1,1) = {"
 b
-d
+t
 f
 f
 f
@@ -303,7 +258,7 @@ a
 "}
 (3,1,1) = {"
 b
-d
+t
 f
 f
 f
@@ -352,14 +307,14 @@ f
 f
 e
 e
-W
-W
-q
+X
+X
+X
 a
 "}
 (5,1,1) = {"
 b
-d
+t
 f
 f
 f
@@ -382,11 +337,21 @@ f
 f
 f
 f
-h
-s
+X
+X
 "}
 (6,1,1) = {"
 b
+t
+f
+f
+f
+f
+f
+f
+f
+d
+d
 d
 f
 f
@@ -401,21 +366,11 @@ f
 f
 f
 f
-f
-f
-f
-f
-f
-f
-f
-f
-f
-f
-O
+X
 "}
 (7,1,1) = {"
 b
-d
+t
 f
 f
 f
@@ -439,7 +394,7 @@ f
 f
 f
 f
-O
+X
 "}
 (8,1,1) = {"
 c
@@ -467,11 +422,11 @@ f
 f
 f
 L
-O
+X
 "}
 (9,1,1) = {"
 b
-d
+t
 f
 f
 f
@@ -495,11 +450,11 @@ f
 f
 f
 f
-O
+X
 "}
 (10,1,1) = {"
 b
-d
+t
 f
 f
 f
@@ -523,35 +478,35 @@ f
 f
 f
 f
-O
+X
 "}
 (11,1,1) = {"
 b
-d
-f
-f
-f
-f
-f
-f
-f
-f
-f
-f
-f
-f
-f
-f
-f
-f
-f
-f
-f
-f
-f
-f
-h
 t
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+f
+X
+X
 "}
 (12,1,1) = {"
 c
@@ -576,14 +531,14 @@ f
 f
 e
 e
-Y
-Y
-r
+X
+X
+X
 a
 "}
 (13,1,1) = {"
 b
-d
+t
 f
 f
 f
@@ -611,7 +566,7 @@ a
 "}
 (14,1,1) = {"
 b
-d
+t
 f
 f
 f
@@ -642,19 +597,19 @@ a
 c
 e
 e
-Y
+X
 e
 e
 e
-Y
+X
 e
 e
 e
-Y
+X
 e
 e
 e
-Y
+X
 e
 e
 p

--- a/_maps/shuttles/emergency_construction_small.dmm
+++ b/_maps/shuttles/emergency_construction_small.dmm
@@ -22,13 +22,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"e" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "f" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty{
@@ -90,12 +83,16 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"j" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+"k" = (
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/structure/shuttle/engine/heater,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "l" = (
 /obj/machinery/door/airlock/titanium{
@@ -129,7 +126,16 @@
 "t" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
+"u" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "w" = (
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"z" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "B" = (
@@ -157,23 +163,8 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"F" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "M" = (
 /turf/closed/wall/mineral/titanium/interior,
-/area/shuttle/escape)
-"P" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/shuttle/engine/heater,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "Q" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
@@ -216,7 +207,7 @@ t
 d
 t
 t
-F
+z
 t
 t
 l
@@ -272,11 +263,11 @@ w
 w
 w
 w
-P
+k
 s
 "}
 (4,1,1) = {"
-e
+z
 w
 w
 w
@@ -286,6 +277,8 @@ w
 w
 w
 w
+u
+u
 w
 w
 w
@@ -294,13 +287,11 @@ w
 w
 w
 w
-w
-w
-P
+k
 s
 "}
 (5,1,1) = {"
-e
+z
 w
 w
 w
@@ -320,11 +311,11 @@ w
 w
 w
 w
-P
+k
 s
 "}
 (6,1,1) = {"
-e
+z
 Z
 w
 w
@@ -344,11 +335,11 @@ w
 w
 w
 w
-P
+k
 s
 "}
 (7,1,1) = {"
-e
+z
 w
 w
 w
@@ -368,11 +359,11 @@ w
 w
 w
 w
-P
+k
 s
 "}
 (8,1,1) = {"
-e
+z
 w
 w
 w
@@ -392,7 +383,7 @@ w
 w
 w
 w
-P
+k
 s
 "}
 (9,1,1) = {"
@@ -416,7 +407,7 @@ w
 w
 w
 w
-P
+k
 s
 "}
 (10,1,1) = {"
@@ -452,15 +443,15 @@ t
 t
 t
 t
-j
+z
 t
 t
 t
-j
+z
 t
 t
 t
-j
+z
 t
 t
 t

--- a/_maps/shuttles/whiteship_cere.dmm
+++ b/_maps/shuttles/whiteship_cere.dmm
@@ -5,29 +5,6 @@
 "ab" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned)
-"ac" = (
-/obj/machinery/door/airlock/titanium{
-	name = "mech bay external airlock"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/docking_port/mobile{
-	dheight = 0;
-	dir = 2;
-	dwidth = 8;
-	height = 16;
-	id = "whiteship";
-	launch_status = 0;
-	name = "NT Recovery White-Ship";
-	port_direction = 8;
-	preferred_direction = 1;
-	width = 16
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
 "ad" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 1
@@ -436,6 +413,29 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/abandoned)
+"cF" = (
+/obj/machinery/door/airlock/titanium{
+	name = "mech bay external airlock"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/docking_port/mobile{
+	dheight = 0;
+	dir = 2;
+	dwidth = 8;
+	height = 16;
+	id = "whiteship";
+	launch_status = 0;
+	name = "NT Recovery White-Ship";
+	port_direction = 8;
+	preferred_direction = 2;
+	width = 16
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
 "HL" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/firedoor/border_only,
@@ -551,7 +551,7 @@ aZ
 HL
 "}
 (7,1,1) = {"
-ac
+cF
 ah
 am
 am


### PR DESCRIPTION
### Intent of your Pull Request
Fixes #10749
Fixes https://github.com/yogstation13/Yogstation/issues/10140
Fixes lockers in maint being open but not really
Gives the diy shuttle some air canisters and better breach protection via window shutters
Lets the seed dudes from lavaland access their vendomats

# Wiki Documentation
Nope, unless you have screenshots of every shuttle in there, I just added cans

# Changelog

:cl:  
bugfix: fixes some minor mapping issues
tweak: byos has air cans 
/:cl:
