### PR TITLE
removes code for "practice" scarabs since it was never actually used and could be used to gain infinite power

### DIFF
--- a/code/modules/antagonists/clockcult/clock_items/construct_chassis.dm
+++ b/code/modules/antagonists/clockcult/clock_items/construct_chassis.dm
@@ -100,4 +100,4 @@
 /obj/item/clockwork/construct_chassis/cogscarab/post_spawn(mob/living/construct)
 	if(seasonal_hat && seasonal_hat != "none")
 		var/obj/item/hat = new seasonal_hat(construct)
-			onstruct.equip_to_slot_or_del(hat, SLOT_HEAD)
+		construct.equip_to_slot_or_del(hat, SLOT_HEAD)

--- a/code/modules/antagonists/clockcult/clock_items/construct_chassis.dm
+++ b/code/modules/antagonists/clockcult/clock_items/construct_chassis.dm
@@ -87,18 +87,9 @@
 	creation_message = "<span class='alloy bold'>The cogscarab clicks and whirrs as it hops up and springs to life!</span>"
 	construct_type = /mob/living/simple_animal/drone/cogscarab
 	w_class = WEIGHT_CLASS_SMALL
-	var/infinite_resources = TRUE
 	var/static/obj/item/seasonal_hat //Share it with all other scarabs, since we're from the same cult!
 
-/obj/item/clockwork/construct_chassis/cogscarab/Initialize()
-	. = ..()
-	if(GLOB.servants_active)
-		infinite_resources = FALSE //For any that are somehow spawned in late
-
 /obj/item/clockwork/construct_chassis/cogscarab/pre_spawn()
-	if(infinite_resources)
-		//During rounds where they can't interact with the station, let them experiment with builds
-		construct_type = /mob/living/simple_animal/drone/cogscarab/ratvar
 	if(!seasonal_hat)
 		var/obj/item/drone_shell/D = locate() in GLOB.poi_list
 		if(D && D.possible_seasonal_hats.len)
@@ -107,12 +98,6 @@
 			seasonal_hat = "none"
 
 /obj/item/clockwork/construct_chassis/cogscarab/post_spawn(mob/living/construct)
-	if(infinite_resources) //Allow them to build stuff and recite scripture
-		var/list/cached_stuff = construct.GetAllContents()
-		for(var/obj/item/clockwork/replica_fabricator/F in cached_stuff)
-			F.uses_power = FALSE
-		for(var/obj/item/clockwork/slab/S in cached_stuff)
-			S.no_cost = TRUE
-		if(seasonal_hat && seasonal_hat != "none")
-			var/obj/item/hat = new seasonal_hat(construct)
-			construct.equip_to_slot_or_del(hat, SLOT_HEAD)
+	if(seasonal_hat && seasonal_hat != "none")
+		var/obj/item/hat = new seasonal_hat(construct)
+			onstruct.equip_to_slot_or_del(hat, SLOT_HEAD)

--- a/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -74,8 +74,6 @@
 		ark_time = 30 //minutes
 	initial_activation_delay = ark_time * 60
 	seconds_until_activation = ark_time * 60 //60 seconds in a minute * number of minutes
-	for(var/obj/item/clockwork/construct_chassis/cogscarab/C in GLOB.all_clockwork_objects)
-		C.infinite_resources = FALSE
 	GLOB.servants_active = TRUE
 	SSshuttle.registerHostileEnvironment(src)
 


### PR DESCRIPTION
not like it matters since they shouldn't be spawning before the gamemode starts any more but
:cl:  
bugfix: old cogscarab code that at some point was used to gain infinite power has been removed
/:cl:
