### PR TITLE
People kept saying crawling under flaps isn't an issue because there are windoors, so this gives windoors damage deflection equivalent to airlocks to make them an actual obstacle.

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -8,6 +8,7 @@
 	resistance_flags = ACID_PROOF
 	var/base_state = "left"
 	max_integrity = 200 //If you change this, consider changing ../door/window/brigdoor/ max_integrity at the bottom of this .dm file
+	damage_deflection = 21
 	integrity_failure = 0
 	armor = list("melee" = 60, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 70, "acid" = 100)
 	visible = FALSE
@@ -366,6 +367,7 @@
 	base_state = "leftsecure"
 	var/id = null
 	max_integrity = 350 //Stronger doors for prison (regular window door health is 200)
+	damage_deflection = 30
 	reinf = 1
 	explosion_block = 1
 


### PR DESCRIPTION
Closes #11034 

# General Documentation

### Intent of your Pull Request
You wanna play the game of "oh but theres windoors" then let's make those windoors be able to be an actual obstacle instead of a 15 seconds click until its gone meme.

### Why is this change good for the game?
Prevents greytiders without making flaps uncrawlable because that "unintuitive" or something

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
You now need to deal atleast 21 damage to windoors and 30 damage to secure windors in a single hit to damage them at all

:cl:  
tweak: To match airlocks, you now need to deal atleast 21 damage to windoors in a single hit to damage them at all.
tweak: Secure windoors need 30 damage to match reinforced airlocks.
/:cl:
