### PR TITLE
Xenomorph embryos now grow based on consistent timers instead of 100% RNG (3% chance every 2s) [PORT]

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -4,13 +4,21 @@
 	name = "alien embryo"
 	icon = 'icons/mob/alien.dmi'
 	icon_state = "larva0_dead"
+	///What stage of growth the embryo is at. Developed embryos give the host symptoms suggesting that an embryo is inside them.
 	var/stage = 0
+	/// Are we bursting out of the poor sucker who's the xeno mom?
 	var/bursting = FALSE
+	/// How long does it take to advance one stage? Growth time * 5 = how long till we make a Larva!
+	var/growth_time = 60 SECONDS
+
+/obj/item/organ/body_egg/alien_embryo/Initialize()
+	. = ..()
+	advance_embryo_stage()
 
 /obj/item/organ/body_egg/alien_embryo/on_find(mob/living/finder)
 	..()
-	if(stage < 4)
-		to_chat(finder, "It's small and weak, barely the size of a foetus.")
+	if(stage < 5)
+		to_chat(finder, "<span class='notice'>It's small and weak, barely the size of a foetus.</span>")
 	else
 		to_chat(finder, "It's grown quite large, and writhes slightly as you look at it.")
 		if(prob(10))
@@ -23,7 +31,7 @@
 
 /obj/item/organ/body_egg/alien_embryo/on_life()
 	switch(stage)
-		if(2, 3)
+		if(3, 4)
 			if(prob(2))
 				owner.emote("sneeze")
 			if(prob(2))
@@ -32,7 +40,7 @@
 				to_chat(owner, "<span class='danger'>Your throat feels sore.</span>")
 			if(prob(2))
 				to_chat(owner, "<span class='danger'>Mucous runs down the back of your throat.</span>")
-		if(4)
+		if(5)
 			if(prob(2))
 				owner.emote("sneeze")
 			if(prob(2))
@@ -49,18 +57,22 @@
 			to_chat(owner, "<span class='danger'>You feel something tearing its way out of your stomach...</span>")
 			owner.adjustToxLoss(10)
 
-/obj/item/organ/body_egg/alien_embryo/egg_process()
-	if(stage < 5 && prob(3))
-		stage++
+/// Controls Xenomorph Embryo growth. If embryo is fully grown (or overgrown), stop the proc. If not, increase the stage by one and if it's not fully grown (stage 6), add a timer to do this proc again after however long the growth time variable is.
+/obj/item/organ/body_egg/alien_embryo/proc/advance_embryo_stage()
+	if(stage >= 6)
+		return
+	if(++stage < 6)
 		INVOKE_ASYNC(src, .proc/RefreshInfectionImage)
+		addtimer(CALLBACK(src, .proc/advance_embryo_stage), growth_time)
 
-	if(stage == 5 && prob(50))
+
+/obj/item/organ/body_egg/alien_embryo/egg_process()
+	if(stage == 6 && prob(50))
 		for(var/datum/surgery/S in owner.surgeries)
 			if(S.location == BODY_ZONE_CHEST && istype(S.get_surgery_step(), /datum/surgery_step/manipulate_organs))
 				AttemptGrow(0)
 				return
 		AttemptGrow()
-
 
 
 /obj/item/organ/body_egg/alien_embryo/proc/AttemptGrow(gib_on_success=TRUE)
@@ -76,7 +88,8 @@
 
 	if(!candidates.len || !owner)
 		bursting = FALSE
-		stage = 4
+		stage = 5	// If no ghosts sign up for the Larva, let's regress our growth by one minute, we will try again!
+		addtimer(CALLBACK(src, .proc/advance_embryo_stage), growth_time)
 		return
 
 	var/mob/dead/observer/ghost = pick(candidates)


### PR DESCRIPTION
# General Documentation
Ports https://github.com/tgstation/tgstation/pull/55755

### Intent of your Pull Request

• Adds documentation to alien_embryo.dm
• Refactors how alien embryos increase their stage var, aka their cute ickle baby development stage. Now it increases stage every minute, which means 5 minutes to grow as opposed to taking 15 seconds to the end of time to grow.
• Growth time is now defined by a variable, so admins can var-edit it in game and future coders can easily change the variable to make it take more or less time to grow. It also means it's a simple one-line edit if any of TG's plentiful downstreams want to change this for their server.

### Why It's Good For The Game
This adds consistency to Xenomorphs and removes the frustration of your entire playthrough as an antagonist potentially being down to literal random chance to when you get a new larva buddy. Will it take two minutes, or ten? You have no idea. But your nest is about to be broken into and this larva could come out in the next second or in a few more minutes.

I tested how long it takes to grow larva using the old system, and the average was roughly around five minutes for a larva to hatch, hence why I chose a static five minutes for the larva to grow.

# Changelog

:cl:  KathrinBailey
tweak: Xenomorph embryos now take a static five minutes (1 minute per 5 stages) to hatch, instead of taking any time between fifteen seconds, till the end of time itself to hatch. Aka it had a 3% chance and rolled every two seconds, now it uses a consistent timer.
/:cl:
