### PR TITLE
Crafted secure closets are now functional - fixes #10789

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -509,10 +509,11 @@
 	reqs = 	list(/obj/item/stack/sheet/cloth = 2, /obj/item/stack/rods = 1)
 	result = /obj/structure/cloth_curtain
 	category = CAT_MISC
-	
+
 /datum/crafting_recipe/secure_closet
 	name = "Secure Closet"
 	reqs = list(/obj/item/stack/sheet/metal = 5, /obj/item/stack/cable_coil = 10, /obj/item/electronics/airlock = 1)
+	parts = list(/obj/item/electronics/airlock = 1)
 	result = /obj/structure/closet/secure_closet
 	category = CAT_MISC
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -6,8 +6,16 @@
 	max_integrity = 250
 	armor = list("melee" = 30, "bullet" = 50, "laser" = 50, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 80)
 	secure = TRUE
+	var/obj/item/electronics/airlock/electronics
 
 /obj/structure/closet/secure_closet/run_obj_armor(damage_amount, damage_type, damage_flag = 0, attack_dir)
 	if(damage_flag == "melee" && damage_amount < 20)
 		return 0
 	. = ..()
+
+/obj/structure/closet/secure_closet/CheckParts(list/parts_list)
+	. = ..()
+	electronics = locate(/obj/item/electronics/airlock) in parts_list
+	if(electronics)
+		req_access = electronics.accesses
+		qdel(electronics)


### PR DESCRIPTION
fixes #10789
Tested!

## WIKI DOCUMENTATION
Crafted secure lockers now decide their access via the airlock electronics. Set your airlock electronics first, then craft the locker, and the locker will have the exact same access permissions. Yay!

# Changelog

:cl:  
bugfix: crafted secure lockers are now secure
/:cl:
