### PR TITLE
Removes Adrenaline and changes Nervous cost to 20 volume per second.

### DIFF
--- a/code/modules/research/designs/nanite_designs.dm
+++ b/code/modules/research/designs/nanite_designs.dm
@@ -222,13 +222,6 @@
 	program_type = /datum/nanite_program/conductive
 	category = list("Augmentation Nanites")
 
-///datum/design/nanites/adrenaline
-//	name = "Adrenaline Burst"
-//	desc = "The nanites cause a burst of adrenaline when triggered, waking the host from stuns and temporarily increasing their speed."
-//	id = "adrenaline_nanites"
-//	program_type = /datum/nanite_program/triggered/adrenaline
-//	category = list("Augmentation Nanites")
-
 /datum/design/nanites/mindshield
 	name = "Mental Barrier"
 	desc = "The nanites form a protective membrane around the host's brain, shielding them from abnormal influences while they're active."

--- a/code/modules/research/designs/nanite_designs.dm
+++ b/code/modules/research/designs/nanite_designs.dm
@@ -222,12 +222,12 @@
 	program_type = /datum/nanite_program/conductive
 	category = list("Augmentation Nanites")
 
-/datum/design/nanites/adrenaline
-	name = "Adrenaline Burst"
-	desc = "The nanites cause a burst of adrenaline when triggered, waking the host from stuns and temporarily increasing their speed."
-	id = "adrenaline_nanites"
-	program_type = /datum/nanite_program/triggered/adrenaline
-	category = list("Augmentation Nanites")
+///datum/design/nanites/adrenaline
+//	name = "Adrenaline Burst"
+//	desc = "The nanites cause a burst of adrenaline when triggered, waking the host from stuns and temporarily increasing their speed."
+//	id = "adrenaline_nanites"
+//	program_type = /datum/nanite_program/triggered/adrenaline
+//	category = list("Augmentation Nanites")
 
 /datum/design/nanites/mindshield
 	name = "Mental Barrier"

--- a/code/modules/research/nanites/nanite_programs/buffing.dm
+++ b/code/modules/research/nanites/nanite_programs/buffing.dm
@@ -3,8 +3,7 @@
 /datum/nanite_program/nervous
 	name = "Nerve Support"
 	desc = "The nanites act as a secondary nervous system, reducing the amount of time the host is stunned."
-	trigger_cost = 15
-	use_rate = 1.5
+	use_rate = 20
 	rogue_types = list(/datum/nanite_program/nerve_decay)
 
 /datum/nanite_program/nervous/enable_passive_effect()

--- a/code/modules/research/nanites/nanite_programs/buffing.dm
+++ b/code/modules/research/nanites/nanite_programs/buffing.dm
@@ -3,6 +3,7 @@
 /datum/nanite_program/nervous
 	name = "Nerve Support"
 	desc = "The nanites act as a secondary nervous system, reducing the amount of time the host is stunned."
+	trigger_cost = 15
 	use_rate = 1.5
 	rogue_types = list(/datum/nanite_program/nerve_decay)
 
@@ -18,22 +19,22 @@
 		var/mob/living/carbon/human/H = host_mob
 		H.physiology.stun_mod /= 0.75
 
-/datum/nanite_program/triggered/adrenaline
-	name = "Adrenaline Burst"
-	desc = "The nanites cause a burst of adrenaline when triggered, waking the host from stuns and temporarily increasing their speed."
-	trigger_cost = 25
-	trigger_cooldown = 1200
-	rogue_types = list(/datum/nanite_program/toxic, /datum/nanite_program/nerve_decay)
-
-/datum/nanite_program/triggered/adrenaline/trigger()
-	if(!..())
-		return
-	to_chat(host_mob, "<span class='notice'>You feel a sudden surge of energy!</span>")
-	host_mob.SetAllImmobility(0)
-	host_mob.adjustStaminaLoss(-75)
-	host_mob.set_resting(FALSE)
-	host_mob.update_mobility()
-	host_mob.reagents.add_reagent(/datum/reagent/medicine/stimulants/nanite, 1.5)
+///datum/nanite_program/triggered/adrenaline
+//	name = "Adrenaline Burst"
+//	desc = "The nanites cause a burst of adrenaline when triggered, waking the host from stuns and temporarily increasing their speed."
+//	trigger_cost = 25
+//	trigger_cooldown = 1200
+//	rogue_types = list(/datum/nanite_program/toxic, /datum/nanite_program/nerve_decay)
+//
+///datum/nanite_program/triggered/adrenaline/trigger()
+//	if(!..())
+//		return
+//	to_chat(host_mob, "<span class='notice'>You feel a sudden surge of energy!</span>")
+//	host_mob.SetAllImmobility(0)
+//	host_mob.adjustStaminaLoss(-75)
+//	host_mob.set_resting(FALSE)
+//	host_mob.update_mobility()
+//	host_mob.reagents.add_reagent(/datum/reagent/medicine/stimulants/nanite, 1.5)
 
 /datum/nanite_program/hardening
 	name = "Dermal Hardening"

--- a/code/modules/research/nanites/nanite_programs/buffing.dm
+++ b/code/modules/research/nanites/nanite_programs/buffing.dm
@@ -18,23 +18,6 @@
 		var/mob/living/carbon/human/H = host_mob
 		H.physiology.stun_mod /= 0.75
 
-///datum/nanite_program/triggered/adrenaline
-//	name = "Adrenaline Burst"
-//	desc = "The nanites cause a burst of adrenaline when triggered, waking the host from stuns and temporarily increasing their speed."
-//	trigger_cost = 25
-//	trigger_cooldown = 1200
-//	rogue_types = list(/datum/nanite_program/toxic, /datum/nanite_program/nerve_decay)
-//
-///datum/nanite_program/triggered/adrenaline/trigger()
-//	if(!..())
-//		return
-//	to_chat(host_mob, "<span class='notice'>You feel a sudden surge of energy!</span>")
-//	host_mob.SetAllImmobility(0)
-//	host_mob.adjustStaminaLoss(-75)
-//	host_mob.set_resting(FALSE)
-//	host_mob.update_mobility()
-//	host_mob.reagents.add_reagent(/datum/reagent/medicine/stimulants/nanite, 1.5)
-
 /datum/nanite_program/hardening
 	name = "Dermal Hardening"
 	desc = "The nanites form a mesh under the host's skin, protecting them from melee and bullet impacts."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1018,7 +1018,7 @@
 	display_name = "Harmonic Nanite Programming"
 	description = "Nanite programs that require seamless integration between nanites and biology."
 	prereq_ids = list("nanite_bio","nanite_smart","nanite_mesh")
-	design_ids = list("fakedeath_nanites","researchplus_nanites","aggressive_nanites","defib_nanites","regenerative_plus_nanites","brainheal_plus_nanites","purging_plus_nanites","adrenaline_nanites")
+	design_ids = list("fakedeath_nanites","researchplus_nanites","aggressive_nanites","defib_nanites","regenerative_plus_nanites","brainheal_plus_nanites","purging_plus_nanites")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000, TECHWEB_POINT_TYPE_NANITES = 2000)
 	export_price = 8000
 

--- a/yogstation/code/modules/research/techweb/all_nodes.dm
+++ b/yogstation/code/modules/research/techweb/all_nodes.dm
@@ -122,4 +122,4 @@
 	export_price = 7000
 
 /datum/techweb_node/nanite_harmonic
-	design_ids = list("fakedeath_nanites","aggressive_nanites","defib_nanites","regenerative_plus_nanites","brainheal_plus_nanites","purging_plus_nanites","adrenaline_nanites","nanite_heart")
+	design_ids = list("fakedeath_nanites","aggressive_nanites","defib_nanites","regenerative_plus_nanites","brainheal_plus_nanites","purging_plus_nanites","nanite_heart")


### PR DESCRIPTION
# General Documentation

## Intent of your Pull Request

Remove adrenaline and changes the cost of the nervous nanite (passive stun resistance) to 20 per second.

## Why is this change good for the game?

The "Mbrain" reasoned that nanites were broken, most notably adrenaline and nervous given how strong the stun resistance is and how negligible it is (Equivalent of getting free meth upon saying QQ according to the discord).

I'm currently working off of this person's vision and they can defend the pr in front of the HCs, along with anyone else who wanted to try to change nanites.
![cpng](https://user-images.githubusercontent.com/62276730/106344393-b3141480-6277-11eb-91da-dabac129a0b9.png)

Adrenaline is apparently flat out broken giving standard crewman traitor/ling abilities and can only be resolved with it's full removal or the change of it's cost to 250 per second among other options. 

Raising nervous cost to 20 per second apparently seeks to have players be more careful with their stun resistance while also allowing for more unique player interactions (i.e baiting the nanite user into wasting his stun resistance). This change is taxing on nanites to reflect how it costs the most out of any nanite program.

Contact @Mqiib for further reasoning and defense, along with anyone else he should choose to mention.. Don't shoot the messenger.

# Wiki Documentation

Guide to Nanites is to be updated with the removal of Adrenaline and the VPS of the nervous nanites to be changed to 20 per second.

### Changelog

:cl:  
rscdel: Removed old things  
tweak: changed nervous nanites vps from 1.5 to 20.  
/:cl:
