### PR TITLE
[admin] Animalize's safe_animal() is now exclusive instead of inclusive

### DIFF
--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -641,33 +641,10 @@
 //Bad mobs! - Remember to add a comment explaining what's wrong with the mob
 	if(!MP)
 		return 0	//Sanity, this should never happen.
+//	if(ispath(MP, /mob/living/simple_animal/pet/cat))
+//		return 0	//Template
 
-	if(ispath(MP, /mob/living/simple_animal/hostile/construct))
-		return 0 //Verbs do not appear for players.
-
-//Good mobs!
-	if(ispath(MP, /mob/living/simple_animal/pet/cat))
-		return 1
-	if(ispath(MP, /mob/living/simple_animal/pet/dog/corgi))
-		return 1
-	if(ispath(MP, /mob/living/simple_animal/crab))
-		return 1
-	if(ispath(MP, /mob/living/simple_animal/hostile/carp))
-		return 1
-	if(ispath(MP, /mob/living/simple_animal/hostile/mushroom))
-		return 1
-	if(ispath(MP, /mob/living/simple_animal/shade))
-		return 1
-	if(ispath(MP, /mob/living/simple_animal/hostile/killertomato))
-		return 1
-	if(ispath(MP, /mob/living/simple_animal/mouse))
-		return 1 //It is impossible to pull up the player panel for mice (Fixed! - Nodrak)
-	if(ispath(MP, /mob/living/simple_animal/hostile/bear))
-		return 1 //Bears will auto-attack mobs, even if they're player controlled (Fixed! - Nodrak)
-	if(ispath(MP, /mob/living/simple_animal/parrot))
-		return 1 //Parrots are no longer unfinished! -Nodrak
-
-	//Not in here? Must be untested!
-	return 0
+	//Not in here? Must be good!
+	return 1
 
 #undef TRANSFORMATION_DURATION


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

We have like 99999 simple mobs and only 10 were in this list to be able to be Animalized by admins
We have a sentience potion that DOESN'T EVEN USE THIS LIST

### Why is this change good for the game?
THIS CODE IS 9 YEARS OLD
THE LIST IS 9 YEARS OLD
SOCIETY HAS PROGRESS PAST THE NEED FOR SAFE_ANIMAL()
