### PR TITLE
goliath tentacles chainstunning will only increase the current stun by 2 seocnds instead of resetting it to 10

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -201,7 +201,7 @@
 		if((!QDELETED(spawner) && spawner.faction_check_mob(L)) || L.stat == DEAD)
 			continue
 		visible_message("<span class='danger'>[src] grabs hold of [L]!</span>")
-		if(!IsStun(L))
+		if(!L.IsStun())
 			L.Stun(100)
 		else
 			L.AdjustStun(20)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -201,7 +201,10 @@
 		if((!QDELETED(spawner) && spawner.faction_check_mob(L)) || L.stat == DEAD)
 			continue
 		visible_message("<span class='danger'>[src] grabs hold of [L]!</span>")
-		L.Stun(100)
+		if(!IsStun(L))
+			L.Stun(100)
+		else
+			L.AdjustStun(20)
 		L.adjustBruteLoss(rand(10,15))
 		latched = TRUE
 	if(!latched)


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Regardless of the contents of a change to this it is clear that goliath chainstuns are unfun to get hit by and anyone who disagrees is wrong and bad

### Why is this change good for the game?
attempts to fix the same problem #11008 does but in a different way
# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
Goliath tentacles will only stun for 2 seconds if the person getting hit is already stunned, if they are not stunned, the tentacles will stun for 10 seconds
### What general grouping does this PR fall under? 
mining

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 

# Changelog

:cl:  
tweak: goliath tentacles will only increase existing stuns by 2 seconds instead of setting them to 10 to reduce chainstunning potential
/:cl:
