### PR TITLE
Reinforces the Area of Atmospherics Exposed to the Incinerator

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -102524,12 +102524,12 @@ bMO
 bMU
 bvA
 aaa
-cfj
-cfj
-cfj
+cmd
+cmd
+cmd
 ewU
-cfj
-cfj
+cmd
+cmd
 aRB
 cfj
 aaa
@@ -102781,7 +102781,7 @@ wAc
 bMA
 bvA
 aaf
-cfj
+cmd
 qQi
 sVj
 vvW
@@ -103038,7 +103038,7 @@ bMA
 bMA
 bvA
 aoV
-cfj
+cmd
 jkG
 nYI
 cQn
@@ -103295,7 +103295,7 @@ bvA
 bvA
 bvA
 aaf
-cfj
+cmd
 fJS
 typ
 hMp
@@ -103552,7 +103552,7 @@ aaf
 aaf
 aaf
 aaf
-cfj
+cmd
 sJh
 reN
 rVk
@@ -103807,9 +103807,9 @@ tQD
 bKT
 bKT
 bKT
-cfj
-cfj
-cfj
+cmd
+cmd
+cmd
 vrb
 oqL
 cmd


### PR DESCRIPTION
## General Documentation

## Intent of your Pull Request

Reinforce the section of Atmospherics exposed to the Incinerator.
![image](https://user-images.githubusercontent.com/62276730/107733016-ea4ae280-6cc7-11eb-9b1a-02bba869abb3.png)

## Why is this change good for the game?

Uniformity. Atmos on all fronts his reinforced against the station and space. Since it's been determined that the incinerator isn't apart of atmospherics, the incinerator isn't something that needs to be kept secure in the head mappers opinion (solars are reinforced) and the walls are apparently meant to be broken for space loop building (so much for the bridge to that nearby airlock) it is outside of atmos, and should be treated as such by the mapping in atmos.

## Wiki Documentation

Update the image of the incinerator and the engineering bridge, wherever the latter appears.

## Changelog

:cl:  
rscadd: Adds reinforcements around the part of atmos facing the incinerator.  
/:cl:
