### PR TITLE
Events prerun text is now much bigger and red and also increase cancel time to 20 seconds

### DIFF
--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -61,7 +61,7 @@
 	triggering = TRUE
 	if (alert_observers)
 		//Yogs start -- 20 seconds instead of 10
-		message_admins("<span class='big bold'><font color = red>Random Event triggering in 20 seconds: [name] (<a href='?src=[REF(src)];cancel=1'>CANCEL</a>)</font color></span>")
+		message_admins("<span class='bold'><font color = red>Random Event triggering in 20 seconds: [name] (<a href='?src=[REF(src)];cancel=1'>CANCEL</a>)</font color></span>")
 		sleep(20 SECONDS)
 		//Yogs end
 		var/gamemode = SSticker.mode.config_tag

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -60,9 +60,9 @@
 
 	triggering = TRUE
 	if (alert_observers)
-		//Yogs start -- 15 seconds instead of 10
-		message_admins("Random Event triggering in 15 seconds: [name] (<a href='?src=[REF(src)];cancel=1'>CANCEL</a>)")
-		sleep(150)
+		//Yogs start -- 20 seconds instead of 10
+		message_admins("<span class='big bold'><font color = red>Random Event triggering in 20 seconds: [name] (<a href='?src=[REF(src)];cancel=1'>CANCEL</a>)</font color></span>")
+		sleep(20 SECONDS)
 		//Yogs end
 		var/gamemode = SSticker.mode.config_tag
 		var/players_amt = get_active_player_count(alive_check = TRUE, afk_check = TRUE, human_check = TRUE)


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

![image](https://user-images.githubusercontent.com/20369082/109447273-4ffdd500-7a11-11eb-8d4b-6fb71d557920.png)
![image](https://user-images.githubusercontent.com/20369082/109447275-53915c00-7a11-11eb-88b6-8004cd58b3d7.png)

Stops missing events

Lyis Approved:tm:

### Why is this change good for the game?

Makes it easier for admins to realize is something bad is about to gamer you

# Changelog

:cl:  
tweak: Event cancel time is 20 seconds
tweak: Event cancel text is scary red
/:cl:
