### PR TITLE
Fixes auxbase on box not having a docking port

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -38602,6 +38602,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"fUt" = (
+/obj/docking_port/stationary/public_mining_dock{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/construction/mining/aux_base)
 "fUP" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -76997,7 +77003,7 @@ apN
 apN
 apN
 apN
-apN
+fUt
 apN
 apN
 apN


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Title
Fixes bug

### Why is this change good for the game?

# Wiki Documentation

N/A

# Changelog

:cl:  
bugfix: Yogstation auxbase can now have the mining shuttle dock with it
/:cl:
