### PR TITLE
chaplain armor balancing

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -128,6 +128,7 @@
 	desc = "The uniform of a bygone institute of learning."
 	icon_state = "studentuni"
 	item_state = "studentuni"
+	armor = list("melee" = 40, "bullet" = 10, "laser" = 10,"energy" = 10, "bomb" = 5, "bio" = 2, "rad" = 0, "fire" = 0, "acid" = 50)
 	body_parts_covered = ARMS|CHEST
 	allowed = list(/obj/item/storage/book/bible, /obj/item/nullrod, /obj/item/reagent_containers/food/drinks/bottle/holywater, /obj/item/storage/box/fancy/candle_box, /obj/item/candle, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman)
 
@@ -137,6 +138,7 @@
 	alternate_worn_icon = 'icons/mob/large-worn-icons/64x64/head.dmi'
 	icon_state = "cage"
 	item_state = "cage"
+	armor = list("melee" = 40, "bullet" = 10, "laser" = 10,"energy" = 10, "bomb" = 5, "bio" = 2, "rad" = 0, "fire" = 0, "acid" = 50)
 	worn_x_dimension = 64
 	worn_y_dimension = 64
 	dynamic_hair_suffix = ""

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -128,7 +128,6 @@
 	desc = "The uniform of a bygone institute of learning."
 	icon_state = "studentuni"
 	item_state = "studentuni"
-	armor = list("melee" = 40, "bullet" = 10, "laser" = 10,"energy" = 10, "bomb" = 5, "bio" = 2, "rad" = 0, "fire" = 0, "acid" = 50)
 	body_parts_covered = ARMS|CHEST
 	allowed = list(/obj/item/storage/book/bible, /obj/item/nullrod, /obj/item/reagent_containers/food/drinks/bottle/holywater, /obj/item/storage/box/fancy/candle_box, /obj/item/candle, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman)
 
@@ -138,7 +137,6 @@
 	alternate_worn_icon = 'icons/mob/large-worn-icons/64x64/head.dmi'
 	icon_state = "cage"
 	item_state = "cage"
-	armor = list("melee" = 40, "bullet" = 10, "laser" = 10,"energy" = 10, "bomb" = 5, "bio" = 2, "rad" = 0, "fire" = 0, "acid" = 50)
 	worn_x_dimension = 64
 	worn_y_dimension = 64
 	dynamic_hair_suffix = ""
@@ -155,14 +153,12 @@
 	desc = "None may pass!"
 	icon_state = "knight_ancient"
 	item_state = "knight_ancient"
-	armor = list("melee" = 40, "bullet" = 10, "laser" = 10,"energy" = 10, "bomb" = 5, "bio" = 2, "rad" = 0, "fire" = 0, "acid" = 50)
 
 /obj/item/clothing/suit/armor/riot/chaplain/ancient
 	name = "ancient armour"
 	desc = "Defend the treasure..."
 	icon_state = "knight_ancient"
 	item_state = "knight_ancient"
-	armor = list("melee" = 40, "bullet" = 10, "laser" = 10,"energy" = 10, "bomb" = 5, "bio" = 2, "rad" = 0, "fire" = 0, "acid" = 50)
 
 /obj/item/storage/box/holy/witchhunter
 	name = "Witchhunter Kit"
@@ -176,7 +172,6 @@
 	desc = "This worn outfit saw much use back in the day."
 	icon_state = "witchhunter"
 	item_state = "witchhunter"
-	armor = list("melee" = 40, "bullet" = 10, "laser" = 10,"energy" = 10, "bomb" = 5, "bio" = 2, "rad" = 0, "fire" = 0, "acid" = 50)
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 
 /obj/item/clothing/head/helmet/chaplain/witchunter_hat
@@ -184,7 +179,6 @@
 	desc = "This hat saw much use back in the day."
 	icon_state = "witchhunterhat"
 	item_state = "witchhunterhat"
-	armor = list("melee" = 40, "bullet" = 10, "laser" = 10,"energy" = 10, "bomb" = 5, "bio" = 2, "rad" = 0, "fire" = 0, "acid" = 50)
 	flags_cover = HEADCOVERSEYES
 
 /obj/item/storage/box/holy/follower

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -11,7 +11,7 @@
 	max_heat_protection_temperature = null
 	clothing_flags = null
 	armor = list("melee" = 25, "bullet" = 10, "laser" = 5, "energy" = 0, "bomb" = 5, "bio" = 0, "fire" = 80, "acid" = 80)
-	slowdown = 0.8
+	slowdown = 0.5
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/darktemplarfollower
 
 /obj/item/clothing/suit/space/hardsuit/darktemplarfollowerchap
@@ -25,7 +25,7 @@
 	max_heat_protection_temperature = null
 	clothing_flags = null
 	armor = list("melee" = 25, "bullet" = 10, "laser" = 5, "energy" = 0, "bomb" = 5, "bio" = 0, "fire" = 80, "acid" = 80)
-	slowdown = 0.8
+	slowdown = 0.33
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/darktemplarfollower
 
 /obj/item/clothing/head/helmet/space/hardsuit/darktemplarfollower
@@ -61,7 +61,7 @@
 	desc = "Deus Vult."
 	icon_state = "knight_templar"
 	item_state = "knight_templar"
-	armor = list("melee" = 41, "bullet" = 15, "laser" = 5,"energy" = 5, "bomb" = 5, "bio" = 2, "rad" = 0, "fire" = 0, "acid" = 50)
+	armor = list("melee" = 40, "bullet" = 10, "laser" = 5,"energy" = 5, "bomb" = 5, "bio" = 2, "rad" = 0, "fire" = 0, "acid" = 50)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	strip_delay = 80
@@ -72,6 +72,7 @@
 	desc = "God wills it!"
 	icon_state = "knight_templar"
 	item_state = "knight_templar"
+	armor = list("melee" = 40, "bullet" = 10, "laser" = 5,"energy" = 5, "bomb" = 5, "bio" = 2, "rad" = 0, "fire" = 0, "acid" = 50)
 	allowed = list(/obj/item/storage/book/bible, /obj/item/nullrod, /obj/item/reagent_containers/food/drinks/bottle/holywater, /obj/item/storage/box/fancy/candle_box, /obj/item/candle, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman)
 	slowdown = 0
 	blocks_shove_knockdown = FALSE
@@ -152,12 +153,14 @@
 	desc = "None may pass!"
 	icon_state = "knight_ancient"
 	item_state = "knight_ancient"
+	armor = list("melee" = 40, "bullet" = 10, "laser" = 10,"energy" = 10, "bomb" = 5, "bio" = 2, "rad" = 0, "fire" = 0, "acid" = 50)
 
 /obj/item/clothing/suit/armor/riot/chaplain/ancient
 	name = "ancient armour"
 	desc = "Defend the treasure..."
 	icon_state = "knight_ancient"
 	item_state = "knight_ancient"
+	armor = list("melee" = 40, "bullet" = 10, "laser" = 10,"energy" = 10, "bomb" = 5, "bio" = 2, "rad" = 0, "fire" = 0, "acid" = 50)
 
 /obj/item/storage/box/holy/witchhunter
 	name = "Witchhunter Kit"
@@ -171,6 +174,7 @@
 	desc = "This worn outfit saw much use back in the day."
 	icon_state = "witchhunter"
 	item_state = "witchhunter"
+	armor = list("melee" = 40, "bullet" = 10, "laser" = 10,"energy" = 10, "bomb" = 5, "bio" = 2, "rad" = 0, "fire" = 0, "acid" = 50)
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 
 /obj/item/clothing/head/helmet/chaplain/witchunter_hat
@@ -178,6 +182,7 @@
 	desc = "This hat saw much use back in the day."
 	icon_state = "witchhunterhat"
 	item_state = "witchhunterhat"
+	armor = list("melee" = 40, "bullet" = 10, "laser" = 10,"energy" = 10, "bomb" = 5, "bio" = 2, "rad" = 0, "fire" = 0, "acid" = 50)
 	flags_cover = HEADCOVERSEYES
 
 /obj/item/storage/box/holy/follower
@@ -211,12 +216,14 @@
 	desc = "Now you're ready for some 50 dollar bling water."
 	icon_state = "chaplain_hoodie_leader"
 	item_state = "chaplain_hoodie_leader"
+	armor = list("melee" = 15, "bullet" = 5, "laser" = 5,"energy" = 5, "bomb" = 5, "bio" = 2, "rad" = 0, "fire" = 0, "acid" = 25)
 	hoodtype = /obj/item/clothing/head/hooded/chaplain_hood/leader
 
 /obj/item/clothing/head/hooded/chaplain_hood/leader
 	name = "leader hood"
 	desc = "I mean, you don't /have/ to seek bling water. I just think you should."
 	icon_state = "chaplain_hood_leader"
+	armor = list("melee" = 15, "bullet" = 5, "laser" = 5,"energy" = 5, "bomb" = 5, "bio" = 2, "rad" = 0, "fire" = 0, "acid" = 25)
 
 /obj/item/storage/box/holy/darktemplar
 	name = "Founder Kit of the Black Templars"


### PR DESCRIPTION

### Intent of your Pull Request
armor of stone sentinel, witch hunter, and profane scholar all reduced slightly. buffs the chaplain follower leader hoodie by giving it a small bit of armor since it previously sucked and had no armor, and lowers the space marine slowdown by a bit.

### Why is this change good for the game?
balances chaplain's armor since some are a bit powerful and some actively hinder you instead of helping you when you wear them

### What should players be aware of when it comes to the changes your PR is implementing?
armor of stone sentinel, witch hunter, and profane scholar all reduced slightly. buffs the chaplain follower leader hoodie by giving it a small bit of armor since it previously sucked and had no armor, and lowers the space marine slowdown by a bit.

### What general grouping does this PR fall under? 
For example, Engineering changes, Medical rebalancing, TEG tweaks, etc.?
chaplain changes

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
For example, "This new chem will heal X brute damage". 
armor of stone sentinel, witch hunter, and profane scholar all reduced slightly. buffs the chaplain follower leader hoodie by giving it a small bit of armor since it previously sucked and had no armor, and lowers the space marine slowdown by a bit.

if you want exact number changes, feel free to look at the commits I'm adding

:cl:  
tweak: tweaked armor and slowdown values of chaplain's armor options
/:cl:
