### PR TITLE
adds a cooldown to throwing things

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -160,7 +160,7 @@
 		log_message("has thrown [thrown_thing]", LOG_ATTACK)
 		newtonian_move(get_dir(target, src))
 		thrown_thing.safe_throw_at(target, thrown_thing.throw_range, thrown_thing.throw_speed, src, null, null, null, move_force)
-		src.changeNext_move(CLICK_CD_RANGE)
+		changeNext_move(CLICK_CD_RANGE)
 
 /mob/living/carbon/restrained(ignore_grab)
 	. = (handcuffed || (!ignore_grab && pulledby && pulledby.grab_state >= GRAB_AGGRESSIVE))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -160,6 +160,7 @@
 		log_message("has thrown [thrown_thing]", LOG_ATTACK)
 		newtonian_move(get_dir(target, src))
 		thrown_thing.safe_throw_at(target, thrown_thing.throw_range, thrown_thing.throw_speed, src, null, null, null, move_force)
+		src.changeNext_move(CLICK_CD_RANGE)
 
 /mob/living/carbon/restrained(ignore_grab)
 	. = (handcuffed || (!ignore_grab && pulledby && pulledby.grab_state >= GRAB_AGGRESSIVE))


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

currently there's no cooldown to throwing stuff, meaning you can effectively throw something as fast as you can pick it up, toggle throw, and click. This introduces a 4 decisecond cooldown after successfully throwing stuff, the same as for firing guns.

### Why is this change good for the game?
you will no longer be able to throw things as fast as you can pick them up
# Changelog

:cl:  
tweak: throwing items will now have a cooldown similarly to other attack methods
/:cl:
