### PR TITLE
Airlocks now tell you if that mineral airlock doesnt exist and doesnt use the sheets

### DIFF
--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -205,6 +205,10 @@
 					if(!mineral)
 						if(istype(G, /obj/item/stack/sheet/mineral) && G.sheettype)
 							var/M = G.sheettype
+							var/mineralassembly = text2path("/obj/structure/door_assembly/door_assembly_[M]")
+							if(!mineralassembly)
+								to_chat(user, "<span class='notice'>Nanotrasen has not provisined a door with [G.name] plating in it.</span>")
+								return FALSE
 							if(G.get_amount() >= 2)
 								playsound(src, 'sound/items/crowbar.ogg', 100, 1)
 								user.visible_message("[user] adds [G.name] to the airlock assembly.", \
@@ -214,10 +218,8 @@
 										return
 									to_chat(user, "<span class='notice'>You install [M] plating into the airlock assembly.</span>")
 									G.use(2)
-									var/mineralassembly = text2path("/obj/structure/door_assembly/door_assembly_[M]")
-									if(mineralassembly)
-										var/obj/structure/door_assembly/MA = new mineralassembly(loc)
-										transfer_assembly_vars(src, MA, TRUE)
+									var/obj/structure/door_assembly/MA = new mineralassembly(loc)
+									transfer_assembly_vars(src, MA, TRUE)
 							else
 								to_chat(user, "<span class='warning'>You need at least two sheets add a mineral cover!</span>")
 					else

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -215,8 +215,9 @@
 									to_chat(user, "<span class='notice'>You install [M] plating into the airlock assembly.</span>")
 									G.use(2)
 									var/mineralassembly = text2path("/obj/structure/door_assembly/door_assembly_[M]")
-									var/obj/structure/door_assembly/MA = new mineralassembly(loc)
-									transfer_assembly_vars(src, MA, TRUE)
+									if(mineralassembly)
+										var/obj/structure/door_assembly/MA = new mineralassembly(loc)
+										transfer_assembly_vars(src, MA, TRUE)
 							else
 								to_chat(user, "<span class='warning'>You need at least two sheets add a mineral cover!</span>")
 					else


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Adds a check to see if the mineral is a valid type and if not return without actually doing anything

### Why is this change good for the game?

Doesnt use your materials

# Changelog

:cl:  
bugfix: Airlocks now wont use invalid materials
/:cl:
