### PR TITLE
[admin] Blocks the creation of new player initiated admin tickets after the round has ended

### DIFF
--- a/yogstation/code/modules/admin/verbs/adminhelp.dm
+++ b/yogstation/code/modules/admin/verbs/adminhelp.dm
@@ -797,8 +797,13 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	set category = "Admin"
 	set name = "Adminhelp"
 
+	//Yes theres nothing after game finished, no i dont care, in the future there might
+	if(SSticket.current_state >= GAME_STATE_FINISHED)
+		to_chat(src, "<span class='danger'>The round has already ended! Make a player complaint on the forums instead.</span>, confidential=TRUE")
+		return
+	
 	if(GLOB.say_disabled)	//This is here to try to identify lag problems
-		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>", confidential=TRUE)
+		to_chat(src, "<span class='danger'>Speech is currently admin-disabled.</span>", confidential=TRUE)
 		return
 
 	//handle muting and automuting

--- a/yogstation/code/modules/admin/verbs/adminhelp.dm
+++ b/yogstation/code/modules/admin/verbs/adminhelp.dm
@@ -798,7 +798,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	set name = "Adminhelp"
 
 	//Yes theres nothing after game finished, no i dont care, in the future there might
-	if(SSticket.current_state >= GAME_STATE_FINISHED)
+	if(SSticker.current_state >= GAME_STATE_FINISHED)
 		to_chat(src, "<span class='danger'>The round has already ended! Make a player complaint on the forums instead.</span>, confidential=TRUE")
 		return
 	


### PR DESCRIPTION
You may be wondering: WHY THE FUCK IS THIS A GOOD IDEA and fair enough it sounds stupid but hear me out.
The way things happen is usually:
* something happens
* they wait 30 minutes until round end
* they see that person wasnt an antag and make a ticket
* that ticket is painful to handle as the events happened 30 minutes ago
* round restart is delayed
* we lose 15 pop because noone likes to not be playing the game

People should be encouraged to ahelp when something happens, not at the end of the round and if they really must, then a player complaint is a better solution as it doesnt delay the restart by 15 minutes. And yes, I do know player complaints dont really get resolved quickly but its a better alternative than delaying restarts.

:cl:  
tweak: You can no longer create admin tickets(ahelps) after the round has ended. You can still respond to existing tickets or as an admin, create new ones to ask people questions.
/:cl:
