### PR TITLE
Blacklists cheap sunglasses from making hud sunglasses

### DIFF
--- a/code/datums/components/crafting/tailoring.dm
+++ b/code/datums/components/crafting/tailoring.dm
@@ -58,6 +58,7 @@
 	reqs = list(/obj/item/clothing/glasses/hud/security = 1,
 				  /obj/item/clothing/glasses/sunglasses = 1,
 				  /obj/item/stack/cable_coil = 5)
+	blacklist = list(/obj/item/clothing/glasses/sunglasses/cheap)
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/hudsunsecremoval
@@ -76,6 +77,7 @@
 	reqs = list(/obj/item/clothing/glasses/hud/health = 1,
 				  /obj/item/clothing/glasses/sunglasses = 1,
 				  /obj/item/stack/cable_coil = 5)
+	blacklist = list(/obj/item/clothing/glasses/sunglasses/cheap)
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/hudsunmedremoval
@@ -94,6 +96,8 @@
 	reqs = list(/obj/item/clothing/glasses/hud/diagnostic = 1,
 				  /obj/item/clothing/glasses/sunglasses = 1,
 				  /obj/item/stack/cable_coil = 5)
+	blacklist = list(/obj/item/clothing/glasses/sunglasses/cheap)
+	
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/hudsundiagremoval
@@ -112,6 +116,7 @@
 	reqs = list(/obj/item/clothing/glasses/science = 1,
 				  /obj/item/clothing/glasses/sunglasses = 1,
 				  /obj/item/stack/cable_coil = 5)
+	blacklist = list(/obj/item/clothing/glasses/sunglasses/cheap)
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/beergogglesremoval


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request
Fixes #10912

### Why is this change good for the game?
yogs mrp, it nerfs antagonists a little and encourages them to roleplay and pretend their sunglasses are flashproof.

### What should players be aware of when it comes to the changes your PR is implementing?
cheap sunglasses cant result in a flashproof hud version. 

# Changelog

:cl:  
bugfix: cheap sunglasses cannot make hudsunglasses now
/:cl:
