### PR TITLE
Removes Stetchkin from several lavaland ruins, replaces some with an Improvised Shotgun

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_cursedtoyshop.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_cursedtoyshop.dmm
@@ -778,13 +778,14 @@
 /obj/item/kitchen/fork,
 /turf/open/floor/wood,
 /area/ruin/powered)
-"bO" = (
+"cG" = (
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
-/obj/item/gun/ballistic/automatic/pistol,
 /obj/effect/mob_spawn/human/clown/corpse,
 /obj/effect/decal/cleanable/blood/old,
+/obj/item/gun/ballistic/shotgun/doublebarrel/improvised,
+/obj/item/ammo_casing/shotgun/improvised,
 /turf/open/floor/wood,
 /area/ruin/powered)
 "pE" = (
@@ -1122,7 +1123,7 @@ aS
 yW
 aa
 bJ
-bO
+cG
 aa
 "}
 (16,1,1) = {"

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicatepod.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicatepod.dmm
@@ -93,11 +93,6 @@
 /obj/item/toy/figure/syndie,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/ruin/powered)
-"u" = (
-/obj/structure/table,
-/obj/item/gun/ballistic/automatic/pistol,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/ruin/powered)
 "v" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/template_noop,
@@ -105,6 +100,10 @@
 "w" = (
 /obj/structure/shuttle/engine/platform,
 /turf/closed/wall/mineral/titanium,
+/area/ruin/powered)
+"E" = (
+/obj/structure/table,
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/ruin/powered)
 
 (1,1,1) = {"
@@ -186,7 +185,7 @@ j
 m
 q
 e
-u
+E
 w
 v
 a

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_xeno_nest.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_xeno_nest.dmm
@@ -40,13 +40,6 @@
 /obj/structure/alien/weeds/node,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/xenonest)
-"o" = (
-/obj/structure/alien/weeds,
-/obj/structure/bed/nest,
-/obj/effect/decal/cleanable/blood/gibs,
-/obj/item/gun/ballistic/automatic/pistol,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/xenonest)
 "r" = (
 /obj/structure/alien/weeds,
 /obj/structure/alien/resin/wall,
@@ -77,16 +70,6 @@
 "y" = (
 /obj/structure/alien/weeds/node,
 /obj/structure/alien/resin/wall,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/xenonest)
-"z" = (
-/obj/structure/alien/weeds,
-/obj/structure/bed/nest,
-/obj/effect/decal/cleanable/blood/gibs,
-/obj/item/clothing/under/rank/security,
-/obj/item/clothing/suit/armor/vest,
-/obj/item/melee/baton/loaded,
-/obj/item/clothing/head/helmet,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/xenonest)
 "B" = (
@@ -172,6 +155,22 @@
 "R" = (
 /obj/structure/alien/weeds,
 /turf/template_noop,
+/area/ruin/unpowered/xenonest)
+"T" = (
+/obj/structure/alien/weeds,
+/obj/structure/bed/nest,
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/item/gun/ballistic/shotgun/doublebarrel/improvised,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/xenonest)
+"W" = (
+/obj/structure/alien/weeds,
+/obj/structure/bed/nest,
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/item/clothing/under/rank/security,
+/obj/item/clothing/suit/armor/vest,
+/obj/item/clothing/head/helmet,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/xenonest)
 
 (1,1,1) = {"
@@ -435,7 +434,7 @@ a
 a
 G
 b
-o
+T
 v
 g
 b
@@ -1077,7 +1076,7 @@ a
 a
 a
 b
-z
+W
 C
 j
 g


### PR DESCRIPTION
General Documentation

Intent of your Pull Request

Removes the stetchkin from the lavaland ruin xeno_nest (the xeno nest), cursedtoyshop (the toy shop) and syndicatepod (the syndicate pod that has only the hostile alien in it. The xeno_nest and cursedtoyshop have had their stetchkins replaced by improv shotguns.

Why is this change good for the game?

This PR was suggested by Theos (@SomeguyManperson) so you're going to have to ask him why it's good for the game.

# Wiki Documentation

https://wiki.yogstation.net/wiki/Ruins
The cursedtoyshop and syndicatepod entry in the ruins area will need to be altered upon completion to mention how the stetchkin has been removed. I'm surprised the it was omitted from the xenonest though.

Changelog
:cl:  
rscadd: Added improv shotguns in place of removed stetchkins in 2/3 of the ruins.
rscdel: Removed stetchkins from lavaland ruins 
/:cl:
