### PR TITLE
Makes teslas absorb each other for power

### DIFF
--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -23,6 +23,7 @@
 	var/energy_to_raise = 32
 	var/energy_to_lower = -20
 	var/max_balls = 10
+	var/zap_range = 7
 
 /obj/singularity/energy_ball/Initialize(mapload, starting_energy = 50, is_miniball = FALSE)
 	miniball = is_miniball
@@ -61,12 +62,18 @@
 		pixel_x = 0
 		pixel_y = 0
 
-		tesla_zap(src, 7, TESLA_DEFAULT_POWER)
+		tesla_zap(src, zap_range, TESLA_DEFAULT_POWER)
 
 		pixel_x = -32
 		pixel_y = -32
+
+		var/list/RG = range(1, src)
+		for(var/obj/singularity/energy_ball/E in RG)
+			if(!E.miniball && E != src)
+				collide(E)
+
 		for (var/ball in orbiting_balls)
-			var/range = rand(1, clamp(orbiting_balls.len, 3, 7))
+			var/range = rand(1, clamp(orbiting_balls.len, 3, zap_range))
 			tesla_zap(ball, range, TESLA_MINI_POWER/7*range)
 	else
 		energy = 0 // ensure we dont have miniballs of miniballs
@@ -75,6 +82,17 @@
 	. = ..()
 	if(orbiting_balls.len)
 		. += "There are [orbiting_balls.len] mini-balls orbiting it."
+
+/obj/singularity/energy_ball/proc/collide(var/obj/singularity/energy_ball/target)
+	if(max_balls < target.max_balls) //we bow down against a stronger tesla
+		return
+	
+	name = "[pick("hypercharged", "super", "powered", "glowing", "unstable", "anomalous", "massive")] [name]"
+	max_balls += target.max_balls - 8 //default 2 more max balls per another tesla, respecting another consumed tesla
+	zap_range += target.zap_range - 6 //also 1 more range for zapping, making it harder to contain
+	add_atom_colour(rgb(255 - max_balls * 10, 255 - max_balls * 10, 255), ADMIN_COLOUR_PRIORITY) //gets more blue with more power
+	playsound(src.loc, 'sound/magic/lightning_chargeup.ogg', 100, 1, extrarange = 30)
+	qdel(target)
 
 
 /obj/singularity/energy_ball/proc/move_the_basket_ball(var/move_amount)


### PR DESCRIPTION
# General Documentation
### Intent of your Pull Request
Alternative to [#11185].
When a tesla touches another tesla, it absorbs it, creating a more powerful tesla that can hold 2 more max miniballs, gets 1 tile longer zapping range, and gets more visibly blue itself per tesla consumed. The weaker tesla gets destroyed without any explosion, just a loud electric charging sound.

### Why is this change good for the game?
Removing tesla stacking because it's bad and lags the game

# Wiki Documentation
Can be noted i guess, as a trivia, since it can be theoritically used to make more power

### Briefly describe your PR and the impacts of it, in layman's terms. 
Makes energy balls (teslas) absorb each other for power, getting stronger and more dangerous when loose, but less dangerous and laggy whan multiple teslas.

### What should players be aware of when it comes to the changes your PR is implementing?
That it's more efficient to have multiple teslas each in its own containment rather than stack 50 teslas in one.

### What general grouping does this PR fall under? 
Engineering Tweak

# Changelog
:cl:  
tweak: teslas now absorb each other for more power, but very inefficiently
/:cl: