### PR TITLE
Allows regenerative cores to be used in-hand for self-application

### DIFF
--- a/code/modules/mining/equipment/regenerative_core.dm
+++ b/code/modules/mining/equipment/regenerative_core.dm
@@ -65,7 +65,17 @@
 	..()
 	if(owner.health <= owner.crit_threshold)
 		ui_action_click()
-
+		
+/obj/item/organ/regenerative_core/attack_self(mob/user)
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	to_chat(user, "<span class='notice'>You crush [src] within your hand. Disgusting tendrils spread across your body, hold you together and allow you to keep moving, but for how long?</span>")
+	SSblackbox.record_feedback("nested tally", "hivelord_core", 1, list("[type]", "used", "self"))
+	H.apply_status_effect(STATUS_EFFECT_REGENERATIVE_CORE)
+	SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "core", /datum/mood_event/healsbadman)
+	qdel(src)
+	
 /obj/item/organ/regenerative_core/afterattack(atom/target, mob/user, proximity_flag)
 	. = ..()
 	if(proximity_flag && ishuman(target))


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request
![obraz](https://user-images.githubusercontent.com/71487903/106523174-01781c00-64e1-11eb-8d01-dcd47427bbb2.png)
Sometimes the big 3x3 megafauna sprites cover so much space you cannot use the regenerative core, because it's obstructing your sprite.

### Why is this change good for the game?
Miners won't get angry by not being able to use regen cores in a clutch.

### Briefly describe your PR and the impacts of it, in layman's terms. 
Allows legion cores to be self-applied by using the core inhand.

### What should players be aware of when it comes to the changes your PR is implementing?
That they can use regenerative cores inhand.

### What general grouping does this PR fall under? 
Mining tweak

# Changelog
:cl:  
tweak: makes it able for a person to use a regenerative core in hand to self-apply it
/:cl: