### PR TITLE
Makes teslas explode when touching another tesla

### DIFF
--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -72,7 +72,8 @@
 				var/turf/T = get_turf(src)
 				message_admins("Two teslas smashed against each other creating a massive explosion at [ADMIN_VERBOSEJMP(T)].")
 				explosion(src.loc,4,7,12,30)  //big ass explosion when touching another tesla ball, to prevent tesla stacking
-				qdel(E) //THERE CAN ONLY BE ONE!
+				qdel(E) 
+				qdel(src) //no tesla remains
 		
 		for (var/ball in orbiting_balls)
 			var/range = rand(1, clamp(orbiting_balls.len, 3, 7))

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -65,6 +65,15 @@
 
 		pixel_x = -32
 		pixel_y = -32
+		
+		var/list/RG = range(1, src)
+		for(var/obj/singularity/energy_ball/E in RG)
+			if(!E.miniball && E != src)
+				var/turf/T = get_turf(src)
+				message_admins("Two teslas smashed against each other creating a massive explosion at [ADMIN_VERBOSEJMP(T)].")
+				explosion(src.loc,4,7,12,30)  //big ass explosion when touching another tesla ball, to prevent tesla stacking
+				qdel(E) //THERE CAN ONLY BE ONE!
+		
 		for (var/ball in orbiting_balls)
 			var/range = rand(1, clamp(orbiting_balls.len, 3, 7))
 			tesla_zap(ball, range, TESLA_MINI_POWER/7*range)


### PR DESCRIPTION
# General Documentation
### Intent of your Pull Request
I made an alternative here: [#11191]
Theos was mad because people stacked way too many teslas in one containment, making lag. This PR prevents stacking Teslas that are in the same containment destroying both of them and creating a massive explosion.

### Why is this change good for the game?
Prevents tesla stacking, which causes lag

# Wiki Documentation
should be noted in bold red NOT TO STACK THOSE TESLAS OR THEY WILL FUCKING SUPERCOLLIDE

### Briefly describe your PR and the impacts of it, in layman's terms. 
Teslas now destroy each other on contact with another teslas in close proximity, causing a massive explosion and making an admin log.

### What should players be aware of when it comes to the changes your PR is implementing?
To not stack teslas under one containment, make a cage for each instead.

### What general grouping does this PR fall under? 
Engineering tweak

# Changelog
:cl:  
tweak: teslas now explode when touching each other, deleting ~one~ both of them
/:cl: