### PR TITLE
Reinforces Back of Courtroom, the Part of Brig Facing Maintenance, and a Wall of Teleporter Room. Gives "Escape Pod 3" Correct Access.

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -23862,9 +23862,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
-"bsh" = (
-/turf/closed/wall,
-/area/teleporter)
 "bsi" = (
 /obj/structure/table,
 /obj/item/hand_tele,
@@ -36384,28 +36381,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"egX" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod Three";
-	req_access_txt = "63"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/security/main)
 "ehJ" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/machinery/door/window/westleft{
@@ -36453,9 +36428,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"ekO" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/fore/secondary)
 "ekT" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -44572,6 +44544,28 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"kkX" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Three";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/security/main)
 "klj" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/blue{
@@ -58370,6 +58364,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"ulz" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Three";
+	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/main)
 "ulD" = (
 /obj/structure/tank_dispenser,
 /obj/effect/turf_decal/bot{
@@ -60197,16 +60201,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"vxh" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod Three";
-	req_access_txt = "63"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/security/main)
 "vyT" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
@@ -62945,6 +62939,9 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"xzp" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/fore/secondary)
 "xzt" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -96331,10 +96328,10 @@ aZV
 aZV
 aZV
 bqH
-bsh
-bsh
-bsh
-bsh
+bqH
+bqH
+bqH
+bqH
 bqH
 aJq
 aJq
@@ -100126,11 +100123,11 @@ abp
 abp
 abp
 abp
-egX
+kkX
 abp
 adR
 jDB
-ekO
+xzp
 jtq
 ahT
 ahT
@@ -100640,7 +100637,7 @@ abp
 abp
 abp
 abp
-vxh
+ulz
 abp
 adR
 aoZ
@@ -113585,7 +113582,7 @@ atN
 atN
 atN
 atN
-wkN
+atN
 vJS
 bPp
 aaa
@@ -115120,7 +115117,7 @@ bQZ
 aRv
 bQZ
 bQZ
-bPN
+bQZ
 cNW
 hVC
 cNW

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -23871,9 +23871,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
-"bsh" = (
-/turf/closed/wall,
-/area/teleporter)
 "bsi" = (
 /obj/structure/table,
 /obj/item/hand_tele,
@@ -96326,10 +96323,10 @@ aZV
 aZV
 aZV
 bqH
-bsh
-bsh
-bsh
-bsh
+bqH
+bqH
+bqH
+bqH
 bqH
 aJq
 aJq
@@ -97814,7 +97811,7 @@ agz
 ahb
 ahI
 bHT
-abp
+adR
 ajh
 ajn
 ajn
@@ -98071,7 +98068,7 @@ agB
 ahd
 ahI
 clS
-abp
+adR
 ajj
 ajP
 aky
@@ -98328,7 +98325,7 @@ aoD
 ahc
 ahJ
 aiq
-abp
+adR
 aji
 ajO
 akL
@@ -98585,7 +98582,7 @@ ahV
 ahf
 ahK
 ait
-abp
+adR
 ajl
 ajR
 ame
@@ -98842,7 +98839,7 @@ aly
 ahe
 ahM
 dFX
-abp
+adR
 ajk
 ajQ
 ake
@@ -99099,7 +99096,7 @@ agE
 ahh
 aic
 uQE
-abp
+adR
 aiY
 ajE
 akf
@@ -99356,7 +99353,7 @@ afY
 ahg
 ahL
 aiu
-abp
+adR
 aaB
 aaG
 ajn
@@ -99613,7 +99610,7 @@ kcy
 eEt
 wCs
 pEk
-abp
+adR
 ajp
 ajU
 ajn
@@ -99868,9 +99865,9 @@ esT
 aga
 abp
 frH
-abp
+adR
 sXv
-abp
+adR
 ajo
 ajo
 ajo
@@ -100119,7 +100116,7 @@ aaa
 acw
 abp
 abp
-adR
+abp
 abp
 kxR
 abp
@@ -100380,7 +100377,7 @@ ppd
 txU
 nAV
 agc
-abp
+adR
 siX
 qKd
 kNa
@@ -100637,7 +100634,7 @@ abp
 abp
 afo
 abp
-abp
+adR
 aoZ
 apx
 ahn
@@ -101147,11 +101144,11 @@ aaa
 aaf
 aaa
 aaa
-adR
+abp
 aaa
 aaa
 aaa
-adR
+abp
 aoL
 apy
 aqq
@@ -113580,7 +113577,7 @@ atN
 atN
 atN
 atN
-wkN
+atN
 vJS
 bPp
 aaa
@@ -115115,7 +115112,7 @@ bQZ
 aRv
 bQZ
 bQZ
-bPN
+bQZ
 cNW
 hVC
 cNW

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -2018,15 +2018,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"afo" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod Three"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/security/main)
 "afp" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -23871,6 +23862,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
+"bsh" = (
+/turf/closed/wall,
+/area/teleporter)
 "bsi" = (
 /obj/structure/table,
 /obj/item/hand_tele,
@@ -36390,6 +36384,28 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"egX" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Three";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/security/main)
 "ehJ" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/machinery/door/window/westleft{
@@ -36437,6 +36453,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"ekO" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/fore/secondary)
 "ekT" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -44874,27 +44893,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"kxR" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod Three"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/security/main)
 "kyA" = (
 /obj/structure/table,
 /obj/item/assembly/flash/handheld{
@@ -60199,6 +60197,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"vxh" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Three";
+	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/main)
 "vyT" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
@@ -96323,10 +96331,10 @@ aZV
 aZV
 aZV
 bqH
-bqH
-bqH
-bqH
-bqH
+bsh
+bsh
+bsh
+bsh
 bqH
 aJq
 aJq
@@ -100118,11 +100126,11 @@ abp
 abp
 abp
 abp
-kxR
+egX
 abp
 adR
 jDB
-ahn
+ekO
 jtq
 ahT
 ahT
@@ -100632,7 +100640,7 @@ abp
 abp
 abp
 abp
-afo
+vxh
 abp
 adR
 aoZ
@@ -113577,7 +113585,7 @@ atN
 atN
 atN
 atN
-atN
+wkN
 vJS
 bPp
 aaa
@@ -115112,7 +115120,7 @@ bQZ
 aRv
 bQZ
 bQZ
-bQZ
+bPN
 cNW
 hVC
 cNW


### PR DESCRIPTION
### Intent of your Pull Request

Reinforces the back of the courtroom, the part of brig facing maint, and a wall of the teleporter room. Gives the "Escape Pod 3" doors (sec pod access doors) proper access (63, same as all other outer doors of sec).
![bpng](https://user-images.githubusercontent.com/62276730/112550451-c7672000-8d95-11eb-8cae-c1e0bfa72d97.png)
![cpng](https://user-images.githubusercontent.com/62276730/112550457-c9c97a00-8d95-11eb-9d9e-071e5fe16059.png)
![dpng](https://user-images.githubusercontent.com/62276730/112550464-cb933d80-8d95-11eb-8415-39fa8684c1a9.png)

### Why is this change good for the game?

Fixes what I believe were just oversights, along with making the station more uniform. The "Escape Pod 3" doors having sec access is in line with Engineering's pod access doors having access restrictions (Only available to engineering and the SAT tech).

I'm not sure why the teleporter room didn't have an entire unreinforced wall.

# Wiki Documentation

Images for Teleporter Room and Security Office will need to be changed, as well as Courtroom.

# Changelog

:cl:  
rscadd: Added Reinforced Walls and proper access to "Escape Pod 3"
/:cl:
