### PR TITLE
Reverts #10129 - Cult golem shells can again be finished by anyone

### DIFF
--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -86,12 +86,6 @@
 		var/obj/item/stack/O = I
 		var/species = golem_shell_species_types[O.merge_type]
 		if(species)
-			if(istype(O, /obj/item/stack/sheet/runed_metal) && !iscultist(user))
-				to_chat(user, "<span class='warning'>Only one with forbidden knowledge could hope to work this metal...</span>")
-				return
-			if(istype(O, /obj/item/stack/tile/brass) && !is_servant_of_ratvar(user))
-				to_chat(user, "<span class='danger'>[src] seems far too fragile and rigid to build with.</span>")
-				return
 			if(O.use(10))
 				to_chat(user, "You finish up the golem shell with ten sheets of [O].")
 				new shell_type(get_turf(src), species, user)


### PR DESCRIPTION
# General Documentation
### Intent of your Pull Request
This change was really unnecesary, many players agree with me that it only hurt free golems being unable to use brass and runic metals found in lavaland ruins (the ratvar ruin literally has 50 brass for this exact purpose, no clock cultist is ever gonna use that).
The main point of that change was that "cult golems are too OP". Yes, they are good, but they are not the option AGAINST CULTISTS, which is a plain adamantine/metallic-hydrogen golem for it's anti-magic properties and tankiness.
Having an occassion to use said material is so rare, it's what makes it so exciting and fun.

### Why is this change good for the game?
Doesn't buff nor nerf cult, many players agreed that it's lame not being able to make golems out of wild materials found in lavaland and brought to sci by miners.

### Briefly describe your PR and the impacts of it, in layman's terms. 
reverts: https://github.com/yogstation13/Yogstation/pull/10129

### What should players be aware of when it comes to the changes your PR is implementing?
That you can make every golem again.
### What general grouping does this PR fall under? 
revert

# Changelog
:cl:  
rscdel: reverts #10129, you can make every single golem again
/:cl: