### PR TITLE
removes unnecessary %

### DIFF
--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -79,7 +79,7 @@
 /obj/machinery/seed_extractor/examine(mob/user)
 	. = ..()
 	if(in_range(user, src) || isobserver(user))
-		. += "<span class='notice'>The status display reads: Extracting <b>[seed_multiplier]</b> seed(s) per piece of produce.<br>Machine can store up to <b>[max_seeds]%</b> seeds.</span>"
+		. += "<span class='notice'>The status display reads: Extracting <b>[seed_multiplier]</b> seed(s) per piece of produce.<br>Machine can store up to <b>[max_seeds]</b> seeds.</span>"
 
 /obj/machinery/seed_extractor/attackby(obj/item/O, mob/user, params)
 


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Removes a % from seed extractor examine text that makes no sense being there
![](https://i.imgur.com/izkT55p.png)

### Why is this change good for the game?

Missing/Inadequate Rationale

:cl:  
spellcheck: Removed an inappropriate "%" from seed extractor examine text
/:cl:
