### PR TITLE
removes "RP" from the server title because it's stupid and makes us look like citadel RP or any other HRP furry server

### DIFF
--- a/config/private_server.txt
+++ b/config/private_server.txt
@@ -11,7 +11,7 @@ $include resources_private.txt
 CROSS_COMMS_NAME Main
 
 ## Server name: This appears at the top of the screen in-game and in the BYOND hub. Replace 'Space station 13' with the name of your choice.
-SERVERNAME Yogstation 13 RP
+SERVERNAME Yogstation 13
 
 ## Server SQL name: This is the name used to identify the server to the SQL DB, distinct from SERVERNAME as it must be at most 32 characters.
 SERVERSQLNAME yogstation


### PR DESCRIPTION
it was funny for like maybe a month
# Changelog


:cl:  
tweak: server title changed
/:cl:
