### PR TITLE
fixes an oversight in plastic flap logic that got introduced when crawling was added a few years ago

### DIFF
--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -93,7 +93,7 @@
 			return TRUE
 		if(M.buckled && istype(M.buckled, /mob/living/simple_animal/bot/mulebot)) // mulebot passenger gets a free pass.
 			return TRUE
-		if((M.mobility_flags & MOBILITY_STAND) && !M.ventcrawler && M.mob_size != MOB_SIZE_TINY)	//If your not laying down, or a ventcrawler or a small creature, no pass.
+		if(((M.mobility_flags & MOBILITY_STAND) && !(M.mobility_flags & MOBILITY_MOVE)) && !M.ventcrawler && M.mob_size != MOB_SIZE_TINY)	//If your not laying down, or a ventcrawler or a small creature, no pass.
 			return FALSE
 
 /obj/structure/plasticflaps/deconstruct(disassembled = TRUE)

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -93,7 +93,7 @@
 			return TRUE
 		if(M.buckled && istype(M.buckled, /mob/living/simple_animal/bot/mulebot)) // mulebot passenger gets a free pass.
 			return TRUE
-		if(((M.mobility_flags & MOBILITY_STAND) && !(M.mobility_flags & MOBILITY_MOVE)) && !M.ventcrawler && M.mob_size != MOB_SIZE_TINY)	//If your not laying down, or a ventcrawler or a small creature, no pass.
+		if(((M.mobility_flags & MOBILITY_STAND) || (M.mobility_flags & MOBILITY_MOVE)) && !M.ventcrawler && M.mob_size != MOB_SIZE_TINY)	//If your not laying down, or a ventcrawler or a small creature, no pass.
 			return FALSE
 
 /obj/structure/plasticflaps/deconstruct(disassembled = TRUE)


### PR DESCRIPTION
Closes #11037

# General Documentation

### Intent of your Pull Request
You can no longer crawl under plastic flaps, dead people can still pass through, it changes the requirement from being standing down to being standing down and not being able to move so stunned people can still be thrown through but alive people can't.

### Why is this change good for the game?
Nerfs powergamers and greytiders who break into the less secure flaps entrances. There's a reason it takes 50 years to deconstruct them, they're meant to be somewhat secure.


# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
Plastic flaps no longer allow you to pass through by crawling

# Changelog

:cl:  
bugfix: You can no longer crawl under plastic flaps.
/:cl:
