### PR TITLE
announces round-end when nar-sie summoned

### DIFF
--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -75,6 +75,7 @@
 	INVOKE_ASYNC(src, .proc/begin_the_end)
 
 /obj/singularity/narsie/large/cult/proc/begin_the_end()
+	to_chat(world, "<BR><BR><BR><span class='big bold'>The round has ended.</span>")
 	sleep(50)
 	priority_announce("An acausal dimensional event has been detected in your sector. Event has been flagged EXTINCTION-CLASS. Directing all available assets toward simulating solutions. SOLUTION ETA: 60 SECONDS.","Central Command Higher Dimensional Affairs", 'sound/misc/airraid.ogg')
 	sleep(500)


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Round is announced to be ended when nar-sie is summoned, and then after the cinematic plays it actually ends
Can't just move the round-end for reasons that alexkar knows and not me

### Why is this change good for the game?

Players are free to act as if the round has already ended once nar-sie is summoned

# Changelog

:cl:  
rscadd: Added a pseudo round-end when nar-sie is summoned
/:cl:
