### PR TITLE
[admin] message admins on afk even if not important

### DIFF
--- a/yogstation/code/modules/client/verbs/afk.dm
+++ b/yogstation/code/modules/client/verbs/afk.dm
@@ -89,6 +89,9 @@
 			adminhelp("I need to go AFK as '[important_role]' for duration of '[time]' [reason ? " with the reason: '[reason]'" : ""]")
 			mob.log_message("is now AFK for [time] [reason ? " with the reason: '[reason]'" : ""]", LOG_OWNERSHIP)
 		else
-			to_chat(src, "<span class='danger'>Admins will not be automatically alerted, because you do not seem to be in a critical station role.</span>")
+			to_chat(src, "<span class='danger'>Admins will be subtly alerted, because you do not seem to be in a critical station role.</span>")
+			var/normal_role = special_role || M.job || initial(M.name) || "unknown job"
+			message_admins("[ADMIN_LOOKUPFLW(src)] has used the AFK verb as '[normal_role]' for duration of '[time]'")
+			log_admin("[key_name(src)] has used the AFK verb as '[normal_role]' for duration of '[time]'")
 	else
 		to_chat(src, "<span class='boldnotice'>It is not necessary to report being AFK if you are not in the game.</span>")

--- a/yogstation/code/modules/client/verbs/afk.dm
+++ b/yogstation/code/modules/client/verbs/afk.dm
@@ -92,6 +92,6 @@
 			to_chat(src, "<span class='danger'>Admins will be subtly alerted, because you do not seem to be in a critical station role.</span>")
 			var/normal_role = special_role || M.job || initial(M.name) || "unknown job"
 			message_admins("[ADMIN_LOOKUPFLW(src)] has used the AFK verb as '[normal_role]' for duration of '[time]'")
-			log_admin("[key_name(src)] has used the AFK verb as '[normal_role]' for duration of '[time]'")
+			log_game("[key_name(src)] has used the AFK verb as '[normal_role]' for duration of '[time]'")
 	else
 		to_chat(src, "<span class='boldnotice'>It is not necessary to report being AFK if you are not in the game.</span>")


### PR DESCRIPTION
```
to_chat(src, "<span class='danger'>Admins will be subtly alerted, because you do not seem to be in a critical station role.</span>")
var/normal_role = special_role || M.job || initial(M.name) || "unknown job"
message_admins("[ADMIN_LOOKUPFLW(src)] has used the AFK verb as '[normal_role]' for duration of '[time]'")
log_admin("[key_name(src)] has used the AFK verb as '[normal_role]' for duration of '[time]'")
```