### PR TITLE
Adds headpats

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -279,10 +279,7 @@
 						"<span class='notice'>You give [src] a pat on the head to make [p_them()] feel better!</span>", target = src,
 						target_message = "<span class='notice'>[M] gives you a pat on the head to make you feel better!</span>")
 			if(S?.can_wag_tail(src) && !dna.species.is_wagging_tail())
-				var/static/list/many_tails = list("tail_human", "tail_lizard", "mam_tail")
-				for(var/T in many_tails)
-					if(S.mutant_bodyparts[T] && dna.features[T] != "None")
-						emote("wag")
+				emote("wag")
 
 	else
 		M.visible_message("<span class='notice'>[M] hugs [src] to make [p_them()] feel better!</span>", \

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -271,15 +271,15 @@
 					"<span class='notice'>You give [src] a pat on the shoulder to make [p_them()] feel better!</span>")
 	
 	else if(check_zone(M.zone_selected) == BODY_ZONE_HEAD)
-			var/datum/species/S
-			if(ishuman(src))
-				S = dna.species
+		var/datum/species/S
+		if(ishuman(src))
+			S = dna.species
 
-			M.visible_message("<span class='notice'>[M] gives [src] a pat on the head to make [p_them()] feel better!</span>", \
-						"<span class='notice'>You give [src] a pat on the head to make [p_them()] feel better!</span>", target = src,
-						target_message = "<span class='notice'>[M] gives you a pat on the head to make you feel better!</span>")
-			if(S?.can_wag_tail(src) && !dna.species.is_wagging_tail())
-				emote("wag")
+		M.visible_message("<span class='notice'>[M] gives [src] a pat on the head to make [p_them()] feel better!</span>", \
+					"<span class='notice'>You give [src] a pat on the head to make [p_them()] feel better!</span>", target = src,
+					target_message = "<span class='notice'>[M] gives you a pat on the head to make you feel better!</span>")
+		if(S?.can_wag_tail(src) && !dna.species.is_wagging_tail())
+			emote("wag")
 
 	else
 		M.visible_message("<span class='notice'>[M] hugs [src] to make [p_them()] feel better!</span>", \

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -269,6 +269,20 @@
 	else if(check_zone(M.zone_selected) == BODY_ZONE_L_ARM || check_zone(M.zone_selected) == BODY_ZONE_R_ARM) //Headpats are too extreme, we have to pat shoulders on yogs
 		M.visible_message("<span class='notice'>[M] gives [src] a pat on the shoulder to make [p_them()] feel better!</span>", \
 					"<span class='notice'>You give [src] a pat on the shoulder to make [p_them()] feel better!</span>")
+	
+	else if(check_zone(M.zone_selected) == BODY_ZONE_HEAD)
+			var/datum/species/S
+			if(ishuman(src))
+				S = dna.species
+
+			M.visible_message("<span class='notice'>[M] gives [src] a pat on the head to make [p_them()] feel better!</span>", \
+						"<span class='notice'>You give [src] a pat on the head to make [p_them()] feel better!</span>", target = src,
+						target_message = "<span class='notice'>[M] gives you a pat on the head to make you feel better!</span>")
+			if(S?.can_wag_tail(src) && !dna.species.is_wagging_tail())
+				var/static/list/many_tails = list("tail_human", "tail_lizard", "mam_tail")
+				for(var/T in many_tails)
+					if(S.mutant_bodyparts[T] && dna.features[T] != "None")
+						emote("wag")
 
 	else
 		M.visible_message("<span class='notice'>[M] hugs [src] to make [p_them()] feel better!</span>", \

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -276,8 +276,7 @@
 			S = dna.species
 
 		M.visible_message("<span class='notice'>[M] gives [src] a pat on the head to make [p_them()] feel better!</span>", \
-					"<span class='notice'>You give [src] a pat on the head to make [p_them()] feel better!</span>", target = src,
-					target_message = "<span class='notice'>[M] gives you a pat on the head to make you feel better!</span>")
+					"<span class='notice'>You give [src] a pat on the head to make [p_them()] feel better!</span>")
 		if(S?.can_wag_tail(src) && !dna.species.is_wagging_tail())
 			emote("wag")
 


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

When you click someone with help intent with their head selected, it gives them a "pats the head" message, instead of the other options, as well as causing a tail wag. 

### Why is this change good for the game?

Allow more options for using help intent. It also gives more options for things to do when there's down time and nothing is going on. More RP options in general.

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 

Using help intent with head will cause a headpat and a tail wag

### What should players be aware of when it comes to the changes your PR is implementing?
It causes tail wag

### What general grouping does this PR fall under? 
General RP stuff

### Are there any aspects of the PR that you would like us not to mention on the Wiki?
no

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 


# Changelog

:cl:  
add: Adds headpats, which is done by using help intent targeting the head
/:cl:
