### PR TITLE
removes heart attacks from being too fat since it's not funny

### DIFF
--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -84,11 +84,6 @@
 			beat = BEAT_NONE
 	if(HAS_TRAIT(owner, TRAIT_FAT) && owner.stat != DEAD) //yogs: being fat causes heart damage
 		owner.adjustOrganLoss(ORGAN_SLOT_HEART, maxHealth * STANDARD_ORGAN_DECAY, 85) //eat happy, eat healthy
-		if(damage >= 80 && beating)
-			if(prob(1))
-				if(owner.stat == CONSCIOUS)
-					owner.visible_message("<span class='userdanger'>[owner] clutches at [owner.p_their()] chest as if [owner.p_their()] heart is stopping!</span>")
-				owner.set_heartattack(TRUE) //yogs end
 	if(organ_flags & ORGAN_FAILING)	//heart broke, stopped beating, death imminent
 		if(owner.stat == CONSCIOUS)
 			owner.visible_message("<span class='userdanger'>[owner] clutches at [owner.p_their()] chest as if [owner.p_their()] heart is stopping!</span>")


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request
hearts will no longer fail from having the fat trait since it's mega uncontrollable, they still take damage from it though
people actually die to this like a lot

### Why is this change good for the game?
reduces RP
# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
probably not documented but hearts will no longer fail solely due to being fat

### What general grouping does this PR fall under? 
medical

# Changelog

:cl:  
tweak: hearts will no longer spontaneously fail due to bad eating habits
/:cl:
