### PR TITLE
Uplink items rebalancing

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -208,7 +208,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			standard contractor gear to help with your mission - comes supplied with the tablet, specialised space suit, chameleon jumpsuit and mask, \
 			agent card, specialised contractor baton, and three randomly selected low cost items. Can include otherwise unobtainable items."
 	item = /obj/item/storage/box/syndicate/contract_kit
-	cost = 20
+	cost = 18
 	player_minimum = 20
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 
@@ -506,7 +506,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A small, easily concealable handgun that uses 10mm auto rounds in 8-round magazines and is compatible \
 			with suppressors."
 	item = /obj/item/gun/ballistic/automatic/pistol
-	cost = 7
+	cost = 6
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 
 /datum/uplink_item/dangerous/bolt_action
@@ -522,7 +522,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/gun/ballistic/revolver
 	cost = 13
 	surplus = 50
-	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/dangerous/foamsmg
 	name = "Toy Submachine Gun"
@@ -613,7 +613,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	slur as if inebriated. It can produce an infinite number \
 	of bolts, but takes time to automatically recharge after each shot."
 	item = /obj/item/gun/energy/kinetic_accelerator/crossbow
-	cost = 10
+	cost = 11
 	surplus = 50
 	exclude_modes = list(/datum/game_mode/nuclear)
 
@@ -852,7 +852,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Box of Riot Darts"
 	desc = "A box of 40 Donksoft riot darts, for reloading any compatible foam dart magazine. Don't forget to share!"
 	item = /obj/item/ammo_box/foambox/riot
-	cost = 2
+	cost = 1
 	manufacturer = /datum/corporation/traitor/donkco
 	surplus = 0
 	illegal_tech = FALSE
@@ -1052,7 +1052,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "The minibomb is a grenade with a five-second fuse. Upon detonation, it will create a small hull breach \
 			in addition to dealing high amounts of damage to nearby personnel."
 	item = /obj/item/grenade/syndieminibomb
-	cost = 6
+	cost = 4
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 
 /datum/uplink_item/explosives/tearstache
@@ -1335,7 +1335,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			such as AI units and cyborgs, over their private binary channel. Caution should \
 			be taken while doing this, as unless they are allied with you, they are programmed to report such intrusions."
 	item = /obj/item/encryptionkey/binary
-	cost = 5
+	cost = 4
 	surplus = 75
 	restricted = TRUE
 
@@ -1346,7 +1346,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			'Advanced Magboots' slow you down in simulated-gravity environments much like the standard issue variety."
 	item = /obj/item/clothing/shoes/magboots/syndie
 	cost = 2
-	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 
 /datum/uplink_item/device_tools/briefcase_launchpad
 	name = "Briefcase Launchpad"
@@ -1479,7 +1478,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			load on the grid, causing a station-wide blackout. The sink is large and cannot be stored in most \
 			traditional bags and boxes. Caution: Will explode if the powernet contains sufficient amounts of energy."
 	item = /obj/item/powersink
-	cost = 10
+	cost = 8
 	manufacturer = /datum/corporation/traitor/waffleco
 
 /datum/uplink_item/device_tools/rad_laser
@@ -1489,7 +1488,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			of humanoids. It has two settings: intensity, which controls the power of the radiation, \
 			and wavelength, which controls the delay before the effect kicks in."
 	item = /obj/item/healthanalyzer/rad_laser
-	cost = 3
+	cost = 4
 	manufacturer = /datum/corporation/traitor/donkco
 
 /datum/uplink_item/device_tools/stimpack
@@ -1761,6 +1760,15 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	restricted_roles = list("Clown")
 	surplus = 0 //No fun unless you're the clown!
 
+/datum/uplink_item/support/honker
+	name = "Dark H.O.N.K."
+	desc = "A clown combat mech equipped with bombanana peel and tearstache grenade launchers, as well as the ubiquitous HoNkER BlAsT 5000."
+	item = /obj/mecha/combat/honker/dark/loaded
+	cost = 35
+	restricted_roles = list("Clown")
+	manufacturer = /datum/corporation/traitor/waffleco
+	surplus = 0
+
 /datum/uplink_item/role_restricted/arm_medical_gun
 	name = "Arm Mounted Medical Beamgun"
 	desc = "An arm mounted medical beamgun to heal your best buds (disclaimer: does not come with friends)."
@@ -1814,7 +1822,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			transported to you that will teleport the actual bomb to it upon activation. Note that this bomb can \
 			be defused, and some crew may attempt to do so."
 	item = /obj/item/sbeacondrop/clownbomb
-	cost = 15
+	cost = 7
 	manufacturer = /datum/corporation/traitor/waffleco
 	restricted_roles = list("Clown")
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -398,7 +398,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/twohanded/dualsaber
 	player_minimum = 25
 	cost = 16
-	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/dangerous/doublesword/get_discount()
 	return pick(4;0.8,2;0.65,1;0.5)
@@ -1447,7 +1447,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A wonder of Syndicate engineering, the Medbeam gun, or Medi-Gun enables a medic to keep his fellow \
 			operatives in the fight, even while under fire. Don't cross the streams!"
 	item = /obj/item/gun/medbeam
-	cost = 15
+	cost = 8
 	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 
 /datum/uplink_item/device_tools/singularity_beacon

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -208,7 +208,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			standard contractor gear to help with your mission - comes supplied with the tablet, specialised space suit, chameleon jumpsuit and mask, \
 			agent card, specialised contractor baton, and three randomly selected low cost items. Can include otherwise unobtainable items."
 	item = /obj/item/storage/box/syndicate/contract_kit
-	cost = 18
+	cost = 20
 	player_minimum = 20
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 
@@ -548,7 +548,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "An innocent-looking toy pistol designed to fire foam darts. Comes loaded with riot-grade \
 			darts effective at incapacitating a target."
 	item = /obj/item/gun/ballistic/automatic/toy/pistol/riot
-	cost = 2
+	cost = 1
 	manufacturer = /datum/corporation/traitor/donkco
 	surplus = 10
 
@@ -1052,7 +1052,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "The minibomb is a grenade with a five-second fuse. Upon detonation, it will create a small hull breach \
 			in addition to dealing high amounts of damage to nearby personnel."
 	item = /obj/item/grenade/syndieminibomb
-	cost = 4
+	cost = 6
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 
 /datum/uplink_item/explosives/tearstache
@@ -1335,7 +1335,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			such as AI units and cyborgs, over their private binary channel. Caution should \
 			be taken while doing this, as unless they are allied with you, they are programmed to report such intrusions."
 	item = /obj/item/encryptionkey/binary
-	cost = 4
+	cost = 2
 	surplus = 75
 	restricted = TRUE
 


### PR DESCRIPTION
# Full list of changes

### Contract Kit
#### Adjustment undone, will instead be buffed in future PR
##
### Stechkin Pistol
Price decreased 7 -> 6
#### The stechkin is a powerful and cool tool, but it just doesn't have enough kick to justify its 7TC price, only being slightly stronger than a typical WT rifle, for instance. With this as well, the suppressor + stechkin combo sits at 9TC. Players should also now be more comfortable purchasing of the fancy ammo types, mixing up gameplay a bit.
##
### Syndicate Revolver
Limited to Nuclear Operatives only
#### A backpack slug shotgun seems way too powerful for a lone traitor, and this is generally just unhealthy for the game, heavily limiting potential gimmick loadouts with its absurd price in favor of big schüt 2 hit crit gun. Hopefully it sees a better place in nukies.
##
### Miniature Energy Crossbow
Price increased 10 -> 11
#### The ebow is very powerful, justified by its heavy hitting price. However, when you have two ebows, you become this unstoppable monster, cutting the recharge timer in half. Considered stealing PKA code to just make them similar, but the price increase seems good enough and might disappoint players investing together or striking a nice discount.
##
### Toy Pistol with Riot Darts
Price decreased 2 -> 1
### Box of Riot Darts
Price decreased 2 -> 1
#### Doesn't need much explanation. You can print this at an autolathe, and riot darts are not necessarily very strong. I don't think I've ever seen anyone buy the riot dart pistol. Worse disabler at best.
##
### Syndicate Minibomb
#### Adjustment undone. Portable gibber is pretty strong, turns out.
##
### Binary Translator Key
Price decreased 5 -> 2
#### Useful, but heavily underused. 5TC is a big price for one radio channel. 2TC keeps silicons relatively secure in their metacomm chat but I'm hoping with this it will be used more, especially when subverting AI.
##
### Power Sink
Price decreased 10 -> 8
#### A decent sabotage tool, even better if paired with some smart wire cutting, but ultimately not powerful enough to justify a 10TC price. Offensively, it turns your crowbar into an AA tool and shuts off the lights for a bit.
##
### Radioactive Microlaser
Price increased 3 -> 4
#### A completely silent, metashielded sleep tool. Very powerful in the right situation and due to its metashield can usually be used repeatedly and the target and everyone surrounding will not know a damn thing going on if you aren't incredibly obvious about it. 3 to 4TC should do it justice.
##
### Dark H.O.N.K.
Allowed for clowns to buy at 35TC
#### If a clown convinces someone to pile TC with him he deserves it. It's most powerful tools are an AoE stun and the punch glove. Designed for crowd control, could be pretty powerful among some coordinated traitors, but otherwise will just be pretty funny (and incredibly annoying for the crew).
##
### Clown Bomb
Price decreased 15 -> 7
#### Summons neutral mob clowns. Not deserving of such a high price, being able to buy two is by no means game breaking, but will make the clown bomb a more relevant (and funny) item for purchase.
##
### Blood-Red Magboots
Allowed for traitors to buy
#### Functioning basically as regular magboots, I don't really see a reason for traitors not to be able to buy this in a pinch if they really want/need to.
##
### Double-Bladed Energy Sword
Limited to Nuclear Operatives only
#### Similar to the revolver, not balanced or reasonable for traitors to have in a typical round.
##
### Medbeam Gun
Price decreased 15 -> 8
#### Takes 26 seconds roughly to heal someone from 50 brute damage to full, takes up a hand slot, really not worth it, especially considering the traitor equivalent that puts it in an implant in your arm is only 8TC.
##
# Changelog

:cl:  
tweak: Stechkin Pistol price decreased 7 -> 6
tweak: Syndicate Revolver limited to Nuclear Operatives only
tweak: Miniature Energy Crossbow price increased 10 -> 11
tweak: Toy Pistol with Riot Darts price decreased 2 -> 1
tweak: Box of Riot Darts price decreased 2 -> 1
tweak: Binary Translator Key price decreased 5 -> 2
tweak: Power Sink price decreased 10 -> 8
tweak: Radioactive Microlaser price increased 3 -> 4
tweak: Dark H.O.N.K. allowed for clowns to buy at 35TC
tweak: Clown Bomb price decreased 15 -> 7
tweak: Blood-Red Magboots allowed for traitors to buy
tweak: Double-Bladed Energy Sword limited to Nuclear Operatives only
tweak: Medbeam Gun price decreased 15 -> 8
/:cl:
