### PR TITLE
mutagen now only mutates people in doses of 5 units or more

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -36,7 +36,7 @@
 		return
 	if(!M.has_dna() || HAS_TRAIT(M, TRAIT_GENELESS) || HAS_TRAIT(M, TRAIT_BADDNA))
 		return  //No robots, AIs, aliens, Ians or other mobs should be affected by this.
-	if((method==VAPOR && prob(min(33, reac_volume))) || method==INGEST || method==PATCH || method==INJECT)
+	if((method==VAPOR && prob(min(33, reac_volume))) || ((method==INGEST || method==PATCH || method==INJECT) && reac_volume >= 5))
 		M.randmuti()
 		if(prob(98))
 			M.easy_randmut(NEGATIVE+MINOR_NEGATIVE)


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

mutagen now causes mutations only when dosed in 5 unit quantities unless applied via vapor which already rolls a chance up to 33% based on volume

### Why is this change good for the game?
currently any amount of mutagen being injected will roll for almost exclusively shit mutations to activate meaning you can shove 0.1 units into something and cause someone to catch cancer
# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
mutagen now only mutates people when taken in a dose of 5 units or more

### What should players be aware of when it comes to the changes your PR is implementing?
no more 0.1 mutagen in deathmixes to cause cancer
### What general grouping does this PR fall under? 
chemistry

# Changelog

:cl:  
tweak: mutagen will now only mutate people if ingested in a dose of 5 units or more
/:cl:
