### PR TITLE
Adds a few more fluff text options to the Mice Migration announcement.

### DIFF
--- a/code/modules/events/mice_migration.dm
+++ b/code/modules/events/mice_migration.dm
@@ -12,10 +12,10 @@
 		"space being cold", "\[REDACTED\]", "climate change",
 		"bad luck")
 	var/plural = pick("a number of", "a horde of", "a pack of", "a swarm of",
-		"a whoop of", "not more than [maximum_mice]")
+		"a whoop of", "not more than [maximum_mice]", "atleast [minimum_mice]")
 	var/name = pick("rodents", "mice", "squeaking things",
 		"wire eating mammals", "\[REDACTED\]", "energy draining parasites")
-	var/movement = pick("migrated", "swarmed", "stampeded", "descended")
+	var/movement = pick("migrated", "swarmed", "stampeded", "descended","magically appeared")
 	var/location = pick("maintenance tunnels", "maintenance areas",
 		"\[REDACTED\]", "place with all those juicy wires")
 


### PR DESCRIPTION
 Intent of your Pull Request

Adds "atleast [minimum_mice]" to var/plural and "magically appeared" to var movement.

Why is this change good for the game?

The change is neutral given how inconsequential it is.

### Changelog

:cl:  
rscadd: Added minor fluff text to Mice Migration announcement  
/:cl:
