### PR TITLE
Luxury Shuttle now correctly, returns FALSE on cross

### DIFF
--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -223,6 +223,7 @@
 
 	if(!isliving(mover)) //No stowaways
 		return FALSE
+	return FALSE
 
 /obj/machinery/scanner_gate/luxury_shuttle/auto_scan(atom/movable/AM)
 	return


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Forces you to stay out if you could somehow pass

### Why is this change good for the game?

Bug

# Changelog
:cl:  
bugfix: Luxury Shuttle now scans you correctly
/:cl:
