### PR TITLE
Lowers Rat Kebab Nutriment to 3 and Vitamin to 1, as is inline with the Rat Burger. Fixes double rat kebab bonus values.

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -43,7 +43,7 @@
 	desc = "Not so delicious rat meat, on a stick."
 	icon_state = "ratkebab"
 	w_class = WEIGHT_CLASS_NORMAL
-	list_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/vitamin = 2)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/consumable/nutriment/vitamin = 1)
 	tastes = list("rat meat" = 1, "metal" = 1)
 	foodtype = MEAT | GROSS
 
@@ -51,7 +51,7 @@
 	name = "double rat kebab"
 	icon_state = "doubleratkebab"
 	tastes = list("rat meat" = 2, "metal" = 1)
-	bonus_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/vitamin = 2)
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/consumable/nutriment/vitamin = 1)
 
 ////////////////////////////////////////////FISH////////////////////////////////////////////
 


### PR DESCRIPTION
# Intent of your Pull Request

Do #10829 right. For more detailed description see #10829 

# Why is this change good for the game?

Rat kebab will now have correct Nutriment and Vitamin values and the double rat kebab will have proper bonus values as a result. This is now inline with the rat burger.

## Wiki Documentation

Change the nutritional value for Rat Kebab and Double Rat Kebab to the new ones.

# Changelog

:cl:  
tweak: Rat kebab and double rat kebab nutriment values  
/:cl:
