### PR TITLE
Replaces the mutagen biogenerator recipe with mutagen crates orderable from cargo

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1742,7 +1742,7 @@
 /datum/supply_pack/organic/mutagen
 	name = "Mutagen Supply Crate"
 	desc = "A couple beakers of mutagen to help mutate more exotic plants. Do not ingest."
-	cost = 900
+	cost = 300
 	small_item = TRUE
 	contains = list(/obj/item/reagent_containers/glass/beaker/large/mutagen,
 					/obj/item/reagent_containers/glass/beaker/large/mutagen)

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1739,6 +1739,13 @@
 	crate_name = "exotic seeds crate"
 	crate_type = /obj/structure/closet/crate/hydroponics
 
+/datum/supply_pack/organic/mutagen
+	name = "Mutagen Supply Crate"
+	desc = "A couple beakers of mutagen to help mutate more exotic plants. Do not ingest."
+	cost = 900
+	contents = list(/obj/item/reagent_containers/glass/beaker/large/mutagen,
+					/obj/item/reagent_containers/glass/beaker/large/mutagen)
+
 /datum/supply_pack/organic/food
 	name = "Food Crate"
 	desc = "Get things cooking with this crate full of useful ingredients! Contains a dozen eggs, three bananas, and some flour, rice, milk, soymilk, salt, pepper, enzyme, sugar, and monkeymeat."

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1743,7 +1743,7 @@
 	name = "Mutagen Supply Crate"
 	desc = "A couple beakers of mutagen to help mutate more exotic plants. Do not ingest."
 	cost = 900
-	contents = list(/obj/item/reagent_containers/glass/beaker/large/mutagen,
+	contains = list(/obj/item/reagent_containers/glass/beaker/large/mutagen,
 					/obj/item/reagent_containers/glass/beaker/large/mutagen)
 
 /datum/supply_pack/organic/food

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1743,6 +1743,7 @@
 	name = "Mutagen Supply Crate"
 	desc = "A couple beakers of mutagen to help mutate more exotic plants. Do not ingest."
 	cost = 900
+	small_item = TRUE
 	contains = list(/obj/item/reagent_containers/glass/beaker/large/mutagen,
 					/obj/item/reagent_containers/glass/beaker/large/mutagen)
 

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -237,6 +237,10 @@
 	name = "epinephrine reserve tank"
 	list_reagents = list(/datum/reagent/medicine/epinephrine = 50)
 
+/obj/item/reagent_containers/glass/beaker/large/mutagen
+	name = "mutagen reserve tank"
+	list_reagents = list(/datum/reagent/toxin/mutagen)
+
 /obj/item/reagent_containers/glass/beaker/synthflesh
 	list_reagents = list(/datum/reagent/medicine/synthflesh = 50)
 

--- a/yogstation/code/modules/research/designs/biogenerator_designs.dm
+++ b/yogstation/code/modules/research/designs/biogenerator_designs.dm
@@ -1,11 +1,3 @@
-/datum/design/mutagen
-	name = "Unstable Mutagen"
-	id = "unstable_mutagen"
-	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass = 600)
-	build_path = /obj/item/reagent_containers/glass/bottle/mutagen
-	category = list("initial","Botany Chemicals")
-
 /datum/design/goat_cube
 	name = "Goat Cube"
 	id = "gcube"


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

while chemistry can also make mutagen they generally  can't/don't want to constantly be making more and more of it throughout a round so cargo is able to order 200 units of it for 300 credits

### Why is this change good for the game?
more department interaction probably good
# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
botany can no longer create mutagen at a biogenerator, but they can now have it ordered by cargo for 300 credits per 200 units
### What should players be aware of when it comes to the changes your PR is implementing?
do bounties
### What general grouping does this PR fall under? 
botany/cargo crates

# Changelog


:cl:  
rscdel: botany can no longer create mutagen with a biogenerator, you'll need to either synthesize it yourself or get it elsewhere
rscadd: cargo can now order crates with 200 units of mutagen in them for 300 credits
/:cl:
