### PR TITLE
damages venus human traps if they are not close to kudzu

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -102,7 +102,7 @@
 	. = ..()
 	pull_vines()
 	if(!kudzu_need())
-		to_chat(owner, "<span class='danger'>You wither away without the support of the kudzu...</span>")
+		to_chat(src, "<span class='danger'>You wither away without the support of the kudzu...</span>")
 		adjustHealth(-5)
 	
 /mob/living/simple_animal/hostile/venus_human_trap/AttackingTarget()
@@ -199,7 +199,7 @@
   * Damages the mob if not
   */
 /mob/living/simple_animal/hostile/venus_human_trap/proc/kudzu_need()
-	for(var/obj/structure/spacevine in view(3,user))
+	for(var/obj/structure/spacevine in view(3,src))
 		return TRUE
 	return FALSE
 		

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -103,7 +103,7 @@
 	pull_vines()
 	if(!kudzu_need())
 		adjustHealth(-5)
-		if(prob(10))
+		if(prob(20))
 			to_chat(src, "<span class='danger'>You wither away without the support of the kudzu...</span>")
 	
 /mob/living/simple_animal/hostile/venus_human_trap/AttackingTarget()

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -102,8 +102,9 @@
 	. = ..()
 	pull_vines()
 	if(!kudzu_need())
-		to_chat(src, "<span class='danger'>You wither away without the support of the kudzu...</span>")
 		adjustHealth(-5)
+		if(prob(10))
+			to_chat(src, "<span class='danger'>You wither away without the support of the kudzu...</span>")
 	
 /mob/living/simple_animal/hostile/venus_human_trap/AttackingTarget()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -101,6 +101,9 @@
 /mob/living/simple_animal/hostile/venus_human_trap/Life()
 	. = ..()
 	pull_vines()
+	if(!kudzu_need())
+		to_chat(owner, "<span class='danger'>You wither away without the support of the kudzu...</span>")
+		adjustHealth(-5)
 	
 /mob/living/simple_animal/hostile/venus_human_trap/AttackingTarget()
 	. = ..()
@@ -186,5 +189,17 @@
   * Arguments:
   * * datum/beam/vine - The vine to be removed from the list.
   */
-mob/living/simple_animal/hostile/venus_human_trap/proc/remove_vine(datum/beam/vine, force)
+/mob/living/simple_animal/hostile/venus_human_trap/proc/remove_vine(datum/beam/vine, force)
 	vines -= vine
+
+/**
+  * Damages the human trap if they're >3 tiles away from a kudzu
+  *
+  * Checks if there is a kudzu within 3 tiles
+  * Damages the mob if not
+  */
+/mob/living/simple_animal/hostile/venus_human_trap/proc/kudzu_need()
+	for(var/obj/structure/spacevine in view(3,user))
+		return TRUE
+	return FALSE
+		


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

damages venus human traps if they are not close to kudzu

### Why is this change good for the game?

venus human traps should not be fucking off away from the kudzu as their own little antag adventure, they should be protecting it and using it as their lifeblood

# Changelog

:cl:  
tweak: Venus human traps now take damage if they stray away from the kudzu
/:cl:
