### PR TITLE
fixes tend wounds being stupidly ineffective in some scenarios by making the bonus healing from damage only apply to the type of damages being healed

### DIFF
--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -58,11 +58,11 @@
 	var/urhealedamt_burn = burnhealing
 	if(missinghpbonus)
 		if(target.stat != DEAD)
-			urhealedamt_brute += round((target.getBruteLoss()/ missinghpbonus),0.1)
-			urhealedamt_burn += round((target.getFireLoss()/ missinghpbonus),0.1)
+			urhealedamt_brute += brutehealing ? round((target.getBruteLoss()/ missinghpbonus,0.1) : 0
+			urhealedamt_burn += burnhealing ? round((target.getFireLoss()/ missinghpbonus),0.1) : 0
 		else //less healing bonus for the dead since they're expected to have lots of damage to begin with (to make TW into defib not TOO simple)
-			urhealedamt_brute += round((target.getBruteLoss()/ (missinghpbonus*5)),0.1)
-			urhealedamt_burn += round((target.getFireLoss()/ (missinghpbonus*5)),0.1)
+			urhealedamt_brute += brutehealing ? round((target.getBruteLoss()/ (missinghpbonus*5)),0.1) : 0
+			urhealedamt_burn += burnhealing ? round((target.getFireLoss()/ (missinghpbonus*5)),0.1) : 0
 	if(!get_location_accessible(target, target_zone))
 		urhealedamt_brute *= 0.55
 		urhealedamt_burn *= 0.55

--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -58,7 +58,7 @@
 	var/urhealedamt_burn = burnhealing
 	if(missinghpbonus)
 		if(target.stat != DEAD)
-			urhealedamt_brute += brutehealing ? round((target.getBruteLoss()/ missinghpbonus,0.1) : 0
+			urhealedamt_brute += brutehealing ? round((target.getBruteLoss()/ missinghpbonus),0.1) : 0
 			urhealedamt_burn += burnhealing ? round((target.getFireLoss()/ missinghpbonus),0.1) : 0
 		else //less healing bonus for the dead since they're expected to have lots of damage to begin with (to make TW into defib not TOO simple)
 			urhealedamt_brute += brutehealing ? round((target.getBruteLoss()/ (missinghpbonus*5)),0.1) : 0


### PR DESCRIPTION
The surgery could select a bodypart with the 1 singular point of brute damage on the body and nothing else and choose to heal that when doing BURN tend wounds allowing it to heal ONLY 0.1 BRUTE damage
:cl:  
bugfix: tend wounds will now work better
/:cl:
