### PR TITLE
Adds fly people and jelly people for the populace. Mushroompeople are added in config.  + a slight jelly nerf

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -13,8 +13,8 @@
 	var/datum/action/innate/regenerate_limbs/regenerate_limbs
 	liked_food = MEAT
 	coldmod = 6   // = 3x cold damage
-	heatmod = 0.5 // = 1/4x heat damage
-	burnmod = 0.5 // = 1/2x generic burn damage
+	heatmod = 0.825 // = 1/4x heat damage
+	burnmod = 0.65 // = 1/2x generic burn damage
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/jelly
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -459,7 +459,7 @@ ROUNDSTART_RACES human
 ## Races that are strictly worse than humans that could probably be turned on without balance concerns
 ROUNDSTART_RACES lizard
 #ROUNDSTART_RACES gorilla
-#ROUNDSTART_RACES fly
+ROUNDSTART_RACES fly
 ROUNDSTART_RACES moth
 ROUNDSTART_RACES plasmaman
 #ROUNDSTART_RACES shadow
@@ -469,7 +469,7 @@ ROUNDSTART_RACES polysmorph
 
 ## Races that are better than humans in some ways, but worse in others
 ROUNDSTART_RACES ethereal
-#ROUNDSTART_RACES jelly
+ROUNDSTART_RACES jelly
 #ROUNDSTART_RACES golem
 #ROUNDSTART_RACES adamantine
 #ROUNDSTART_RACES plasma
@@ -490,6 +490,8 @@ ROUNDSTART_RACES pod
 
 ## Races that are for EPIC GAMERS only
 #MENTOR_RACES polysmorph
+MENTOR_RACES mush
+
 
 ##-------------------------------------------------------------------------------------------
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -490,7 +490,7 @@ ROUNDSTART_RACES pod
 
 ## Races that are for EPIC GAMERS only
 #MENTOR_RACES polysmorph
-MENTOR_RACES mush
+#MENTOR_RACES mush
 
 
 ##-------------------------------------------------------------------------------------------


### PR DESCRIPTION
# General Documentation

enable flypeople, jellypeople and mushroompeople (disabled in config)

15% nerf to burn resistance to jelly people

### Intent of your Pull Request

to add fun races and diversify the station's ecosystem. 
AKA: fuck humans

### Why is this change good for the game?

more choice is always good

# Wiki Documentation

Mushroom people are slow, have a special punch that stuns, does 15 to 30 damage but takes 2.5 seconds to windup. They also take 25% more burn damage and are 50% more fucked by heat. They are only available to donors and mentors for the moment. 

### What should players be aware of when it comes to the changes your PR is implementing?

new races

### What general grouping does this PR fall under? 

round start options


tweak: enable flypeople
tweak: enable jelly people
tweak: adds mushroompeople to the config
/:cl:
