### PR TITLE
Removes a terrible balance decision from the speed potions

### DIFF
--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -401,13 +401,7 @@
 	required_other = TRUE
 // yogs start
 /datum/chemical_reaction/slime/slimespeed/on_reaction(datum/reagents/holder)
-	if(prob(1))
-		explosion(get_turf(holder.my_atom), 1 ,3, 6)
-		return
-	if(prob(50))
-		new /mob/living/simple_animal/pet/gondola/gondolapod(get_turf(holder.my_atom))
-	else
-		new /obj/item/slimepotion/speed(get_turf(holder.my_atom))
+	new /obj/item/slimepotion/speed(get_turf(holder.my_atom))
 	..()
 // yogs end
 


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Red slime core or however the fuck you make speed potion nolonger blow you up or spawn gondola pods

### Why is this change good for the game?

Shit balance, just nerf the speed effect which it did, so it's only logical to remove this nerf

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
Slime extract works consistently

### What general grouping does this PR fall under? 
Xenobio buff

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
100% spawnrate for potion

# Changelog

:cl:  
tweak: Red slime cores nolonger explode or spawn gondola pods
/:cl:
