### PR TITLE
prevents the fireball spellbook from spawning in lavaland ruins

### DIFF
--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -304,7 +304,7 @@
 
 /obj/item/book/granter/spell/random/Initialize()
 	. = ..()
-	var/static/banned_spells = list(/obj/item/book/granter/spell/mimery_blockade, /obj/item/book/granter/spell/mimery_guns)
+	var/static/banned_spells = list(/obj/item/book/granter/spell/mimery_blockade, /obj/item/book/granter/spell/mimery_guns, /obj/item/book/granter/spell/fireball)
 	var/real_type = pick(subtypesof(/obj/item/book/granter/spell) - banned_spells)
 	new real_type(loc)
 	return INITIALIZE_HINT_QDEL


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

low cooldown ranged bomb spell should not be mining loot. Generally wizard spells are not something crew should have but at least the rest of them aren't an explosive projectile

### Why is this change good for the game?
hate fireball


# Changelog

:cl:  
rscdel: fireball spell granting books will no longer spawn in random spellbook drops
/:cl:
