### PR TITLE
Foolproofs the Emergency Arena

### DIFF
--- a/_maps/templates/arena.dmm
+++ b/_maps/templates/arena.dmm
@@ -325,7 +325,7 @@ b
 b
 b
 b
-b
+a
 b
 a
 "}
@@ -341,7 +341,7 @@ b
 b
 a
 b
-d
+a
 d
 d
 b
@@ -860,7 +860,7 @@ b
 b
 b
 b
-b
+a
 b
 b
 b
@@ -2437,7 +2437,7 @@ d
 d
 d
 d
-d
+a
 d
 d
 d


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request
After the first successful Arena shuttle in 2 years, i noticed that people keep moving right after teleporting on shuttle, this resulted in 2 people moving onto lava. This change makes it so if you keep moving right, you'll hit a wall.

### Why is this change good for the game?
Makes people less angry.

### Briefly describe your PR and the impacts of it, in layman's terms. 
RIP AND TEAR, BUT NOT YOURSELF

### What general grouping does this PR fall under? 
arena shuttle map tweak

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
There are now 4 more walls on the emergency arena.

# Changelog
:cl:  
tweak: foolproofs the arena by placing walls right of the teleport exits
/:cl: