### PR TITLE
probably fixes heretic mark underlays sticking around after the effect is gone

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -860,13 +860,13 @@
 
 /datum/status_effect/eldritch/on_apply()
 	if(owner.mob_size >= MOB_SIZE_HUMAN)
-		owner.underlays += marked_underlay
+		owner.underlays |= marked_underlay
 		//owner.update_icon()
 		return TRUE
 	return FALSE
 
 /datum/status_effect/eldritch/Destroy()
-	owner.underlays -= marked_underlay
+	owner.underlays &= marked_underlay
 	QDEL_NULL(marked_underlay)
 	return ..()
 


### PR DESCRIPTION


:cl:  
bugfix: heretic underlays from stabbing people won't stick around after the effect is gone any more
/:cl:
