### PR TITLE
puts golf in games vendor

### DIFF
--- a/code/modules/vending/games.dm
+++ b/code/modules/vending/games.dm
@@ -10,7 +10,11 @@
 		            /obj/item/toy/cards/deck/cas/black = 3,
 					/obj/item/hourglass = 2,
 					/obj/item/toy/turn_tracker = 6,
-					/obj/item/instrument/musicalmoth = 1)
+					/obj/item/instrument/musicalmoth = 1,
+					/obj/machinery/golfhole = 4,
+					/obj/machinery/golfhole/blue = 4,
+					/obj/item/golfclub = 4,
+					/obj/item/golfball = 8)
 	contraband = list(/obj/item/dice/fudge = 9)
 	premium = list(/obj/item/melee/skateboard/pro = 3,
 					/obj/item/melee/skateboard/hoverboard = 1)


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

golf items in library games vendor

### Why is this change good for the game?

golf accessible

# Changelog

:cl:  
tweak: Put golf equipment in the Good Clean Fun vendor
/:cl:
