### PR TITLE
Adds 2 new steal objectives: The Champion's Belt and Lamarr

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -82,6 +82,12 @@
 	targetitem = /obj/item/clothing/suit/armor/laserproof
 	difficulty = 3
 	excludefromjob = list("Head of Security", "Warden")
+	
+/datum/objective_item/steal/champion
+	name = "the championship belt."
+	targetitem = /obj/item/storage/belt/champion
+	difficulty = 5
+	excludefromjob = list("Quartermaster", "Head of Personnel")
 
 /datum/objective_item/steal/reactive
 	name = "the reactive teleport armor."

--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -88,6 +88,12 @@
 	targetitem = /obj/item/storage/belt/champion
 	difficulty = 5
 	excludefromjob = list("Quartermaster", "Head of Personnel")
+	
+/datum/objective_item/steal/lamarr
+	name = "Lamarr, the Research Director's facehugger."
+	targetitem = /obj/item/clothing/mask/facehugger/lamarr
+	difficulty = 5
+	excludefromjob = list("Research Director")
 
 /datum/objective_item/steal/reactive
 	name = "the reactive teleport armor."


### PR DESCRIPTION
Two new steal objectives: steal the Champion's belt from the vault and Lamarr from the RD's office (the facehugger)


### Why is this change good for the game?

More variety for antag steal objectives

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 

This PR literally just adds two new objectives: steal the vault gold belt and Lamarr the facehugger

### What should players be aware of when it comes to the changes your PR is implementing?

They are new steal objectives

### What general grouping does this PR fall under? 

Antag tweaking - new objectives

### Are there any aspects of the PR that you would like us not to mention on the Wiki?

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here.

Filling out 50 sections on a PR sucks 

# Changelog


:cl:  
rscadd: Adds two new steal objectives: champion's belt and lamarr
/:cl:
