### PR TITLE
Adds 'Shepard' to the last names list.

### DIFF
--- a/strings/names/last.txt
+++ b/strings/names/last.txt
@@ -455,6 +455,7 @@ Shaffer
 Shaner
 Shaw
 Sheets
+Shepard
 Shick
 Shirey
 Sholl


### PR DESCRIPTION
### Intent of your Pull Request

I went to look and ERTs don't have their own name list, instead they only use the last names list and put their rank in front. This means there is a 1 in 570 chance for an ERT commander to be called Commander Shepard. We can only hope.

### Why is this change good for the game?

[https://www.youtube.com/watch?v=0o4AmXtYVFE](url)

# Changelog

:cl:  Identification
rscadd: 'Shepard' is now a possible random last name.
/:cl:
