### PR TITLE
adds framework for bounties unlocking new crates and adds a few as an alterantive to mining tech

### DIFF
--- a/code/modules/cargo/bounties/progression.dm
+++ b/code/modules/cargo/bounties/progression.dm
@@ -1,0 +1,42 @@
+/datum/bounty/item/progression
+	var/list/unlocked_crates = list()
+
+/datum/bounty/progression/reward_string()
+	return "[reward] Credits and clearance to order new crates"
+
+/datum/bounty/item/progression/claim(mob/user)
+	..()
+	for(var/i in unlocked_crates)
+		var/datum/supply_pack/to_unlock = SSshuttle.supply_packs[i]
+		to_unlock.special_enabled = TRUE
+
+/datum/bounty/item/progression/mining_basic
+	name = "Common Mineral Prospecting"
+	description = "Basic materials are worth pocket change, but are integral for station longevity. Ship us a sheet of gold, uranium, or silver to certify your mining program as \"functional\""
+	reward = 1000
+	wanted_types = list(/obj/item/stack/sheet/mineral/silver,/obj/item/stack/sheet/mineral/gold,/obj/item/stack/sheet/mineral/uranium)
+	unlocked_crates = list(/datum/supply_pack/clearance/ka_damage,/datum/supply_pack/clearance/ka_cooldown,/datum/supply_pack/clearance/ka_range)
+
+/datum/bounty/item/progression/mining_basic/reward_string()
+	return "[reward] Credits and clearance to order basic kinetic accelerator modification crates"
+
+/datum/bounty/item/progression/mining_plasma
+	name = "Plasma Extraction"
+	description = "The reason you're here: plasma. Ship us a stack of it and we can certify your mining program as \"profitable\", allowing access to plasma-based mining equipment."
+	reward = 9000 //1000 less than a normal ship of plasma as a fee
+	wanted_types = list(/obj/item/stack/sheet/mineral/plasma)
+	required_count = 50
+	unlocked_crates = list(/datum/supply_pack/clearance/plasmacutter)
+
+/datum/bounty/item/progression/mining_plasma/reward_string()
+	return "[reward] Credits and clearance to order plasmacutters"
+
+/datum/bounty/item/progression/mining_advanced
+	name = "Strange Material Prospecting"
+	description = "Initial scanning of your mining locale showed anomalous readings in line with that of bluespace crystals. ship us one to confirm their presence and we'll allow you to order a special treat."
+	reward = 1000
+	wanted_types = list(/obj/item/stack/sheet/bluespace_crystal, /obj/item/stack/ore/bluespace_crystal) //we'll let them send artficial crystals since those would require department cooperation or shooting swarmers
+	unlocked_crates = list(/datum/supply_pack/clearance/plasmacutter_advanced)
+
+/datum/bounty/item/progression/mining_advanced/reward_string()
+	return "[reward] Credits and clearance to order high quality mining gear"

--- a/code/modules/cargo/bounty.dm
+++ b/code/modules/cargo/bounty.dm
@@ -176,6 +176,12 @@ GLOBAL_LIST_EMPTY(bounties_list)
 	var/datum/bounty/B = pick(GLOB.bounties_list)
 	B.mark_high_priority()
 
+	/********************************Progression Gens********************************/
+	var/list/progression_type_list = typesof(/datum/bounty/item/progression)
+
+	for(var/progression_bounty in progression_type_list)
+		try_add_bounty(new progression_bounty)
+
 	/********************************Low Priority Gens********************************/
 	var/list/low_priority_strict_type_list = list(  /datum/bounty/item/alien_organs,
 													/datum/bounty/item/syndicate_documents,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1664,6 +1664,45 @@
 	crate_name = "crate"
 
 //////////////////////////////////////////////////////////////////////////////
+//////////////////////////// Special Clearance////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
+/datum/supply_pack/clearance
+	group = "Unlocked Clearance"
+	special = TRUE
+	small_item = TRUE
+
+/datum/supply_pack/clearance/ka_damage
+	name = "KA Damage Mods"
+	desc = "Modifiers for a kinetic accelerator that increase the force of its projectiles."
+	cost = 700
+	contains = list(/obj/item/borg/upgrade/modkit/damage,/obj/item/borg/upgrade/modkit/damage,/obj/item/borg/upgrade/modkit/damage)
+
+/datum/supply_pack/clearance/ka_cooldown
+	name = "KA Cooldown Mods"
+	desc = "Modifiers for a kinetic accelerator that decrease the time needed for the accelerator to cool between shots."
+	cost = 700
+	contains = list(/obj/item/borg/upgrade/modkit/cooldown,/obj/item/borg/upgrade/modkit/cooldown,/obj/item/borg/upgrade/modkit/cooldown)
+
+/datum/supply_pack/clearance/ka_range
+	name = "KA Range Mods"
+	desc = "Modifiers for a kinetic accelerator that increase the range of its projectiles."
+	cost = 700
+	contains = list(/obj/item/borg/upgrade/modkit/range,/obj/item/borg/upgrade/modkit/range,/obj/item/borg/upgrade/modkit/range)
+
+/datum/supply_pack/clearance/plasmacutter
+	name = "Plasmacutter Crate"
+	desc = "Two plasmacutters, experimental mining equipment that uses heated plasma as fuel."
+	cost = 900
+	contains = list(/obj/item/gun/energy/plasmacutter,/obj/item/gun/energy/plasmacutter)
+
+/datum/supply_pack/clearance/plasmacutter_advanced
+	name = "Advanced Plasmacutter Crate"
+	desc = "A prototype plasmacutter variant with lower cooldown, more efficient fuel usage, and higher range."
+	cost = 2000
+	contains = list(/obj/item/gun/energy/plasmacutter/adv)
+
+//////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Organic /////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -1638,6 +1638,7 @@
 #include "code\modules\cargo\bounties\mech.dm"
 #include "code\modules\cargo\bounties\medical.dm"
 #include "code\modules\cargo\bounties\mining.dm"
+#include "code\modules\cargo\bounties\progression.dm"
 #include "code\modules\cargo\bounties\reagent.dm"
 #include "code\modules\cargo\bounties\science.dm"
 #include "code\modules\cargo\bounties\security.dm"


### PR DESCRIPTION
# General Documentation
numbers not final, let me know if they're too cheap
### Intent of your Pull Request

adds progression bounties, which unlock the ability to order new crates on completion, and puts important mining gear behind them
since mining gear is also used by things without access to a cargo shuttle mining tech isn't yeeted 
yet

### Why is this change good for the game?
reduces the reliance of mining on science by allowing them to rely on a department that profits off their successes, and the requirement for science to burn points on a tech tax to not stall the round
# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
three new bounties that unlock the ability to purchase KA modkits, plasmacutters, and advanced plasmacutters respectively

# Changelog

:cl:  
rscadd: new cargo bounties and a system to allow bounties to unlock the ability to order new crates
tweak: miners can now do bounties to unlock mining gear so they can wait for the cargo shuttle instead of waiting for science
/:cl:
