### PR TITLE
You can now delete mecha keycodes

### DIFF
--- a/code/game/mecha/mecha_topic.dm
+++ b/code/game/mecha/mecha_topic.dm
@@ -271,12 +271,16 @@
 				internal_tank_valve = new_pressure
 				to_chat(usr, "The internal pressure valve has been set to [internal_tank_valve]kPa.")
 
-		if(href_list["add_req_access"] && add_req_access && id_card)
+		if(href_list["add_req_access"])
+			if(!(add_req_access && id_card))
+				return
 			operation_req_access += text2num(href_list["add_req_access"])
 			output_access_dialog(id_card,usr)
 
-		if(href_list["del_req_access"] && add_req_access && id_card)
-			operation_req_access -= text2num(href_list["add_req_access"])
+		if(href_list["del_req_access"])
+			if(!(add_req_access && id_card))
+				return
+			operation_req_access -= text2num(href_list["del_req_access"])
 			output_access_dialog(id_card, usr)
 
 		if(href_list["finish_req_access"])


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Fixes mecha codes not being deleted

### Why is this change good for the game?

Fixes: https://github.com/yogstation13/Yogstation/issues/10800

# Changelog

:cl:  
bugfix: You can now delete mecha keycodes
/:cl:
