### PR TITLE
cloning now requires organs

### DIFF
--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -113,3 +113,5 @@
 //cloning defines. These are flags.
 #define CLONING_SUCCESS (1<<0)
 #define CLONING_DELETE_RECORD (1<<1)
+#define CLONING_FAIL_MISSING_ORGAN (1<<2)
+#define CLONING_FAIL_DECAY (1<<3)

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -89,62 +89,6 @@ GLOBAL_VAR_INIT(clones, 0)
 		if(efficiency > 5)
 			. += "<span class='notice'>Pod has been upgraded to support autoprocessing and apply beneficial mutations.<span>"
 
-/obj/machinery/clonepod/attackby(obj/item/I, mob/user)
-	if(user.a_intent == INTENT_HARM)
-		return ..()
-	var/obj/item/organ/O = I
-	if(!O)
-		to_chat(user, "<span class='warning'>[src] doesn't have a recepticle for [I]!</span>")
-		return
-	if((O.organ_flags & ORGAN_SYNTHETIC))
-		to_chat(user, "<span class='warning'>[src] refuses to accept [I]; it's only capable of using organic organs!</span>")
-		return
-	if((O.organ_flags & ORGAN_FAILING))
-		to_chat(user, "<span class='warning'>[src] refuses to accept [I]; the organ is too damaged to be used!</span>")
-		return
-	var/obj/item/organ/heart/H = I
-	if(istype(H))
-		if(heart)
-			if(!(heart.organ_flags & ORGAN_FAILING))
-				to_chat(user, "<span class='notice'>A green light flashes over the heart recepticle, it's already full.</span>")
-				return
-			heart.forceMove(get_turf(src))
-			to_chat(user, "<span class='notice'>A red light flashes over the heart recepticle, and an old decaying heart falls out.</span>")
-			heart = null
-		if(!user.transferItemToLoc(H, src))
-			return
-		heart = H
-		user.visible_message("<span class='notice'>[user] deposits [I] into [src].</span>", "<span class='notice'>You deposit [I] into [src].</span>")
-		return
-	var/obj/item/organ/lungs/L = I
-	if(istype(L))
-		if(lungs)
-			if(!(lungs.organ_flags & ORGAN_FAILING))
-				to_chat(user, "<span class='notice'>A green light flashes over the lung recepticle, it's already full.</span>")
-				return
-			lungs.forceMove(get_turf(src))
-			to_chat(user, "<span class='notice'>A red light flashes over the lung recepticle, and an old decaying pair of lungs falls out.</span>")
-			lungs = null
-		if(!user.transferItemToLoc(L, src))
-			return
-		lungs = L
-		user.visible_message("<span class='notice'>[user] deposits [I] into [src].</span>", "<span class='notice'>You deposit [I] into [src].</span>")
-		return
-	var/obj/item/organ/liver/V = I
-	if(istype(V))
-		if(liver)
-			if(!(liver.organ_flags & ORGAN_FAILING))
-				to_chat(user, "<span class='notice'>A green light flashes over the liver recepticle, it's already full.</span>")
-				return
-			liver.forceMove(get_turf(src))
-			to_chat(user, "<span class='notice'>A red light flashes over the liver recepticle, and an old decaying liver falls out.</span>")
-			liver = null
-		if(!user.transferItemToLoc(V, src))
-			return
-		liver = V
-		user.visible_message("<span class='notice'>[user] deposits [I] into [src].</span>", "<span class='notice'>You deposit [I] into [src].</span>")
-		return
-
 /obj/machinery/clonepod/attack_hand(mob/user)
 	var/dumped_organ = FALSE
 	if(heart && (heart.organ_flags & ORGAN_FAILING))
@@ -225,7 +169,7 @@ GLOBAL_VAR_INIT(clones, 0)
 		return NONE
 	if(!(heart && liver && lungs))
 		return CLONING_FAIL_MISSING_ORGAN
-	if((liver.organ_flags & ORGAN_FAILING) || (lungs.organ_flags & ORGAN_FAILING) || (liver.organ_flags & ORGAN_FAILING))
+	if((heart.organ_flags & ORGAN_FAILING) || (lungs.organ_flags & ORGAN_FAILING) || (liver.organ_flags & ORGAN_FAILING))
 		return CLONING_FAIL_DECAY
 	QDEL_NULL(heart)
 	QDEL_NULL(liver)
@@ -467,7 +411,60 @@ GLOBAL_VAR_INIT(clones, 0)
 			to_chat(user, "<span class='notice'>You force an emergency ejection. </span>")
 			go_out()
 	else
-		return ..()
+		if(user.a_intent == INTENT_HARM)
+			return ..()
+		var/obj/item/organ/O = W
+		if(!istype(O))
+			to_chat(user, "<span class='warning'>[src] doesn't have a recepticle for [W]!</span>")
+			return
+		if((O.organ_flags & ORGAN_SYNTHETIC))
+			to_chat(user, "<span class='warning'>[src] refuses to accept [W]; it's only capable of using organic organs!</span>")
+			return
+		if((O.organ_flags & ORGAN_FAILING))
+			to_chat(user, "<span class='warning'>[src] refuses to accept [W]; the organ is too damaged to be used!</span>")
+			return
+		var/obj/item/organ/heart/H = W
+		if(istype(H))
+			if(heart)
+				if(!(heart.organ_flags & ORGAN_FAILING))
+					to_chat(user, "<span class='notice'>A green light flashes over the heart recepticle, it's already full.</span>")
+				return
+				heart.forceMove(get_turf(src))
+				to_chat(user, "<span class='notice'>A red light flashes over the heart recepticle, and an old decaying heart falls out.</span>")
+				heart = null
+			if(!user.transferItemToLoc(H, src))
+				return
+			heart = H
+			user.visible_message("<span class='notice'>[user] deposits [W] into [src].</span>", "<span class='notice'>You deposit [W] into [src].</span>")
+			return
+		var/obj/item/organ/lungs/L = W
+		if(istype(L))
+			if(lungs)
+				if(!(lungs.organ_flags & ORGAN_FAILING))
+					to_chat(user, "<span class='notice'>A green light flashes over the lung recepticle, it's already full.</span>")
+					return
+				lungs.forceMove(get_turf(src))
+				to_chat(user, "<span class='notice'>A red light flashes over the lung recepticle, and an old decaying pair of lungs falls out.</span>")
+				lungs = null
+			if(!user.transferItemToLoc(L, src))
+				return
+			lungs = L
+			user.visible_message("<span class='notice'>[user] deposits [W] into [src].</span>", "<span class='notice'>You deposit [W] into [src].</span>")
+			return
+		var/obj/item/organ/liver/V = W
+		if(istype(V))
+			if(liver)
+				if(!(liver.organ_flags & ORGAN_FAILING))
+					to_chat(user, "<span class='notice'>A green light flashes over the liver recepticle, it's already full.</span>")
+					return
+				liver.forceMove(get_turf(src))
+				to_chat(user, "<span class='notice'>A red light flashes over the liver recepticle, and an old decaying liver falls out.</span>")
+				liver = null
+			if(!user.transferItemToLoc(V, src))
+				return
+			liver = V
+			user.visible_message("<span class='notice'>[user] deposits [W] into [src].</span>", "<span class='notice'>You deposit [W] into [src].</span>")
+			return
 
 /obj/machinery/clonepod/emag_act(mob/user)
 	if(!occupant)

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -224,6 +224,9 @@ GLOBAL_VAR_INIT(clones, 0)
 		return CLONING_FAIL_MISSING_ORGAN
 	if((liver.organ_flags & ORGAN_FAILING) || (lungs.organ_flags & ORGAN_FAILING) || (liver.organ_flags & ORGAN_FAILING))
 		return CLONING_FAIL_DECAY
+	QDEL_NULL(heart)
+	QDEL_NULL(liver)
+	QDEL_NULL(lungs)
 
 	if(!empty) //Doesn't matter if we're just making a copy
 		clonemind = locate(mindref) in SSticker.minds

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -149,12 +149,15 @@ GLOBAL_VAR_INIT(clones, 0)
 	var/dumped_organ = FALSE
 	if(heart && (heart.organ_flags & ORGAN_FAILING))
 		heart.forceMove(get_turf(src))
+		heart = null
 		dumped_organ = TRUE
 	if(lungs && (lungs.organ_flags & ORGAN_FAILING))
 		lungs.forceMove(get_turf(src))
+		lungs = null
 		dumped_organ = TRUE
 	if(liver && (liver.organ_flags & ORGAN_FAILING))
 		liver.forceMove(get_turf(src))
+		liver = null
 		dumped_organ = TRUE
 	if(dumped_organ)
 		user.visible_message("<span class='notice'>[user] presses the organ scan button on [src], causing any decayed organs to fall out!</span>", "<span class='notice'>You press the organ scan button on [src], causing it to detach any decayed organs!</span>")

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -428,7 +428,7 @@ GLOBAL_VAR_INIT(clones, 0)
 			if(heart)
 				if(!(heart.organ_flags & ORGAN_FAILING))
 					to_chat(user, "<span class='notice'>A green light flashes over the heart recepticle, it's already full.</span>")
-				return
+					return
 				heart.forceMove(get_turf(src))
 				to_chat(user, "<span class='notice'>A red light flashes over the heart recepticle, and an old decaying heart falls out.</span>")
 				heart = null

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -411,6 +411,7 @@ GLOBAL_VAR_INIT(clones, 0)
 			to_chat(user, "<span class='notice'>You force an emergency ejection. </span>")
 			go_out()
 	else
+		var/obj/item/organ/O
 		if(!istype(O))
 			return ..()
 		if((O.organ_flags & ORGAN_SYNTHETIC))

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -82,29 +82,33 @@ GLOBAL_VAR_INIT(clones, 0)
 
 /obj/machinery/clonepod/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'>The <i>linking</i> device can be <i>scanned<i> with a multitool.</span>"
+	. += "<span class='notice'>The <i>linking</i> device can be <i>scanned</i> with a multitool.</span>"
 	if(in_range(user, src) || isobserver(user))
-		. += "<span class='notice'>You can see a button labeled \"check organs\" at the pod's base and slots to place a heart, a liver, and a set of lungs.</span>"
 		. += "<span class='notice'>The status display reads: Cloning speed at <b>[speed_coeff*50]%</b>.<br>Predicted amount of cellular damage: <b>[100-heal_level]%</b>.<span>"
 		if(efficiency > 5)
 			. += "<span class='notice'>Pod has been upgraded to support autoprocessing and apply beneficial mutations.<span>"
+		. += "<span class='notice'>There are three receptacles for organs at the base of the pod:\n<b>\
+				Heart: [heart ? (heart.organ_flags & ORGAN_FAILING) ? "<font color='red'>DECAYED</font>" : "<span class='nicegreen'>ACTIVE</span>" : "<font color='black'>MISSING</font>"]\n\
+				Lungs: [lungs ? (lungs.organ_flags & ORGAN_FAILING) ? "<font color='red'>DECAYED</font>" : "<span class='nicegreen'>ACTIVE</span>" : "<font color='black'>MISSING</font>"]\n\
+				Liver: [liver ? (liver.organ_flags & ORGAN_FAILING) ? "<font color='red'>DECAYED</font>" : "<span class='nicegreen'>ACTIVE</span>" : "<font color='black'>MISSING</font>"]</b></span>"
+		. += "<span class='notice'>You can see a button labeled <b>\"Organ Release\"</b> near the base of the clone pod.</span>"
 
 /obj/machinery/clonepod/attack_hand(mob/user)
 	var/dumped_organ = FALSE
-	if(heart && (heart.organ_flags & ORGAN_FAILING))
+	if(heart)
 		heart.forceMove(get_turf(src))
 		heart = null
 		dumped_organ = TRUE
-	if(lungs && (lungs.organ_flags & ORGAN_FAILING))
+	if(lungs)
 		lungs.forceMove(get_turf(src))
 		lungs = null
 		dumped_organ = TRUE
-	if(liver && (liver.organ_flags & ORGAN_FAILING))
+	if(liver)
 		liver.forceMove(get_turf(src))
 		liver = null
 		dumped_organ = TRUE
 	if(dumped_organ)
-		user.visible_message("<span class='notice'>[user] presses the organ scan button on [src], causing any decayed organs to fall out!</span>", "<span class='notice'>You press the organ scan button on [src], causing it to detach any decayed organs!</span>")
+		user.visible_message("<span class='notice'>[user] presses the organ release button on [src], causing its stored organs to fall out!</span>", "<span class='notice'>You press the organ release button on [src], causing it to drop its stored organs!</span>")
 
 //The return of data disks?? Just for transferring between genetics machine/cloning machine.
 //TO-DO: Make the genetics machine accept them.

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -411,12 +411,8 @@ GLOBAL_VAR_INIT(clones, 0)
 			to_chat(user, "<span class='notice'>You force an emergency ejection. </span>")
 			go_out()
 	else
-		if(user.a_intent == INTENT_HARM)
-			return ..()
-		var/obj/item/organ/O = W
 		if(!istype(O))
-			to_chat(user, "<span class='warning'>[src] doesn't have a recepticle for [W]!</span>")
-			return
+			return ..()
 		if((O.organ_flags & ORGAN_SYNTHETIC))
 			to_chat(user, "<span class='warning'>[src] refuses to accept [W]; it's only capable of using organic organs!</span>")
 			return

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -411,7 +411,7 @@ GLOBAL_VAR_INIT(clones, 0)
 			to_chat(user, "<span class='notice'>You force an emergency ejection. </span>")
 			go_out()
 	else
-		var/obj/item/organ/O
+		var/obj/item/organ/O = W
 		if(!istype(O))
 			return ..()
 		if((O.organ_flags & ORGAN_SYNTHETIC))

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -473,7 +473,7 @@
 				temp = "<font class='bad'>Cannot initiate regular cloning with body-only scans.</font>"
 				playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
 			var/obj/machinery/clonepod/pod = GetAvailablePod()
-			var/success = FALSE
+			var/no_generic_message = FALSE
 			//Can't clone without someone to clone.  Or a pod.  Or if the pod is busy. Or full of gibs.
 			if(!LAZYLEN(pods))
 				temp = "<font class='bad'>No Clonepods detected.</font>"
@@ -495,7 +495,7 @@
 					if(active_record == C)
 						active_record = null
 					menu = 1
-					success = TRUE
+					no_generic_message = TRUE
 					if(!empty)
 						log_cloning("[key_name(usr)] initiated cloning of [key_name(C.fields["mindref"])] via [src] at [AREACOORD(src)]. Pod: [pod] at [AREACOORD(pod)].")
 					else
@@ -507,10 +507,14 @@
 					records -= C
 				if(result & CLONING_FAIL_DECAY)
 					temp = "[C.fields["name"]] => <font class='bad'>Cloning failed: Pod reports decay in organs, replace any damaged organs in the cloning pod and try again.</font>"
+					playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
+					no_generic_message = TRUE
 				if(result & CLONING_FAIL_MISSING_ORGAN)
 					temp = "[C.fields["name"]] => <font class='bad'>Cloning failed: Pod reports missing organs, insert healthy organs into the cloning pod and try again.</font>"
+					playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
+					no_generic_message = TRUE
 
-			if(!success)
+			if(!no_generic_message)
 				temp = "[C.fields["name"]] => <font class='bad'>Initialisation failure.</font>"
 				playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
 

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -505,6 +505,10 @@
 						active_record = null
 					menu = 1
 					records -= C
+				if(result & CLONING_FAIL_DECAY)
+					temp = "[C.fields["name"]] => <font class='bad'>Cloning failed: Pod reports decay in organs, replace any damaged organs in the cloning pod and try again.</font>"
+				if(result & CLONING_FAIL_MISSING_ORGAN)
+					temp = "[C.fields["name"]] => <font class='bad'>Cloning failed: Pod reports missing organs, insert healthy organs into the cloning pod and try again.</font>"
 
 			if(!success)
 				temp = "[C.fields["name"]] => <font class='bad'>Initialisation failure.</font>"


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

cloning will now require a healthy organic heart liver and pair of lungs to begin per clone
The clone pod (thing that grows the clone for the uneducated) can have these organs inserted into it by hitting it with them, only one of each can be stored at a time and they will still decay while inside the pod meaning storage should not be inside the pod when it is not in active use
hitting the pod with a fresh organ will dump the current organ if it is decayed
hitting the pod with an empty hand will dump all decayed organs

### Why is this change good for the game?
have fun learning surgery "why not just clone" people
# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
This will be the basis of the Wiki entry for your PR, and more information / detail is better for Wiki editors to integrate.
cloning now requires the clone pod to have a healthy heart liver and lung set inserted into it, organs inside the clone pod will still decay however
### What should players be aware of when it comes to the changes your PR is implementing?
to insert an organ into the cloning pod hit it while not on harm intent
to remove any decayed organs from the cloning pod hit it with an empty hand or a replacement organ
ONLY organic organs work, synthetic organs aren't accepted
### What general grouping does this PR fall under? 
Medical rebalancing

# Changelog


:cl:  
tweak: the cloning pod will now have to have a heart liver and lungs added to it to clone someone, with the organs decaying over time like normal
/:cl:
