### PR TITLE
removes the coom from two of the random maint rooms

### DIFF
--- a/_maps/RandomRuins/StationRuins/maint/3x3/3x3_boxbedroom.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/3x3/3x3_boxbedroom.dmm
@@ -14,10 +14,9 @@
 /obj/item/trash/sosjerky,
 /turf/open/floor/plating,
 /area/template_noop)
-"o" = (
+"q" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
-/obj/effect/decal/cleanable/food/pie_smudge,
 /turf/open/floor/plating,
 /area/template_noop)
 "H" = (
@@ -38,7 +37,7 @@ b
 b
 "}
 (3,1,1) = {"
-o
+q
 b
 H
 "}

--- a/_maps/RandomRuins/StationRuins/maint/3x3/3x3_naughtyroom.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/3x3/3x3_naughtyroom.dmm
@@ -19,16 +19,15 @@
 /obj/item/restraints/handcuffs/fake,
 /turf/open/floor/carpet/purple,
 /area/template_noop)
-"k" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/obj/effect/decal/cleanable/food/pie_smudge,
-/turf/open/floor/carpet/purple,
-/area/template_noop)
 "q" = (
 /obj/structure/closet/crate/wooden,
 /obj/item/clothing/head/kitty,
 /obj/item/clothing/under/schoolgirl/red,
+/turf/open/floor/carpet/purple,
+/area/template_noop)
+"S" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
 /turf/open/floor/carpet/purple,
 /area/template_noop)
 
@@ -39,7 +38,7 @@ e
 "}
 (2,1,1) = {"
 b
-k
+S
 b
 "}
 (3,1,1) = {"


### PR DESCRIPTION
#### Read our contributing.md if you haven't already: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md

# General Documentation

### Intent of your Pull Request

Removes the "smashed pie" on top of the beds in the two bedroom maint rooms.

### Why is this change good for the game?

For one of them it's not needed at all and for the other the joke is obvious enough.

# Wiki Documentation

Not needed

# Changelog
:cl:  
rscdel: removed erp
/:cl:
