### PR TITLE
 Makes polysmorphs bleed green like actual xenos

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -295,6 +295,13 @@
 	if(!(NOBLOOD in dna.species.species_traits))
 		..()
 
+/mob/living/carbon/human/species/polysmorph/add_splatter_floor(turf/T, small_drip)
+	if(!T)
+		T = get_turf(src)
+	var/obj/effect/decal/cleanable/xenoblood/B = locate() in T.contents
+	if(!B)
+		B = new(T)
+
 /mob/living/carbon/alien/add_splatter_floor(turf/T, small_drip)
 	if(!T)
 		T = get_turf(src)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -649,6 +649,12 @@
 	else
 		return pick("trails_1", "trails_2")
 
+/mob/living/carbon/human/species/polysmorph/getTrail()
+	if(getBruteLoss() < 300)
+		return pick("xltrails_1", "xltrails_2")
+	else
+		return pick("xttrails_1", "xttrails_2")
+
 /mob/living/experience_pressure_difference(pressure_difference, direction, pressure_resistance_prob_delta = 0)
 	if(buckled)
 		return

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -169,7 +169,7 @@
 			var/splatter_dir = dir
 			if(starting)
 				splatter_dir = get_dir(starting, target_loca)
-			if(isalien(L))
+			if(isalien(L) || ispolysmorph(L))
 				new /obj/effect/temp_visual/dir_setting/bloodsplatter/xenosplatter(target_loca, splatter_dir)
 			else
 				new /obj/effect/temp_visual/dir_setting/bloodsplatter(target_loca, splatter_dir)


### PR DESCRIPTION
# General Documentation
### Intent of your Pull Request
BLOOD FOR THE BLOOD GOD

### Why is this change good for the game?
SWEET BLOOD, IT SINGS TO ME

### Briefly describe your PR and the impacts of it, in layman's terms. 
Makes polysmorphs bleed actual xeno blood, since their blood is already established to be acid.
It is both the blood splatter on floor, as well as when they get hit by a projectile.

### What should players be aware of when it comes to the changes your PR is implementing?
CRAWLING IN MY SKIN

### What general grouping does this PR fall under? 
BLOOOOD, SO MUCH BLOOD

# Changelog
:cl:  
rscadd: Polysmorphs now bleed green like they always should have.
/:cl:
