### PR TITLE
fixes donor borgs not having proper overlays

### DIFF
--- a/yogstation/code/modules/mob/living/silicon/robot/robot.dm
+++ b/yogstation/code/modules/mob/living/silicon/robot/robot.dm
@@ -52,6 +52,19 @@
 		eye_lights.icon_state = "[icon_state]_e[is_servant_of_ratvar(src) ? "_r" : ""]"
 		add_overlay(eye_lights)
 
+		if(opened)
+			if(wiresexposed)
+				add_overlay("ov-opencover +w")
+			else if(cell)
+				add_overlay("ov-opencover +c")
+			else
+				add_overlay("ov-opencover -c")
+		if(hat)
+			var/mutable_appearance/head_overlay = hat.build_worn_icon(state = hat.icon_state, default_layer = 20, default_icon_file = 'icons/mob/head.dmi')
+			head_overlay.pixel_y += hat_offset
+			add_overlay(head_overlay)
+		update_fire()
+
 /mob/living/silicon/robot/examine(mob/user)
 	. = ..()
 	. += "It seems to have the <b>[module.name] module</b> loaded."


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

so basically prior, the code would run the original update_icons()

if the user had a donor skin, it would cut all overlays off, reapply the donor skin, and add back only the eye lights

this would kill every other overlay that isn't eye lights

there might be a better way to do this but I'm assuming the person that coded it like this had good-ish reasons to do so, so i just reattached the missing overlays to the donor borg check

![](https://i.imgur.com/fjCjmxu.png)

# Changelog

:cl:  
bugfix: Fixed donator borg skins not showing hats and covers and fire
/:cl:
