### PR TITLE
Fixes autolathe incorrectly identifying the processing item as the last requested item

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -336,8 +336,6 @@
 
 /obj/machinery/autolathe/proc/make_item(datum/design/D, multiplier)
 	var/is_stack = ispath(D.build_path, /obj/item/stack)
-	if(is_stack)
-	else
 	var/coeff = (is_stack ? 1 : prod_coeff) //stacks are unaffected by production coefficient
 	var/total_amount = 0
 	for(var/MAT in D.materials)

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -154,7 +154,7 @@
 	id = "cable_coil"
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 10, /datum/material/glass = 5)
-	build_path = /obj/item/stack/cable_coil
+	build_path = /obj/item/stack/cable_coil/random
 	category = list("initial","Tools","Tool Designs")
 	maxstack = MAXCOIL
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -154,7 +154,7 @@
 	id = "cable_coil"
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 10, /datum/material/glass = 5)
-	build_path = /obj/item/stack/cable_coil/random
+	build_path = /obj/item/stack/cable_coil
 	category = list("initial","Tools","Tool Designs")
 	maxstack = MAXCOIL
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Apparently that was a bug _lmao_

So what happens is when it goes to the make_item proc it uses the last requested item instead of the design it's making it use the last queued item (eg. 1 cable coil, 1 toolbox) which then causes it to freak the fuck out and make _way_ more than it should

Fixes: https://github.com/yogstation13/Yogstation/issues/11061

### Why is this change good for the game?

Fixes a bug in which the cable-coil monster would emerge

# Changelog

:cl:  
bugfix: Cable coils no longer print in sets of 30 if something is queued after it
/:cl:
