### PR TITLE
Changes how the push for actually using anesthetics works so it's more intuitive

### DIFF
--- a/code/datums/brain_damage/special.dm
+++ b/code/datums/brain_damage/special.dm
@@ -155,11 +155,13 @@
 /datum/brain_trauma/special/tenacity/on_gain()
 	ADD_TRAIT(owner, TRAIT_NOSOFTCRIT, TRAUMA_TRAIT)
 	ADD_TRAIT(owner, TRAIT_NOHARDCRIT, TRAUMA_TRAIT)
+	ADD_TRAIT(owner, TRAIT_SURGERY_PREPARED, TRAUMA_TRAIT)
 	..()
 
 /datum/brain_trauma/special/tenacity/on_lose()
 	REMOVE_TRAIT(owner, TRAIT_NOSOFTCRIT, TRAUMA_TRAIT)
 	REMOVE_TRAIT(owner, TRAIT_NOHARDCRIT, TRAUMA_TRAIT)
+	REMOVE_TRAIT(owner, TRAIT_SURGERY_PREPARED, TRAUMA_TRAIT)
 	..()
 
 /datum/brain_trauma/special/death_whispers

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -577,9 +577,6 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 			adjustToxLoss(1)
 			if(prob(5) && !stat)
 				to_chat(src, "<span class='warning'>Maybe you should lie down for a bit...</span>")
-			ADD_TRAIT(src, TRAIT_SURGERY_PREPARED, "drunkashell")
-		else
-			REMOVE_TRAIT(src, TRAIT_SURGERY_PREPARED, "drunkashell")
 
 		if(drunkenness >= 91)
 			adjustToxLoss(1)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -94,8 +94,6 @@
 	var/list/status_effects //a list of all status effects the mob has
 	var/druggy = 0
 
-	var/surgery_fail_mod = 1 //multiplied by UNPREPARED_SURGERY_PENALTY for an increase in surgery fail chance when doing surgery on someone who is not prepared properly for surgery, reduced by some chemicals
-
 	/// List of changes to body temperature, used by desease symtoms like fever
 	var/list/body_temp_changes = list()
 

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2205,12 +2205,6 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_name = "Painkiller"
 	glass_desc = "A combination of tropical juices and rum. Surely this will make you feel better."
 
-/datum/reagent/consumable/ethanol/painkiller/on_mob_metabolize(mob/living/M)
-	M.surgery_fail_mod *= 0.5
-
-/datum/reagent/consumable/ethanol/painkiller/on_mob_end_metabolize(mob/living/M)
-	M.surgery_fail_mod /= 0.5
-
 /datum/reagent/consumable/ethanol/pina_colada
 	name = "Pina Colada"
 	description = "A fresh pineapple drink with coconut rum. Yum."
@@ -2255,7 +2249,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	taste_description = "sweet corn beer and the hood life"
 	glass_name = "glass of malt liquor"
 	glass_desc = "A freezing pint of malt liquor."
-	
+
 /datum/reagent/consumable/ethanol/ratvarnac
 	name = "Justicars Juice"
 	description = "I don't even know what an eminence is, but I want him to recall."

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -376,12 +376,7 @@
 				to_chat(M, "<span class='danger'>You feel your wounds fade away to nothing!</span>" )
 	..()
 
-/datum/reagent/medicine/mine_salve/on_mob_metabolize(mob/living/M)
-	..()
-	M.surgery_fail_mod *= 0.5
-
 /datum/reagent/medicine/mine_salve/on_mob_end_metabolize(mob/living/M)
-	M.surgery_fail_mod /= 0.5
 	if(iscarbon(M))
 		var/mob/living/carbon/N = M
 		N.hal_screwyhud = SCREWYHUD_NONE

--- a/code/modules/surgery/advanced/lobotomy.dm
+++ b/code/modules/surgery/advanced/lobotomy.dm
@@ -26,6 +26,7 @@
 	implements = list(/obj/item/scalpel = 85, /obj/item/melee/transforming/energy/sword = 55, /obj/item/kitchen/knife = 35,
 		/obj/item/shard = 25, /obj/item = 20)
 	time = 100
+	fuckup_damage = 20
 
 /datum/surgery_step/lobotomize/tool_check(mob/user, obj/item/tool)
 	if(implement_type == /obj/item && !tool.is_sharp())

--- a/code/modules/surgery/brain_surgery.dm
+++ b/code/modules/surgery/brain_surgery.dm
@@ -16,6 +16,7 @@
 	name = "fix brain"
 	implements = list(/obj/item/hemostat = 85, TOOL_SCREWDRIVER = 35, /obj/item/pen = 15) //don't worry, pouring some alcohol on their open brain will get that chance to 100
 	time = 120 //long and complicated
+	fuckup_damage = 20
 
 /datum/surgery/brain_surgery/can_start(mob/user, mob/living/carbon/target)
 	var/obj/item/organ/brain/B = target.getorganslot(ORGAN_SLOT_BRAIN)

--- a/code/modules/surgery/coronary_bypass.dm
+++ b/code/modules/surgery/coronary_bypass.dm
@@ -18,6 +18,7 @@
 	implements = list(/obj/item/scalpel = 90, /obj/item/melee/transforming/energy/sword = 45, /obj/item/kitchen/knife = 45,
 		/obj/item/shard = 25)
 	time = 16
+	fuckup_damage = 20
 
 /datum/surgery_step/incise_heart/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, "<span class='notice'>You begin to make an incision in [target]'s heart...</span>",
@@ -50,6 +51,7 @@
 	name = "graft coronary bypass"
 	implements = list(/obj/item/hemostat = 90, TOOL_WIRECUTTER = 35, /obj/item/stack/packageWrap = 15, /obj/item/stack/cable_coil = 5)
 	time = 90
+	fuckup_damage = 20
 
 /datum/surgery_step/coronary_bypass/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, "<span class='notice'>You begin to graft a bypass onto [target]'s heart...</span>",

--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -26,7 +26,7 @@
 	implements = list(/obj/item/hemostat = 100, TOOL_SCREWDRIVER = 65, /obj/item/pen = 55)
 	repeatable = TRUE
 	time = 25
-	fuckup_damage = 5
+	fuckup_damage = 0
 	var/brutehealing = 0
 	var/burnhealing = 0
 	var/missinghpbonus = 0 //heals an extra point of damager per X missing damage of type (burn damage for burn healing, brute for brute). Smaller Number = More Healing!

--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -26,6 +26,7 @@
 	implements = list(/obj/item/hemostat = 100, TOOL_SCREWDRIVER = 65, /obj/item/pen = 55)
 	repeatable = TRUE
 	time = 25
+	fuckup_damage = 5
 	var/brutehealing = 0
 	var/burnhealing = 0
 	var/missinghpbonus = 0 //heals an extra point of damager per X missing damage of type (burn damage for burn healing, brute for brute). Smaller Number = More Healing!

--- a/code/modules/surgery/lobectomy.dm
+++ b/code/modules/surgery/lobectomy.dm
@@ -18,6 +18,7 @@
 	implements = list(/obj/item/scalpel = 95, /obj/item/melee/transforming/energy/sword = 65, /obj/item/kitchen/knife = 45,
 		/obj/item/shard = 35)
 	time = 42
+	fuckup_damage = 20
 
 /datum/surgery_step/lobectomy/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, "<span class='notice'>You begin to make an incision in [target]'s lungs...</span>",

--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -65,6 +65,7 @@
 	implements = list(/obj/item/cautery = 100, /obj/item/gun/energy/laser = 90, TOOL_WELDER = 70,
 		/obj/item = 30) // 30% success with any hot item.
 	time = 24
+	fuckup_damage_type = BURN
 
 /datum/surgery_step/close/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, "<span class='notice'>You begin to mend the incision in [target]'s [parse_zone(target_zone)]...</span>",
@@ -94,6 +95,7 @@
 		/obj/item/melee/arm_blade = 75, /obj/item/mounted_chainsaw = 65, /obj/item/twohanded/required/chainsaw = 50,
 		/obj/item/twohanded/fireaxe = 50, /obj/item/hatchet = 35, /obj/item/kitchen/knife/butcher = 25)
 	time = 54
+	fuckup_damage = 20
 
 /datum/surgery_step/saw/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, "<span class='notice'>You begin to saw through the bone in [target]'s [parse_zone(target_zone)]...</span>",
@@ -112,6 +114,7 @@
 	name = "drill bone"
 	implements = list(/obj/item/surgicaldrill = 100, /obj/item/pickaxe/drill = 60, /obj/item/mecha_parts/mecha_equipment/drill = 60, TOOL_SCREWDRIVER = 20)
 	time = 30
+	fuckup_damage = 15
 
 /datum/surgery_step/drill/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, "<span class='notice'>You begin to drill into the bone in [target]'s [parse_zone(target_zone)]...</span>",

--- a/code/modules/surgery/plastic_surgery.dm
+++ b/code/modules/surgery/plastic_surgery.dm
@@ -8,6 +8,7 @@
 	name = "reshape face"
 	implements = list(/obj/item/scalpel = 100, /obj/item/kitchen/knife = 50, TOOL_WIRECUTTER = 35)
 	time = 64
+	fuckup_damage = 0
 
 /datum/surgery_step/reshape_face/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	user.visible_message("[user] begins to alter [target]'s appearance.", "<span class='notice'>You begin to alter [target]'s appearance...</span>")

--- a/code/modules/surgery/remove_embedded_object.dm
+++ b/code/modules/surgery/remove_embedded_object.dm
@@ -8,6 +8,7 @@
 	name = "remove embedded objects"
 	time = 32
 	accept_hand = 1
+	fuckup_damage = 2
 	var/obj/item/bodypart/L = null
 
 

--- a/code/modules/surgery/remove_embedded_object.dm
+++ b/code/modules/surgery/remove_embedded_object.dm
@@ -8,7 +8,7 @@
 	name = "remove embedded objects"
 	time = 32
 	accept_hand = 1
-	fuckup_damage = 2
+	fuckup_damage = 0
 	var/obj/item/bodypart/L = null
 
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -1,5 +1,3 @@
-#define UNPREPARED_SURGERY_PENALTY 0.5
-
 /datum/surgery
 	var/name = "surgery"
 	var/desc = "surgery description"
@@ -124,20 +122,16 @@
 
 /datum/surgery/proc/get_probability_multiplier()
 	var/probability = 0.5
-	var/failure_multiplier = 0
 	var/turf/T = get_turf(target)
 
-	if(locate(/obj/structure/table/optable, T))
+	if(locate(/obj/structure/table/optable, T) || locate(/obj/machinery/stasis, T))
 		probability = 1
-	else if(locate(/obj/structure/table, T) || locate(/obj/machinery/stasis, T))
+	else if(locate(/obj/structure/table, T))
 		probability = 0.8
 	else if(locate(/obj/structure/bed, T))
 		probability = 0.7
-	if(!HAS_TRAIT(target, TRAIT_SURGERY_PREPARED) && target.stat != DEAD && !IS_IN_STASIS(target)) //not under the effects of anaesthetics or a strong painkiller, harsh penalty to success chance
-		if(operated_bodypart.status == BODYPART_ORGANIC) //additionally robot limbs don't feel pain
-			failure_multiplier = UNPREPARED_SURGERY_PENALTY * target.surgery_fail_mod
 
-	return propability + success_multiplier - failure_multiplier
+	return probability + success_multiplier
 
 /datum/surgery/advanced
 	name = "advanced surgery"

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -122,18 +122,17 @@
 	SSblackbox.record_feedback("tally", "surgeries_completed", 1, type)
 	qdel(src)
 
-/datum/surgery/proc/get_propability_multiplier()
-	var/propability = 0.5
+/datum/surgery/proc/get_probability_multiplier()
+	var/probability = 0.5
 	var/failure_multiplier = 0
 	var/turf/T = get_turf(target)
 
 	if(locate(/obj/structure/table/optable, T))
-		propability = 1
+		probability = 1
 	else if(locate(/obj/structure/table, T) || locate(/obj/machinery/stasis, T))
-		propability = 0.8
+		probability = 0.8
 	else if(locate(/obj/structure/bed, T))
-		propability = 0.7
-
+		probability = 0.7
 	if(!HAS_TRAIT(target, TRAIT_SURGERY_PREPARED) && target.stat != DEAD && !IS_IN_STASIS(target)) //not under the effects of anaesthetics or a strong painkiller, harsh penalty to success chance
 		if(operated_bodypart.status == BODYPART_ORGANIC) //additionally robot limbs don't feel pain
 			failure_multiplier = UNPREPARED_SURGERY_PENALTY * target.surgery_fail_mod

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -1,3 +1,5 @@
+#define SURGERY_FUCKUP_CHANCE 50
+
 /datum/surgery_step
 	var/name
 	var/list/implements = list()	//format is path = probability of success. alternatively
@@ -8,6 +10,9 @@
 	var/repeatable = FALSE				//can this step be repeated? Make shure it isn't last step, or it used in surgery with `can_cancel = 1`. Or surgion will be stuck in the loop
 	var/list/chems_needed = list()  //list of chems needed to complete the step. Even on success, the step will have no effect if there aren't the chems required in the mob.
 	var/require_all_chems = TRUE    //any on the list or all on the list?
+	var/list/ouchie_reduction_chems = list(/datum/reagent/consumable/ethanol/painkiller = 0.5, /datum/reagent/medicine/morphine = 0.5) //chems that will reduce the chance for fuckups while operating on conscious patients, stacks.
+	var/fuckup_damage = 10			//base damage dealt on a surgery being done without anesthetics on SURGERY_FUCKUP_CHANCE percent chance
+	var/fuckup_damage_type = BRUTE	//damage type fuckup_damage is dealt as
 
 /datum/surgery_step/proc/try_op(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, try_to_fail = FALSE)
 	var/success = FALSE
@@ -90,7 +95,10 @@
 		else
 			if(failure(user, target, target_zone, tool, surgery))
 				advance = TRUE
-
+		if(!HAS_TRAIT(target, TRAIT_SURGERY_PREPARED) && target.stat != DEAD && !IS_IN_STASIS(target)) //not under the effects of anaesthetics or a strong painkiller, harsh penalty to success chance
+			var/obj/item/bodypart/operated_bodypart = target.get_bodypart(target_zone)
+			if(!operated_bodypart || operated_bodypart?.status == BODYPART_ORGANIC) //robot limbs don't feel pain but attaching a new bodypart will
+				cause_ouchie(user, target, target_zone, tool, advance)
 		if(advance && !repeatable)
 			surgery.status++
 			if(surgery.status > surgery.steps.len)
@@ -160,3 +168,22 @@
 		detailed_mobs -= target //The patient can't see well what's going on, unless it's something like getting cut
 	user.visible_message(detailed_message, self_message, vision_distance = 1, ignored_mobs = target_detailed ? null : target)
 	user.visible_message(vague_message, "", ignored_mobs = detailed_mobs)
+
+/datum/surgery_step/proc/cause_ouchie(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, success)
+	var/ouchie_mod = 1
+	for(var/datum/reagent/R in ouchie_reduction_chems)
+		if(target.reagents?.has_reagent(R))
+			ouchie_mod *= ouchie_reduction_chems[R]
+	if(target.stat == UNCONSCIOUS)
+		ouchie_mod *= 0.8
+	ouchie_mod *= clamp(1-target.drunkenness/100, 0, 1)
+	if(!success)
+		ouchie_mod *= 2
+	var/final_ouchie_chance = SURGERY_FUCKUP_CHANCE * ouchie_mod
+	if(!prob(final_ouchie_chance))
+		return
+	user.visible_message("<span class='boldwarning'>[target] flinches, bumping [user]'s [tool ? tool.name : "hand"] into something important!", "[target]  flinches, bumping your [tool ? tool.name : "hand"] into something important!</span>")
+	target.apply_damage(fuckup_damage, fuckup_damage_type, target_zone)
+	if(ishuman(target) &&fuckup_damage_type == BRUTE && prob(final_ouchie_chance/2))
+		var/mob/living/carbon/human/H = target
+		H.bleed_rate += min(fuckup_damage/4, 10)

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -182,7 +182,7 @@
 	var/final_ouchie_chance = SURGERY_FUCKUP_CHANCE * ouchie_mod
 	if(!prob(final_ouchie_chance))
 		return
-	user.visible_message("<span class='boldwarning'>[target] flinches, bumping [user]'s [tool ? tool.name : "hand"] into something important!", "[target]  flinches, bumping your [tool ? tool.name : "hand"] into something important!</span>")
+	user.visible_message("<span class='boldwarning'>[target] flinches, bumping [user]'s [tool ? tool.name : "hand"] into something important!</span>", "<span class='boldwarning'>[target]  flinches, bumping your [tool ? tool.name : "hand"] into something important!</span>")
 	target.apply_damage(fuckup_damage, fuckup_damage_type, target_zone)
 	if(ishuman(target) &&fuckup_damage_type == BRUTE && prob(final_ouchie_chance/2))
 		var/mob/living/carbon/human/H = target

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -96,7 +96,7 @@
 			if(failure(user, target, target_zone, tool, surgery))
 				advance = TRUE
 		if(!HAS_TRAIT(target, TRAIT_SURGERY_PREPARED) && target.stat != DEAD && !IS_IN_STASIS(target)) //not under the effects of anaesthetics or a strong painkiller, harsh penalty to success chance
-			if(!issilicon(user) || !HAS_TRAIT(user, TRAIT_SURGEON)) //borgs and abductors are immune to this
+			if(!issilicon(user) && !HAS_TRAIT(user, TRAIT_SURGEON)) //borgs and abductors are immune to this
 				var/obj/item/bodypart/operated_bodypart = target.get_bodypart(target_zone)
 				if(!operated_bodypart || operated_bodypart?.status == BODYPART_ORGANIC) //robot limbs don't feel pain
 					cause_ouchie(user, target, target_zone, tool, advance)

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -10,7 +10,7 @@
 	var/repeatable = FALSE				//can this step be repeated? Make shure it isn't last step, or it used in surgery with `can_cancel = 1`. Or surgion will be stuck in the loop
 	var/list/chems_needed = list()  //list of chems needed to complete the step. Even on success, the step will have no effect if there aren't the chems required in the mob.
 	var/require_all_chems = TRUE    //any on the list or all on the list?
-	var/list/ouchie_reduction_chems = list(/datum/reagent/consumable/ethanol/painkiller = 0.5, /datum/reagent/medicine/morphine = 0.5) //chems that will reduce the chance for fuckups while operating on conscious patients, stacks.
+	var/list/ouchie_modifying_chems = list(/datum/reagent/consumable/ethanol/painkiller = 0.5, /datum/reagent/medicine/morphine = 0.5) //chems that will modify the chance for fuckups while operating on conscious patients, stacks.
 	var/fuckup_damage = 10			//base damage dealt on a surgery being done without anesthetics on SURGERY_FUCKUP_CHANCE percent chance
 	var/fuckup_damage_type = BRUTE	//damage type fuckup_damage is dealt as
 
@@ -172,9 +172,9 @@
 
 /datum/surgery_step/proc/cause_ouchie(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, success)
 	var/ouchie_mod = 1
-	for(var/datum/reagent/R in ouchie_reduction_chems)
+	for(var/datum/reagent/R in ouchie_modifying_chems)
 		if(target.reagents?.has_reagent(R))
-			ouchie_mod *= ouchie_reduction_chems[R]
+			ouchie_mod *= ouchie_modifying_chems[R]
 	if(target.stat == UNCONSCIOUS)
 		ouchie_mod *= 0.8
 	ouchie_mod *= clamp(1-target.drunkenness/100, 0, 1)

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -96,7 +96,7 @@
 			if(failure(user, target, target_zone, tool, surgery))
 				advance = TRUE
 		if((!HAS_TRAIT(target, TRAIT_SURGERY_PREPARED) && target.stat != DEAD && !IS_IN_STASIS(target)) //not under the effects of anaesthetics or a strong painkiller, harsh penalty to success chance
-			if(!issilicon(user) || !HAS_TRAIT(user, TRAIT_SURGEON))) //borgs and abductors are immune to this
+			if(!issilicon(user) || !HAS_TRAIT(user, TRAIT_SURGEON)) //borgs and abductors are immune to this
 				var/obj/item/bodypart/operated_bodypart = target.get_bodypart(target_zone)
 				if(!operated_bodypart || operated_bodypart?.status == BODYPART_ORGANIC) //robot limbs don't feel pain
 					cause_ouchie(user, target, target_zone, tool, advance)

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -95,7 +95,7 @@
 		else
 			if(failure(user, target, target_zone, tool, surgery))
 				advance = TRUE
-		if(!HAS_TRAIT(target, TRAIT_SURGERY_PREPARED) && target.stat != DEAD && !IS_IN_STASIS(target)) //not under the effects of anaesthetics or a strong painkiller, harsh penalty to success chance
+		if(!HAS_TRAIT(target, TRAIT_SURGERY_PREPARED) && target.stat != DEAD && !IS_IN_STASIS(target) || !issilicon(user)) //not under the effects of anaesthetics or a strong painkiller, harsh penalty to success chance
 			var/obj/item/bodypart/operated_bodypart = target.get_bodypart(target_zone)
 			if(!operated_bodypart || operated_bodypart?.status == BODYPART_ORGANIC) //robot limbs don't feel pain but attaching a new bodypart will
 				cause_ouchie(user, target, target_zone, tool, advance)

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -81,7 +81,7 @@
 
 		if(implement_type)	//this means it isn't a require hand or any item step.
 			prob_chance = implements[implement_type]
-		prob_chance *= surgery.get_propability_multiplier()
+		prob_chance *= surgery.get_probability_multiplier()
 
 		if((prob(prob_chance) || iscyborg(user)) && chem_check(target, user,
 	 tool) && !try_to_fail)

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -95,7 +95,7 @@
 		else
 			if(failure(user, target, target_zone, tool, surgery))
 				advance = TRUE
-		if(!HAS_TRAIT(target, TRAIT_SURGERY_PREPARED) && target.stat != DEAD && !IS_IN_STASIS(target)) //not under the effects of anaesthetics or a strong painkiller, harsh penalty to success chance
+		if(!HAS_TRAIT(target, TRAIT_SURGERY_PREPARED) && target.stat != DEAD && !IS_IN_STASIS(target) && fuckup_damage) //not under the effects of anaesthetics or a strong painkiller, harsh penalty to success chance
 			if(!issilicon(user) && !HAS_TRAIT(user, TRAIT_SURGEON)) //borgs and abductors are immune to this
 				var/obj/item/bodypart/operated_bodypart = target.get_bodypart(target_zone)
 				if(!operated_bodypart || operated_bodypart?.status == BODYPART_ORGANIC) //robot limbs don't feel pain

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -95,10 +95,11 @@
 		else
 			if(failure(user, target, target_zone, tool, surgery))
 				advance = TRUE
-		if(!HAS_TRAIT(target, TRAIT_SURGERY_PREPARED) && target.stat != DEAD && !IS_IN_STASIS(target) || !issilicon(user)) //not under the effects of anaesthetics or a strong painkiller, harsh penalty to success chance
-			var/obj/item/bodypart/operated_bodypart = target.get_bodypart(target_zone)
-			if(!operated_bodypart || operated_bodypart?.status == BODYPART_ORGANIC) //robot limbs don't feel pain but attaching a new bodypart will
-				cause_ouchie(user, target, target_zone, tool, advance)
+		if((!HAS_TRAIT(target, TRAIT_SURGERY_PREPARED) && target.stat != DEAD && !IS_IN_STASIS(target)) //not under the effects of anaesthetics or a strong painkiller, harsh penalty to success chance
+			if(!issilicon(user) || !HAS_TRAIT(user, TRAIT_SURGEON))) //borgs and abductors are immune to this
+				var/obj/item/bodypart/operated_bodypart = target.get_bodypart(target_zone)
+				if(!operated_bodypart || operated_bodypart?.status == BODYPART_ORGANIC) //robot limbs don't feel pain but attaching a new bodypart will
+					cause_ouchie(user, target, target_zone, tool, advance)
 		if(advance && !repeatable)
 			surgery.status++
 			if(surgery.status > surgery.steps.len)

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -98,7 +98,7 @@
 		if((!HAS_TRAIT(target, TRAIT_SURGERY_PREPARED) && target.stat != DEAD && !IS_IN_STASIS(target)) //not under the effects of anaesthetics or a strong painkiller, harsh penalty to success chance
 			if(!issilicon(user) || !HAS_TRAIT(user, TRAIT_SURGEON))) //borgs and abductors are immune to this
 				var/obj/item/bodypart/operated_bodypart = target.get_bodypart(target_zone)
-				if(!operated_bodypart || operated_bodypart?.status == BODYPART_ORGANIC) //robot limbs don't feel pain but attaching a new bodypart will
+				if(!operated_bodypart || operated_bodypart?.status == BODYPART_ORGANIC) //robot limbs don't feel pain
 					cause_ouchie(user, target, target_zone, tool, advance)
 		if(advance && !repeatable)
 			surgery.status++

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -95,7 +95,7 @@
 		else
 			if(failure(user, target, target_zone, tool, surgery))
 				advance = TRUE
-		if((!HAS_TRAIT(target, TRAIT_SURGERY_PREPARED) && target.stat != DEAD && !IS_IN_STASIS(target)) //not under the effects of anaesthetics or a strong painkiller, harsh penalty to success chance
+		if(!HAS_TRAIT(target, TRAIT_SURGERY_PREPARED) && target.stat != DEAD && !IS_IN_STASIS(target)) //not under the effects of anaesthetics or a strong painkiller, harsh penalty to success chance
 			if(!issilicon(user) || !HAS_TRAIT(user, TRAIT_SURGEON)) //borgs and abductors are immune to this
 				var/obj/item/bodypart/operated_bodypart = target.get_bodypart(target_zone)
 				if(!operated_bodypart || operated_bodypart?.status == BODYPART_ORGANIC) //robot limbs don't feel pain

--- a/yogstation/code/datums/diseases/advance/symptoms/confusion.dm
+++ b/yogstation/code/datums/diseases/advance/symptoms/confusion.dm
@@ -37,6 +37,7 @@
 		if(prob(base_message_chance) && !suppress_warning)
 			to_chat(M, "<span class='notice'>[pick("You feel better.")]</span>")
 	else
+		ADD_TRAIT(M, TRAIT_SURGERY_PREPARED, DISEASE_TRAIT)
 		M.AdjustStun(stun_reduce, 0)
 		M.set_screwyhud(SCREWYHUD_HEALTHY)
 		if(stamina_regen)
@@ -50,6 +51,7 @@
 	if(!..())
 		return
 	else
+		REMOVE_TRAIT(M, TRAIT_SURGERY_PREPARED, DISEASE_TRAIT)
 		M.set_screwyhud(SCREWYHUD_NONE)
 		M.updatehealth()
 	return

--- a/yogstation/code/modules/surgery/healing_surgeries.dm
+++ b/yogstation/code/modules/surgery/healing_surgeries.dm
@@ -19,6 +19,7 @@
 	name = "apply gauze"
 	implements = list(/obj/item/stack/medical/gauze = 100, /obj/item/medical/bandage/improvised = 65, /obj/item/clothing/torncloth = 35)
 	time = 24
+	fuckup_damage = 0
 	var/dressing_type = "brute"
 
 /datum/surgery_step/apply_dressing/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Surgeries no longer have the stupid innate 0.5 subtracted from their success multiplier without proper preparation
instead there is an innate 50% chance for surgeries without anesthetics/painkillers to have a slip-up regardless of success
this chance is altered multiplicatively by:
failing the surgery (*2)
the target having the chems "painkiller" and "miner's salve" in their reagents (*0.5 for each)
the target being unconscious through any means (*0.8)
the target's drunkenness (treated as a % value that is removed i.e. 50 drunkenness is *0.5, 100 drunkenness is *0)
a slip-up will not fail the surgery step, but will deal extra damage and can cause bleeding with the amount depending on the surgery step. Healing steps and the plastic surgery step can't cause slipups
The numbness symptom analgesia and tenacity brain trauma also count as painkillers
tldr failing surgeries actually matters now

### Why is this change good for the game?
current system isn't functioning as fully intended

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
This will be the basis of the Wiki entry for your PR, and more information / detail is better for Wiki editors to integrate.
surgeries without the patient being under anesthetics, morphine, or the effects of a stasis bed will have a 50% chance to deal damage on each step, this can also cause bleeding if the step that fails isn't the cautery one
this chance is doubled if the step fails so don't do that
### What should players be aware of when it comes to the changes your PR is implementing?
ghetto surgery is now riskier than normal surgery since you can die from doing it wrong, also use of an anesthetic tank, morphine, or a stasis bed for normal surgeries is preferred over the lack of one
Cyborgs, as with normal surgery failure chance, don't have to deal with this because they are special snowflakes who can't use hands
steps that heal i.e. tend wounds, patch/treat and removal of embedded objects as well as the reshape face step of plastic surgery will not trigger this effect
### What general grouping does this PR fall under? 
surgery

### Are there any aspects of the PR that you would like us not to mention on the Wiki?
no


# Changelog

:cl:  
tweak: surgeries will no longer have a high fail chance if the target is not under anesthetics or painkillers, instead they'll have a high chance to cause a small to moderate amount of damage. This chance can be reduced through high alcohol intake and certain chemicals and outright removed with the application of morphine or an anesthetic gas
tweak: stasis bed success modifier returned to 1 from 0.8
/:cl:
