### PR TITLE
Adds Monstermos Airlocks and Holopads to Bar Variants

### DIFF
--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_arcade.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_arcade.dmm
@@ -603,6 +603,10 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"lJ" = (
+/obj/machinery/holopad,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "nA" = (
 /obj/structure/chair{
 	dir = 8
@@ -723,6 +727,12 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/eighties,
 /area/crew_quarters/bar)
+"xf" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/table,
+/obj/item/clothing/head/hardhat/cakehat,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "xh" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -763,12 +773,6 @@
 	pixel_y = -26
 	},
 /turf/open/floor/eighties,
-/area/crew_quarters/bar)
-"CI" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/candy,
-/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "CV" = (
 /obj/structure/disposalpipe/segment,
@@ -848,12 +852,6 @@
 	id = "barshutters";
 	name = "bar shutters"
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"Mt" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/soda_cans/sprited_cranberry,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "MG" = (
@@ -1007,6 +1005,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
+"WU" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/candy,
+/obj/item/reagent_containers/food/drinks/soda_cans/sprited_cranberry{
+	pixel_x = 5;
+	pixel_y = 10
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "Xl" = (
 /obj/structure/table/reinforced,
 /obj/item/lighter,
@@ -1144,7 +1152,7 @@ ag
 ab
 jv
 ST
-Mt
+xf
 qp
 qp
 qp
@@ -1160,7 +1168,7 @@ ag
 ac
 fy
 QX
-CI
+WU
 eK
 eK
 eK
@@ -1242,7 +1250,7 @@ sf
 ZQ
 HX
 aB
-aB
+lJ
 aB
 JH
 JH

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_box.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_box.dmm
@@ -997,13 +997,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"cy" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/reagent_containers/food/snacks/pie/cream,
-/obj/machinery/door/window/westright,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "cz" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/enzyme{
@@ -1285,6 +1278,18 @@
 /obj/item/storage/box/donkpockets{
 	pixel_x = 3;
 	pixel_y = 3
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"sY" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/pie/cream,
+/obj/machinery/door/window/westright,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
@@ -1698,7 +1703,7 @@ al
 al
 cd
 al
-cy
+sY
 al
 cO
 al

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_casino.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_casino.dmm
@@ -492,12 +492,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"br" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/westright,
-/turf/open/floor/plasteel/ameridiner,
-/area/crew_quarters/kitchen)
 "bs" = (
 /obj/machinery/door/airlock{
 	name = "Kitchen cold room";
@@ -916,6 +910,10 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"yX" = (
+/obj/machinery/holopad,
+/turf/open/floor/carpet,
+/area/crew_quarters/bar)
 "zc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8;
@@ -1029,6 +1027,17 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
+"Tn" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westright,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/crew_quarters/kitchen)
 "TA" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/mint,
@@ -1174,7 +1183,7 @@ aD
 aD
 aD
 bW
-ap
+yX
 ck
 bw
 bv
@@ -1317,9 +1326,9 @@ ag
 ag
 am
 am
-br
+Tn
 am
-br
+Tn
 am
 bE
 am

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_cheese.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_cheese.dmm
@@ -967,6 +967,15 @@
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"vy" = (
+/obj/structure/table/wood,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/obj/item/clothing/head/hardhat/cakehat,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "we" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria,
@@ -1065,6 +1074,10 @@
 	id = "barshutters";
 	name = "privacy shutters"
 	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"Uj" = (
+/obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "Ux" = (
@@ -1238,7 +1251,7 @@ cG
 aB
 aB
 aB
-aB
+Uj
 aB
 dh
 "}
@@ -1279,7 +1292,7 @@ ag
 ag
 ag
 aC
-IK
+vy
 aB
 au
 aE

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_citadel.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_citadel.dmm
@@ -405,6 +405,11 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"iM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/holopad,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "iO" = (
 /obj/structure/chair/sofa/right,
 /obj/structure/window{
@@ -508,25 +513,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"oZ" = (
-/obj/structure/table/wood/fancy,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 20
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	dir = 1;
-	pixel_x = 3;
-	pixel_y = 20
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "pd" = (
 /obj/effect/landmark/start/cook,
 /turf/open/floor/plasteel/cafeteria,
@@ -912,6 +898,26 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"FO" = (
+/obj/structure/table/wood/fancy,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 20
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	dir = 1;
+	pixel_x = 3;
+	pixel_y = 20
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/item/clothing/head/hardhat/cakehat,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "FR" = (
 /obj/machinery/camera{
 	c_tag = "Kitchen Cold Room"
@@ -1592,7 +1598,7 @@ bx
 "}
 (8,1,1) = {"
 OC
-oZ
+FO
 Ls
 Ls
 Hy
@@ -1613,7 +1619,7 @@ wZ
 wZ
 wZ
 RZ
-LT
+iM
 LT
 LT
 LT

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_clock.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_clock.dmm
@@ -520,6 +520,11 @@
 	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/theatre)
+"uK" = (
+/obj/structure/table/bronze,
+/obj/item/clothing/head/hardhat/cakehat,
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
 "ve" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair/bronze,
@@ -637,10 +642,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/bronze,
 /area/crew_quarters/kitchen)
-"BA" = (
-/obj/structure/table/bronze,
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
 "BC" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -982,6 +983,17 @@
 	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
+"QQ" = (
+/obj/effect/landmark/start/assistant,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/holopad,
+/turf/open/floor/bronze,
+/area/crew_quarters/bar)
 "Re" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -1109,16 +1121,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1;
 	icon_state = "vent_map_on-1"
-	},
-/turf/open/floor/bronze,
-/area/crew_quarters/bar)
-"Vt" = (
-/obj/effect/landmark/start/assistant,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
 	},
 /turf/open/floor/bronze,
 /area/crew_quarters/bar)
@@ -1261,7 +1263,7 @@ ve
 ug
 jy
 dw
-BA
+uK
 QB
 Wx
 Ws
@@ -1292,7 +1294,7 @@ Wx
 Wx
 Wx
 Cw
-Vt
+QQ
 Vl
 Wx
 Wx

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_conveyor.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_conveyor.dmm
@@ -580,18 +580,6 @@
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
-"bM" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "conveyorbar"
-	},
-/obj/machinery/door/window/westleft{
-	name = "Conveyor Door";
-	req_access_txt = "25"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/kitchen)
 "bN" = (
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/kitchen)
@@ -669,10 +657,6 @@
 "cc" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/kitchen)
-"cd" = (
-/obj/effect/spawner/structure/window/plasma,
-/turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "ce" = (
 /mob/living/carbon/monkey{
@@ -1059,6 +1043,27 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
+"kf" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "conveyorbar"
+	},
+/obj/machinery/door/window/westleft{
+	name = "Conveyor Door";
+	req_access_txt = "25"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/kitchen)
+"kM" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/bar)
 "nE" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only{
@@ -1149,6 +1154,16 @@
 	pixel_y = 6
 	},
 /turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/kitchen)
+"vH" = (
+/obj/effect/spawner/structure/window/plasma,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "wt" = (
 /obj/structure/disposalpipe/segment,
@@ -1416,7 +1431,7 @@ jj
 ao
 ao
 ao
-ao
+kM
 ao
 hc
 RP
@@ -1530,9 +1545,9 @@ ab
 ab
 al
 al
-bM
+kf
 al
-cd
+vH
 al
 cB
 al

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_diner.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_diner.dmm
@@ -592,14 +592,6 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
-"bC" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/westright,
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/kitchen)
 "bD" = (
 /turf/open/floor/plasteel{
 	icon_state = "cafeteria"
@@ -930,6 +922,19 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/crew_quarters/bar)
+"fR" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westright,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
 "hl" = (
 /obj/machinery/vending/cola,
 /obj/structure/window/reinforced,
@@ -1232,6 +1237,11 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
+"Tv" = (
+/obj/effect/turf_decal/ameritard,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "Up" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/enzyme{
@@ -1321,7 +1331,7 @@ aO
 aO
 bc
 az
-az
+Tv
 az
 bu
 az
@@ -1529,9 +1539,9 @@ ab
 ab
 aj
 aj
-bC
+fR
 aj
-bC
+fR
 aj
 cf
 aj

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_disco.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_disco.dmm
@@ -337,12 +337,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"aV" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/westright,
-/turf/open/floor/plasteel/ameridiner,
-/area/crew_quarters/kitchen)
 "aW" = (
 /obj/structure/closet/secure_closet/bar{
 	req_access_txt = "25"
@@ -660,13 +654,6 @@
 /obj/machinery/jukebox/disco,
 /turf/open/floor/light/colour_cycle/dancefloor_a,
 /area/crew_quarters/bar)
-"bS" = (
-/obj/machinery/door/airlock{
-	name = "Kitchen";
-	req_access_txt = "28"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/kitchen)
 "bT" = (
 /obj/machinery/processor,
 /obj/machinery/firealarm{
@@ -865,15 +852,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/bar)
-"jD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "kM" = (
 /obj/machinery/smartfridge/drinks,
 /obj/machinery/door/poddoor/preopen{
@@ -990,6 +968,17 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
+"Lf" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westright,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/crew_quarters/kitchen)
 "Mm" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/barman_recipes,
@@ -1036,6 +1025,19 @@
 	},
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/kitchen)
+"SI" = (
+/obj/machinery/door/airlock{
+	name = "Kitchen";
+	req_access_txt = "28"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/kitchen)
 "Ta" = (
 /obj/item/storage/secure/safe{
 	pixel_x = -6
@@ -1046,6 +1048,16 @@
 /obj/effect/landmark/blobstart,
 /obj/item/toy/beach_ball/holoball,
 /turf/open/floor/plating,
+/area/crew_quarters/bar)
+"VS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "Zg" = (
 /obj/structure/table,
@@ -1123,7 +1135,7 @@ ai
 (5,1,1) = {"
 ac
 ao
-jD
+VS
 an
 bc
 bc
@@ -1304,11 +1316,11 @@ ai
 ai
 ak
 ak
-aV
+Lf
 ak
-aV
+Lf
 ak
-bS
+SI
 ak
 ak
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_purple.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_purple.dmm
@@ -1379,6 +1379,15 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
+"Ey" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "ER" = (
 /obj/structure/table,
 /obj/machinery/requests_console{
@@ -1621,7 +1630,7 @@ aT
 aT
 aT
 UJ
-aT
+Ey
 di
 du
 ab

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_spacious.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_spacious.dmm
@@ -939,6 +939,14 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/bar)
+"gP" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "lI" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/turf_decal/tile/bar,
@@ -1000,15 +1008,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/bar)
-"rr" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/machinery/door/window/westright,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "ti" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/table/reinforced,
@@ -1080,6 +1079,21 @@
 "Lp" = (
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"MB" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/machinery/door/window/westright,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "PW" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -1163,7 +1177,7 @@ ba
 ba
 ba
 cC
-ba
+gP
 ba
 ba
 ci
@@ -1369,9 +1383,9 @@ ab
 ab
 aj
 aj
-rr
-rr
-rr
+MB
+MB
+MB
 aj
 cb
 aj

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_trek.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_trek.dmm
@@ -1272,7 +1272,15 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"ek" = (
+"ni" = (
+/obj/structure/table,
+/obj/item/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/mineral/titanium,
+/area/crew_quarters/kitchen)
+"oK" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1281,8 +1289,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
+	dir = 1
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
@@ -1292,16 +1299,12 @@
 	id = "barshutters";
 	name = "bar shutters"
 	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
 /turf/open/floor/mineral/titanium/white,
 /area/crew_quarters/bar)
-"ni" = (
-/obj/structure/table,
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/turf/open/floor/mineral/titanium,
-/area/crew_quarters/kitchen)
 "qW" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor/preopen{
@@ -1675,7 +1678,7 @@ ag
 ax
 aO
 aY
-ek
+oK
 Pz
 GZ
 GB


### PR DESCRIPTION
### General Documentation

# Intent of your Pull Request

Bar variants are further consistent, with the addition of the holopad (though bar_diner can't show it in fastdmm because of the american diner decals, still there though). Monstermos firelocks have been added to replace the old firelocks, one door just had no firelocks.

### Why is this change good for the game?

Makes variants consistent. Also those monstermos firelocks were long overdue.

# Wiki Documentation

Photos for the bar variants will need to be redone.

# Changelog

:cl:  
rscadd: Airlocks and holopads to bar variants.  
/:cl:
