### PR TITLE
makes rad collector research per minute "accurate"

### DIFF
--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -185,7 +185,7 @@
 		if(!bitcoinmining)
 			. +=  "<span class='notice'>[src]'s display states that it has stored <b>[DisplayPower(stored_power)]</b>, and processing <b>[DisplayPower(RAD_COLLECTOR_OUTPUT)]</b>.</span>"
 		else
-			. += "<span class='notice'>[src]'s display states that it has stored a total of <b>[stored_power*RAD_COLLECTOR_MINING_CONVERSION_RATE]</b>, and producing [RAD_COLLECTOR_OUTPUT*RAD_COLLECTOR_MINING_CONVERSION_RATE] research points per minute.</span>"
+			. += "<span class='notice'>[src]'s display states that it has stored a total of <b>[stored_power*RAD_COLLECTOR_MINING_CONVERSION_RATE]</b>, and producing [RAD_COLLECTOR_OUTPUT*RAD_COLLECTOR_MINING_CONVERSION_RATE*30] research points per minute.</span>"
 	else
 		if(!bitcoinmining)
 			. += "<span class='notice'><b>[src]'s display displays the words:</b> \"Power production mode. Please insert <b>Plasma</b>. Use a multitool to change production modes.\"</span>"


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

multiplies the per minute examine amount by 30 to account for how many times that value is given in a minute since it's actually giving the per process amount which is NOT once per minute

# Changelog
:cl:  
tweak: rad collectors now display an accurater amount of research per minute when examined
/:cl:
