### PR TITLE
Allows chitin plate armor to carry emergency tanks

### DIFF
--- a/yogstation/code/modules/clothing/suits/armor.dm
+++ b/yogstation/code/modules/clothing/suits/armor.dm
@@ -7,6 +7,7 @@
 	resistance_flags = FIRE_PROOF
 	armor = list(melee = 65, bullet = 35, laser = 15, energy = 10, bomb = 35, fire = 50, bio = 0, rad = 0)
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
+	allowed = list(/obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman) // allows ling armor to carry the usual space suit tanks.
 
 /obj/item/clothing/suit/armor/vest/rycliesarmour
 	name = "war armour"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24533979/108872275-9d1c1a00-75bf-11eb-9f33-82bea6929336.png)

whoops

Original:

![image](https://user-images.githubusercontent.com/24533979/108872394-bfae3300-75bf-11eb-960a-ffcefe5525f0.png)


:cl:  Hopek
bugfix: Allowed chitin plate armor to carry emergency tanks
/:cl:
