### PR TITLE
probably fixes gangtools giving a deconvert message when promoting someone

### DIFF
--- a/yogstation/code/modules/antagonists/gang/gang.dm
+++ b/yogstation/code/modules/antagonists/gang/gang.dm
@@ -84,6 +84,7 @@
 /datum/antagonist/gang/proc/promote() // Bump up to boss
 	var/datum/team/gang/old_gang = gang
 	var/datum/mind/old_owner = owner
+	silent = TRUE
 	owner.remove_antag_datum(/datum/antagonist/gang)
 	var/datum/antagonist/gang/boss/lieutenant/new_boss = new
 	new_boss.silent = TRUE


### PR DESCRIPTION
fixes #11180
:cl:  
bugfix: gang promotions no longer show a demotion message
/:cl:
