### PR TITLE
Human Species Subtypes are nolonger immune to viruses

### DIFF
--- a/code/datums/diseases/_MobProcs.dm
+++ b/code/datums/diseases/_MobProcs.dm
@@ -22,7 +22,13 @@
 	if(!can_infect)
 		return FALSE
 
-	if(!(type in D.viable_mobtypes))
+	can_infect = FALSE // var reuse
+	for(var/viable_types in D.viable_mobtypes)
+		if(typesof(src,viable_types))
+			can_infect = TRUE
+			break
+
+	if(!can_infect)
 		return FALSE
 
 	return TRUE


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

🦀 

when byonds `type` only looks for exactly that type no subtypes

Fixes: https://github.com/yogstation13/Yogstation/issues/6853

### Why is this change good for the game?

NGL this is a really bad bug

# Changelog

:cl:  
bugfix: Human Species Subtypes are nolonger immune to viruses
/:cl:
