### PR TITLE
syndicate shuttle console is no longer deconstructable

### DIFF
--- a/code/modules/shuttle/syndicate.dm
+++ b/code/modules/shuttle/syndicate.dm
@@ -12,6 +12,9 @@
 	possible_destinations = "syndicate_away;syndicate_z5;syndicate_ne;syndicate_nw;syndicate_n;syndicate_se;syndicate_sw;syndicate_s;syndicate_custom"
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
+/obj/machinery/computer/shuttle/syndicate/screwdriver_act(mob/living/user, obj/item/I) //no
+	return FALSE
+
 /obj/machinery/computer/shuttle/syndicate/allowed(mob/M)
 	if(issilicon(M) && !(ROLE_SYNDICATE in M.faction))
 		return FALSE

--- a/code/modules/shuttle/syndicate.dm
+++ b/code/modules/shuttle/syndicate.dm
@@ -11,9 +11,7 @@
 	shuttleId = "syndicate"
 	possible_destinations = "syndicate_away;syndicate_z5;syndicate_ne;syndicate_nw;syndicate_n;syndicate_se;syndicate_sw;syndicate_s;syndicate_custom"
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
-
-/obj/machinery/computer/shuttle/syndicate/screwdriver_act(mob/living/user, obj/item/I) //no
-	return FALSE
+	flags_1 = NODECONSTRUCT_1
 
 /obj/machinery/computer/shuttle/syndicate/allowed(mob/M)
 	if(issilicon(M) && !(ROLE_SYNDICATE in M.faction))


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

actually fight the ops losers

### Why is this change good for the game?
forcing a stalemate by sneaking onto the op ship just to space something is bad

:cl:  
tweak: the syndicate infiltrator's control console is no longer deconstructable
/:cl:
