### PR TITLE
Adds gas miners to omega

### DIFF
--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -30813,20 +30813,6 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"iNU" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/port)
 "iOW" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -35571,6 +35557,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"nYY" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "nZf" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 8
@@ -80190,7 +80190,7 @@ lqV
 ddE
 sKx
 aOH
-iNU
+nYY
 aMu
 aOH
 aOH

--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -9827,20 +9827,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"anG" = (
-/obj/structure/sign/directions/engineering{
-	dir = 2;
-	pixel_y = -8
-	},
-/obj/structure/sign/directions/security{
-	dir = 8
-	},
-/obj/structure/sign/directions/command{
-	dir = 1;
-	pixel_y = 8
-	},
-/turf/closed/wall,
-/area/security/brig)
 "anH" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -10266,17 +10252,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"aoj" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aok" = (
@@ -19405,14 +19380,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"aSS" = (
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/glasses/meson/engine,
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "aSU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -24755,14 +24722,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"ckx" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/miner/toxins,
-/turf/open/floor/engine/plasma,
-/area/engine/atmos)
 "clF" = (
 /obj/machinery/light{
 	dir = 1
@@ -25265,6 +25224,12 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
+"cQy" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/miner/oxygen,
+/turf/open/floor/engine/o2,
+/area/engine/atmos)
 "cRn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26474,6 +26439,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"emD" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/miner/toxins,
+/turf/open/floor/engine/plasma,
+/area/engine/atmos)
 "eos" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -26881,6 +26854,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"eIl" = (
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/glasses/meson/engine,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "eJL" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -30670,6 +30653,14 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
+/area/engine/atmos)
+"iIQ" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/miner/n2o,
+/turf/open/floor/engine/n2o,
 /area/engine/atmos)
 "iIY" = (
 /obj/effect/turf_decal/tile/purple{
@@ -35164,14 +35155,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"nIH" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/miner/carbon_dioxide,
-/turf/open/floor/engine/co2,
-/area/engine/atmos)
 "nIT" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -35549,14 +35532,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"nXN" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/miner/n2o,
-/turf/open/floor/engine/n2o,
-/area/engine/atmos)
 "nXQ" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Custodial Maintenance";
@@ -38208,12 +38183,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"qNT" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/miner/oxygen,
-/turf/open/floor/engine/o2,
-/area/engine/atmos)
 "qOO" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "ceblast";
@@ -38857,6 +38826,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/medical)
+"ruu" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/miner/nitrogen,
+/turf/open/floor/engine/n2,
+/area/engine/atmos)
 "rvh" = (
 /obj/structure/cable/white{
 	icon_state = "2-8"
@@ -38998,6 +38973,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"rDw" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/miner/carbon_dioxide,
+/turf/open/floor/engine/co2,
+/area/engine/atmos)
 "rEx" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -42917,6 +42900,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"tXY" = (
+/obj/structure/sign/directions/engineering{
+	dir = 2;
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/security{
+	dir = 8
+	},
+/obj/structure/sign/directions/command{
+	dir = 1;
+	pixel_y = 8
+	},
+/turf/closed/wall/r_wall,
+/area/security/brig)
 "tYm" = (
 /obj/machinery/processor,
 /turf/open/floor/plasteel/cafeteria{
@@ -43489,12 +43486,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"uyz" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/miner/nitrogen,
-/turf/open/floor/engine/n2,
-/area/engine/atmos)
 "uyI" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/engine,
@@ -46869,6 +46860,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
+"yjQ" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ylL" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/cooking_to_serve_man,
@@ -74491,7 +74496,7 @@ aac
 aac
 aac
 pNE
-nIH
+rDw
 iqC
 aqA
 kHA
@@ -75519,7 +75524,7 @@ aad
 aad
 aad
 pNE
-ckx
+emD
 ddI
 aqA
 vmU
@@ -76047,7 +76052,7 @@ eaf
 agS
 aAi
 axi
-qNT
+cQy
 uok
 fTS
 mdy
@@ -76547,7 +76552,7 @@ aaW
 aad
 aad
 pNE
-nXN
+iIQ
 fnp
 aqA
 viy
@@ -77075,7 +77080,7 @@ eaf
 ahb
 aAi
 atx
-uyz
+ruu
 uok
 iNt
 aFu
@@ -77091,7 +77096,7 @@ aMX
 sJG
 sQu
 aRK
-aSS
+eIl
 aLk
 aUS
 aUU
@@ -79912,7 +79917,7 @@ aAf
 urZ
 rBK
 aoi
-aoj
+yjQ
 rel
 xPI
 ddE
@@ -82971,7 +82976,7 @@ atM
 agF
 atM
 atM
-anG
+tXY
 sYw
 aeq
 agF

--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -7012,25 +7012,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
-"ajH" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Access";
-	req_access_txt = "10"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ajI" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -25224,12 +25205,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
-"cQy" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/miner/oxygen,
-/turf/open/floor/engine/o2,
-/area/engine/atmos)
 "cRn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25857,6 +25832,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"dFW" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/miner/nitrogen,
+/turf/open/floor/engine/n2,
+/area/engine/atmos)
 "dGc" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -26439,14 +26420,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"emD" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/miner/toxins,
-/turf/open/floor/engine/plasma,
-/area/engine/atmos)
 "eos" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -26854,16 +26827,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"eIl" = (
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/glasses/meson/engine,
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/line,
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "eJL" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -28092,6 +28055,12 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"ggc" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/miner/oxygen,
+/turf/open/floor/engine/o2,
+/area/engine/atmos)
 "ggq" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -30300,6 +30269,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/medical/morgue)
+"isz" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/miner/n2o,
+/turf/open/floor/engine/n2o,
+/area/engine/atmos)
 "itl" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral{
@@ -30496,6 +30473,14 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/science/research)
+"iyF" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/miner/toxins,
+/turf/open/floor/engine/plasma,
+/area/engine/atmos)
 "izv" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -30653,14 +30638,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
-"iIQ" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/miner/n2o,
-/turf/open/floor/engine/n2o,
 /area/engine/atmos)
 "iIY" = (
 /obj/effect/turf_decal/tile/purple{
@@ -32073,6 +32050,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"kdE" = (
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/glasses/meson/engine,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "ked" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/landmark/start/head_of_security,
@@ -32626,6 +32613,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"kJw" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/miner/carbon_dioxide,
+/turf/open/floor/engine/co2,
+/area/engine/atmos)
 "kJB" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
@@ -35820,6 +35815,20 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/maintenance/port)
+"omm" = (
+/obj/structure/sign/directions/engineering{
+	dir = 2;
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/security{
+	dir = 8
+	},
+/obj/structure/sign/directions/command{
+	dir = 1;
+	pixel_y = 8
+	},
+/turf/closed/wall/r_wall,
+/area/security/brig)
 "omq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -36748,6 +36757,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"pqk" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "pqs" = (
 /obj/machinery/power/turbine{
 	dir = 8;
@@ -38826,12 +38849,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/medical)
-"ruu" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/miner/nitrogen,
-/turf/open/floor/engine/n2,
-/area/engine/atmos)
 "rvh" = (
 /obj/structure/cable/white{
 	icon_state = "2-8"
@@ -38973,14 +38990,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"rDw" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/miner/carbon_dioxide,
-/turf/open/floor/engine/co2,
-/area/engine/atmos)
 "rEx" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -42859,6 +42868,31 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"tTA" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Access";
+	req_access_txt = "10"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "tVa" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -42900,20 +42934,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"tXY" = (
-/obj/structure/sign/directions/engineering{
-	dir = 2;
-	pixel_y = -8
-	},
-/obj/structure/sign/directions/security{
-	dir = 8
-	},
-/obj/structure/sign/directions/command{
-	dir = 1;
-	pixel_y = 8
-	},
-/turf/closed/wall/r_wall,
-/area/security/brig)
 "tYm" = (
 /obj/machinery/processor,
 /turf/open/floor/plasteel/cafeteria{
@@ -46860,20 +46880,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
-"yjQ" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ylL" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/cooking_to_serve_man,
@@ -74496,7 +74502,7 @@ aac
 aac
 aac
 pNE
-rDw
+kJw
 iqC
 aqA
 kHA
@@ -75524,7 +75530,7 @@ aad
 aad
 aad
 pNE
-emD
+iyF
 ddI
 aqA
 vmU
@@ -76052,7 +76058,7 @@ eaf
 agS
 aAi
 axi
-cQy
+ggc
 uok
 fTS
 mdy
@@ -76552,7 +76558,7 @@ aaW
 aad
 aad
 pNE
-iIQ
+isz
 fnp
 aqA
 viy
@@ -77080,7 +77086,7 @@ eaf
 ahb
 aAi
 atx
-ruu
+dFW
 uok
 iNt
 aFu
@@ -77096,7 +77102,7 @@ aMX
 sJG
 sQu
 aRK
-eIl
+kdE
 aLk
 aUS
 aUU
@@ -79659,7 +79665,7 @@ aEt
 aEt
 aEt
 aEt
-ajH
+tTA
 aEt
 aEt
 aEt
@@ -79917,7 +79923,7 @@ aAf
 urZ
 rBK
 aoi
-yjQ
+pqk
 rel
 xPI
 ddE
@@ -80430,7 +80436,7 @@ aHx
 aIs
 aEt
 wYt
-ajH
+tTA
 aEt
 aEt
 ntp
@@ -82976,7 +82982,7 @@ atM
 agF
 atM
 atM
-tXY
+omm
 sYw
 aeq
 agF

--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -14681,11 +14681,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aCs" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light/small,
-/turf/open/floor/engine/o2,
-/area/engine/atmos)
 "aCt" = (
 /obj/structure/table,
 /obj/item/paper,
@@ -14716,11 +14711,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aCw" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/light/small,
-/turf/open/floor/engine/n2,
-/area/engine/atmos)
 "aCz" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -24765,6 +24755,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"ckx" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/miner/toxins,
+/turf/open/floor/engine/plasma,
+/area/engine/atmos)
 "clF" = (
 /obj/machinery/light{
 	dir = 1
@@ -28050,13 +28048,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"gap" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/engine/n2o,
-/area/engine/atmos)
 "gaE" = (
 /obj/item/storage/box/firingpins,
 /obj/item/storage/box/firingpins,
@@ -29754,13 +29745,6 @@
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos)
-"hOh" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/engine/co2,
 /area/engine/atmos)
 "hOC" = (
 /obj/structure/cable/white{
@@ -32142,13 +32126,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical)
-"kit" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/engine/plasma,
-/area/engine/atmos)
 "kiv" = (
 /obj/structure/cable/white{
 	icon_state = "1-8"
@@ -35187,6 +35164,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"nIH" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/miner/carbon_dioxide,
+/turf/open/floor/engine/co2,
+/area/engine/atmos)
 "nIT" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -35564,6 +35549,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"nXN" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/miner/n2o,
+/turf/open/floor/engine/n2o,
+/area/engine/atmos)
 "nXQ" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Custodial Maintenance";
@@ -38215,6 +38208,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"qNT" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/miner/oxygen,
+/turf/open/floor/engine/o2,
+/area/engine/atmos)
 "qOO" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "ceblast";
@@ -43490,6 +43489,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"uyz" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/miner/nitrogen,
+/turf/open/floor/engine/n2,
+/area/engine/atmos)
 "uyI" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/engine,
@@ -74486,7 +74491,7 @@ aac
 aac
 aac
 pNE
-hOh
+nIH
 iqC
 aqA
 kHA
@@ -75514,7 +75519,7 @@ aad
 aad
 aad
 pNE
-kit
+ckx
 ddI
 aqA
 vmU
@@ -76042,7 +76047,7 @@ eaf
 agS
 aAi
 axi
-aCs
+qNT
 uok
 fTS
 mdy
@@ -76542,7 +76547,7 @@ aaW
 aad
 aad
 pNE
-gap
+nXN
 fnp
 aqA
 viy
@@ -77070,7 +77075,7 @@ eaf
 ahb
 aAi
 atx
-aCw
+uyz
 uok
 iNt
 aFu


### PR DESCRIPTION
### Intent of your Pull Request

Last station that doesnt have them i believe

Since im touching omega
also fixes an oversight in brig, and adds rpd's for engis to work on the sm


### Why is this change good for the game?
Makes omega not worse
# Wiki Documentation
does not apply

# Changelog

:cl:  
tweak: adds gas miners to omega, various other engi related fixes for omega
/:cl:
