### PR TITLE
the tacticool fake syndicate turtleneck now has suit sensors

### DIFF
--- a/code/modules/clothing/under/syndicate.dm
+++ b/code/modules/clothing/under/syndicate.dm
@@ -14,6 +14,7 @@
 	icon_state = "tactifool"
 	item_state = "bl_suit"
 	item_color = "tactifool"
+	has_sensor = HAS_SENSORS
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 40)
 
 /obj/item/clothing/under/syndicate/sniper


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

makes the tacticool turtleneck that's purchaseable from a hacked clothes vendor actually have suit sensors like the majority if not all other clothing items

### Why is this change good for the game?
lack of sensors on the tactical turtleneck is because it's syndie shit and doesn't need them, the tacticool turtleneck is a marketable plushie variant that would have them similar to the gladiator outfit from the autodrobe

# Changelog

:cl:  
tweak: tacticool turtlenecks now have suit sensors
/:cl:
