### PR TITLE
chitinous mass armor now accepts oxygen tanks

### DIFF
--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -531,6 +531,7 @@
 	flags_inv = HIDEJUMPSUIT
 	cold_protection = 0
 	heat_protection = 0
+	allowed = list(/obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman) // allows ling armor to carry the usual space suit tanks.
 
 /obj/item/clothing/suit/armor/changeling/Initialize()
 	. = ..()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24533979/108803593-b2159080-7560-11eb-8037-15a341f3ea3a.png)


:cl:  Hopek
bugfix: chitinous armor now accepts oxygen tanks.
/:cl:
