### PR TITLE
actually fixes reinforced floors and walls interacting with singularity

### DIFF
--- a/code/game/turfs/simulated/floor/reinf_floor.dm
+++ b/code/game/turfs/simulated/floor/reinf_floor.dm
@@ -77,7 +77,6 @@
 				ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 
 /turf/open/floor/engine/singularity_pull(S, current_size)
-	..()
 	if(current_size >= STAGE_FIVE)
 		if(floor_tile)
 			if(prob(30))

--- a/code/game/turfs/simulated/wall/reinf_walls.dm
+++ b/code/game/turfs/simulated/wall/reinf_walls.dm
@@ -203,7 +203,6 @@
 		icon_state = "r_wall"
 
 /turf/closed/wall/r_wall/singularity_pull(S, current_size)
-	..()
 	if(current_size >= STAGE_FIVE)
 		if(prob(30))
 			dismantle_wall()


### PR DESCRIPTION
issue was in normal floor singularity_pull which would attempt to replace the tile with a plating and fail while also spawning in the tile used to make the floor which is the rods = infinite rods
tldr you can now easily(tm)(r) contain a tier 4 singularity


:cl:  
bugfix: singularities will now not spawn infinite rods when near reinforced floors
bugfix: singularities will no longer eat rwalls like normal walls
/:cl:
