### PR TITLE
This PR should make acid delete itself correctly

### DIFF
--- a/code/game/objects/effects/alien_acid.dm
+++ b/code/game/objects/effects/alien_acid.dm
@@ -33,9 +33,13 @@
 
 /obj/effect/acid/process()
 	. = 1
+	if(acid_level <= 0)
+		qdel(src)
+		return FALSE
+
 	if(!target)
 		qdel(src)
-		return 0
+		return FALSE
 
 	if(prob(5))
 		playsound(loc, 'sound/items/welder.ogg', 100, 1)
@@ -48,9 +52,6 @@
 				acid_level = max(0, acid_level - acid_used*10)
 
 	acid_level = max(acid_level - (5 + 2*round(sqrt(acid_level))), 0)
-	if(acid_level <= 0)
-		qdel(src)
-		return 0
 
 /obj/effect/acid/Crossed(AM as mob|obj)
 	. = ..()


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Makes acid delete itself correctly

How does this work, I dont know. I made sure to emp the chem machine a billiontimes and it worked fine, splashed a full beaker of acid onto 100 powercells and it still worked fine

### Why is this change good for the game?

Bug fixes

# Changelog

:cl:  
bugfix: Acid should now self-delete
/:cl:
