### PR TITLE
Renames View Admin Remarks to View Own Admin Notes because I couldnt find the button and I was looking for it

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -232,7 +232,7 @@ GLOBAL_VAR_INIT(mentor_ooc_colour, YOGS_MENTOR_OOC_COLOUR) // yogs - mentor ooc 
 		to_chat(src, "<span class='notice'>The Message of the Day has not been set.</span>")
 
 /client/proc/self_notes()
-	set name = "View Admin Remarks"
+	set name = "View Own Notes"
 	set category = "OOC"
 	set desc = "View the notes that admins have written about you"
 

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -232,7 +232,7 @@ GLOBAL_VAR_INIT(mentor_ooc_colour, YOGS_MENTOR_OOC_COLOUR) // yogs - mentor ooc 
 		to_chat(src, "<span class='notice'>The Message of the Day has not been set.</span>")
 
 /client/proc/self_notes()
-	set name = "View Own Notes"
+	set name = "View Own Admin Notes"
 	set category = "OOC"
 	set desc = "View the notes that admins have written about you"
 


### PR DESCRIPTION
fuck the template, does this because its more descriptive