### PR TITLE
I can't believe it's not magic!

### DIFF
--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -32,6 +32,7 @@
 	desc = "Get a scent off of the item you're currently holding to track it. With an empty hand, you'll track the scent you've remembered."
 	charge_max = 100
 	clothes_req = FALSE
+	antimagic_allowed = TRUE
 	range = -1
 	include_user = TRUE
 	action_icon_state = "nose"
@@ -118,6 +119,7 @@
 	school = "evocation"
 	charge_max = 600
 	clothes_req = FALSE
+	antimagic_allowed = TRUE
 	range = 20
 	projectile_type = /obj/item/projectile/magic/aoe/fireball/firebreath
 	base_icon_state = "fireball"
@@ -177,6 +179,7 @@ obj/effect/proc_holder/spell/aimed/firebreath/fire_projectile(mob/user)
 	desc = "A rare genome that attracts odd forces not usually observed. May sometimes pull you in randomly."
 	school = "evocation"
 	clothes_req = FALSE
+	antimagic_allowed = TRUE
 	charge_max = 600
 	invocation = "DOOOOOOOOOOOOOOOOOOOOM!!!"
 	invocation_type = "shout"

--- a/code/datums/mutations/antenna.dm
+++ b/code/datums/mutations/antenna.dm
@@ -45,6 +45,7 @@
 	charge_max = 50
 	range = 7
 	clothes_req = FALSE
+	antimagic_allowed = TRUE
 	action_icon_state = "mindread"
 
 /obj/effect/proc_holder/spell/targeted/mindread/cast(list/targets, mob/living/carbon/human/user = usr)

--- a/code/datums/mutations/cold.dm
+++ b/code/datums/mutations/cold.dm
@@ -14,6 +14,7 @@
 	item_type = /obj/item/stack/sheet/mineral/snow
 	charge_max = 50
 	delete_old = FALSE
+	antimagic_allowed = TRUE
 	action_icon_state = "snow"
 
 
@@ -33,6 +34,7 @@
 	charge_max = 150
 	cooldown_min = 150
 	clothes_req = FALSE
+	antimagic_allowed = TRUE
 	range = 3
 	projectile_type = /obj/item/projectile/temp/cryo
 	base_icon_state = "icebeam"

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -18,6 +18,7 @@
 	hand_path = /obj/item/melee/touch_attack/shock
 	charge_max = 100
 	clothes_req = FALSE
+	antimagic_allowed = TRUE
 	icon = 'icons/mob/actions/humble/actions_humble.dmi'
 	action_icon_state = "zap"
 


### PR DESCRIPTION
# General Documentation
### Intent of your Pull Request
Adds proper antimagic checks for all mutation based actions, meaning you can now use them when being magic immune, like holding a nullrod, or wearing an antimagic suit.

### Why is this change good for the game?
Fixes a long time bug, mutations are not magic, dummy!

# Wiki Documentation
### Briefly describe your PR and the impacts of it, in layman's terms. 
Makes it able to use mutations when under effect of magic immunity.

### What general grouping does this PR fall under? 
genetics fix

# Changelog
:cl:   
bugfix: mutation based abilities can now be cast when magic immune 
/:cl: