### PR TITLE
Silver swords

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -59,6 +59,41 @@
 	hitsound = 'sound/weapons/rapierhit.ogg'
 	materials = list(/datum/material/iron = 1000)
 
+/obj/item/melee/silversword
+	name = "silver sword"
+	desc = "A sword made out of the purest of metals, made to banish unholy creatures of the night, such as vampires and werewolves."
+	icon_state = "claymore"
+	item_state = "claymore"
+	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
+	hitsound = 'sound/weapons/bladeslice.ogg'
+	flags_1 = CONDUCT_1
+	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
+	force = 12 //Has to be weak as a weapon against normal people or it'll be abused.
+	throwforce = 10
+	w_class = WEIGHT_CLASS_NORMAL
+	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	sharpness = IS_SHARP
+	max_integrity = 200
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
+	resistance_flags = FIRE_PROOF
+	materials = list(/datum/material/iron = 1000)
+	var/bonus_burn = 0 //doesn't burn the unholy
+
+/obj/item/melee/silversword/attack(mob/living/target, mob/living/carbon/human/user)
+	. = ..()
+	bonus_burn = 0
+	if(!QDELETED(target) && target.stat != DEAD) 
+		if(is_vampire(target))
+			target.visible_message("<span class='warning'>[target] burns violently at [src]'s touch!</span>")
+			to_chat(target, "<span class='userdanger'>Your body flares with agony at [src]'s presence!</span>")
+			bonus_burn = 13 //total 25 damage on vampire. Yes, it is powerful, but a gun is still generally better.
+	target.adjustFireLoss(bonus_burn)
+
+/obj/item/melee/silversword/Initialize()
+	. = ..()
+	AddComponent(/datum/component/butchering, 40, 105)
+
 /obj/item/melee/cutlass
 	name = "cutlass"
 	desc = "A true pirates weapon, seems somewhat dull though"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -383,6 +383,15 @@
                     /obj/item/key/security)
     crate_name = "secway crate"
 
+/datum/supply_pack/security/silverswords
+	name = "Silver Swords"
+	desc = "Blades forged from silver, meant to arm anti-vampire personnel. Requires security access to open."
+	cost = 5000
+	contains = list(/obj/item/melee/silversword,
+					/obj/item/melee/silversword,
+					/obj/item/melee/silversword)
+	crate_name = "silver swords crate"
+
 /datum/supply_pack/security/firingpins
 	name = "Standard Firing Pins Crate"
 	desc = "Upgrade your arsenal with 10 standard firing pins. Requires Security access to open."


### PR DESCRIPTION

### Intent of your Pull Request

to add silver swords
They have the same model as the claymore since claymores already look kind of silverish.
### Why is this change good for the game?

lets you start anti-vampire crusades

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
This will be the basis of the Wiki entry for your PR, and more information / detail is better for Wiki editors to integrate.

adds silver swords. They deal only 12 damage by default, but can reveal vampires and deal extra burn damage to them. They are only purchasable in cargo and require sec access to open, and they also cost 5,000 credits for 3 of them (laser guns are 2,000 for 3)

### What should players be aware of when it comes to the changes your PR is implementing?

^^^

### What general grouping does this PR fall under? 
For example, Engineering changes, Medical rebalancing, TEG tweaks, etc.?

### Are there any aspects of the PR that you would like us not to mention on the Wiki?
no
### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
adds silver swords. They deal only 12 damage by default, but can reveal vampires and deal extra burn damage to them. They are only purchasable in cargo and require sec access to open, and they also cost 5,000 credits for 3 of them (laser guns are 2,000 for 3)

# Changelog

:cl:  
rscadd: Adds silver swords
/:cl:
