### PR TITLE
probably fixes firedoors being jank

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -348,7 +348,9 @@
 	var/turf/T2 = get_step(T, dir)
 	if(!T || !T2)
 		return
-	if(check_door_side(T) != check_door_side(T2))
+	var/status1 = check_door_side(T)
+	var/status2 = check_door_side(T2)	
+	if((status1 == 1 && status2 == -1) || (status1 == -1 && status2 == 1))
 		to_chat(user, "<span class='warning'>Access denied. Try closing another firedoor to minimize decompression, or using a crowbar.</span>")
 		return FALSE
 	return TRUE


### PR DESCRIPTION
1 = "this is safe"
-1 = "this is not safe"
0 = "literally doesn't matter"
1 isn't 0
:cl:  
bugfix: firelocks should cycle as intended
/:cl:
