### PR TITLE
Makes polysmorphs bleed green like actual xenos

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -649,6 +649,12 @@
 	else
 		return pick("trails_1", "trails_2")
 
+/mob/living/carbon/human/species/polysmorph/getTrail()
+	if(getBruteLoss() < 300)
+		return pick("xltrails_1", "xltrails_2")
+	else
+		return pick("xttrails_1", "xttrails_2")
+		
 /mob/living/experience_pressure_difference(pressure_difference, direction, pressure_resistance_prob_delta = 0)
 	if(buckled)
 		return


### PR DESCRIPTION
# General Documentation
### Intent of your Pull Request
BLOOD FOR THE BLOOD GOD

### Why is this change good for the game?
SWEET BLOOD, IT SINGS TO ME

### Briefly describe your PR and the impacts of it, in layman's terms. 
Polysmorphs bleed actual xeno blood now.

### What general grouping does this PR fall under? 
BLOOD

### Are there any aspects of the PR that you would like us not to mention on the Wiki?
CRAWLING IN MY SKIIIIN

# Changelog
:cl:  
rscadd: Polysmorphs now bleed green blood like xenos do.
/:cl: