### PR TITLE
Adds a new bullet component PENETRATE

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -217,7 +217,13 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 #define DAMAGE_PRECISION 0.1
 
 //bullet_act() return values
+/// It's a successful hit, whatever that means in the context of the thing it's hitting.
 #define BULLET_ACT_HIT				"HIT"		//It's a successful hit, whatever that means in the context of the thing it's hitting.
-#define BULLET_ACT_BLOCK			"BLOCK"		//It's a blocked hit, whatever that means in the context of the thing it's hitting.
-#define BULLET_ACT_FORCE_PIERCE		"PIERCE"	//It pierces through the object regardless of the bullet being piercing by default.
-#define BULLET_ACT_TURF				"TURF"		//It hit us but it should hit something on the same turf too. Usually used for turfs.
+/// It's a blocked hit, whatever that means in the context of the thing it's hitting.
+#define BULLET_ACT_BLOCK			"BLOCK"
+/// It pierces through the object regardless of the bullet being piercing by default.
+#define BULLET_ACT_FORCE_PIERCE		"PIERCE"
+/// It hit us but it should hit something on the same turf too. Usually used for turfs.
+#define BULLET_ACT_TURF				"TURF"
+/// It hit something, but it should just keep going until it hit something else, basically over-penetration
+#define BULLET_ACT_PHASE			"PHASE"

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -225,5 +225,5 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 #define BULLET_ACT_FORCE_PIERCE		"PIERCE"
 /// It hit us but it should hit something on the same turf too. Usually used for turfs.
 #define BULLET_ACT_TURF				"TURF"
-/// It hit something, but it should just keep going until it hit something else, basically over-penetration
-#define BULLET_ACT_PHASE			"PHASE"
+/// It hit something, but it should just keep going until it hit something else
+#define BULLET_ACT_PENETRATE		"PENETRATE"

--- a/code/game/objects/items/shooting_range.dm
+++ b/code/game/objects/items/shooting_range.dm
@@ -90,7 +90,7 @@
 			bullet_hole.icon_state = "dent"
 		add_overlay(bullet_hole)
 		return BULLET_ACT_HIT
-	return BULLET_ACT_FORCE_PIERCE
+	return BULLET_ACT_PHASE // Prevents a unholy exploit where they would just go through walls
 
 #undef DECALTYPE_SCORCH
 #undef DECALTYPE_BULLET

--- a/code/game/objects/items/shooting_range.dm
+++ b/code/game/objects/items/shooting_range.dm
@@ -90,7 +90,7 @@
 			bullet_hole.icon_state = "dent"
 		add_overlay(bullet_hole)
 		return BULLET_ACT_HIT
-	return BULLET_ACT_PHASE // Prevents a unholy exploit where they would just go through walls
+	return BULLET_ACT_PENETRATE // Prevents a unholy exploit where they would just go through walls
 
 #undef DECALTYPE_SCORCH
 #undef DECALTYPE_BULLET

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -280,7 +280,7 @@
 			temporary_unstoppable_movement = TRUE
 			ENABLE_BITFIELD(movement_type, UNSTOPPABLE)
 		return process_hit(T, select_target(T), qdel_self, TRUE)		//Hit whatever else we can since we're piercing through but we're still on the same tile.
-	else if(result == BULLET_ACT_PHASE) // This is slightly different from ACT_TURF in that it goes through the first thing
+	else if(result == BULLET_ACT_PENETRATE) // This is slightly different from ACT_TURF in that it goes through the first thing
 		return process_hit(T, select_target(T), qdel_self, TRUE)
 	else if(result == BULLET_ACT_TURF)									//We hit the turf but instead we're going to also hit something else on it.
 		return process_hit(T, select_target(T), QDEL_SELF, TRUE)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -280,6 +280,8 @@
 			temporary_unstoppable_movement = TRUE
 			ENABLE_BITFIELD(movement_type, UNSTOPPABLE)
 		return process_hit(T, select_target(T), qdel_self, TRUE)		//Hit whatever else we can since we're piercing through but we're still on the same tile.
+	else if(result == BULLET_ACT_PHASE) // This is slightly different from ACT_TURF in that it goes through the first thing
+		return process_hit(T, select_target(T), qdel_self, TRUE)
 	else if(result == BULLET_ACT_TURF)									//We hit the turf but instead we're going to also hit something else on it.
 		return process_hit(T, select_target(T), QDEL_SELF, TRUE)
 	else		//Whether it hit or blocked, we're done!


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Adds BULLET_ACT_PENETRATE which allows over penetration but not going through everything

_Tested thoroughly_

### Why is this change good for the game?

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
You can nolonger have xray bullets
You can have cooler weapon effects ig

### What should players be aware of when it comes to the changes your PR is implementing?
It can allow guns to go though an object and hit something behind it

### What general grouping does this PR fall under? 
Bullet Code changes

# Changelog

:cl:  
rscadd: Add a new bullet component PENETRATE
bugfix: Bullets are nolonger xray if they hit a practice target
/:cl:
