### PR TITLE
Changes Oak's Birthday to Gondola Day for some goddamn reason.

### DIFF
--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -21,6 +21,11 @@
 /datum/round_event/carp_migration/start()
 	var/mob/living/simple_animal/hostile/carp/fish
 	for(var/obj/effect/landmark/carpspawn/C in GLOB.landmarks_list)
+		//yogs -- Gondola Day for some goddamn reason. Can't they just let go of Oak?
+		if(SSevents.holidays["Gondola Day"])
+			fish = new /mob/living/simple_animal/pet/gondola
+			return
+		//yogs end
 		if(prob(95))
 			fish = new (C.loc)
 		else

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -21,11 +21,6 @@
 /datum/round_event/carp_migration/start()
 	var/mob/living/simple_animal/hostile/carp/fish
 	for(var/obj/effect/landmark/carpspawn/C in GLOB.landmarks_list)
-		//yogs -- Oak's birthday :D
-		if(SSevents.holidays["Oak's Birthday"])
-			fish = new /mob/living/simple_animal/pet/gondola
-			return
-		//yogs end
 		if(prob(95))
 			fish = new (C.loc)
 		else

--- a/yogstation/code/modules/holidays/holidays.dm
+++ b/yogstation/code/modules/holidays/holidays.dm
@@ -32,27 +32,6 @@
 		"https://www.youtube.com/watch?v=ckNIMPQoBPw" // And on mars there will be apple blossoms
 		)
 
-/datum/holiday/oakday
-	name = "Oak's Birthday"
-	begin_day = 5
-	begin_month = JULY
-	drone_hat = /obj/item/clothing/head/hardhat/cakehat
-	lobby_music = list(
-		"https://www.youtube.com/watch?v=lM2Lr3NqUcg", // Maamme (Finnish Anthem)
-		"https://www.youtube.com/watch?v=OEtyScs6djU", // Vapaussoturin Valloituslaulu
-		"https://www.youtube.com/watch?v=uMszu_VgMfY", // Säkkijärven Polkka
-		"https://www.youtube.com/watch?v=Qn16z3fn-j4", // Kremlin Uni
-		"https://www.youtube.com/watch?v=d91FuK11QvU", // Jääkärimarssi
-		"https://www.youtube.com/watch?v=8IaUXefAsCU", // The Song of the Pioneers
-		"https://www.youtube.com/watch?v=PJR3xTdbXH8" // Nyet Molotov
-		)
-
-/datum/holiday/oakday/getStationPrefix()
-	return pick("Gondola","Finnish","Council","Oakreich","Perkele")
-	
-/datum/holiday/oakday/greet()
-	return "Happy birthday to Oakboscage!"
-
 /datum/holiday/yogsday
 	name = "Yogstation Day"
 	begin_day = 11

--- a/yogstation/code/modules/holidays/holidays.dm
+++ b/yogstation/code/modules/holidays/holidays.dm
@@ -32,6 +32,21 @@
 		"https://www.youtube.com/watch?v=ckNIMPQoBPw" // And on mars there will be apple blossoms
 		)
 
+/datum/holiday/gondoladay
+	name = "Gondola Day"
+	begin_day = 5
+	begin_month = JULY
+	drone_hat = /obj/item/clothing/head/hardhat/cakehat
+	lobby_music = list(
+		"https://www.youtube.com/watch?v=lM2Lr3NqUcg", // Maamme (Finnish Anthem)
+		"https://www.youtube.com/watch?v=OEtyScs6djU", // Vapaussoturin Valloituslaulu
+		"https://www.youtube.com/watch?v=uMszu_VgMfY", // Säkkijärven Polkka
+		"https://www.youtube.com/watch?v=Qn16z3fn-j4", // Kremlin Uni
+		"https://www.youtube.com/watch?v=d91FuK11QvU", // Jääkärimarssi
+		"https://www.youtube.com/watch?v=8IaUXefAsCU", // The Song of the Pioneers
+		"https://www.youtube.com/watch?v=PJR3xTdbXH8" // Nyet Molotov
+		)
+
 /datum/holiday/yogsday
 	name = "Yogstation Day"
 	begin_day = 11

--- a/yogstation/code/modules/holidays/holidays.dm
+++ b/yogstation/code/modules/holidays/holidays.dm
@@ -36,7 +36,6 @@
 	name = "Gondola Day"
 	begin_day = 5
 	begin_month = JULY
-	drone_hat = /obj/item/clothing/head/hardhat/cakehat
 	lobby_music = list(
 		"https://www.youtube.com/watch?v=lM2Lr3NqUcg", // Maamme (Finnish Anthem)
 		"https://www.youtube.com/watch?v=OEtyScs6djU", // Vapaussoturin Valloituslaulu
@@ -46,6 +45,12 @@
 		"https://www.youtube.com/watch?v=8IaUXefAsCU", // The Song of the Pioneers
 		"https://www.youtube.com/watch?v=PJR3xTdbXH8" // Nyet Molotov
 		)
+		
+/datum/holiday/gondoladay/getStationPrefix()
+	return pick("Gondola","Finnish","Finland","Karelia","Perkele")
+	
+/datum/holiday/gondoladay/greet()
+	return "Happy Gondola Day!"
 
 /datum/holiday/yogsday
 	name = "Yogstation Day"


### PR DESCRIPTION
# Intent of your Pull Request

Changes Oak's Birthday (Oak Day) to Gondola Day, as opposed to the initial proposition of just removing Oakday.

# Why is this change good for the game?

We're not exactly strapped for holidays, we have 7 excluding this in July already. We could've just pitted this PR and a Remove Oakday PR against each other and see which was better, but we just have to work with 1 PR and 1 vision.

# Wiki Documentation

https://wiki.yogstation.net/wiki/Holiday_events#Oak.27s_Birthday
Is to be deleted changed PR's merging.

###################### Changelog

:cl:  
tweak: Removes Oakday, and references to it in carp_migration  
/:cl:

i get theres a feature freeze just merge it after the feature freeze damnit