### PR TITLE
Cloning now requires meat.

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -82,7 +82,7 @@ GLOBAL_VAR_INIT(clones, 0)
 	. += "<span class='notice'>The <i>linking</i> device can be <i>scanned<i> with a multitool.</span>"
 	if(in_range(user, src) || isobserver(user))
 		. += "<span class='notice'>The status display reads: Cloning speed at <b>[speed_coeff*50]%</b>.<br>Predicted amount of cellular damage: <b>[100-heal_level]%</b>.<span>"
-		. += "<span class='notice'>The status display reads: Biomass levels at <b>[biomass]</b><span>" // read out the amount of biomass if you examine
+		. += "<span class='notice'>The status display reads: Biomass levels at <b>[biomass]%</b><span>" // read out the amount of biomass if you examine
 		if(efficiency > 5)
 			. += "<span class='notice'>Pod has been upgraded to support autoprocessing and apply beneficial mutations.<span>"
 

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -117,6 +117,7 @@ GLOBAL_VAR_INIT(clones, 0)
 	var/tempbiomass = biomass
 	if(istype(W, /obj/item))
 		if(istype(W, /obj/item/stack/sheet/animalhide/human)) // lets play flesh or meat
+			var/obj/item/stack/S = W
 			tempbiomass += 50 * S.amount
 		else if(istype(W, /obj/item/reagent_containers/food/snacks/meat/slab)) // Are we inserting meat?
 			if(istype(W, /obj/item/reagent_containers/food/snacks/meat/slab/human)) // human meat is the easiest to turn into new human materials

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -114,24 +114,31 @@ GLOBAL_VAR_INIT(clones, 0)
 // Biomass
 
 /obj/machinery/clonepod/attackby(obj/item/W, mob/user, params)
-	var/old_biomass = biomass // saves biomas variable
+	var/tempbiomass = biomass
 	if(istype(W, /obj/item))
 		if(istype(W, /obj/item/stack/sheet/animalhide/human)) // lets play flesh or meat
-			biomass += 50
-		if(istype(W, /obj/item/reagent_containers/food/snacks/meat/slab)) // Are we inserting meat?
+			tempbiomass += 50 * S.amount
+		else if(istype(W, /obj/item/reagent_containers/food/snacks/meat/slab)) // Are we inserting meat?
 			if(istype(W, /obj/item/reagent_containers/food/snacks/meat/slab/human)) // human meat is the easiest to turn into new human materials
-				biomass += 50
+				tempbiomass += 50
 			else if(istype(W, /obj/item/reagent_containers/food/snacks/meat/slab/synthmeat))
-				biomass += 34 // synthmeat can be many different things, thus it should be decently high. This ensures 3 of them gives you a full clone, without fucking with decimals.
+				tempbiomass += 34 // synthmeat can be many different things, thus it should be decently high. This ensures 3 of them gives you a full clone, without fucking with decimals.
 			else if(istype(W, /obj/item/reagent_containers/food/snacks/meat/slab/monkey))
-				biomass += 25 // Monkey meat is close to human, but not actually human.
+				tempbiomass += 25 // Monkey meat is close to human, but not actually human.
 			// if(istype W, /obj/item/reagent_containers/) //  this space will eventually be for my biomass cartidge, which aren't done.
 			else
-				biomass = biomass + 20 // Not actually human meat? Means that you need more of it.
-	if(biomass != old_biomass) // deletes the item you inserted if biomass changed.
-		qdel(W)
+				tempbiomass += 20 // Not actually human meat? Means that you need more of it.
+		else
+			return
 	if(biomass > 100)
-		biomass = 100 // no going over 100 biomass, you can't just ingore meat requirements for the rest of the shift because some chemist made 80,000 synthmeat
+		to_chat(user, "<span class = 'notice'>[src]'s biomass containers are full!.</span>")
+		return // if biomass is already 100 then yell at those stupid idiots
+	else
+		to_chat(user, "<span class = 'notice'>You insert [W] into [src].</span>") // feel free to fill it.
+		biomass = tempbiomass
+		qdel(W)
+		if(biomass > 100)
+			biomass = 100
 //Clonepod
 
 /obj/machinery/clonepod/examine(mob/user)

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -130,6 +130,8 @@ GLOBAL_VAR_INIT(clones, 0)
 				biomass = biomass + 20 // Not actually human meat? Means that you need more of it.
 	if(biomass != old_biomass) // deletes the item you inserted if biomass changed.
 		qdel(W)
+	if(biomass > 100)
+		biomass = 100 // no going over 100 biomass, you can't just ingore meat requirements for the rest of the shift because some chemist made 80,000 synthmeat
 //Clonepod
 
 /obj/machinery/clonepod/examine(mob/user)

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -474,7 +474,7 @@
 				playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
 			var/obj/machinery/clonepod/pod = GetAvailablePod()
 			var/success = FALSE
-			//Can't clone without someone to clone.  Or a pod.  Or if the pod is busy. Or full of gibs.
+			//Can't clone without someone to clone.  Or a pod.  Or if the pod is busy. Or full of gibs. Or if there isn't any meat available.
 			if(!LAZYLEN(pods))
 				temp = "<font class='bad'>No Clonepods detected.</font>"
 				playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
@@ -486,6 +486,9 @@
 				playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
 			else if(pod.occupant)
 				temp = "<font class='bad'>Cloning cycle already in progress.</font>"
+				playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
+			else if(pod.biomass < 100)
+				temp = "<font class ='bad'>Insufficient biomass levels.</font>"
 				playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
 			else
 				var/result = grow_clone_from_record(pod, C, empty)


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Cloning now requires meat. Prior to this PR cloning is a medical win button. You take head, put head in scanner, out pops newly made body. This PR is a step in the right direction. Cloning is no longer just press button out comes body. You'll now need to aquire some sort of meat, either by a chemist making synthmeat, or a chef.

### Why is this change good for the game?
 
Cloning is no longer the ultimate medical winbutton. Regardless of how little cloning is actually used, it's ridiculously overpowered and makes death a joke. Death is still mostly a joke with this PR, but it's no longer "take dead body put in magical body making machine." I've made cloning harder to do by requiring you to put meat into the machine if you want a fresh body.


This complicates the medical system even a slight bit more, which is good to the game. Medical requiring even the slightest bit more buttons pressed is better in my opinion. This doesn't make cloning useless, its still a very viable thing, but now it requires more work. 

I've also made synthmeat an decently viable source for resources to help with cloning, only three of it being required to produce a body. 

Everything is tested, I'm a slightly competent coder.
# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
Cloning requires meat. It's % based. 
### What should players be aware of when it comes to the changes your PR is implementing?
Doctors will be needing to do more effort when they bring bodies to cloning, and a good chemist will make a decent amount of synthmeat. You'll need to actually supply cloning with meat, and leaving plenty somewhere in the room is probably a good idea.
(If this is testmerged something should be put in the wiki or around the roundstart "You are the Medical Doctor" thing, like that line that sends if you're sec.)
### What general grouping does this PR fall under? 
Medical
Cloning changes
### Are there any aspects of the PR that you would like us not to mention on the Wiki?
nah
### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
Need 100 total "biomass" to make a single clone.
Human Flesh provides 50 Biomass
Humanoid Meat (Anything that's included in meat/slab/human/, which appears to be all humanoids.) provides 50
Synthmeat provides 34
Monkey Meat provides 25
Anything else in meat/slab is 20

# Changelog

:cl:  
rscadd: Cloning requires meat.
/:cl:
