### PR TITLE
(port) adds warp implant

### DIFF
--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -153,3 +153,21 @@
 	name = "implanter (internal syndicate radio)"
 	imp_type = /obj/item/implant/radio/syndicate
 
+/obj/item/implant/warp
+	name = "warp implant"
+	desc = "Saves your position somewhere, and then warps you back to it after five seconds."
+	icon_state = "warp"
+	uses = 15
+
+/obj/item/implant/warp/activate()
+	. = ..()
+	uses--
+	imp_in.do_adrenaline(150, TRUE, 0, 0, TRUE, list(/datum/reagent/fermi/eigenstate = 1.2), "<span class='boldnotice'>You feel an internal prick as as the bluespace starts ramping up!</span>")
+	to_chat(imp_in, "<span class='notice'>You feel an internal prick as as the bluespace starts ramping up!</span>")
+	if(!uses)
+		qdel(src)
+
+/obj/item/implanter/warp
+	name = "implanter (warp)"
+	imp_type = /obj/item/implant/warp
+

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -598,3 +598,11 @@
 /obj/item/storage/box/syndie_kit/bee_grenades/PopulateContents()
 	for(var/i in 1 to 3)
 		new /obj/item/grenade/spawnergrenade/buzzkill(src)
+
+/obj/item/storage/box/syndie_kit/imp_warp
+	name = "boxed warp implant (with injector)"
+
+/obj/item/storage/box/syndie_kit/imp_warp/PopulateContents()
+	var/obj/item/implanter/O = new(src)
+	O.imp = new /obj/item/implant/warp(O)
+	O.update_icon()

--- a/code/modules/reagents/chemistry/reagents/eigentstasium.dm
+++ b/code/modules/reagents/chemistry/reagents/eigentstasium.dm
@@ -1,0 +1,204 @@
+////////////////////////////////////////////////////////////////////////////////////////////////////
+//										EIGENSTASIUM
+///////////////////////////////////////////////////////////////////////////////////////////////////
+//eigenstate Chem
+//Teleports you to chemistry and back
+//OD teleports you randomly around the Station
+//Addiction send you on a wild ride and replaces you with an alternative reality version of yourself.
+//During the process you get really hungry, then your items start teleporting randomly,
+//then alternative versions of yourself are brought in from a different universe and they yell at you.
+//and finally you yourself get teleported to an alternative universe, and character your playing is replaced with said alternative
+
+/datum/reagent/fermi/eigenstate
+	name = "Eigenstasium"
+	description = "A strange mixture formed from a controlled reaction of bluespace with plasma, that causes localised eigenstate fluxuations within the patient"
+	taste_description = "wiggly cosmic dust."
+	color = "#5020F4" // rgb: 50, 20, 255
+	overdose_threshold = 15
+	addiction_threshold = 15
+	metabolization_rate = 1 * REAGENTS_METABOLISM
+	addiction_stage2_end = 30
+	addiction_stage3_end = 41
+	addiction_stage4_end = 44 //Incase it's too long
+	data = list("location_created" = null)
+	var/turf/location_created
+	var/obj/effect/overlay/holo_pad_hologram/Eigenstate
+	var/turf/open/location_return = null
+	var/addictCyc3 = 0
+	var/mob/living/carbon/fermi_Tclone = null
+	var/teleBool = FALSE
+	pH = 3.7
+	can_synth = TRUE
+	value = REAGENT_VALUE_EXCEPTIONAL
+
+/datum/reagent/fermi/eigenstate/on_new(list/data)
+	location_created = data["location_created"]
+
+//Main functions
+/datum/reagent/fermi/eigenstate/on_mob_life(mob/living/M) //Teleports to chemistry!
+	if(current_cycle == 0)
+		log_reagent("FERMICHEM: [M] ckey: [M.key] took eigenstasium")
+
+		//make hologram at return point
+		Eigenstate = new(loc)
+		Eigenstate.appearance = M.appearance
+		Eigenstate.alpha = 170
+		Eigenstate.add_atom_colour("#77abff", FIXED_COLOUR_PRIORITY)
+		Eigenstate.mouse_opacity = MOUSE_OPACITY_TRANSPARENT//So you can't click on it.
+		Eigenstate.layer = FLY_LAYER//Above all the other objects/mobs. Or the vast majority of them.
+		Eigenstate.setAnchored(TRUE)//So space wind cannot drag it.
+		Eigenstate.name = "[M]'s' eigenstate"//If someone decides to right click.
+		Eigenstate.set_light(2)	//hologram lighting
+
+		location_return = get_turf(M)	//sets up return point
+		to_chat(M, "<span class='userdanger'>You feel your wavefunction split!</span>")
+		if(cached_purity > 0.9) //Teleports you home if it's pure enough
+			if(!location_created && data) //Just in case
+				location_created = data["location_created"]
+			log_reagent("FERMICHEM: [M] ckey: [M.key] returned to [location_created] using eigenstasium")
+			do_sparks(5,FALSE,M)
+			do_teleport(M, location_created, 0, asoundin = 'sound/effects/phasein.ogg')
+			do_sparks(5,FALSE,M)
+			SSblackbox.record_feedback("tally", "fermi_chem", 1, "Pure eigentstate jumps")
+
+
+	if(prob(20))
+		do_sparks(5,FALSE,M)
+	..()
+
+/datum/reagent/fermi/eigenstate/on_mob_delete(mob/living/M) //returns back to original location
+	do_sparks(5,FALSE,M)
+	to_chat(M, "<span class='userdanger'>You feel your wavefunction collapse!</span>")
+	if(!M.reagents.has_reagent(/datum/reagent/stabilizing_agent))
+		do_teleport(M, location_return, 0, asoundin = 'sound/effects/phasein.ogg') //Teleports home
+		do_sparks(5,FALSE,M)
+	qdel(Eigenstate)
+	..()
+
+/datum/reagent/fermi/eigenstate/overdose_start(mob/living/M) //Overdose, makes you teleport randomly
+	. = ..()
+	to_chat(M, "<span class='userdanger'>Oh god, you feel like your wavefunction is about to tear.</span>")
+	log_reagent("FERMICHEM: [M] ckey: [M.key] has overdosed on eigenstasium")
+	M.Jitter(20)
+	metabolization_rate += 0.5 //So you're not stuck forever teleporting.
+
+/datum/reagent/fermi/eigenstate/overdose_process(mob/living/M) //Overdose, makes you teleport randomly, probably one of my favourite effects. Sometimes kills you.
+	do_sparks(5,FALSE,M)
+	do_teleport(M, get_turf(M), 10, asoundin = 'sound/effects/phasein.ogg')
+	do_sparks(5,FALSE,M)
+	..()
+
+//Addiction
+/datum/reagent/fermi/eigenstate/addiction_act_stage1(mob/living/M) //Welcome to Fermis' wild ride.
+	if(addiction_stage == 1)
+		to_chat(M, "<span class='userdanger'>Your wavefunction feels like it's been ripped in half. You feel empty inside.</span>")
+		log_reagent("FERMICHEM: [M] ckey: [M.key] has become addicted to eigenstasium")
+		M.Jitter(10)
+	M.adjust_nutrition(-M.nutrition/15)
+	..()
+
+/datum/reagent/fermi/eigenstate/addiction_act_stage2(mob/living/M)
+	if(addiction_stage == 11)
+		to_chat(M, "<span class='userdanger'>You start to convlse violently as you feel your consciousness split and merge across realities as your possessions fly wildy off your body.</span>")
+		M.Jitter(200)
+		M.DefaultCombatKnockdown(200)
+		M.Stun(80)
+	var/items = M.get_contents()
+	if(!LAZYLEN(items))
+		return ..()
+	var/obj/item/I = pick(items)
+	if(istype(I, /obj/item/implant))
+		qdel(I)
+		to_chat(M, "<span class='userdanger'>You feel your implant rip itself out of you, sent flying off to another dimention!</span>")
+	else
+		M.dropItemToGround(I, TRUE)
+	do_sparks(5,FALSE,I)
+	do_teleport(I, get_turf(I), 5, no_effects=TRUE);
+	do_sparks(5,FALSE,I)
+	..()
+
+/datum/reagent/fermi/eigenstate/addiction_act_stage3(mob/living/M)//Pulls multiple copies of the character from alternative realities while teleporting them around!
+	//Clone function - spawns a clone then deletes it - simulates multiple copies of the player teleporting in
+	switch(addictCyc3) //Loops 0 -> 1 -> 2 -> 1 -> 2 -> 1 ...ect.
+		if(0)
+			M.Jitter(100)
+			to_chat(M, "<span class='userdanger'>Your eigenstate starts to rip apart, causing a localised collapsed field as you're ripped from alternative universes, trapped around the densisty of the event horizon.</span>")
+		if(1)
+			var/typepath = M.type
+			fermi_Tclone = new typepath(M.loc)
+			var/mob/living/carbon/C = fermi_Tclone
+			fermi_Tclone.appearance = M.appearance
+			C.real_name = M.real_name
+			M.visible_message("[M] collapses in from an alternative reality!")
+			do_teleport(C, get_turf(C), 2, no_effects=TRUE) //teleports clone so it's hard to find the real one!
+			do_sparks(5,FALSE,C)
+			C.emote("spin")
+			M.emote("spin")
+			M.emote("me",1,"flashes into reality suddenly, gasping as they gaze around in a bewildered and highly confused fashion!",TRUE)
+			C.emote("me",1,"[pick("says", "cries", "mewls", "giggles", "shouts", "screams", "gasps", "moans", "whispers", "announces")], \"[pick("Bugger me, whats all this then?", "Hot damn, where is this?", "sacre bleu! Ou suis-je?!", "Yee haw! This is one hell of a hootenanny!", "WHAT IS HAPPENING?!", "Picnic!", "Das ist nicht deutschland. Das ist nicht akzeptabel!!!", "I've come from the future to warn you to not take eigenstasium! Oh no! I'm too late!", "You fool! You took too much eigenstasium! You've doomed us all!", "What...what's with these teleports? It's like one of my Japanese animes...!", "Ik stond op het punt om mehki op tafel te zetten, en nu, waar ben ik?", "This must be the will of Stein's gate.", "Fermichem was a mistake", "This is one hell of a beepsky smash.", "Now neither of us will be virgins!")]\"")
+		if(2)
+			var/mob/living/carbon/C = fermi_Tclone
+			do_sparks(5,FALSE,C)
+			qdel(C) //Deletes CLONE, or at least I hope it is.
+			M.visible_message("[M] is snapped across to a different alternative reality!")
+			addictCyc3 = 0 //counter
+			fermi_Tclone = null
+	addictCyc3++
+	do_teleport(M, get_turf(M), 2, no_effects=TRUE) //Teleports player randomly
+	do_sparks(5,FALSE,M)
+	..()
+
+/datum/reagent/fermi/eigenstate/addiction_act_stage4(mob/living/M) //Thanks for riding Fermis' wild ride. Mild jitter and player buggery.
+	if(addiction_stage == 42)
+		do_sparks(5,FALSE,M)
+		do_teleport(M, get_turf(M), 2, no_effects=TRUE) //teleports clone so it's hard to find the real one!
+		do_sparks(5,FALSE,M)
+		M.Sleeping(100, 0)
+		M.Jitter(50)
+		M.DefaultCombatKnockdown(100)
+		to_chat(M, "<span class='userdanger'>You feel your eigenstate settle, snapping an alternative version of yourself into reality. All your previous memories are lost and replaced with the alternative version of yourself.</span>")
+		M.emote("me",1,"flashes into reality suddenly, gasping as they gaze around in a bewildered and highly confused fashion!",TRUE)
+		log_reagent("FERMICHEM: [M] ckey: [M.key] has become an alternative universe version of themselves.")
+		M.reagents.remove_all_type(/datum/reagent, 100, 0, 1)
+		/*
+		for(var/datum/mood_event/Me in M)
+			SEND_SIGNAL(M, COMSIG_CLEAR_MOOD_EVENT, Me) //Why does this not work?
+		*/
+		SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "Alternative dimension", /datum/mood_event/eigenstate)
+		SSblackbox.record_feedback("tally", "fermi_chem", 1, "Wild rides ridden")
+
+	if(prob(20))
+		do_sparks(5,FALSE,M)
+	SEND_SIGNAL(M, COMSIG_CLEAR_MOOD_EVENT, "[type]_overdose")//holdover until above fix works
+	..()
+
+/datum/reagent/fermi/eigenstate/reaction_turf(turf/T, reac_volume)
+	//if(cached_purity < 0.99) To add with next batch of fixes and tweaks.
+	var/obj/structure/closet/First
+	var/obj/structure/closet/Previous
+	for(var/obj/structure/closet/C in T.contents)
+		if(C.eigen_teleport == TRUE)
+			C.visible_message("[C] fizzes, it's already linked to something else!")
+			continue
+		if(!Previous)
+			First = C
+			Previous = C
+			continue
+		C.eigen_teleport = TRUE
+		C.eigen_target = Previous
+		C.color = "#9999FF" //Tint the locker slightly.
+		C.alpha = 200
+		do_sparks(5,FALSE,C)
+		Previous = C
+	if(!First)
+		return
+	if(Previous == First)
+		return
+	First.eigen_teleport = TRUE
+	First.eigen_target = Previous
+	First.color = "#9999FF"
+	First.alpha = 200
+	do_sparks(5,FALSE,First)
+	First.visible_message("The lockers' eigenstates spilt and merge, linking each of their contents together.")
+
+//eigenstate END

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1591,6 +1591,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 8
 	player_minimum = 25
 
+/datum/uplink_item/implants/warp
+	name = "Warp Implant"
+	desc = "An implant injected into the body and later activated at the user's will. It will inject eigenstasium which saves the user's location and teleports them there after five seconds. Lasts only fifteen times."
+	item = /obj/item/storage/box/syndie_kit/imp_warp
+	cost = 6
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
+
 /datum/uplink_item/implants/antistun
 	name = "CNS Rebooter Implant"
 	desc = "This implant will help you get back up on your feet faster after being stunned. Comes with an autosurgeon."

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2706,6 +2706,7 @@
 #include "code\modules\reagents\chemistry\reagents\alcohol_reagents.dm"
 #include "code\modules\reagents\chemistry\reagents\drink_reagents.dm"
 #include "code\modules\reagents\chemistry\reagents\drug_reagents.dm"
+#include "code\modules\reagents\chemistry/reagents\eigentstasium.dm"
 #include "code\modules\reagents\chemistry\reagents\food_reagents.dm"
 #include "code\modules\reagents\chemistry\reagents\medicine_reagents.dm"
 #include "code\modules\reagents\chemistry\reagents\other_reagents.dm"


### PR DESCRIPTION
Original Pr https://github.com/Citadel-Station-13/Citadel-Station-13/pull/12991
"Adds the warp implant, an implant that makes use of the chem eigenstasium to save your location and then warp you back there after a few seconds."
:cl:  
rscadd: Adds new implants for traitors to mess with
/:cl:
