### PR TITLE
Removes Security Records Console Board from 5x4_deltadetective

### DIFF
--- a/_maps/RandomRuins/StationRuins/maint/5x4/5x4_deltadetective.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/5x4/5x4_deltadetective.dmm
@@ -105,7 +105,7 @@
 	},
 /turf/open/floor/carpet/red,
 /area/template_noop)
-"M" = (
+"H" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/frame/computer{
 	dir = 4
@@ -114,7 +114,6 @@
 	pixel_x = -32
 	},
 /obj/machinery/light/small,
-/obj/item/circuitboard/computer/secure_data,
 /turf/open/floor/carpet/red,
 /area/template_noop)
 "T" = (
@@ -153,7 +152,7 @@
 a
 r
 f
-M
+H
 "}
 (2,1,1) = {"
 b


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Removes sec records console board from 5x4_deltadetective.

### Why is this change good for the game?

Enforces the idea that sec boards, no matter how mundane or what little use it has, always falls within a secure area (checkpoints, brig) with the only exception being tech storage. Why the couldn't argue that point on the discord when defending this is beyond me.

# Wiki Documentation

Random maints are not documented.

# Changelog

:cl:   
rscdel: Removed sec records board from 5x4_deltadetective
/:cl:
