### PR TITLE
Nerfs Lavaland Wall Ruin Loot and Fixes the Ruin

### DIFF
--- a/_maps/map_files/mining/Lavaland.dmm
+++ b/_maps/map_files/mining/Lavaland.dmm
@@ -215,18 +215,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/mine/laborcamp)
-"cr" = (
-/obj/structure/mineral_door/iron,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile,
-/obj/structure/stone_tile/block{
-	dir = 1
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "cu" = (
 /obj/item/pickaxe,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -241,21 +229,6 @@
 /obj/item/bedsheet/prisoner,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"cV" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
-/obj/item/coin/gold,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "cZ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -272,6 +245,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/laborcamp)
+"dd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile/block/cracked,
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/skeleton{
+	mob_biotypes = list("mining","undead","humanoid")
+	},
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "du" = (
 /obj/machinery/conveyor{
 	id = "gulag"
@@ -315,6 +302,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"dK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile/block/cracked,
+/obj/structure/stone_tile/cracked{
+	dir = 4
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
+/obj/item/coin/gold,
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "ef" = (
 /obj/item/shovel,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -438,18 +437,6 @@
 /obj/structure/stone_tile/center,
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
-"gn" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile/block/cracked,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/skeleton,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "go" = (
 /obj/structure/stone_tile/block,
 /turf/open/lava/smooth/lava_land_surface,
@@ -682,18 +669,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"ia" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile,
-/obj/structure/stone_tile/block/cracked{
-	dir = 1
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/skeleton,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "id" = (
 /obj/structure/stone_tile{
 	dir = 4
@@ -758,6 +733,22 @@
 /obj/structure/stone_tile/block/cracked,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"iH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile{
+	dir = 8
+	},
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/obj/structure/stone_tile,
+/obj/structure/mineral_door/iron,
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "iK" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile/cracked{
@@ -1011,21 +1002,6 @@
 /obj/structure/stone_tile,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"kq" = (
-/obj/structure/mineral_door/iron,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile/block,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "kx" = (
 /obj/structure/chair/stool,
 /obj/structure/sign/poster/official/work_for_a_future{
@@ -1820,18 +1796,6 @@
 /obj/structure/stone_tile/cracked,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/dragonslair)
-"oW" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/block/cracked{
-	dir = 1
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/obj/item/coin/gold,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "pb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -1897,21 +1861,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"pK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile,
-/obj/structure/mineral_door/iron,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "qd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/stone_tile/block/cracked,
@@ -2168,6 +2117,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"tP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile,
+/obj/structure/stone_tile/block/cracked{
+	dir = 1
+	},
+/obj/structure/stone_tile{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/skeleton{
+	mob_biotypes = list("mining","undead","humanoid")
+	},
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "uu" = (
 /obj/machinery/door/airlock{
 	name = "Labor Camp Library"
@@ -2530,6 +2493,18 @@
 /mob/living/simple_animal/hostile/megafauna/dragon,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/dragonslair)
+"Ck" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile/block/cracked{
+	dir = 1
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/cracked,
+/obj/item/coin/gold,
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "Cl" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/stone_tile{
@@ -2787,18 +2762,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"Gu" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/block/cracked,
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
-/obj/item/coin/gold,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "GK" = (
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
@@ -2849,22 +2812,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"Iw" = (
+"In" = (
+/obj/structure/mineral_door/iron,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/block/cracked{
+/obj/structure/stone_tile{
 	dir = 1
 	},
-/obj/structure/stone_tile/cracked{
+/obj/structure/stone_tile{
 	dir = 4
 	},
-/obj/structure/stone_tile/cracked{
-	dir = 8
+/obj/structure/stone_tile{
+	dir = 4
 	},
-/obj/structure/stone_tile/cracked,
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
-/obj/item/coin/gold,
+/obj/structure/stone_tile/block,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/dragonslair)
 "IC" = (
@@ -2880,6 +2842,21 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/mine/laborcamp)
+"Jm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile/cracked{
+	dir = 4
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/cracked,
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
+/obj/item/coin/gold,
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "Js" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/stone_tile{
@@ -2890,21 +2867,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
-"Jw" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/skeleton,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/dragonslair)
 "Kg" = (
@@ -2974,12 +2936,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/stone_tile/block/burnt,
 /turf/open/lava/smooth/lava_land_surface,
-/area/ruin/unpowered/dragonslair)
-"Lp" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/slab/cracked,
-/obj/item/coin/gold,
-/turf/open/indestructible/boss,
 /area/ruin/unpowered/dragonslair)
 "Lq" = (
 /obj/machinery/airalarm{
@@ -3179,6 +3135,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"PJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile/block/cracked{
+	dir = 1
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 4
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/cracked,
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
+/obj/item/coin/gold,
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "PW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/holopad,
@@ -3419,6 +3393,19 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/plasteel/dark,
 /area/mine/laborcamp)
+"Tr" = (
+/obj/structure/mineral_door/iron,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile{
+	dir = 8
+	},
+/obj/structure/stone_tile,
+/obj/structure/stone_tile/block{
+	dir = 1
+	},
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "Ts" = (
 /obj/machinery/vending/sustenance,
 /obj/effect/decal/cleanable/dirt,
@@ -3438,6 +3425,23 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/mine/laborcamp)
+"TK" = (
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/obj/structure/stone_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile{
+	dir = 8
+	},
+/obj/structure/stone_tile,
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/skeleton{
+	mob_biotypes = list("mining","undead","humanoid")
+	},
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "Ub" = (
 /turf/closed/wall/r_wall,
 /area/lavaland/surface/outdoors/explored)
@@ -3571,6 +3575,12 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/mine/laborcamp)
+"WH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile/slab/cracked,
+/obj/item/coin/gold,
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "WJ" = (
 /obj/structure/stone_tile/surrounding/cracked,
 /turf/open/lava/smooth/lava_land_surface,
@@ -3584,6 +3594,23 @@
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"Xd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile,
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/obj/structure/stone_tile{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/skeleton{
+	mob_biotypes = list("mining","undead","humanoid")
+	},
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "Xg" = (
 /obj/structure/stone_tile{
 	dir = 4
@@ -38440,7 +38467,7 @@ aj
 aa
 aa
 Xg
-Gh
+TK
 Xg
 Xg
 Gh
@@ -39216,7 +39243,7 @@ aa
 gS
 aa
 Cl
-Jw
+Xd
 aa
 aa
 ab
@@ -39468,7 +39495,7 @@ aj
 aa
 aa
 Kg
-Jw
+Xd
 gS
 mg
 gS
@@ -40241,7 +40268,7 @@ aa
 QI
 gS
 gS
-Jw
+Xd
 gS
 gS
 LV
@@ -40495,13 +40522,13 @@ aj
 (144,1,1) = {"
 aa
 aa
-Jw
+gS
 gS
 aa
 aa
 aa
 gS
-Jw
+Xd
 aa
 aa
 ad
@@ -41012,7 +41039,7 @@ aa
 aa
 gS
 gS
-Jw
+Xd
 XI
 mg
 aa
@@ -41528,7 +41555,7 @@ rt
 gS
 gS
 gS
-ia
+tP
 aa
 aa
 aa
@@ -42040,7 +42067,7 @@ aa
 aa
 Js
 gS
-Jw
+Xd
 gS
 GZ
 aa
@@ -42552,7 +42579,7 @@ aj
 aa
 aa
 aa
-gn
+dd
 gS
 gS
 qO
@@ -43325,7 +43352,7 @@ aa
 aa
 aa
 qO
-Jw
+Xd
 Qp
 aa
 aa
@@ -44096,7 +44123,7 @@ aa
 aa
 RY
 CJ
-Jw
+Xd
 wl
 GZ
 aa
@@ -44352,9 +44379,9 @@ aa
 aa
 aa
 aa
-kq
-pK
-cr
+In
+iH
+Tr
 aa
 aa
 aa
@@ -47435,11 +47462,11 @@ aj
 aa
 aa
 qd
-cV
+Jm
 Ya
 Ya
 Ya
-cV
+Jm
 ow
 aa
 aa
@@ -47691,13 +47718,13 @@ aj
 (172,1,1) = {"
 aa
 aa
-Gu
-cV
+dK
+Jm
 Ya
 Cb
-cV
-cV
-oW
+Jm
+Jm
+Ck
 aa
 aa
 ab
@@ -47948,13 +47975,13 @@ aj
 (173,1,1) = {"
 aa
 aa
-Gu
-cV
-cV
-cV
-cV
-cV
-oW
+dK
+Jm
+Jm
+Jm
+Jm
+Jm
+Ck
 aa
 aa
 it
@@ -48206,11 +48233,11 @@ aj
 aa
 aa
 aa
-Gu
-cV
-cV
-cV
-Iw
+dK
+Jm
+Jm
+Jm
+PJ
 aa
 aa
 aa
@@ -48464,7 +48491,7 @@ aa
 aa
 aa
 aa
-Lp
+WH
 Ep
 ce
 aa

--- a/_maps/map_files/mining/Lavaland.dmm
+++ b/_maps/map_files/mining/Lavaland.dmm
@@ -124,10 +124,30 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plating,
 /area/mine/laborcamp)
+"bf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile/slab/cracked,
+/obj/item/coin/gold,
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "bi" = (
 /obj/structure/gulag_beacon,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"bj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile/block/cracked,
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/skeleton{
+	mob_biotypes = list("mining","undead","humanoid")
+	},
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "bl" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -223,6 +243,23 @@
 /obj/structure/ore_box,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"cL" = (
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/obj/structure/stone_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile{
+	dir = 8
+	},
+/obj/structure/stone_tile,
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/skeleton{
+	mob_biotypes = list("mining","undead","humanoid")
+	},
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "cU" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/dirt,
@@ -245,20 +282,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/laborcamp)
-"dd" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile/block/cracked,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/skeleton{
-	mob_biotypes = list("mining","undead","humanoid")
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "du" = (
 /obj/machinery/conveyor{
 	id = "gulag"
@@ -302,18 +325,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"dK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/block/cracked,
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
-/obj/item/coin/gold,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "ef" = (
 /obj/item/shovel,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -388,6 +399,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/mine/laborcamp)
+"ga" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile/cracked{
+	dir = 4
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/cracked,
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
+/obj/item/coin/gold,
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "gb" = (
 /obj/machinery/conveyor{
 	id = "gulag"
@@ -574,6 +600,20 @@
 	},
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/dragonslair)
+"gV" = (
+/obj/structure/stone_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile,
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/obj/structure/stone_tile{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "gY" = (
 /obj/docking_port/stationary{
 	area_type = /area/lavaland/surface/outdoors;
@@ -733,22 +773,6 @@
 /obj/structure/stone_tile/block/cracked,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"iH" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile,
-/obj/structure/mineral_door/iron,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "iK" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile/cracked{
@@ -768,6 +792,22 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/mine/laborcamp)
+"iV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile{
+	dir = 8
+	},
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/obj/structure/stone_tile,
+/obj/structure/mineral_door/iron,
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "iX" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -883,11 +923,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"jC" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/slab/cracked,
-/turf/open/lava/smooth/lava_land_surface,
-/area/ruin/unpowered/dragonslair)
 "jF" = (
 /obj/structure/stone_tile/surrounding_tile,
 /obj/structure/stone_tile/surrounding_tile{
@@ -977,21 +1012,6 @@
 /obj/structure/fluff/drake_statue/falling,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"kn" = (
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/ash,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "ko" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -1845,6 +1865,18 @@
 	},
 /turf/open/floor/plating,
 /area/mine/laborcamp)
+"pB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile/block/cracked,
+/obj/structure/stone_tile/cracked{
+	dir = 4
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
+/obj/item/coin/gold,
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "pC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -1915,36 +1947,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"qO" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
-"qY" = (
-/obj/effect/decal/remains/human,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "ro" = (
 /obj/machinery/computer/prisoner{
 	dir = 4;
@@ -1955,18 +1957,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
-"rt" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/ash,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile/block/cracked,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "rX" = (
 /obj/item/pickaxe,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -2117,11 +2107,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"tP" = (
+"um" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile,
-/obj/structure/stone_tile/block/cracked{
+/obj/structure/stone_tile{
 	dir = 1
+	},
+/obj/structure/stone_tile,
+/obj/structure/stone_tile{
+	dir = 4
 	},
 /obj/structure/stone_tile{
 	dir = 8
@@ -2223,21 +2216,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"wl" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/ash,
-/obj/structure/stone_tile,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "wI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -2280,6 +2258,20 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/mine/laborcamp)
+"xl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/obj/structure/stone_tile{
+	dir = 8
+	},
+/obj/structure/stone_tile/cracked,
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "xO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/seeds/redbeet,
@@ -2292,6 +2284,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/mine/laborcamp)
+"xX" = (
+/obj/structure/mineral_door/iron,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile{
+	dir = 8
+	},
+/obj/structure/stone_tile,
+/obj/structure/stone_tile/block{
+	dir = 1
+	},
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "yx" = (
 /obj/structure/chair/stool,
 /obj/structure/sign/poster/official/obey{
@@ -2493,33 +2498,6 @@
 /mob/living/simple_animal/hostile/megafauna/dragon,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/dragonslair)
-"Ck" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/block/cracked{
-	dir = 1
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/obj/item/coin/gold,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
-"Cl" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "Cu" = (
 /obj/machinery/door/airlock/external{
 	glass = 1;
@@ -2614,19 +2592,9 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/freezer,
 /area/mine/laborcamp)
-"DY" = (
+"DV" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/obj/effect/decal/remains/human,
+/obj/structure/stone_tile/slab/burnt,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/dragonslair)
 "DZ" = (
@@ -2812,23 +2780,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"In" = (
-/obj/structure/mineral_door/iron,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile/block,
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "IC" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -2842,8 +2793,11 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/mine/laborcamp)
-"Jm" = (
+"IW" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile/block/cracked{
+	dir = 1
+	},
 /obj/structure/stone_tile/cracked{
 	dir = 4
 	},
@@ -2857,31 +2811,18 @@
 /obj/item/coin/gold,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/dragonslair)
-"Js" = (
+"Kk" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile/block/cracked,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
-"Kg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
 /obj/structure/stone_tile,
-/obj/structure/stone_tile{
-	dir = 4
+/obj/structure/stone_tile/block/cracked{
+	dir = 1
 	},
 /obj/structure/stone_tile{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
+/mob/living/simple_animal/hostile/skeleton{
+	mob_biotypes = list("mining","undead","humanoid")
+	},
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/dragonslair)
 "Km" = (
@@ -3058,15 +2999,6 @@
 	},
 /turf/open/floor/plating,
 /area/mine/laborcamp)
-"Nh" = (
-/obj/effect/decal/remains/human{
-	desc = "They look like human remains. They appear to have short pants on them.";
-	name = "Rather Dashing"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/slab/burnt,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "NJ" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
@@ -3135,21 +3067,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"PJ" = (
+"PI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/stone_tile/block/cracked{
 	dir = 1
 	},
 /obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
 	dir = 8
 	},
 /obj/structure/stone_tile/cracked,
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
 /obj/item/coin/gold,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/dragonslair)
@@ -3181,21 +3107,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"Qp" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "Qw" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -3241,21 +3152,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"QI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "QU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/closed/wall/r_wall,
@@ -3305,21 +3201,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"RW" = (
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "RY" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/stone_tile{
@@ -3393,19 +3274,6 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/plasteel/dark,
 /area/mine/laborcamp)
-"Tr" = (
-/obj/structure/mineral_door/iron,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile,
-/obj/structure/stone_tile/block{
-	dir = 1
-	},
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "Ts" = (
 /obj/machinery/vending/sustenance,
 /obj/effect/decal/cleanable/dirt,
@@ -3425,23 +3293,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/mine/laborcamp)
-"TK" = (
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile,
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/skeleton{
-	mob_biotypes = list("mining","undead","humanoid")
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "Ub" = (
 /turf/closed/wall/r_wall,
 /area/lavaland/surface/outdoors/explored)
@@ -3521,6 +3372,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
+"Vm" = (
+/obj/structure/mineral_door/iron,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/obj/structure/stone_tile/block,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "Vn" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -3575,12 +3443,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/mine/laborcamp)
-"WH" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/slab/cracked,
-/obj/item/coin/gold,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "WJ" = (
 /obj/structure/stone_tile/surrounding/cracked,
 /turf/open/lava/smooth/lava_land_surface,
@@ -3594,23 +3456,6 @@
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"Xd" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/skeleton{
-	mob_biotypes = list("mining","undead","humanoid")
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "Xg" = (
 /obj/structure/stone_tile{
 	dir = 4
@@ -3652,21 +3497,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"XI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/ash,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "Ya" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/stone_tile/cracked{
@@ -37439,7 +37269,7 @@ aj
 aa
 aa
 Xg
-qY
+Xg
 Bs
 Bs
 Bs
@@ -37697,7 +37527,7 @@ aa
 aa
 Xg
 Xg
-kn
+Xg
 Xg
 Xg
 qn
@@ -37958,7 +37788,7 @@ qn
 Gh
 zm
 Xg
-RW
+Xg
 aa
 aa
 aa
@@ -38209,7 +38039,7 @@ aj
 (135,1,1) = {"
 aa
 aa
-RW
+Xg
 Xg
 Xg
 Xg
@@ -38467,11 +38297,11 @@ aj
 aa
 aa
 Xg
-TK
+cL
 Xg
 Xg
 Gh
-qY
+Xg
 Xg
 aa
 aa
@@ -38723,7 +38553,7 @@ aj
 (137,1,1) = {"
 aa
 aa
-jC
+LI
 gg
 gg
 gu
@@ -39242,8 +39072,8 @@ gS
 aa
 gS
 aa
-Cl
-Xd
+gS
+um
 aa
 aa
 ab
@@ -39494,8 +39324,8 @@ aj
 (140,1,1) = {"
 aa
 aa
-Kg
-Xd
+gS
+um
 gS
 mg
 gS
@@ -40014,7 +39844,7 @@ aa
 aa
 aa
 aa
-qO
+gS
 aa
 aa
 aa
@@ -40265,10 +40095,10 @@ aj
 (143,1,1) = {"
 aa
 aa
-QI
 gS
 gS
-Xd
+gS
+um
 gS
 gS
 LV
@@ -40528,7 +40358,7 @@ aa
 aa
 aa
 gS
-Xd
+um
 aa
 aa
 ad
@@ -41039,8 +40869,8 @@ aa
 aa
 gS
 gS
-Xd
-XI
+um
+gS
 mg
 aa
 aa
@@ -41296,7 +41126,7 @@ aa
 aa
 aa
 gS
-DY
+xl
 gS
 aa
 aa
@@ -41551,11 +41381,11 @@ aj
 aa
 aa
 aa
-rt
+RY
 gS
 gS
 gS
-tP
+Kk
 aa
 aa
 aa
@@ -42065,9 +41895,9 @@ aj
 aa
 aa
 aa
-Js
+RY
 gS
-Xd
+um
 gS
 GZ
 aa
@@ -42579,10 +42409,10 @@ aj
 aa
 aa
 aa
-dd
+bj
 gS
 gS
-qO
+gS
 GZ
 aa
 aa
@@ -42838,7 +42668,7 @@ aa
 aa
 lY
 gS
-qO
+gS
 gS
 WJ
 aa
@@ -43351,9 +43181,9 @@ aa
 aa
 aa
 aa
-qO
-Xd
-Qp
+gV
+um
+xl
 aa
 aa
 aa
@@ -44123,8 +43953,8 @@ aa
 aa
 RY
 CJ
-Xd
-wl
+um
+gS
 GZ
 aa
 aa
@@ -44379,9 +44209,9 @@ aa
 aa
 aa
 aa
-In
-iH
-Tr
+Vm
+iV
+xX
 aa
 aa
 aa
@@ -45922,7 +45752,7 @@ aa
 qd
 LI
 Cx
-Nh
+DV
 Cx
 Zg
 ow
@@ -47462,11 +47292,11 @@ aj
 aa
 aa
 qd
-Jm
+ga
 Ya
 Ya
 Ya
-Jm
+ga
 ow
 aa
 aa
@@ -47718,13 +47548,13 @@ aj
 (172,1,1) = {"
 aa
 aa
-dK
-Jm
+pB
+ga
 Ya
 Cb
-Jm
-Jm
-Ck
+ga
+ga
+PI
 aa
 aa
 ab
@@ -47975,13 +47805,13 @@ aj
 (173,1,1) = {"
 aa
 aa
-dK
-Jm
-Jm
-Jm
-Jm
-Jm
-Ck
+pB
+ga
+ga
+ga
+ga
+ga
+PI
 aa
 aa
 it
@@ -48233,11 +48063,11 @@ aj
 aa
 aa
 aa
-dK
-Jm
-Jm
-Jm
-PJ
+pB
+ga
+ga
+ga
+IW
 aa
 aa
 aa
@@ -48491,7 +48321,7 @@ aa
 aa
 aa
 aa
-WH
+bf
 Ep
 ce
 aa

--- a/_maps/map_files/mining/Lavaland.dmm
+++ b/_maps/map_files/mining/Lavaland.dmm
@@ -128,6 +128,21 @@
 /obj/structure/gulag_beacon,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"bk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile/cracked{
+	dir = 4
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/cracked,
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
+/obj/item/coin/gold,
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "bl" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -337,6 +352,24 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"eS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile/block/cracked{
+	dir = 1
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 4
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/cracked,
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
+/obj/item/coin/gold,
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "fs" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/plasteel,
@@ -1728,39 +1761,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"nn" = (
-/obj/item/stack/sheet/mineral/gold,
+"nj" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/block/cracked,
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
+/obj/structure/stone_tile/slab/cracked,
+/obj/item/coin/gold,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/dragonslair)
 "nC" = (
 /obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/plating,
 /area/mine/laborcamp)
-"nM" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
-/obj/item/stack/sheet/mineral/gold{
-	amount = 25
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "nT" = (
 /obj/structure/stone_tile/surrounding/burnt,
 /turf/open/lava/smooth/lava_land_surface,
@@ -1808,6 +1818,18 @@
 	dir = 8
 	},
 /obj/structure/stone_tile/cracked,
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
+"oS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile/block/cracked,
+/obj/structure/stone_tile/cracked{
+	dir = 4
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
+/obj/item/coin/gold,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/dragonslair)
 "pb" = (
@@ -1920,6 +1942,18 @@
 /obj/structure/stone_tile/cracked{
 	dir = 4
 	},
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
+"qy" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile/block/cracked{
+	dir = 1
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/cracked,
+/obj/item/coin/gold,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/dragonslair)
 "qE" = (
@@ -2157,13 +2191,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"uw" = (
-/obj/item/immortality_talisman,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/crate/coffin,
-/obj/structure/stone_tile/slab/cracked,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "uD" = (
 /obj/machinery/computer/security/labor{
 	dir = 4;
@@ -2294,21 +2321,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
-"wT" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile/block/cracked,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/skeleton/templar{
-	speak = list("THE NECROPOLIS WILLS IT!","DEUS VULT!","REMOVE KABAB!");
-	speak_chance = 0
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "wZ" = (
 /obj/machinery/camera{
 	c_tag = "Labor Camp External West";
@@ -2426,6 +2438,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"zO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile/block/cracked,
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/skeleton,
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "zX" = (
 /obj/structure/ore_box,
 /obj/effect/decal/cleanable/dirt,
@@ -2461,21 +2485,6 @@
 	},
 /turf/open/floor/plating,
 /area/mine/laborcamp)
-"Aw" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/stack/sheet/mineral/diamond/fifty,
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "AO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -2619,21 +2628,6 @@
 /obj/structure/stone_tile/cracked,
 /obj/structure/stone_tile/burnt{
 	dir = 4
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
-"Da" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile,
-/obj/structure/stone_tile/block/cracked{
-	dir = 1
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/skeleton/templar{
-	speak = list("THE NECROPOLIS WILLS IT!","DEUS VULT!","REMOVE KABAB!");
-	speak_chance = 0
 	},
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/dragonslair)
@@ -2827,18 +2821,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"GX" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/block/cracked,
-/obj/item/stack/sheet/mineral/gold,
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "GZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/stone_tile,
@@ -2879,18 +2861,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"Ih" = (
-/obj/item/stack/sheet/mineral/gold,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/block/cracked{
-	dir = 1
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "IC" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -2904,24 +2874,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/mine/laborcamp)
-"Jh" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/skeleton/templar{
-	speak = list("THE NECROPOLIS WILLS IT!","DEUS VULT!","REMOVE KABAB!");
-	speak_chance = 0
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "Js" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/stone_tile{
@@ -2971,21 +2923,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"Kn" = (
-/obj/item/stack/sheet/mineral/gold,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "Kr" = (
 /obj/machinery/light/small,
 /obj/machinery/camera{
@@ -3207,6 +3144,18 @@
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/mine/laborcamp)
+"OT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile,
+/obj/structure/stone_tile/block/cracked{
+	dir = 1
+	},
+/obj/structure/stone_tile{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/skeleton,
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "Pg" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -3542,35 +3491,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"UK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/block/cracked,
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
-/obj/item/stack/sheet/mineral/gold{
-	amount = 25
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
-"UL" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/stack/sheet/mineral/gold/fifty,
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "UM" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -3610,26 +3530,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"VF" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/block/cracked{
-	dir = 1
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
-/obj/item/stack/sheet/mineral/gold{
-	amount = 25
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "VP" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
@@ -41112,7 +41012,7 @@ aa
 aa
 gS
 gS
-gS
+Jw
 XI
 mg
 aa
@@ -41628,7 +41528,7 @@ rt
 gS
 gS
 gS
-Da
+OT
 aa
 aa
 aa
@@ -41883,7 +41783,7 @@ aa
 aa
 nT
 gS
-Jh
+gS
 gS
 lY
 aa
@@ -42140,7 +42040,7 @@ aa
 aa
 Js
 gS
-gS
+Jw
 gS
 GZ
 aa
@@ -42396,7 +42296,7 @@ aa
 aa
 aa
 aa
-Jh
+gS
 oQ
 gS
 aa
@@ -42652,7 +42552,7 @@ aj
 aa
 aa
 aa
-RY
+zO
 gS
 gS
 qO
@@ -43425,7 +43325,7 @@ aa
 aa
 aa
 qO
-gS
+Jw
 Qp
 aa
 aa
@@ -43680,11 +43580,11 @@ aj
 aa
 aa
 aa
-wT
+RY
 gS
 Ml
 gS
-Da
+GZ
 aa
 aa
 aa
@@ -44196,7 +44096,7 @@ aa
 aa
 RY
 CJ
-Jh
+Jw
 wl
 GZ
 aa
@@ -47535,11 +47435,11 @@ aj
 aa
 aa
 qd
+bk
 Ya
-Kn
 Ya
 Ya
-Kn
+bk
 ow
 aa
 aa
@@ -47791,11 +47691,11 @@ aj
 (172,1,1) = {"
 aa
 aa
-nn
-Kn
+oS
+bk
 Ya
 Cb
-Kn
+bk
 Ya
 ow
 aa
@@ -48048,13 +47948,13 @@ aj
 (173,1,1) = {"
 aa
 aa
-GX
-nM
-nM
-nM
-nM
-nM
-Ih
+oS
+bk
+bk
+bk
+bk
+bk
+qy
 aa
 aa
 it
@@ -48306,11 +48206,11 @@ aj
 aa
 aa
 aa
-UK
-Aw
-UL
-UL
-VF
+oS
+bk
+bk
+bk
+eS
 aa
 aa
 aa
@@ -48564,7 +48464,7 @@ aa
 aa
 aa
 aa
-uw
+nj
 Ep
 ce
 aa

--- a/_maps/map_files/mining/Lavaland.dmm
+++ b/_maps/map_files/mining/Lavaland.dmm
@@ -128,21 +128,6 @@
 /obj/structure/gulag_beacon,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"bk" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
-/obj/item/coin/gold,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "bl" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -256,6 +241,21 @@
 /obj/item/bedsheet/prisoner,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"cV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile/cracked{
+	dir = 4
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/cracked,
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
+/obj/item/coin/gold,
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "cZ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -352,24 +352,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"eS" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/block/cracked{
-	dir = 1
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
-/obj/item/coin/gold,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "fs" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/plasteel,
@@ -456,6 +438,18 @@
 /obj/structure/stone_tile/center,
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
+"gn" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile/block/cracked,
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/skeleton,
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "go" = (
 /obj/structure/stone_tile/block,
 /turf/open/lava/smooth/lava_land_surface,
@@ -688,6 +682,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"ia" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile,
+/obj/structure/stone_tile/block/cracked{
+	dir = 1
+	},
+/obj/structure/stone_tile{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/skeleton,
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "id" = (
 /obj/structure/stone_tile{
 	dir = 4
@@ -1761,12 +1767,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"nj" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/slab/cracked,
-/obj/item/coin/gold,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "nC" = (
 /obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/plating,
@@ -1820,15 +1820,15 @@
 /obj/structure/stone_tile/cracked,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/dragonslair)
-"oS" = (
+"oW" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/block/cracked,
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
+/obj/structure/stone_tile/block/cracked{
 	dir = 1
 	},
+/obj/structure/stone_tile/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/cracked,
 /obj/item/coin/gold,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/dragonslair)
@@ -1942,18 +1942,6 @@
 /obj/structure/stone_tile/cracked{
 	dir = 4
 	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
-"qy" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/block/cracked{
-	dir = 1
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/obj/item/coin/gold,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/dragonslair)
 "qE" = (
@@ -2438,18 +2426,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"zO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile/block/cracked,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/skeleton,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "zX" = (
 /obj/structure/ore_box,
 /obj/effect/decal/cleanable/dirt,
@@ -2811,6 +2787,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"Gu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile/block/cracked,
+/obj/structure/stone_tile/cracked{
+	dir = 4
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
+/obj/item/coin/gold,
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "GK" = (
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
@@ -2861,6 +2849,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"Iw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile/block/cracked{
+	dir = 1
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 4
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/cracked,
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
+/obj/item/coin/gold,
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "IC" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -2968,6 +2974,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/stone_tile/block/burnt,
 /turf/open/lava/smooth/lava_land_surface,
+/area/ruin/unpowered/dragonslair)
+"Lp" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/stone_tile/slab/cracked,
+/obj/item/coin/gold,
+/turf/open/indestructible/boss,
 /area/ruin/unpowered/dragonslair)
 "Lq" = (
 /obj/machinery/airalarm{
@@ -3144,18 +3156,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/mine/laborcamp)
-"OT" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile,
-/obj/structure/stone_tile/block/cracked{
-	dir = 1
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/skeleton,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "Pg" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -41528,7 +41528,7 @@ rt
 gS
 gS
 gS
-OT
+ia
 aa
 aa
 aa
@@ -42552,7 +42552,7 @@ aj
 aa
 aa
 aa
-zO
+gn
 gS
 gS
 qO
@@ -47435,11 +47435,11 @@ aj
 aa
 aa
 qd
-bk
+cV
 Ya
 Ya
 Ya
-bk
+cV
 ow
 aa
 aa
@@ -47691,13 +47691,13 @@ aj
 (172,1,1) = {"
 aa
 aa
-oS
-bk
+Gu
+cV
 Ya
 Cb
-bk
-Ya
-ow
+cV
+cV
+oW
 aa
 aa
 ab
@@ -47948,13 +47948,13 @@ aj
 (173,1,1) = {"
 aa
 aa
-oS
-bk
-bk
-bk
-bk
-bk
-qy
+Gu
+cV
+cV
+cV
+cV
+cV
+oW
 aa
 aa
 it
@@ -48206,11 +48206,11 @@ aj
 aa
 aa
 aa
-oS
-bk
-bk
-bk
-eS
+Gu
+cV
+cV
+cV
+Iw
 aa
 aa
 aa
@@ -48464,7 +48464,7 @@ aa
 aa
 aa
 aa
-nj
+Lp
 Ep
 ce
 aa


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Nerfs lavaland loot following balance concerns on the mbrain. Adds barricade to the door before the ash drake and sets all the mobs to the same faction. All fluff decals have also been removed from the ruin. Goodbye, Rather Dashing.
![cpng](https://user-images.githubusercontent.com/62276730/113061732-8483be80-9180-11eb-9422-1b1ffd49a286.png)
![bpng](https://user-images.githubusercontent.com/62276730/113061738-864d8200-9180-11eb-8084-18635396c881.png)
A gold coin is 25 each, so thats 500 credits in total of value. The 50 mithrill and 50 diamond mats are still there though.

### Why is this change good for the game?

Ping rdrazga#4186, Marmio64#9527, and Dick Steele#0142 for reasoning. Something about 6 claymores + armor being overkill, mats apparently being "legitimate loot" instead of the filler it was meant to be (to people really use that crap for anything other than statues and floor tiles?) among other concerns.

# Wiki Documentation

Lavaland ruin image has to be updated, as in we need to get an image of the damn ruin up.

# Changelog

:cl:  
rscadd: Added tons of coins and skeletons to act as proper loot filler  
rscdel: Removed old loot that was apparently too much.
/:cl:
