### PR TITLE
Fixes shuttle catastrophe event not happening

### DIFF
--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -6,7 +6,7 @@
 
 /datum/round_event_control/shuttle_catastrophe/canSpawnEvent(players, gamemode)
 	if((SSshuttle.emergency.name == "Build your own shuttle kit") || (SSshuttle.emergency.mode == SHUTTLE_CALL || SSshuttle.emergency.mode == SHUTTLE_RECALL || SSshuttle.emergency.mode == SHUTTLE_DOCKED))
-		return FALSE //don't undo manual player engineering, it also would unload people and ghost them, there's just a lot of problems
+		return FALSE // don't undo manual player engineering, it also would unload people and ghost them, there's just a lot of problems
 	return ..()
 
 

--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -5,7 +5,7 @@
 	max_occurrences = 1
 
 /datum/round_event_control/shuttle_catastrophe/canSpawnEvent(players, gamemode)
-	if((SSshuttle.emergency.name == "Build your own shuttle kit") || (SSshuttle.emergency.mode != SHUTTLE_CALL || SSshuttle.emergency.mode != SHUTTLE_RECALL || SSshuttle.emergency.mode != SHUTTLE_DOCKED))
+	if((SSshuttle.emergency.name == "Build your own shuttle kit") || (SSshuttle.emergency.mode == SHUTTLE_CALL || SSshuttle.emergency.mode == SHUTTLE_RECALL || SSshuttle.emergency.mode == SHUTTLE_DOCKED))
 		return FALSE //don't undo manual player engineering, it also would unload people and ghost them, there's just a lot of problems
 	return ..()
 

--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -5,7 +5,7 @@
 	max_occurrences = 1
 
 /datum/round_event_control/shuttle_catastrophe/canSpawnEvent(players, gamemode)
-	if((SSshuttle.emergency.name == "Build your own shuttle kit") || (SSshuttle.emergency.mode != SHUTTLE_CALL || SSshuttle.emergency.mode != SHUTTLE_RECALL || SSshuttle.emergency.mode != SHUTTLE_IDLE))
+	if((SSshuttle.emergency.name == "Build your own shuttle kit") || (SSshuttle.emergency.mode != SHUTTLE_CALL || SSshuttle.emergency.mode != SHUTTLE_RECALL || SSshuttle.emergency.mode != SHUTTLE_DOCKED))
 		return FALSE //don't undo manual player engineering, it also would unload people and ghost them, there's just a lot of problems
 	return ..()
 


### PR DESCRIPTION
# General Documentation
### Intent of your Pull Request
Jamie, while fixing the event, in the check if the event can't happen, made it check if the shuttle in SHUTTLE_IDLE state (which is the state in centcom, in which we WANT the event to happen), instead of SHUTTLE_DOCKED state. (shuttle docked at station, we don't want the event to happen).

### Why is this change good for the game?
bugfixes are always good, definitely improves RP

### Briefly describe your PR and the impacts of it, in layman's terms. 
Hopefully makes the shuttle catastrophe even happen again.

### What general grouping does this PR fall under? 
event fix

# Changelog
:cl:  
bugfix: hopefully makes the shuttle catastrophe event happen on its own again  
/:cl: