### PR TITLE
makes synthfesh heal burn husks when they are under 50 damage and there is over 100 units of synthflesh present

### DIFF
--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -29,3 +29,7 @@
 #define REM_REAGENT		3	// reagent removed (may still exist)
 
 #define MIMEDRINK_SILENCE_DURATION 30  //ends up being 60 seconds given 1 tick every 2 seconds
+///Health threshold for synthflesh and rezadone to unhusk someone
+#define UNHUSK_DAMAGE_THRESHOLD 50
+///Amount of synthflesh required to unhusk someone
+#define SYNTHFLESH_UNHUSK_AMOUNT 100

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -527,7 +527,7 @@
 	update_stat()
 	update_mobility()
 	if(((maxHealth - total_burn) < HEALTH_THRESHOLD_DEAD) && stat == DEAD )
-		become_husk("burn")
+		become_husk(BURN)
 	med_hud_set_health()
 	if(stat == SOFT_CRIT)
 		add_movespeed_modifier(MOVESPEED_ID_CARBON_SOFTCRIT, TRUE, multiplicative_slowdown = SOFTCRIT_ADD_SLOWDOWN)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -405,7 +405,7 @@
 				if(method == TOUCH)
 					M.reagents.add_reagent(/datum/reagent/medicine/synthflesh, reac_volume)
 				if(HAS_TRAIT_FROM(M, TRAIT_HUSK, BURN) && (S?.volume + reac_volume >= SYNTHFLESH_UNHUSK_AMOUNT && M.getFireLoss <= UNHUSK_DAMAGE_THRESHOLD) && M.cure_husk(BURN)) //cure husk will return true if it cures the final husking source
-					visible_message("<span class='notice'>The synthflesh soaks into [M]'s burns and their skin regains its natural color!</span>")
+					visible_message("<span class='notice'>The synthflesh soaks into [M]'s burns and they regain their natural color!</span>")
 	..()
 
 /datum/reagent/medicine/charcoal

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -394,16 +394,18 @@
 		if (M.stat == DEAD)
 			can_heal = TRUE
 		if((method in list(PATCH, TOUCH)) && can_heal)
+			var/datum/reagent/S = M.reagents.get_reagent(/datum/reagent/medicine/synthflesh)
 			if(!ishuman(M))
 				M.adjustBruteLoss(-1.25 * reac_volume)
 				M.adjustFireLoss(-1.25 * reac_volume)
 			else
-				var/datum/reagent/S = M.reagents.get_reagent(/datum/reagent/medicine/synthflesh)
 				var/heal_amt = clamp(reac_volume, 0, 60 - S?.volume)
 				M.adjustBruteLoss(-2*heal_amt)
 				M.adjustFireLoss(-2*heal_amt)
 				if(method == TOUCH)
 					M.reagents.add_reagent(/datum/reagent/medicine/synthflesh, reac_volume)
+				if(HAS_TRAIT_FROM(M, TRAIT_HUSK, BURN) && (S?.volume + reac_volume >= SYNTHFLESH_UNHUSK_AMOUNT && M.getFireLoss <= UNHUSK_DAMAGE_THRESHOLD) && M.cure_husk(BURN)) //cure husk will return true if it cures the final husking source
+					visible_message("<span class='notice'>The synthflesh soaks into [M]'s burns and their skin regains its natural color!</span>")
 	..()
 
 /datum/reagent/medicine/charcoal

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -404,8 +404,8 @@
 				M.adjustFireLoss(-2*heal_amt)
 				if(method == TOUCH)
 					M.reagents.add_reagent(/datum/reagent/medicine/synthflesh, reac_volume)
-				if(HAS_TRAIT_FROM(M, TRAIT_HUSK, BURN) && (S?.volume + reac_volume >= SYNTHFLESH_UNHUSK_AMOUNT && M.getFireLoss <= UNHUSK_DAMAGE_THRESHOLD) && M.cure_husk(BURN)) //cure husk will return true if it cures the final husking source
-					visible_message("<span class='notice'>The synthflesh soaks into [M]'s burns and they regain their natural color!</span>")
+				if(HAS_TRAIT_FROM(M, TRAIT_HUSK, BURN) && (S?.volume + reac_volume >= SYNTHFLESH_UNHUSK_AMOUNT && M.getFireLoss() <= UNHUSK_DAMAGE_THRESHOLD) && M.cure_husk(BURN)) //cure husk will return true if it cures the final husking source
+					M.visible_message("<span class='notice'>The synthflesh soaks into [M]'s burns and they regain their natural color!</span>")
 	..()
 
 /datum/reagent/medicine/charcoal


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

make synthflesh more viable by giving it more utility
also needing a high tier surgery to just unhusk someone is a pain in the ass

### Why is this change good for the game?
make medbay less pain and less reliant on clooning
# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
synthflesh can now heal burn husks specifically if the total volume reaches 100 while  burn damage is under 50

### What should players be aware of when it comes to the changes your PR is implementing?
synthflesh can now unhusk people if the husking is solely from burns
### What general grouping does this PR fall under? 
medbay

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
Synthflesh will unhusk burn-related husk corpses when:
the corpse has less than 50 burn damage
synthflesh is dosed to at least 100 units
unhusking will ONLY occur on synthflesh being applied so make sure to do that part first

# Changelog

:cl:  
tweak: synthflesh will now heal burn husks if their burn damage is under 50 and the total amount of synthflesh dosed reaches 100
/:cl:
