### PR TITLE
Losing a family heirloom impacts your mood significantly more.

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -121,8 +121,8 @@
 	mood_change = -3
 
 /datum/mood_event/family_heirloom_missing
-	description = "<span class='warning'>I'm missing my family heirloom...</span>\n"
-	mood_change = -4
+	description = "<span class='boldwarning'>I'm missing my family heirloom...</span>\n"
+	mood_change = -50
 
 /datum/mood_event/healsbadman
 	description = "<span class='warning'>I feel like I'm held together by flimsy string, and could fall apart at any moment!</span>\n"

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -122,7 +122,7 @@
 
 /datum/mood_event/family_heirloom_missing
 	description = "<span class='boldwarning'>I'm missing my family heirloom...</span>\n"
-	mood_change = -50
+	mood_change = -30
 
 /datum/mood_event/healsbadman
 	description = "<span class='warning'>I feel like I'm held together by flimsy string, and could fall apart at any moment!</span>\n"


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Instead of doing a "small" -4 mood penalty, it now gives you a -30 mood penalty for as long as you don't have it, making it the third worst moodlet in the game. Only cultists, changelings, and people drugged on Happiness can negate this mood with a single moodlet.

### Why is this change good for the game?

-4 can be negated by just eating food - losing your extremely important "passed-down for generations" family heirloom should _not_ be that easy to ignore.

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
losing heirlooms TANKS your mood now

### What should players be aware of when it comes to the changes your PR is implementing?
losing heirlooms TANKS your mood now

### What general grouping does this PR fall under? 
mood

### Are there any aspects of the PR that you would like us not to mention on the Wiki?
no

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
-4 to -30

# Changelog

Edit this changelog for changes that are noticeable by the players. Remove it if this isn't the case. If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. Prefix the PR title with [admin] if it's something admin related. Prefix the PR title with [s] if you are fixing an exploit so it is not announced on discord and the server.

:cl:  
tweak: losing your heirloom now obliterates your mood
/:cl:
