### PR TITLE
Blacklist maint hatches from airlock painters

### DIFF
--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -393,6 +393,7 @@
 	anim_parts = "ul=-15,0,0,5,-90;ur=0,15,0,5,-90;dl=0,-15,0,5,-90;dr=15,0,0,5,-90"
 	note_attachment = "ul"
 	panel_attachment = "dr"
+	can_repaint = FALSE
 
 //////////////////////////////////
 /*


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Blacklists maint hatches due to their really fucky transforms _monsterrrrr_

### Why is this change good for the game?

Fixes Bug

# Changelog

:cl:  
bugfix: Blacklisted maint hatches from airlock painter
/:cl:
