### PR TITLE
Speeds up legionnaire so the sentient one actually matches the non-sentient one

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
@@ -32,7 +32,7 @@
 	//attack_verb_simple = "slash your arms at"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	throw_message = "doesn't affect the sturdiness of"
-	speed = 1
+	speed = 0
 	move_to_delay = 3
 	mouse_opacity = MOUSE_OPACITY_ICON
 	deathsound = 'sound/magic/curse.ogg'


### PR DESCRIPTION
# General Documentation
### Intent of your Pull Request
Legionnaire is a lavaland elite, which is currently considered to be the weakest. However, in his non-sentient state he's pretty challenging, because his speed almost matches yours.
However, once the elite is sentient (which is supposed to be "harder"), it moves extremely slow and cannot properly charge at people like the AI does.

### Why is this change good for the game?
Buffs the weakest of the elites, hopefully not making me sad every time i fight one.

### Briefly describe your PR and the impacts of it, in layman's terms. 
speeds up the sentient legionnaire

### What general grouping does this PR fall under? 
mining tweak

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
Legionnaire's speed is now 0 instead of 1. (lower is faster)

# Changelog
:cl:  
tweak: speeds up the legionnaire  
/:cl: