### PR TITLE
Makes the herald cloak fire- and acid-proof

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
@@ -249,6 +249,7 @@
 	icon = 'icons/obj/lavaland/elite_trophies.dmi'
 	icon_state = "herald_cloak"
 	body_parts_covered = CHEST|GROIN|ARMS
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	hit_reaction_chance = 10
 
 /obj/item/clothing/neck/cloak/herald_cloak/proc/reactionshot(mob/living/carbon/owner)


### PR DESCRIPTION
# General Documentation
### Intent of your Pull Request
This cloak drops from a sentient herald elite.
Cool looking cape, except it immediately gets destroyed when you catch fire (which is every 5 seconds for miners).
Now you'll actually get to use it.

### Why is this change good for the game?
Makes the cloak more durable, improving RP - based relations between players.

### Briefly describe your PR and the impacts of it, in layman's terms. 
The herald cloak is now fireproof and acidproof like most of late miner clothing.

### What general grouping does this PR fall under? 
mining loot tweak

# Changelog
:cl:  
tweak: Herald cloak is now fire and acid proof.
/:cl:
