### PR TITLE
report healthy organs on health scanner

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -292,7 +292,7 @@ GENE SCANNER
 				else
 					minor_damage = "\t<span class='info'>Mildly Damaged Organs: "
 					minor_damage += organ.name
-			else if (organ.damage < organ.low_threshold)
+			else if ((organ.damage < organ.low_threshold) && (organ.name != "black tumor" || "festering ooze"))
 				report_organs = TRUE // if no organs get reported, it means they have no organs
 				if(no_damage)
 					no_damage += ", "

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -259,6 +259,7 @@ GENE SCANNER
 	//Organ damages report
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
+		var/no_damage
 		var/minor_damage
 		var/major_damage
 		var/max_damage
@@ -291,6 +292,14 @@ GENE SCANNER
 				else
 					minor_damage = "\t<span class='info'>Mildly Damaged Organs: "
 					minor_damage += organ.name
+			else if (organ.damage < organ.low_threshold)
+				report_organs = TRUE // if no organs get reported, it means they have no organs
+				if(no_damage)
+					no_damage += ", "
+					no_damage += organ.name
+				else
+					no_damage = "\t<span class='info'>Healthy Organs: "
+					no_damage += organ.name
 
 		if(report_organs)	//we either finish the list, or set it to be empty if no organs were reported in that category
 			if(!max_damage)
@@ -305,6 +314,11 @@ GENE SCANNER
 				minor_damage = "\t<span class='info'>Mildly Damaged Organs: </span>"
 			else
 				minor_damage += "</span>"
+			if(!no_damage)
+				no_damage = "\t<span class='info'>Healthy Organs: </span>"
+			else
+				no_damage += "</span>"
+			to_chat(user, no_damage)
 			to_chat(user, minor_damage)
 			to_chat(user, major_damage)
 			to_chat(user, max_damage)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -292,7 +292,7 @@ GENE SCANNER
 				else
 					minor_damage = "\t<span class='info'>Mildly Damaged Organs: "
 					minor_damage += organ.name
-			else if ((organ.damage < organ.low_threshold) && (organ.name != "black tumor" || "festering ooze"))
+			else if ((organ.damage < organ.low_threshold) && (organ.name != "festering ooze"))
 				report_organs = TRUE // if no organs get reported, it means they have no organs
 				if(no_damage)
 					no_damage += ", "


### PR DESCRIPTION
# General Documentation

tested with zombie organ and sling organ on felinids

### Intent of your Pull Request

healthy organs will be reported on health scanners
antag organs will not show up unless damaged

### Why is this change good for the game?

doctors can now tell if someone is missing an organ

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 

healthy organs will be reported on health scanners

### What should players be aware of when it comes to the changes your PR is implementing?

doctors can now tell if someone is missing an organ

### What general grouping does this PR fall under? 
Medical

# Changelog

:cl:  
rscadd: Added healthy organs to health scanner report
/:cl:
