### PR TITLE
makes mosins medium size

### DIFF
--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -92,6 +92,7 @@ obj/item/gun/ballistic/rifle/attackby(obj/item/A, mob/user, params)
 	if(.)
 		spread = 36
 		can_bayonet = FALSE
+		weapon_weight = WEAPON_LIGHT
 
 /obj/item/gun/ballistic/rifle/boltaction/blow_up(mob/user)
 	. = 0

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -61,6 +61,7 @@ obj/item/gun/ballistic/rifle/attackby(obj/item/A, mob/user, params)
 	knife_x_offset = 27
 	knife_y_offset = 13
 	can_be_sawn_off = TRUE
+	weapon_weight = WEAPON_MEDIUM
 
 /obj/item/gun/ballistic/rifle/boltaction/sawoff(mob/user)
 	. = ..()


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

mosin is now medium sized and can't be dual fired
sawing it off into an obrez will allow you to dual fire it again

### Why is this change good for the game?
large high damage weapons generally should be harder to fire quickly to make up for their high damage
# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
This will be the basis of the Wiki entry for your PR, and more information / detail is better for Wiki editors to integrate.

### What should players be aware of when it comes to the changes your PR is implementing?
mosin can no longer be dual wield fired with harm intent dual firing
### What general grouping does this PR fall under? 
guns


# Changelog

:cl:  
tweak: mosin is now classified as a medium sized weapon and cannot be dual fired with harm intent 
/:cl:
