### PR TITLE
Fixes Wrong Git Appearing on the Bluescreen

### DIFF
--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -508,7 +508,7 @@ o8o        `8    "888"  `Y8bood8P'  8""88888P'
 A fatal exception has occurred at 002B:C562F1B7 in TGUI.
 The current application will be terminated.
 Send the copy of the following stack trace to an authorized
-Nanotrasen incident handler at https://github.com/tgstation/tgstation.
+Nanotrasen incident handler at https://github.com/yogstation13/Yogstation.
 Thank you for your cooperation.
 </marquee>
 <div id="FatalError__stack" class="FatalError__stack"></div>


### PR DESCRIPTION
# General Documentation

# Intent of your Pull Request

Fixes wrong issue appearing in git. 
Before:
![bpng](https://user-images.githubusercontent.com/62276730/109457074-20a69280-7a28-11eb-8d6d-f276e14e674c.png)

I'd put an after image here but I didn't compile nor test this, so you're going to have to take my word that this works, I know I am.

# Why is this change good for the game?

Removes mention of the TG scourge from our sacred game.

# Changelog

:cl:  
tweak: Fixes incorrect github repository mention in bluescreen. Should this go under spellcheck?  
/:cl:
