### PR TITLE
Lets abductors buy more batons and pistols

### DIFF
--- a/code/modules/antagonists/abductor/equipment/orderable_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/orderable_gear.dm
@@ -30,13 +30,8 @@ GLOBAL_LIST_INIT(abductor_gear, subtypesof(/datum/abductor_gear))
 	name = "Advanced Baton"
 	description = "A advanced baton with four modes allowing it to stun, sleep, cuff, and probe victims."
 	id = "baton"
+	cost = 2
 	build_path = /obj/item/abductor/baton
-
-/datum/abductor_gear/alien_pistol
-	name = "Agent Pistol"
-	description = "A small self defence pistol for dealing with rowdy patients with blasts of high-intensity radiation."
-	id = "alien_pistol"
-	build_path = /obj/item/gun/energy/alien
 
 /datum/abductor_gear/radio_silencer
 	name = "Radio Silencer"

--- a/code/modules/antagonists/abductor/equipment/orderable_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/orderable_gear.dm
@@ -29,13 +29,13 @@ GLOBAL_LIST_INIT(abductor_gear, subtypesof(/datum/abductor_gear))
 /datum/abductor_gear/baton
 	name = "Advanced Baton"
 	description = "A advanced baton with four modes allowing it to stun, sleep, cuff, and probe victims."
-	id = "agent_vest"
+	id = "baton"
 	build_path = /obj/item/abductor/baton
 
 /datum/abductor_gear/alien_pistol
 	name = "Agent Pistol"
 	description = "A small self defence pistol for dealing with rowdy patients with blasts of high-intensity radiation."
-	id = "agent_vest"
+	id = "alien_pistol"
 	build_path = /obj/item/gun/energy/alien
 
 /datum/abductor_gear/radio_silencer

--- a/code/modules/antagonists/abductor/equipment/orderable_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/orderable_gear.dm
@@ -26,6 +26,18 @@ GLOBAL_LIST_INIT(abductor_gear, subtypesof(/datum/abductor_gear))
 	id = "agent_vest"
 	build_path = /obj/item/clothing/suit/armor/abductor/vest
 
+/datum/abductor_gear/baton
+	name = "Advanced Baton"
+	description = "A advanced baton with four modes allowing it to stun, sleep, cuff, and probe victims."
+	id = "agent_vest"
+	build_path = /obj/item/abductor/baton
+
+/datum/abductor_gear/alien_pistol
+	name = "Agent Pistol"
+	description = "A small self defence pistol for dealing with rowdy patients with blasts of high-intensity radiation."
+	id = "agent_vest"
+	build_path = /obj/item/gun/energy/alien
+
 /datum/abductor_gear/radio_silencer
 	name = "Radio Silencer"
 	description = "A compact device used to shut down communications equipment."


### PR DESCRIPTION
They can buy pretty much everything else they start with, so why not their baton and pistol? Allows abductors to continue to use only alien gear, and not have to make a stun prod if someone pushes them.

### Why is this change good for the game?
Lets abductors rebound from mistakes if they get enough patients.

### What should players be aware of when it comes to the changes your PR is implementing?
you can buy more batons and guns as abductor

### What general grouping does this PR fall under? 
For example, Engineering changes, Medical rebalancing, TEG tweaks, etc.?
antag changes

### Are there any aspects of the PR that you would like us not to mention on the Wiki?
no?

:cl:  
rscadd: Adds abductor batons and guns to their purchase menu
/:cl:
