### PR TITLE
Fixes oversight where holotool is unable to be turned off

### DIFF
--- a/yogstation/code/game/objects/items/holotool/holotool.dm
+++ b/yogstation/code/game/objects/items/holotool/holotool.dm
@@ -42,6 +42,7 @@
 	if(current_tool)
 		current_tool.on_unset(src)
 	current_tool = mode
+
 	current_tool.on_set(src)
 	playsound(loc, 'yogstation/sound/items/holotool.ogg', get_clamped_volume(), 1, -1)
 	update_icon()
@@ -72,7 +73,10 @@
 		holo_item.color = current_color
 		item_state = current_tool.name
 		add_overlay(holo_item)
-		set_light(3, null, current_color)
+		if(current_tool.name == "off")
+			set_light(0)
+		else
+			set_light(3, null, current_color)
 	else
 		item_state = "holotool"
 		icon_state = "holotool"

--- a/yogstation/code/game/objects/items/holotool/holotool.dm
+++ b/yogstation/code/game/objects/items/holotool/holotool.dm
@@ -42,7 +42,6 @@
 	if(current_tool)
 		current_tool.on_unset(src)
 	current_tool = mode
-
 	current_tool.on_set(src)
 	playsound(loc, 'yogstation/sound/items/holotool.ogg', get_clamped_volume(), 1, -1)
 	update_icon()

--- a/yogstation/code/game/objects/items/holotool/modes.dm
+++ b/yogstation/code/game/objects/items/holotool/modes.dm
@@ -19,6 +19,10 @@
 
 ////////////////////////////////////////////////
 
+/datum/holotool_mode/off
+	name = "off"
+	sound = 'yogstation/sound/items/holotool.ogg'
+
 /datum/holotool_mode/screwdriver
 	name = "holo-screwdriver"
 	sound = 'yogstation/sound/items/holotool.ogg'


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Adds a new holotool mode - "off". Previously it didn't have one nor did it have the option of apparently ever turning it off once you picked a mode. This adds a new radial menu and regular menu option to set it to "off". it removes the tool behavior and shuts off the light.

### Why is this change good for the game?

Gives Research Director's actual incentive to use it. I avoid it because there seems to be no way or combination of keys to turn the damn thing off, so everyone knows if you have it on your person if you don't set it to white.

Is the experimental part of it that it can't be turned off?

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
Adds a new holotool mode "off".

### What should players be aware of when it comes to the changes your PR is implementing?
Make them aware they can actually be turned off now.

# Changelog

Edit this changelog for changes that are noticeable by the players. Remove it if this isn't the case. If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. Prefix the PR title with [admin] if it's something admin related. Prefix the PR title with [s] if you are fixing an exploit so it is not announced on discord and the server.

:cl:  
tweak: adds a new holotool mode and makes it so when you set that mode it turns off the light
/:cl:
