### PR TITLE
reduces the damage of shotgun slugs to 46 down from 60

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,6 +1,6 @@
 /obj/item/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
-	damage = 60
+	damage = 46
 
 /obj/item/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

make other ammo types viable again

### Why is this change good for the game?

most viable single shot round is now either pulse rounds or beanbags, most viable straight damage is now point blank buckshot

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
shotgun slug damage is now 46
### What should players be aware of when it comes to the changes your PR is implementing?
shotgun slug damage is now 46
### What general grouping does this PR fall under? 
weapons
### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
shotgun slug damage is now 46

# Changelog

:cl:  
tweak: shotgun slug damage is now 46 down from 60
/:cl:
