### PR TITLE
Renames COG-NAC to Justicars Juice because of a bug

### DIFF
--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -816,10 +816,10 @@
 	results = list(/datum/reagent/consumable/ethanol/flaming_moe = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol/tequila = 1, /datum/reagent/consumable/ethanol/creme_de_menthe = 1, /datum/reagent/medicine/synaptizine = 1)
 
-/datum/chemical_reaction/coggernac
-	name = "COG-Nac"
-	id = /datum/reagent/consumable/ethanol/coggernac
-	results = list(/datum/reagent/consumable/ethanol/coggernac = 4)
+/datum/chemical_reaction/ratvarnac
+	name = "Justicars Juice"
+	id = /datum/reagent/consumable/ethanol/ratvarnac
+	results = list(/datum/reagent/consumable/ethanol/ratvarnac = 4)
 	required_reagents = list(/datum/reagent/consumable/lemonjuice = 1, /datum/reagent/consumable/ethanol/cognac = 1, /datum/reagent/iron = 1, /datum/reagent/consumable/ethanol/tequila_sunrise = 1)
 
 /datum/chemical_reaction/godfather

--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -817,7 +817,7 @@
 	required_reagents = list(/datum/reagent/consumable/ethanol/tequila = 1, /datum/reagent/consumable/ethanol/creme_de_menthe = 1, /datum/reagent/medicine/synaptizine = 1)
 
 /datum/chemical_reaction/ratvarnac
-	name = "Justicars Juice"
+	name = "Justiciar Juice"
 	id = /datum/reagent/consumable/ethanol/ratvarnac
 	results = list(/datum/reagent/consumable/ethanol/ratvarnac = 4)
 	required_reagents = list(/datum/reagent/consumable/lemonjuice = 1, /datum/reagent/consumable/ethanol/cognac = 1, /datum/reagent/iron = 1, /datum/reagent/consumable/ethanol/tequila_sunrise = 1)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2250,8 +2250,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_name = "glass of malt liquor"
 	glass_desc = "A freezing pint of malt liquor."
 	
-/datum/reagent/consumable/ethanol/coggernac
-	name = "COG-Nac"
+/datum/reagent/consumable/ethanol/ratvarnac
+	name = "Justicars Juice"
 	description = "I don't even know what an eminence is, but I want him to recall."
 	metabolization_rate = INFINITY
 	boozepwr = 30
@@ -2261,7 +2261,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_name = "COG-Nac"
 	glass_desc = "Just looking at this makes your head spin. How the hell is it ticking?"
 
-/datum/reagent/consumable/ethanol/coggernac/on_mob_life(mob/living/carbon/M)
+/datum/reagent/consumable/ethanol/ratvarnac/on_mob_life(mob/living/carbon/M)
 	M.emote("spin")
 	..()
 


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Renames COG-NAC to Justicars Juice

### Why is this change good for the game?

Find proc takes too much of a shortcut and mistakes cog-nac for cognac

# Changelog

:cl:  
bugfix: You can dispense cognac again
tweak: Renames COG-NAC to Justicars Juice
/:cl:
