### PR TITLE
Only shows the "You may call the shuttle whenever you find it appropriate." part of the end of shift announcement if the shuttle is idle(not called)

### DIFF
--- a/yogstation/code/controllers/subsystem/yogs.dm
+++ b/yogstation/code/controllers/subsystem/yogs.dm
@@ -144,7 +144,7 @@ SUBSYSTEM_DEF(Yogs)
 /datum/controller/subsystem/Yogs/fire(resumed = 0)
 	//END OF SHIFT ANNOUNCER
 	if(world.time > (ROUND_END_ANNOUNCEMENT_TIME*600) && !endedshift && !(EMERGENCY_AT_LEAST_DOCKED))
-		priority_announce("Crew, your shift has come to an end. \n You may call the shuttle whenever you find it appropriate.", "End of shift announcement", 'sound/ai/commandreport.ogg')
+		priority_announce("Crew, your shift has come to an end. [SSshuttle.emergency.mode != SHUTTLE_IDLE ? "\n You may call the shuttle whenever you find it appropriate." : ""]", "End of shift announcement", 'sound/ai/commandreport.ogg')
 		endedshift = TRUE
 	
 	//UNCLAIMED TICKET BWOINKER


### PR DESCRIPTION
It always bothered me, this improves RP because CC are not idiots, they are going to know that the shuttle is called and theyre not going to tell you to feel free to call it if its already called