### PR TITLE
Syndicate lavaland syndie snipers are no longer usable by crew

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -114,8 +114,10 @@
 	var/obj/item/gun/G = locate(/obj/item/gun) in contents
 	if(G)
 		G.forceMove(loc)
-		QDEL_NULL(G.pin)
-		visible_message("[G] can now fit a new pin, but the old one was destroyed in the process.", null, null, 3)
+		var/pin = G.pin
+		if(G.pin.gun_remove()) //if this returns false the gun and pin are not going to exist
+			visible_message("[G] can now fit a new pin, but the old one was destroyed in the process.", null, null, 3)
+			QDEL_NULL(pin)
 		qdel(src)
 
 /obj/item/gun/examine(mob/user)

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -323,7 +323,7 @@
 	pin = /obj/item/firing_pin/implant/pindicate
 
 /obj/item/gun/ballistic/automatic/sniper_rifle/ultrasecure
-	pin = /obj/item/firing_pin/dredd/fucked
+	pin = /obj/item/firing_pin/fucked
 
 // Old Semi-Auto Rifle //
 

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -322,6 +322,9 @@
 	can_unsuppress = TRUE
 	pin = /obj/item/firing_pin/implant/pindicate
 
+/obj/item/gun/ballistic/automatic/sniper_rifle/syndicate
+	pin = /obj/item/firing_pin/dredd/fucked
+
 // Old Semi-Auto Rifle //
 
 /obj/item/gun/ballistic/automatic/surplus

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -322,7 +322,7 @@
 	can_unsuppress = TRUE
 	pin = /obj/item/firing_pin/implant/pindicate
 
-/obj/item/gun/ballistic/automatic/sniper_rifle/syndicate
+/obj/item/gun/ballistic/automatic/sniper_rifle/ultrasecure
 	pin = /obj/item/firing_pin/dredd/fucked
 
 // Old Semi-Auto Rifle //

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -43,20 +43,24 @@
 	obj_flags |= EMAGGED
 	to_chat(user, "<span class='notice'>You override the authentication mechanism.</span>")
 
+///what do we do when we are being added to a gun
 /obj/item/firing_pin/proc/gun_insert(mob/living/user, obj/item/gun/G)
 	gun = G
 	forceMove(gun)
 	gun.pin = src
 	return
 
+///pin removal proc, return TRUE if the gun is still intact when it's done, false if there is a "tragic" "accident"
 /obj/item/firing_pin/proc/gun_remove(mob/living/user)
 	gun.pin = null
 	gun = null
 	return TRUE
 
+///can the pin be used by whoever is firing its gun
 /obj/item/firing_pin/proc/pin_auth(mob/living/user)
 	return TRUE
 
+///what happens if an authorization is failed, defaults to exploding
 /obj/item/firing_pin/proc/auth_fail(mob/living/user)
 	user.show_message(fail_message, MSG_VISUAL)
 	if(selfdestruct)
@@ -150,9 +154,15 @@
 
 // fun pin
 // for when you need a gun to not be fired by anyone else ever
-/obj/item/firing_pin/dredd/fucked
+/obj/item/firing_pin/fucked
 	name = "Syndicate Ultrasecure Firing Pin"
 	desc = "Get fuuuuuuuuucked."
+	selfdestruct = TRUE
+
+/obj/item/firing_pin/fucked/pin_auth(mob/living/user)
+	if(faction_check(user.faction, list(ROLE_SYNDICATE), FALSE)
+		return TRUE
+	return FALSE
 
 /obj/item/firing_pin/fucked/gun_remove(mob/living/user)
 	auth_fail(user)

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -160,7 +160,7 @@
 	selfdestruct = TRUE
 
 /obj/item/firing_pin/fucked/pin_auth(mob/living/user)
-	if(faction_check(user.faction, list(ROLE_SYNDICATE), FALSE)
+	if(faction_check(user.faction, list(ROLE_SYNDICATE), FALSE))
 		return TRUE
 	return FALSE
 

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -60,9 +60,9 @@
 /obj/item/firing_pin/proc/pin_auth(mob/living/user)
 	return TRUE
 
-///what happens if an authorization is failed, defaults to exploding
+///what happens if an authorization is failed, explodes if selfdestruct is TRUE
 /obj/item/firing_pin/proc/auth_fail(mob/living/user)
-	user.show_message(fail_message, MSG_VISUAL)
+	user?.show_message(fail_message, MSG_VISUAL)
 	if(selfdestruct)
 		if(user)
 			user.show_message("<span class='danger'>SELF-DESTRUCTING...</span><br>", MSG_VISUAL)

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -25,7 +25,8 @@
 			var/obj/item/gun/G = target
 			if(G.pin && (force_replace || G.pin.pin_removeable))
 				G.pin.forceMove(get_turf(G))
-				G.pin.gun_remove(user)
+				if(!G.pin.gun_remove(user))
+					return
 				to_chat(user, "<span class ='notice'>You remove [G]'s old pin.</span>")
 
 			if(!G.pin)
@@ -51,7 +52,7 @@
 /obj/item/firing_pin/proc/gun_remove(mob/living/user)
 	gun.pin = null
 	gun = null
-	return
+	return TRUE
 
 /obj/item/firing_pin/proc/pin_auth(mob/living/user)
 	return TRUE
@@ -147,6 +148,15 @@
 	desc = "Advanced clowntech that can convert any firearm into a far more useful object. It has a small nitrobananium charge on it."
 	selfdestruct = TRUE
 
+// fun pin
+// for when you need a gun to not be fired by anyone else ever
+/obj/item/firing_pin/dredd/fucked
+	name = "Syndicate Ultrasecure Firing Pin"
+	desc = "Get fuuuuuuuuucked."
+
+/obj/item/firing_pin/fucked/gun_remove(mob/living/user)
+	auth_fail(user)
+	return FALSE
 
 // DNA-keyed pin.
 // When you want to keep your toys for yourself.

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -118,7 +118,7 @@
 
 /datum/outfit/lavaland_syndicate
 	name = "Lavaland Syndicate Agent"
-	r_hand = /obj/item/gun/ballistic/automatic/sniper_rifle
+	r_hand = /obj/item/gun/ballistic/automatic/sniper_rifle/ultrasecure
 	uniform = /obj/item/clothing/under/syndicate
 	suit = /obj/item/clothing/suit/toggle/labcoat
 	shoes = /obj/item/clothing/shoes/combat


### PR DESCRIPTION
# at all

### ever

syndie lavaland snipers now have a super secure firing pin that explodes when someone not of the syndicate faction tries to fire it, or when its pin is removed
have fun

### Why is this change good for the game?
no more 19 dollar sniper rifles

# Changelog


:cl:  
tweak: lavaland syndicate sniper rifles are no longer safe to be fired by crew
tweak: some firing pin removal stuff actually gets called when it's supposed to be i.e. on firing pin removal
/:cl:
