### PR TITLE
items fried now keep their old reagents

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -122,7 +122,9 @@ God bless America.
 			return ..()
 		else if(!frying && user.transferItemToLoc(I, src))
 			to_chat(user, "<span class='notice'>You put [I] into [src].</span>")
+			var/item_reags = I.grind_results
 			frying = new/obj/item/reagent_containers/food/snacks/deepfryholder(src, I)
+			frying.reagents.add_reagent_list(item_reags)
 			icon_state = "fryer_on"
 			if(superfry)
 				icon_state = "syndie_fryer_on"


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

items fried now keep their old reagents
'old reagents' meaning what they would spit out if shoved in a grinder
tested ingame

### Why is this change good for the game?

adds a bit of risk to senselessly frying things, maybe some potential for ghetto chem

# Changelog

:cl:  
tweak: Items now keep their old reagents when fried
/:cl:
