### PR TITLE
surgkit node fix

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -331,6 +331,7 @@
 	display_name = "Cyborg Upgrade: Medical Advanced Surgical Kit"
 	description = "Advanced Surgical Kit upgrade design for medical cyborgs."
 	prereq_ids = list("cyborg_upg_med", "exp_tools")
+	design_ids = list("borg_upgrade_surgerykit")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
 	export_price = 2000
 

--- a/code/modules/research/techweb/layout.dm
+++ b/code/modules/research/techweb/layout.dm
@@ -215,6 +215,10 @@
         ui_x = 352
         ui_y = -160
 
+/datum/techweb_node/cyborg_upg_surgkit
+        ui_x = 416
+        ui_y = -160
+
 /datum/techweb_node/cyber_organs
         ui_x = 352
         ui_y = -96


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Fixes adv surgery borg kit not being present in its own node
Fixes the node being 0,0 in the node layout

# Changelog

:cl:  
bugfix: Fixed cyborg advanced surgical tools not being in the appropriate node
bugfix: Fixed cyborg advanced surgical node being 0,0 in the techweb layout
/:cl:
