### PR TITLE
removes the tesla engine/coils from orderable cargo crates

### DIFF
--- a/code/modules/cargo/bounties/engineering.dm
+++ b/code/modules/cargo/bounties/engineering.dm
@@ -1,16 +1,3 @@
-/datum/bounty/item/engineering/energy_ball
-	name = "Contained Tesla Ball"
-	description = "Station 24 is being overrun by hordes of angry Mothpeople. They are requesting the ultimate bug zapper."
-	reward = 75000 //requires 14k credits of purchases, not to mention cooperation with engineering/heads of staff to set up inside the cramped shuttle
-	wanted_types = list(/obj/singularity/energy_ball)
-
-/datum/bounty/item/engineering/energy_ball/applies_to(obj/O)
-	if(!..())
-		return FALSE
-	var/obj/singularity/energy_ball/T = O
-	return !T.miniball
-
-
 /datum/bounty/item/atmos
 	wanted_types = list(/obj/item/tank)
 	var/moles_required = 20 // A full tank is 28 moles, but CentCom ignores that fact.

--- a/code/modules/cargo/bounty.dm
+++ b/code/modules/cargo/bounty.dm
@@ -111,18 +111,15 @@ GLOBAL_LIST_EMPTY(bounties_list)
 			var/subtype = pick(subtypesof(/datum/bounty/item/slime))
 			return new subtype
 		if(10)
-			var/subtype = pick(subtypesof(/datum/bounty/item/engineering))
-			return new subtype
-		if(11)
 			var/subtype = pick(subtypesof(/datum/bounty/item/mining))
 			return new subtype
-		if(12)
+		if(11)
 			var/subtype = pick(subtypesof(/datum/bounty/item/medical))
 			return new subtype
-		if(13)
+		if(12)
 			var/subtype = pick(subtypesof(/datum/bounty/item/botany))
 			return new subtype
-		if(14)
+		if(13)
 			var/subtype
 			if(rand(2) == 1)
 				subtype = pick(subtypesof(/datum/bounty/item/atmos/simple))
@@ -141,7 +138,6 @@ GLOBAL_LIST_EMPTY(bounties_list)
 											/datum/bounty/item/chef = 3,
 											/datum/bounty/item/security = 1,
 											/datum/bounty/virus = 1,
-											/datum/bounty/item/engineering = 1,
 											/datum/bounty/item/mining = 3,
 											/datum/bounty/item/medical = 2,
 											/datum/bounty/item/botany = 3,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -957,7 +957,7 @@
 /datum/supply_pack/engine/sing_gen
 	name = "Singularity Generator Crate"
 	desc = "The key to unlocking the power of Lord Singuloth. Particle Accelerator not included."
-	cost = 5000
+	cost = 10000
 	contains = list(/obj/machinery/the_singularitygen)
 	crate_name = "singularity generator crate"
 
@@ -1016,7 +1016,7 @@
 /datum/supply_pack/engine/tesla_gen
 	name = "Tesla Generator Crate"
 	desc = "The key to unlocking the power of the Tesla energy ball. Particle Accelerator not included."
-	cost = 5000
+	cost = 50000
 	contains = list(/obj/machinery/the_singularitygen/tesla)
 	crate_name = "tesla generator crate"
 

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1016,7 +1016,7 @@
 /datum/supply_pack/engine/tesla_gen
 	name = "Tesla Generator Crate"
 	desc = "The key to unlocking the power of the Tesla energy ball. Particle Accelerator not included."
-	cost = 50000
+	cost = 100000
 	contains = list(/obj/machinery/the_singularitygen/tesla)
 	crate_name = "tesla generator crate"
 

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1002,24 +1002,6 @@
 	crate_type = /obj/structure/closet/crate/secure/engineering
 	dangerous = TRUE
 
-/datum/supply_pack/engine/tesla_coils
-	name = "Tesla Coil Crate"
-	desc = "Whether it's high-voltage executions, creating research points, or just plain old power generation: This pack of four Tesla coils can do it all!"
-	cost = 2500
-	contains = list(/obj/machinery/power/tesla_coil,
-					/obj/machinery/power/tesla_coil,
-					/obj/machinery/power/tesla_coil,
-					/obj/machinery/power/tesla_coil)
-	crate_name = "tesla coil crate"
-	crate_type = /obj/structure/closet/crate/engineering/electrical
-
-/datum/supply_pack/engine/tesla_gen
-	name = "Tesla Generator Crate"
-	desc = "The key to unlocking the power of the Tesla energy ball. Particle Accelerator not included."
-	cost = 100000
-	contains = list(/obj/machinery/the_singularitygen/tesla)
-	crate_name = "tesla generator crate"
-
 //////////////////////////////////////////////////////////////////////////////
 /////////////////////// Canisters & Materials ////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -957,7 +957,7 @@
 /datum/supply_pack/engine/sing_gen
 	name = "Singularity Generator Crate"
 	desc = "The key to unlocking the power of Lord Singuloth. Particle Accelerator not included."
-	cost = 10000
+	cost = 5000
 	contains = list(/obj/machinery/the_singularitygen)
 	crate_name = "singularity generator crate"
 


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

I am reducing the amount of lag from teslas by reducing the number of teslas on the station

### Why is this change good for the game?
reduces lag
# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
tesla crate is now doesn't exist

### What general grouping does this PR fall under? 
cargo crates

# Changelog

:cl:  
rscdel: you can no longer order tesla generators or coils from cargo. This is why we can't have nice things.
rscdel: removes the cargo tesla bounty
/:cl:
