### PR TITLE
make gas chems nosynth and makes healium's knockout harder to bypass

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1204,6 +1204,7 @@
 	reagent_state = GAS
 	metabolization_rate = REAGENTS_METABOLISM * 0.5 // Because stimulum/nitryl are handled through gas breathing, metabolism must be lower for breathcode to keep up
 	color = "E1A116"
+	can_synth = FALSE
 	taste_description = "sourness"
 
 /datum/reagent/stimulum/on_mob_metabolize(mob/living/L)
@@ -1226,6 +1227,7 @@
 	reagent_state = GAS
 	metabolization_rate = REAGENTS_METABOLISM * 0.5 // Because stimulum/nitryl are handled through gas breathing, metabolism must be lower for breathcode to keep up
 	color = "90560B"
+	can_synth = FALSE
 	taste_description = "burning"
 
 /datum/reagent/nitryl/on_mob_metabolize(mob/living/L)
@@ -1242,24 +1244,31 @@
 	reagent_state = GAS
 	metabolization_rate = REAGENTS_METABOLISM * 0.5 // Because stimulum/nitryl/freon/hypernoblium are handled through gas breathing, metabolism must be lower for breathcode to keep up
 	color = "90560B"
+	can_synth = FALSE
 	taste_description = "burning"
+
 /datum/reagent/freon/on_mob_metabolize(mob/living/L)
 	. = ..()
 	L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=1.6, blacklisted_movetypes=(FLYING|FLOATING))
+
 /datum/reagent/freon/on_mob_end_metabolize(mob/living/L)
 	L.remove_movespeed_modifier(type)
 	return ..()
+
 /datum/reagent/hypernoblium
 	name = "Hyper-Noblium"
 	description = "A suppressive gas that stops gas reactions on those who inhale it."
 	reagent_state = GAS
 	metabolization_rate = REAGENTS_METABOLISM * 0.5 // Because stimulum/nitryl/freon/hyper-nob are handled through gas breathing, metabolism must be lower for breathcode to keep up
 	color = "90560B"
+	can_synth = FALSE
 	taste_description = "searingly cold"
+
 /datum/reagent/hypernoblium/on_mob_metabolize(mob/living/L)
 	. = ..()
 	if(isplasmaman(L))
 		ADD_TRAIT(L, TRAIT_NOFIRE, type)
+
 /datum/reagent/hypernoblium/on_mob_end_metabolize(mob/living/L)
 	if(isplasmaman(L))
 		REMOVE_TRAIT(L, TRAIT_NOFIRE, type)
@@ -1271,14 +1280,22 @@
 	reagent_state = GAS
 	metabolization_rate = REAGENTS_METABOLISM * 0.5
 	color = "90560B"
+	can_synth = FALSE
 	taste_description = "rubbery"
 
 /datum/reagent/healium/on_mob_metabolize(mob/living/L)
 	. = ..()
 	L.SetSleeping(1000)
+	L.SetUnconscious(1000)
+
+/datum/reagent/healium/on_mob_life(mob/living/carbon/M)
+	M.SetSleeping(1000)
+	M.SetUnconscious(1000) //in case you have sleep immunity :^)
+	..()
 
 /datum/reagent/healium/on_mob_end_metabolize(mob/living/L)
 	L.SetSleeping(10)
+	L.SetUnconscious(10)
 	return ..()
 
 /datum/reagent/halon
@@ -1287,6 +1304,7 @@
 	reagent_state = GAS
 	metabolization_rate = REAGENTS_METABOLISM * 0.5
 	color = "90560B"
+	can_synth = FALSE
 	taste_description = "minty"
 
 /datum/reagent/halon/on_mob_metabolize(mob/living/L)
@@ -1305,6 +1323,7 @@
 	reagent_state = GAS
 	metabolization_rate = REAGENTS_METABOLISM * 0.5
 	color = "90560B"
+	can_synth = FALSE
 	taste_description = "fresh"
 
 /datum/reagent/hexane/on_mob_metabolize(mob/living/L)


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request
gas chems are now non-synthesizeable since they're meant to compliment the gas's inhale effects not be used on their own
also healium causes unconscious as well as sleeping and refreshes it on mob life to make bypassing the knockout harder
### Why is this change good for the game?
this substantially nerfs the chems you can get from a maint pill but the chance someone gets stimulum or healium from one and abuses it is decent. These chems are also not meant to be used on their own as their other effects are handled on inhalation in the lungs
healium can also (but hasn't yet) be gamed with certain chems, making it also cause unconsciousness makes it harder to bypass
# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
none of this stuff should substantially effect wiki documentation but in short gas chems are no longer found in maint pills and healium also causes unconsciousness as well as sleeping

# Changelog

:cl:  
bugfix: gas chems will no longer be found in maint pills or strange plants
tweak: healium's knockout is harder to bypass
/:cl:
