### PR TITLE
prevents special effects from being triggered by items that shouldn't cause them after melee attacks

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -70,11 +70,11 @@
 
 	if(force && HAS_TRAIT(user, TRAIT_PACIFISM))
 		to_chat(user, "<span class='warning'>You don't want to harm other living beings!</span>")
-		return
+		return TRUE
 	
 	if((item_flags & SURGICAL_TOOL) && (user.a_intent != INTENT_HARM)) // checks for if harm intent with surgery tool
 		to_chat(user, "<span class='warning'>You aren't doing surgery!</span>") //yells at you
-		return
+		return TRUE
 
 	if(!force)
 		playsound(loc, 'sound/weapons/tap.ogg', get_clamped_volume(), 1, -1)


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

pacifism and surgery tools returning in attack() now return TRUE to prevent afterattack effects

### Why is this change good for the game?
fixes a bug letting heretics that can't use their  blades proc blade effects without any feedback

# Changelog

:cl:  
bugfix: heretic blades will no longer activate blade effects if the user can't stab people
/:cl:
