### PR TITLE
Vomitcrawling now ends if the pool of vomit you entered gets cleaned.

### DIFF
--- a/yogstation/code/datums/components/crawl.dm
+++ b/yogstation/code/datums/components/crawl.dm
@@ -400,8 +400,8 @@
 	if(holder)
 		if(iscarbon(mob))
 			var/mob/living/carbon/C = mob
-			for(var/obj/item/vomitcrawl/B in C)
-				qdel(B)
+			for(var/obj/item/vomitcrawl/V in C)
+				qdel(V)
 		mob.forceMove(get_turf(src))
 		mob.visible_message("<span class='warning'><B>[mob] suddenly appears from the vomit they had entered!</B></span>")
 		mob.Stun(50)

--- a/yogstation/code/datums/components/crawl.dm
+++ b/yogstation/code/datums/components/crawl.dm
@@ -404,8 +404,8 @@
 				qdel(B)
 		mob.forceMove(get_turf(src))
 		mob.visible_message("<span class='warning'><B>[mob] suddenly appears from the vomit they had entered!</B></span>")
-		mob.Stun(100)
-		mob.Knockdown(200)
+		mob.Stun(50)
+		mob.Knockdown(100)
 		qdel(holder.holder)
 		holder.holder = null
 		holder = null

--- a/yogstation/code/datums/components/crawl.dm
+++ b/yogstation/code/datums/components/crawl.dm
@@ -331,6 +331,7 @@
 	
 ////////////VOMITCRAWL
 /datum/component/crawl/vomit //ABSOLUTELY DISGUSIN
+	var/obj/item/vomitcrawlholder/crawl
 	crawling_types = list(/obj/effect/decal/cleanable/vomit,/obj/effect/decal/cleanable/insectguts)
 	gain_message = "<span class='boldnotice'>You can now vomitcrawl! Alt-click pools of vomit to phase in and out.</span>"
 	loss_message = "<span class='warning'>You can no longer vomitcrawl.</span>"
@@ -346,6 +347,9 @@
 
 /datum/component/crawl/vomit/start_crawling(atom/target, mob/living/user)
 	if(iscarbon(user))
+		crawl = new(target)
+		crawl.holder = src
+		crawl.mob = user
 		var/mob/living/carbon/C = user
 		var/obj/item/vomitcrawl/B1 = new(C)
 		var/obj/item/vomitcrawl/B2 = new(C)
@@ -381,8 +385,31 @@
 		for(var/obj/item/vomitcrawl/B in C)
 			qdel(B)
 	..()
+	crawl.holder = null
+	qdel(crawl)
+	crawl = null
 	user.visible_message("<span class='warning'><B>[user] rises out of the pool of vomit!?</B></span>")
 	exit_vomit_effect(target, user)
+
+/obj/item/vomitcrawlholder	//if the pool of vomit we entered gets destroyed, we appear stunned on top of it
+	desc = "If you see this, contact a coder"
+	var/datum/component/crawl/vomit/holder
+	var/mob/living/mob
+	
+/obj/item/vomitcrawlholder/Destroy()
+	if(holder)
+		if(iscarbon(mob))
+			var/mob/living/carbon/C = mob
+			for(var/obj/item/vomitcrawl/B in C)
+				qdel(B)
+		mob.forceMove(get_turf(src))
+		mob.visible_message("<span class='warning'><B>[mob] suddenly appears from the vomit they had entered!</B></span>")
+		mob.Stun(100)
+		mob.Knockdown(200)
+		qdel(holder.holder)
+		holder.holder = null
+		holder = null
+	. = ..()
 
 /obj/item/vomitcrawl
 	name = "vomit crawl"
@@ -393,4 +420,3 @@
 /obj/item/vomitcrawl/Initialize()
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, ABSTRACT_ITEM_TRAIT)
-


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request
Vomit is rare, and you can get stuck in limbo if you enter it and all vomit pools get cleaned up.

### Why is this change good for the game?
Nobody likes being stuck in an ethereal plane forever. Security can also catch a person that vomitcrawls away by cleaning the vomit away.

### What should players be aware of when it comes to the changes your PR is implementing?
Cleaning the pool of vomit you entered will immediately throw you out of it, stunned and knocked down.
### What general grouping does this PR fall under? 
Vomitcrawl tweak

# Changelog
:cl:  
tweak: vomitcrawl ends if the pool of blood you entered gets cleaned, leaving you knocked down and stunned
/:cl:
