### PR TITLE
Change abductor machine beacon spawn conditions

### DIFF
--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -655,7 +655,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 		var/turf/T = loc
 		viable = TRUE
 		for(var/obj/thing in T.contents)
-			if(thing.density || ismachinery(thing) || isstructure(thing))
+			if(thing.density)
 				viable = FALSE
 	if(viable)
 		playsound(src, 'sound/effects/phasein.ogg', 50, TRUE)


### PR DESCRIPTION
:cl: monster860
tweak: Non-dense machines like light fixtures and holopads no longer block abductor machine beacons
/:cl: