### PR TITLE
Pepper/Spray travels 33% faster

### DIFF
--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -92,16 +92,15 @@
 			log_game("[user.real_name] ([user.ckey]) sprayed \a [src] containing [viruslist]")
 // yogs end
 	D.color = mix_color_from_reagents(D.reagents.reagent_list)
-	var/wait_step = max(round(2+3/range), 2)
-	do_spray(A, wait_step, D, range, puff_reagent_left, user)
+	do_spray(A, D, range, puff_reagent_left, user)
 
-/obj/item/reagent_containers/spray/proc/do_spray(atom/A, wait_step, obj/effect/decal/chempuff/D, range, puff_reagent_left, mob/user)
+/obj/item/reagent_containers/spray/proc/do_spray(atom/A, obj/effect/decal/chempuff/D, range, puff_reagent_left, mob/user)
 	set waitfor = FALSE
 	var/range_left = range
 	for(var/i=0, i<range, i++)
 		range_left--
 		step_towards(D,A)
-		sleep(wait_step)
+		sleep(2)
 
 		for(var/atom/T in get_turf(D))
 			if(T == D || T.invisibility) //we ignore the puff itself and stuff below the floor


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Pepperspray is 33% faster in speed
[Demo](https://youtu.be/ARTXofIJb58)

Changes it from some weird ass calculation to a flat 2 deciseconds(0.2s)

### Why is this change good for the game?

Was a little bit too slow, this basically wont affect too much other than most sprays being faster

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
Pepperspray is faster

### What should players be aware of when it comes to the changes your PR is implementing?

### What general grouping does this PR fall under? 
Self Defense buff

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
Sprays travel 33% faster

# Changelog

:cl:  
tweak: Pepper/Sprays move 33% faster
/:cl:
