### PR TITLE
reduces the penalty for tend wounds on dead people from 5* to 3* more damage required for bonus point of healing

### DIFF
--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -61,8 +61,8 @@
 			urhealedamt_brute += brutehealing ? round((target.getBruteLoss()/ missinghpbonus),0.1) : 0
 			urhealedamt_burn += burnhealing ? round((target.getFireLoss()/ missinghpbonus),0.1) : 0
 		else //less healing bonus for the dead since they're expected to have lots of damage to begin with (to make TW into defib not TOO simple)
-			urhealedamt_brute += brutehealing ? round((target.getBruteLoss()/ (missinghpbonus*5)),0.1) : 0
-			urhealedamt_burn += burnhealing ? round((target.getFireLoss()/ (missinghpbonus*5)),0.1) : 0
+			urhealedamt_brute += brutehealing ? round((target.getBruteLoss()/ (missinghpbonus*3)),0.1) : 0
+			urhealedamt_burn += burnhealing ? round((target.getFireLoss()/ (missinghpbonus*3)),0.1) : 0
 	if(!get_location_accessible(target, target_zone))
 		urhealedamt_brute *= 0.55
 		urhealedamt_burn *= 0.55


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

basically tend wounds has 2 healing values, a static healing value (5 for specific 1 for mixed) and a bonus for damage that depends on the tier of the surgery (x amount of points of damage = 1 more health per cycle of tend wounds)
the bonus for damage has its damage requirement multiplied by 5 on corpses, meaning basic level surgeries that get 1 point per 15 damage now only get 1 point per 75 damage
this reduces that to 3, meaning basic tier tend wounds will get a 1 point bonus per 45 damage

### Why is this change good for the game?
makes tend wounds slightly faster on corpses
# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
This will be the basis of the Wiki entry for your PR, and more information / detail is better for Wiki editors to integrate.
tend wounds now heals corpses faster
### What general grouping does this PR fall under? 
medical

### Are there any aspects of the PR that you would like us not to mention on the Wiki?

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
tend wounds surgeries now have a 3* penalty instead of 5* penalty for bonus healing when done on corpses

# Changelog

:cl:  
tweak: tend wounds will now only multiply its damage per bonus healing point by 3 down from 5 when done on corpses (tldr tend wounds on corpse penalty is lower)
/:cl:
