### PR TITLE
prevents activating eldritch blade effects on yourself

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -106,7 +106,7 @@
 /obj/item/melee/sickly_blade/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
 	var/datum/antagonist/heretic/cultie = user.mind.has_antag_datum(/datum/antagonist/heretic)
-	if(!cultie || !proximity_flag)
+	if(!cultie || !proximity_flag || target == user)
 		return
 	var/list/knowledge = cultie.get_all_knowledge()
 	for(var/X in knowledge)


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

eldritch blade effects will no longer trigger on their user

### Why is this change good for the game?
makes eldritch essence use require buying the actual ritual not just disabling your leg then stabbing it 200 times
# Changelog

:cl:  
bugfix: eldritch blade effects will no longer get activated if you stab yourself on accident or something
/:cl:
