### PR TITLE
Adds Gift Shop Toxins Test Range

### DIFF
--- a/_maps/RandomRuins/StationRuins/BoxStation/testingsite_range4.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/testingsite_range4.dmm
@@ -1,0 +1,617 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/door/window/eastright{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/test_area)
+"c" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
+"e" = (
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'BOMB RANGE";
+	name = "BOMB RANGE"
+	},
+/turf/closed/wall,
+/area/science/test_area)
+"f" = (
+/obj/item/beacon,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/test_area)
+"g" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/flashlight/lamp,
+/turf/open/floor/plasteel,
+/area/science/test_area)
+"h" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/door/window/eastright{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/science/test_area)
+"i" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/test_area)
+"j" = (
+/turf/open/space/basic,
+/area/space)
+"k" = (
+/obj/structure/table_frame,
+/obj/item/stack/sheet/metal,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plasteel,
+/area/science/test_area)
+"m" = (
+/turf/closed/indestructible{
+	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
+	icon_state = "riveted";
+	name = "hyper-reinforced wall"
+	},
+/area/science/test_area)
+"q" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/item/a_gift,
+/obj/item/a_gift,
+/turf/open/floor/plasteel,
+/area/science/test_area)
+"s" = (
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/science/test_area)
+"t" = (
+/turf/closed/wall,
+/area/science/test_area)
+"v" = (
+/obj/machinery/camera{
+	active_power_usage = 0;
+	c_tag = "Bomb Test Site";
+	desc = "A specially-reinforced camera with a long lasting battery, used to monitor the bomb testing site.";
+	dir = 8;
+	invuln = 1;
+	name = "Hardened Bomb-Test Camera";
+	network = list("toxins");
+	use_power = 0
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/vending/autodrobe,
+/turf/open/floor/plasteel,
+/area/science/test_area)
+"w" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/table,
+/obj/item/storage/belt/utility{
+	contents = list(/obj/item/screwdriver,/obj/item/wrench,/obj/item/weldingtool,/obj/item/crowbar,/obj/item/wirecutters,/obj/item/multitool)
+	},
+/obj/item/clothing/gloves/color/yellow,
+/turf/open/floor/plasteel,
+/area/science/test_area)
+"E" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/test_area)
+"H" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/test_area)
+"J" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/science/test_area)
+"M" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/end,
+/obj/structure/statue/sandstone/assistant,
+/turf/open/floor/plasteel,
+/area/science/test_area)
+"N" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/item/target,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/test_area)
+"S" = (
+/obj/structure/closet/crate,
+/obj/item/target/syndicate,
+/obj/item/target,
+/obj/item/target/alien,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/test_area)
+"U" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/test_area)
+"W" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/paystand/register{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/test_area)
+"Y" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/science/test_area)
+"Z" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/item/instrument/violin,
+/obj/item/instrument/guitar{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/turf/open/floor/plasteel,
+/area/science/test_area)
+
+(1,1,1) = {"
+j
+j
+j
+j
+j
+j
+c
+j
+c
+j
+j
+j
+j
+j
+j
+"}
+(2,1,1) = {"
+j
+j
+j
+j
+j
+c
+c
+j
+c
+c
+j
+j
+j
+j
+j
+"}
+(3,1,1) = {"
+j
+j
+j
+j
+c
+c
+t
+U
+t
+c
+c
+j
+j
+j
+j
+"}
+(4,1,1) = {"
+j
+j
+j
+c
+c
+e
+t
+E
+t
+e
+c
+c
+j
+j
+j
+"}
+(5,1,1) = {"
+j
+j
+c
+c
+t
+t
+i
+i
+a
+t
+t
+c
+c
+j
+j
+"}
+(6,1,1) = {"
+j
+j
+c
+t
+t
+q
+W
+k
+i
+w
+t
+t
+c
+j
+j
+"}
+(7,1,1) = {"
+c
+c
+c
+J
+s
+Z
+N
+f
+i
+H
+M
+J
+c
+c
+c
+"}
+(8,1,1) = {"
+j
+j
+c
+t
+t
+g
+i
+i
+i
+h
+t
+t
+c
+j
+j
+"}
+(9,1,1) = {"
+j
+j
+c
+c
+t
+t
+S
+i
+v
+t
+t
+c
+c
+j
+j
+"}
+(10,1,1) = {"
+j
+j
+j
+c
+c
+e
+t
+Y
+t
+e
+c
+c
+j
+j
+j
+"}
+(11,1,1) = {"
+j
+j
+j
+j
+c
+c
+t
+m
+t
+c
+c
+j
+j
+j
+j
+"}
+(12,1,1) = {"
+j
+j
+j
+j
+j
+c
+c
+c
+c
+c
+j
+j
+j
+j
+j
+"}
+(13,1,1) = {"
+j
+j
+j
+j
+j
+j
+c
+c
+c
+j
+j
+j
+j
+j
+j
+"}
+(14,1,1) = {"
+j
+j
+j
+j
+j
+j
+j
+c
+j
+j
+j
+j
+j
+j
+j
+"}
+(15,1,1) = {"
+j
+j
+j
+j
+j
+j
+j
+c
+j
+j
+j
+j
+j
+j
+j
+"}

--- a/_maps/RandomRuins/StationRuins/BoxStation/testingsite_range4.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/testingsite_range4.dmm
@@ -174,7 +174,7 @@
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/plasteel,
 /area/science/test_area)
-"w" = (
+"z" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -192,10 +192,12 @@
 	dir = 10
 	},
 /obj/structure/table,
-/obj/item/storage/belt/utility{
-	contents = list(/obj/item/screwdriver,/obj/item/wrench,/obj/item/weldingtool,/obj/item/crowbar,/obj/item/wirecutters,/obj/item/multitool)
-	},
 /obj/item/clothing/gloves/color/yellow,
+/obj/item/storage/belt/utility,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 2;
+	pixel_y = 1
+	},
 /turf/open/floor/plasteel,
 /area/science/test_area)
 "E" = (
@@ -455,7 +457,7 @@ q
 W
 k
 i
-w
+z
 t
 t
 c

--- a/yogstation/code/datums/ruins/station.dm
+++ b/yogstation/code/datums/ruins/station.dm
@@ -104,6 +104,11 @@
 	id = "testing_site_3"
 	suffix = "testingsite_range3.dmm"
 	name = "Clown Bomb Range"
+	
+/datum/map_template/ruin/station/box/testingsite/clerk
+	id = "testing_site_4"
+	suffix = "testingsite_range4.dmm"
+	name = "Clerk Bomb Range"
 
 /datum/map_template/ruin/station/box/medbay/morgue
 	id = "medbay_morgue1"

--- a/yogstation/code/game/objects/effects/landmarks.dm
+++ b/yogstation/code/game/objects/effects/landmarks.dm
@@ -112,7 +112,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 	template_names = list("Xenobiology Bridge", "Xenobiology Lattice")
 
 /obj/effect/landmark/stationroom/box/testingsite
-	template_names = list("Bunker Bomb Range","Syndicate Bomb Range","Clown Bomb Range")
+	template_names = list("Bunker Bomb Range","Syndicate Bomb Range","Clown Bomb Range", "Clerk Bomb Range")
 
 /obj/effect/landmark/stationroom/box/medbay/morgue
 	template_names = list("Morgue", "Morgue 2", "Morgue 3", "Morgue 4", "Morgue 5")


### PR DESCRIPTION
# OF-9 Documentation

### Intent of your Pull Request

Adds a Gift Shop variant of the Toxins Testing Range
![bpng](https://user-images.githubusercontent.com/62276730/112669638-53c91f80-8e36-11eb-9ce4-7c4086e8186b.png)
Features a toolbelt, a toolbox and insulated gloves, along with standard clerk gear (Autodrobe, crate full of targets, register, 2 gifts, etc.).

### Why is this change good for the game?

clerk.

# Wiki Documentation

Random Test Ranges are not documented and nothing on the wiki needs to be changed.

# Changelog

:cl:  
rscadd: da Gift Shop Testing Range  
/:cl:
