### PR TITLE
Adds a check to prevent compiling with versions above 1538 because thats the last working version with extools

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -65,3 +65,13 @@
 #error BYOND version 513.1537 contains a bug that prevents the codebase from compiling properly. Please upgrade/downgrade your BYOND version
 #error ==================================
 #endif
+
+//If you update these values, update the message in the #error
+#define MAX_BYOND_MAJOR 513
+#define MAX_BYOND_MINOR 1538
+
+///Uncomment to bypass the max version check. Note: This will likely break the game, only use if you know what you're doing
+//#define IGNORE_MAX_BYOND_VERSION
+#if ((DM_VERSION > MAX_BYOND_MAJOR) || (DM_BUILD > MAX_BYOND_MINOR)) && !defined(IGNORE_MAX_BYOND_VERSION)
+#error Your version of BYOND is too new to compile this project. Download version 513.1538 at www.byond.com/download/build/513/513.1538_byond_setup.exe
+#endif


### PR DESCRIPTION
Will show a message telling you to downgrade along with a link on where to go to download version 1538

also adds a commented define that will bypass that check if for some reason you need to disable it one time