### PR TITLE
makes simplemobs actually do emotes

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -169,37 +169,37 @@
 /mob/living/simple_animal/pet/cat/Life()
 	if(!stat && !buckled && !client)
 		if(prob(1))
-			emote("me", 1, pick("stretches out for a belly rub.", "wags its tail.", "lies down."))
+			emote("me", 1, pick("stretches out for a belly rub.", "wags its tail.", "lies down."), TRUE)
 			icon_state = "[icon_living]_rest"
 			collar_type = "[initial(collar_type)]_rest"
 			set_resting(TRUE)
 		else if (prob(1))
-			emote("me", 1, pick("sits down.", "crouches on its hind legs.", "looks alert."))
+			emote("me", 1, pick("sits down.", "crouches on its hind legs.", "looks alert."), TRUE)
 			icon_state = "[icon_living]_sit"
 			collar_type = "[initial(collar_type)]_sit"
 			set_resting(TRUE)
 		else if (prob(1))
 			if (resting)
-				emote("me", 1, pick("gets up and meows.", "walks around.", "stops resting."))
+				emote("me", 1, pick("gets up and meows.", "walks around.", "stops resting."), TRUE)
 				icon_state = "[icon_living]"
 				collar_type = "[initial(collar_type)]"
 				set_resting(FALSE)
 			else
-				emote("me", 1, pick("grooms its fur.", "twitches its whiskers.", "shakes out its coat."))
+				emote("me", 1, pick("grooms its fur.", "twitches its whiskers.", "shakes out its coat."), TRUE)
 
 	//MICE!
 	if((src.loc) && isturf(src.loc))
 		if(!stat && !resting && !buckled)
 			for(var/mob/living/simple_animal/mouse/M in view(1,src))
 				if(!M.stat && Adjacent(M))
-					emote("me", 1, "splats \the [M]!")
+					emote("me", 1, "splats \the [M]!", TRUE)
 					M.splat()
 					movement_target = null
 					stop_automated_movement = 0
 					break
 			for(var/obj/item/toy/cattoy/T in view(1,src))
 				if (T.cooldown < (world.time - 400))
-					emote("me", 1, "bats \the [T] around with its paw!")
+					emote("me", 1, "bats \the [T] around with its paw!", TRUE)
 					T.cooldown = world.time
 
 	..()
@@ -238,13 +238,13 @@
 		if(change > 0)
 			if(M && stat != DEAD)
 				new /obj/effect/temp_visual/heart(loc)
-				emote("me", 1, "purrs!")
+				emote("me", 1, "purrs!", TRUE)
 				if(flags_1 & HOLOGRAM_1)
 					return
 				SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, src, /datum/mood_event/pet_animal, src)
 		else
 			if(M && stat != DEAD)
-				emote("me", 1, "hisses!")
+				emote("me", 1, "hisses!", TRUE)
 
 /mob/living/simple_animal/pet/cat/cak //I told you I'd do it, Remie
 	name = "Keeki"

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -512,10 +512,10 @@
 						movement_target.attack_animal(src)
 					else if(ishuman(movement_target.loc) )
 						if(prob(20))
-							emote("me", 1, "stares at [movement_target.loc]'s [movement_target] with a sad puppy-face")
+							emote("me", 1, "stares at [movement_target.loc]'s [movement_target] with a sad puppy-face", TRUE)
 
 		if(prob(1))
-			emote("me", 1, pick("dances around.","chases its tail!"))
+			emote("me", 1, pick("dances around.","chases its tail!"), TRUE)
 			spawn(0)
 				for(var/i in list(1,2,4,8,4,2,1,2,4,8,4,2,1,2,4,8,4,2))
 					setDir(i)
@@ -671,7 +671,7 @@
 
 	if(!stat && !resting && !buckled)
 		if(prob(1))
-			emote("me", 1, pick("dances around.","chases her tail."))
+			emote("me", 1, pick("dances around.","chases her tail."), TRUE)
 			spawn(0)
 				for(var/i in list(1,2,4,8,4,2,1,2,4,8,4,2,1,2,4,8,4,2))
 					setDir(i)
@@ -682,7 +682,7 @@
 
 	if(!stat && !resting && !buckled)
 		if(prob(1))
-			emote("me", 1, pick("chases its tail."))
+			emote("me", 1, pick("chases its tail."), TRUE)
 			spawn(0)
 				for(var/i in list(1,2,4,8,4,2,1,2,4,8,4,2,1,2,4,8,4,2))
 					setDir(i)
@@ -701,11 +701,11 @@
 		if(change > 0)
 			if(M && stat != DEAD) // Added check to see if this mob (the dog) is dead to fix issue 2454
 				new /obj/effect/temp_visual/heart(loc)
-				emote("me", 1, "yaps happily!")
+				emote("me", 1, "yaps happily!", TRUE)
 				SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, src, /datum/mood_event/pet_animal, src)
 		else
 			if(M && stat != DEAD) // Same check here, even though emote checks it as well (poor form to check it only in the help case)
-				emote("me", 1, "growls!")
+				emote("me", 1, "growls!", TRUE)
 
 /mob/living/simple_animal/pet/dog/bullterrier
 	name = "\improper bull terrier"

--- a/code/modules/mob/living/simple_animal/friendly/fox.dm
+++ b/code/modules/mob/living/simple_animal/friendly/fox.dm
@@ -42,8 +42,8 @@
 		if(change > 0)
 			if(M && stat != DEAD) // dead :,(((((
 				new /obj/effect/temp_visual/heart(loc)
-				emote("me", 1, "yaps happily!")
+				emote("me", 1, "yaps happily!", TRUE)
 				SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, src, /datum/mood_event/pet_animal, src)
 		else
 			if(M && stat != DEAD) // Same check here, even though emote checks it as well (poor form to check it only in the help case)
-				emote("me", 1, "growls!")
+				emote("me", 1, "growls!", TRUE)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -190,9 +190,9 @@
 					else
 						randomValue -= speak.len
 						if(emote_see && randomValue <= emote_see.len)
-							emote("me [pick(emote_see)]", 1)
+							emote("me [pick(emote_see)]", 1, TRUE)
 						else
-							emote("me [pick(emote_hear)]", 2)
+							emote("me [pick(emote_hear)]", 2, TRUE)
 				else
 					say(pick(speak), forced = "poly")
 			else
@@ -204,9 +204,9 @@
 					var/length = emote_hear.len + emote_see.len
 					var/pick = rand(1,length)
 					if(pick <= emote_see.len)
-						emote("me", 1, pick(emote_see))
+						emote("me", 1, pick(emote_see), TRUE)
 					else
-						emote("me", 2, pick(emote_hear))
+						emote("me", 2, pick(emote_hear), TRUE)
 
 
 /mob/living/simple_animal/proc/environment_is_safe(datum/gas_mixture/environment, check_temp = FALSE)


### PR DESCRIPTION
me emotes have a special prevention when not intentional for some probably good reason so I've decided to make automated speech bypass that allowing simplemobs to do audible and visible emotes again


:cl:  
bugfix: simplemobs will now do audible and visible emotes again
bugfix: pets will now do emotes on being pet and other stuff
/:cl:
