### PR TITLE
Lowers Rat Kebab Nutriment to 3 and Vitamin to 1 (Double Rat Kebab will have actual double values) and makes Double Rat Kebabs meat | gross.

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -43,7 +43,7 @@
 	desc = "Not so delicious rat meat, on a stick."
 	icon_state = "ratkebab"
 	w_class = WEIGHT_CLASS_NORMAL
-	list_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/vitamin = 2)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 1)
 	tastes = list("rat meat" = 1, "metal" = 1)
 	foodtype = MEAT | GROSS
 
@@ -52,6 +52,7 @@
 	icon_state = "doubleratkebab"
 	tastes = list("rat meat" = 2, "metal" = 1)
 	bonus_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/vitamin = 2)
+	foodtype = MEAT | GROSS
 
 ////////////////////////////////////////////FISH////////////////////////////////////////////
 


### PR DESCRIPTION
# Intent of your Pull Request

Lowers Rat Kebab Nutriment to 3 and Vitamin to 1 (Double Rat Kebab nutriment is kept at 6 and vitamin is kept at 2, making actual double values).

Double Rat Kebab now as Meat|Gross foodtype.

# Why is this change good for the game?

This change is being done for the sake of consistency, the Rat Kebab is now in line with the Rat Burger, which similarly uses 1 rat and has 3 Nutriment along with 1 Vitamin.

Moreover the Double Rat Kebab actually has twice the nutriment and vitamin, making the effort going to finding those oh so rare and elusive rats worthwhile.

# Wiki Documentation

The Rat Kebab entry in https://wiki.yogstation.net/wiki/Guide_to_food should be edited to reflect these changes should (and by god they should) be merged. 
![cpng](https://user-images.githubusercontent.com/62276730/103972017-12c84580-513a-11eb-947f-6226cbbe8a87.png)
who the hell typed that in without stopping to say, "hmm, what the fuck?"

### Changelog

:cl:  
rscadd: Adds Gross and Meat food type to Double Rat Kebab.
tweak: Tweaks rat kebab nutriment and vitamin values to 3 and 1 respectively.    
/:cl:
