### PR TITLE
makes ocular warden code less shit by 2 characters and makes them not attack stunned people for real

### DIFF
--- a/code/modules/antagonists/clockcult/clock_structures/ocular_warden.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/ocular_warden.dm
@@ -119,7 +119,7 @@
 			continue
 		if(is_servant_of_ratvar(L) || (HAS_TRAIT(L, TRAIT_BLIND)) || L.anti_magic_check(TRUE, TRUE))
 			continue
-		if(L.stat || (L.IsStun())) //yogs: changes mobility flag to IsStun so people have to taze themselves to ignore warden attacks
+		if(L.stat || L.IsStun() || L.IsParalyzed()) //yogs: changes mobility flag to IsStun so people have to taze themselves to ignore warden attacks
 			continue
 		if(isslime(L)) //Ocular wardens heal slimes
 			continue

--- a/code/modules/antagonists/clockcult/clock_structures/ocular_warden.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/ocular_warden.dm
@@ -119,7 +119,7 @@
 			continue
 		if(is_servant_of_ratvar(L) || (HAS_TRAIT(L, TRAIT_BLIND)) || L.anti_magic_check(TRUE, TRUE))
 			continue
-		if(L.stat || L.IsStun() || L.IsParalyzed()) //yogs: changes mobility flag to IsStun so people have to taze themselves to ignore warden attacks
+		if(L.stat || L.IsStun() || L.IsParalyzed() || L.restrained()) //yogs: changes mobility flag to IsStun so people have to taze themselves to ignore warden attacks
 			continue
 		if(isslime(L)) //Ocular wardens heal slimes
 			continue

--- a/code/modules/antagonists/clockcult/clock_structures/ocular_warden.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/ocular_warden.dm
@@ -119,7 +119,7 @@
 			continue
 		if(is_servant_of_ratvar(L) || (HAS_TRAIT(L, TRAIT_BLIND)) || L.anti_magic_check(TRUE, TRUE))
 			continue
-		if(L.stat || L.IsStun() || L.IsParalyzed() || L.restrained()) //yogs: changes mobility flag to IsStun so people have to taze themselves to ignore warden attacks
+		if(L.stat || L.IsStun() || L.IsParalyzed()) //yogs: changes mobility flag to IsStun so people have to taze themselves to ignore warden attacks
 			continue
 		if(isslime(L)) //Ocular wardens heal slimes
 			continue


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

did this like 2 years ago but as it turns out the Stun effect is rarely used in favor of Paralyze so that's now checked as well
also

### Why is this change good for the game?
less shitcode good more function as intended also good
# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
ocular wardens won't attack people who are stunned any more
# Changelog


:cl:  
tweak: ocular wardens won't attack people who are stunned
/:cl:
