### PR TITLE
Adds a syndicate EMP bomb

### DIFF
--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -125,6 +125,10 @@
 /obj/item/sbeacondrop/bomb
 	desc = "A label on it reads: <i>Warning: Activating this device will send a high-ordinance explosive to your location</i>."
 	droptype = /obj/machinery/syndicatebomb
+	
+/obj/item/sbeacondrop/emp
+	desc = "A label on it reads: <i>Warning: Activating this device will send a high-powered electromagnetic device to your location</i>."
+	droptype = /obj/machinery/syndicatebomb/emp
 
 /obj/item/sbeacondrop/powersink
 	desc = "A label on it reads: <i>Warning: Activating this device will send a power draining device to your location</i>."

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -213,6 +213,11 @@
 	icon_state = "training-bomb"
 	desc = "A salvaged syndicate device gutted of its explosives to be used as a training aid for aspiring bomb defusers."
 	payload = /obj/item/bombcore/training
+	
+/obj/machinery/syndicatebomb/emp
+	name = "EMP Bomb"
+	desc = "A modified bomb designed to release a crippling electromagnetic pulse instead of explode"
+	payload = /obj/item/bombcore/emp
 
 /obj/machinery/syndicatebomb/badmin
 	name = "generic summoning badmin bomb"
@@ -484,8 +489,20 @@
 
 		qdel(G)
 
+/obj/item/bombcore/emp
+	name = "EMP payload"
+	desc = "A set of superconducting electromagnetic coils designed to release a powerful pulse to destroy electronics and scramble circuits"
+	range_heavy = 15
+	range_medium = 25
 
+/obj/item/bombcore/emp/detonate()
+	if(adminlog)
+		message_admins(adminlog)
+		log_game(adminlog)
 
+	empulse(src, range_heavy, range_medium)
+	
+	qdel(src)
 
 ///Syndicate Detonator (aka the big red button)///
 

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -216,7 +216,7 @@
 	
 /obj/machinery/syndicatebomb/emp
 	name = "EMP Bomb"
-	desc = "A modified bomb designed to release a crippling electromagnetic pulse instead of explode"
+	desc = "A modified bomb designed to release a crippling electromagnetic pulse instead of an explosion"
 	payload = /obj/item/bombcore/emp
 
 /obj/machinery/syndicatebomb/badmin

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1037,6 +1037,12 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/sbeacondrop/bomb
 	cost = 11
 
+/datum/uplink_item/explosives/syndicate_bomb/emp
+	name = "Syndicate EMP Bomb"
+	desc = "A variation of the syndicate bomb designed to produce a large EMP effect."
+	item = /obj/item/sbeacondrop/emp
+	cost = 7
+
 /datum/uplink_item/explosives/syndicate_detonator
 	name = "Syndicate Detonator"
 	desc = "The Syndicate detonator is a companion device to the Syndicate bomb. Simply press the included button \


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Adds a version of the syndicate bomb that produces a large EMP effect instead of exploding.

### Why is this change good for the game?

Alternative to boom boom explosion. Now you can shock shit and fuck the AI. 🖕   It's less destructive but more disruptive.

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 

It's an alternative version of the Syndicate Bomb where it EMPs. Costs 7 tc

### What should players be aware of when it comes to the changes your PR is implementing?
New traitor item

### What general grouping does this PR fall under? 
Traitor changes

### Are there any aspects of the PR that you would like us not to mention on the Wiki?

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
Heavy range of 15
Medium range of 25

# Changelog

Edit this changelog for changes that are noticeable by the players. Remove it if this isn't the case. If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. Prefix the PR title with [admin] if it's something admin related. Prefix the PR title with [s] if you are fixing an exploit so it is not announced on discord and the server.

:cl:  
rscadd: Adds the syndicate EMP bomb
/:cl:
