### PR TITLE
compactifies operating computer backend into a list

### DIFF
--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -59,6 +59,9 @@
 			thaw_them(L)
 	. = ..()
 
+/obj/machinery/stasis/proc/get_computer()
+	return computer
+
 /obj/machinery/stasis/proc/stasis_running()
 	return stasis_enabled && is_operational()
 

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -532,6 +532,9 @@
 			computer.table = src
 			break
 
+/obj/structure/table/optable/proc/get_computer()
+	return computer
+
 /obj/structure/table/optable/Destroy()
 	. = ..()
 	if(computer && computer.table == src)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -71,11 +71,11 @@
 	var/list/computer_viable_surfaces = list(/obj/structure/table/optable, /obj/machinery/stasis) //make sure anything in this list has a get_computer() proc thanks :)
 	for(var/thing in computer_viable_surfaces)
 		var/thingy = locate(thing, T)
-		if(!thingy)
-			continue
-		opcomputer = call(thingy, "get_computer")()
+		if(thingy)
+			opcomputer = call(thingy, "get_computer")()
 		if(opcomputer)
 			break
+
 	if(!opcomputer)
 		return
 	if(opcomputer.stat & (NOPOWER|BROKEN))

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -69,10 +69,10 @@
 	//Get the relevant operating computer
 	var/obj/machinery/computer/operating/opcomputer
 	var/list/computer_viable_surfaces = list(/obj/structure/table/optable, /obj/machinery/stasis) //make sure anything in this list has a get_computer() proc thanks :)
-	for(var/thing in computer_viable_surfaces)
-		var/thingy = locate(thing, T)
-		if(thingy)
-			opcomputer = call(thingy, "get_computer")()
+	for(var/potential_surface in computer_viable_surfaces)
+		var/actual_surface = locate(potential_surface, T)
+		if(actual_surface)
+			opcomputer = call(actual_surface, "get_computer")()
 		if(opcomputer)
 			break
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -68,14 +68,11 @@
 
 	//Get the relevant operating computer
 	var/obj/machinery/computer/operating/opcomputer
-	var/obj/structure/table/optable/table = locate(/obj/structure/table/optable, T)
-	if(table?.computer)
-		opcomputer = table.computer
-	else
-		var/obj/machinery/stasis/the_stasis_bed = locate(/obj/machinery/stasis, T)
-		if(the_stasis_bed?.computer)
-			opcomputer = the_stasis_bed.computer
-
+	var/list/computer_viable_surfaces = list(/obj/structure/table/optable, /obj/machinery/stasis) //make sure anything in this list has a get_computer() proc thanks :)
+	for(var/thing in computer_viable_surfaces)
+		opcomputer = call(thing, "get_computer")()
+		if(opcomputer)
+			break
 	if(!opcomputer)
 		return
 	if(opcomputer.stat & (NOPOWER|BROKEN))

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -70,7 +70,10 @@
 	var/obj/machinery/computer/operating/opcomputer
 	var/list/computer_viable_surfaces = list(/obj/structure/table/optable, /obj/machinery/stasis) //make sure anything in this list has a get_computer() proc thanks :)
 	for(var/thing in computer_viable_surfaces)
-		opcomputer = call(thing, "get_computer")()
+		var/thingy = locate(thing, T)
+		if(!thingy)
+			continue
+		opcomputer = call(thingy, "get_computer")()
 		if(opcomputer)
 			break
 	if(!opcomputer)


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request
this is probably a terrible idea for several reasons but I have no reason to believe it won't work
now instead of needing to add another check for a specific thing in the surgery's can_start proc you just add it to the list and give it a get_computer proc that returns its connected computer easy
has been tested and works fine
### Why is this change good for the game?
it is DEFINITELY not
# Wiki Documentation

# Changelog
:cl:  
experimental: slight change to how surgeries check operating computers for if they can be started to make the code for it look less bad
/:cl:
