### PR TITLE
Adds Poppys to maint loot table

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -69,6 +69,7 @@
 			/obj/item/trash/popcorn = 1,
 			/obj/item/trash/raisins = 1,
 			/obj/item/trash/sosjerky = 1,
+			/obj/item/reagent_containers/food/snacks/grown/poppy = 1,
 			/obj/item/trash/syndi_cakes = 1)
 
 /obj/effect/spawner/lootdrop/trashbin
@@ -83,6 +84,7 @@
 			/obj/item/trash/popcorn = 1,
 			/obj/item/trash/raisins = 1,
 			/obj/item/trash/sosjerky = 1,
+			/obj/item/reagent_containers/food/snacks/grown/poppy = 1,
 			/obj/item/trash/syndi_cakes = 1)
 
 /obj/effect/spawner/lootdrop/three_course_meal


### PR DESCRIPTION
### Intent of your Pull Request

Adds Poppys to the maintenance trash loot table so heretics can't be meta'd for trying to create an imperfect ritual, or creating a new living heart.

### Why is this change good for the game?

Adds a way for heretics to cover their ass if they're caught with some Poppy's for those meta gamers.

### What should players be aware of when it comes to the changes your PR is implementing?

Poppys now spawn in maintenance.

### What general grouping does this PR fall under? 

Loot table changes?

:cl:  Xoxeyos
rscadd: Poppys now spawn in maintenance.
/:cl:
