### PR TITLE
Adds new Heretic hallucinations.

### DIFF
--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -744,6 +744,7 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 					"revolver","energy sword","cryptographic sequencer","power sink","energy bow",\
 					"hybrid taser","stun baton","flash","syringe gun","circular saw","tank transfer valve",\
 					"ritual dagger","clockwork slab","spellbook",\
+					"Codex Cicatrix", "living heart", "sickly blade", "medallion",\
 					"pulse rifle","captain's spare ID","hand teleporter","hypospray","antique laser gun","X-01 MultiPhase Energy Gun","station's blueprints"\
 					)] into [equipped_backpack].</span>")
 


### PR DESCRIPTION
### Intent of your Pull Request

Adds the Codex Cicatrix, the Living Heart, a medallion, and a sickly blade to the list of items that you can hallucinate someone stowing into a backpack.

### Why is this change good for the game?

Adds some consistency between differing antagonistic items that can be hallucinated.

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
This will be the basis of the Wiki entry for your PR, and more information / detail is better for Wiki editors to integrate.

Four new hallucinations were added, regarding heretic items.

### What should players be aware of when it comes to the changes your PR is implementing?

Only that new hallucinations were added.

### What general grouping does this PR fall under? 
Hallucination additions.

### Are there any aspects of the PR that you would like us not to mention on the Wiki?

What said hallucinations are.

:cl:  Xoxeyos
rscadd: Adds more variety to the hallucinations that can be seen.
/:cl:
