### PR TITLE
Removes gatfruit

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -178,7 +178,7 @@
 		reagents.del_reagent(/datum/reagent/consumable/nutriment)
 		reagents.del_reagent(/datum/reagent/consumable/nutriment/vitamin)
 
-// For item-containing growns such as eggy or gatfruit
+// For item-containing growns such as eggy
 /obj/item/reagent_containers/food/snacks/grown/shell/attack_self(mob/user)
 	var/obj/item/T
 	if(trash)

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -117,37 +117,6 @@
 	foodtype = VEGETABLES | SUGAR
 	distill_reagent = /datum/reagent/consumable/ethanol/rum
 
-// Gatfruit
-/obj/item/seeds/gatfruit
-	name = "pack of gatfruit seeds"
-	desc = "These seeds grow into .357 revolvers. A prized commodity among the criminal shadow-collective."
-	icon_state = "seed-gatfruit"
-	species = "gatfruit"
-	plantname = "Gatfruit Tree"
-	product = /obj/item/reagent_containers/food/snacks/grown/shell/gatfruit
-	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	lifespan = 20
-	endurance = 20
-	maturation = 40
-	production = 10
-	yield = 2
-	potency = 60
-	growthstages = 2
-	rarity = 60 // Obtainable only with xenobio+superluck.
-	growing_icon = 'icons/obj/hydroponics/growing_fruits.dmi'
-	reagents_add = list(/datum/reagent/sulfur = 0.1, /datum/reagent/carbon = 0.1, /datum/reagent/nitrogen = 0.07, /datum/reagent/potassium = 0.05)
-
-/obj/item/reagent_containers/food/snacks/grown/shell/gatfruit
-	seed = /obj/item/seeds/gatfruit
-	name = "gatfruit"
-	desc = "It smells like burning."
-	icon_state = "gatfruit"
-	trash = /obj/item/gun/ballistic/revolver
-	bitesize_mod = 2
-	foodtype = FRUIT
-	tastes = list("gunpowder" = 1)
-	wine_power = 90 //It burns going down, too.
-
 //Cherry Bombs
 /obj/item/seeds/cherry/bomb
 	name = "pack of cherry bomb pits"

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -10,8 +10,7 @@
 	name = "seed vault seeds"
 	lootcount = 1
 
-	loot = list(/obj/item/seeds/gatfruit = 10,
-				/obj/item/seeds/cherry/bomb = 10,
+	loot = list(/obj/item/seeds/cherry/bomb = 10,
 				/obj/item/seeds/berry/glow = 10,
 				/obj/item/seeds/sunflower/moonflower = 8
 				)

--- a/yogstation/code/modules/stock_market/stockmarket.dm
+++ b/yogstation/code/modules/stock_market/stockmarket.dm
@@ -60,7 +60,7 @@
 		return d
 
 /datum/stockMarket/proc/generateStocks(var/amt = 15)
-	var/list/fruits = list("Banana", "Mimana", "Watermelon", "Ambrosia", "Pomegranate", "Reishi", "Papaya", "Mango", "Tomato", "Conkerberry", "Wood", "Lychee", "Mandarin", "Harebell", "Pumpkin", "Rhubarb", "Tamarillo", "Yantok", "Ziziphus", "Oranges", "Gatfruit", "Daisy", "Kudzu")
+	var/list/fruits = list("Banana", "Mimana", "Watermelon", "Ambrosia", "Pomegranate", "Reishi", "Papaya", "Mango", "Tomato", "Conkerberry", "Wood", "Lychee", "Mandarin", "Harebell", "Pumpkin", "Rhubarb", "Tamarillo", "Yantok", "Ziziphus", "Oranges", "Daisy", "Kudzu")
 	var/list/tech_prefix = list("Nano", "Cyber", "Funk", "Astro", "Fusion", "Tera", "Exo", "Star", "Virtual", "Plasma", "Robust", "Bit", "Future", "Hugbox", "Carbon", "Nerf", "Buff", "Nova", "Space", "Meta", "Cyber")
 	var/list/tech_short = list("soft", "tech", "prog", "tec", "tek", "ware", "", "gadgets", "nics", "tric", "trasen", "tronic", "coin")
 	var/list/random_nouns = list("Johnson", "Cluwne", "General", "Specific", "Master", "King", "Queen", "Table", "Rupture", "Dynamic", "Massive", "Mega", "Giga", "Certain", "Singulo", "State", "National", "International", "Interplanetary", "Sector", "Planet", "Burn", "Robust", "Exotic", "Solar", "Lunar", "Chelp", "Corgi", "Lag", "Lizard")


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request
It removes gatfruit.

### Why is this change good for the game?
Mass producing nuke ops weapons is not *fun* to play against for anyone, no matter how hard it is to get.

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
Gatfruit is gone

### What should players be aware of when it comes to the changes your PR is implementing?
Gatfruit is gone

### What general grouping does this PR fall under? 
Removal

### Are there any aspects of the PR that you would like us not to mention on the Wiki?
No

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
Gatfruit amount that exists: 0

# Changelog

:cl:  
rscdel: Gats gatfruit
/:cl:
