### PR TITLE
increases plasma consumption in radiation collectors from 0.001 moles to 0.01 moles

### DIFF
--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -23,7 +23,7 @@
 	var/active = 0
 	var/locked = FALSE
 	var/drainratio = 1
-	var/powerproduction_drain = 0.005
+	var/powerproduction_drain = 0.01
 
 	var/bitcoinproduction_drain = 0.15
 	var/bitcoinmining = FALSE

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -23,7 +23,7 @@
 	var/active = 0
 	var/locked = FALSE
 	var/drainratio = 1
-	var/powerproduction_drain = 0.001
+	var/powerproduction_drain = 0.005
 
 	var/bitcoinproduction_drain = 0.15
 	var/bitcoinmining = FALSE


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

increase plasma consumption in radiation collectors by 1000% or whatever so their fullness actually MATTERS
with a 0.01 mole usage per process (generally occur every 2 seconds according to round timer) a radiation collector will have burnt through 10 moles of plasma or ~303 kpa in just over 30 minutes, with filled plasma tanks lasting roughly 90 minutes before needing to be refilled or replaced, with cooled tanks being able to hold more plasma and therefore lasting even longer.
all plasma consumed by this is transformed into tritium which can be mixed with oxygen in a rad collector to make research points as if that even matters. The consumption of trit/oxygen has not been changed.

number might be a bit high

### Why is this change good for the game?
more engine maintenance = more for engineers to do when not sticking thumb in ass
# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
filling plasma tanks for rad collectors matters now

### What should players be aware of when it comes to the changes your PR is implementing?
the amount of plasma in a rad collector will actually matter, meaning more filled tanks being used in collectors = less needing to refill them
### What general grouping does this PR fall under? 
For example, Engineering changes, Medical rebalancing, TEG tweaks, etc.?
engineering


# Changelog

:cl:  
tweak: increased plasma to tritium rate in radiation collectors from 0.001 to 0.01
/:cl:
