### PR TITLE
Indicates that admin-cluwned cluwnes are very valid via flavortext

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -153,6 +153,7 @@
 #define TRAIT_ACIDBLOOD         "acid_blood"
 #define TRAIT_PRESERVED_ORGANS	"preserved_organs"
 #define TRAIT_SURGERY_PREPARED	"surgery_prepared"
+#define TRAIT_VALID				"valid"
 
 //non-mob traits
 #define TRAIT_PARALYSIS			"paralysis" //Used for limb-based paralysis, where replacing the limb will fix it

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -1399,7 +1399,8 @@
 				to_chat(usr, "Mob doesn't exist anymore")
 				return
 			H.cluwneify()
-			message_admins("<span class='notice'>[key_name(usr)] has made [key_name(H)] into a Cluwne.</span>")
+			ADD_TRAIT(H, TRAIT_VALID, "adminverb")
+			message_admins("<span class='notice'>[key_name(usr)] has made [key_name(H)] into a valid cluwne.</span>")
 			return // yogs end
 
 		else if(href_list["makepacman"])

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -551,6 +551,9 @@
 /mob/proc/common_trait_examine()
 	if(HAS_TRAIT(src, TRAIT_DISSECTED))
 		. += "<span class='notice'>This body has been dissected and analyzed. It is no longer worth experimenting on.</span><br>"
+	
+	if(HAS_TRAIT(src, TRAIT_VALID))
+		. += "<span class='warning'>Looking at [src] makes you seething with rage! Beat the shit out of [p_them()]!</span><br>"
 
 /**
   * Get the list of keywords for policy config


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Adds examine text that says "Looking at [src] makes you seething with rage! Beat the shit out of [p_them()]!"

Make admincluwnes especially valid
It's a surprise tool that will help us later

# Changelog

:cl:  
rscadd: Added flavor text to admin cluwnes 
/:cl:
