### PR TITLE
makes science's greytide gun unobtainable

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -296,16 +296,6 @@
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
-/datum/design/wormhole_projector
-	name = "Bluespace Wormhole Projector"
-	desc = "A projector that emits high density quantum-coupled bluespace beams."
-	id = "wormholeprojector"
-	build_type = PROTOLATHE
-	materials = list(/datum/material/silver = 2000, /datum/material/iron = 5000, /datum/material/diamond = 2000, /datum/material/bluespace = 3000)
-	build_path = /obj/item/gun/energy/wormhole_projector
-	category = list("Weapons")
-	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
-
 //WT550 Mags
 
 /datum/design/mag_oldsmg

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -212,7 +212,7 @@
 	display_name = "Miniaturized Bluespace Research"
 	description = "Extreme reduction in space required for bluespace engines, leading to portable bluespace technology."
 	prereq_ids = list("bluespace_travel", "practical_bluespace", "high_efficiency")
-	design_ids = list("bluespace_matter_bin", "femto_mani", "bluespacebodybag", "triphasic_scanning", "quantum_keycard", "wormholeprojector")
+	design_ids = list("bluespace_matter_bin", "femto_mani", "bluespacebodybag", "triphasic_scanning", "quantum_keycard")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	export_price = 5000
 


### PR DESCRIPTION
#### Read our contributing.md if you haven't already: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md

# General Documentation

### Intent of your Pull Request

removes the bluespace wormhole projector from the techweb - it completely negates any and all access restrictions that exist excepting those rare rooms that for some reason dont have a window and i dont understand why people even thought the item was a good idea in the first place

### Why is this change good for the game?

science can no longer teleport wherever the fuck they want now

still exists as an adminbus item or w/e

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
wormhole projector is gone

### What should players be aware of when it comes to the changes your PR is implementing?
wormhole projector is gone

### What general grouping does this PR fall under? 
science tech tree changes

### Are there any aspects of the PR that you would like us not to mention on the Wiki?
no

# Changelog
:cl:  
rscdel: bluespace wormhole projector is no longer researchable
/:cl:
