### PR TITLE
Adds Ian Hitchkoff to death_commando.txt

### DIFF
--- a/strings/names/death_commando.txt
+++ b/strings/names/death_commando.txt
@@ -38,9 +38,10 @@ GORE Vidal
 Gristle McThornBody
 Hank Chesthair
 Hans Testosteroneson
+Ian Hitchkoff
+Jet Handblood
 Killiam Shakespeare
 Killing McKillingalot
-Jet Handblood
 Lance Killiam
 Leonardo Da Viking
 Lump Beefrock


### PR DESCRIPTION
### Intent of your Pull Request

Okay I would be completely understand if this got rejected but two neurons in my brain came together and came up with this idea, and then another came along saying "this just feels like it should be".

### Why is this change good for the game?

I think it is very fitting he became a Deathsquad Trooper.

Also fixed an alphabetical error.

# Changelog

:cl:  Identification
rscadd: Adds 'Ian Hitchkoff' to the Deathsquad Trooper name list.
/:cl:
