### PR TITLE
shades can no longer cast or be used in runes

### DIFF
--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -135,7 +135,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 						continue
 				if(L.stat)
 					continue
-				if(!istype(user, /mob/living/simple_animal/shade))
+				if(istype(user, /mob/living/simple_animal/shade))
 					continue
 				invokers += L
 	return invokers

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -73,6 +73,9 @@ Runes can either be invoked by one's self or with many different cultists. Each 
 	if(!iscultist(user))
 		to_chat(user, "<span class='warning'>You aren't able to understand the words of [src].</span>")
 		return
+	if(istype(user, /mob/living/simple_animal/shade))
+		to_chat(user, "<span class='warning'>Your form is not yet strong enough to utilize the [src].</span>")
+		return
 	var/list/invokers = can_invoke(user)
 	if(invokers.len >= req_cultists)
 		invoke(invokers)
@@ -131,6 +134,8 @@ structure_check() searches for nearby cultist structures required for the invoca
 					if((HAS_TRAIT(H, TRAIT_MUTE)) || H.silent)
 						continue
 				if(L.stat)
+					continue
+				if(!istype(user, /mob/living/simple_animal/shade))
 					continue
 				invokers += L
 	return invokers


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Remove the rune-slave shade meta

### Why is this change good for the game?

Being kept in someone's pocket and used as a rune-slave to cast multiple-cultist runes is neither balanced nor engaging.

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
Shades can no longer cast or be used in runes

### What general grouping does this PR fall under? 
Antagonists, Blood Cult

# Changelog

:cl:  
tweak: Shades can no longer cast or be used in runes
/:cl:
