### PR TITLE
Dual Toy-Eswords no longer inhert DESword damage

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -354,6 +354,7 @@
 	name = "double-bladed toy sword"
 	desc = "A cheap, plastic replica of TWO energy swords.  Double the fun!"
 	force = 0
+	force_wielded = 0 // Why did someone make this a subtype of dualsabers
 	throwforce = 0
 	throw_speed = 3
 	throw_range = 5


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Who changes subtypes?

### Why is this change good for the game?

Easily gettable desword damage is not ok

# Changelog

:cl:  
bugfix: Toy Deswords nolonger have the power of a desword
/:cl:
