### PR TITLE
Moves the give() proc down to /mob/living so it doesnt make runtimes

### DIFF
--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -147,7 +147,8 @@
   
   This handles creating an alert and adding an overlay to it
   */
-/mob/living/carbon/proc/give()
+/mob/living/carbon/give()
+	. = ..()
 	var/obj/item/receiving = get_active_held_item()
 	if(!receiving)
 		to_chat(src, "<span class='warning'>You're not holding anything to give!</span>")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -909,6 +909,10 @@
 /mob/living/proc/harvest(mob/living/user) //used for extra objects etc. in butchering
 	return
 
+// Hotkeys Exist, so this stops it from making runtimes
+/mob/living/proc/give()
+	return
+
 /mob/living/canUseTopic(atom/movable/M, be_close=FALSE, no_dextery=FALSE, no_tk=FALSE)
 	if(incapacitated())
 		to_chat(src, "<span class='warning'>You can't do that right now!</span>")


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

_It should probably be on /mob but that case would probably never happen_

Anyways moves give definition from /mob/living/carbon to /mob/living due to other livings being able to use the give hotkey

### Why is this change good for the game?

Runtimes bad unga

# Changelog

:cl:  
bugfix: Trying to give as a non-carbon nolonger runtimes
/:cl:
