### PR TITLE
Experimental PR: Cap boxstation to 60 players

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -13,6 +13,7 @@ Format:
 	votable (is this map votable)
 
 map yogstation
+	maxplayers 60
 	voteweight 0.9
 	votable
 endmap


### PR DESCRIPTION
Note this is 60 players on the server, regardless of if they're dead or alive
![](https://i.imgur.com/7SZY6mO.png)

I'm not 100% sold on the idea but I want to see how people react to this. Box can get quite cramped on high pop and meta is a good box inspired map that gives more breathing room.

:cl:  
experimental: Box can no longer be chosen over 60 players
/:cl:
