### PR TITLE
Gives skeleton key a cargo value

### DIFF
--- a/code/modules/cargo/exports/lavaland.dm
+++ b/code/modules/cargo/exports/lavaland.dm
@@ -25,7 +25,8 @@
 						/obj/item/gun/magic/staff/honk,
 						/obj/item/kitchen/knife/envy,
 						/obj/item/gun/ballistic/revolver/russian/soul,
-						/obj/item/veilrender/vealrender)
+						/obj/item/veilrender/vealrender,
+						/obj/item/keycard/necropolis)
 
 /datum/export/lavaland/major //valuable chest/ruin loot and staff of storms
 	cost = 20000


### PR DESCRIPTION
# General Documentation
### Intent of your Pull Request
Skeleton key drops from Legion megafauna, opens the door to the ruin behind him. After using it on the locked door, it becomes useless, so it might as well be sold as a minor lavaland artifact.

### Why is this change good for the game?
Makes an "invaluable" item have a price.

# Wiki Documentation
### Briefly describe your PR and the impacts of it, in layman's terms. 
Adds the skeleton key to minor lavaland artifacts list.

### What should players be aware of when it comes to the changes your PR is implementing?

### What general grouping does this PR fall under? 
lil change to mining and cargo

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
Centcom will now pay 10k for the skeleton key.

# Changelog
:cl:  
tweak: gives skeleton key a cargo value
/:cl: