### PR TITLE
Hudglasses nerf: Flashproof hud glasses can no longer be crafted from cheap sunglasses.

### DIFF
--- a/_maps/RandomRuins/StationRuins/EclipseStation/ebar_casino.dmm
+++ b/_maps/RandomRuins/StationRuins/EclipseStation/ebar_casino.dmm
@@ -544,7 +544,7 @@
 /area/crew_quarters/kitchen)
 "uT" = (
 /obj/structure/table/wood/poker,
-/obj/item/clothing/glasses/sunglasses/cheap,
+/obj/item/clothing/glasses/cheap/sunglasses,
 /obj/item/toy/cards/cardhand,
 /turf/open/floor/carpet/black,
 /area/crew_quarters/bar)
@@ -887,7 +887,7 @@
 /area/crew_quarters/kitchen)
 "HE" = (
 /obj/structure/table/wood/poker,
-/obj/item/clothing/glasses/sunglasses/cheap,
+/obj/item/clothing/glasses/cheap/sunglasses,
 /turf/open/floor/carpet/black,
 /area/crew_quarters/bar)
 "HJ" = (

--- a/_maps/RandomRuins/StationRuins/maint/10x10/10x10_beach.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/10x10/10x10_beach.dmm
@@ -148,9 +148,9 @@
 /obj/item/clothing/shoes/sandal,
 /obj/item/clothing/shoes/sandal,
 /obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/glasses/sunglasses/cheap,
-/obj/item/clothing/glasses/sunglasses/cheap,
-/obj/item/clothing/glasses/sunglasses/cheap,
+/obj/item/clothing/glasses/cheap/sunglasses,
+/obj/item/clothing/glasses/cheap/sunglasses,
+/obj/item/clothing/glasses/cheap/sunglasses,
 /turf/open/floor/plating/beach/sand,
 /area/template_noop)
 "J" = (

--- a/_maps/RandomRuins/StationRuins/maint/5x4/5x4_deltalounge.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/5x4/5x4_deltalounge.dmm
@@ -12,7 +12,7 @@
 /area/template_noop)
 "c" = (
 /obj/structure/table/wood/poker,
-/obj/item/clothing/glasses/sunglasses/cheap,
+/obj/item/clothing/glasses/cheap/sunglasses,
 /turf/open/floor/carpet/green,
 /area/template_noop)
 "d" = (

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -50376,7 +50376,7 @@
 	pixel_x = -8;
 	pixel_y = 9
 	},
-/obj/item/clothing/glasses/sunglasses/cheap{
+/obj/item/clothing/glasses/cheap/sunglasses{
 	pixel_x = 6;
 	pixel_y = -4
 	},

--- a/code/datums/components/crafting/tailoring.dm
+++ b/code/datums/components/crafting/tailoring.dm
@@ -119,6 +119,24 @@
 				  /obj/item/stack/cable_coil = 5)
 	category = CAT_CLOTHING
 
+/datum/crafting_recipe/hudsundiagcheap
+	name = "Cheap Diagnostic HUDsunglasses"
+	result = /obj/item/clothing/glasses/hud/diagnostic/sunglasses/cheap
+	time = 2 SECONDS
+	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	reqs = list(/obj/item/clothing/glasses/hud/diagnostic = 1,
+				  /obj/item/clothing/glasses/cheap/sunglasses = 1,
+				  /obj/item/stack/cable_coil = 10)
+	category = CAT_CLOTHING
+
+/datum/crafting_recipe/hudsundiagcheapremove
+	name = "Diagnostic HUD removal"
+	result = /obj/item/clothing/glasses/cheap/sunglasses
+	time = 2 SECONDS
+	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	reqs = list(/obj/item/clothing/glasses/hud/diagnostic/sunglasses/cheap)
+	category = CAT_CLOTHING
+
 /datum/crafting_recipe/hudsundiagremoval
 	name = "Diagnostic HUD removal"
 	result = /obj/item/clothing/glasses/sunglasses

--- a/code/datums/components/crafting/tailoring.dm
+++ b/code/datums/components/crafting/tailoring.dm
@@ -84,7 +84,7 @@
 //also, these dont have flash protection
 /datum/crafting_recipe/hudsunmedcheap
 	name = "Cheap Medical HUDsunglasses"
-	result = /obj/item/clothing/glasses/hud/health/sunglasses
+	result = /obj/item/clothing/glasses/hud/health/sunglasses/cheap
 	time = 2 SECONDS
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/hud/health = 1,

--- a/code/datums/components/crafting/tailoring.dm
+++ b/code/datums/components/crafting/tailoring.dm
@@ -60,6 +60,8 @@
 				  /obj/item/stack/cable_coil = 5)
 	category = CAT_CLOTHING
 
+//lets not add cheap security hud glasses
+
 /datum/crafting_recipe/hudsunsecremoval
 	name = "Security HUD removal"
 	result = /obj/item/clothing/glasses/sunglasses
@@ -77,6 +79,27 @@
 				  /obj/item/clothing/glasses/sunglasses = 1,
 				  /obj/item/stack/cable_coil = 5)
 	category = CAT_CLOTHING
+
+//lets make this require a 10 cable coil instead of 5; it requires more janky wiring to make it work with a cheap pair of chinese sunglasses
+//also, these dont have flash protection
+/datum/crafting_recipe/hudsunmedcheap
+	name = "Cheap Medical HUDsunglasses"
+	result = /obj/item/clothing/glasses/hud/health/sunglasses
+	time = 2 SECONDS
+	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	reqs = list(/obj/item/clothing/glasses/hud/health = 1,
+				  /obj/item/clothing/glasses/cheap/sunglasses = 1,
+				  /obj/item/stack/cable_coil = 10)
+	category = CAT_CLOTHING
+
+/datum/crafting_recipe/hudsunmedcheapremoval
+	name = "Medical HUD removal"
+	result = /obj/item/clothing/glasses/cheap/sunglasses
+	time = 2 SECONDS
+	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	reqs = list(/obj/item/clothing/glasses/hud/health/sunglasses/cheap = 1)
+	category = CAT_CLOTHING
+
 
 /datum/crafting_recipe/hudsunmedremoval
 	name = "Medical HUD removal"

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -65,6 +65,12 @@
 	tint = 1
 	glass_colour_type = /datum/client_colour/glass_colour/blue
 
+/obj/item/clothing/glasses/hud/health/sunglasses/cheap
+	. = ..()
+	name = "cheap medical HUDSunglasses"
+	desc = "A crudely fashioned amalgamation of cheap sunglasses and electronics that show the user a medical HUD."
+	flash_protect = 0
+
 /obj/item/clothing/glasses/hud/diagnostic
 	name = "diagnostic HUD"
 	desc = "A heads-up display capable of analyzing the integrity and status of robotics and exosuits."

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -66,7 +66,6 @@
 	glass_colour_type = /datum/client_colour/glass_colour/blue
 
 /obj/item/clothing/glasses/hud/health/sunglasses/cheap
-	. = ..()
 	name = "cheap medical HUDSunglasses"
 	desc = "A crudely fashioned amalgamation of cheap sunglasses and electronics that show the user a medical HUD."
 	flash_protect = 0

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -67,7 +67,7 @@
 
 /obj/item/clothing/glasses/hud/health/sunglasses/cheap
 	name = "cheap medical HUDSunglasses"
-	desc = "A crudely fashioned amalgamation of cheap sunglasses and electronics that show the user a medical HUD."
+	desc = "A crudely fashioned amalgamation of cheap sunglasses and electronics that shows the user a medical HUD."
 	flash_protect = 0
 
 /obj/item/clothing/glasses/hud/diagnostic

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -95,6 +95,11 @@
 	flash_protect = 1
 	tint = 1
 
+/obj/item/clothing/glasses/hud/diagnostic/sunglasses/cheap
+	name = "cheap diagnostic HUDSunglasses"
+	desc = "A crudely fashioned amalgamation of cheap sunglasses and electronics that shows the user a diagnostic HUD."
+	flash_protect = 0
+
 /obj/item/clothing/glasses/hud/security
 	name = "security HUD"
 	desc = "A heads-up display that scans the humans in view and provides accurate data about their ID status and security records."

--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -161,7 +161,7 @@
 		            /obj/item/clothing/under/yogs/whitetuxedo = 1,
 		            /obj/item/clothing/under/yogs/whitedress = 1,
 		            /obj/item/clothing/under/yogs/fancysuit = 1,
-		            /obj/item/clothing/glasses/sunglasses/cheap = 2,
+		            /obj/item/clothing/glasses/cheap/sunglasses = 2,
 		            /obj/item/clothing/glasses/yogs/threed = 2,
 		            /obj/item/clothing/shoes/sneakers/black = 3,
 		            /obj/item/clothing/shoes/yogs/fire_crocs = 1,

--- a/yogstation/code/modules/clothing/glasses/_glasses.dm
+++ b/yogstation/code/modules/clothing/glasses/_glasses.dm
@@ -1,3 +1,9 @@
+/obj/item/clothing/glasses/cheap
+	name = "prescription glasses"
+	desc = "Made by Nerd Co. They appear to have fake lenses."
+	icon_state = "glasses"
+	item_state = "glasses"
+
 /obj/item/clothing/glasses/cheap/sunglasses
 	name = "cheap sunglasses"
 	desc = "Made in china"

--- a/yogstation/code/modules/clothing/glasses/_glasses.dm
+++ b/yogstation/code/modules/clothing/glasses/_glasses.dm
@@ -1,4 +1,4 @@
-/obj/item/clothing/glasses/sunglasses/cheap
+/obj/item/clothing/glasses/cheap/sunglasses
 	name = "cheap sunglasses"
 	desc = "Made in china"
 	icon_state = "sun"


### PR DESCRIPTION

# General Documentation

### Intent of your Pull Request

This PR solves and closes #10912 , and is a step to the coder redemption arc

### Why is this change good for the game?

This PR removes a meta strategy of crafting flashproof eyewear from non-flashproof eyewear

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
Removes the ability to use cheap sunglasses to craft flash-proof hudglasses. Adds a new item, cheap hudglasses. Same hudglasses, but without flash protection. Cheap security hud sunglasses are not included due to powergaming fears.

### What should players be aware of when it comes to the changes your PR is implementing?
No more free flashproof eye protection

### What general grouping does this PR fall under? 
Game rebalancing

### Are there any aspects of the PR that you would like us not to mention on the Wiki?

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
Cheap HUDGlasses require more cable than their more expensive counterparts due to them requiring more janky wiring 

# Changelog

:cl:  
rscadd: Adds cheap HUDSunglasses
bugfix: Fixes being able to get relatively cheap flash protection
tweak: changes the item path of cheap sunglasses
/:cl:

yes, this has been tested