### PR TITLE
Rune scimitar's damage is now 28 from 35

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -578,7 +578,7 @@
 	righthand_file = 'yogstation/icons/mob/inhands/weapons/scimmy_righthand.dmi'
 	icon = 'yogstation/icons/obj/lavaland/artefacts.dmi'
 	icon_state = "rune_scimmy"
-	force = 35
+	force = 28
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
 	damtype = BRUTE
 	sharpness = IS_SHARP


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Reduces the force of the rune scimitar from 35 to 28.

### Why is this change good for the game?
Nerfs a weapon miners get that is almost as good as a desword.
# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
Changes rune scimitar damage to 28 from 35. It's a necropolis chest drop.

### What general grouping does this PR fall under? 
Mining change

# Changelog

:cl:  
tweak: rune scimitar now does 28 damage.  
/:cl:
