### PR TITLE
You can now examine megaphones to see if they're recharging. Useful when you wanna scream shit at people but you dont wanna say it softly.

### DIFF
--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -10,6 +10,11 @@
 	siemens_coefficient = 1
 	var/spamcheck = 0
 	var/list/voicespan = list(SPAN_COMMAND)
+	
+/obj/item/megaphone/examine(mob/user)
+	. = ..()
+	if(spamcheck > world.time)
+		. += "<span class='warning'>\The [src] is recharging!</span>"
 
 /obj/item/megaphone/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] is uttering [user.p_their()] last words into \the [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")


### PR DESCRIPTION
### Intent of your Pull Request

You can now examine megaphones to see if they're recharging. 

### Why is this change good for the game?

Useful when you wanna scream shit at people but you dont wanna say it softly.

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
You can now examine megaphones to see if they're recharging. 

### What should players be aware of when it comes to the changes your PR is implementing?
You can now examine megaphones to see if they're recharging. 

### What general grouping does this PR fall under? 
Megaphones

# Changelog

:cl:  
rscadd: You can now examine megaphones to see if they're recharging. 
/:cl:
