### PR TITLE
Makes it so you only see voice in conversation

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -53,7 +53,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	var/freqpart = radio_freq ? "\[[get_radio_name(radio_freq)]\] " : ""
 	//Speaker name
 	var/realnamepart = "[speaker.GetVoice(TRUE)][speaker.get_alt_name()]" // Yogs -- for NTSL and AI tracking
-	var/namepart = "[speaker.GetVoice()][speaker.get_alt_name()]"
+	var/namepart = "[speaker.GetVoice()]"
 	if(face_name && ishuman(speaker))
 		var/mob/living/carbon/human/H = speaker
 		namepart = "[H.get_face_name()]" //So "fake" speaking like in hallucinations does not give the speaker away if disguised


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Tested on private server

ID no longer shows up in chat when someone is talking
You will only see the voice that you hear

What exactly does this mean?
Chat will no longer display the following:
> Urist (as Captain) says, "Hello, world"
> Urist (as Unknown) says, "Hello, world"

Chat will instead display:
> Urist says, "Hello, world"
> Urist says, "Hello, world"

You will still be able to see their ID by seeing your mouse hover or by examining them, as visual display text has not been changed, only what shows up when someone talks

### Why is this change good for the game?

Runechat exists. The technology is here and this code is from an age where you could not tell where a voice was coming from. You needed this identifying information and now you do not. If you want to match the voice to the face to see if any tomfoolery is about, you need to actually look at the person.

# Changelog

:cl:  
tweak: You can now only see voices in chat
/:cl:
