### PR TITLE
removes the tinfoil hat because it's useless and bugged

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -458,14 +458,6 @@
 	category = list("initial","Misc", "Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
 
-/datum/design/foilhat
-	name = "Tinfoil Hat"
-	id = "tinfoil_hat"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 5500)
-	build_path = /obj/item/clothing/head/foilhat
-	category = list("hacked", "Misc")
-
 /datum/design/scalpel
 	name = "Scalpel"
 	id = "scalpel"


### PR DESCRIPTION
i mean, who wants to use the misc tab on an autolathe when it's hacked, right? the entire tab goes fucked over when you hack it and everything is replaced with tinfoil hats. it keeps growing in the list of hats and if you change tabs it crashes the autolathe and you have to reopen the autolathe menu.

:cl:  
rscdel: removes tinfoil hat from autolathe, fixing a bug
/:cl:
