### PR TITLE
Changes the threshold from which jobs get their access expanded due to lowpop from 8 to 25

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -327,7 +327,7 @@ GATEWAY_DELAY 18000
 ## If the number of players ready at round starts exceeds this threshold, JOBS_HAVE_MINIMAL_ACCESS will automatically be enabled. Otherwise, it will be disabled.
 ## This is useful for accomodating both low and high population rounds on the same server.
 ## Comment this out or set to 0 to disable this automatic toggle.
-MINIMAL_ACCESS_THRESHOLD 25
+MINIMAL_ACCESS_THRESHOLD 18
 
 ## Comment this out this if you wish to use the setup where jobs have more access.
 ## This is intended for servers with low populations - where there are not enough

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -327,7 +327,7 @@ GATEWAY_DELAY 18000
 ## If the number of players ready at round starts exceeds this threshold, JOBS_HAVE_MINIMAL_ACCESS will automatically be enabled. Otherwise, it will be disabled.
 ## This is useful for accomodating both low and high population rounds on the same server.
 ## Comment this out or set to 0 to disable this automatic toggle.
-MINIMAL_ACCESS_THRESHOLD 8
+MINIMAL_ACCESS_THRESHOLD 25
 
 ## Comment this out this if you wish to use the setup where jobs have more access.
 ## This is intended for servers with low populations - where there are not enough


### PR DESCRIPTION
8 is ridiculously low, it might as well be disabled at that point.

For those who don't know, the additional access thingy gives jobs more access(usually related to their departments) on lowpop. For example, the doctors gain access to chemistry.