### PR TITLE
bad wizard can no longer roll 0 of their 9 loadouts

### DIFF
--- a/yogstation/code/modules/events/bad_wizard.dm
+++ b/yogstation/code/modules/events/bad_wizard.dm
@@ -36,7 +36,7 @@
 	make_spells()
 
 /datum/antagonist/wizard/meme/proc/make_spells()
-	switch(rand(9)) //keep this consistent with the amount of loadouts.
+	switch(rand(1,9)) //keep this consistent with the amount of loadouts.
 
 		if(1) //5x jaunt
 			SpellAdd(/obj/effect/proc_holder/spell/targeted/ethereal_jaunt, 4)


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

improve rp

# Changelog
:cl:  
bugfix: bad wizards will no longer spawn with 0 spells
/:cl:
