### PR TITLE
luxury shuttle blockers are no longer breakable

### DIFF
--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -210,6 +210,7 @@
 	density = FALSE //allows shuttle airlocks to close, nothing but an approved passenger gets past CanPass
 	locked = TRUE
 	use_power = FALSE
+	resistance_flags = INDESTRUCTIBLE
 	var/threshold = 500
 	var/static/list/approved_passengers = list()
 	var/static/list/check_times = list()


### PR DESCRIPTION
SORRY LINK, I DON'T GIVE CREDIT
COME BACK WHEN YOU'RE A LITTLE, MMMMMMMMMM, RICHER

:cl:  
bugfix: you can no longer break the luxury shuttle ticket acceptors
/:cl:
