### PR TITLE
changes 500 uranium goal to 50 of every sheet

### DIFF
--- a/code/modules/goals/department_goals/cargo.dm
+++ b/code/modules/goals/department_goals/cargo.dm
@@ -22,10 +22,7 @@
 		/datum/material/plasma,
 		/datum/material/glass,
 		/datum/material/iron)
-	for(var/datum/material/I in material_list)
-		if(!materials.has_enough_of_material(I, MINERAL_MATERIAL_AMOUNT, 50))
-			return FALSE
-	return TRUE
+	return materials.has_materials(material_list, 50*MINERAL_MATERIAL_AMOUNT)
 
 // Setup a tesla in cargo
 /datum/department_goal/car/tesla

--- a/code/modules/goals/department_goals/cargo.dm
+++ b/code/modules/goals/department_goals/cargo.dm
@@ -22,8 +22,8 @@
 		"plasma",
 		"glass",
 		"iron")
-	for(var/I in material_list)
-		if(!materials.has_enough_of_material(/datum/material/I, MINERAL_MATERIAL_AMOUNT, 50))
+	for(var/datum/material/I in material_list)
+		if(!materials.has_enough_of_material(I, MINERAL_MATERIAL_AMOUNT, 50))
 			return FALSE
 	return TRUE
 

--- a/code/modules/goals/department_goals/cargo.dm
+++ b/code/modules/goals/department_goals/cargo.dm
@@ -2,18 +2,26 @@
 	account = ACCOUNT_CAR
 
 
-// Have 500 plasteel sheets in the ore silo
-// I'ven't played this game for so long I have no clue how viable this even is.
-// Is this easy? Is this hard? Is the reward too high? Who knows?
-/datum/department_goal/car/uranium
-	name = "Have 500 uranium"
-	desc = "Store 500 uranium sheets in the ore silo"
-	reward = "50000"
+// Have 50 of every (traditional) sheet (not bananium or plastic)
+/datum/department_goal/car/sheets
+	name = "Have 50 of every ore sheet"
+	desc = "Store 50 of every ore sheet in the ore silo"
+	reward = 5000
+	continuous = 3000 // rewards every 5 minutes
 
-/datum/department_goal/car/uranium/check_complete()
+/datum/department_goal/car/sheets/check_complete()
 	var/obj/machinery/ore_silo/O = GLOB.ore_silo_default
 	var/datum/component/material_container/materials = O.GetComponent(/datum/component/material_container)
-	return materials.has_enough_of_material(/datum/material/uranium, MINERAL_MATERIAL_AMOUNT, 500)
+	if(materials.has_enough_of_material(/datum/material/iron, MINERAL_MATERIAL_AMOUNT, 50))
+		if(materials.has_enough_of_material(/datum/material/glass, MINERAL_MATERIAL_AMOUNT, 50))
+			if(materials.has_enough_of_material(/datum/material/silver, MINERAL_MATERIAL_AMOUNT, 50))
+				if(materials.has_enough_of_material(/datum/material/gold, MINERAL_MATERIAL_AMOUNT, 50))
+					if(materials.has_enough_of_material(/datum/material/diamond, MINERAL_MATERIAL_AMOUNT, 50))
+						if(materials.has_enough_of_material(/datum/material/uranium, MINERAL_MATERIAL_AMOUNT, 50))
+							if(materials.has_enough_of_material(/datum/material/plasma, MINERAL_MATERIAL_AMOUNT, 50))
+								if(materials.has_enough_of_material(/datum/material/bluespace, MINERAL_MATERIAL_AMOUNT, 50))
+									if(materials.has_enough_of_material(/datum/material/titanium, MINERAL_MATERIAL_AMOUNT, 50))
+										return TRUE
 
 // Setup a tesla in cargo
 /datum/department_goal/car/tesla

--- a/code/modules/goals/department_goals/cargo.dm
+++ b/code/modules/goals/department_goals/cargo.dm
@@ -13,15 +13,15 @@
 	var/obj/machinery/ore_silo/O = GLOB.ore_silo_default
 	var/datum/component/material_container/materials = O.GetComponent(/datum/component/material_container)
 	var/list/materials = list(
-		bluespace,
-		diamond,
-		uranium,
-		gold,
-		titanium,
-		silver,
-		plasma,
-		glass,
-		iron)
+		"bluespace",
+		"diamond",
+		"uranium",
+		"gold",
+		"titanium",
+		"silver",
+		"plasma",
+		"glass",
+		"iron")
 	for(var/I in materials)
 		if(!materials.has_enough_of_material(/datum/material/I, MINERAL_MATERIAL_AMOUNT, 50))
 			return FALSE

--- a/code/modules/goals/department_goals/cargo.dm
+++ b/code/modules/goals/department_goals/cargo.dm
@@ -12,16 +12,20 @@
 /datum/department_goal/car/sheets/check_complete()
 	var/obj/machinery/ore_silo/O = GLOB.ore_silo_default
 	var/datum/component/material_container/materials = O.GetComponent(/datum/component/material_container)
-	if(materials.has_enough_of_material(/datum/material/bluespace, MINERAL_MATERIAL_AMOUNT, 50))
-		if(materials.has_enough_of_material(/datum/material/diamond, MINERAL_MATERIAL_AMOUNT, 50))
-			if(materials.has_enough_of_material(/datum/material/uranium, MINERAL_MATERIAL_AMOUNT, 50))
-				if(materials.has_enough_of_material(/datum/material/gold, MINERAL_MATERIAL_AMOUNT, 50))
-					if(materials.has_enough_of_material(/datum/material/titanium, MINERAL_MATERIAL_AMOUNT, 50))
-						if(materials.has_enough_of_material(/datum/material/silver, MINERAL_MATERIAL_AMOUNT, 50))
-							if(materials.has_enough_of_material(/datum/material/plasma, MINERAL_MATERIAL_AMOUNT, 50))
-								if(materials.has_enough_of_material(/datum/material/glass, MINERAL_MATERIAL_AMOUNT, 50))
-									if(materials.has_enough_of_material(/datum/material/iron, MINERAL_MATERIAL_AMOUNT, 50))
-										return TRUE
+	var/list/materials = list(
+		bluespace,
+		diamond,
+		uranium,
+		gold,
+		titanium,
+		silver,
+		plasma,
+		glass,
+		iron)
+	for(var/I in materials)
+		if(!materials.has_enough_of_material(/datum/material/I, MINERAL_MATERIAL_AMOUNT, 50))
+			return FALSE
+	return TRUE
 
 // Setup a tesla in cargo
 /datum/department_goal/car/tesla

--- a/code/modules/goals/department_goals/cargo.dm
+++ b/code/modules/goals/department_goals/cargo.dm
@@ -12,22 +12,22 @@
 /datum/department_goal/car/sheets/check_complete()
 	var/obj/machinery/ore_silo/O = GLOB.ore_silo_default
 	var/datum/component/material_container/materials = O.GetComponent(/datum/component/material_container)
-	if(materials.has_enough_of_material(/datum/material/iron, MINERAL_MATERIAL_AMOUNT, 50))
-		if(materials.has_enough_of_material(/datum/material/glass, MINERAL_MATERIAL_AMOUNT, 50))
-			if(materials.has_enough_of_material(/datum/material/silver, MINERAL_MATERIAL_AMOUNT, 50))
+	if(materials.has_enough_of_material(/datum/material/bluespace, MINERAL_MATERIAL_AMOUNT, 50))
+		if(materials.has_enough_of_material(/datum/material/diamond, MINERAL_MATERIAL_AMOUNT, 50))
+			if(materials.has_enough_of_material(/datum/material/uranium, MINERAL_MATERIAL_AMOUNT, 50))
 				if(materials.has_enough_of_material(/datum/material/gold, MINERAL_MATERIAL_AMOUNT, 50))
-					if(materials.has_enough_of_material(/datum/material/diamond, MINERAL_MATERIAL_AMOUNT, 50))
-						if(materials.has_enough_of_material(/datum/material/uranium, MINERAL_MATERIAL_AMOUNT, 50))
+					if(materials.has_enough_of_material(/datum/material/titanium, MINERAL_MATERIAL_AMOUNT, 50))
+						if(materials.has_enough_of_material(/datum/material/silver, MINERAL_MATERIAL_AMOUNT, 50))
 							if(materials.has_enough_of_material(/datum/material/plasma, MINERAL_MATERIAL_AMOUNT, 50))
-								if(materials.has_enough_of_material(/datum/material/bluespace, MINERAL_MATERIAL_AMOUNT, 50))
-									if(materials.has_enough_of_material(/datum/material/titanium, MINERAL_MATERIAL_AMOUNT, 50))
+								if(materials.has_enough_of_material(/datum/material/glass, MINERAL_MATERIAL_AMOUNT, 50))
+									if(materials.has_enough_of_material(/datum/material/iron, MINERAL_MATERIAL_AMOUNT, 50))
 										return TRUE
 
 // Setup a tesla in cargo
 /datum/department_goal/car/tesla
 	name = "Create a tesla"
 	desc = "Create a tesla engine in the cargo bay"
-	reward = "50000"
+	reward = 50000
 
 /datum/department_goal/car/tesla/check_complete()
 	for(var/obj/singularity/energy_ball/e in GLOB.singularities)

--- a/code/modules/goals/department_goals/cargo.dm
+++ b/code/modules/goals/department_goals/cargo.dm
@@ -12,7 +12,7 @@
 /datum/department_goal/car/sheets/check_complete()
 	var/obj/machinery/ore_silo/O = GLOB.ore_silo_default
 	var/datum/component/material_container/materials = O.GetComponent(/datum/component/material_container)
-	var/list/materials = list(
+	var/list/material_list = list(
 		"bluespace",
 		"diamond",
 		"uranium",
@@ -22,7 +22,7 @@
 		"plasma",
 		"glass",
 		"iron")
-	for(var/I in materials)
+	for(var/I in material_list)
 		if(!materials.has_enough_of_material(/datum/material/I, MINERAL_MATERIAL_AMOUNT, 50))
 			return FALSE
 	return TRUE

--- a/code/modules/goals/department_goals/cargo.dm
+++ b/code/modules/goals/department_goals/cargo.dm
@@ -13,15 +13,15 @@
 	var/obj/machinery/ore_silo/O = GLOB.ore_silo_default
 	var/datum/component/material_container/materials = O.GetComponent(/datum/component/material_container)
 	var/list/material_list = list(
-		"bluespace",
-		"diamond",
-		"uranium",
-		"gold",
-		"titanium",
-		"silver",
-		"plasma",
-		"glass",
-		"iron")
+		/datum/material/bluespace,
+		/datum/material/diamond,
+		/datum/material/uranium,
+		/datum/material/gold,
+		/datum/material/titanium,
+		/datum/material/silver,
+		/datum/material/plasma,
+		/datum/material/glass,
+		/datum/material/iron)
 	for(var/datum/material/I in material_list)
 		if(!materials.has_enough_of_material(I, MINERAL_MATERIAL_AMOUNT, 50))
 			return FALSE


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

changes 500 uranium goal to 50 of every traditional sheet (no bananium, plastic, etc)
reward is 5000 creds for every 5 minutes of meeting this goal
removes the quotes on the reward values because they dont need it

don't look at the code it's bad

### Why is this change good for the game?

better, more dynamic goal, actually rewards

:cl:  
tweak: Changes cargo's 500 uranium goal to 50 of every sheet
/:cl:
