### PR TITLE
cant accidentally stab people with scalpels except this time I didn't mess up

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -71,6 +71,10 @@
 	if(force && HAS_TRAIT(user, TRAIT_PACIFISM))
 		to_chat(user, "<span class='warning'>You don't want to harm other living beings!</span>")
 		return
+	
+	if((item_flags & SURGICAL_TOOL) && (user.a_intent != INTENT_HARM)) // checks for if harm intent with surgery tool
+		to_chat(user, "<span class='warning'>You aren't doing surgery!</span>") //yells at you
+		return
 
 	if(!force)
 		playsound(loc, 'sound/weapons/tap.ogg', get_clamped_volume(), 1, -1)


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request
Repost of #10826 except I didn't mess up and panic and break my branch.

Somebody told me to do something minor to start off becoming a pro yogstation coder, so I tried that.

This prevents any surgical tools from harming people while not on HARM intent.
I tested this, it works, it doesn't mess up surgery, and you can still hit yourself with other things while off harm intent if you want. (only tried this with the medical wrench but it should only affect things tagged as surgery items)

### Why is this change good for the game?
Not sure if this is a common problem but I kept stabbing people with scalpels because I forget not all of the clothing items are off so I made this to prevent that.
# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
This is a very minor change I don't see why it needs to be on the wiki

### What should players be aware of when it comes to the changes your PR is implementing?

### What general grouping does this PR fall under? 
For example, Engineering changes, Medical rebalancing, TEG tweaks, etc.?
Quality of life?
### Are there any aspects of the PR that you would like us not to mention on the Wiki?

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
For example, "This new chem will heal X brute damage". 
no values
# Changelog

:cl:  
rscadd: you can no longer accidentally stab somebody because you don't look to see if the drapes placed correctly.
/:cl:
