### PR TITLE
turns out I fucked up a merge conflict resolution and the dragon chest only rolled for 3 of its items

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -763,7 +763,7 @@
 	name = "dragon chest"
 
 /obj/structure/closet/crate/necropolis/dragon/PopulateContents()
-	var/loot = rand(1,3)
+	var/loot = rand(1,4)
 	switch(loot)
 		if(1)
 			new /obj/item/melee/ghost_sword(src)


### PR DESCRIPTION

:cl:  
bugfix: dragon's blood is now back in the dragon chest loot pool 
/:cl:
