### PR TITLE
Gives the bar privacy shutters so that the bartender can actually close down their bar

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -442,14 +442,6 @@
 	},
 /turf/open/floor/pod/dark,
 /area/ruin/powered/beach)
-"eR" = (
-/obj/structure/table/wood,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/ruin/powered/beach)
 "hY" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer,
@@ -554,6 +546,14 @@
 /obj/structure/closet/athletic_mixed,
 /turf/open/floor/pod/dark,
 /area/ruin/powered/beach)
+"wz" = (
+/obj/structure/table/wood,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/ruin/powered/beach)
 "wY" = (
 /turf/open/floor/pod/light,
 /area/ruin/powered/beach)
@@ -599,21 +599,21 @@
 /obj/effect/turf_decal/sand,
 /turf/open/floor/pod/dark,
 /area/ruin/powered/beach)
+"Qc" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/ruin/powered/beach)
 "QS" = (
 /obj/effect/turf_decal/sand,
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plating/beach/sand,
-/area/ruin/powered/beach)
-"QU" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
 /area/ruin/powered/beach)
 "TP" = (
 /obj/machinery/light{
@@ -626,12 +626,12 @@
 "VO" = (
 /turf/open/floor/pod/dark,
 /area/ruin/powered/beach)
-"VT" = (
+"Ws" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/tequila,
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
-	name = "privacy shutters"
+	name = "bar shutters"
 	},
 /turf/open/floor/wood,
 /area/ruin/powered/beach)
@@ -1004,7 +1004,7 @@ as
 aw
 aC
 jl
-eR
+wz
 aW
 aK
 Ga
@@ -1036,7 +1036,7 @@ as
 aj
 aD
 aC
-QU
+Qc
 aW
 oK
 sO
@@ -1068,7 +1068,7 @@ at
 ax
 hY
 aC
-eR
+wz
 aW
 aK
 sy
@@ -1100,7 +1100,7 @@ aj
 aj
 aF
 aC
-VT
+Ws
 aW
 aK
 aK

--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -457,7 +457,7 @@
 "jl" = (
 /obj/machinery/button/door{
 	id = "barshutters";
-	name = "bar shutters";
+	name = "Bar Shutters Control";
 	pixel_x = -24
 	},
 /turf/open/floor/wood,

--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -202,20 +202,6 @@
 /obj/structure/weightmachine/stacklifter,
 /turf/open/floor/plating/beach/sand,
 /area/ruin/powered/beach)
-"aP" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/ruin/powered/beach)
-"aQ" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/turf/open/floor/wood,
-/area/ruin/powered/beach)
-"aR" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/tequila,
-/turf/open/floor/wood,
-/area/ruin/powered/beach)
 "aS" = (
 /obj/machinery/processor,
 /turf/open/floor/wood,
@@ -456,6 +442,14 @@
 	},
 /turf/open/floor/pod/dark,
 /area/ruin/powered/beach)
+"eR" = (
+/obj/structure/table/wood,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/ruin/powered/beach)
 "hY" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer,
@@ -467,6 +461,14 @@
 	dir = 8
 	},
 /turf/open/floor/pod/dark,
+/area/ruin/powered/beach)
+"jl" = (
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = -24
+	},
+/turf/open/floor/wood,
 /area/ruin/powered/beach)
 "jF" = (
 /obj/effect/turf_decal/sand,
@@ -604,6 +606,15 @@
 	},
 /turf/open/floor/plating/beach/sand,
 /area/ruin/powered/beach)
+"QU" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/ruin/powered/beach)
 "TP" = (
 /obj/machinery/light{
 	dir = 8
@@ -614,6 +625,15 @@
 /area/ruin/powered/beach)
 "VO" = (
 /turf/open/floor/pod/dark,
+/area/ruin/powered/beach)
+"VT" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/tequila,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
 /area/ruin/powered/beach)
 "Xp" = (
 /obj/effect/turf_decal/sand,
@@ -983,8 +1003,8 @@ ag
 as
 aw
 aC
-aC
-aP
+jl
+eR
 aW
 aK
 Ga
@@ -1016,7 +1036,7 @@ as
 aj
 aD
 aC
-aQ
+QU
 aW
 oK
 sO
@@ -1048,7 +1068,7 @@ at
 ax
 hY
 aC
-aP
+eR
 aW
 aK
 sy
@@ -1080,7 +1100,7 @@ aj
 aj
 aF
 aC
-aR
+VT
 aW
 aK
 aK

--- a/_maps/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacebar.dmm
@@ -59,12 +59,33 @@
 /obj/machinery/jukebox,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
+"bF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/powered/spacebar)
 "co" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel,
+/area/ruin/space/has_grav/powered/spacebar)
+"ex" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line,
+/mob/living/carbon/monkey/punpun,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/spacebar)
 "eC" = (
 /obj/effect/turf_decal/tile/bar{
@@ -318,6 +339,18 @@
 	},
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/powered/spacebar)
+"nv" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/powered/spacebar)
 "nK" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1;
@@ -340,20 +373,6 @@
 /obj/structure/chair,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
-"oo" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/powered/spacebar)
 "oC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -368,7 +387,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/cafeteria,
 /area/ruin/space/has_grav/powered/spacebar)
-"pP" = (
+"pc" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -377,11 +396,12 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/sign/poster/random{
-	pixel_x = 32
-	},
 /obj/structure/window/reinforced{
 	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/spacebar)
@@ -446,6 +466,20 @@
 /obj/item/reagent_containers/food/condiment/enzyme,
 /turf/open/floor/plasteel/cafeteria,
 /area/ruin/space/has_grav/powered/spacebar)
+"sI" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/reagent_containers/food/drinks/bottle/lizardwine{
+	pixel_y = 6
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/powered/spacebar)
 "sM" = (
 /turf/closed/mineral,
 /area/ruin/unpowered/no_grav)
@@ -504,13 +538,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/ruin/space/has_grav/powered/spacebar)
-"uu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/powered/spacebar)
 "uD" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -520,14 +547,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
-/area/ruin/space/has_grav/powered/spacebar)
-"vd" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/spacebar)
 "vh" = (
 /obj/effect/turf_decal/stripes/line{
@@ -584,6 +603,17 @@
 	},
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/plasteel,
+/area/ruin/space/has_grav/powered/spacebar)
+"yz" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/spacebar)
 "yK" = (
 /obj/machinery/vending/boozeomat,
@@ -667,16 +697,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/ruin/space/has_grav/powered/spacebar)
-"Ee" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/item/reagent_containers/food/drinks/bottle/lizardwine{
-	pixel_y = 6
-	},
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/powered/spacebar)
 "Ej" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1;
@@ -715,16 +735,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
-"GA" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/item/book/manual/wiki/barman_recipes{
-	pixel_y = -4
-	},
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/powered/spacebar)
 "GD" = (
 /turf/open/floor/plasteel/freezer,
 /area/ruin/space/has_grav/powered/spacebar)
@@ -746,15 +756,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
-"GM" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/reagent_containers/glass/rag,
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/powered/spacebar)
 "Hf" = (
 /obj/structure/chair/stool,
 /obj/item/toy/figure/bartender{
@@ -764,13 +765,6 @@
 	pixel_y = -4
 	},
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/spacebar)
-"Hi" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/spacebar)
 "Hk" = (
 /obj/effect/turf_decal/tile/bar{
@@ -806,23 +800,11 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/spacebar)
-"Jw" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/powered/spacebar)
 "JG" = (
 /obj/structure/chair/stool,
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/powered/spacebar)
 "JO" = (
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/powered/spacebar)
-"JU" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/spacebar)
 "KO" = (
@@ -903,12 +885,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
-"Nn" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line,
-/mob/living/carbon/monkey/punpun,
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/powered/spacebar)
 "NH" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -923,6 +899,19 @@
 "NQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall,
+/area/ruin/space/has_grav/powered/spacebar)
+"NR" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/spacebar)
 "Ok" = (
 /obj/machinery/autolathe,
@@ -947,12 +936,35 @@
 "Ow" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/ruin/space/has_grav/powered/spacebar)
+"OL" = (
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = 25;
+	pixel_y = 24
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/powered/spacebar)
 "OV" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
+/area/ruin/space/has_grav/powered/spacebar)
+"Po" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/book/manual/wiki/barman_recipes{
+	pixel_y = -4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/spacebar)
 "PE" = (
 /obj/effect/turf_decal/tile/bar{
@@ -1026,6 +1038,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
+"Sg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/powered/spacebar)
 "TK" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -1087,6 +1110,15 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/ruin/space/has_grav/powered/spacebar)
+"WF" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/powered/spacebar)
 "WM" = (
 /obj/structure/closet,
 /obj/item/vending_refill/cigarette,
@@ -1105,6 +1137,24 @@
 "YH" = (
 /turf/template_noop,
 /area/template_noop)
+"YJ" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/powered/spacebar)
 "YY" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "25"
@@ -1646,11 +1696,11 @@ yg
 yg
 yg
 PZ
-uu
-GA
-GM
-Ee
-Jw
+Sg
+Po
+NR
+sI
+yz
 PZ
 yg
 KZ
@@ -1679,11 +1729,11 @@ eC
 yg
 yg
 PZ
-Hi
+bF
 JO
 JO
 JO
-JU
+WF
 PZ
 yg
 Hk
@@ -1712,11 +1762,11 @@ Hk
 yg
 yg
 yg
-oo
+YJ
 JO
 JO
 JO
-Nn
+ex
 PZ
 yg
 Ej
@@ -1745,11 +1795,11 @@ fy
 yg
 mQ
 aX
-pP
+pc
+OL
 JO
 JO
-JO
-vd
+nv
 PZ
 yg
 yg
@@ -1785,7 +1835,7 @@ yK
 FB
 jk
 yg
-yg
+mQ
 yg
 yg
 Ls

--- a/_maps/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacebar.dmm
@@ -20,6 +20,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
+"ap" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/chem_dispenser/drinks/fullupgrade,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/powered/spacebar)
 "as" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -35,6 +53,20 @@
 /obj/effect/turf_decal/tile/bar,
 /obj/machinery/vending/snack,
 /turf/open/floor/plasteel,
+/area/ruin/space/has_grav/powered/spacebar)
+"aC" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/book/manual/wiki/barman_recipes{
+	pixel_y = -4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/spacebar)
 "aH" = (
 /obj/effect/turf_decal/tile/bar{
@@ -59,33 +91,12 @@
 /obj/machinery/jukebox,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
-"bF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/powered/spacebar)
 "co" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel,
-/area/ruin/space/has_grav/powered/spacebar)
-"ex" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line,
-/mob/living/carbon/monkey/punpun,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/spacebar)
 "eC" = (
 /obj/effect/turf_decal/tile/bar{
@@ -140,6 +151,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
+"fH" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/powered/spacebar)
 "gh" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1;
@@ -173,6 +195,24 @@
 	tag = ""
 	},
 /turf/open/floor/plasteel,
+/area/ruin/space/has_grav/powered/spacebar)
+"hf" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/spacebar)
 "hh" = (
 /obj/machinery/door/airlock/external,
@@ -339,18 +379,6 @@
 	},
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/powered/spacebar)
-"nv" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/powered/spacebar)
 "nK" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1;
@@ -387,24 +415,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/cafeteria,
 /area/ruin/space/has_grav/powered/spacebar)
-"pc" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/chem_dispenser/drinks/fullupgrade,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/powered/spacebar)
 "pV" = (
 /obj/machinery/light{
 	dir = 4
@@ -439,6 +449,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
+"rf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/powered/spacebar)
 "rE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -465,20 +486,6 @@
 /obj/item/storage/box/donkpockets,
 /obj/item/reagent_containers/food/condiment/enzyme,
 /turf/open/floor/plasteel/cafeteria,
-/area/ruin/space/has_grav/powered/spacebar)
-"sI" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/item/reagent_containers/food/drinks/bottle/lizardwine{
-	pixel_y = 6
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/spacebar)
 "sM" = (
 /turf/closed/mineral,
@@ -604,17 +611,6 @@
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
-"yz" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/powered/spacebar)
 "yK" = (
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall,
@@ -708,6 +704,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
+"ES" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/powered/spacebar)
+"Ft" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/reagent_containers/food/drinks/bottle/lizardwine{
+	pixel_y = 6
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/powered/spacebar)
 "Fy" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -775,6 +797,15 @@
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
+"Hp" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/powered/spacebar)
 "HM" = (
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered/no_grav)
@@ -805,6 +836,16 @@
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/powered/spacebar)
 "JO" = (
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/powered/spacebar)
+"KL" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line,
+/mob/living/carbon/monkey/punpun,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/spacebar)
 "KO" = (
@@ -900,19 +941,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall,
 /area/ruin/space/has_grav/powered/spacebar)
-"NR" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/reagent_containers/glass/rag,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/powered/spacebar)
 "Ok" = (
 /obj/machinery/autolathe,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -951,20 +979,6 @@
 	},
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/spacebar)
-"Po" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/item/book/manual/wiki/barman_recipes{
-	pixel_y = -4
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/spacebar)
 "PE" = (
 /obj/effect/turf_decal/tile/bar{
@@ -1038,14 +1052,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
-"Sg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+"Tw" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/preopen{
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
-	name = "privacy shutters"
+	name = "bar shutters"
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/spacebar)
@@ -1104,20 +1120,22 @@
 /obj/structure/closet/crate/rcd,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
+"VY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/powered/spacebar)
 "Wl" = (
 /obj/structure/sign/poster/contraband/eat{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/cafeteria,
-/area/ruin/space/has_grav/powered/spacebar)
-"WF" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/spacebar)
 "WM" = (
 /obj/structure/closet,
@@ -1137,24 +1155,6 @@
 "YH" = (
 /turf/template_noop,
 /area/template_noop)
-"YJ" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/powered/spacebar)
 "YY" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "25"
@@ -1696,11 +1696,11 @@ yg
 yg
 yg
 PZ
-Sg
-Po
-NR
-sI
-yz
+VY
+aC
+Tw
+Ft
+fH
 PZ
 yg
 KZ
@@ -1729,11 +1729,11 @@ eC
 yg
 yg
 PZ
-bF
+rf
 JO
 JO
 JO
-WF
+Hp
 PZ
 yg
 Hk
@@ -1762,11 +1762,11 @@ Hk
 yg
 yg
 yg
-YJ
+hf
 JO
 JO
 JO
-ex
+KL
 PZ
 yg
 Ej
@@ -1795,11 +1795,11 @@ fy
 yg
 mQ
 aX
-pc
+ap
 OL
 JO
 JO
-nv
+ES
 PZ
 yg
 yg

--- a/_maps/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacebar.dmm
@@ -967,7 +967,7 @@
 "OL" = (
 /obj/machinery/button/door{
 	id = "barshutters";
-	name = "bar shutters";
+	name = "Bar Shutters Control";
 	pixel_x = 25;
 	pixel_y = 24
 	},

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_arcade.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_arcade.dmm
@@ -577,16 +577,31 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"kv" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = 32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_x = -25;
+	pixel_y = 24;
+	req_access_txt = "25"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "lE" = (
 /obj/machinery/door/window/southright{
 	name = "Bar Door";
 	req_one_access_txt = "25;28"
 	},
 /turf/open/floor/wood,
-/area/crew_quarters/bar)
-"nf" = (
-/obj/machinery/smartfridge/drinks,
-/turf/open/floor/eighties,
 /area/crew_quarters/bar)
 "nA" = (
 /obj/structure/chair{
@@ -835,25 +850,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"Km" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "Bar Shutters Control";
-	pixel_x = -25;
-	pixel_y = 24;
-	req_access_txt = "28"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "Mt" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/table,
@@ -1071,6 +1067,14 @@
 /obj/item/instrument/piano_synth,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"ZY" = (
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 
 (1,1,1) = {"
 aa
@@ -1270,7 +1274,7 @@ ay
 aE
 Nf
 ag
-Km
+kv
 aB
 ef
 aB
@@ -1307,7 +1311,7 @@ Xt
 aB
 MG
 aB
-nf
+ZY
 aB
 nA
 ag

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_arcade.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_arcade.dmm
@@ -18,18 +18,6 @@
 "ac" = (
 /turf/closed/wall,
 /area/crew_quarters/theatre)
-"ad" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_access_txt = "12"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "ae" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -422,14 +410,6 @@
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"bT" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "barShutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "ce" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
@@ -543,11 +523,6 @@
 /obj/effect/landmark/start/bartender,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"en" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "eK" = (
 /obj/machinery/computer/arcade{
 	dir = 4
@@ -567,8 +542,13 @@
 	},
 /turf/open/floor/eighties,
 /area/crew_quarters/bar)
-"gE" = (
+"fP" = (
 /obj/structure/table/reinforced,
+/obj/item/lighter,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "hb" = (
@@ -586,6 +566,25 @@
 "is" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"iv" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = 32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_x = -25;
+	pixel_y = 24;
+	req_access_txt = "28"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -618,13 +617,20 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"pc" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+"op" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
 	},
-/obj/structure/window/reinforced,
-/turf/open/floor/wood,
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
+"pa" = (
+/obj/structure/sign/plaques/deempisi{
+	pixel_x = -6;
+	pixel_y = -8
+	},
+/turf/closed/wall,
 /area/crew_quarters/bar)
 "pw" = (
 /obj/item/twohanded/required/kirbyplants/random,
@@ -663,6 +669,15 @@
 	dir = 8
 	},
 /obj/machinery/light,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"rL" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "sb" = (
@@ -721,17 +736,6 @@
 	},
 /turf/open/floor/eighties,
 /area/crew_quarters/bar)
-"vP" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"vQ" = (
-/obj/structure/table/reinforced,
-/obj/item/lighter,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "wF" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/eighties,
@@ -760,6 +764,15 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"zO" = (
+/obj/structure/table/reinforced,
+/obj/item/toy/cards/deck,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "Ak" = (
 /obj/machinery/light,
 /obj/machinery/firealarm{
@@ -767,10 +780,6 @@
 	pixel_y = -26
 	},
 /turf/open/floor/eighties,
-/area/crew_quarters/bar)
-"BO" = (
-/obj/structure/sign/plaques/deempisi,
-/turf/closed/wall,
 /area/crew_quarters/bar)
 "CI" = (
 /obj/effect/turf_decal/siding/wood,
@@ -808,23 +817,7 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"JH" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"Kl" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"KU" = (
+"JG" = (
 /obj/machinery/disposal/bin,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -832,11 +825,14 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"LE" = (
-/obj/structure/table/reinforced,
-/obj/item/toy/cards/deck,
+"JH" = (
+/obj/structure/chair/stool/bar,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "Mt" = (
@@ -964,6 +960,14 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"TH" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "UF" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/landmark/start/assistant,
@@ -982,6 +986,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
+"WT" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "Xq" = (
 /obj/machinery/computer/arcade{
 	dir = 4
@@ -1002,6 +1018,18 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"Xy" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	req_one_access_txt = "12;25"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "Yn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -1012,6 +1040,16 @@
 /obj/machinery/vending/snack/random,
 /obj/machinery/light{
 	dir = 8
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"Zf" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -1042,11 +1080,11 @@ ag
 ag
 ag
 bE
-bT
+op
 ag
-bT
+op
 ag
-bT
+op
 ag
 ag
 "}
@@ -1144,7 +1182,7 @@ hb
 hb
 hb
 hb
-bT
+op
 "}
 (8,1,1) = {"
 ac
@@ -1179,7 +1217,7 @@ hb
 dh
 "}
 (10,1,1) = {"
-ad
+Xy
 Yn
 aJ
 Ow
@@ -1215,13 +1253,13 @@ ag
 ag
 ag
 ag
-BO
-KU
-pc
-LE
-en
-vQ
-gE
+pa
+JG
+WT
+zO
+rL
+fP
+TH
 JH
 yM
 ag
@@ -1232,12 +1270,12 @@ ay
 aE
 Nf
 ag
-Kl
+iv
 aB
 ef
 aB
 aB
-vP
+Zf
 UF
 He
 ag

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_arcade.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_arcade.dmm
@@ -542,7 +542,7 @@
 	},
 /turf/open/floor/eighties,
 /area/crew_quarters/bar)
-"fP" = (
+"gz" = (
 /obj/structure/table/reinforced,
 /obj/item/lighter,
 /obj/machinery/door/poddoor/preopen{
@@ -569,25 +569,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"iv" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "Bar Shutters Control";
-	pixel_x = -25;
-	pixel_y = 24;
-	req_access_txt = "28"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "iF" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
@@ -597,10 +578,29 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"lh" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "lE" = (
 /obj/machinery/door/window/southright{
 	name = "Bar Door";
 	req_one_access_txt = "25;28"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"mz" = (
+/obj/structure/table/reinforced,
+/obj/item/toy/cards/deck,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -616,21 +616,6 @@
 	pixel_y = -30
 	},
 /turf/open/floor/wood,
-/area/crew_quarters/bar)
-"op" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
-"pa" = (
-/obj/structure/sign/plaques/deempisi{
-	pixel_x = -6;
-	pixel_y = -8
-	},
-/turf/closed/wall,
 /area/crew_quarters/bar)
 "pw" = (
 /obj/item/twohanded/required/kirbyplants/random,
@@ -669,15 +654,6 @@
 	dir = 8
 	},
 /obj/machinery/light,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"rL" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "sb" = (
@@ -736,9 +712,30 @@
 	},
 /turf/open/floor/eighties,
 /area/crew_quarters/bar)
+"vS" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "wF" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/eighties,
+/area/crew_quarters/bar)
+"wQ" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "xh" = (
 /obj/structure/extinguisher_cabinet{
@@ -764,15 +761,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"zO" = (
-/obj/structure/table/reinforced,
-/obj/item/toy/cards/deck,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "Ak" = (
 /obj/machinery/light,
 /obj/machinery/firealarm{
@@ -787,9 +775,42 @@
 /obj/item/reagent_containers/food/snacks/candy,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"CV" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"Ep" = (
+/obj/machinery/disposal/bin,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "FY" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/eighties,
+/area/crew_quarters/bar)
+"Go" = (
+/obj/structure/sign/plaques/deempisi{
+	pixel_x = -6;
+	pixel_y = -8
+	},
+/turf/closed/wall,
 /area/crew_quarters/bar)
 "He" = (
 /obj/structure/chair{
@@ -817,22 +838,35 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"JG" = (
-/obj/machinery/disposal/bin,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
+"JF" = (
+/obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plating,
 /area/crew_quarters/bar)
 "JH" = (
 /obj/structure/chair/stool/bar,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"Km" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = 32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_x = -25;
+	pixel_y = 24;
+	req_access_txt = "28"
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "Mt" = (
@@ -932,6 +966,14 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"Rx" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "RD" = (
 /obj/effect/landmark/event_spawn,
 /obj/item/radio/intercom{
@@ -960,14 +1002,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"TH" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "UF" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/landmark/start/assistant,
@@ -986,18 +1020,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
-"WT" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "Xq" = (
 /obj/machinery/computer/arcade{
 	dir = 4
@@ -1018,18 +1040,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"Xy" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_one_access_txt = "12;25"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "Yn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -1040,16 +1050,6 @@
 /obj/machinery/vending/snack/random,
 /obj/machinery/light{
 	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"Zf" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -1080,11 +1080,11 @@ ag
 ag
 ag
 bE
-op
+JF
 ag
-op
+JF
 ag
-op
+JF
 ag
 ag
 "}
@@ -1182,7 +1182,7 @@ hb
 hb
 hb
 hb
-op
+JF
 "}
 (8,1,1) = {"
 ac
@@ -1217,7 +1217,7 @@ hb
 dh
 "}
 (10,1,1) = {"
-Xy
+CV
 Yn
 aJ
 Ow
@@ -1253,13 +1253,13 @@ ag
 ag
 ag
 ag
-pa
-JG
-WT
-zO
-rL
-fP
-TH
+Go
+Ep
+vS
+mz
+wQ
+gz
+Rx
 JH
 yM
 ag
@@ -1270,12 +1270,12 @@ ay
 aE
 Nf
 ag
-iv
+Km
 aB
 ef
 aB
 aB
-Zf
+lh
 UF
 He
 ag

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_arcade.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_arcade.dmm
@@ -509,6 +509,14 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/crew_quarters/bar)
+"dC" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "dL" = (
 /obj/machinery/light{
 	dir = 1
@@ -542,15 +550,6 @@
 	},
 /turf/open/floor/eighties,
 /area/crew_quarters/bar)
-"gz" = (
-/obj/structure/table/reinforced,
-/obj/item/lighter,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "hb" = (
 /turf/open/floor/eighties,
 /area/crew_quarters/bar)
@@ -578,29 +577,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"lh" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "lE" = (
 /obj/machinery/door/window/southright{
 	name = "Bar Door";
 	req_one_access_txt = "25;28"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"mz" = (
-/obj/structure/table/reinforced,
-/obj/item/toy/cards/deck,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -648,6 +628,18 @@
 	dir = 8
 	},
 /turf/open/floor/eighties,
+/area/crew_quarters/bar)
+"qQ" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "rb" = (
 /obj/effect/turf_decal/siding/wood{
@@ -712,30 +704,9 @@
 	},
 /turf/open/floor/eighties,
 /area/crew_quarters/bar)
-"vS" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "wF" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/eighties,
-/area/crew_quarters/bar)
-"wQ" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "xh" = (
 /obj/structure/extinguisher_cabinet{
@@ -750,6 +721,15 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"xZ" = (
+/obj/structure/table/reinforced,
+/obj/item/toy/cards/deck,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "yg" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/eighties,
@@ -787,17 +767,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"Ep" = (
-/obj/machinery/disposal/bin,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/preopen{
+"DE" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
-	name = "privacy shutters"
+	name = "bar shutters"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -848,6 +824,15 @@
 /area/crew_quarters/bar)
 "JH" = (
 /obj/structure/chair/stool/bar,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"JQ" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "Km" = (
@@ -966,14 +951,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"Rx" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "RD" = (
 /obj/effect/landmark/event_spawn,
 /obj/item/radio/intercom{
@@ -1007,6 +984,20 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"UI" = (
+/obj/machinery/disposal/bin,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "Wx" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Kitchen";
@@ -1020,6 +1011,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
+"Xl" = (
+/obj/structure/table/reinforced,
+/obj/item/lighter,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "Xq" = (
 /obj/machinery/computer/arcade{
 	dir = 4
@@ -1254,12 +1254,12 @@ ag
 ag
 ag
 Go
-Ep
-vS
-mz
-wQ
-gz
-Rx
+UI
+qQ
+xZ
+JQ
+Xl
+dC
 JH
 yM
 ag
@@ -1275,7 +1275,7 @@ aB
 ef
 aB
 aB
-lh
+DE
 UF
 He
 ag

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_box.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_box.dmm
@@ -18,18 +18,6 @@
 "ac" = (
 /turf/closed/wall,
 /area/crew_quarters/theatre)
-"ad" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_access_txt = "12"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "ae" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -622,30 +610,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
-"bA" = (
-/obj/machinery/disposal/bin,
-/obj/structure/sign/warning/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
-	pixel_x = -28;
-	pixel_y = -4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "barShutters";
-	name = "bar shutters";
-	pixel_x = 4;
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "bB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -706,15 +670,6 @@
 /area/crew_quarters/bar)
 "bH" = (
 /obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"bI" = (
-/obj/structure/table/reinforced,
-/obj/item/lighter,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -793,14 +748,6 @@
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"bT" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "barShutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "bU" = (
 /obj/structure/chair{
 	dir = 4
@@ -880,14 +827,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"cb" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -992,17 +931,6 @@
 "cn" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/spawner/xmastree,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"co" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that{
-	throwforce = 1
-	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -1316,6 +1244,32 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/crew_quarters/bar)
+"gd" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"gf" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/item/reagent_containers/glass/rag,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "jO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -1325,15 +1279,18 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"mg" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
+"kz" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/smartfridge/drinks,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	req_one_access_txt = "12;25"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "sb" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets{
@@ -1342,6 +1299,34 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"sh" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that{
+	throwforce = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"uW" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "xI" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/mixbowl{
@@ -1349,6 +1334,28 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"xQ" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
+"Kq" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_x = -25;
+	pixel_y = 24;
+	req_access_txt = "28"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "KF" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/tile/bar,
@@ -1383,16 +1390,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"OA" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/item/reagent_containers/glass/rag,
-/obj/item/book/manual/wiki/barman_recipes,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "QH" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin{
@@ -1409,6 +1406,19 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"Sp" = (
+/obj/structure/table/reinforced,
+/obj/item/lighter,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "SG" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -1416,6 +1426,24 @@
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"WH" = (
+/obj/machinery/disposal/bin,
+/obj/structure/sign/warning/securearea{
+	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
+	icon_state = "monkey_painting";
+	name = "Mr. Deempisi portrait";
+	pixel_x = -27;
+	pixel_y = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -1428,11 +1456,11 @@ ac
 ac
 ag
 bE
-bT
+xQ
 ag
-bT
+xQ
 ag
-bT
+xQ
 ag
 ag
 "}
@@ -1530,7 +1558,7 @@ bX
 cc
 bx
 bx
-bT
+xQ
 "}
 (8,1,1) = {"
 ac
@@ -1565,7 +1593,7 @@ cY
 dh
 "}
 (10,1,1) = {"
-ad
+kz
 am
 bw
 KF
@@ -1603,11 +1631,11 @@ ag
 ag
 ag
 ag
-bI
-cb
-co
-cb
-cb
+Sp
+gd
+sh
+gd
+gd
 cM
 db
 ag
@@ -1618,12 +1646,12 @@ ay
 aE
 bd
 ag
-bA
-bx
+WH
+Kq
 bx
 cp
 bx
-OA
+gf
 cN
 dc
 ag
@@ -1655,7 +1683,7 @@ bJ
 bx
 cq
 bx
-mg
+uW
 bx
 SG
 ag

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_box.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_box.dmm
@@ -1244,26 +1244,28 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"gd" = (
+"dF" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
+/obj/machinery/smartfridge/drinks,
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"gf" = (
+"hu" = (
 /obj/structure/table/reinforced,
+/obj/item/clothing/head/that{
+	throwforce = 1
+	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/item/reagent_containers/glass/rag,
-/obj/item/book/manual/wiki/barman_recipes,
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
@@ -1279,18 +1281,18 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"kz" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
+"qr" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_one_access_txt = "12;25"
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "sb" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets{
@@ -1299,34 +1301,18 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"sh" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that{
-	throwforce = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
+"tP" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	req_access_txt = "12"
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"uW" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/smartfridge/drinks,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "xI" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/mixbowl{
@@ -1334,25 +1320,48 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"xQ" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
-"Kq" = (
+"AJ" = (
+/obj/structure/table/reinforced,
+/obj/item/lighter,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/machinery/button/door{
+/obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
-	name = "Bar Shutters Control";
-	pixel_x = -25;
-	pixel_y = 24;
-	req_access_txt = "28"
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"IS" = (
+/obj/machinery/disposal/bin,
+/obj/structure/sign/warning/securearea{
+	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
+	icon_state = "monkey_painting";
+	name = "Mr. Deempisi portrait";
+	pixel_x = -27;
+	pixel_y = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"Ke" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/item/reagent_containers/glass/rag,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -1406,18 +1415,13 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"Sp" = (
-/obj/structure/table/reinforced,
-/obj/item/lighter,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
+"Sf" = (
+/obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/crew_quarters/bar)
 "SG" = (
 /obj/effect/turf_decal/tile/bar,
@@ -1429,21 +1433,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"WH" = (
-/obj/machinery/disposal/bin,
-/obj/structure/sign/warning/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
-	pixel_x = -27;
-	pixel_y = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
+"Xj" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_x = -25;
+	pixel_y = 24;
+	req_access_txt = "28"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -1456,11 +1456,11 @@ ac
 ac
 ag
 bE
-xQ
+Sf
 ag
-xQ
+Sf
 ag
-xQ
+Sf
 ag
 ag
 "}
@@ -1558,7 +1558,7 @@ bX
 cc
 bx
 bx
-xQ
+Sf
 "}
 (8,1,1) = {"
 ac
@@ -1593,7 +1593,7 @@ cY
 dh
 "}
 (10,1,1) = {"
-kz
+tP
 am
 bw
 KF
@@ -1631,11 +1631,11 @@ ag
 ag
 ag
 ag
-Sp
-gd
-sh
-gd
-gd
+AJ
+qr
+hu
+qr
+qr
 cM
 db
 ag
@@ -1646,12 +1646,12 @@ ay
 aE
 bd
 ag
-WH
-Kq
+IS
+Xj
 bx
 cp
 bx
-gf
+Ke
 cN
 dc
 ag
@@ -1683,7 +1683,7 @@ bJ
 bx
 cq
 bx
-uW
+dF
 bx
 SG
 ag

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_box.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_box.dmm
@@ -971,6 +971,20 @@
 /obj/item/reagent_containers/food/snacks/mint,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"cu" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_x = -25;
+	pixel_y = 24;
+	req_access_txt = "25"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "cv" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/cafeteria,
@@ -1433,20 +1447,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"Xj" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "Bar Shutters Control";
-	pixel_x = -25;
-	pixel_y = 24;
-	req_access_txt = "28"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 
 (1,1,1) = {"
 aa
@@ -1647,7 +1647,7 @@ aE
 bd
 ag
 IS
-Xj
+cu
 bx
 cp
 bx

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_box.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_box.dmm
@@ -1257,21 +1257,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"hu" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that{
-	throwforce = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "jO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -1281,18 +1266,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"qr" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "sb" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets{
@@ -1313,6 +1286,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"vA" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that{
+	throwforce = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "xI" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/mixbowl{
@@ -1320,16 +1308,29 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"AJ" = (
+"Bo" = (
 /obj/structure/table/reinforced,
-/obj/item/lighter,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/machinery/door/poddoor/preopen{
+/obj/item/reagent_containers/glass/rag,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
-	name = "privacy shutters"
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"CJ" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -1348,20 +1349,6 @@
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"Ke" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/item/reagent_containers/glass/rag,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -1430,6 +1417,19 @@
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"TX" = (
+/obj/structure/table/reinforced,
+/obj/item/lighter,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -1631,11 +1631,11 @@ ag
 ag
 ag
 ag
-AJ
-qr
-hu
-qr
-qr
+TX
+CJ
+vA
+CJ
+CJ
 cM
 db
 ag
@@ -1651,7 +1651,7 @@ Xj
 bx
 cp
 bx
-Ke
+Bo
 cN
 dc
 ag

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_casino.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_casino.dmm
@@ -847,6 +847,19 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
+"df" = (
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 4;
+	icon_state = "soda_dispenser"
+	},
+/obj/machinery/door/window/westright,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "dg" = (
 /obj/structure/sign/barsign,
 /turf/closed/wall,
@@ -867,6 +880,15 @@
 	},
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/kitchen)
+"jz" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "pr" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -894,23 +916,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"rC" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"wF" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "zc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8;
@@ -928,16 +933,17 @@
 /obj/item/stack/packageWrap,
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/kitchen)
-"BX" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 4;
-	icon_state = "soda_dispenser"
+"CC" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/obj/machinery/door/window/westright,
-/obj/machinery/door/poddoor/preopen{
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
-	name = "privacy shutters"
+	name = "bar shutters"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -979,35 +985,11 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
-"Pi" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "Qz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/rockvault,
-/area/crew_quarters/bar)
-"Rp" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "RH" = (
 /obj/structure/sign/plaques/deempisi{
@@ -1030,6 +1012,14 @@
 /obj/effect/landmark/event_spawn,
 /turf/closed/wall,
 /area/crew_quarters/bar)
+"SD" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "SW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -1044,6 +1034,16 @@
 /obj/item/reagent_containers/food/snacks/mint,
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/kitchen)
+"Up" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "UT" = (
 /obj/structure/table,
 /obj/machinery/requests_console{
@@ -1251,12 +1251,12 @@ ag
 ag
 ag
 RH
-Pi
-BX
-rC
-wF
-rC
-rC
+CC
+df
+SD
+jz
+SD
+SD
 ap
 ap
 Nq
@@ -1272,7 +1272,7 @@ cm
 cm
 bZ
 cm
-Rp
+Up
 Gp
 bJ
 ac

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_casino.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_casino.dmm
@@ -35,18 +35,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
-"af" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_access_txt = "12"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "ag" = (
 /turf/closed/wall{
 	icon = 'icons/turf/walls/reinforced_wall.dmi';
@@ -234,16 +222,6 @@
 /obj/item/storage/bag/money,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
-"aH" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "aI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -328,15 +306,6 @@
 /obj/machinery/chem_dispenser/drinks/beer{
 	dir = 8
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"aS" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 4;
-	icon_state = "soda_dispenser"
-	},
-/obj/machinery/door/window/westright,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aT" = (
@@ -509,12 +478,6 @@
 	},
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/kitchen)
-"bo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "bp" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -32
@@ -588,10 +551,6 @@
 	pixel_x = 2
 	},
 /turf/open/floor/carpet/black,
-/area/crew_quarters/bar)
-"by" = (
-/obj/machinery/smartfridge/drinks,
-/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "bz" = (
 /obj/structure/extinguisher_cabinet{
@@ -730,12 +689,6 @@
 /obj/effect/landmark/start/cook,
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/kitchen)
-"bR" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "bS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -783,11 +736,6 @@
 	light_color = "#e8eaff"
 	},
 /turf/open/floor/carpet,
-/area/crew_quarters/bar)
-"bY" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that,
-/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "bZ" = (
 /obj/effect/landmark/start/bartender,
@@ -837,10 +785,6 @@
 /obj/effect/landmark/event_spawn,
 /obj/structure/chair/americandiner,
 /turf/open/floor/carpet,
-/area/crew_quarters/bar)
-"cl" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "cm" = (
 /turf/open/floor/wood,
@@ -923,13 +867,49 @@
 	},
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/kitchen)
-"ij" = (
-/obj/structure/sign/plaques/deempisi,
+"he" = (
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"ig" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_x = -26;
+	pixel_y = 24;
+	req_access_txt = "28"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"jK" = (
+/obj/structure/sign/plaques/deempisi{
+	pixel_x = 6;
+	pixel_y = 5
+	},
 /turf/closed/wall{
 	icon = 'icons/turf/walls/reinforced_wall.dmi';
 	icon_state = "r_wall"
 	},
 /area/crew_quarters/bar)
+"pd" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	req_one_access_txt = "12;25"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "pr" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -944,6 +924,23 @@
 /obj/effect/spawner/xmastree,
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
+"rg" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"xv" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "zc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8;
@@ -953,6 +950,14 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
+"zx" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "AK" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/enzyme{
@@ -961,6 +966,20 @@
 /obj/item/stack/packageWrap,
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/kitchen)
+"Di" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "Fj" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets{
@@ -1000,6 +1019,16 @@
 /obj/effect/landmark/event_spawn,
 /turf/closed/wall,
 /area/crew_quarters/bar)
+"SA" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "SW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -1026,16 +1055,29 @@
 	},
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/kitchen)
+"ZJ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 4;
+	icon_state = "soda_dispenser"
+	},
+/obj/machinery/door/window/westright,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 
 (1,1,1) = {"
 aa
 ac
 ac
-ab
+xv
 ac
-ab
+xv
 Sl
-ab
+xv
 ac
 ac
 ac
@@ -1137,7 +1179,7 @@ ck
 bw
 bv
 ap
-ab
+xv
 "}
 (8,1,1) = {"
 ac
@@ -1172,7 +1214,7 @@ ap
 bO
 "}
 (10,1,1) = {"
-af
+pd
 as
 ap
 ap
@@ -1208,16 +1250,16 @@ ag
 ag
 ag
 ag
-ij
-aH
-aS
-cl
-bY
-cl
-cl
+jK
+Di
+ZJ
+zx
+rg
+zx
+zx
 ap
 ap
-ab
+xv
 "}
 (13,1,1) = {"
 ah
@@ -1225,12 +1267,12 @@ ax
 aK
 aW
 be
-bo
+ig
 cm
 cm
 bZ
 cm
-bR
+SA
 Gp
 bJ
 ac
@@ -1262,7 +1304,7 @@ bq
 cm
 bh
 cm
-by
+he
 ap
 db
 ac

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_casino.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_casino.dmm
@@ -867,49 +867,6 @@
 	},
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/kitchen)
-"he" = (
-/obj/machinery/smartfridge/drinks,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"ig" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "Bar Shutters Control";
-	pixel_x = -26;
-	pixel_y = 24;
-	req_access_txt = "28"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"jK" = (
-/obj/structure/sign/plaques/deempisi{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/turf/closed/wall{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall"
-	},
-/area/crew_quarters/bar)
-"pd" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_one_access_txt = "12;25"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "pr" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -924,7 +881,28 @@
 /obj/effect/spawner/xmastree,
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
-"rg" = (
+"qD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_x = -26;
+	pixel_y = 24;
+	req_access_txt = "28"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"rC" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"wF" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/head/that,
 /obj/machinery/door/poddoor/preopen{
@@ -932,14 +910,6 @@
 	name = "privacy shutters"
 	},
 /turf/open/floor/wood,
-/area/crew_quarters/bar)
-"xv" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
 /area/crew_quarters/bar)
 "zc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -950,14 +920,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
-"zx" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "AK" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/enzyme{
@@ -966,14 +928,21 @@
 /obj/item/stack/packageWrap,
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/kitchen)
-"Di" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+"BX" = (
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 4;
+	icon_state = "soda_dispenser"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/door/window/westright,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
 	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"Dp" = (
+/obj/machinery/smartfridge/drinks,
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
@@ -1002,11 +971,53 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
+"Nq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
+"Pi" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "Qz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/rockvault,
+/area/crew_quarters/bar)
+"Rp" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"RH" = (
+/obj/structure/sign/plaques/deempisi{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/turf/closed/wall{
+	icon = 'icons/turf/walls/reinforced_wall.dmi';
+	icon_state = "r_wall"
+	},
 /area/crew_quarters/bar)
 "Sb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -1018,16 +1029,6 @@
 "Sl" = (
 /obj/effect/landmark/event_spawn,
 /turf/closed/wall,
-/area/crew_quarters/bar)
-"SA" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "SW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -1055,29 +1056,28 @@
 	},
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/kitchen)
-"ZJ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 4;
-	icon_state = "soda_dispenser"
+"ZU" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/machinery/door/window/westright,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	req_access_txt = "12"
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 
 (1,1,1) = {"
 aa
 ac
 ac
-xv
+Nq
 ac
-xv
+Nq
 Sl
-xv
+Nq
 ac
 ac
 ac
@@ -1179,7 +1179,7 @@ ck
 bw
 bv
 ap
-xv
+Nq
 "}
 (8,1,1) = {"
 ac
@@ -1214,7 +1214,7 @@ ap
 bO
 "}
 (10,1,1) = {"
-pd
+ZU
 as
 ap
 ap
@@ -1250,16 +1250,16 @@ ag
 ag
 ag
 ag
-jK
-Di
-ZJ
-zx
-rg
-zx
-zx
+RH
+Pi
+BX
+rC
+wF
+rC
+rC
 ap
 ap
-xv
+Nq
 "}
 (13,1,1) = {"
 ah
@@ -1267,12 +1267,12 @@ ax
 aK
 aW
 be
-ig
+qD
 cm
 cm
 bZ
 cm
-SA
+Rp
 Gp
 bJ
 ac
@@ -1304,7 +1304,7 @@ bq
 cm
 bh
 cm
-he
+Dp
 ap
 db
 ac

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_cheese.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_cheese.dmm
@@ -15,14 +15,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
-"ad" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_access_txt = "12"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "ae" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -318,15 +310,6 @@
 /obj/item/reagent_containers/food/snacks/cracker,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"aV" = (
-/obj/machinery/button/door{
-	id = "barShutters";
-	name = "bar shutters";
-	pixel_x = 4;
-	pixel_y = 28
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "aX" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
@@ -404,10 +387,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"bk" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "bl" = (
 /obj/machinery/door/airlock{
 	name = "Bar Storage";
@@ -426,11 +405,6 @@
 "bn" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"bo" = (
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "bq" = (
@@ -563,13 +537,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"bK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "bO" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/cook,
@@ -616,14 +583,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"bT" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "barShutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "bU" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/store/cheesewheel/blue,
@@ -639,30 +598,11 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"bW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"bX" = (
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "bY" = (
 /obj/machinery/door/window/southright{
 	name = "Bar Door";
 	req_one_access_txt = "25;28"
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"bZ" = (
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/reagent_containers/glass/rag,
-/obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "ca" = (
@@ -924,9 +864,38 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"fc" = (
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/glass/rag,
+/obj/structure/table/wood,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"gu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "hk" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/wood,
+/area/crew_quarters/bar)
+"jE" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
 /area/crew_quarters/bar)
 "jQ" = (
 /obj/structure/table,
@@ -943,6 +912,14 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 26
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"nN" = (
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -979,12 +956,36 @@
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"sb" = (
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = 4;
+	pixel_y = 28
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "tG" = (
 /obj/machinery/food_cart,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "ul" = (
 /obj/machinery/vending/boozeomat,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"uv" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/food/drinks/bottle/lizardwine,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "we" = (
@@ -1020,19 +1021,50 @@
 /obj/machinery/icecream_vat,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"Ra" = (
+"FA" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	req_one_access_txt = "12;25"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"JE" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/wine{
-	pixel_x = -4
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
 	},
-/obj/item/reagent_containers/food/drinks/bottle/wine{
-	pixel_x = 4
-	},
-/obj/item/reagent_containers/food/drinks/bottle/lizardwine,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"RF" = (
-/obj/machinery/smartfridge/drinks,
+"KO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"Mp" = (
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/structure/table/wood,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"Nu" = (
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/structure/table/wood,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "Ux" = (
@@ -1071,13 +1103,13 @@ aa
 aa
 ag
 ag
-bT
-bT
+jE
+jE
 ag
 ag
 ag
-bT
-bT
+jE
+jE
 ag
 ag
 ag
@@ -1128,7 +1160,7 @@ bh
 bh
 cp
 aB
-bT
+jE
 "}
 (5,1,1) = {"
 ab
@@ -1144,7 +1176,7 @@ bh
 bh
 cp
 aB
-bT
+jE
 "}
 (6,1,1) = {"
 ag
@@ -1211,7 +1243,7 @@ aB
 dh
 "}
 (10,1,1) = {"
-ad
+FA
 ar
 aB
 aX
@@ -1231,11 +1263,11 @@ ag
 as
 aJ
 aY
-bk
-bo
-bK
-bW
-bk
+JE
+Mp
+gu
+KO
+JE
 aY
 aB
 aB
@@ -1247,11 +1279,11 @@ ag
 ag
 ag
 aC
-bk
+JE
 aB
 au
 aE
-Ra
+uv
 aY
 aB
 aX
@@ -1267,7 +1299,7 @@ ag
 ul
 cD
 cK
-bX
+Nu
 aY
 aB
 aB
@@ -1280,10 +1312,10 @@ at
 Ew
 ba
 ag
-aV
+sb
 au
 aB
-bZ
+fc
 aY
 aB
 aB
@@ -1315,7 +1347,7 @@ ag
 ag
 dI
 kC
-RF
+nN
 cd
 aB
 cr

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_cheese.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_cheese.dmm
@@ -1015,20 +1015,20 @@
 /obj/machinery/icecream_vat,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"Hm" = (
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_y = 24;
+	req_access_txt = "25"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "IK" = (
 /obj/structure/table/wood,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
 	name = "bar shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"JD" = (
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters";
-	pixel_x = 4;
-	pixel_y = 28
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -1312,7 +1312,7 @@ at
 Ew
 ba
 ag
-JD
+Hm
 au
 aB
 jf

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_cheese.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_cheese.dmm
@@ -864,38 +864,18 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"fc" = (
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/reagent_containers/glass/rag,
-/obj/structure/table/wood,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"gu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/table/wood,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "hk" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"jE" = (
-/obj/effect/spawner/structure/window,
+"il" = (
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/structure/table/wood,
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "jQ" = (
 /obj/structure/table,
@@ -915,8 +895,10 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"nN" = (
-/obj/machinery/smartfridge/drinks,
+"mK" = (
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/glass/rag,
+/obj/structure/table/wood,
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
@@ -930,6 +912,29 @@
 /obj/item/flashlight/lamp,
 /obj/item/flashlight/lamp/green,
 /obj/structure/closet/secure_closet/bartender,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"oN" = (
+/obj/structure/table/wood,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"qt" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/food/drinks/bottle/lizardwine,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "rk" = (
@@ -956,12 +961,14 @@
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"sb" = (
-/obj/machinery/button/door{
+"sn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
-	name = "bar shutters";
-	pixel_x = 4;
-	pixel_y = 28
+	name = "privacy shutters"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -971,21 +978,6 @@
 /area/crew_quarters/kitchen)
 "ul" = (
 /obj/machinery/vending/boozeomat,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"uv" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/wine{
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/food/drinks/bottle/wine{
-	pixel_x = 4
-	},
-/obj/item/reagent_containers/food/drinks/bottle/lizardwine,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "we" = (
@@ -1021,46 +1013,54 @@
 /obj/machinery/icecream_vat,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"FA" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_one_access_txt = "12;25"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"JE" = (
-/obj/structure/table/wood,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"KO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/table/wood,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"Mp" = (
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/structure/table/wood,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"Nu" = (
+"IO" = (
 /obj/item/book/manual/wiki/barman_recipes,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /obj/structure/table/wood,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"JD" = (
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = 4;
+	pixel_y = 28
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"KK" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"PP" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
+"QK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"SE" = (
+/obj/machinery/smartfridge/drinks,
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
@@ -1103,13 +1103,13 @@ aa
 aa
 ag
 ag
-jE
-jE
+PP
+PP
 ag
 ag
 ag
-jE
-jE
+PP
+PP
 ag
 ag
 ag
@@ -1160,7 +1160,7 @@ bh
 bh
 cp
 aB
-jE
+PP
 "}
 (5,1,1) = {"
 ab
@@ -1176,7 +1176,7 @@ bh
 bh
 cp
 aB
-jE
+PP
 "}
 (6,1,1) = {"
 ag
@@ -1243,7 +1243,7 @@ aB
 dh
 "}
 (10,1,1) = {"
-FA
+KK
 ar
 aB
 aX
@@ -1263,11 +1263,11 @@ ag
 as
 aJ
 aY
-JE
-Mp
-gu
-KO
-JE
+oN
+il
+QK
+sn
+oN
 aY
 aB
 aB
@@ -1279,11 +1279,11 @@ ag
 ag
 ag
 aC
-JE
+oN
 aB
 au
 aE
-uv
+qt
 aY
 aB
 aX
@@ -1299,7 +1299,7 @@ ag
 ul
 cD
 cK
-Nu
+IO
 aY
 aB
 aB
@@ -1312,10 +1312,10 @@ at
 Ew
 ba
 ag
-sb
+JD
 au
 aB
-fc
+mK
 aY
 aB
 aB
@@ -1347,7 +1347,7 @@ ag
 ag
 dI
 kC
-nN
+SE
 cd
 aB
 cr

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_cheese.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_cheese.dmm
@@ -868,12 +868,24 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"il" = (
-/obj/item/reagent_containers/food/drinks/drinkingglass,
+"iI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
 /obj/structure/table/wood,
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
-	name = "privacy shutters"
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"jf" = (
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/glass/rag,
+/obj/structure/table/wood,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -895,13 +907,12 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"mK" = (
+"nY" = (
 /obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/reagent_containers/glass/rag,
 /obj/structure/table/wood,
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
-	name = "privacy shutters"
+	name = "bar shutters"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -914,26 +925,13 @@
 /obj/structure/closet/secure_closet/bartender,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"oN" = (
+"qS" = (
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
 /obj/structure/table/wood,
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"qt" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/wine{
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/food/drinks/bottle/wine{
-	pixel_x = 4
-	},
-/obj/item/reagent_containers/food/drinks/bottle/lizardwine,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
+	name = "bar shutters"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -961,17 +959,6 @@
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"sn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/table/wood,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "tG" = (
 /obj/machinery/food_cart,
 /turf/open/floor/plasteel/cafeteria,
@@ -987,6 +974,21 @@
 "BJ" = (
 /obj/machinery/light/small{
 	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"BM" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/food/drinks/bottle/lizardwine,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -1013,13 +1015,11 @@
 /obj/machinery/icecream_vat,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"IO" = (
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
+"IK" = (
 /obj/structure/table/wood,
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
-	name = "privacy shutters"
+	name = "bar shutters"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -1040,6 +1040,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"PB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "PP" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/preopen{
@@ -1047,17 +1058,6 @@
 	name = "privacy shutters"
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/bar)
-"QK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/table/wood,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "SE" = (
 /obj/machinery/smartfridge/drinks,
@@ -1263,11 +1263,11 @@ ag
 as
 aJ
 aY
-oN
-il
-QK
-sn
-oN
+IK
+nY
+iI
+PB
+IK
 aY
 aB
 aB
@@ -1279,11 +1279,11 @@ ag
 ag
 ag
 aC
-oN
+IK
 aB
 au
 aE
-qt
+BM
 aY
 aB
 aX
@@ -1299,7 +1299,7 @@ ag
 ul
 cD
 cK
-IO
+qS
 aY
 aB
 aB
@@ -1315,7 +1315,7 @@ ag
 JD
 au
 aB
-mK
+jf
 aY
 aB
 aB

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_citadel.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_citadel.dmm
@@ -298,22 +298,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"dz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters";
-	pixel_x = -26;
-	pixel_y = 27
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "dP" = (
 /obj/structure/chair/sofa/left,
 /obj/structure/window{
@@ -358,26 +342,6 @@
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"gv" = (
-/obj/machinery/disposal/bin,
-/obj/structure/sign/plaques/deempisi{
-	pixel_x = -28;
-	pixel_y = -4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	name = "Bar Lights";
-	pixel_x = -6;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "gN" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/bar,
@@ -704,6 +668,16 @@
 	dir = 5
 	},
 /turf/open/floor/wood,
+/area/crew_quarters/bar)
+"tP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "uE" = (
 /obj/machinery/chem_master/condimaster{
@@ -1242,6 +1216,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"PT" = (
+/obj/machinery/disposal/bin,
+/obj/structure/sign/plaques/deempisi{
+	pixel_x = -28;
+	pixel_y = -4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	name = "Bar Lights";
+	pixel_x = -6;
+	pixel_y = 28
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_x = 6;
+	pixel_y = 24;
+	req_access_txt = "25"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "Qa" = (
 /obj/structure/chair/sofa/right{
 	dir = 1
@@ -1675,7 +1676,7 @@ RL
 Ic
 Al
 OC
-gv
+PT
 kk
 Pe
 cK
@@ -1691,7 +1692,7 @@ Ko
 wQ
 cj
 rP
-dz
+tP
 Pe
 Hm
 Pe

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_citadel.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_citadel.dmm
@@ -261,6 +261,14 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"bx" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "bM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -284,27 +292,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"dg" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "dl" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = 32
 	},
 /turf/open/floor/wood,
+/area/crew_quarters/bar)
+"dz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = -26;
+	pixel_y = 27
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "dP" = (
 /obj/structure/chair/sofa/left,
@@ -335,22 +343,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"fe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters";
-	pixel_x = -26;
-	pixel_y = 27
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "ft" = (
 /obj/effect/landmark/event_spawn,
 /turf/closed/wall,
@@ -366,7 +358,7 @@
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"go" = (
+"gv" = (
 /obj/machinery/disposal/bin,
 /obj/structure/sign/plaques/deempisi{
 	pixel_x = -28;
@@ -383,25 +375,6 @@
 	name = "Bar Lights";
 	pixel_x = -6;
 	pixel_y = 28
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"gK" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/item/reagent_containers/food/drinks/soda_cans/starkist{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -503,6 +476,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"kz" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/item/reagent_containers/food/drinks/soda_cans/starkist{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "kK" = (
 /obj/machinery/camera{
 	c_tag = "Bar Storage"
@@ -512,6 +504,18 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"lk" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "nv" = (
 /obj/structure/chair/sofa{
 	dir = 1
@@ -628,6 +632,22 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"ri" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "ro" = (
 /obj/structure/sign/barsign,
 /turf/closed/wall,
@@ -724,18 +744,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"wE" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_one_access_txt = "12;25"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "wQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/xeno_spawn,
@@ -808,19 +816,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"AR" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/smartfridge/drinks,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "Be" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -875,21 +870,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"Cv" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "CB" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -911,23 +891,15 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"DZ" = (
+"DD" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/item/paper_bin/bundlenatural{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/pen/fountain{
-	pixel_x = 6
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/item/pen/fourcolor,
+/obj/effect/turf_decal/stripes/line,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
@@ -944,6 +916,21 @@
 /obj/machinery/gibber,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"Fg" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "Fi" = (
 /obj/structure/table,
 /obj/item/storage/pill_bottle/dice{
@@ -1012,6 +999,29 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"GV" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/item/paper_bin/bundlenatural{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/pen/fountain{
+	pixel_x = 6
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/pen/fourcolor,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "He" = (
 /obj/machinery/light,
 /turf/open/floor/wood,
@@ -1087,21 +1097,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"IZ" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "Jq" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/enzyme{
@@ -1372,14 +1367,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"VT" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "WX" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -1472,6 +1459,19 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"ZK" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "ZR" = (
 /obj/machinery/vending/cola/black,
 /turf/open/floor/wood,
@@ -1483,13 +1483,13 @@ uY
 OC
 OC
 OC
-VT
+bx
 ft
 OC
-VT
+bx
 OC
 OC
-VT
+bx
 OC
 OC
 "}
@@ -1523,7 +1523,7 @@ Zr
 To
 HN
 nv
-VT
+bx
 "}
 (4,1,1) = {"
 OC
@@ -1587,7 +1587,7 @@ vh
 ap
 Kj
 wZ
-VT
+bx
 "}
 (8,1,1) = {"
 OC
@@ -1622,7 +1622,7 @@ He
 ro
 "}
 (10,1,1) = {"
-wE
+lk
 xY
 wZ
 wZ
@@ -1660,11 +1660,11 @@ OC
 OC
 OC
 OC
-DZ
-IZ
-dg
-IZ
-gK
+GV
+Fg
+ri
+Fg
+kz
 sC
 sr
 OC
@@ -1675,12 +1675,12 @@ RL
 Ic
 Al
 OC
-go
+gv
 kk
 Pe
 cK
 Pe
-Cv
+DD
 TU
 xa
 OC
@@ -1691,7 +1691,7 @@ Ko
 wQ
 cj
 rP
-fe
+dz
 Pe
 Hm
 Pe
@@ -1712,7 +1712,7 @@ ac
 Pe
 IO
 Pe
-AR
+ZK
 wZ
 dl
 OC

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_citadel.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_citadel.dmm
@@ -284,6 +284,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"dg" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "dl" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = 32
@@ -319,15 +335,20 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"fm" = (
-/obj/structure/table/reinforced,
+"fe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = -26;
+	pixel_y = 27
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "ft" = (
@@ -345,6 +366,45 @@
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"go" = (
+/obj/machinery/disposal/bin,
+/obj/structure/sign/plaques/deempisi{
+	pixel_x = -28;
+	pixel_y = -4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	name = "Bar Lights";
+	pixel_x = -6;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"gK" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/item/reagent_containers/food/drinks/soda_cans/starkist{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "hD" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/bluecherrycupcake{
@@ -476,14 +536,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"oj" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "barShutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "oz" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/cafeteria,
@@ -580,17 +632,6 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"ry" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "rP" = (
 /obj/machinery/door/airlock{
 	name = "Bar Storage";
@@ -683,6 +724,18 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"wE" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	req_one_access_txt = "12;25"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "wQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/xeno_spawn,
@@ -704,18 +757,6 @@
 /obj/effect/spawner/xmastree,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"xv" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_access_txt = "12"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "xP" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -767,6 +808,19 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"AR" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "Be" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -821,6 +875,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"Cv" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "CB" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -842,13 +911,7 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"Ei" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"EE" = (
+"DZ" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -865,7 +928,17 @@
 	dir = 8
 	},
 /obj/item/pen/fourcolor,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
 /turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"Ei" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "EJ" = (
 /obj/machinery/gibber,
@@ -1014,6 +1087,21 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"IZ" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "Jq" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/enzyme{
@@ -1032,32 +1120,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"JP" = (
-/obj/machinery/disposal/bin,
-/obj/structure/sign/plaques/deempisi{
-	pixel_x = -28;
-	pixel_y = -4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "barShutters";
-	name = "bar shutters";
-	pixel_x = 4;
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	name = "Bar Lights";
-	pixel_x = -6;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "Kj" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -1151,18 +1213,6 @@
 /obj/machinery/icecream_vat,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"MM" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "MY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -1256,21 +1306,6 @@
 "SZ" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"Ta" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/item/reagent_containers/food/drinks/soda_cans/starkist{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "Tn" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -1337,6 +1372,14 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"VT" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "WX" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -1350,15 +1393,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"WZ" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/smartfridge/drinks,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "Xf" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood,
@@ -1368,16 +1402,6 @@
 /obj/item/book/manual/chef_recipes,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"Xm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "XH" = (
 /obj/machinery/door/airlock{
 	name = "Kitchen cold room";
@@ -1459,13 +1483,13 @@ uY
 OC
 OC
 OC
-oj
+VT
 ft
 OC
-oj
+VT
 OC
 OC
-oj
+VT
 OC
 OC
 "}
@@ -1499,7 +1523,7 @@ Zr
 To
 HN
 nv
-oj
+VT
 "}
 (4,1,1) = {"
 OC
@@ -1563,7 +1587,7 @@ vh
 ap
 Kj
 wZ
-oj
+VT
 "}
 (8,1,1) = {"
 OC
@@ -1598,7 +1622,7 @@ He
 ro
 "}
 (10,1,1) = {"
-xv
+wE
 xY
 wZ
 wZ
@@ -1636,11 +1660,11 @@ OC
 OC
 OC
 OC
-EE
-ry
-MM
-ry
-Ta
+DZ
+IZ
+dg
+IZ
+gK
 sC
 sr
 OC
@@ -1651,12 +1675,12 @@ RL
 Ic
 Al
 OC
-JP
+go
 kk
 Pe
 cK
 Pe
-fm
+Cv
 TU
 xa
 OC
@@ -1667,7 +1691,7 @@ Ko
 wQ
 cj
 rP
-Xm
+fe
 Pe
 Hm
 Pe
@@ -1688,7 +1712,7 @@ ac
 Pe
 IO
 Pe
-WZ
+AR
 wZ
 dl
 OC

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_citadel.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_citadel.dmm
@@ -378,6 +378,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"gN" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/item/reagent_containers/food/drinks/soda_cans/starkist{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "hD" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/bluecherrycupcake{
@@ -473,25 +492,6 @@
 	pixel_x = -30;
 	pixel_y = 45;
 	receive_ore_updates = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"kz" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/item/reagent_containers/food/drinks/soda_cans/starkist{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -626,15 +626,8 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"rd" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
-"ri" = (
+"qY" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/head/that,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -642,12 +635,18 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
-	name = "privacy shutters"
+	name = "bar shutters"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"rd" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen)
 "ro" = (
 /obj/structure/sign/barsign,
 /turf/closed/wall,
@@ -778,6 +777,29 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"yH" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/item/paper_bin/bundlenatural{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/pen/fountain{
+	pixel_x = 6
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/pen/fourcolor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "zJ" = (
 /obj/machinery/computer/arcade/minesweeper,
 /turf/open/floor/wood,
@@ -891,21 +913,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"DD" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "Ei" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -916,21 +923,6 @@
 /obj/machinery/gibber,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"Fg" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "Fi" = (
 /obj/structure/table,
 /obj/item/storage/pill_bottle/dice{
@@ -999,29 +991,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"GV" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/item/paper_bin/bundlenatural{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/pen/fountain{
-	pixel_x = 6
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/item/pen/fourcolor,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "He" = (
 /obj/machinery/light,
 /turf/open/floor/wood,
@@ -1064,6 +1033,22 @@
 	pixel_y = 9
 	},
 /turf/open/floor/wood,
+/area/crew_quarters/bar)
+"HS" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "Ic" = (
 /obj/machinery/reagentgrinder,
@@ -1208,6 +1193,21 @@
 /obj/machinery/icecream_vat,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"MT" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "MY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -1660,11 +1660,11 @@ OC
 OC
 OC
 OC
-GV
-Fg
-ri
-Fg
-kz
+yH
+qY
+HS
+qY
+gN
 sC
 sr
 OC
@@ -1680,7 +1680,7 @@ kk
 Pe
 cK
 Pe
-DD
+MT
 TU
 xa
 OC

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_clock.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_clock.dmm
@@ -21,18 +21,6 @@
 /obj/structure/table/bronze,
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/theatre)
-"ad" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_access_txt = "12"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "ai" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Kitchen Maintenance";
@@ -90,11 +78,6 @@
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"au" = (
-/obj/item/lighter,
-/obj/structure/table/bronze,
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
 "aw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -324,6 +307,14 @@
 	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
+"jl" = (
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
 "js" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -396,13 +387,17 @@
 "nF" = (
 /turf/closed/wall,
 /area/crew_quarters/theatre)
-"nZ" = (
-/obj/item/clockwork/alloy_shards/clockgolem_remains,
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
-"oo" = (
+"nL" = (
 /obj/item/clothing/head/that,
 /obj/structure/table/bronze,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
+"nZ" = (
+/obj/item/clockwork/alloy_shards/clockgolem_remains,
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
 "pv" = (
@@ -442,6 +437,15 @@
 	dir = 4
 	},
 /turf/open/floor/bronze/reebe,
+/area/crew_quarters/theatre)
+"rd" = (
+/obj/structure/grille/ratvar,
+/obj/structure/window/reinforced/fulltile/bronze,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
 /area/crew_quarters/theatre)
 "rj" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
@@ -522,15 +526,6 @@
 /obj/structure/chair/bronze,
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
-"vs" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "barShutters";
-	name = "privacy shutters"
-	},
-/obj/structure/grille/ratvar,
-/obj/structure/window/reinforced/fulltile/bronze,
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "vK" = (
 /obj/structure/table/bronze,
 /obj/item/reagent_containers/glass/mixbowl{
@@ -543,6 +538,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/bronze,
 /area/crew_quarters/theatre)
+"wq" = (
+/obj/item/lighter,
+/obj/structure/table/bronze,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
 "wz" = (
 /mob/living/carbon/monkey/punpun,
 /turf/open/floor/bronze/reebe,
@@ -554,6 +558,18 @@
 	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/kitchen)
+"xa" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	req_one_access_txt = "12;25"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "xr" = (
 /obj/machinery/light{
 	dir = 8
@@ -766,10 +782,6 @@
 	},
 /turf/open/floor/bronze,
 /area/crew_quarters/kitchen)
-"Gs" = (
-/obj/machinery/smartfridge/drinks,
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
 "Gv" = (
 /obj/machinery/chem_dispenser/drinks/beer{
 	dir = 8
@@ -793,12 +805,6 @@
 /area/crew_quarters/bar)
 "GL" = (
 /obj/item/clockwork/alloy_shards/small,
-/turf/open/floor/bronze,
-/area/crew_quarters/bar)
-"GN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /turf/open/floor/bronze,
 /area/crew_quarters/bar)
 "Hp" = (
@@ -827,29 +833,6 @@
 /obj/structure/table/bronze,
 /turf/open/floor/bronze,
 /area/crew_quarters/kitchen)
-"Iq" = (
-/obj/machinery/disposal/bin,
-/obj/structure/sign/warning/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
-	pixel_x = -28;
-	pixel_y = -4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "barShutters";
-	name = "bar shutters";
-	pixel_x = 4;
-	pixel_y = 28
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/bronze,
-/area/crew_quarters/bar)
 "IF" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -873,15 +856,6 @@
 	},
 /turf/open/floor/bronze,
 /area/crew_quarters/bar)
-"JB" = (
-/obj/structure/grille/ratvar,
-/obj/machinery/door/poddoor/preopen{
-	id = "barShutters";
-	name = "privacy shutters"
-	},
-/obj/structure/window/reinforced/fulltile/bronze,
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "JU" = (
 /obj/structure/chair/brass{
 	dir = 8
@@ -893,6 +867,18 @@
 	pixel_y = 28
 	},
 /turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
+"Ki" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = -24;
+	pixel_y = 26
+	},
+/turf/open/floor/bronze,
 /area/crew_quarters/bar)
 "Lp" = (
 /obj/item/reagent_containers/food/drinks/shaker,
@@ -937,6 +923,14 @@
 	},
 /turf/open/floor/bronze,
 /area/crew_quarters/bar)
+"MZ" = (
+/obj/structure/table/bronze,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
 "Nc" = (
 /obj/item/clockwork/component/geis_capacitor/fallen_armor,
 /turf/open/floor/bronze,
@@ -956,6 +950,15 @@
 	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/theatre)
+"Pe" = (
+/obj/structure/grille/ratvar,
+/obj/structure/window/reinforced/fulltile/bronze,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "PF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -1029,12 +1032,6 @@
 /obj/structure/table/bronze,
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
-"Sf" = (
-/obj/structure/table/bronze,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
 "SD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -1077,15 +1074,6 @@
 /obj/structure/table/bronze,
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/kitchen)
-"Uf" = (
-/obj/structure/grille/ratvar,
-/obj/machinery/door/poddoor/preopen{
-	id = "barShutters";
-	name = "privacy shutters"
-	},
-/obj/structure/window/reinforced/fulltile/bronze,
-/turf/open/floor/plating,
-/area/crew_quarters/theatre)
 "Uv" = (
 /obj/effect/landmark/start/cook,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -1130,6 +1118,23 @@
 	},
 /turf/open/floor/bronze,
 /area/crew_quarters/bar)
+"VF" = (
+/obj/machinery/disposal/bin,
+/obj/structure/sign/warning/securearea{
+	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
+	icon_state = "monkey_painting";
+	name = "Mr. Deempisi portrait";
+	pixel_x = -28;
+	pixel_y = -4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/bronze,
+/area/crew_quarters/bar)
 "Wq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -1145,6 +1150,16 @@
 /area/crew_quarters/bar)
 "Wx" = (
 /turf/open/floor/bronze,
+/area/crew_quarters/bar)
+"WM" = (
+/obj/structure/table/bronze,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
 "WQ" = (
 /obj/machinery/light{
@@ -1191,15 +1206,15 @@
 aa
 aa
 BE
-Uf
+rd
 BE
-JB
+Pe
 nb
-vs
+Pe
 Ws
-vs
+Pe
 Ws
-vs
+Pe
 Ws
 Ws
 "}
@@ -1297,7 +1312,7 @@ aw
 EX
 AD
 Wx
-vs
+Pe
 "}
 (8,1,1) = {"
 nF
@@ -1332,7 +1347,7 @@ rR
 Fv
 "}
 (10,1,1) = {"
-ad
+xa
 PF
 Wx
 ax
@@ -1370,11 +1385,11 @@ Ws
 Ws
 Ws
 Ws
-au
-oo
-BA
-BA
-BA
+wq
+nL
+MZ
+MZ
+MZ
 GK
 Re
 Ws
@@ -1385,12 +1400,12 @@ QK
 Xj
 jf
 Ws
-Iq
+VF
 AD
 AD
 zN
 AD
-Sf
+WM
 yQ
 Rh
 Ws
@@ -1401,7 +1416,7 @@ Hw
 IU
 AS
 gC
-GN
+Ki
 AD
 wz
 AD
@@ -1422,7 +1437,7 @@ BM
 AD
 BH
 AD
-Gs
+jl
 AD
 MA
 Ws

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_clock.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_clock.dmm
@@ -192,6 +192,16 @@
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/kitchen)
+"bP" = (
+/obj/structure/table/bronze,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
 "di" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/bronze,
@@ -235,6 +245,15 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/window/reinforced/bronze,
 /turf/open/floor/bronze/reebe,
+/area/crew_quarters/theatre)
+"fJ" = (
+/obj/structure/grille/ratvar,
+/obj/structure/window/reinforced/fulltile/bronze,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
 /area/crew_quarters/theatre)
 "fT" = (
 /obj/structure/disposalpipe/segment{
@@ -307,14 +326,6 @@
 	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
-"jl" = (
-/obj/machinery/smartfridge/drinks,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
 "js" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -360,6 +371,14 @@
 	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
+"mE" = (
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
 "nb" = (
 /obj/effect/landmark/event_spawn,
 /turf/closed/wall/mineral/bronze,
@@ -387,15 +406,6 @@
 "nF" = (
 /turf/closed/wall,
 /area/crew_quarters/theatre)
-"nL" = (
-/obj/item/clothing/head/that,
-/obj/structure/table/bronze,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
 "nZ" = (
 /obj/item/clockwork/alloy_shards/clockgolem_remains,
 /turf/open/floor/bronze/reebe,
@@ -438,17 +448,16 @@
 	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/theatre)
-"rd" = (
-/obj/structure/grille/ratvar,
-/obj/structure/window/reinforced/fulltile/bronze,
+"rj" = (
+/obj/machinery/vending/wardrobe/bar_wardrobe,
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
+"rs" = (
+/obj/structure/table/bronze,
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
 	},
-/turf/open/floor/plating,
-/area/crew_quarters/theatre)
-"rj" = (
-/obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
 "rB" = (
@@ -482,6 +491,15 @@
 /obj/structure/table/bronze,
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/kitchen)
+"sm" = (
+/obj/item/clothing/head/that,
+/obj/structure/table/bronze,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
 "tF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -538,15 +556,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/bronze,
 /area/crew_quarters/theatre)
-"wq" = (
-/obj/item/lighter,
-/obj/structure/table/bronze,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
 "wz" = (
 /mob/living/carbon/monkey/punpun,
 /turf/open/floor/bronze/reebe,
@@ -558,18 +567,15 @@
 	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/kitchen)
-"xa" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+"wW" = (
+/obj/item/lighter,
+/obj/structure/table/bronze,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
 	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_one_access_txt = "12;25"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
 "xr" = (
 /obj/machinery/light{
 	dir = 8
@@ -750,6 +756,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/bronze,
 /area/crew_quarters/kitchen)
+"DT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = -24;
+	pixel_y = 26
+	},
+/turf/open/floor/bronze,
+/area/crew_quarters/bar)
 "Ej" = (
 /turf/closed/wall,
 /area/crew_quarters/bar)
@@ -845,6 +863,23 @@
 	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/theatre)
+"IS" = (
+/obj/machinery/disposal/bin,
+/obj/structure/sign/warning/securearea{
+	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
+	icon_state = "monkey_painting";
+	name = "Mr. Deempisi portrait";
+	pixel_x = -28;
+	pixel_y = -4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/bronze,
+/area/crew_quarters/bar)
 "IU" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/xeno_spawn,
@@ -868,18 +903,18 @@
 	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
-"Ki" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+"KX" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters";
-	pixel_x = -24;
-	pixel_y = 26
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	req_access_txt = "12"
 	},
-/turf/open/floor/bronze,
-/area/crew_quarters/bar)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "Lp" = (
 /obj/item/reagent_containers/food/drinks/shaker,
 /obj/item/stack/spacecash/c10,
@@ -923,14 +958,6 @@
 	},
 /turf/open/floor/bronze,
 /area/crew_quarters/bar)
-"MZ" = (
-/obj/structure/table/bronze,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
 "Nc" = (
 /obj/item/clockwork/component/geis_capacitor/fallen_armor,
 /turf/open/floor/bronze,
@@ -950,15 +977,6 @@
 	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/theatre)
-"Pe" = (
-/obj/structure/grille/ratvar,
-/obj/structure/window/reinforced/fulltile/bronze,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "PF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -1074,6 +1092,15 @@
 /obj/structure/table/bronze,
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/kitchen)
+"TL" = (
+/obj/structure/grille/ratvar,
+/obj/structure/window/reinforced/fulltile/bronze,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "Uv" = (
 /obj/effect/landmark/start/cook,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -1118,23 +1145,6 @@
 	},
 /turf/open/floor/bronze,
 /area/crew_quarters/bar)
-"VF" = (
-/obj/machinery/disposal/bin,
-/obj/structure/sign/warning/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
-	pixel_x = -28;
-	pixel_y = -4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/bronze,
-/area/crew_quarters/bar)
 "Wq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -1150,16 +1160,6 @@
 /area/crew_quarters/bar)
 "Wx" = (
 /turf/open/floor/bronze,
-/area/crew_quarters/bar)
-"WM" = (
-/obj/structure/table/bronze,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
 "WQ" = (
 /obj/machinery/light{
@@ -1206,15 +1206,15 @@
 aa
 aa
 BE
-rd
+fJ
 BE
-Pe
+TL
 nb
-Pe
+TL
 Ws
-Pe
+TL
 Ws
-Pe
+TL
 Ws
 Ws
 "}
@@ -1312,7 +1312,7 @@ aw
 EX
 AD
 Wx
-Pe
+TL
 "}
 (8,1,1) = {"
 nF
@@ -1347,7 +1347,7 @@ rR
 Fv
 "}
 (10,1,1) = {"
-xa
+KX
 PF
 Wx
 ax
@@ -1385,11 +1385,11 @@ Ws
 Ws
 Ws
 Ws
-wq
-nL
-MZ
-MZ
-MZ
+wW
+sm
+rs
+rs
+rs
 GK
 Re
 Ws
@@ -1400,12 +1400,12 @@ QK
 Xj
 jf
 Ws
-VF
+IS
 AD
 AD
 zN
 AD
-WM
+bP
 yQ
 Rh
 Ws
@@ -1416,7 +1416,7 @@ Hw
 IU
 AS
 gC
-Ki
+DT
 AD
 wz
 AD
@@ -1437,7 +1437,7 @@ BM
 AD
 BH
 AD
-jl
+mE
 AD
 MA
 Ws

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_clock.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_clock.dmm
@@ -192,16 +192,6 @@
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/kitchen)
-"bP" = (
-/obj/structure/table/bronze,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
 "di" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/bronze,
@@ -241,6 +231,14 @@
 /obj/machinery/deepfryer,
 /turf/open/floor/bronze,
 /area/crew_quarters/kitchen)
+"fa" = (
+/obj/structure/table/bronze,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
 "fz" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/window/reinforced/bronze,
@@ -452,14 +450,6 @@
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
-"rs" = (
-/obj/structure/table/bronze,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
 "rB" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -491,15 +481,6 @@
 /obj/structure/table/bronze,
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/kitchen)
-"sm" = (
-/obj/item/clothing/head/that,
-/obj/structure/table/bronze,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
 "tF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -567,15 +548,6 @@
 	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/kitchen)
-"wW" = (
-/obj/item/lighter,
-/obj/structure/table/bronze,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
 "xr" = (
 /obj/machinery/light{
 	dir = 8
@@ -951,12 +923,31 @@
 /obj/effect/landmark/start/cook,
 /turf/open/floor/bronze,
 /area/crew_quarters/kitchen)
+"Mh" = (
+/obj/structure/table/bronze,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
 "MA" = (
 /obj/item/clockwork/alloy_shards,
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = 32
 	},
 /turf/open/floor/bronze,
+/area/crew_quarters/bar)
+"MF" = (
+/obj/item/lighter,
+/obj/structure/table/bronze,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
 "Nc" = (
 /obj/item/clockwork/component/geis_capacitor/fallen_armor,
@@ -1003,6 +994,15 @@
 "QK" = (
 /obj/machinery/reagentgrinder,
 /obj/structure/table/bronze,
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
+"QP" = (
+/obj/item/clothing/head/that,
+/obj/structure/table/bronze,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
 "Re" = (
@@ -1385,11 +1385,11 @@ Ws
 Ws
 Ws
 Ws
-wW
-sm
-rs
-rs
-rs
+MF
+QP
+fa
+fa
+fa
 GK
 Re
 Ws
@@ -1405,7 +1405,7 @@ AD
 AD
 zN
 AD
-bP
+Mh
 yQ
 Rh
 Ws

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_clock.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_clock.dmm
@@ -728,18 +728,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/bronze,
 /area/crew_quarters/kitchen)
-"DT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters";
-	pixel_x = -24;
-	pixel_y = 26
-	},
-/turf/open/floor/bronze,
-/area/crew_quarters/bar)
 "Ej" = (
 /turf/closed/wall,
 /area/crew_quarters/bar)
@@ -835,23 +823,6 @@
 	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/theatre)
-"IS" = (
-/obj/machinery/disposal/bin,
-/obj/structure/sign/warning/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
-	pixel_x = -28;
-	pixel_y = -4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/bronze,
-/area/crew_quarters/bar)
 "IU" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/xeno_spawn,
@@ -968,6 +939,12 @@
 	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/theatre)
+"Pf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/bronze,
+/area/crew_quarters/bar)
 "PF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -1191,6 +1168,29 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
+"Ya" = (
+/obj/machinery/disposal/bin,
+/obj/structure/sign/warning/securearea{
+	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
+	icon_state = "monkey_painting";
+	name = "Mr. Deempisi portrait";
+	pixel_x = -28;
+	pixel_y = -4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_y = 25;
+	req_access_txt = "25"
+	},
+/turf/open/floor/bronze,
+/area/crew_quarters/bar)
 "YH" = (
 /obj/item/clockwork/alloy_shards/small,
 /turf/open/floor/bronze/reebe,
@@ -1400,7 +1400,7 @@ QK
 Xj
 jf
 Ws
-IS
+Ya
 AD
 AD
 zN
@@ -1416,7 +1416,7 @@ Hw
 IU
 AS
 gC
-DT
+Pf
 AD
 wz
 AD

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_conveyor.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_conveyor.dmm
@@ -973,6 +973,42 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
+"dI" = (
+/obj/structure/table/reinforced,
+/obj/structure/plasticflaps,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "conveyorbar"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
+"dK" = (
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
+"eL" = (
+/obj/effect/spawner/structure/window/plasma,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "eU" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -989,25 +1025,8 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
-"hc" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
 "ht" = (
 /obj/effect/landmark/event_spawn,
-/turf/closed/wall,
-/area/crew_quarters/bar)
-"hG" = (
-/obj/item/storage/secure/safe{
-	pixel_x = -2;
-	pixel_y = 4
-	},
 /turf/closed/wall,
 /area/crew_quarters/bar)
 "jj" = (
@@ -1025,6 +1044,18 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
+"nE" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "ow" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin{
@@ -1041,19 +1072,14 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/kitchen)
-"pR" = (
+"oZ" = (
 /obj/structure/window/reinforced{
-	dir = 8
+	dir = 1
 	},
-/obj/structure/table/reinforced,
-/obj/item/storage/bag/tray,
-/obj/item/storage/bag/tray,
-/obj/item/storage/bag/tray,
-/obj/item/storage/bag/tray,
-/obj/item/storage/bag/tray,
-/obj/item/reagent_containers/food/snacks/dolphinmeat,
-/obj/item/reagent_containers/food/snacks/dolphinmeat,
-/obj/item/reagent_containers/food/snacks/dolphinmeat,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "conveyorbar"
+	},
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
@@ -1090,6 +1116,36 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/kitchen)
+"vF" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "conveyorbar"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
+"vO" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/bag/tray,
+/obj/item/storage/bag/tray,
+/obj/item/storage/bag/tray,
+/obj/item/storage/bag/tray,
+/obj/item/storage/bag/tray,
+/obj/item/reagent_containers/food/snacks/dolphinmeat,
+/obj/item/reagent_containers/food/snacks/dolphinmeat,
+/obj/item/reagent_containers/food/snacks/dolphinmeat,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
 "wt" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -1101,7 +1157,45 @@
 /obj/item/reagent_containers/food/snacks/mint,
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/kitchen)
-"wK" = (
+"wy" = (
+/obj/item/storage/secure/safe{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/turf/closed/wall,
+/area/crew_quarters/bar)
+"yS" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
+"Bq" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
+"BP" = (
+/obj/effect/spawner/xmastree,
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
+"EC" = (
+/obj/structure/chair/stool,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
+"GX" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/mask/cigarette/rollie/cannabis,
 /obj/item/clothing/mask/cigarette/rollie/cannabis,
@@ -1117,37 +1211,6 @@
 	id = "barshutters";
 	name = "privacy shutters"
 	},
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
-"yj" = (
-/obj/effect/spawner/structure/window/plasma,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
-"BP" = (
-/obj/effect/spawner/xmastree,
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
-"DY" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "conveyorbar"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
-"EC" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
 "KY" = (
@@ -1165,76 +1228,13 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/kitchen)
-"Mn" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "conveyorbar"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
-"Ow" = (
+"PH" = (
 /obj/structure/table/reinforced,
-/obj/structure/plasticflaps,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "conveyorbar"
-	},
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
-"PG" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
-"Qr" = (
-/obj/machinery/smartfridge/drinks,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
-"QR" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
-"Rm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters";
-	pixel_x = -25;
-	pixel_y = 25
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
@@ -1243,18 +1243,6 @@
 /obj/item/clothing/mask/cigarette/rollie/cannabis,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
-"Tz" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_one_access_txt = "12;25"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "VM" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/mixbowl{
@@ -1284,6 +1272,18 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/kitchen)
+"XY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = -25;
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
 
 (1,1,1) = {"
 aa
@@ -1291,11 +1291,11 @@ ab
 ab
 ab
 ab
-yj
+eL
 ht
-yj
+eL
 ab
-yj
+eL
 ab
 ab
 ab
@@ -1395,7 +1395,7 @@ cJ
 cL
 df
 ao
-yj
+eL
 "}
 (8,1,1) = {"
 ac
@@ -1421,29 +1421,29 @@ ao
 ao
 ao
 ao
-Ow
-QR
-QR
-QR
+dI
+Bq
+Bq
+Bq
 aP
 ds
 ab
 "}
 (10,1,1) = {"
-Tz
+nE
 at
 ao
 ao
 ao
 ao
 ao
-DY
+oZ
 ao
 ao
-wK
+GX
 aP
 ao
-yj
+eL
 "}
 (11,1,1) = {"
 ab
@@ -1453,10 +1453,10 @@ aV
 bh
 bx
 ao
-DY
+oZ
 cu
 ao
-QR
+Bq
 aP
 cC
 ab
@@ -1467,12 +1467,12 @@ ab
 ab
 ab
 aS
-PG
-pR
-Mn
+yS
+vO
+vF
 cv
 ao
-QR
+Bq
 aP
 ao
 cG
@@ -1482,13 +1482,13 @@ ah
 aw
 aJ
 aW
-hG
+wy
 bz
 ao
 cL
 ao
 ao
-hc
+PH
 dh
 ao
 ab
@@ -1499,7 +1499,7 @@ wt
 aK
 ai
 cA
-Rm
+XY
 bf
 cL
 ce
@@ -1520,7 +1520,7 @@ bK
 cL
 cy
 ao
-Qr
+dK
 ao
 dx
 ab

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_conveyor.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_conveyor.dmm
@@ -494,12 +494,6 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
-"bz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
 "bA" = (
 /obj/machinery/camera{
 	c_tag = "Kitchen";
@@ -1211,6 +1205,12 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
+"HW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
 "KY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4;
@@ -1226,6 +1226,19 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/kitchen)
+"Rl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_x = 1;
+	pixel_y = 23;
+	req_access_txt = "25"
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
 "RP" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -1268,18 +1281,6 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/kitchen)
-"XY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters";
-	pixel_x = -25;
-	pixel_y = 25
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
 
 (1,1,1) = {"
 aa
@@ -1479,7 +1480,7 @@ aw
 aJ
 aW
 wy
-bz
+Rl
 ao
 cL
 ao
@@ -1495,7 +1496,7 @@ wt
 aK
 ai
 cA
-XY
+HW
 bf
 cL
 ce

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_conveyor.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_conveyor.dmm
@@ -973,26 +973,6 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
-"dI" = (
-/obj/structure/table/reinforced,
-/obj/structure/plasticflaps,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "conveyorbar"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
 "dK" = (
 /obj/machinery/smartfridge/drinks,
 /obj/machinery/door/poddoor/preopen{
@@ -1019,9 +999,50 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
+"eZ" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
+"gb" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "conveyorbar"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
 "gz" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-26"
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
+"hc" = (
+/obj/structure/table/reinforced,
+/obj/structure/plasticflaps,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "conveyorbar"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
@@ -1072,20 +1093,6 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/kitchen)
-"oZ" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "conveyorbar"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
 "qM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -1104,30 +1111,7 @@
 /obj/item/clothing/head/hardhat/cakehat,
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
-"up" = (
-/obj/structure/table,
-/obj/machinery/requests_console{
-	department = "Kitchen";
-	departmentType = 2;
-	pixel_x = 30
-	},
-/obj/machinery/reagentgrinder/kitchen{
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/kitchen)
-"vF" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "conveyorbar"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
-"vO" = (
+"sI" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -1140,12 +1124,38 @@
 /obj/item/reagent_containers/food/snacks/dolphinmeat,
 /obj/item/reagent_containers/food/snacks/dolphinmeat,
 /obj/item/reagent_containers/food/snacks/dolphinmeat,
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
-	name = "privacy shutters"
+	name = "bar shutters"
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
+"tR" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "conveyorbar"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
+"up" = (
+/obj/structure/table,
+/obj/machinery/requests_console{
+	department = "Kitchen";
+	departmentType = 2;
+	pixel_x = 30
+	},
+/obj/machinery/reagentgrinder/kitchen{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/kitchen)
 "wt" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -1164,28 +1174,6 @@
 	},
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"yS" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
-"Bq" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
 "BP" = (
 /obj/effect/spawner/xmastree,
 /turf/open/floor/plasteel/vaporwave,
@@ -1195,7 +1183,7 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
-"GX" = (
+"Hq" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/mask/cigarette/rollie/cannabis,
 /obj/item/clothing/mask/cigarette/rollie/cannabis,
@@ -1207,9 +1195,19 @@
 /obj/item/clothing/mask/cigarette/rollie/cannabis,
 /obj/item/clothing/mask/cigarette/rollie/cannabis,
 /obj/item/clothing/mask/cigarette/rollie/cannabis,
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
-	name = "privacy shutters"
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
+"HR" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
@@ -1228,13 +1226,11 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/kitchen)
-"PH" = (
+"RP" = (
 /obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
-	name = "privacy shutters"
+	name = "bar shutters"
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
@@ -1421,10 +1417,10 @@ ao
 ao
 ao
 ao
-dI
-Bq
-Bq
-Bq
+hc
+RP
+RP
+RP
 aP
 ds
 ab
@@ -1437,10 +1433,10 @@ ao
 ao
 ao
 ao
-oZ
+tR
 ao
 ao
-GX
+Hq
 aP
 ao
 eL
@@ -1453,10 +1449,10 @@ aV
 bh
 bx
 ao
-oZ
+tR
 cu
 ao
-Bq
+RP
 aP
 cC
 ab
@@ -1467,12 +1463,12 @@ ab
 ab
 ab
 aS
-yS
-vO
-vF
+eZ
+sI
+gb
 cv
 ao
-Bq
+RP
 aP
 ao
 cG
@@ -1488,7 +1484,7 @@ ao
 cL
 ao
 ao
-PH
+HR
 dh
 ao
 ab

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_conveyor.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_conveyor.dmm
@@ -30,18 +30,6 @@
 /obj/structure/musician/piano,
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
-"ag" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_access_txt = "12"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "ah" = (
 /obj/item/reagent_containers/food/drinks/shaker,
 /obj/structure/table/wood,
@@ -313,10 +301,6 @@
 /obj/structure/sign/plaques/deempisi,
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"aT" = (
-/obj/item/storage/secure/safe,
-/turf/closed/wall,
-/area/crew_quarters/bar)
 "aU" = (
 /obj/structure/statue/sandstone/venus,
 /turf/open/floor/plasteel/vaporwave,
@@ -332,12 +316,6 @@
 	},
 /obj/item/gun/ballistic/revolver/russian,
 /turf/open/floor/wood,
-/area/crew_quarters/bar)
-"aX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
 "aY" = (
 /obj/structure/kitchenspike,
@@ -516,16 +494,6 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
-"by" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
 "bz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -610,37 +578,12 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/beach/sand,
 /area/crew_quarters/bar)
-"bI" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/obj/item/storage/bag/tray,
-/obj/item/storage/bag/tray,
-/obj/item/storage/bag/tray,
-/obj/item/storage/bag/tray,
-/obj/item/storage/bag/tray,
-/obj/item/reagent_containers/food/snacks/dolphinmeat,
-/obj/item/reagent_containers/food/snacks/dolphinmeat,
-/obj/item/reagent_containers/food/snacks/dolphinmeat,
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
 "bJ" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/kitchen)
 "bK" = (
 /obj/machinery/vending/boozeomat,
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
-"bL" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "conveyorbar"
-	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
 "bM" = (
@@ -700,10 +643,6 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/kitchen)
-"bT" = (
-/obj/machinery/smartfridge/drinks,
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
 "bU" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/vaporwave,
@@ -723,18 +662,6 @@
 	dir = 4
 	},
 /turf/open/floor/plating/beach/sand,
-/area/crew_quarters/bar)
-"bZ" = (
-/obj/structure/table/reinforced,
-/obj/structure/plasticflaps,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "conveyorbar"
-	},
-/turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
 "ca" = (
 /obj/structure/table,
@@ -771,12 +698,6 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/kitchen)
-"ch" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
 "cj" = (
 /obj/machinery/light_switch{
 	pixel_y = -25
@@ -830,10 +751,6 @@
 /obj/structure/flora/ausbushes/leafybush,
 /mob/living/simple_animal/hostile/lizard,
 /turf/open/floor/plating/beach/sand,
-/area/crew_quarters/bar)
-"cs" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
 "ct" = (
 /obj/structure/table/reinforced,
@@ -1026,20 +943,6 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
-"cY" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/mask/cigarette/rollie/cannabis,
-/obj/item/clothing/mask/cigarette/rollie/cannabis,
-/obj/item/clothing/mask/cigarette/rollie/cannabis,
-/obj/item/clothing/mask/cigarette/rollie/cannabis,
-/obj/item/clothing/mask/cigarette/rollie/cannabis,
-/obj/item/clothing/mask/cigarette/rollie/cannabis,
-/obj/item/clothing/mask/cigarette/rollie/cannabis,
-/obj/item/clothing/mask/cigarette/rollie/cannabis,
-/obj/item/clothing/mask/cigarette/rollie/cannabis,
-/obj/item/clothing/mask/cigarette/rollie/cannabis,
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/bar)
 "df" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/assistant,
@@ -1086,8 +989,25 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
+"hc" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
 "ht" = (
 /obj/effect/landmark/event_spawn,
+/turf/closed/wall,
+/area/crew_quarters/bar)
+"hG" = (
+/obj/item/storage/secure/safe{
+	pixel_x = -2;
+	pixel_y = 4
+	},
 /turf/closed/wall,
 /area/crew_quarters/bar)
 "jj" = (
@@ -1105,10 +1025,6 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
-"nw" = (
-/obj/effect/spawner/structure/window/plasma,
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "ow" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin{
@@ -1125,6 +1041,25 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/kitchen)
+"pR" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/bag/tray,
+/obj/item/storage/bag/tray,
+/obj/item/storage/bag/tray,
+/obj/item/storage/bag/tray,
+/obj/item/storage/bag/tray,
+/obj/item/reagent_containers/food/snacks/dolphinmeat,
+/obj/item/reagent_containers/food/snacks/dolphinmeat,
+/obj/item/reagent_containers/food/snacks/dolphinmeat,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
 "qM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -1166,8 +1101,48 @@
 /obj/item/reagent_containers/food/snacks/mint,
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/kitchen)
+"wK" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/mask/cigarette/rollie/cannabis,
+/obj/item/clothing/mask/cigarette/rollie/cannabis,
+/obj/item/clothing/mask/cigarette/rollie/cannabis,
+/obj/item/clothing/mask/cigarette/rollie/cannabis,
+/obj/item/clothing/mask/cigarette/rollie/cannabis,
+/obj/item/clothing/mask/cigarette/rollie/cannabis,
+/obj/item/clothing/mask/cigarette/rollie/cannabis,
+/obj/item/clothing/mask/cigarette/rollie/cannabis,
+/obj/item/clothing/mask/cigarette/rollie/cannabis,
+/obj/item/clothing/mask/cigarette/rollie/cannabis,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
+"yj" = (
+/obj/effect/spawner/structure/window/plasma,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "BP" = (
 /obj/effect/spawner/xmastree,
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
+"DY" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "conveyorbar"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
 "EC" = (
@@ -1190,11 +1165,96 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/kitchen)
+"Mn" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "conveyorbar"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
+"Ow" = (
+/obj/structure/table/reinforced,
+/obj/structure/plasticflaps,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "conveyorbar"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
+"PG" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
+"Qr" = (
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
+"QR" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
+"Rm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = -25;
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
 "SA" = (
 /obj/effect/landmark/blobstart,
 /obj/item/clothing/mask/cigarette/rollie/cannabis,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
+"Tz" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	req_one_access_txt = "12;25"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "VM" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/mixbowl{
@@ -1231,11 +1291,11 @@ ab
 ab
 ab
 ab
-nw
+yj
 ht
-nw
+yj
 ab
-nw
+yj
 ab
 ab
 ab
@@ -1335,7 +1395,7 @@ cJ
 cL
 df
 ao
-nw
+yj
 "}
 (8,1,1) = {"
 ac
@@ -1361,29 +1421,29 @@ ao
 ao
 ao
 ao
-bZ
-cs
-cs
-cs
+Ow
+QR
+QR
+QR
 aP
 ds
 ab
 "}
 (10,1,1) = {"
-ag
+Tz
 at
 ao
 ao
 ao
 ao
 ao
-bL
+DY
 ao
 ao
-cY
+wK
 aP
 ao
-nw
+yj
 "}
 (11,1,1) = {"
 ab
@@ -1393,10 +1453,10 @@ aV
 bh
 bx
 ao
-bL
+DY
 cu
 ao
-cs
+QR
 aP
 cC
 ab
@@ -1407,12 +1467,12 @@ ab
 ab
 ab
 aS
-by
-bI
-cL
+PG
+pR
+Mn
 cv
 ao
-cs
+QR
 aP
 ao
 cG
@@ -1422,13 +1482,13 @@ ah
 aw
 aJ
 aW
-aT
+hG
 bz
 ao
 cL
 ao
 ao
-ch
+hc
 dh
 ao
 ab
@@ -1439,7 +1499,7 @@ wt
 aK
 ai
 cA
-aX
+Rm
 bf
 cL
 ce
@@ -1460,7 +1520,7 @@ bK
 cL
 cy
 ao
-bT
+Qr
 ao
 dx
 ab

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_diner.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_diner.dmm
@@ -19,22 +19,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
-"ad" = (
-/obj/item/storage/secure/safe,
-/turf/closed/wall,
-/area/crew_quarters/bar)
-"ae" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_access_txt = "12"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "af" = (
 /obj/item/reagent_containers/food/drinks/shaker,
 /obj/structure/table/wood,
@@ -342,19 +326,6 @@
 /obj/effect/turf_decal/ameritard,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"aT" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/bar)
 "aU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -412,24 +383,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
-"bb" = (
-/obj/structure/table/american/end{
-	dir = 1;
-	icon_state = "table-end";
-	tag = ""
-	},
-/obj/item/reagent_containers/food/snacks/burger/plain,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8;
-	icon_state = "warningline_red"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/bar)
 "bc" = (
 /obj/effect/turf_decal/ameritard,
 /obj/structure/chair/americandiner/booth/end_left{
@@ -513,14 +466,6 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
-"bo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/bar)
 "bp" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -622,22 +567,6 @@
 /area/crew_quarters/bar)
 "by" = (
 /obj/machinery/vending/boozeomat,
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/bar)
-"bz" = (
-/obj/structure/table/american,
-/obj/item/clothing/head/that,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8;
-	icon_state = "warningline_red"
-	},
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
 /turf/open/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -744,20 +673,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"bL" = (
-/obj/structure/table/american,
-/obj/item/reagent_containers/food/snacks/burger/plain,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8;
-	icon_state = "warningline_red"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/bar)
 "bM" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel{
@@ -806,20 +721,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"bT" = (
-/obj/structure/table/american,
-/obj/item/reagent_containers/food/snacks/burger/superbite,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8;
-	icon_state = "warningline_red"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/bar)
 "bU" = (
 /obj/effect/landmark/start/cook,
 /turf/open/floor/plasteel{
@@ -853,32 +754,12 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/bar)
-"bX" = (
-/obj/structure/table/american/end,
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8;
-	icon_state = "warningline_red"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/bar)
 "bY" = (
 /obj/machinery/door/window/southright{
 	name = "Bar Door";
 	req_access_txt = "25";
 	req_one_access_txt = "25;28"
 	},
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/bar)
-"bZ" = (
-/obj/machinery/smartfridge/drinks,
 /turf/open/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -981,18 +862,6 @@
 /obj/effect/turf_decal/ameritard,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"cJ" = (
-/obj/machinery/vending/cola,
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/bar)
-"cK" = (
-/obj/effect/spawner/structure/window,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "cQ" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/ameritard,
@@ -1061,6 +930,35 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/crew_quarters/bar)
+"do" = (
+/obj/structure/table/american,
+/obj/item/clothing/head/that,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8;
+	icon_state = "warningline_red"
+	},
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/bar)
+"eB" = (
+/obj/effect/spawner/structure/window,
+/obj/effect/landmark/event_spawn,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "if" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/mint,
@@ -1071,6 +969,12 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
+"jA" = (
+/obj/item/storage/secure/safe{
+	pixel_x = -7
+	},
+/turf/closed/wall,
+/area/crew_quarters/bar)
 "lT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8;
@@ -1080,9 +984,22 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
-"mc" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
+"oC" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
 /area/crew_quarters/bar)
 "pQ" = (
 /obj/structure/table/reinforced,
@@ -1129,6 +1046,17 @@
 /obj/effect/turf_decal/ameritard,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"vQ" = (
+/obj/machinery/vending/cola,
+/obj/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/bar)
 "xx" = (
 /obj/structure/sign/plaques/deempisi,
 /turf/closed/wall,
@@ -1137,6 +1065,42 @@
 /obj/effect/landmark/blobstart,
 /obj/item/reagent_containers/food/snacks/burger/plain,
 /turf/open/floor/plating,
+/area/crew_quarters/bar)
+"zL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = 4;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/bar)
+"zT" = (
+/obj/structure/table/american/end{
+	dir = 1;
+	icon_state = "table-end";
+	tag = ""
+	},
+/obj/item/reagent_containers/food/snacks/burger/plain,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8;
+	icon_state = "warningline_red"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
 /area/crew_quarters/bar)
 "Aw" = (
 /obj/structure/table,
@@ -1152,6 +1116,18 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
+"Cn" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	req_one_access_txt = "12;25"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "Dn" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only,
@@ -1175,6 +1151,42 @@
 /obj/effect/turf_decal/ameritard,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"IO" = (
+/obj/structure/table/american/end,
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8;
+	icon_state = "warningline_red"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/bar)
+"Jf" = (
+/obj/structure/table/american,
+/obj/item/reagent_containers/food/snacks/burger/plain,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8;
+	icon_state = "warningline_red"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/bar)
 "JN" = (
 /mob/living/carbon/monkey{
 	name = "Pun Pun"
@@ -1193,6 +1205,16 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
+"Sz" = (
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/bar)
 "Tm" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only,
@@ -1231,6 +1253,32 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"XB" = (
+/obj/structure/table/american,
+/obj/item/reagent_containers/food/snacks/burger/superbite,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8;
+	icon_state = "warningline_red"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/bar)
+"XP" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 
 (1,1,1) = {"
 aa
@@ -1240,11 +1288,11 @@ ab
 ab
 ab
 ab
-cK
+eB
 ab
-mc
+XP
 ab
-mc
+XP
 ab
 ab
 "}
@@ -1342,7 +1390,7 @@ cs
 bc
 az
 az
-mc
+XP
 "}
 (8,1,1) = {"
 ab
@@ -1377,7 +1425,7 @@ dc
 dj
 "}
 (10,1,1) = {"
-ae
+Cn
 ar
 az
 az
@@ -1414,12 +1462,12 @@ ab
 ab
 ab
 xx
-aT
-bb
-bz
-bL
-bT
-bX
+oC
+zT
+do
+Jf
+XB
+IO
 az
 az
 ab
@@ -1429,13 +1477,13 @@ af
 at
 aG
 aV
-ad
-bo
+jA
+zL
 cv
 cv
 cg
 cv
-cJ
+vQ
 cQ
 df
 ab
@@ -1467,7 +1515,7 @@ by
 cv
 bW
 cv
-bZ
+Sz
 az
 dh
 ab

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_diner.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_diner.dmm
@@ -930,15 +930,24 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"do" = (
-/obj/structure/table/american,
-/obj/item/clothing/head/that,
+"gX" = (
+/obj/machinery/vending/cola,
+/obj/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/bar)
+"hl" = (
+/obj/structure/table/american/end,
+/obj/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8;
 	icon_state = "warningline_red"
 	},
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -950,15 +959,36 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/bar)
-"eB" = (
-/obj/effect/spawner/structure/window,
-/obj/effect/landmark/event_spawn,
+"hy" = (
+/obj/structure/table/american,
+/obj/item/reagent_containers/food/snacks/burger/plain,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8;
+	icon_state = "warningline_red"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
 /area/crew_quarters/bar)
+"hW" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "if" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/mint,
@@ -969,7 +999,7 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
-"jA" = (
+"iA" = (
 /obj/item/storage/secure/safe{
 	pixel_x = -7
 	},
@@ -984,23 +1014,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
-"oC" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/bar)
 "pQ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only,
@@ -1017,6 +1030,23 @@
 /obj/effect/turf_decal/ameritard,
 /obj/effect/spawner/xmastree,
 /turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"uM" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
 /area/crew_quarters/bar)
 "vo" = (
 /obj/structure/table,
@@ -1046,17 +1076,6 @@
 /obj/effect/turf_decal/ameritard,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"vQ" = (
-/obj/machinery/vending/cola,
-/obj/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/bar)
 "xx" = (
 /obj/structure/sign/plaques/deempisi,
 /turf/closed/wall,
@@ -1066,21 +1085,43 @@
 /obj/item/reagent_containers/food/snacks/burger/plain,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
-"zL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"Aw" = (
+/obj/structure/table,
+/obj/machinery/requests_console{
+	department = "Kitchen";
+	departmentType = 2;
+	pixel_x = 30
 	},
-/obj/machinery/button/door{
+/obj/machinery/reagentgrinder/kitchen{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
+"Dn" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/item/reagent_containers/food/snacks/burger/superbite,
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
+"Dt" = (
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
-	name = "bar shutters";
-	pixel_x = 4;
-	pixel_y = 28
+	name = "privacy shutters"
 	},
 /turf/open/floor/plasteel{
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/bar)
-"zT" = (
+"He" = (
 /obj/structure/table/american/end{
 	dir = 1;
 	icon_state = "table-end";
@@ -1102,44 +1143,6 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/bar)
-"Aw" = (
-/obj/structure/table,
-/obj/machinery/requests_console{
-	department = "Kitchen";
-	departmentType = 2;
-	pixel_x = 30
-	},
-/obj/machinery/reagentgrinder/kitchen{
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/kitchen)
-"Cn" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_one_access_txt = "12;25"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"Dn" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/item/reagent_containers/food/snacks/burger/superbite,
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/kitchen)
 "HO" = (
 /obj/structure/table,
 /obj/item/clothing/head/hardhat/cakehat,
@@ -1151,45 +1154,47 @@
 /obj/effect/turf_decal/ameritard,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"IO" = (
-/obj/structure/table/american/end,
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8;
-	icon_state = "warningline_red"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/bar)
-"Jf" = (
-/obj/structure/table/american,
-/obj/item/reagent_containers/food/snacks/burger/plain,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8;
-	icon_state = "warningline_red"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/bar)
 "JN" = (
 /mob/living/carbon/monkey{
 	name = "Pun Pun"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/bar)
+"JR" = (
+/obj/structure/table/american,
+/obj/item/clothing/head/that,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8;
+	icon_state = "warningline_red"
+	},
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/bar)
+"Md" = (
+/obj/structure/table/american,
+/obj/item/reagent_containers/food/snacks/burger/superbite,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8;
+	icon_state = "warningline_red"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
 	},
 /turf/open/floor/plasteel{
 	icon_state = "cafeteria"
@@ -1205,15 +1210,22 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
-"Sz" = (
-/obj/machinery/smartfridge/drinks,
+"NF" = (
+/obj/effect/spawner/structure/window,
+/obj/effect/landmark/event_spawn,
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
 	},
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
+"Oo" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
 	},
+/turf/open/floor/plating,
 /area/crew_quarters/bar)
 "Tm" = (
 /obj/structure/table/reinforced,
@@ -1253,31 +1265,19 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"XB" = (
-/obj/structure/table/american,
-/obj/item/reagent_containers/food/snacks/burger/superbite,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8;
-	icon_state = "warningline_red"
+"Zi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/button/door{
 	id = "barshutters";
-	name = "privacy shutters"
+	name = "bar shutters";
+	pixel_x = 4;
+	pixel_y = 28
 	},
 /turf/open/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/crew_quarters/bar)
-"XP" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
 /area/crew_quarters/bar)
 
 (1,1,1) = {"
@@ -1288,11 +1288,11 @@ ab
 ab
 ab
 ab
-eB
+NF
 ab
-XP
+Oo
 ab
-XP
+Oo
 ab
 ab
 "}
@@ -1390,7 +1390,7 @@ cs
 bc
 az
 az
-XP
+Oo
 "}
 (8,1,1) = {"
 ab
@@ -1425,7 +1425,7 @@ dc
 dj
 "}
 (10,1,1) = {"
-Cn
+hW
 ar
 az
 az
@@ -1462,12 +1462,12 @@ ab
 ab
 ab
 xx
-oC
-zT
-do
-Jf
-XB
-IO
+uM
+He
+JR
+hy
+Md
+hl
 az
 az
 ab
@@ -1477,13 +1477,13 @@ af
 at
 aG
 aV
-jA
-zL
+iA
+Zi
 cv
 cv
 cg
 cv
-vQ
+gX
 cQ
 df
 ab
@@ -1515,7 +1515,7 @@ by
 cv
 bW
 cv
-Sz
+Dt
 az
 dh
 ab

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_diner.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_diner.dmm
@@ -1016,6 +1016,21 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
+"mh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_x = 4;
+	pixel_y = 24;
+	req_access_txt = "25"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/bar)
 "pQ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only,
@@ -1265,20 +1280,6 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/bar)
-"Zi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters";
-	pixel_x = 4;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/bar)
 
 (1,1,1) = {"
 aa
@@ -1478,7 +1479,7 @@ at
 aG
 aV
 iA
-Zi
+mh
 cv
 cv
 cg

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_diner.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_diner.dmm
@@ -930,48 +930,12 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"gX" = (
+"hl" = (
 /obj/machinery/vending/cola,
 /obj/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/bar)
-"hl" = (
-/obj/structure/table/american/end,
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8;
-	icon_state = "warningline_red"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/bar)
-"hy" = (
-/obj/structure/table/american,
-/obj/item/reagent_containers/food/snacks/burger/plain,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8;
-	icon_state = "warningline_red"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
+	name = "bar shutters"
 	},
 /turf/open/floor/plasteel{
 	icon_state = "cafeteria"
@@ -999,11 +963,49 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
+"io" = (
+/obj/structure/table/american/end,
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8;
+	icon_state = "warningline_red"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/bar)
 "iA" = (
 /obj/item/storage/secure/safe{
 	pixel_x = -7
 	},
 /turf/closed/wall,
+/area/crew_quarters/bar)
+"kJ" = (
+/obj/structure/table/american,
+/obj/item/clothing/head/that,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8;
+	icon_state = "warningline_red"
+	},
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
 /area/crew_quarters/bar)
 "lT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -1030,23 +1032,6 @@
 /obj/effect/turf_decal/ameritard,
 /obj/effect/spawner/xmastree,
 /turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"uM" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
 /area/crew_quarters/bar)
 "vo" = (
 /obj/structure/table,
@@ -1121,23 +1106,18 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/bar)
-"He" = (
-/obj/structure/table/american/end{
-	dir = 1;
-	icon_state = "table-end";
-	tag = ""
+"Ec" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/obj/item/reagent_containers/food/snacks/burger/plain,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8;
-	icon_state = "warningline_red"
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/door/poddoor/preopen{
+/obj/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
-	name = "privacy shutters"
+	name = "bar shutters"
 	},
 /turf/open/floor/plasteel{
 	icon_state = "cafeteria"
@@ -1162,29 +1142,9 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/bar)
-"JR" = (
+"Ku" = (
 /obj/structure/table/american,
-/obj/item/clothing/head/that,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8;
-	icon_state = "warningline_red"
-	},
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/bar)
-"Md" = (
-/obj/structure/table/american,
-/obj/item/reagent_containers/food/snacks/burger/superbite,
+/obj/item/reagent_containers/food/snacks/burger/plain,
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8;
 	icon_state = "warningline_red"
@@ -1192,9 +1152,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
-	name = "privacy shutters"
+	name = "bar shutters"
 	},
 /turf/open/floor/plasteel{
 	icon_state = "cafeteria"
@@ -1226,6 +1186,24 @@
 	name = "privacy shutters"
 	},
 /turf/open/floor/plating,
+/area/crew_quarters/bar)
+"Su" = (
+/obj/structure/table/american,
+/obj/item/reagent_containers/food/snacks/burger/superbite,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8;
+	icon_state = "warningline_red"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
 /area/crew_quarters/bar)
 "Tm" = (
 /obj/structure/table/reinforced,
@@ -1264,6 +1242,28 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
+/area/crew_quarters/bar)
+"Ye" = (
+/obj/structure/table/american/end{
+	dir = 1;
+	icon_state = "table-end";
+	tag = ""
+	},
+/obj/item/reagent_containers/food/snacks/burger/plain,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8;
+	icon_state = "warningline_red"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
 /area/crew_quarters/bar)
 "Zi" = (
 /obj/structure/disposalpipe/segment{
@@ -1462,12 +1462,12 @@ ab
 ab
 ab
 xx
-uM
-He
-JR
-hy
-Md
-hl
+Ec
+Ye
+kJ
+Ku
+Su
+io
 az
 az
 ab
@@ -1483,7 +1483,7 @@ cv
 cv
 cg
 cv
-gX
+hl
 cQ
 df
 ab

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_disco.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_disco.dmm
@@ -28,10 +28,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
-"ad" = (
-/obj/item/storage/secure/safe,
-/turf/closed/wall,
-/area/crew_quarters/bar)
 "ae" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Bar Maintenance";
@@ -237,16 +233,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"aG" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "aH" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/dark,
@@ -423,11 +409,6 @@
 	},
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/kitchen)
-"be" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "bf" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = -31
@@ -487,12 +468,6 @@
 /area/crew_quarters/kitchen)
 "bo" = (
 /obj/machinery/smartfridge/drinks,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"bp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "bq" = (
@@ -613,12 +588,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"bD" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks,
-/obj/machinery/door/window/westright,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "bE" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/plasteel/ameridiner,
@@ -694,12 +663,6 @@
 "bP" = (
 /obj/machinery/jukebox/disco,
 /turf/open/floor/light/colour_cycle/dancefloor_a,
-/area/crew_quarters/bar)
-"bQ" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "bS" = (
 /obj/machinery/door/airlock{
@@ -800,10 +763,6 @@
 "ct" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/light/colour_cycle/dancefloor_a,
-/area/crew_quarters/bar)
-"cu" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "cv" = (
 /turf/open/floor/wood,
@@ -923,6 +882,28 @@
 /obj/effect/spawner/xmastree,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"nK" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"pw" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "vH" = (
 /obj/structure/table,
 /obj/machinery/requests_console{
@@ -953,6 +934,15 @@
 	},
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/kitchen)
+"Eq" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "FH" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin{
@@ -983,9 +973,41 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
+"Kw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = 4;
+	pixel_y = 28
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"Mm" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "Nh" = (
 /obj/structure/sign/plaques/deempisi,
 /turf/closed/wall,
+/area/crew_quarters/bar)
+"Nq" = (
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/drinks,
+/obj/machinery/door/window/westright,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "OT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -1009,6 +1031,12 @@
 	},
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/kitchen)
+"Ta" = (
+/obj/item/storage/secure/safe{
+	pixel_x = -6
+	},
+/turf/closed/wall,
+/area/crew_quarters/bar)
 "VI" = (
 /obj/effect/landmark/blobstart,
 /obj/item/toy/beach_ball/holoball,
@@ -1205,12 +1233,12 @@ ai
 ai
 ai
 Nh
-aG
-bD
-cu
-be
-cu
-cu
+pw
+Nq
+nK
+Eq
+nK
+nK
 an
 an
 ai
@@ -1220,13 +1248,13 @@ ab
 au
 aI
 aW
-ad
-bp
+Ta
+Kw
 cv
 cv
 ci
 cv
-bQ
+Mm
 cQ
 de
 ai

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_disco.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_disco.dmm
@@ -466,10 +466,6 @@
 	},
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/kitchen)
-"bo" = (
-/obj/machinery/smartfridge/drinks,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "bq" = (
 /obj/machinery/door/airlock{
 	name = "Bar Storage";
@@ -878,6 +874,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"kM" = (
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "lg" = (
 /obj/effect/spawner/xmastree,
 /turf/open/floor/plasteel/dark,
@@ -934,6 +938,19 @@
 	},
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/kitchen)
+"Cr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_x = 6;
+	pixel_y = 24;
+	req_access_txt = "25"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "Eq" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/head/that,
@@ -973,18 +990,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
-"Kw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters";
-	pixel_x = 4;
-	pixel_y = 28
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "Mm" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/barman_recipes,
@@ -1249,7 +1254,7 @@ au
 aI
 aW
 Ta
-Kw
+Cr
 cv
 cv
 ci
@@ -1286,7 +1291,7 @@ br
 cv
 ck
 cv
-bo
+kM
 an
 dg
 ai

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_irish.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_irish.dmm
@@ -1630,7 +1630,7 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"pd" = (
+"kY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -1644,12 +1644,6 @@
 /obj/effect/turf_decal/tile/darkgreen{
 	dir = 1;
 	icon_state = "tile_corner"
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters";
-	pixel_x = -26;
-	pixel_y = 25
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -1689,31 +1683,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
-"zj" = (
-/obj/machinery/disposal/bin,
-/obj/structure/sign/warning/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
-	pixel_x = -28;
-	pixel_y = -4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/darkgreen,
-/obj/effect/turf_decal/tile/darkgreen{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "Bj" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/head/that{
@@ -1752,6 +1721,38 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"Jv" = (
+/obj/machinery/disposal/bin,
+/obj/structure/sign/warning/securearea{
+	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
+	icon_state = "monkey_painting";
+	name = "Mr. Deempisi portrait";
+	pixel_x = -28;
+	pixel_y = -4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkgreen,
+/obj/effect/turf_decal/tile/darkgreen{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_x = 1;
+	pixel_y = 24;
+	req_access_txt = "25"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -2038,7 +2039,7 @@ au
 aL
 bb
 ad
-zj
+Jv
 aI
 aI
 ci
@@ -2054,7 +2055,7 @@ ag
 aM
 bc
 bn
-pd
+kY
 aI
 bV
 aI

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_irish.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_irish.dmm
@@ -1610,28 +1610,6 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"fJ" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that{
-	throwforce = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/darkgreen,
-/obj/effect/turf_decal/tile/darkgreen{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "hD" = (
 /obj/structure/table,
 /obj/machinery/requests_console{
@@ -1682,7 +1660,7 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"pJ" = (
+"vu" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -1697,28 +1675,9 @@
 	},
 /obj/item/book/manual/wiki/barman_recipes,
 /obj/item/reagent_containers/glass/rag,
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"qf" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/darkgreen,
-/obj/effect/turf_decal/tile/darkgreen{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
+	name = "bar shutters"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -1752,6 +1711,28 @@
 /obj/effect/turf_decal/tile/darkgreen{
 	dir = 1;
 	icon_state = "tile_corner"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"Bj" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that{
+	throwforce = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkgreen,
+/obj/effect/turf_decal/tile/darkgreen{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -1790,6 +1771,25 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"Nh" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkgreen,
+/obj/effect/turf_decal/tile/darkgreen{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "PA" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only,
@@ -1819,7 +1819,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"UK" = (
+"Wp" = (
 /obj/structure/table/reinforced,
 /obj/item/lighter,
 /obj/effect/turf_decal/tile/green{
@@ -1833,9 +1833,9 @@
 	dir = 1;
 	icon_state = "tile_corner"
 	},
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
-	name = "privacy shutters"
+	name = "bar shutters"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -2023,11 +2023,11 @@ ad
 ad
 ad
 ad
-UK
-qf
-fJ
-qf
-qf
+Wp
+Nh
+Bj
+Nh
+Nh
 cH
 cW
 ad
@@ -2043,7 +2043,7 @@ aI
 aI
 ci
 aI
-pJ
+vu
 cI
 cX
 ad

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_irish.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_irish.dmm
@@ -21,18 +21,6 @@
 "ad" = (
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"ae" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_access_txt = "12"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "af" = (
 /obj/item/reagent_containers/food/drinks/shaker,
 /obj/structure/table/wood,
@@ -1622,9 +1610,10 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"hs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+"fJ" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that{
+	throwforce = 1
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -1637,11 +1626,9 @@
 	dir = 1;
 	icon_state = "tile_corner"
 	},
-/obj/machinery/button/door{
+/obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
-	name = "bar shutters";
-	pixel_x = -26;
-	pixel_y = 25
+	name = "privacy shutters"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -1665,10 +1652,9 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"iD" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that{
-	throwforce = 1
+"pd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -1681,9 +1667,11 @@
 	dir = 1;
 	icon_state = "tile_corner"
 	},
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/button/door{
 	id = "barshutters";
-	name = "privacy shutters"
+	name = "bar shutters";
+	pixel_x = -26;
+	pixel_y = 25
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -1694,7 +1682,7 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"rc" = (
+"pJ" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -1715,62 +1703,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"BW" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/darkgreen,
-/obj/effect/turf_decal/tile/darkgreen{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/obj/machinery/smartfridge/drinks,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"Mh" = (
-/obj/structure/table/reinforced,
-/obj/item/lighter,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/darkgreen,
-/obj/effect/turf_decal/tile/darkgreen{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"MM" = (
-/obj/structure/table,
-/obj/item/kitchen/rollingpin{
-	pixel_x = 5;
-	pixel_y = -1
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = -3;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -7;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"OP" = (
+"qf" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -1789,24 +1722,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"PQ" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/darkgreen,
-/obj/effect/turf_decal/tile/darkgreen{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"Rd" = (
+"yt" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
@@ -1814,7 +1730,7 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
-"TD" = (
+"zj" = (
 /obj/machinery/disposal/bin,
 /obj/structure/sign/warning/securearea{
 	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
@@ -1839,6 +1755,90 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"IS" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkgreen,
+/obj/effect/turf_decal/tile/darkgreen{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"MM" = (
+/obj/structure/table,
+/obj/item/kitchen/rollingpin{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"PA" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"PQ" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkgreen,
+/obj/effect/turf_decal/tile/darkgreen{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"UK" = (
+/obj/structure/table/reinforced,
+/obj/item/lighter,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkgreen,
+/obj/effect/turf_decal/tile/darkgreen{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 
 (1,1,1) = {"
 aa
@@ -1848,11 +1848,11 @@ ab
 ab
 ad
 bA
-Rd
+yt
 ad
-Rd
+yt
 ad
-Rd
+yt
 ad
 ad
 "}
@@ -1950,7 +1950,7 @@ cq
 cA
 aI
 aI
-Rd
+yt
 "}
 (8,1,1) = {"
 ab
@@ -1985,7 +1985,7 @@ cT
 dc
 "}
 (10,1,1) = {"
-ae
+PA
 as
 aJ
 aZ
@@ -2023,11 +2023,11 @@ ad
 ad
 ad
 ad
-Mh
-OP
-iD
-OP
-OP
+UK
+qf
+fJ
+qf
+qf
 cH
 cW
 ad
@@ -2038,12 +2038,12 @@ au
 aL
 bb
 ad
-TD
+zj
 aI
 aI
 ci
 aI
-rc
+pJ
 cI
 cX
 ad
@@ -2054,7 +2054,7 @@ ag
 aM
 bc
 bn
-hs
+pd
 aI
 bV
 aI
@@ -2075,7 +2075,7 @@ bF
 aI
 cj
 aI
-BW
+IS
 aI
 PQ
 ad

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_irish.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_irish.dmm
@@ -672,54 +672,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
-"bw" = (
-/obj/machinery/disposal/bin,
-/obj/structure/sign/warning/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
-	pixel_x = -28;
-	pixel_y = -4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "barShutters";
-	name = "bar shutters";
-	pixel_x = 4;
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/darkgreen,
-/obj/effect/turf_decal/tile/darkgreen{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"bx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/darkgreen,
-/obj/effect/turf_decal/tile/darkgreen{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "by" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -799,22 +751,6 @@
 /area/crew_quarters/bar)
 "bD" = (
 /obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/darkgreen,
-/obj/effect/turf_decal/tile/darkgreen{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"bE" = (
-/obj/structure/table/reinforced,
-/obj/item/lighter,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
@@ -920,14 +856,6 @@
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"bP" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "barShutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "bQ" = (
 /obj/structure/chair{
 	dir = 4
@@ -981,21 +909,6 @@
 "bT" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/darkgreen,
-/obj/effect/turf_decal/tile/darkgreen{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"bU" = (
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
@@ -1138,24 +1051,6 @@
 /area/crew_quarters/bar)
 "cg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/darkgreen,
-/obj/effect/turf_decal/tile/darkgreen{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"ch" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that{
-	throwforce = 1
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
@@ -1727,7 +1622,10 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"dd" = (
+"hs" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
@@ -1739,7 +1637,12 @@
 	dir = 1;
 	icon_state = "tile_corner"
 	},
-/obj/machinery/smartfridge/drinks,
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = -26;
+	pixel_y = 25
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "hD" = (
@@ -1762,6 +1665,28 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"iD" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that{
+	throwforce = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkgreen,
+/obj/effect/turf_decal/tile/darkgreen{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "pI" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/mixbowl{
@@ -1769,7 +1694,7 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"qV" = (
+"rc" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -1784,6 +1709,49 @@
 	},
 /obj/item/book/manual/wiki/barman_recipes,
 /obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"BW" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkgreen,
+/obj/effect/turf_decal/tile/darkgreen{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"Mh" = (
+/obj/structure/table/reinforced,
+/obj/item/lighter,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkgreen,
+/obj/effect/turf_decal/tile/darkgreen{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "MM" = (
@@ -1802,6 +1770,25 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"OP" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkgreen,
+/obj/effect/turf_decal/tile/darkgreen{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "PQ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -1819,6 +1806,39 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"Rd" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
+"TD" = (
+/obj/machinery/disposal/bin,
+/obj/structure/sign/warning/securearea{
+	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
+	icon_state = "monkey_painting";
+	name = "Mr. Deempisi portrait";
+	pixel_x = -28;
+	pixel_y = -4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkgreen,
+/obj/effect/turf_decal/tile/darkgreen{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 
 (1,1,1) = {"
 aa
@@ -1828,11 +1848,11 @@ ab
 ab
 ad
 bA
-bP
+Rd
 ad
-bP
+Rd
 ad
-bP
+Rd
 ad
 ad
 "}
@@ -1930,7 +1950,7 @@ cq
 cA
 aI
 aI
-bP
+Rd
 "}
 (8,1,1) = {"
 ab
@@ -2003,11 +2023,11 @@ ad
 ad
 ad
 ad
-bE
-bU
-ch
-bU
-bU
+Mh
+OP
+iD
+OP
+OP
 cH
 cW
 ad
@@ -2018,12 +2038,12 @@ au
 aL
 bb
 ad
-bw
+TD
 aI
 aI
 ci
 aI
-qV
+rc
 cI
 cX
 ad
@@ -2034,7 +2054,7 @@ ag
 aM
 bc
 bn
-bx
+hs
 aI
 bV
 aI
@@ -2055,7 +2075,7 @@ bF
 aI
 cj
 aI
-dd
+BW
 aI
 PQ
 ad

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_purple.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_purple.dmm
@@ -28,18 +28,6 @@
 /obj/item/radio/intercom,
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"af" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_access_txt = "12"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "ag" = (
 /obj/item/reagent_containers/food/drinks/shaker,
 /obj/structure/table/wood,
@@ -1181,6 +1169,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"dh" = (
+/obj/effect/spawner/structure/window{
+	color = "purple"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "di" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4;
@@ -1302,19 +1300,7 @@
 /obj/item/clothing/head/hardhat/cakehat,
 /turf/open/floor/mineral/titanium/purple,
 /area/crew_quarters/bar)
-"kM" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
-"nV" = (
+"ii" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -1331,12 +1317,34 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"rS" = (
+"kM" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4;
+	icon_state = "scrub_map_on-3"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
+"pi" = (
+/obj/structure/table/reinforced{
+	color = "purple"
+	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1;
 	icon_state = "tile_corner"
 	},
-/obj/machinery/smartfridge/drinks,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/item/clothing/head/that{
+	throwforce = 1;
+	throwing = 1
+	},
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
@@ -1363,16 +1371,6 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"vF" = (
-/obj/effect/spawner/structure/window{
-	color = "purple"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "xW" = (
 /obj/structure/chair/stool/bar{
 	color = "purple"
@@ -1381,18 +1379,49 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"zp" = (
+/obj/structure/table/reinforced{
+	color = "purple"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/item/gun/ballistic/revolver/russian,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
+"AB" = (
+/obj/structure/table/reinforced{
+	color = "purple"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/item/reagent_containers/food/snacks/burger/purple,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "BD" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
-"BE" = (
-/obj/item/storage/secure/safe{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/turf/closed/wall,
 /area/crew_quarters/bar)
 "Dl" = (
 /obj/item/clothing/gloves/color/purple,
@@ -1465,43 +1494,17 @@
 	},
 /turf/open/floor/mineral/titanium/purple,
 /area/crew_quarters/kitchen)
-"HO" = (
-/obj/structure/table/reinforced{
-	color = "purple"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
-	},
-/obj/item/reagent_containers/food/snacks/burger/purple,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "Jf" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/mint,
 /turf/open/floor/mineral/titanium/purple,
 /area/crew_quarters/kitchen)
-"KT" = (
-/obj/structure/table/reinforced{
-	color = "purple"
-	},
+"Ki" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1;
 	icon_state = "tile_corner"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
-	},
-/obj/item/gun/ballistic/revolver/russian,
+/obj/machinery/smartfridge/drinks,
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
@@ -1531,7 +1534,19 @@
 /obj/effect/spawner/xmastree,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"UQ" = (
+"WM" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"WY" = (
 /obj/structure/table/reinforced{
 	color = "purple"
 	},
@@ -1555,27 +1570,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"Ve" = (
-/obj/structure/table/reinforced{
-	color = "purple"
+"YX" = (
+/obj/item/storage/secure/safe{
+	pixel_x = 1;
+	pixel_y = 5
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
-	},
-/obj/item/clothing/head/that{
-	throwforce = 1;
-	throwing = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel/dark,
+/turf/closed/wall,
 /area/crew_quarters/bar)
 
 (1,1,1) = {"
@@ -1586,11 +1586,11 @@ ab
 ab
 ab
 bH
-vF
+dh
 ab
-vF
+dh
 ab
-vF
+dh
 ab
 ab
 "}
@@ -1688,7 +1688,7 @@ bx
 bh
 df
 ar
-vF
+dh
 "}
 (8,1,1) = {"
 ab
@@ -1723,7 +1723,7 @@ ar
 dF
 "}
 (10,1,1) = {"
-af
+WM
 ad
 aZ
 ce
@@ -1744,13 +1744,13 @@ at
 cd
 cf
 aW
-UQ
-HO
-Ve
-HO
-KT
-KT
-rS
+WY
+AB
+pi
+AB
+zp
+zp
+Ki
 bF
 ab
 "}
@@ -1775,8 +1775,8 @@ ag
 au
 aK
 ba
-BE
-nV
+YX
+ii
 aw
 aw
 cx

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_purple.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_purple.dmm
@@ -1300,23 +1300,6 @@
 /obj/item/clothing/head/hardhat/cakehat,
 /turf/open/floor/mineral/titanium/purple,
 /area/crew_quarters/bar)
-"ii" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters";
-	pixel_x = 7;
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "kM" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8;
@@ -1474,6 +1457,23 @@
 /obj/effect/landmark/blobstart,
 /obj/item/toy/crayon/purple,
 /turf/open/floor/plating,
+/area/crew_quarters/bar)
+"Qw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_y = 24;
+	req_access_txt = "25"
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "QV" = (
 /obj/structure/table/reinforced{
@@ -1776,7 +1776,7 @@ au
 aK
 ba
 YX
-ii
+Qw
 aw
 aw
 cx

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_purple.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_purple.dmm
@@ -588,10 +588,6 @@
 /obj/structure/sign/plaques/deempisi,
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"bn" = (
-/obj/item/storage/secure/safe,
-/turf/closed/wall,
-/area/crew_quarters/bar)
 "bo" = (
 /obj/machinery/door/airlock{
 	name = "Kitchen";
@@ -722,17 +718,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
-"bC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
-	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bD" = (
@@ -1147,21 +1132,6 @@
 	},
 /turf/open/floor/mineral/titanium/purple,
 /area/crew_quarters/kitchen)
-"cJ" = (
-/obj/structure/table/reinforced{
-	color = "purple"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
-	},
-/obj/item/reagent_containers/food/snacks/burger/purple,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "cK" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -1197,21 +1167,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mineral/titanium/purple,
 /area/crew_quarters/kitchen)
-"cY" = (
-/obj/structure/table/reinforced{
-	color = "purple"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
-	},
-/obj/item/gun/ballistic/revolver/russian,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "db" = (
 /turf/open/floor/mineral/titanium/purple,
 /area/crew_quarters/kitchen)
@@ -1359,24 +1314,33 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"kV" = (
-/obj/structure/table/reinforced{
-	color = "purple"
+"nV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
+/obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8;
 	icon_state = "tile_corner"
 	},
-/obj/item/toy/crayon/purple,
-/obj/item/toy/crayon/purple,
-/obj/item/toy/crayon/purple,
-/obj/item/toy/crayon/purple,
-/obj/item/toy/crayon/purple,
-/obj/item/toy/cards/deck,
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = 7;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
+"rS" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "vD" = (
@@ -1399,6 +1363,16 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"vF" = (
+/obj/effect/spawner/structure/window{
+	color = "purple"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "xW" = (
 /obj/structure/chair/stool/bar{
 	color = "purple"
@@ -1412,6 +1386,13 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
+"BE" = (
+/obj/item/storage/secure/safe{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/turf/closed/wall,
 /area/crew_quarters/bar)
 "Dl" = (
 /obj/item/clothing/gloves/color/purple,
@@ -1484,12 +1465,23 @@
 	},
 /turf/open/floor/mineral/titanium/purple,
 /area/crew_quarters/kitchen)
-"IV" = (
+"HO" = (
+/obj/structure/table/reinforced{
+	color = "purple"
+	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1;
 	icon_state = "tile_corner"
 	},
-/obj/machinery/smartfridge/drinks,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/item/reagent_containers/food/snacks/burger/purple,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "Jf" = (
@@ -1497,6 +1489,25 @@
 /obj/item/reagent_containers/food/snacks/mint,
 /turf/open/floor/mineral/titanium/purple,
 /area/crew_quarters/kitchen)
+"KT" = (
+/obj/structure/table/reinforced{
+	color = "purple"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/item/gun/ballistic/revolver/russian,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "Px" = (
 /obj/effect/landmark/blobstart,
 /obj/item/toy/crayon/purple,
@@ -1511,7 +1522,40 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/mineral/titanium/purple,
 /area/crew_quarters/bar)
-"Tj" = (
+"UJ" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/spawner/xmastree,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
+"UQ" = (
+/obj/structure/table/reinforced{
+	color = "purple"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/item/toy/crayon/purple,
+/obj/item/toy/crayon/purple,
+/obj/item/toy/crayon/purple,
+/obj/item/toy/crayon/purple,
+/obj/item/toy/crayon/purple,
+/obj/item/toy/cards/deck,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
+"Ve" = (
 /obj/structure/table/reinforced{
 	color = "purple"
 	},
@@ -1527,15 +1571,10 @@
 	throwforce = 1;
 	throwing = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
-"UJ" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/spawner/xmastree,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 
@@ -1547,11 +1586,11 @@ ab
 ab
 ab
 bH
-aW
+vF
 ab
-aW
+vF
 ab
-aW
+vF
 ab
 ab
 "}
@@ -1649,7 +1688,7 @@ bx
 bh
 df
 ar
-aW
+vF
 "}
 (8,1,1) = {"
 ab
@@ -1705,13 +1744,13 @@ at
 cd
 cf
 aW
-kV
-cJ
-Tj
-cJ
-cY
-cY
-IV
+UQ
+HO
+Ve
+HO
+KT
+KT
+rS
 bF
 ab
 "}
@@ -1736,8 +1775,8 @@ ag
 au
 aK
 ba
-bn
-bC
+BE
+nV
 aw
 aw
 cx

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_purple.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_purple.dmm
@@ -1329,28 +1329,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"pi" = (
-/obj/structure/table/reinforced{
-	color = "purple"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
-	},
-/obj/item/clothing/head/that{
-	throwforce = 1;
-	throwing = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "vD" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin{
@@ -1377,44 +1355,6 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
-"zp" = (
-/obj/structure/table/reinforced{
-	color = "purple"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
-	},
-/obj/item/gun/ballistic/revolver/russian,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
-"AB" = (
-/obj/structure/table/reinforced{
-	color = "purple"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
-	},
-/obj/item/reagent_containers/food/snacks/burger/purple,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "BD" = (
@@ -1511,10 +1451,48 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"Lt" = (
+/obj/structure/table/reinforced{
+	color = "purple"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/item/reagent_containers/food/snacks/burger/purple,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "Px" = (
 /obj/effect/landmark/blobstart,
 /obj/item/toy/crayon/purple,
 /turf/open/floor/plating,
+/area/crew_quarters/bar)
+"QV" = (
+/obj/structure/table/reinforced{
+	color = "purple"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/item/gun/ballistic/revolver/russian,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "SV" = (
 /obj/structure/chair/comfy/brown{
@@ -1525,28 +1503,7 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/mineral/titanium/purple,
 /area/crew_quarters/bar)
-"UJ" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/spawner/xmastree,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
-"WM" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"WY" = (
+"TH" = (
 /obj/structure/table/reinforced{
 	color = "purple"
 	},
@@ -1564,12 +1521,55 @@
 /obj/item/toy/crayon/purple,
 /obj/item/toy/crayon/purple,
 /obj/item/toy/cards/deck,
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
-	name = "privacy shutters"
+	name = "bar shutters"
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"UJ" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/spawner/xmastree,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
+"Vc" = (
+/obj/structure/table/reinforced{
+	color = "purple"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/item/clothing/head/that{
+	throwforce = 1;
+	throwing = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
+"WM" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "YX" = (
 /obj/item/storage/secure/safe{
 	pixel_x = 1;
@@ -1744,12 +1744,12 @@ at
 cd
 cf
 aW
-WY
-AB
-pi
-AB
-zp
-zp
+TH
+Lt
+Vc
+Lt
+QV
+QV
 Ki
 bF
 ab

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_spacious.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_spacious.dmm
@@ -925,6 +925,20 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"dn" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/bar)
 "fo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -934,15 +948,6 @@
 	name = "bar shutters";
 	pixel_x = 4;
 	pixel_y = 28
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/bar)
-"hU" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/bar)
@@ -962,15 +967,6 @@
 	name = "privacy shutters"
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/bar)
-"ny" = (
-/obj/machinery/holopad,
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/bar)
 "nP" = (
 /obj/structure/table,
@@ -996,6 +992,14 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"qv" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/bar)
 "rr" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -1005,6 +1009,15 @@
 /obj/machinery/door/window/westright,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"ti" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/bar)
 "vL" = (
 /obj/machinery/smartfridge/drinks,
 /obj/machinery/door/poddoor/preopen{
@@ -1013,42 +1026,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/bar)
-"yc" = (
+"xj" = (
+/obj/machinery/holopad,
 /obj/structure/table/reinforced,
-/obj/item/clothing/head/hardhat/cakehat,
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/bar)
-"BN" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/bar)
-"Dm" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/bar)
-"DB" = (
-/obj/machinery/chem_dispenser/drinks,
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
+	name = "bar shutters"
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/bar)
@@ -1076,9 +1059,40 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"Ft" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/hardhat/cakehat,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/bar)
+"Ij" = (
+/obj/machinery/chem_dispenser/drinks,
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/bar)
 "Lp" = (
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"PW" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/bar)
 "Rx" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only,
@@ -1098,20 +1112,6 @@
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"Wo" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/bar)
 "Wu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -1209,10 +1209,10 @@ cQ
 cT
 ba
 cI
-yc
-hU
-ny
-Dm
+Ft
+ti
+xj
+qv
 cI
 ba
 ct
@@ -1225,10 +1225,10 @@ Lp
 cT
 ba
 cI
-Dm
+qv
 bj
 bj
-Dm
+qv
 lI
 ba
 lR
@@ -1241,10 +1241,10 @@ cR
 cU
 ba
 cI
-Dm
+qv
 bj
 bj
-Dm
+qv
 cI
 ba
 ct
@@ -1257,10 +1257,10 @@ ba
 ba
 ba
 cI
-Dm
+qv
 bj
 bj
-Dm
+qv
 cI
 cl
 cu
@@ -1273,10 +1273,10 @@ ba
 ba
 ba
 cI
-Dm
+qv
 bj
 bj
-Dm
+qv
 lI
 cm
 ab
@@ -1289,10 +1289,10 @@ aS
 ba
 ba
 cI
-Dm
+qv
 bj
 bj
-Dm
+qv
 cI
 bE
 ab
@@ -1303,12 +1303,12 @@ ab
 ab
 ab
 Eu
-Wo
-BN
-DB
+dn
+PW
+Ij
 cE
 bj
-Dm
+qv
 cI
 co
 ab
@@ -1324,7 +1324,7 @@ bj
 bj
 bj
 bj
-Dm
+qv
 cM
 cp
 ab

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_spacious.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_spacious.dmm
@@ -5,18 +5,6 @@
 "ab" = (
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"ad" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_access_txt = "12"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "ae" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -937,6 +925,27 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"fo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = 4;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/bar)
+"hU" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/bar)
 "lI" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/turf_decal/tile/bar,
@@ -946,8 +955,17 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"mg" = (
-/obj/machinery/smartfridge/drinks,
+"lR" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
+"ny" = (
+/obj/machinery/holopad,
+/obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
@@ -966,14 +984,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"ou" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/bar)
 "pB" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -995,35 +1005,47 @@
 /obj/machinery/door/window/westright,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"uj" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
-"vg" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+"vL" = (
+/obj/machinery/smartfridge/drinks,
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/bar)
-"xu" = (
+"yc" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/hardhat/cakehat,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/bar)
+"BN" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/item/book/manual/wiki/barman_recipes,
 /obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/bar)
+"Dm" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/bar)
+"DB" = (
+/obj/machinery/chem_dispenser/drinks,
+/obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
@@ -1054,39 +1076,21 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"Hf" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/bar)
-"Jb" = (
-/obj/machinery/chem_dispenser/drinks,
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/bar)
 "Lp" = (
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"Sl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"Rx" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters";
-	pixel_x = 4;
-	pixel_y = 28
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	req_access_txt = "12"
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/bar)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "Sp" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -1095,9 +1099,14 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"Va" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/hardhat/cakehat,
+"Wo" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
@@ -1111,15 +1120,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"XK" = (
-/obj/machinery/holopad,
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/bar)
 
 (1,1,1) = {"
 aa
@@ -1129,11 +1129,11 @@ an
 an
 ab
 bm
-uj
+lR
 ab
-uj
+lR
 ab
-uj
+lR
 ab
 ab
 "}
@@ -1209,10 +1209,10 @@ cQ
 cT
 ba
 cI
-Va
-Hf
-XK
-ou
+yc
+hU
+ny
+Dm
 cI
 ba
 ct
@@ -1225,13 +1225,13 @@ Lp
 cT
 ba
 cI
-ou
+Dm
 bj
 bj
-ou
+Dm
 lI
 ba
-uj
+lR
 "}
 (8,1,1) = {"
 an
@@ -1241,10 +1241,10 @@ cR
 cU
 ba
 cI
-ou
+Dm
 bj
 bj
-ou
+Dm
 cI
 ba
 ct
@@ -1257,26 +1257,26 @@ ba
 ba
 ba
 cI
-ou
+Dm
 bj
 bj
-ou
+Dm
 cI
 cl
 cu
 "}
 (10,1,1) = {"
-ad
+Rx
 ae
 ba
 ba
 ba
 ba
 cI
-ou
+Dm
 bj
 bj
-ou
+Dm
 lI
 cm
 ab
@@ -1289,10 +1289,10 @@ aS
 ba
 ba
 cI
-ou
+Dm
 bj
 bj
-ou
+Dm
 cI
 bE
 ab
@@ -1303,12 +1303,12 @@ ab
 ab
 ab
 Eu
-vg
-xu
-Jb
+Wo
+BN
+DB
 cE
 bj
-ou
+Dm
 cI
 co
 ab
@@ -1319,12 +1319,12 @@ ao
 as
 aD
 ab
-Sl
+fo
 bj
 bj
 bj
 bj
-ou
+Dm
 cM
 cp
 ab
@@ -1356,7 +1356,7 @@ bD
 bj
 bj
 bj
-mg
+vL
 ba
 ba
 ab

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_spacious.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_spacious.dmm
@@ -473,21 +473,6 @@
 "bj" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/bar)
-"bk" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/bar)
-"bl" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/hardhat/cakehat,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/bar)
 "bm" = (
 /obj/effect/landmark/event_spawn,
 /turf/closed/wall,
@@ -570,34 +555,10 @@
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"bw" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "barShutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "bx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/bar)
-"by" = (
-/obj/machinery/button/door{
-	id = "barShutters";
-	name = "bar shutters";
-	pixel_x = 4;
-	pixel_y = 28
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/bar)
-"bz" = (
-/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/bar)
 "bA" = (
@@ -879,25 +840,11 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"cy" = (
-/obj/machinery/chem_dispenser/drinks,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/bar)
 "cz" = (
 /obj/machinery/door/window/southright{
 	name = "Bar Door";
 	req_one_access_txt = "25;28"
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/bar)
-"cA" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/bar)
 "cC" = (
@@ -908,18 +855,8 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"cD" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/bar)
 "cE" = (
 /obj/effect/landmark/start/bartender,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/bar)
-"cF" = (
-/obj/machinery/holopad,
-/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/bar)
 "cG" = (
@@ -948,10 +885,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"cN" = (
-/obj/machinery/smartfridge/drinks,
-/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/bar)
 "cO" = (
 /obj/structure/table/wood,
@@ -1013,6 +946,14 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"mg" = (
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/bar)
 "nP" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin{
@@ -1025,6 +966,14 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"ou" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/bar)
 "pB" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -1046,6 +995,41 @@
 /obj/machinery/door/window/westright,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"uj" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
+"vg" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/bar)
+"xu" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/bar)
 "Eu" = (
 /obj/structure/sign/plaques/deempisi,
 /turf/closed/wall,
@@ -1070,9 +1054,39 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"Hf" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/bar)
+"Jb" = (
+/obj/machinery/chem_dispenser/drinks,
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/bar)
 "Lp" = (
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"Sl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = 4;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/bar)
 "Sp" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -1081,12 +1095,30 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"Va" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/hardhat/cakehat,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/bar)
 "Wu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8;
 	icon_state = "vent_map_on-1"
 	},
 /turf/open/floor/wood,
+/area/crew_quarters/bar)
+"XK" = (
+/obj/machinery/holopad,
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/bar)
 
 (1,1,1) = {"
@@ -1097,11 +1129,11 @@ an
 an
 ab
 bm
-bw
+uj
 ab
-bw
+uj
 ab
-bw
+uj
 ab
 ab
 "}
@@ -1177,10 +1209,10 @@ cQ
 cT
 ba
 cI
-bl
-cD
-cF
-bz
+Va
+Hf
+XK
+ou
 cI
 ba
 ct
@@ -1193,13 +1225,13 @@ Lp
 cT
 ba
 cI
-bz
+ou
 bj
 bj
-bz
+ou
 lI
 ba
-bw
+uj
 "}
 (8,1,1) = {"
 an
@@ -1209,10 +1241,10 @@ cR
 cU
 ba
 cI
-bz
+ou
 bj
 bj
-bz
+ou
 cI
 ba
 ct
@@ -1225,10 +1257,10 @@ ba
 ba
 ba
 cI
-bz
+ou
 bj
 bj
-bz
+ou
 cI
 cl
 cu
@@ -1241,10 +1273,10 @@ ba
 ba
 ba
 cI
-bz
+ou
 bj
 bj
-bz
+ou
 lI
 cm
 ab
@@ -1257,10 +1289,10 @@ aS
 ba
 ba
 cI
-bz
+ou
 bj
 bj
-bz
+ou
 cI
 bE
 ab
@@ -1271,12 +1303,12 @@ ab
 ab
 ab
 Eu
-bk
-cA
-cy
+vg
+xu
+Jb
 cE
 bj
-bz
+ou
 cI
 co
 ab
@@ -1287,12 +1319,12 @@ ao
 as
 aD
 ab
-by
+Sl
 bj
 bj
 bj
 bj
-bz
+ou
 cM
 cp
 ab
@@ -1324,7 +1356,7 @@ bD
 bj
 bj
 bj
-cN
+mg
 ba
 ba
 ab

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_spacious.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_spacious.dmm
@@ -939,18 +939,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/bar)
-"fo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters";
-	pixel_x = 4;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/bar)
 "lI" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/turf_decal/tile/bar,
@@ -997,6 +985,18 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
 	name = "bar shutters"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/bar)
+"qE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_y = 24;
+	req_access_txt = "25"
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/bar)
@@ -1319,7 +1319,7 @@ ao
 as
 aD
 ab
-fo
+qE
 bj
 bj
 bj

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_trek.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_trek.dmm
@@ -1326,6 +1326,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
+"Cd" = (
+/obj/machinery/computer,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_y = 24;
+	req_access_txt = "25"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/crew_quarters/bar)
 "Eh" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only,
@@ -1452,25 +1472,6 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
 	name = "bar shutters"
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/crew_quarters/bar)
-"Qb" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters";
-	pixel_x = -26;
-	pixel_y = 24
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/crew_quarters/bar)
@@ -1707,7 +1708,7 @@ ay
 aP
 aZ
 ag
-bp
+Cd
 aL
 aM
 bX
@@ -1723,7 +1724,7 @@ ae
 aR
 bb
 bl
-Qb
+aM
 bz
 bO
 aM

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_trek.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_trek.dmm
@@ -608,20 +608,6 @@
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/bar)
-"bk" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/crew_quarters/bar)
 "bl" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -636,16 +622,6 @@
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium,
-/area/crew_quarters/bar)
-"bm" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
 /area/crew_quarters/bar)
 "bn" = (
 /obj/effect/landmark/blobstart,
@@ -682,26 +658,6 @@
 /obj/machinery/gibber,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"bt" = (
-/obj/machinery/button/door{
-	id = "barShutters";
-	name = "bar shutters";
-	pixel_x = 4;
-	pixel_y = 28
-	},
-/obj/machinery/computer,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/crew_quarters/bar)
 "bu" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -726,17 +682,6 @@
 "bw" = (
 /obj/machinery/holopad,
 /turf/open/floor/mineral/titanium/blue,
-/area/crew_quarters/bar)
-"bx" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/mineral/titanium/white,
 /area/crew_quarters/bar)
 "bz" = (
 /obj/machinery/light{
@@ -860,20 +805,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
-"bN" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/crew_quarters/bar)
 "bO" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -888,22 +819,6 @@
 /mob/living/carbon/monkey/punpun,
 /turf/open/floor/mineral/titanium/white,
 /area/crew_quarters/bar)
-"bP" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barShutters";
-	name = "privacy shutters"
-	},
-/obj/item/reagent_containers/food/snacks/spacetwinkie,
-/obj/machinery/door/window/westright,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/kitchen)
 "bQ" = (
 /turf/open/floor/mineral/titanium,
 /area/crew_quarters/kitchen)
@@ -977,14 +892,6 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/crew_quarters/bar)
-"bY" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "barShutters";
-	name = "privacy shutters"
-	},
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "bZ" = (
 /obj/machinery/requests_console{
 	department = "Bar";
@@ -1044,22 +951,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mineral/titanium,
 /area/crew_quarters/kitchen)
-"ch" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/snacks/pie/cream,
-/obj/machinery/door/poddoor/preopen{
-	id = "barShutters";
-	name = "privacy shutters"
-	},
-/obj/machinery/door/window/westright,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/kitchen)
 "ci" = (
 /obj/effect/turf_decal/stripes{
 	dir = 4;
@@ -1107,20 +998,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium/white,
-/area/crew_quarters/bar)
-"cp" = (
-/obj/machinery/smartfridge/drinks,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/mineral/titanium/white,
 /area/crew_quarters/bar)
 "cq" = (
@@ -1384,22 +1261,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"cM" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/turf/open/floor/mineral/titanium/white,
-/area/crew_quarters/bar)
 "cN" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/chair/comfy/shuttle{
@@ -1423,6 +1284,43 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/crew_quarters/bar)
+"gN" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = -26;
+	pixel_y = 24
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/crew_quarters/bar)
+"mS" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/crew_quarters/bar)
 "ni" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets{
@@ -1431,6 +1329,89 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/crew_quarters/kitchen)
+"qg" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/crew_quarters/bar)
+"rV" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/crew_quarters/bar)
+"tj" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/pie/cream,
+/obj/machinery/door/window/westright,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/kitchen)
+"ua" = (
+/obj/machinery/smartfridge/drinks,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/crew_quarters/bar)
+"IL" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/crew_quarters/bar)
 "MN" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin{
@@ -1454,6 +1435,48 @@
 	pixel_y = 3
 	},
 /turf/open/floor/mineral/titanium,
+/area/crew_quarters/kitchen)
+"PF" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
+"Qy" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/crew_quarters/bar)
+"QZ" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/spacetwinkie,
+/obj/machinery/door/window/westright,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "Rz" = (
 /obj/structure/sign/plaques/deempisi,
@@ -1480,11 +1503,11 @@ aa
 ag
 ag
 ag
-bY
+PF
 bC
-bY
+PF
 ag
-bY
+PF
 ag
 ag
 ag
@@ -1600,7 +1623,7 @@ aI
 aI
 aI
 aM
-bY
+PF
 "}
 (9,1,1) = {"
 ag
@@ -1639,13 +1662,13 @@ ag
 ax
 aO
 aY
-bk
-bm
-bx
-bN
-bN
-bN
-bN
+mS
+qg
+IL
+Qy
+Qy
+Qy
+Qy
 aL
 cD
 ag
@@ -1661,7 +1684,7 @@ aL
 aM
 aM
 aM
-bN
+Qy
 aL
 cE
 ag
@@ -1672,12 +1695,12 @@ ay
 aP
 aZ
 ag
-bt
+bp
 aL
 aM
 bX
 aM
-cM
+rV
 ct
 aM
 ag
@@ -1688,7 +1711,7 @@ ae
 aR
 bb
 bl
-aM
+gN
 bz
 bO
 aM
@@ -1709,7 +1732,7 @@ bA
 aM
 bZ
 aM
-cp
+ua
 aM
 cI
 ag
@@ -1722,9 +1745,9 @@ ag
 ag
 al
 bM
-bP
+QZ
 al
-ch
+tj
 bM
 cu
 al

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_trek.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_trek.dmm
@@ -2,18 +2,6 @@
 "aa" = (
 /turf/template_noop,
 /area/template_noop)
-"ab" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_access_txt = "12"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "ac" = (
 /obj/item/reagent_containers/food/drinks/shaker,
 /obj/item/stack/spacecash/c10,
@@ -1284,66 +1272,7 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"gN" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters";
-	pixel_x = -26;
-	pixel_y = 24
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/crew_quarters/bar)
-"mS" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/crew_quarters/bar)
-"ni" = (
-/obj/structure/table,
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/turf/open/floor/mineral/titanium,
-/area/crew_quarters/kitchen)
-"qg" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/crew_quarters/bar)
-"rV" = (
+"fm" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -1363,9 +1292,25 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/crew_quarters/bar)
-"tj" = (
+"ni" = (
+/obj/structure/table,
+/obj/item/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/mineral/titanium,
+/area/crew_quarters/kitchen)
+"qW" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
+"zM" = (
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/snacks/pie/cream,
+/obj/item/reagent_containers/food/snacks/spacetwinkie,
 /obj/machinery/door/window/westright,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -1379,7 +1324,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
-"ua" = (
+"Ai" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/crew_quarters/bar)
+"Eh" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"FT" = (
 /obj/machinery/smartfridge/drinks,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -1397,7 +1368,7 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/crew_quarters/bar)
-"IL" = (
+"Lb" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1405,7 +1376,10 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
@@ -1436,16 +1410,22 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/crew_quarters/kitchen)
-"PF" = (
-/obj/effect/spawner/structure/window/shuttle,
+"NC" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/mineral/titanium/white,
 /area/crew_quarters/bar)
-"Qy" = (
-/obj/structure/table/reinforced,
+"Qb" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -1456,28 +1436,14 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/button/door{
 	id = "barshutters";
-	name = "privacy shutters"
+	name = "bar shutters";
+	pixel_x = -26;
+	pixel_y = 24
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/crew_quarters/bar)
-"QZ" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/snacks/spacetwinkie,
-/obj/machinery/door/window/westright,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/kitchen)
 "Rz" = (
 /obj/structure/sign/plaques/deempisi,
 /turf/closed/wall,
@@ -1496,6 +1462,40 @@
 /obj/item/twohanded/required/kirbyplants/photosynthetic,
 /turf/open/floor/mineral/titanium/white,
 /area/crew_quarters/bar)
+"Sl" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/pie/cream,
+/obj/machinery/door/window/westright,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/kitchen)
+"Xi" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/crew_quarters/bar)
 
 (1,1,1) = {"
 aa
@@ -1503,11 +1503,11 @@ aa
 ag
 ag
 ag
-PF
+qW
 bC
-PF
+qW
 ag
-PF
+qW
 ag
 ag
 ag
@@ -1623,7 +1623,7 @@ aI
 aI
 aI
 aM
-PF
+qW
 "}
 (9,1,1) = {"
 ag
@@ -1642,7 +1642,7 @@ aM
 cL
 "}
 (10,1,1) = {"
-ab
+Eh
 aw
 aN
 aN
@@ -1662,13 +1662,13 @@ ag
 ax
 aO
 aY
-mS
-qg
-IL
-Qy
-Qy
-Qy
-Qy
+Lb
+Ai
+NC
+Xi
+Xi
+Xi
+Xi
 aL
 cD
 ag
@@ -1684,7 +1684,7 @@ aL
 aM
 aM
 aM
-Qy
+Xi
 aL
 cE
 ag
@@ -1700,7 +1700,7 @@ aL
 aM
 bX
 aM
-rV
+fm
 ct
 aM
 ag
@@ -1711,7 +1711,7 @@ ae
 aR
 bb
 bl
-gN
+Qb
 bz
 bO
 aM
@@ -1732,7 +1732,7 @@ bA
 aM
 bZ
 aM
-ua
+FT
 aM
 cI
 ag
@@ -1745,9 +1745,9 @@ ag
 ag
 al
 bM
-QZ
+zM
 al
-tj
+Sl
 bM
 cu
 al

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_trek.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_trek.dmm
@@ -1272,23 +1272,25 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"fm" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+"ek" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/crew_quarters/bar)
@@ -1324,20 +1326,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
-"Ai" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/crew_quarters/bar)
 "Eh" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only,
@@ -1368,7 +1356,25 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/crew_quarters/bar)
-"Lb" = (
+"GB" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/crew_quarters/bar)
+"GZ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1376,13 +1382,14 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
+/obj/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/crew_quarters/bar)
@@ -1410,7 +1417,27 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/crew_quarters/kitchen)
-"NC" = (
+"Nh" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/crew_quarters/bar)
+"Pz" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1418,10 +1445,13 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/crew_quarters/bar)
@@ -1478,24 +1508,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
-"Xi" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/crew_quarters/bar)
 
 (1,1,1) = {"
 aa
@@ -1662,13 +1674,13 @@ ag
 ax
 aO
 aY
-Lb
-Ai
-NC
-Xi
-Xi
-Xi
-Xi
+ek
+Pz
+GZ
+GB
+GB
+GB
+GB
 aL
 cD
 ag
@@ -1684,7 +1696,7 @@ aL
 aM
 aM
 aM
-Xi
+GB
 aL
 cE
 ag
@@ -1700,7 +1712,7 @@ aL
 aM
 bX
 aM
-fm
+Nh
 ct
 aM
 ag

--- a/_maps/RandomRuins/StationRuins/EclipseStation/ebar_beach.dmm
+++ b/_maps/RandomRuins/StationRuins/EclipseStation/ebar_beach.dmm
@@ -161,6 +161,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"fh" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "fw" = (
 /obj/machinery/camera{
 	c_tag = "Bar North"
@@ -242,21 +257,6 @@
 	},
 /obj/effect/turf_decal/sand,
 /turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"jo" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "jp" = (
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -416,6 +416,17 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"qZ" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "rl" = (
 /obj/item/toy/beach_ball,
 /turf/open/floor/plating/beach/sand,
@@ -587,18 +598,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"xd" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/tequila,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "xC" = (
 /obj/effect/turf_decal/sand,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -756,17 +755,6 @@
 "CL" = (
 /obj/effect/turf_decal/sand,
 /turf/open/floor/plating/beach/sand,
-/area/crew_quarters/bar)
-"Di" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/stripes/asteroid/line,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "Dm" = (
 /obj/effect/spawner/structure/window,
@@ -1099,17 +1087,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"MW" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 10
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "Nk" = (
 /obj/machinery/light,
 /obj/machinery/disposal/bin,
@@ -1118,6 +1095,17 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"Ns" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 10
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "NK" = (
 /obj/effect/turf_decal/sand,
 /obj/structure/chair/stool/bar,
@@ -1223,6 +1211,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"Uo" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/tequila,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "UD" = (
 /turf/open/floor/plating/beach/coastline_t{
 	dir = 4
@@ -1313,17 +1313,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"XC" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "Yn" = (
 /turf/closed/wall,
 /area/crew_quarters/bar)
@@ -1357,6 +1346,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"ZF" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/stripes/asteroid/line,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "ZP" = (
@@ -1594,11 +1594,11 @@ Js
 Ld
 Yn
 Yn
-jo
-XC
-xd
-XC
-MW
+fh
+qZ
+Uo
+qZ
+Ns
 sW
 OU
 Ty
@@ -1618,7 +1618,7 @@ pk
 pk
 Kl
 pk
-Di
+ZF
 sW
 OU
 mv

--- a/_maps/RandomRuins/StationRuins/EclipseStation/ebar_beach.dmm
+++ b/_maps/RandomRuins/StationRuins/EclipseStation/ebar_beach.dmm
@@ -79,6 +79,15 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"bV" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "bW" = (
 /obj/structure/table/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -138,14 +147,6 @@
 "cY" = (
 /obj/item/reagent_containers/spray/spraytan,
 /turf/open/floor/plating/beach/sand,
-/area/crew_quarters/bar)
-"dg" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
 /area/crew_quarters/bar)
 "dm" = (
 /obj/effect/turf_decal/sand,
@@ -242,6 +243,21 @@
 /obj/effect/turf_decal/sand,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"jo" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "jp" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = 32
@@ -276,18 +292,6 @@
 "kD" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plating/beach/sand,
-/area/crew_quarters/bar)
-"lh" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/tequila,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "lp" = (
 /obj/structure/table,
@@ -372,6 +376,15 @@
 /area/crew_quarters/bar)
 "pk" = (
 /turf/open/floor/wood,
+/area/crew_quarters/bar)
+"pv" = (
+/obj/structure/sign/barsign,
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
 /area/crew_quarters/bar)
 "px" = (
 /obj/structure/window/reinforced{
@@ -574,6 +587,18 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"xd" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/tequila,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "xC" = (
 /obj/effect/turf_decal/sand,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -732,6 +757,25 @@
 /obj/effect/turf_decal/sand,
 /turf/open/floor/plating/beach/sand,
 /area/crew_quarters/bar)
+"Di" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/stripes/asteroid/line,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"Dm" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "Dv" = (
 /turf/closed/wall/mineral/sandstone,
 /area/crew_quarters/kitchen)
@@ -785,15 +829,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"EN" = (
-/obj/effect/turf_decal/stripes/asteroid/line,
-/obj/machinery/smartfridge/drinks,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "Fj" = (
 /obj/effect/turf_decal/sand,
 /obj/machinery/holopad,
@@ -840,17 +875,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"GR" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "Hb" = (
 /obj/machinery/vending/dinnerware{
 	contraband = list(/obj/item/kitchen/rollingpin = 2, /obj/item/kitchen/knife/butcher = 2, /obj/item/reagent_containers/food/condiment/flour = 4)
@@ -874,17 +898,6 @@
 "HW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"HZ" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 10
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -986,15 +999,6 @@
 /obj/item/instrument/eguitar,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"Kd" = (
-/obj/structure/sign/barsign,
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "Kl" = (
 /obj/effect/landmark/start/bartender,
 /turf/open/floor/wood,
@@ -1095,6 +1099,17 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"MW" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 10
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "Nk" = (
 /obj/machinery/light,
 /obj/machinery/disposal/bin,
@@ -1158,17 +1173,6 @@
 "PY" = (
 /obj/effect/overlay/coconut,
 /turf/open/floor/plating/beach/sand,
-/area/crew_quarters/bar)
-"QQ" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/stripes/asteroid/line,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "RB" = (
 /obj/machinery/light/small,
@@ -1309,14 +1313,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"Xc" = (
+"XC" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp,
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
@@ -1378,13 +1378,13 @@ ai
 ai
 Js
 Js
-dg
+Dm
 Js
 Js
-dg
+Dm
 Js
 Js
-dg
+Dm
 Js
 Js
 "}
@@ -1506,7 +1506,7 @@ Aw
 Wj
 CL
 OU
-Kd
+pv
 "}
 (8,1,1) = {"
 Js
@@ -1526,7 +1526,7 @@ oQ
 Wj
 CL
 OU
-dg
+Dm
 "}
 (9,1,1) = {"
 Js
@@ -1594,11 +1594,11 @@ Js
 Ld
 Yn
 Yn
-Xc
-GR
-lh
-GR
-HZ
+jo
+XC
+xd
+XC
+MW
 sW
 OU
 Ty
@@ -1618,7 +1618,7 @@ pk
 pk
 Kl
 pk
-QQ
+Di
 sW
 OU
 mv
@@ -1638,7 +1638,7 @@ Jv
 vh
 tI
 pk
-EN
+bV
 OU
 OU
 eZ

--- a/_maps/RandomRuins/StationRuins/EclipseStation/ebar_beach.dmm
+++ b/_maps/RandomRuins/StationRuins/EclipseStation/ebar_beach.dmm
@@ -139,18 +139,19 @@
 /obj/item/reagent_containers/spray/spraytan,
 /turf/open/floor/plating/beach/sand,
 /area/crew_quarters/bar)
+"dg" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "dm" = (
 /obj/effect/turf_decal/sand,
 /obj/structure/table/wood,
 /obj/item/instrument/guitar,
 /turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"dy" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/stripes/asteroid/line,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "eZ" = (
 /obj/effect/turf_decal/sand,
@@ -174,17 +175,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"gm" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "gE" = (
 /obj/machinery/firealarm{
@@ -227,11 +217,6 @@
 /area/crew_quarters/kitchen)
 "hX" = (
 /turf/open/floor/plating/beach/coastline_t/sandwater_inner,
-/area/crew_quarters/bar)
-"ie" = (
-/obj/structure/sign/barsign,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
 /area/crew_quarters/bar)
 "ip" = (
 /turf/template_noop,
@@ -288,14 +273,21 @@
 /obj/effect/spawner/lootdrop/mob/kitchen_animal,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"km" = (
-/obj/effect/turf_decal/stripes/asteroid/line,
-/obj/machinery/smartfridge/drinks,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "kD" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plating/beach/sand,
+/area/crew_quarters/bar)
+"lh" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/tequila,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "lp" = (
 /obj/structure/table,
@@ -728,14 +720,6 @@
 /obj/effect/turf_decal/sand,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"Cu" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/tequila,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "Cz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -762,13 +746,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"Ea" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "Eg" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/wood,
@@ -807,6 +784,15 @@
 	network = list("SS13")
 	},
 /turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"EN" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "Fj" = (
 /obj/effect/turf_decal/sand,
@@ -854,6 +840,17 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"GR" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "Hb" = (
 /obj/machinery/vending/dinnerware{
 	contraband = list(/obj/item/kitchen/rollingpin = 2, /obj/item/kitchen/knife/butcher = 2, /obj/item/reagent_containers/food/condiment/flour = 4)
@@ -877,6 +874,17 @@
 "HW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"HZ" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 10
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -977,6 +985,15 @@
 /obj/structure/table/wood,
 /obj/item/instrument/eguitar,
 /turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"Kd" = (
+/obj/structure/sign/barsign,
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
 /area/crew_quarters/bar)
 "Kl" = (
 /obj/effect/landmark/start/bartender,
@@ -1101,13 +1118,6 @@
 	dir = 2
 	},
 /area/crew_quarters/bar)
-"OQ" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 10
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "OU" = (
 /obj/effect/turf_decal/sand,
 /turf/open/floor/plasteel,
@@ -1148,6 +1158,17 @@
 "PY" = (
 /obj/effect/overlay/coconut,
 /turf/open/floor/plating/beach/sand,
+/area/crew_quarters/bar)
+"QQ" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/stripes/asteroid/line,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "RB" = (
 /obj/machinery/light/small,
@@ -1280,10 +1301,6 @@
 /mob/living/simple_animal/bot/honkbot,
 /turf/open/floor/plating/beach/sand,
 /area/crew_quarters/bar)
-"WK" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "Xb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -1292,6 +1309,21 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"Xc" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "Yn" = (
 /turf/closed/wall,
 /area/crew_quarters/bar)
@@ -1346,13 +1378,13 @@ ai
 ai
 Js
 Js
-WK
+dg
 Js
 Js
-WK
+dg
 Js
 Js
-WK
+dg
 Js
 Js
 "}
@@ -1474,7 +1506,7 @@ Aw
 Wj
 CL
 OU
-ie
+Kd
 "}
 (8,1,1) = {"
 Js
@@ -1494,7 +1526,7 @@ oQ
 Wj
 CL
 OU
-WK
+dg
 "}
 (9,1,1) = {"
 Js
@@ -1562,11 +1594,11 @@ Js
 Ld
 Yn
 Yn
-gm
-Ea
-Cu
-Ea
-OQ
+Xc
+GR
+lh
+GR
+HZ
 sW
 OU
 Ty
@@ -1586,7 +1618,7 @@ pk
 pk
 Kl
 pk
-dy
+QQ
 sW
 OU
 mv
@@ -1606,7 +1638,7 @@ Jv
 vh
 tI
 pk
-km
+EN
 OU
 OU
 eZ

--- a/_maps/RandomRuins/StationRuins/EclipseStation/ebar_casino.dmm
+++ b/_maps/RandomRuins/StationRuins/EclipseStation/ebar_casino.dmm
@@ -221,6 +221,16 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
+"km" = (
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/drinks,
+/obj/machinery/door/window/westright,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "kw" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /obj/machinery/light/small{
@@ -258,6 +268,16 @@
 	icon_state = "scrub_map_on-3"
 	},
 /turf/open/floor/carpet,
+/area/crew_quarters/bar)
+"md" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "ml" = (
 /obj/structure/chair/office/light{
@@ -362,14 +382,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"pz" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "pB" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
@@ -422,15 +434,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"qX" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "rc" = (
 /obj/machinery/button/door{
 	id = "kitchen";
@@ -682,6 +685,14 @@
 "zN" = (
 /turf/template_noop,
 /area/template_noop)
+"zU" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "zW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8;
@@ -723,16 +734,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"BE" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "BJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -790,6 +791,15 @@
 "EG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/carpet,
+/area/crew_quarters/bar)
+"EQ" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "Fg" = (
 /obj/structure/table/wood/poker,
@@ -1016,16 +1026,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/rockvault,
 /area/crew_quarters/bar)
-"Nx" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks,
-/obj/machinery/door/window/westright,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "Oi" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/showroomfloor,
@@ -1245,23 +1245,6 @@
 /obj/machinery/computer/slot_machine/casino,
 /turf/open/floor/carpet/black,
 /area/crew_quarters/bar)
-"VO" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "Wv" = (
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
@@ -1326,6 +1309,23 @@
 /area/crew_quarters/bar)
 "YX" = (
 /turf/open/floor/carpet,
+/area/crew_quarters/bar)
+"Zb" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 
 (1,1,1) = {"
@@ -1553,12 +1553,12 @@ rV
 rV
 le
 rV
-VO
-Nx
-pz
-qX
-pz
-pz
+Zb
+km
+zU
+EQ
+zU
+zU
 su
 ka
 YX
@@ -1578,7 +1578,7 @@ al
 al
 gi
 al
-BE
+md
 su
 TZ
 EG

--- a/_maps/RandomRuins/StationRuins/EclipseStation/ebar_casino.dmm
+++ b/_maps/RandomRuins/StationRuins/EclipseStation/ebar_casino.dmm
@@ -75,14 +75,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
-"bw" = (
-/obj/machinery/smartfridge/drinks,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "bC" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/head/hardhat/cakehat,
@@ -120,14 +112,6 @@
 	network = list("SS13")
 	},
 /turf/open/floor/wood,
-/area/crew_quarters/bar)
-"eO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
 /area/crew_quarters/bar)
 "gi" = (
 /obj/effect/landmark/start/bartender,
@@ -244,23 +228,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"kN" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "le" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Bar Maintenance";
@@ -377,6 +344,32 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
+"oS" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/structure/sign/plaques/deempisi{
+	pixel_y = 38
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = 25;
+	pixel_y = 24
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"pz" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "pB" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
@@ -429,6 +422,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"qX" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "rc" = (
 /obj/machinery/button/door{
 	id = "kitchen";
@@ -579,14 +581,6 @@
 /obj/machinery/light,
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
-"vR" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "vX" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = 32
@@ -676,6 +670,15 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"zB" = (
+/obj/structure/sign/barsign,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "zN" = (
 /turf/template_noop,
 /area/template_noop)
@@ -720,6 +723,16 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"BE" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "BJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -906,21 +919,20 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
+"Ju" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "JP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"Kh" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "Ko" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -932,6 +944,14 @@
 	pixel_y = -12
 	},
 /turf/open/floor/carpet/black,
+/area/crew_quarters/bar)
+"Kt" = (
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "KA" = (
 /obj/structure/window/reinforced{
@@ -996,10 +1016,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/rockvault,
 /area/crew_quarters/bar)
-"MH" = (
+"Nx" = (
 /obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
+/obj/machinery/chem_dispenser/drinks,
+/obj/machinery/door/window/westright,
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
@@ -1122,15 +1142,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
-"Tc" = (
-/obj/structure/sign/barsign,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "Tk" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -1151,16 +1162,6 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/rockvault,
-/area/crew_quarters/bar)
-"Tz" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks,
-/obj/machinery/door/window/westright,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "TP" = (
 /obj/effect/turf_decal/stripes/line{
@@ -1215,24 +1216,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"UB" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/sign/plaques/deempisi{
-	pixel_y = 38
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters";
-	pixel_x = 25;
-	pixel_y = 24
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "UK" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1261,6 +1244,23 @@
 "VK" = (
 /obj/machinery/computer/slot_machine/casino,
 /turf/open/floor/carpet/black,
+/area/crew_quarters/bar)
+"VO" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "Wv" = (
 /turf/closed/wall,
@@ -1339,8 +1339,8 @@ iu
 rV
 rV
 rV
-eO
-eO
+Ju
+Ju
 rV
 rV
 rV
@@ -1486,7 +1486,7 @@ nD
 Ko
 xC
 YX
-Tc
+zB
 "}
 (9,1,1) = {"
 rV
@@ -1506,7 +1506,7 @@ Rg
 TP
 vh
 YX
-eO
+Ju
 "}
 (10,1,1) = {"
 GK
@@ -1553,12 +1553,12 @@ rV
 rV
 le
 rV
-kN
-Tz
-vR
-Kh
-vR
-vR
+VO
+Nx
+pz
+qX
+pz
+pz
 su
 ka
 YX
@@ -1578,7 +1578,7 @@ al
 al
 gi
 al
-MH
+BE
 su
 TZ
 EG
@@ -1593,12 +1593,12 @@ zN
 zN
 zN
 rV
-UB
+oS
 Qd
 nr
 hy
 al
-bw
+Kt
 YX
 YX
 YX

--- a/_maps/RandomRuins/StationRuins/EclipseStation/ebar_casino.dmm
+++ b/_maps/RandomRuins/StationRuins/EclipseStation/ebar_casino.dmm
@@ -376,7 +376,7 @@
 	},
 /obj/machinery/button/door{
 	id = "barshutters";
-	name = "bar shutters";
+	name = "Bar Shutters Control";
 	pixel_x = 25;
 	pixel_y = 24
 	},

--- a/_maps/RandomRuins/StationRuins/EclipseStation/ebar_casino.dmm
+++ b/_maps/RandomRuins/StationRuins/EclipseStation/ebar_casino.dmm
@@ -75,6 +75,14 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
+"bw" = (
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "bC" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/head/hardhat/cakehat,
@@ -113,17 +121,13 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"eG" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
+"eO" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/sign/plaques/deempisi{
-	pixel_y = 38
-	},
-/turf/open/floor/wood,
+/turf/open/floor/plating,
 /area/crew_quarters/bar)
 "gi" = (
 /obj/effect/landmark/start/bartender,
@@ -220,11 +224,6 @@
 /obj/effect/spawner/lootdrop/mob/kitchen_animal,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"jD" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "jJ" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 28
@@ -245,8 +244,21 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"kY" = (
-/obj/machinery/smartfridge/drinks,
+"kN" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "le" = (
@@ -567,6 +579,14 @@
 /obj/machinery/light,
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
+"vR" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "vX" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = 32
@@ -701,11 +721,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"Bx" = (
-/obj/structure/sign/barsign,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "BJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -727,19 +742,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet,
-/area/crew_quarters/bar)
-"CD" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "CP" = (
 /turf/open/floor/plasteel/cafeteria,
@@ -831,12 +833,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"Ga" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks,
-/obj/machinery/door/window/westright,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "Gc" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -916,6 +912,15 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"Kh" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "Ko" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -990,6 +995,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/rockvault,
+/area/crew_quarters/bar)
+"MH" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "Oi" = (
 /obj/structure/reagent_dispensers/cooking_oil,
@@ -1107,11 +1122,14 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
-"ST" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/turf/open/floor/wood,
+"Tc" = (
+/obj/structure/sign/barsign,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
 /area/crew_quarters/bar)
 "Tk" = (
 /obj/structure/table/reinforced,
@@ -1133,6 +1151,16 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/rockvault,
+/area/crew_quarters/bar)
+"Tz" = (
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/drinks,
+/obj/machinery/door/window/westright,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "TP" = (
 /obj/effect/turf_decal/stripes/line{
@@ -1184,6 +1212,24 @@
 	},
 /obj/machinery/light{
 	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"UB" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/structure/sign/plaques/deempisi{
+	pixel_y = 38
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = 25;
+	pixel_y = 24
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -1281,10 +1327,6 @@
 "YX" = (
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
-"ZA" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 
 (1,1,1) = {"
 rV
@@ -1297,8 +1339,8 @@ iu
 rV
 rV
 rV
-tn
-tn
+eO
+eO
 rV
 rV
 rV
@@ -1444,7 +1486,7 @@ nD
 Ko
 xC
 YX
-Bx
+Tc
 "}
 (9,1,1) = {"
 rV
@@ -1464,7 +1506,7 @@ Rg
 TP
 vh
 YX
-tn
+eO
 "}
 (10,1,1) = {"
 GK
@@ -1511,12 +1553,12 @@ rV
 rV
 le
 rV
-CD
-Ga
-ZA
-jD
-ZA
-ZA
+kN
+Tz
+vR
+Kh
+vR
+vR
 su
 ka
 YX
@@ -1536,7 +1578,7 @@ al
 al
 gi
 al
-ST
+MH
 su
 TZ
 EG
@@ -1551,12 +1593,12 @@ zN
 zN
 zN
 rV
-eG
+UB
 Qd
 nr
 hy
 al
-kY
+bw
 YX
 YX
 YX

--- a/_maps/RandomRuins/StationRuins/EclipseStation/ebar_clock.dmm
+++ b/_maps/RandomRuins/StationRuins/EclipseStation/ebar_clock.dmm
@@ -177,14 +177,6 @@
 "fU" = (
 /turf/open/floor/bronze,
 /area/crew_quarters/theatre)
-"gm" = (
-/obj/item/lighter,
-/obj/structure/table/bronze,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
 "gq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -256,10 +248,16 @@
 	},
 /turf/open/floor/bronze,
 /area/crew_quarters/bar)
-"jM" = (
+"jQ" = (
+/obj/item/lighter,
 /obj/structure/table/bronze,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
 "jS" = (
@@ -281,10 +279,6 @@
 /obj/effect/spawner/lootdrop/mob/kitchen_animal,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"km" = (
-/obj/machinery/smartfridge/drinks,
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
 "kB" = (
 /obj/structure/table/bronze,
 /obj/structure/disposalpipe/segment{
@@ -343,15 +337,6 @@
 	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/kitchen)
-"lu" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
 "me" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
@@ -412,6 +397,14 @@
 "pb" = (
 /obj/structure/chair/bronze,
 /turf/open/floor/bronze,
+/area/crew_quarters/bar)
+"pk" = (
+/obj/structure/table/bronze,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
 "px" = (
 /obj/structure/window/reinforced{
@@ -729,11 +722,6 @@
 	},
 /turf/open/floor/bronze,
 /area/crew_quarters/bar)
-"Cu" = (
-/obj/item/clothing/head/that,
-/obj/structure/table/bronze,
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
 "Cz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -747,6 +735,16 @@
 /obj/structure/window/reinforced/bronze,
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/theatre)
+"DB" = (
+/obj/structure/table/bronze,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
 "DH" = (
 /obj/structure/chair/bronze{
 	dir = 4
@@ -770,10 +768,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"Ea" = (
-/obj/structure/table/bronze,
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
 "Eg" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/bronze/reebe,
@@ -793,6 +787,15 @@
 	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/kitchen)
+"Ew" = (
+/obj/item/clothing/head/that,
+/obj/structure/table/bronze,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
 "EA" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -938,6 +941,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
+"JH" = (
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
 "JQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -963,6 +974,21 @@
 	},
 /obj/item/clockwork/alloy_shards/medium,
 /turf/open/floor/bronze,
+/area/crew_quarters/bar)
+"KJ" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = 25;
+	pixel_y = 24
+	},
+/turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
 "KL" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -1578,11 +1604,11 @@ aC
 Ld
 aC
 aC
-gm
-Ea
-Cu
-Ea
-Ea
+jQ
+pk
+Ew
+pk
+pk
 xi
 kZ
 pb
@@ -1602,7 +1628,7 @@ OU
 OU
 Kl
 OU
-jM
+DB
 xi
 Hr
 ms
@@ -1617,12 +1643,12 @@ ip
 ip
 ip
 aC
-lu
+KJ
 Jv
 vh
 tI
 OU
-km
+JH
 ms
 OU
 OU

--- a/_maps/RandomRuins/StationRuins/EclipseStation/ebar_clock.dmm
+++ b/_maps/RandomRuins/StationRuins/EclipseStation/ebar_clock.dmm
@@ -154,6 +154,31 @@
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"er" = (
+/obj/structure/table/bronze,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
+"fe" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = 25;
+	pixel_y = 24
+	},
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
 "fw" = (
 /obj/machinery/camera{
 	c_tag = "Theatre Stage";
@@ -177,6 +202,14 @@
 "fU" = (
 /turf/open/floor/bronze,
 /area/crew_quarters/theatre)
+"gm" = (
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
 "gq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -247,18 +280,6 @@
 	pixel_x = 32
 	},
 /turf/open/floor/bronze,
-/area/crew_quarters/bar)
-"jQ" = (
-/obj/item/lighter,
-/obj/structure/table/bronze,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
 "jS" = (
 /obj/machinery/door/firedoor/border_only{
@@ -398,7 +419,8 @@
 /obj/structure/chair/bronze,
 /turf/open/floor/bronze,
 /area/crew_quarters/bar)
-"pk" = (
+"pn" = (
+/obj/item/clothing/head/that,
 /obj/structure/table/bronze,
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
@@ -735,16 +757,6 @@
 /obj/structure/window/reinforced/bronze,
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/theatre)
-"DB" = (
-/obj/structure/table/bronze,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
 "DH" = (
 /obj/structure/chair/bronze{
 	dir = 4
@@ -768,6 +780,18 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"Ef" = (
+/obj/item/lighter,
+/obj/structure/table/bronze,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
 "Eg" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/bronze/reebe,
@@ -787,15 +811,6 @@
 	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/kitchen)
-"Ew" = (
-/obj/item/clothing/head/that,
-/obj/structure/table/bronze,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
 "EA" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -941,14 +956,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
-"JH" = (
-/obj/machinery/smartfridge/drinks,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
 "JQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -974,21 +981,6 @@
 	},
 /obj/item/clockwork/alloy_shards/medium,
 /turf/open/floor/bronze,
-/area/crew_quarters/bar)
-"KJ" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters";
-	pixel_x = 25;
-	pixel_y = 24
-	},
-/turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
 "KL" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -1145,6 +1137,14 @@
 /obj/item/reagent_containers/food/snacks/spaghetti/boiledspaghetti,
 /obj/item/reagent_containers/food/snacks/spaghetti/boiledspaghetti{
 	pixel_y = 12
+	},
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
+"QP" = (
+/obj/structure/table/bronze,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
 	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
@@ -1604,11 +1604,11 @@ aC
 Ld
 aC
 aC
-jQ
-pk
-Ew
-pk
-pk
+Ef
+QP
+pn
+QP
+QP
 xi
 kZ
 pb
@@ -1628,7 +1628,7 @@ OU
 OU
 Kl
 OU
-DB
+er
 xi
 Hr
 ms
@@ -1643,12 +1643,12 @@ ip
 ip
 ip
 aC
-KJ
+fe
 Jv
 vh
 tI
 OU
-JH
+gm
 ms
 OU
 OU

--- a/_maps/RandomRuins/StationRuins/EclipseStation/ebar_clock.dmm
+++ b/_maps/RandomRuins/StationRuins/EclipseStation/ebar_clock.dmm
@@ -154,16 +154,6 @@
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"er" = (
-/obj/structure/table/bronze,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
 "fe" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 28
@@ -207,6 +197,16 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
+	},
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
+"gp" = (
+/obj/structure/table/bronze,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
 	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
@@ -419,15 +419,6 @@
 /obj/structure/chair/bronze,
 /turf/open/floor/bronze,
 /area/crew_quarters/bar)
-"pn" = (
-/obj/item/clothing/head/that,
-/obj/structure/table/bronze,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
 "px" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -454,6 +445,14 @@
 "pW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
+	},
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
+"pZ" = (
+/obj/structure/table/bronze,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
 	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
@@ -780,18 +779,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"Ef" = (
-/obj/item/lighter,
-/obj/structure/table/bronze,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
 "Eg" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/bronze/reebe,
@@ -1106,6 +1093,15 @@
 /obj/item/toy/plush/plushvar,
 /turf/open/floor/bronze,
 /area/crew_quarters/bar)
+"OL" = (
+/obj/item/clothing/head/that,
+/obj/structure/table/bronze,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
 "OR" = (
 /obj/machinery/computer/arcade/amputation,
 /turf/open/floor/bronze,
@@ -1137,14 +1133,6 @@
 /obj/item/reagent_containers/food/snacks/spaghetti/boiledspaghetti,
 /obj/item/reagent_containers/food/snacks/spaghetti/boiledspaghetti{
 	pixel_y = 12
-	},
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
-"QP" = (
-/obj/structure/table/bronze,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
 	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
@@ -1289,6 +1277,18 @@
 	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/kitchen)
+"WG" = (
+/obj/item/lighter,
+/obj/structure/table/bronze,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
 "WH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -1604,11 +1604,11 @@ aC
 Ld
 aC
 aC
-Ef
-QP
-pn
-QP
-QP
+WG
+pZ
+OL
+pZ
+pZ
 xi
 kZ
 pb
@@ -1628,7 +1628,7 @@ OU
 OU
 Kl
 OU
-er
+gp
 xi
 Hr
 ms

--- a/_maps/RandomRuins/StationRuins/EclipseStation/ebar_clock.dmm
+++ b/_maps/RandomRuins/StationRuins/EclipseStation/ebar_clock.dmm
@@ -163,7 +163,7 @@
 	},
 /obj/machinery/button/door{
 	id = "barshutters";
-	name = "bar shutters";
+	name = "Bar Shutters Control";
 	pixel_x = 25;
 	pixel_y = 24
 	},

--- a/_maps/RandomRuins/StationRuins/EclipseStation/ebar_disco.dmm
+++ b/_maps/RandomRuins/StationRuins/EclipseStation/ebar_disco.dmm
@@ -93,6 +93,22 @@
 /obj/structure/chair/americandiner/booth/end_right,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"dB" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/bar)
 "dO" = (
 /obj/machinery/requests_console{
 	department = "Bar";
@@ -130,6 +146,14 @@
 /area/crew_quarters/bar)
 "gi" = (
 /obj/effect/landmark/start/bartender,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"he" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "hk" = (
@@ -240,39 +264,6 @@
 /obj/item/clothing/head/hardhat/cakehat,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"ly" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/westright,
-/obj/machinery/chem_dispenser/drinks,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"lz" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters";
-	pixel_x = 25;
-	pixel_y = 24
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"lN" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "lU" = (
 /obj/machinery/light{
 	dir = 1
@@ -280,6 +271,15 @@
 /obj/item/clothing/under/shorts/purple,
 /turf/open/floor/light/colour_cycle/dancefloor_b,
 /area/crew_quarters/theatre)
+"my" = (
+/obj/structure/sign/barsign,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "mH" = (
 /obj/machinery/button/door{
 	id = "kitchenwindow";
@@ -328,10 +328,23 @@
 /mob/living/carbon/monkey/punpun,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"oa" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
+"oz" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = 25;
+	pixel_y = 24
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"oF" = (
+/obj/machinery/smartfridge/drinks,
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
 	name = "privacy shutters"
@@ -390,14 +403,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"qX" = (
-/obj/machinery/smartfridge/drinks,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "rc" = (
 /obj/machinery/button/door{
 	id = "kitchen";
@@ -468,15 +473,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"ty" = (
-/obj/structure/sign/barsign,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "tz" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -490,6 +486,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
+"tP" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westright,
+/obj/machinery/chem_dispenser/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "tY" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = 32
@@ -584,6 +590,15 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"xF" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "xJ" = (
 /obj/machinery/icecream_vat,
 /turf/open/floor/plasteel/showroomfloor,
@@ -600,6 +615,23 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
+"yk" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "zd" = (
 /obj/structure/disposalpipe/segment,
@@ -750,22 +782,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"GK" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
 "GN" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
@@ -802,15 +818,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/light/colour_cycle/dancefloor_b,
 /area/crew_quarters/theatre)
-"Ib" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "KA" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -839,6 +846,16 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/ameridiner,
+/area/crew_quarters/bar)
+"Ly" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "LK" = (
 /obj/machinery/door/firedoor/border_only,
@@ -1023,14 +1040,6 @@
 /obj/structure/closet/secure_closet/bartender,
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/bar)
-"SA" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "SL" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/light/colour_cycle/dancefloor_a,
@@ -1040,6 +1049,14 @@
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
+"Td" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
 /area/crew_quarters/bar)
 "Tk" = (
 /obj/structure/table/reinforced,
@@ -1235,23 +1252,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"ZI" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 
 (1,1,1) = {"
 ir
@@ -1263,13 +1263,13 @@ iu
 iu
 rV
 rV
-SA
+Td
 rV
 rV
-SA
+Td
 rV
 rV
-SA
+Td
 rV
 rV
 "}
@@ -1391,7 +1391,7 @@ SL
 Xi
 ak
 VK
-ty
+my
 "}
 (8,1,1) = {"
 ir
@@ -1411,7 +1411,7 @@ Xi
 Xi
 zO
 VK
-SA
+Td
 "}
 (9,1,1) = {"
 ir
@@ -1434,7 +1434,7 @@ VK
 tn
 "}
 (10,1,1) = {"
-GK
+dB
 Pn
 jN
 jN
@@ -1478,12 +1478,12 @@ rV
 rV
 le
 rV
-ZI
-ly
-lN
-Ib
-lN
-lN
+yk
+tP
+he
+xF
+he
+he
 rF
 VK
 hk
@@ -1503,7 +1503,7 @@ Ru
 Ru
 gi
 Ru
-oa
+Ly
 rF
 VK
 de
@@ -1518,12 +1518,12 @@ zN
 zN
 zN
 rV
-lz
+oz
 Qd
 nr
 hy
 Ru
-qX
+oF
 VK
 VK
 VK

--- a/_maps/RandomRuins/StationRuins/EclipseStation/ebar_disco.dmm
+++ b/_maps/RandomRuins/StationRuins/EclipseStation/ebar_disco.dmm
@@ -93,6 +93,15 @@
 /obj/structure/chair/americandiner/booth/end_right,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"dn" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "dB" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -146,14 +155,6 @@
 /area/crew_quarters/bar)
 "gi" = (
 /obj/effect/landmark/start/bartender,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"he" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "hk" = (
@@ -443,6 +444,16 @@
 /obj/effect/landmark/start/cook,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"sP" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westright,
+/obj/machinery/chem_dispenser/drinks,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "tn" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -486,16 +497,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
-"tP" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/westright,
-/obj/machinery/chem_dispenser/drinks,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "tY" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = 32
@@ -590,15 +591,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"xF" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "xJ" = (
 /obj/machinery/icecream_vat,
 /turf/open/floor/plasteel/showroomfloor,
@@ -615,23 +607,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
-"yk" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "zd" = (
 /obj/structure/disposalpipe/segment,
@@ -740,6 +715,14 @@
 /obj/item/reagent_containers/food/snacks/mint,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"EQ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "Fn" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/plasteel/ameridiner,
@@ -847,16 +830,6 @@
 	},
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/bar)
-"Ly" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "LK" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/window/reinforced,
@@ -897,6 +870,23 @@
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"Nz" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "NL" = (
 /obj/item/instrument/accordion,
 /turf/open/floor/light/colour_cycle/dancefloor_b,
@@ -1093,6 +1083,16 @@
 	},
 /turf/open/floor/light/colour_cycle/dancefloor_b,
 /area/crew_quarters/theatre)
+"Ua" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "Ui" = (
 /obj/item/clothing/under/schoolgirl,
 /obj/machinery/door/firedoor/border_only,
@@ -1478,12 +1478,12 @@ rV
 rV
 le
 rV
-yk
-tP
-he
-xF
-he
-he
+Nz
+sP
+EQ
+dn
+EQ
+EQ
 rF
 VK
 hk
@@ -1503,7 +1503,7 @@ Ru
 Ru
 gi
 Ru
-Ly
+Ua
 rF
 VK
 de

--- a/_maps/RandomRuins/StationRuins/EclipseStation/ebar_disco.dmm
+++ b/_maps/RandomRuins/StationRuins/EclipseStation/ebar_disco.dmm
@@ -338,7 +338,7 @@
 	},
 /obj/machinery/button/door{
 	id = "barshutters";
-	name = "bar shutters";
+	name = "Bar Shutters Control";
 	pixel_x = 25;
 	pixel_y = 24
 	},

--- a/_maps/RandomRuins/StationRuins/EclipseStation/ebar_disco.dmm
+++ b/_maps/RandomRuins/StationRuins/EclipseStation/ebar_disco.dmm
@@ -115,15 +115,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"eG" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "eI" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/light/colour_cycle/dancefloor_a,
@@ -210,11 +201,6 @@
 /obj/machinery/computer/slot_machine/casino,
 /turf/open/floor/carpet/black,
 /area/crew_quarters/bar)
-"jD" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "jJ" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 28
@@ -236,10 +222,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"kY" = (
-/obj/machinery/smartfridge/drinks,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "le" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Bar Maintenance";
@@ -257,6 +239,39 @@
 /obj/structure/table/reinforced,
 /obj/item/clothing/head/hardhat/cakehat,
 /turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
+"ly" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westright,
+/obj/machinery/chem_dispenser/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"lz" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = 25;
+	pixel_y = 24
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"lN" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "lU" = (
 /obj/machinery/light{
@@ -313,10 +328,15 @@
 /mob/living/carbon/monkey/punpun,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"nJ" = (
-/obj/structure/sign/barsign,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+"oa" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "pG" = (
 /obj/structure/table/wood,
@@ -370,6 +390,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"qX" = (
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "rc" = (
 /obj/machinery/button/door{
 	id = "kitchen";
@@ -440,6 +468,15 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"ty" = (
+/obj/structure/sign/barsign,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "tz" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -622,10 +659,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"Bx" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "BJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -647,19 +680,6 @@
 "CA" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"CD" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "CP" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
@@ -720,12 +740,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"Ga" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/westright,
-/obj/machinery/chem_dispenser/drinks,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "Gc" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -788,6 +802,15 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/light/colour_cycle/dancefloor_b,
 /area/crew_quarters/theatre)
+"Ib" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "KA" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1000,6 +1023,14 @@
 /obj/structure/closet/secure_closet/bartender,
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/bar)
+"SA" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "SL" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/light/colour_cycle/dancefloor_a,
@@ -1009,12 +1040,6 @@
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
-"ST" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "Tk" = (
 /obj/structure/table/reinforced,
@@ -1210,8 +1235,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"ZA" = (
-/obj/structure/table/reinforced,
+"ZI" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 
@@ -1225,13 +1263,13 @@ iu
 iu
 rV
 rV
-Bx
+SA
 rV
 rV
-Bx
+SA
 rV
 rV
-Bx
+SA
 rV
 rV
 "}
@@ -1353,7 +1391,7 @@ SL
 Xi
 ak
 VK
-nJ
+ty
 "}
 (8,1,1) = {"
 ir
@@ -1373,7 +1411,7 @@ Xi
 Xi
 zO
 VK
-Bx
+SA
 "}
 (9,1,1) = {"
 ir
@@ -1440,12 +1478,12 @@ rV
 rV
 le
 rV
-CD
-Ga
-ZA
-jD
-ZA
-ZA
+ZI
+ly
+lN
+Ib
+lN
+lN
 rF
 VK
 hk
@@ -1465,7 +1503,7 @@ Ru
 Ru
 gi
 Ru
-ST
+oa
 rF
 VK
 de
@@ -1480,12 +1518,12 @@ zN
 zN
 zN
 rV
-eG
+lz
 Qd
 nr
 hy
 Ru
-kY
+qX
 VK
 VK
 VK

--- a/_maps/RandomRuins/StationRuins/EclipseStation/ebar_eclipse.dmm
+++ b/_maps/RandomRuins/StationRuins/EclipseStation/ebar_eclipse.dmm
@@ -56,22 +56,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"dk" = (
-/obj/structure/table/reinforced,
-/obj/item/lighter,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "dw" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/mint,
@@ -134,6 +118,14 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"fB" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "fL" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/bluecherrycupcake{
@@ -168,25 +160,6 @@
 /obj/effect/spawner/xmastree,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"gN" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters";
-	pixel_x = 25;
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "gS" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -204,13 +177,7 @@
 /obj/item/reagent_containers/food/snacks/nachos,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"hz" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"hH" = (
+"hu" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
@@ -222,6 +189,12 @@
 	name = "privacy shutters"
 	},
 /turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"hz" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "hZ" = (
 /obj/machinery/computer/slot_machine,
@@ -281,14 +254,15 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"jN" = (
+"jt" = (
 /obj/structure/table/reinforced,
+/obj/item/lighter,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/stripes/line{
-	dir = 10
+	dir = 8
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
@@ -320,15 +294,6 @@
 "kR" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/wood,
-/area/crew_quarters/bar)
-"lo" = (
-/obj/structure/sign/barsign,
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
 /area/crew_quarters/bar)
 "lA" = (
 /obj/machinery/deepfryer,
@@ -384,24 +349,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"mj" = (
-/obj/machinery/jukebox,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "mm" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -419,6 +366,22 @@
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"mp" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/bar)
 "ms" = (
 /obj/machinery/light,
 /turf/open/floor/wood,
@@ -429,6 +392,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
+"mV" = (
+/obj/structure/sign/barsign,
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "nF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -475,21 +447,6 @@
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"oG" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "pf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -528,14 +485,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"rf" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "rk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -634,10 +583,47 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"tM" = (
+/obj/machinery/jukebox,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "up" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"uC" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = 25;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "uP" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -700,6 +686,21 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
+/area/crew_quarters/bar)
+"yc" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "yd" = (
 /obj/structure/table,
@@ -1003,6 +1004,21 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"GU" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/stripes/line,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "GZ" = (
 /obj/structure/table/wood,
 /obj/item/clothing/head/hardhat/cakehat,
@@ -1033,21 +1049,6 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/crew_quarters/bar)
-"Ik" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/stripes/line,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "Ip" = (
 /turf/closed/wall,
@@ -1144,6 +1145,21 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
+/area/crew_quarters/bar)
+"NI" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "Od" = (
 /obj/structure/table/reinforced,
@@ -1308,22 +1324,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"RO" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "RV" = (
 /obj/machinery/camera{
 	c_tag = "Theatre Stage";
@@ -1375,6 +1375,22 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"Te" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "TA" = (
@@ -1549,22 +1565,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"Yk" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
 "Yn" = (
 /obj/machinery/computer/arcade/minesweeper,
 /turf/open/floor/wood,
@@ -1599,13 +1599,13 @@ gS
 gS
 Ip
 Ip
-rf
+fB
 Ip
 Ip
-rf
+fB
 Ip
 Ip
-rf
+fB
 Ip
 Ip
 "}
@@ -1727,7 +1727,7 @@ Dc
 mi
 KS
 KS
-lo
+mV
 "}
 (8,1,1) = {"
 qd
@@ -1747,7 +1747,7 @@ OM
 mi
 KS
 KS
-rf
+fB
 "}
 (9,1,1) = {"
 Ip
@@ -1770,7 +1770,7 @@ KS
 QJ
 "}
 (10,1,1) = {"
-Yk
+mp
 zs
 Qv
 mh
@@ -1814,12 +1814,12 @@ Ip
 Ip
 fV
 Ip
-mj
-dk
-oG
-RO
-oG
-jN
+tM
+jt
+yc
+Te
+yc
+NI
 Zu
 Vm
 aU
@@ -1839,7 +1839,7 @@ Ux
 Td
 UX
 Td
-Ik
+GU
 Zu
 xw
 KS
@@ -1854,12 +1854,12 @@ kh
 kh
 kh
 Ip
-gN
+uC
 Yc
 IG
 RX
 Td
-hH
+hu
 KS
 KS
 KS

--- a/_maps/RandomRuins/StationRuins/EclipseStation/ebar_eclipse.dmm
+++ b/_maps/RandomRuins/StationRuins/EclipseStation/ebar_eclipse.dmm
@@ -56,6 +56,22 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"dk" = (
+/obj/structure/table/reinforced,
+/obj/item/lighter,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "dw" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/mint,
@@ -92,19 +108,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light{
 	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"ef" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/structure/disposalpipe/segment{
-	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -160,14 +163,29 @@
 /obj/structure/closet/secure_closet/bartender,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"gu" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "gM" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/spawner/xmastree,
 /turf/open/floor/wood,
+/area/crew_quarters/bar)
+"gN" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = 25;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "gS" = (
 /obj/machinery/door/firedoor/border_only{
@@ -192,6 +210,19 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"hH" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "hZ" = (
 /obj/machinery/computer/slot_machine,
 /obj/machinery/light{
@@ -209,11 +240,6 @@
 	},
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"ii" = (
-/obj/structure/sign/barsign,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
 /area/crew_quarters/bar)
 "io" = (
 /obj/structure/extinguisher_cabinet{
@@ -255,6 +281,21 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"jN" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "jZ" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = 32
@@ -268,17 +309,6 @@
 "kh" = (
 /turf/template_noop,
 /area/template_noop)
-"kk" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "kn" = (
 /obj/effect/turf_decal/loading_area,
 /obj/machinery/airalarm{
@@ -291,16 +321,14 @@
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"kS" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+"lo" = (
+/obj/structure/sign/barsign,
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
 	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/stripes/line,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/crew_quarters/bar)
 "lA" = (
 /obj/machinery/deepfryer,
@@ -355,6 +383,24 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
+/area/crew_quarters/bar)
+"mj" = (
+/obj/machinery/jukebox,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "mm" = (
 /obj/machinery/disposal/bin,
@@ -421,8 +467,16 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"oy" = (
-/obj/machinery/jukebox,
+"oF" = (
+/obj/machinery/vending/boozeomat,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"oG" = (
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
@@ -430,17 +484,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"oF" = (
-/obj/machinery/vending/boozeomat,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "pf" = (
@@ -469,15 +516,6 @@
 "qd" = (
 /turf/closed/wall,
 /area/crew_quarters/theatre)
-"qk" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/smartfridge/drinks,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "qO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -490,6 +528,14 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"rf" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "rk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -750,18 +796,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"AC" = (
-/obj/structure/table/reinforced,
-/obj/item/lighter,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "AU" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/cafeteria,
@@ -1000,6 +1034,21 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"Ik" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/stripes/line,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "Ip" = (
 /turf/closed/wall,
 /area/crew_quarters/bar)
@@ -1052,17 +1101,6 @@
 /area/crew_quarters/bar)
 "KS" = (
 /turf/open/floor/wood,
-/area/crew_quarters/bar)
-"LF" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "LY" = (
 /obj/machinery/button/door{
@@ -1270,6 +1308,22 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"RO" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "RV" = (
 /obj/machinery/camera{
 	c_tag = "Theatre Stage";
@@ -1326,18 +1380,6 @@
 "TA" = (
 /obj/machinery/computer/arcade/amputation,
 /turf/open/floor/wood,
-/area/crew_quarters/bar)
-"TK" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "TZ" = (
 /obj/structure/chair/comfy/brown,
@@ -1557,13 +1599,13 @@ gS
 gS
 Ip
 Ip
-gu
+rf
 Ip
 Ip
-gu
+rf
 Ip
 Ip
-gu
+rf
 Ip
 Ip
 "}
@@ -1685,7 +1727,7 @@ Dc
 mi
 KS
 KS
-ii
+lo
 "}
 (8,1,1) = {"
 qd
@@ -1705,7 +1747,7 @@ OM
 mi
 KS
 KS
-gu
+rf
 "}
 (9,1,1) = {"
 Ip
@@ -1772,12 +1814,12 @@ Ip
 Ip
 fV
 Ip
-oy
-AC
-kk
-TK
-kk
-LF
+mj
+dk
+oG
+RO
+oG
+jN
 Zu
 Vm
 aU
@@ -1797,7 +1839,7 @@ Ux
 Td
 UX
 Td
-kS
+Ik
 Zu
 xw
 KS
@@ -1812,12 +1854,12 @@ kh
 kh
 kh
 Ip
-ef
+gN
 Yc
 IG
 RX
 Td
-qk
+hH
 KS
 KS
 KS

--- a/_maps/RandomRuins/StationRuins/EclipseStation/ebar_eclipse.dmm
+++ b/_maps/RandomRuins/StationRuins/EclipseStation/ebar_eclipse.dmm
@@ -617,7 +617,7 @@
 	},
 /obj/machinery/button/door{
 	id = "barshutters";
-	name = "bar shutters";
+	name = "Bar Shutters Control";
 	pixel_x = 25;
 	pixel_y = 24
 	},

--- a/_maps/RandomRuins/StationRuins/EclipseStation/ebar_eclipse.dmm
+++ b/_maps/RandomRuins/StationRuins/EclipseStation/ebar_eclipse.dmm
@@ -31,6 +31,24 @@
 /obj/item/toy/turn_tracker,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"cd" = (
+/obj/machinery/jukebox,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "ch" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4;
@@ -155,6 +173,21 @@
 /obj/structure/closet/secure_closet/bartender,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"gE" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "gM" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/spawner/xmastree,
@@ -253,22 +286,6 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/crew_quarters/bar)
-"jt" = (
-/obj/structure/table/reinforced,
-/obj/item/lighter,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "jZ" = (
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -583,24 +600,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"tM" = (
-/obj/machinery/jukebox,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "up" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/plasteel/showroomfloor,
@@ -686,21 +685,6 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/crew_quarters/bar)
-"yc" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "yd" = (
 /obj/structure/table,
@@ -797,6 +781,22 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"AG" = (
+/obj/structure/table/reinforced,
+/obj/item/lighter,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "AU" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/cafeteria,
@@ -815,9 +815,39 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"BT" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/stripes/line,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "Cw" = (
 /obj/machinery/vending/cola/sodie,
 /turf/open/floor/wood,
+/area/crew_quarters/bar)
+"CD" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "CH" = (
 /obj/structure/reagent_dispensers/cooking_oil,
@@ -1004,21 +1034,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"GU" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/stripes/line,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "GZ" = (
 /obj/structure/table/wood,
 /obj/item/clothing/head/hardhat/cakehat,
@@ -1145,21 +1160,6 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/crew_quarters/bar)
-"NI" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "Od" = (
 /obj/structure/table/reinforced,
@@ -1377,22 +1377,6 @@
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"Te" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "TA" = (
 /obj/machinery/computer/arcade/amputation,
 /turf/open/floor/wood,
@@ -1458,6 +1442,22 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
+/area/crew_quarters/bar)
+"VN" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "VO" = (
 /obj/machinery/vending/cigarette,
@@ -1814,12 +1814,12 @@ Ip
 Ip
 fV
 Ip
-tM
-jt
-yc
-Te
-yc
-NI
+cd
+AG
+CD
+VN
+CD
+gE
 Zu
 Vm
 aU
@@ -1839,7 +1839,7 @@ Ux
 Td
 UX
 Td
-GU
+BT
 Zu
 xw
 KS

--- a/_maps/RandomRuins/StationRuins/EclipseStation/ebar_saloon.dmm
+++ b/_maps/RandomRuins/StationRuins/EclipseStation/ebar_saloon.dmm
@@ -1418,7 +1418,7 @@
 	},
 /obj/machinery/button/door{
 	id = "barshutters";
-	name = "bar shutters";
+	name = "Bar Shutters Control";
 	pixel_x = 25;
 	pixel_y = 24
 	},

--- a/_maps/RandomRuins/StationRuins/EclipseStation/ebar_saloon.dmm
+++ b/_maps/RandomRuins/StationRuins/EclipseStation/ebar_saloon.dmm
@@ -1,4 +1,17 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ac" = (
+/obj/item/lighter,
+/obj/structure/table/wood,
+/obj/item/clothing/mask/cigarette/pipe/cobpipe,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "ad" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -198,16 +211,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"eZ" = (
-/obj/structure/table/wood,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "fw" = (
 /obj/machinery/camera{
 	c_tag = "Theatre Stage";
@@ -275,19 +278,6 @@
 "ip" = (
 /turf/template_noop,
 /area/template_noop)
-"iE" = (
-/obj/item/lighter,
-/obj/structure/table/wood,
-/obj/item/clothing/mask/cigarette/pipe/cobpipe,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "iO" = (
 /obj/machinery/smartfridge,
 /turf/closed/wall,
@@ -317,18 +307,6 @@
 /obj/effect/spawner/lootdrop/mob/kitchen_animal,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"kp" = (
-/obj/structure/table/wood,
-/obj/item/clothing/head/yogs/truecowboy2{
-	desc = "Yee where no man has hawed before with the official cowboy hat of NanoTrasen!";
-	pixel_y = -2
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "kM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -424,6 +402,16 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"oX" = (
+/obj/structure/table/wood,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -553,6 +541,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"uw" = (
+/obj/structure/table/wood,
+/obj/item/clothing/head/yogs/truecowboy2{
+	desc = "Yee where no man has hawed before with the official cowboy hat of NanoTrasen!";
+	pixel_y = -2
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "vh" = (
 /obj/structure/disposalpipe/segment,
 /mob/living/carbon/monkey/punpun,
@@ -865,14 +865,6 @@
 /obj/item/storage/box/mixedcubes,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"FH" = (
-/obj/structure/table/wood,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "Gr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4;
@@ -1183,6 +1175,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"Pz" = (
+/obj/structure/table/wood,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "PP" = (
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
@@ -1651,11 +1651,11 @@ Uk
 Ld
 Uk
 Uk
-iE
-FH
-kp
-FH
-FH
+ac
+Pz
+uw
+Pz
+Pz
 TE
 OU
 PX
@@ -1675,7 +1675,7 @@ OU
 OU
 Kl
 OU
-eZ
+oX
 TE
 OU
 OU

--- a/_maps/RandomRuins/StationRuins/EclipseStation/ebar_saloon.dmm
+++ b/_maps/RandomRuins/StationRuins/EclipseStation/ebar_saloon.dmm
@@ -213,15 +213,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"gm" = (
-/obj/item/lighter,
-/obj/structure/table/wood,
-/obj/item/clothing/mask/cigarette/pipe/cobpipe,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "gE" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -254,11 +245,6 @@
 /obj/machinery/food_cart,
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
-"ie" = (
-/obj/structure/sign/barsign,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "ip" = (
 /turf/template_noop,
 /area/template_noop)
@@ -269,6 +255,14 @@
 "jb" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = 32
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"jD" = (
+/obj/structure/table/wood,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -291,10 +285,6 @@
 /obj/effect/spawner/lootdrop/mob/kitchen_animal,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"km" = (
-/obj/machinery/smartfridge/drinks,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "kM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -316,15 +306,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
-"lu" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "lJ" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck/uno{
@@ -453,6 +434,14 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"rC" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "rD" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -484,6 +473,19 @@
 /area/crew_quarters/bar)
 "sK" = (
 /obj/machinery/vending/cigarette,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"tk" = (
+/obj/item/lighter,
+/obj/structure/table/wood,
+/obj/item/clothing/mask/cigarette/pipe/cobpipe,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "tt" = (
@@ -531,6 +533,14 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
+"vL" = (
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "vY" = (
 /obj/structure/chair/pew/left{
 	dir = 1
@@ -736,14 +746,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
-"Cu" = (
-/obj/structure/table/wood,
-/obj/item/clothing/head/yogs/truecowboy2{
-	desc = "Yee where no man has hawed before with the official cowboy hat of NanoTrasen!";
-	pixel_y = -2
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "Cz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -968,12 +970,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"JA" = (
-/obj/structure/table/wood,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "JQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -1148,6 +1144,18 @@
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
+"Pi" = (
+/obj/structure/table/wood,
+/obj/item/clothing/head/yogs/truecowboy2{
+	desc = "Yee where no man has hawed before with the official cowboy hat of NanoTrasen!";
+	pixel_y = -2
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "Pw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
@@ -1226,6 +1234,25 @@
 "Uk" = (
 /turf/closed/wall/mineral/wood,
 /area/crew_quarters/bar)
+"Uo" = (
+/obj/structure/sign/barsign,
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
+"UB" = (
+/obj/structure/table/wood,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "UM" = (
 /obj/structure/chair/pew/right{
 	dir = 1
@@ -1267,6 +1294,21 @@
 /obj/machinery/icecream_vat,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"Wf" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = 25;
+	pixel_y = 24
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "Wj" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -1332,10 +1374,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"WK" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "WZ" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/soup/stew{
@@ -1397,13 +1435,13 @@ ai
 ai
 Uk
 Uk
-WK
+rC
 Uk
 Uk
-WK
+rC
 Uk
 Uk
-WK
+rC
 Uk
 Uk
 "}
@@ -1525,7 +1563,7 @@ gj
 gh
 OU
 OU
-ie
+Uo
 "}
 (8,1,1) = {"
 EP
@@ -1545,7 +1583,7 @@ OU
 dO
 OU
 OU
-WK
+rC
 "}
 (9,1,1) = {"
 Uk
@@ -1613,11 +1651,11 @@ Uk
 Ld
 Uk
 Uk
-gm
-Ea
-Cu
-Ea
-Ea
+tk
+jD
+Pi
+jD
+jD
 TE
 OU
 PX
@@ -1637,7 +1675,7 @@ OU
 OU
 Kl
 OU
-JA
+UB
 TE
 OU
 OU
@@ -1652,12 +1690,12 @@ ip
 ip
 ip
 Uk
-lu
+Wf
 Jv
 vh
 tI
 OU
-km
+vL
 OU
 OU
 OU

--- a/_maps/RandomRuins/StationRuins/EclipseStation/ebar_saloon.dmm
+++ b/_maps/RandomRuins/StationRuins/EclipseStation/ebar_saloon.dmm
@@ -76,6 +76,15 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"bd" = (
+/obj/structure/sign/barsign,
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "be" = (
 /obj/machinery/processor,
 /obj/machinery/firealarm{
@@ -92,6 +101,14 @@
 /obj/item/reagent_containers/food/drinks/coffee{
 	pixel_x = -6;
 	pixel_y = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"bO" = (
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -181,6 +198,16 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"eZ" = (
+/obj/structure/table/wood,
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "fw" = (
 /obj/machinery/camera{
 	c_tag = "Theatre Stage";
@@ -248,6 +275,19 @@
 "ip" = (
 /turf/template_noop,
 /area/template_noop)
+"iE" = (
+/obj/item/lighter,
+/obj/structure/table/wood,
+/obj/item/clothing/mask/cigarette/pipe/cobpipe,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "iO" = (
 /obj/machinery/smartfridge,
 /turf/closed/wall,
@@ -255,14 +295,6 @@
 "jb" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = 32
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"jD" = (
-/obj/structure/table/wood,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -285,6 +317,18 @@
 /obj/effect/spawner/lootdrop/mob/kitchen_animal,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"kp" = (
+/obj/structure/table/wood,
+/obj/item/clothing/head/yogs/truecowboy2{
+	desc = "Yee where no man has hawed before with the official cowboy hat of NanoTrasen!";
+	pixel_y = -2
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "kM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -424,6 +468,14 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
+"rw" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "rB" = (
 /obj/machinery/door/window/southright{
 	name = "Bar Door";
@@ -433,14 +485,6 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/crew_quarters/bar)
-"rC" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
 /area/crew_quarters/bar)
 "rD" = (
 /obj/machinery/airalarm{
@@ -473,19 +517,6 @@
 /area/crew_quarters/bar)
 "sK" = (
 /obj/machinery/vending/cigarette,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"tk" = (
-/obj/item/lighter,
-/obj/structure/table/wood,
-/obj/item/clothing/mask/cigarette/pipe/cobpipe,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "tt" = (
@@ -533,14 +564,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
-"vL" = (
-/obj/machinery/smartfridge/drinks,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "vY" = (
 /obj/structure/chair/pew/left{
 	dir = 1
@@ -842,6 +865,14 @@
 /obj/item/storage/box/mixedcubes,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"FH" = (
+/obj/structure/table/wood,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "Gr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4;
@@ -1144,18 +1175,6 @@
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
-"Pi" = (
-/obj/structure/table/wood,
-/obj/item/clothing/head/yogs/truecowboy2{
-	desc = "Yee where no man has hawed before with the official cowboy hat of NanoTrasen!";
-	pixel_y = -2
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "Pw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
@@ -1234,25 +1253,6 @@
 "Uk" = (
 /turf/closed/wall/mineral/wood,
 /area/crew_quarters/bar)
-"Uo" = (
-/obj/structure/sign/barsign,
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
-"UB" = (
-/obj/structure/table/wood,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "UM" = (
 /obj/structure/chair/pew/right{
 	dir = 1
@@ -1294,21 +1294,6 @@
 /obj/machinery/icecream_vat,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"Wf" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters";
-	pixel_x = 25;
-	pixel_y = 24
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "Wj" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -1424,6 +1409,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"Zw" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = 25;
+	pixel_y = 24
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 
 (1,1,1) = {"
 EP
@@ -1435,13 +1435,13 @@ ai
 ai
 Uk
 Uk
-rC
+rw
 Uk
 Uk
-rC
+rw
 Uk
 Uk
-rC
+rw
 Uk
 Uk
 "}
@@ -1563,7 +1563,7 @@ gj
 gh
 OU
 OU
-Uo
+bd
 "}
 (8,1,1) = {"
 EP
@@ -1583,7 +1583,7 @@ OU
 dO
 OU
 OU
-rC
+rw
 "}
 (9,1,1) = {"
 Uk
@@ -1651,11 +1651,11 @@ Uk
 Ld
 Uk
 Uk
-tk
-jD
-Pi
-jD
-jD
+iE
+FH
+kp
+FH
+FH
 TE
 OU
 PX
@@ -1675,7 +1675,7 @@ OU
 OU
 Kl
 OU
-UB
+eZ
 TE
 OU
 OU
@@ -1690,12 +1690,12 @@ ip
 ip
 ip
 Uk
-Wf
+Zw
 Jv
 vh
 tI
 OU
-vL
+bO
 OU
 OU
 OU

--- a/_maps/map_files/IceBox/IceBox.dmm
+++ b/_maps/map_files/IceBox/IceBox.dmm
@@ -56934,6 +56934,24 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
+"drj" = (
+/obj/machinery/disposal/bin,
+/obj/structure/sign/warning/securearea{
+	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
+	icon_state = "monkey_painting";
+	name = "Mr. Deempisi portrait";
+	pixel_x = -28;
+	pixel_y = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "dus" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern,
@@ -57120,20 +57138,6 @@
 /obj/item/storage/belt/utility,
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"eoD" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "Bar Shutters Control";
-	pixel_x = -25;
-	pixel_y = 24;
-	req_access_txt = "28"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "erz" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -57169,6 +57173,33 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
+"etS" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"eut" = (
+/obj/machinery/door/window/southright{
+	name = "Bar Door";
+	req_one_access_txt = "25;28"
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "euu" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
@@ -58156,24 +58187,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"hiM" = (
-/obj/machinery/disposal/bin,
-/obj/structure/sign/warning/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
-	pixel_x = -28;
-	pixel_y = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "hkg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
@@ -58332,23 +58345,6 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/aft)
-"hLL" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
-	},
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "barshutters";
-	name = "bar shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "hMp" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 9
@@ -58467,9 +58463,14 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/cryopods)
-"ihE" = (
+"ihS" = (
+/turf/closed/wall/r_wall,
+/area/medical/sleeper)
+"ijl" = (
 /obj/structure/table/reinforced,
-/obj/item/lighter,
+/obj/item/clothing/head/that{
+	throwforce = 1
+	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -58480,9 +58481,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"ihS" = (
-/turf/closed/wall/r_wall,
-/area/medical/sleeper)
 "ikS" = (
 /obj/effect/landmark/stationroom/box/execution,
 /turf/template_noop,
@@ -58883,14 +58881,6 @@
 /obj/structure/sign/warning/vacuum,
 /turf/closed/wall,
 /area/engine/engineering)
-"jmI" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "jnp" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -59069,6 +59059,19 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"jRX" = (
+/obj/structure/table/reinforced,
+/obj/item/lighter,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "jTt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -59209,18 +59212,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"kmS" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_one_access_txt = "12;25"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "kmT" = (
 /obj/machinery/computer/med_data,
 /turf/open/floor/plasteel/grimy,
@@ -59914,21 +59905,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/layer2,
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
-"mvm" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that{
-	throwforce = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "barshutters";
-	name = "bar shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "mxJ" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -60242,6 +60218,18 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"nlv" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "npR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -60302,18 +60290,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"nzC" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "barshutters";
-	name = "bar shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "nCV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -61713,6 +61689,23 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/storage/tools)
+"rRr" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 32
+	},
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "rSv" = (
 /obj/machinery/advanced_airlock_controller/lavaland{
 	dir = 4;
@@ -62131,6 +62124,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"sJy" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_x = -25;
+	pixel_y = 24;
+	req_access_txt = "28"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "sJz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
@@ -63287,21 +63294,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"wjx" = (
-/obj/machinery/door/window/southright{
-	name = "Bar Door";
-	req_one_access_txt = "25;28"
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "barshutters";
-	name = "bar shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "wkN" = (
 /turf/closed/wall,
 /area/science/nanite)
@@ -63538,6 +63530,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"wML" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "wPB" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -99329,11 +99329,11 @@ aCr
 aCr
 cam
 ccq
-jmI
+wML
 cam
-jmI
+wML
 cam
-jmI
+wML
 cam
 cam
 xDQ
@@ -100877,7 +100877,7 @@ cdA
 cdK
 cba
 cba
-jmI
+wML
 aYV
 aYV
 bes
@@ -101635,7 +101635,7 @@ aae
 alQ
 bSP
 bTp
-kmS
+nlv
 caG
 cbb
 cbD
@@ -102155,11 +102155,11 @@ cam
 cam
 cam
 cam
-ihE
-nzC
-mvm
-nzC
-nzC
+jRX
+etS
+ijl
+etS
+etS
 cdX
 cev
 cam
@@ -102411,12 +102411,12 @@ caI
 cbd
 cbF
 cam
-hiM
-eoD
+drj
+sJy
 cba
 cdp
 cba
-nzC
+etS
 cdY
 cew
 cam
@@ -102673,7 +102673,7 @@ cba
 ccO
 cba
 cba
-wjx
+eut
 cba
 cex
 cam
@@ -102930,7 +102930,7 @@ ccx
 cba
 cdq
 cba
-hLL
+rRr
 cba
 cba
 cam

--- a/_maps/map_files/IceBox/IceBox.dmm
+++ b/_maps/map_files/IceBox/IceBox.dmm
@@ -51068,18 +51068,6 @@
 "cam" = (
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"can" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_access_txt = "12"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "cao" = (
 /obj/item/reagent_containers/food/drinks/shaker,
 /obj/structure/table/wood,
@@ -51933,30 +51921,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
-"cci" = (
-/obj/machinery/disposal/bin,
-/obj/structure/sign/warning/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
-	pixel_x = -28;
-	pixel_y = -4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "barShutters";
-	name = "bar shutters";
-	pixel_x = 4;
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "ccj" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -52085,15 +52049,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"ccv" = (
-/obj/structure/table/reinforced,
-/obj/item/lighter,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "ccw" = (
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
@@ -52180,14 +52135,6 @@
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"ccH" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "barShutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/bar)
 "ccI" = (
 /obj/structure/chair{
 	dir = 4
@@ -52230,14 +52177,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"ccN" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "ccO" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -52447,17 +52386,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cdo" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that{
-	throwforce = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "cdp" = (
 /obj/effect/landmark/start/bartender,
 /obj/effect/turf_decal/tile/bar,
@@ -52698,36 +52626,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"cdM" = (
-/obj/machinery/door/window/southright{
-	name = "Bar Door";
-	req_one_access_txt = "25;28"
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "cdN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"cdO" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
-	},
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "cdP" = (
 /obj/effect/landmark/start/cook,
 /turf/open/floor/plasteel/cafeteria,
@@ -57216,6 +57120,20 @@
 /obj/item/storage/belt/utility,
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"eoD" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_x = -25;
+	pixel_y = 24;
+	req_access_txt = "28"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "erz" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -58238,6 +58156,24 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"hiM" = (
+/obj/machinery/disposal/bin,
+/obj/structure/sign/warning/securearea{
+	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
+	icon_state = "monkey_painting";
+	name = "Mr. Deempisi portrait";
+	pixel_x = -28;
+	pixel_y = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "hkg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
@@ -58396,6 +58332,23 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/aft)
+"hLL" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 32
+	},
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "hMp" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 9
@@ -58514,6 +58467,19 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/cryopods)
+"ihE" = (
+/obj/structure/table/reinforced,
+/obj/item/lighter,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "ihS" = (
 /turf/closed/wall/r_wall,
 /area/medical/sleeper)
@@ -58917,6 +58883,14 @@
 /obj/structure/sign/warning/vacuum,
 /turf/closed/wall,
 /area/engine/engineering)
+"jmI" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "jnp" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -59235,6 +59209,18 @@
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"kmS" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	req_one_access_txt = "12;25"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "kmT" = (
 /obj/machinery/computer/med_data,
 /turf/open/floor/plasteel/grimy,
@@ -59928,6 +59914,21 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/layer2,
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
+"mvm" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that{
+	throwforce = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "mxJ" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -60301,6 +60302,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"nzC" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "nCV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -63274,6 +63287,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"wjx" = (
+/obj/machinery/door/window/southright{
+	name = "Bar Door";
+	req_one_access_txt = "25;28"
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "wkN" = (
 /turf/closed/wall,
 /area/science/nanite)
@@ -99301,11 +99329,11 @@ aCr
 aCr
 cam
 ccq
-ccH
+jmI
 cam
-ccH
+jmI
 cam
-ccH
+jmI
 cam
 cam
 xDQ
@@ -100849,7 +100877,7 @@ cdA
 cdK
 cba
 cba
-ccH
+jmI
 aYV
 aYV
 bes
@@ -101607,7 +101635,7 @@ aae
 alQ
 bSP
 bTp
-can
+kmS
 caG
 cbb
 cbD
@@ -102127,11 +102155,11 @@ cam
 cam
 cam
 cam
-ccv
-ccN
-cdo
-ccN
-ccN
+ihE
+nzC
+mvm
+nzC
+nzC
 cdX
 cev
 cam
@@ -102383,12 +102411,12 @@ caI
 cbd
 cbF
 cam
-cci
-cba
+hiM
+eoD
 cba
 cdp
 cba
-ccN
+nzC
 cdY
 cew
 cam
@@ -102645,7 +102673,7 @@ cba
 ccO
 cba
 cba
-cdM
+wjx
 cba
 cex
 cam
@@ -102902,7 +102930,7 @@ ccx
 cba
 cdq
 cba
-cdO
+hLL
 cba
 cba
 cam

--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -15879,6 +15879,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aGK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "aGY" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -30697,29 +30706,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/library)
-"iIf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/rag{
-	pixel_x = 5;
-	pixel_y = 15
-	},
-/obj/machinery/newscaster{
-	pixel_y = -30
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/item/reagent_containers/food/drinks/shaker{
-	pixel_x = -9
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "iIj" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
 	dir = 4
@@ -31453,6 +31439,35 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"jvH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/rag{
+	pixel_x = 5;
+	pixel_y = 15
+	},
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26
+	},
+/obj/item/reagent_containers/food/drinks/shaker{
+	pixel_x = -9
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "jvR" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -39683,21 +39698,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"set" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "bar shutters";
-	pixel_x = 5;
-	pixel_y = -33
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "sfP" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -90180,8 +90180,8 @@ qVR
 qVR
 ajn
 cVd
-set
-iIf
+aGK
+jvH
 xXO
 apd
 akN

--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -23975,14 +23975,6 @@
 /obj/structure/girder,
 /turf/open/floor/plating/airless,
 /area/asteroid/nearstation)
-"bvt" = (
-/obj/structure/table/reinforced,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "bvI" = (
 /obj/item/pickaxe/emergency,
 /turf/open/floor/plating/asteroid/airless,
@@ -24236,29 +24228,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
-"bHP" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/rag{
-	pixel_y = 5
-	},
-/obj/item/book/manual/wiki/barman_recipes{
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/machinery/newscaster{
-	pixel_y = -30
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "bIG" = (
 /turf/open/floor/plating/asteroid/airless,
 /area/maintenance/port)
@@ -25561,6 +25530,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"dcS" = (
+/obj/structure/table/reinforced,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "ddn" = (
 /obj/machinery/suit_storage_unit/hos,
 /turf/open/floor/carpet,
@@ -26017,6 +25998,23 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"dKJ" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that{
+	throwforce = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "dLl" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/structure/cable/white{
@@ -26118,14 +26116,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"dRZ" = (
-/obj/structure/table/reinforced,
-/obj/item/lighter,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "dTh" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -26772,19 +26762,6 @@
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
-"eyd" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that{
-	throwforce = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "eyT" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -30279,16 +30256,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"ipM" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/matches{
-	pixel_y = 5
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "iqC" = (
 /obj/machinery/air_sensor/atmos/carbon_tank,
 /turf/open/floor/engine/co2,
@@ -30713,6 +30680,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/library)
+"iIf" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/rag{
+	pixel_x = 5;
+	pixel_y = 15
+	},
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26
+	},
+/obj/item/reagent_containers/food/drinks/shaker{
+	pixel_x = -9
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "iIj" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
 	dir = 4
@@ -32049,6 +32039,18 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"kaZ" = (
+/obj/structure/table/reinforced,
+/obj/item/lighter,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "kbD" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -32662,15 +32664,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical)
-"kKb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "kKr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 2;
@@ -32980,6 +32973,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/library)
+"lgS" = (
+/obj/structure/table/wood,
+/obj/item/book/manual/wiki/barman_recipes{
+	pixel_y = 5
+	},
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/gun/ballistic/shotgun/doublebarrel{
+	pixel_y = -5
+	},
+/obj/item/gun/ballistic/shotgun/doublebarrel{
+	pixel_y = -5
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "lhM" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -34677,14 +34685,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"nfA" = (
-/obj/item/gun/ballistic/shotgun/doublebarrel,
-/obj/structure/table/wood,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/gun/ballistic/shotgun/doublebarrel,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "nfB" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
@@ -39403,19 +39403,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"rZJ" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "sak" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/blue{
@@ -39679,6 +39666,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"set" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "bar shutters";
+	pixel_x = 5;
+	pixel_y = -33
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "sfP" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -41769,6 +41771,23 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"sQG" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "sRl" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -45675,6 +45694,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"wZk" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/matches{
+	pixel_y = 5
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "barshutters";
+	name = "privacy shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "xbr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -89374,9 +89407,9 @@ bTM
 oEX
 lxq
 fPe
-eyd
-ipM
-rZJ
+dKJ
+wZk
+sQG
 xXO
 xXO
 aOr
@@ -89631,7 +89664,7 @@ fJE
 aiE
 nWT
 fHZ
-bvt
+dcS
 jXX
 aju
 aJY
@@ -89888,7 +89921,7 @@ gVt
 oEX
 lxq
 fPe
-dRZ
+kaZ
 bXm
 sBA
 try
@@ -90147,8 +90180,8 @@ qVR
 qVR
 ajn
 cVd
-kKb
-bHP
+set
+iIf
 xXO
 apd
 akN
@@ -91174,7 +91207,7 @@ aiF
 lxq
 lzd
 xXO
-nfA
+lgS
 jED
 fYS
 akb

--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -25530,18 +25530,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"dcS" = (
-/obj/structure/table/reinforced,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "ddn" = (
 /obj/machinery/suit_storage_unit/hos,
 /turf/open/floor/carpet,
@@ -25998,23 +25986,6 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"dKJ" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that{
-	throwforce = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "dLl" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/structure/cable/white{
@@ -26988,6 +26959,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"eMH" = (
+/obj/structure/table/reinforced,
+/obj/item/lighter,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "ePo" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Morgue";
@@ -29883,6 +29866,23 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/library)
+"hRM" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that{
+	throwforce = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "hSR" = (
 /obj/structure/cable/white{
 	icon_state = "2-4"
@@ -29988,6 +29988,23 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"hXw" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "hXB" = (
 /obj/machinery/light{
 	dir = 8
@@ -32039,18 +32056,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"kaZ" = (
-/obj/structure/table/reinforced,
-/obj/item/lighter,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "kbD" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -37071,6 +37076,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"pDu" = (
+/obj/structure/table/reinforced,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "pEA" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -41771,23 +41788,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"sQG" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "sRl" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -42249,6 +42249,20 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
+"tnJ" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/matches{
+	pixel_y = 5
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "tnV" = (
 /obj/structure/girder,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
@@ -45694,20 +45708,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"wZk" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/matches{
-	pixel_y = 5
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "xbr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -89407,9 +89407,9 @@ bTM
 oEX
 lxq
 fPe
-dKJ
-wZk
-sQG
+hRM
+tnJ
+hXw
 xXO
 xXO
 aOr
@@ -89664,7 +89664,7 @@ fJE
 aiE
 nWT
 fHZ
-dcS
+pDu
 jXX
 aju
 aJY
@@ -89921,7 +89921,7 @@ gVt
 oEX
 lxq
 fPe
-kaZ
+eMH
 bXm
 sBA
 try

--- a/_maps/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/map_files/YogsDelta/YogsDelta.dmm
@@ -125468,6 +125468,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"jrG" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "juf" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /obj/effect/turf_decal/stripes/line{
@@ -125594,6 +125612,32 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"kkw" = (
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_x = 25;
+	pixel_y = 24;
+	req_access_txt = "28"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "kra" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -126109,6 +126153,28 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"mPF" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/matches{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "mQb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -126174,24 +126240,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/captain/private)
-"nkA" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "barshutters";
-	name = "bar shutters"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "now" = (
 /turf/closed/wall,
 /area/storage/art)
@@ -126523,6 +126571,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"oYh" = (
+/obj/structure/table/reinforced,
+/obj/item/lighter{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/lighter,
+/obj/machinery/camera{
+	c_tag = "Bar - Fore";
+	dir = 4;
+	name = "service camera"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "oYI" = (
 /obj/machinery/igniter/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
@@ -127145,32 +127221,6 @@
 /obj/machinery/door/poddoor/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
-"szq" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "Bar Shutters Control";
-	pixel_x = 25;
-	pixel_y = 24;
-	req_access_txt = "28"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "sFC" = (
 /obj/machinery/status_display/evac{
 	pixel_x = 32
@@ -127928,34 +127978,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"xHG" = (
-/obj/structure/table/reinforced,
-/obj/item/lighter{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/lighter,
-/obj/machinery/camera{
-	c_tag = "Bar - Fore";
-	dir = 4;
-	name = "service camera"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "barshutters";
-	name = "bar shutters"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "xJl" = (
 /obj/structure/table,
 /obj/item/folder/white,
@@ -128041,28 +128063,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"xZG" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/matches{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "barshutters";
-	name = "bar shutters"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "xZM" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
@@ -164722,7 +164722,7 @@ aDL
 aEU
 aCx
 aHB
-xHG
+oYh
 aKy
 aLK
 aLL
@@ -164979,7 +164979,7 @@ aDL
 aEV
 aCF
 aHi
-nkA
+jrG
 aKz
 aLL
 aDe
@@ -165236,7 +165236,7 @@ aDL
 aEW
 aCS
 aHB
-nkA
+jrG
 aKz
 aLL
 aNh
@@ -165493,7 +165493,7 @@ aDL
 aEX
 aog
 aHC
-xZG
+mPF
 aKz
 aLL
 aNh
@@ -165750,7 +165750,7 @@ aDL
 aEY
 aod
 aHB
-nkA
+jrG
 aKz
 aLL
 aNh
@@ -166007,7 +166007,7 @@ aDL
 aEZ
 aof
 aHD
-nkA
+jrG
 aKA
 aLL
 aNi
@@ -166262,9 +166262,9 @@ auj
 agx
 aDL
 aFa
-szq
+kkw
 aHE
-nkA
+jrG
 aKB
 aLM
 aLL

--- a/_maps/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/map_files/YogsDelta/YogsDelta.dmm
@@ -18439,20 +18439,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"aFa" = (
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "aFb" = (
 /obj/structure/table,
 /obj/structure/cable/white{
@@ -125612,32 +125598,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"kkw" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "Bar Shutters Control";
-	pixel_x = 25;
-	pixel_y = 24;
-	req_access_txt = "28"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "kra" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -126448,6 +126408,32 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/closed/wall/r_wall,
 /area/engine/atmospherics_engine)
+"oGu" = (
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_x = 25;
+	pixel_y = 24;
+	req_access_txt = "25"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "oHB" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -127778,6 +127764,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"wrp" = (
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "wsq" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/water_vapor,
@@ -166261,8 +166262,8 @@ aAp
 auj
 agx
 aDL
-aFa
-kkw
+wrp
+oGu
 aHE
 jrG
 aKB

--- a/_maps/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/map_files/YogsDelta/YogsDelta.dmm
@@ -19176,25 +19176,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"aGl" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "aGm" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
@@ -21244,62 +21225,6 @@
 "aIY" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
-/area/crew_quarters/bar)
-"aIZ" = (
-/obj/structure/table/reinforced,
-/obj/item/lighter{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/lighter,
-/obj/machinery/camera{
-	c_tag = "Bar - Fore";
-	dir = 4;
-	name = "service camera"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
-"aJa" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
-"aJb" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/matches{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aJc" = (
 /obj/structure/sign/nanotrasen,
@@ -126249,6 +126174,24 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/captain/private)
+"nkA" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "now" = (
 /turf/closed/wall,
 /area/storage/art)
@@ -127202,6 +127145,32 @@
 /obj/machinery/door/poddoor/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
+"szq" = (
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_x = 25;
+	pixel_y = 24;
+	req_access_txt = "28"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "sFC" = (
 /obj/machinery/status_display/evac{
 	pixel_x = 32
@@ -127959,6 +127928,34 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"xHG" = (
+/obj/structure/table/reinforced,
+/obj/item/lighter{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/lighter,
+/obj/machinery/camera{
+	c_tag = "Bar - Fore";
+	dir = 4;
+	name = "service camera"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "xJl" = (
 /obj/structure/table,
 /obj/item/folder/white,
@@ -128044,6 +128041,28 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"xZG" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/matches{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "xZM" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
@@ -164703,7 +164722,7 @@ aDL
 aEU
 aCx
 aHB
-aIZ
+xHG
 aKy
 aLK
 aLL
@@ -164960,7 +164979,7 @@ aDL
 aEV
 aCF
 aHi
-aJa
+nkA
 aKz
 aLL
 aDe
@@ -165217,7 +165236,7 @@ aDL
 aEW
 aCS
 aHB
-aJa
+nkA
 aKz
 aLL
 aNh
@@ -165474,7 +165493,7 @@ aDL
 aEX
 aog
 aHC
-aJb
+xZG
 aKz
 aLL
 aNh
@@ -165731,7 +165750,7 @@ aDL
 aEY
 aod
 aHB
-aJa
+nkA
 aKz
 aLL
 aNh
@@ -165988,7 +166007,7 @@ aDL
 aEZ
 aof
 aHD
-aJa
+nkA
 aKA
 aLL
 aNi
@@ -166243,9 +166262,9 @@ auj
 agx
 aDL
 aFa
-aGl
+szq
 aHE
-aJa
+nkA
 aKB
 aLM
 aLL

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -74407,6 +74407,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"dvC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_x = 25;
+	pixel_y = 24;
+	req_access_txt = "25"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "dvE" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -76282,25 +76301,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"gXo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "Bar Shutters Control";
-	pixel_x = 25;
-	pixel_y = 24;
-	req_access_txt = "28"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "gXA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -117717,7 +117717,7 @@ aYr
 brh
 brR
 bta
-gXo
+dvC
 bwy
 lUm
 bxA

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -75462,6 +75462,18 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"fjm" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "fnc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -75632,6 +75644,24 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"fKn" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "fKC" = (
 /obj/structure/chair{
 	dir = 1
@@ -75918,6 +75948,19 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"gpy" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "gpB" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -76239,6 +76282,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"gXo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_x = 25;
+	pixel_y = 24;
+	req_access_txt = "28"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "gXA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -76349,22 +76411,6 @@
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"hjt" = (
-/obj/structure/table/reinforced,
-/obj/item/lighter,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -31
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "barshutters";
-	name = "bar shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "hjD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -76706,6 +76752,22 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"hTB" = (
+/obj/structure/table/reinforced,
+/obj/item/lighter,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -31
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "hUo" = (
 /obj/machinery/shower{
 	dir = 8
@@ -76845,21 +76907,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"ijR" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/matches{
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "barshutters";
-	name = "bar shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "ilr" = (
 /obj/machinery/door/airlock{
 	id_tag = "AuxShower";
@@ -77443,6 +77490,21 @@
 	},
 /turf/open/space/basic,
 /area/maintenance/port/aft)
+"jHe" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/matches{
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "jJj" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -78147,19 +78209,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"lmF" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "barshutters";
-	name = "bar shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "lob" = (
 /turf/closed/wall,
 /area/maintenance/department/science/central)
@@ -78380,18 +78429,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/lab)
-"lRx" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "barshutters";
-	name = "bar shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "lTW" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/hallway/secondary/exit/departure_lounge";
@@ -78404,6 +78441,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"lUm" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "lUV" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/firedoor/border_only{
@@ -78886,20 +78937,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"nvX" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "barshutters";
-	name = "bar shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "nwS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -79541,6 +79578,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"paS" = (
+/obj/structure/sign/plaques/deempisi{
+	pixel_x = 5;
+	pixel_y = 24
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/obj/machinery/light_switch{
+	pixel_x = 25
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "pce" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -80605,24 +80660,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"rPQ" = (
-/obj/structure/sign/plaques/deempisi{
-	pixel_x = 5;
-	pixel_y = 24
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/machinery/light_switch{
-	pixel_x = 25
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "rQn" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/mixbowl{
@@ -82756,25 +82793,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"wDf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "Bar Shutters Control";
-	pixel_x = 25;
-	pixel_y = 24;
-	req_access_txt = "28"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "wEj" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -83016,24 +83034,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/fore)
-"wYV" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "barshutters";
-	name = "bar shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "xbX" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -116434,7 +116434,7 @@ btl
 bmO
 bku
 bwO
-hjt
+hTB
 bBT
 bwO
 brc
@@ -116691,7 +116691,7 @@ btm
 bmO
 bwL
 byy
-lRx
+fjm
 bBT
 bwO
 brc
@@ -116948,7 +116948,7 @@ bgh
 bmO
 bwM
 bwO
-lmF
+gpy
 bBT
 bwO
 brc
@@ -117205,7 +117205,7 @@ bmO
 bmO
 bwN
 byz
-lRx
+fjm
 bBU
 bwO
 brk
@@ -117462,7 +117462,7 @@ bto
 buN
 dCS
 bwO
-ijR
+jHe
 bBT
 bwO
 bJF
@@ -117717,9 +117717,9 @@ aYr
 brh
 brR
 bta
-wDf
+gXo
 bwy
-nvX
+lUm
 bxA
 byJ
 bKk
@@ -117974,9 +117974,9 @@ boR
 bri
 btq
 bmP
-rPQ
+paS
 bwO
-wYV
+fKn
 bBT
 bwO
 bKW

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -37617,18 +37617,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/white/side,
 /area/science/research)
-"buk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "bul" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -38754,16 +38742,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bwJ" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "bwK" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -38831,23 +38809,6 @@
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
-"bwQ" = (
-/obj/structure/sign/plaques/deempisi{
-	pixel_y = 28
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/machinery/light_switch{
-	pixel_x = 25
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "bwR" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/crew_quarters/bar";
@@ -40519,46 +40480,6 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
-"bAi" = (
-/obj/structure/table/reinforced,
-/obj/item/lighter,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -31
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"bAj" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"bAk" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"bAl" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/matches{
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "bAm" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Library"
@@ -40577,20 +40498,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"bAn" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "bAo" = (
 /obj/machinery/smartfridge/drinks{
 	icon_state = "boozeomat"
@@ -76442,6 +76349,22 @@
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"hjt" = (
+/obj/structure/table/reinforced,
+/obj/item/lighter,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -31
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "hjD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -76922,6 +76845,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"ijR" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/matches{
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "ilr" = (
 /obj/machinery/door/airlock{
 	id_tag = "AuxShower";
@@ -78209,6 +78147,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"lmF" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/that,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "lob" = (
 /turf/closed/wall,
 /area/maintenance/department/science/central)
@@ -78429,6 +78380,18 @@
 	},
 /turf/open/floor/plating,
 /area/science/lab)
+"lRx" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "lTW" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/hallway/secondary/exit/departure_lounge";
@@ -78923,6 +78886,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"nvX" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "nwS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -80628,6 +80605,24 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"rPQ" = (
+/obj/structure/sign/plaques/deempisi{
+	pixel_x = 5;
+	pixel_y = 24
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/obj/machinery/light_switch{
+	pixel_x = 25
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "rQn" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/mixbowl{
@@ -82761,6 +82756,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"wDf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_x = 25;
+	pixel_y = 24;
+	req_access_txt = "28"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "wEj" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -83002,6 +83016,24 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/fore)
+"wYV" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "xbX" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -116402,7 +116434,7 @@ btl
 bmO
 bku
 bwO
-bAi
+hjt
 bBT
 bwO
 brc
@@ -116659,7 +116691,7 @@ btm
 bmO
 bwL
 byy
-bAj
+lRx
 bBT
 bwO
 brc
@@ -116916,7 +116948,7 @@ bgh
 bmO
 bwM
 bwO
-bAk
+lmF
 bBT
 bwO
 brc
@@ -117173,7 +117205,7 @@ bmO
 bmO
 bwN
 byz
-bAj
+lRx
 bBU
 bwO
 brk
@@ -117430,7 +117462,7 @@ bto
 buN
 dCS
 bwO
-bAl
+ijR
 bBT
 bwO
 bJF
@@ -117685,9 +117717,9 @@ aYr
 brh
 brR
 bta
-buk
+wDf
 bwy
-bwJ
+nvX
 bxA
 byJ
 bKk
@@ -117942,9 +117974,9 @@ boR
 bri
 btq
 bmP
-bwQ
+rPQ
 bwO
-bAn
+wYV
 bBT
 bwO
 bKW


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

This gives the bar actual privacy shutters over the tables in the bar, which lets the bartender close their bar down without needing to worry about people hopping the tables and greytiding their shit while the barman is gone.

Includes:
IceBox
Meta
Delta
Omega
Eclipsestation (all variants)
Box (all variants)
Space Bartender ghost role
Lavaland beach biodome bartender ghost role

### Why is this change good for the game?

bartenders can lower their shutters to get greytided less

mmmm shutter crush monke funny

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
there's shutters now

### What should players be aware of when it comes to the changes your PR is implementing?
you can open and close them like a door

### What general grouping does this PR fall under? 
mapping

### Are there any aspects of the PR that you would like us not to mention on the Wiki?
no

# Changelog

:cl:  
rscadd: shutters, and a lot of them
/:cl:
