### PR TITLE
Lowers Damage done by the Mosin-Nagant bullets to 40 (as opposed to the 60)

### DIFF
--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -8,7 +8,7 @@
 
 /obj/item/projectile/bullet/a762
 	name = "7.62 bullet"
-	damage = 60
+	damage = 40
 
 /obj/item/projectile/bullet/a762_enchanted
 	name = "enchanted 7.62 bullet"


### PR DESCRIPTION
# генерал Documentation

### Intent of your Pull Request

Lowers the damage done by Mosin-Nagants (the bolt action rifle) to 40 by altering the damage the projectile it shoots does.

### Why is this change good for the game?

https://discord.com/channels/134720091576205312/134720091576205312/824797096787181599
![bpng](https://user-images.githubusercontent.com/62276730/112565768-1459ef00-8db4-11eb-9c19-fa08ec7fc608.png)
Ask Ynot (@ynot01) and Theos (@SomeguyManperson) why its good. Something about balance and how the 60 made it op.

### Wiki Documentation

Mosin damage isnt documented anywhere so nothing to change.

# Changelog

:cl:  
tweak: lowered 7.62 bullet (the one mosins use) from 60 to 40  
/:cl:
