### PR TITLE
re/vitiligo's effect now gets reverted if the disease is cured and it works on nonhumans

### DIFF
--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -1,16 +1,13 @@
 /*
 //////////////////////////////////////
 Vitiligo
-
 	Hidden.
 	No change to resistance.
 	Increases stage speed.
 	Slightly increases transmittability.
 	Critical Level.
-
 BONUS
 	Makes the mob lose skin pigmentation.
-
 //////////////////////////////////////
 */
 
@@ -23,73 +20,133 @@ BONUS
 	stage_speed = 3
 	transmittable = 1
 	level = 5
-	severity = 1
+	severity = 0
 	symptom_delay_min = 25
 	symptom_delay_max = 75
+	var/cachedcolor = null
+
+/datum/symptom/vitiligo/Start(datum/disease/advance/A)
+	. = ..()
+	var/mob/living/M = A.affected_mob
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.dna.species.use_skintones)
+			cachedcolor = H.skin_tone 
+		else if(MUTCOLORS in H.dna.species.species_traits)
+			cachedcolor	= H.dna.features["mcolor"]
 
 /datum/symptom/vitiligo/Activate(datum/disease/advance/A)
-	. = ..()
-	if(!.)
+	if(!..())
 		return
 	var/mob/living/M = A.affected_mob
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.skin_tone == "albino")
 			return
+		if(H.dna.features["mcolor"] == "EEE")
+			return
 		switch(A.stage)
 			if(5)
-				H.skin_tone = "albino"
-				H.update_body(0)
+				if(H.dna.species.use_skintones)
+					H.skin_tone = "albino"
+				else if(MUTCOLORS in H.dna.species.species_traits)
+					H.dna.features["mcolor"] = "EEE" //pure white.
+				H.regenerate_icons()
 			else
 				H.visible_message("<span class='warning'>[H] looks a bit pale...</span>", "<span class='notice'>Your skin suddenly appears lighter...</span>")
 
+/datum/symptom/vitiligo/End(datum/disease/advance/A)
+	. = ..()
+	var/mob/living/M = A.affected_mob
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.dna.species.use_skintones)
+			H.skin_tone = cachedcolor
+		else if(MUTCOLORS in H.dna.species.species_traits)
+			H.dna.features["mcolor"] = cachedcolor
+		H.regenerate_icons()
 
 /*
 //////////////////////////////////////
 Revitiligo
-
 	Slightly noticable.
 	Increases resistance.
 	Increases stage speed slightly.
 	Increases transmission.
 	Critical Level.
-
 BONUS
 	Makes the mob gain skin pigmentation.
-
 //////////////////////////////////////
 */
 
 /datum/symptom/revitiligo
-
 	name = "Revitiligo"
 	desc = "The virus causes increased production of skin pigment cells, making the host's skin grow darker over time."
-	stealth = -1
-	resistance = 3
+	stealth = 1
+	resistance = 2
 	stage_speed = 1
 	transmittable = 2
 	level = 5
-	severity = 1
+	severity = 0
 	symptom_delay_min = 7
 	symptom_delay_max = 14
+	var/cachedcolor = null
+
+/datum/symptom/revitiligo/Start(datum/disease/advance/A)
+	. = ..()
+	var/mob/living/M = A.affected_mob
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.dna.species.use_skintones)
+			cachedcolor = H.skin_tone 
+		else if(MUTCOLORS in H.dna.species.species_traits)
+			cachedcolor	= H.dna.features["mcolor"]
 
 /datum/symptom/revitiligo/Activate(datum/disease/advance/A)
-	. = ..()
-	if(!.)
+	if(!..())
 		return
 	var/mob/living/M = A.affected_mob
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.skin_tone == "african2")
 			return
+		if(H.dna.features["mcolor"] == "000")
+			return
 		switch(A.stage)
 			if(5)
-				H.skin_tone = "african2"
-				H.update_body(0)
+				if(H.dna.species.use_skintones)
+					H.skin_tone = "african2"
+				else if(MUTCOLORS in H.dna.species.species_traits)
+					H.dna.features["mcolor"] = "000" //pure black.
+				H.regenerate_icons()
 			else
 				H.visible_message("<span class='warning'>[H] looks a bit dark...</span>", "<span class='notice'>Your skin suddenly appears darker...</span>")
 
-/datum/symptom/polyvitiligo //tgport
+/datum/symptom/revitiligo/End(datum/disease/advance/A)
+	. = ..()
+	var/mob/living/M = A.affected_mob
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.dna.species.use_skintones)
+			H.skin_tone = cachedcolor
+		else if(MUTCOLORS in H.dna.species.species_traits)
+			H.dna.features["mcolor"] = cachedcolor
+		H.regenerate_icons()
+
+/*
+//////////////////////////////////////
+Polyvitiligo
+	Not Noticeable.
+	Increases resistance slightly.
+	Increases stage speed.
+	Transmittable.
+	Low Level.
+BONUS
+	Makes the host change color
+//////////////////////////////////////
+*/
+
+/datum/symptom/polyvitiligo
 	name = "Polyvitiligo"
 	desc = "The virus replaces the melanin in the skin with reactive pigment."
 	stealth = -1

--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -20,7 +20,7 @@ BONUS
 	stage_speed = 3
 	transmittable = 1
 	level = 5
-	severity = 0
+	severity = 1
 	symptom_delay_min = 25
 	symptom_delay_max = 75
 	var/cachedcolor = null
@@ -82,12 +82,12 @@ BONUS
 /datum/symptom/revitiligo
 	name = "Revitiligo"
 	desc = "The virus causes increased production of skin pigment cells, making the host's skin grow darker over time."
-	stealth = 1
-	resistance = 2
+	stealth = -1
+	resistance = 3
 	stage_speed = 1
 	transmittable = 2
 	level = 5
-	severity = 0
+	severity = 1
 	symptom_delay_min = 7
 	symptom_delay_max = 14
 	var/cachedcolor = null


### PR DESCRIPTION
BeeStation/BeeStation-Hornet#2358

reduces the shitter potential of the skin color diseases by making them reversible like the other cosmetic diseases making them maybe slightly 0.001% more usable

:cl:  zeskorion
rscadd: revitiligo and vitiligo will now work on mutant colors
tweak: revitiligo and vitiligo will now reverse their effects on being cured
/:cl:
