### PR TITLE
Halves Maintenance Drone Health

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -23,8 +23,8 @@
 	icon_living = "drone_maint_grey"
 	icon_dead = "drone_maint_dead"
 	possible_a_intents = list(INTENT_HELP, INTENT_HARM)
-	health = 30
-	maxHealth = 30
+	health = 15
+	maxHealth = 15
 	unsuitable_atmos_damage = 0
 	wander = 0
 	speed = -1 //YOGS - drones //Buffed to not be a fucking god damn piece of slug matter writhing on the fucking floor


### PR DESCRIPTION
# General Documentation

# Intent of your Pull Request

Halves the health of Maintenance Drones.
I've received on good enough authority this won't affect any other drones
![dpng](https://user-images.githubusercontent.com/62276730/109449375-42971980-7a16-11eb-9c47-85413874127c.png)


# Why is this change good for the game?
https://discord.com/channels/134720091576205312/134720091576205312/815788278971105320
![bpng](https://user-images.githubusercontent.com/62276730/109449178-c8669500-7a15-11eb-8f14-163f56aa9474.png)
I and a few other people believe bots have too much health given what they do for the station (mitigate any and all damages done to the station short of heat and rads maybe, can fix spaced or toxic areas with 0 risk to themselves, essentially infinite if a drone is smart enough).

# Wiki Documentation

The health of Maintenance Drones is now 15, as opposed to the initial 30. The health of drones aren't listed anywhere so nothing on the wiki has to be changed.

########################################### Changelog

:cl:  
tweak: Halved drone health.
/:cl:
