### PR TITLE
Fixes headslug interaction with mindswapping

### DIFF
--- a/code/modules/antagonists/changeling/powers/headcrab.dm
+++ b/code/modules/antagonists/changeling/powers/headcrab.dm
@@ -13,7 +13,6 @@
 	if(alert("Are we sure we wish to kill ourself and create a headslug?",,"Yes", "No") == "No")
 		return
 	..()
-	var/datum/mind/M = user.mind
 	var/list/organs = user.getorganszone(BODY_ZONE_HEAD, 1)
 
 	for(var/obj/item/organ/I in organs)
@@ -32,14 +31,11 @@
 		to_chat(S, "<span class='userdanger'>Your sensors are disabled by a shower of blood!</span>")
 		S.Paralyze(60)
 	var/turf = get_turf(user)
-	user.gib()
 	. = TRUE
 	sleep(5) // So it's not killed in explosion
 	var/mob/living/simple_animal/hostile/headcrab/crab = new(turf)
 	for(var/obj/item/organ/I in organs)
 		I.forceMove(crab)
-	crab.origin = M
-	if(crab.origin)
-		crab.origin.active = 1
-		crab.origin.transfer_to(crab)
-		to_chat(crab, "<span class='warning'>You burst out of the remains of your former body in a shower of gore!</span>")
+	user.mind.transfer_to(crab)
+	to_chat(crab, "<span class='warning'>You burst out of the remains of your former body in a shower of gore!</span>")
+	user.gib()

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -20,17 +20,13 @@
 	environment_smash = ENVIRONMENT_SMASH_NONE
 	speak_emote = list("squeaks")
 	ventcrawler = VENTCRAWLER_ALWAYS
-	var/datum/mind/origin
 	var/egg_lain = 0
 	gold_core_spawnable = NO_SPAWN //yogs
 
 /mob/living/simple_animal/hostile/headcrab/proc/Infect(mob/living/carbon/victim)
 	var/obj/item/organ/body_egg/changeling_egg/egg = new(victim)
 	egg.Insert(victim)
-	if(origin)
-		egg.origin = origin
-	else if(mind) // Let's make this a feature
-		egg.origin = mind
+	egg.origin = mind
 	for(var/obj/item/organ/I in src)
 		I.forceMove(egg)
 	visible_message("<span class='warning'>[src] plants something in [victim]'s flesh!</span>", \


### PR DESCRIPTION
# General Documentation
### Intent of your Pull Request
For some god unknown reasons, headslug stores the mind of original owner of the body, and passes it down when laying eggs.
This means, if you had a changeling that turned into a headslug, and then someone mindswapped with the headslug, resulting egg hatch results in the old mind being put in there. This clearly isn't intended.

### Why is this change good for the game?
Allows people to mindswap into changeling headslugs properly.

### Briefly describe your PR and the impacts of it, in layman's terms. 
makes the headslug pass its current mind into the egg, instead of a variable that isn't changed when mindswapped

### What general grouping does this PR fall under? 
extremely minor bugfix to headslug

# Changelog
:cl:  
bugfix: headslugs now properly pass their current mind onto eggs
/:cl: