### PR TITLE
Tweaks the lavaland ruin behind Legion to be more of a lair

### DIFF
--- a/_maps/map_files/mining/Lavaland.dmm
+++ b/_maps/map_files/mining/Lavaland.dmm
@@ -2158,16 +2158,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/mine/laborcamp)
-"xs" = (
-/mob/living/simple_animal/hostile/skeleton/templar{
-	faction = list("skeleton","mining");
-	loot = list(/obj/effect/decal/remains/human)
-	},
-/mob/living/simple_animal/hostile/skeleton/templar{
-	faction = list("skeleton","mining")
-	},
-/turf/open/indestructible/necropolis,
-/area/ruin/unpowered/dragonslair)
 "xO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/seeds/redbeet,
@@ -2285,6 +2275,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"Ac" = (
+/obj/effect/decal/cleanable/ash,
+/obj/item/reagent_containers/hypospray/medipen/survival{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/sord{
+	desc = "The famous Dragons Layer, proof that fashion alone doesn't get you anywhere.";
+	name = "\improper Dragonslayer";
+	pixel_x = 11;
+	pixel_y = -5
+	},
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
 "Al" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -2707,20 +2711,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/mine/laborcamp)
-"JX" = (
-/obj/effect/decal/cleanable/ash,
-/obj/item/reagent_containers/hypospray/medipen/survival{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/sord{
-	desc = "The famous Dragons Layer, proof that fashion doesn't get you anywhere.";
-	name = "\improper Dragonslayer";
-	pixel_x = 11;
-	pixel_y = -5
-	},
-/turf/open/indestructible/necropolis,
-/area/ruin/unpowered/dragonslair)
 "Km" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -36869,7 +36859,7 @@ BA
 ZR
 Od
 XB
-XB
+DF
 aa
 aa
 gR
@@ -43803,7 +43793,7 @@ aj
 aa
 aa
 aa
-xs
+DF
 XB
 XB
 FC
@@ -44317,7 +44307,7 @@ aj
 aa
 aa
 aa
-JX
+Ac
 XB
 XB
 XB

--- a/_maps/map_files/mining/Lavaland.dmm
+++ b/_maps/map_files/mining/Lavaland.dmm
@@ -79,6 +79,10 @@
 "aq" = (
 /turf/closed/wall,
 /area/mine/laborcamp)
+"ar" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
 "aw" = (
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors/explored)
@@ -180,27 +184,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/mine/laborcamp)
-"bX" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/twohanded/spear,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
-"ce" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/slab/cracked,
-/obj/item/stack/sheet/mineral/diamond/fifty,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "cg" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -215,18 +198,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/mine/laborcamp)
-"cr" = (
-/obj/structure/mineral_door/iron,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile,
-/obj/structure/stone_tile/block{
-	dir = 1
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "cu" = (
 /obj/item/pickaxe,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -282,6 +253,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"dA" = (
+/obj/effect/decal/cleanable/blood/gibs/torso,
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
 "dF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -316,6 +291,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/mine/laborcamp)
+"ez" = (
+/obj/effect/decal/cleanable/shreds,
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
+"eA" = (
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
 "eE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
@@ -337,6 +320,19 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"eP" = (
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
+"eY" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 4
+	},
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 8
+	},
+/turf/open/lava/smooth/lava_land_surface,
+/area/ruin/unpowered/dragonslair)
 "fs" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/plasteel,
@@ -388,17 +384,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/mine/laborcamp/security)
-"gg" = (
-/obj/structure/stone_tile/block{
-	dir = 8
-	},
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "gj" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 1
@@ -453,20 +438,6 @@
 /obj/structure/stone_tile,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"gu" = (
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "gy" = (
 /obj/structure/stone_tile/cracked,
 /obj/structure/stone_tile{
@@ -523,6 +494,11 @@
 /obj/structure/stone_tile/cracked,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"gL" = (
+/obj/machinery/door/keycard/necropolis,
+/obj/structure/stone_tile/slab,
+/turf/open/indestructible/boss,
+/area/ruin/unpowered/dragonslair)
 "gM" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -546,20 +522,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"gS" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "gY" = (
 /obj/docking_port/stationary{
 	area_type = /area/lavaland/surface/outdoors;
@@ -671,6 +633,17 @@
 "if" = (
 /turf/closed/wall/r_wall,
 /area/mine/laborcamp)
+"ig" = (
+/obj/structure/stone_tile/center/burnt,
+/obj/structure/stone_tile/surrounding,
+/turf/open/lava/smooth/lava_land_surface,
+/area/ruin/unpowered/dragonslair)
+"ii" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/stone_tile/cracked,
+/obj/structure/spider/stickyweb,
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
 "ir" = (
 /obj/structure/stone_tile/slab/cracked{
 	dir = 5
@@ -738,6 +711,18 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/mine/laborcamp)
+"iW" = (
+/obj/item/coin/adamantine{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/item/stack/sheet/mineral/gold{
+	amount = 35;
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
 "iX" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -785,6 +770,12 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"ji" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/tarantula{
+	faction = list("mining")
+	},
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
 "jk" = (
 /obj/structure/stone_tile/center,
 /obj/structure/stone_tile/surrounding_tile,
@@ -853,11 +844,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"jC" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/slab/cracked,
-/turf/open/lava/smooth/lava_land_surface,
-/area/ruin/unpowered/dragonslair)
 "jF" = (
 /obj/structure/stone_tile/surrounding_tile,
 /obj/structure/stone_tile/surrounding_tile{
@@ -947,21 +933,6 @@
 /obj/structure/fluff/drake_statue/falling,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"kn" = (
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/ash,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "ko" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -972,21 +943,6 @@
 /obj/structure/stone_tile,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"kq" = (
-/obj/structure/mineral_door/iron,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile/block,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "kx" = (
 /obj/structure/chair/stool,
 /obj/structure/sign/poster/official/work_for_a_future{
@@ -1089,6 +1045,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/laborcamp)
+"kZ" = (
+/obj/structure/stone_tile/cracked{
+	dir = 4
+	},
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
 "la" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/ore_box,
@@ -1250,6 +1212,13 @@
 	},
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"lL" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/cracked,
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
 "lP" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
@@ -1326,20 +1295,6 @@
 	},
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"mg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile,
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "mk" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -1728,38 +1683,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"nn" = (
-/obj/item/stack/sheet/mineral/gold,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/block/cracked,
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
+"nv" = (
+/obj/structure/stone_tile/block/burnt,
+/obj/structure/stone_tile/surrounding_tile{
 	dir = 1
 	},
-/turf/open/indestructible/boss,
+/mob/living/simple_animal/hostile/asteroid/gutlunch/grublunch,
+/turf/open/lava/smooth/lava_land_surface,
 /area/ruin/unpowered/dragonslair)
 "nC" = (
 /obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/plating,
 /area/mine/laborcamp)
-"nM" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
-/obj/item/stack/sheet/mineral/gold{
-	amount = 25
-	},
-/turf/open/indestructible/boss,
+"nR" = (
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/indestructible/necropolis,
 /area/ruin/unpowered/dragonslair)
 "nT" = (
 /obj/structure/stone_tile/surrounding/burnt,
@@ -1770,16 +1708,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"ow" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/block/cracked{
-	dir = 1
+"of" = (
+/obj/item/coin{
+	pixel_x = 6;
+	pixel_y = 7
 	},
-/obj/structure/stone_tile/cracked{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/turf/open/indestructible/boss,
+/turf/open/indestructible/necropolis,
 /area/ruin/unpowered/dragonslair)
 "oy" = (
 /obj/machinery/light/small,
@@ -1793,22 +1727,11 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"oQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/turf/open/indestructible/boss,
+"oV" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/decal/cleanable/food/pie_smudge,
+/obj/effect/decal/cleanable/food/egg_smudge,
+/turf/open/indestructible/necropolis,
 /area/ruin/unpowered/dragonslair)
 "pb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -1875,32 +1798,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"pK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile,
-/obj/structure/mineral_door/iron,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
-"qd" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/block/cracked,
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "qh" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/cloth_curtain{
@@ -1908,20 +1805,6 @@
 	},
 /turf/open/floor/plating,
 /area/mine/laborcamp)
-"qn" = (
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "qE" = (
 /obj/structure/table,
 /obj/item/toy/cards/deck,
@@ -1944,35 +1827,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"qO" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
-"qY" = (
-/obj/effect/decal/remains/human,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/boss,
+"ri" = (
+/obj/effect/decal/cleanable/ash,
+/turf/open/indestructible/necropolis,
 /area/ruin/unpowered/dragonslair)
 "ro" = (
 /obj/machinery/computer/prisoner{
@@ -1984,17 +1841,36 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
-"rt" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/ash,
-/obj/structure/stone_tile{
-	dir = 1
+"rr" = (
+/obj/item/coin/mythril{
+	pixel_x = 7;
+	pixel_y = -6
 	},
-/obj/structure/stone_tile/block/cracked,
-/obj/structure/stone_tile{
-	dir = 4
+/obj/item/coin/mythril{
+	pixel_x = -9;
+	pixel_y = -7
 	},
-/turf/open/indestructible/boss,
+/obj/item/coin/mythril{
+	pixel_x = 2;
+	pixel_y = 8
+	},
+/obj/item/coin/mythril{
+	pixel_x = 7;
+	pixel_y = -4
+	},
+/obj/item/coin/mythril{
+	pixel_x = 7;
+	pixel_y = -2
+	},
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
+"ru" = (
+/obj/structure/stone_tile/slab/cracked,
+/turf/open/lava/smooth/lava_land_surface,
+/area/ruin/unpowered/dragonslair)
+"rC" = (
+/obj/item/ectoplasm,
+/turf/open/indestructible/necropolis,
 /area/ruin/unpowered/dragonslair)
 "rX" = (
 /obj/item/pickaxe,
@@ -2039,6 +1915,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/mine/laborcamp)
+"sE" = (
+/obj/structure/stone_tile/block/cracked,
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
 "sG" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -2058,6 +1938,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"sH" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
 "sY" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -2098,20 +1983,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"ts" = (
-/obj/structure/stone_tile/block{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "tA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/loading_area{
@@ -2146,6 +2017,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"tQ" = (
+/obj/item/coin/diamond{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/coin/diamond{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/coin/diamond{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/coin/diamond{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/stack/sheet/mineral/diamond{
+	amount = 30;
+	pixel_x = -4;
+	pixel_y = -7
+	},
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
 "uu" = (
 /obj/machinery/door/airlock{
 	name = "Labor Camp Library"
@@ -2157,13 +2052,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"uw" = (
-/obj/item/immortality_talisman,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/crate/coffin,
-/obj/structure/stone_tile/slab/cracked,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "uD" = (
 /obj/machinery/computer/security/labor{
 	dir = 4;
@@ -2187,6 +2075,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"uZ" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/stone_tile/cracked{
+	dir = 4
+	},
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
+"vr" = (
+/obj/item/coin/silver,
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
 "vC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/public/glass{
@@ -2218,20 +2117,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"vO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked,
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 8
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "wc" = (
 /obj/structure/closet/crate/internals,
 /obj/item/tank/internals/emergency_oxygen,
@@ -2245,21 +2130,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"wl" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/ash,
-/obj/structure/stone_tile,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "wI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -2273,20 +2143,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"wM" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/cracked{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "wP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -2294,21 +2150,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
-"wT" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile/block/cracked,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/skeleton/templar{
-	speak = list("THE NECROPOLIS WILLS IT!","DEUS VULT!","REMOVE KABAB!");
-	speak_chance = 0
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "wZ" = (
 /obj/machinery/camera{
 	c_tag = "Labor Camp External West";
@@ -2317,6 +2158,16 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/mine/laborcamp)
+"xs" = (
+/mob/living/simple_animal/hostile/skeleton/templar{
+	faction = list("skeleton","mining");
+	loot = list(/obj/effect/decal/remains/human)
+	},
+/mob/living/simple_animal/hostile/skeleton/templar{
+	faction = list("skeleton","mining")
+	},
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
 "xO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/seeds/redbeet,
@@ -2329,6 +2180,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/mine/laborcamp)
+"xY" = (
+/obj/structure/stone_tile/slab,
+/mob/living/simple_animal/hostile/poison/giant_spider/tarantula{
+	faction = list("mining")
+	},
+/obj/structure/spider/stickyweb,
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
 "yx" = (
 /obj/structure/chair/stool,
 /obj/structure/sign/poster/official/obey{
@@ -2386,22 +2245,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"zm" = (
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/twohanded/spear,
-/obj/item/flashlight/lantern,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "zv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
@@ -2461,20 +2304,51 @@
 	},
 /turf/open/floor/plating,
 /area/mine/laborcamp)
-"Aw" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/stack/sheet/mineral/diamond/fifty,
-/obj/structure/stone_tile/cracked{
-	dir = 4
+"Aq" = (
+/obj/item/coin/gold{
+	pixel_x = 7;
+	pixel_y = 5
 	},
-/obj/structure/stone_tile/cracked{
-	dir = 8
+/obj/item/coin/gold{
+	pixel_x = -8;
+	pixel_y = -9
 	},
-/obj/structure/stone_tile/cracked,
-/obj/structure/stone_tile/cracked{
-	dir = 1
+/obj/item/instrument/violin/golden{
+	pixel_x = -6;
+	pixel_y = 15
 	},
-/turf/open/indestructible/boss,
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
+"AG" = (
+/obj/item/coin/gold{
+	pixel_x = 2;
+	pixel_y = -9
+	},
+/obj/item/coin/gold{
+	pixel_x = -9;
+	pixel_y = -2
+	},
+/obj/item/coin/gold{
+	pixel_x = -9;
+	pixel_y = 1
+	},
+/obj/item/coin/gold{
+	pixel_x = -9;
+	pixel_y = 4
+	},
+/obj/item/coin/gold{
+	pixel_x = -9;
+	pixel_y = 7
+	},
+/obj/item/coin/gold{
+	pixel_x = -9;
+	pixel_y = 10
+	},
+/obj/item/coin/gold{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/turf/open/indestructible/necropolis,
 /area/ruin/unpowered/dragonslair)
 "AO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2509,8 +2383,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"Bs" = (
-/turf/closed/indestructible/riveted/boss,
+"BA" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 1
+	},
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
+"BF" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 1
+	},
+/obj/structure/stone_tile/cracked,
+/turf/open/lava/smooth/lava_land_surface,
+/area/ruin/unpowered/dragonslair)
+"BP" = (
+/obj/structure/stone_tile/center,
+/obj/structure/stone_tile/surrounding_tile,
+/obj/structure/stone_tile/surrounding/cracked,
+/turf/open/lava/smooth/lava_land_surface,
 /area/ruin/unpowered/dragonslair)
 "BW" = (
 /obj/structure/sign/poster/official/safety_report{
@@ -2530,35 +2420,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"Cb" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 8
-	},
+"Cd" = (
 /obj/structure/stone_tile/cracked,
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
-/mob/living/simple_animal/hostile/megafauna/dragon,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
-"Cl" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/indestructible/boss,
+/obj/structure/spider/stickyweb,
+/turf/open/indestructible/necropolis,
 /area/ruin/unpowered/dragonslair)
 "Cu" = (
 /obj/machinery/door/airlock/external{
@@ -2568,11 +2433,6 @@
 	},
 /turf/open/floor/plating,
 /area/mine/laborcamp)
-"Cx" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/slab/cracked,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "Cz" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -2608,34 +2468,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"CJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
+"CG" = (
+/obj/structure/stone_tile/center/burnt,
+/obj/structure/stone_tile/surrounding_tile{
 	dir = 1
 	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/obj/structure/stone_tile/burnt{
-	dir = 4
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
-"Da" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile,
-/obj/structure/stone_tile/block/cracked{
-	dir = 1
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/skeleton/templar{
-	speak = list("THE NECROPOLIS WILLS IT!","DEUS VULT!","REMOVE KABAB!");
-	speak_chance = 0
-	},
-/turf/open/indestructible/boss,
+/turf/open/lava/smooth/lava_land_surface,
 /area/ruin/unpowered/dragonslair)
 "Df" = (
 /obj/effect/turf_decal/bot,
@@ -2669,20 +2507,12 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/freezer,
 /area/mine/laborcamp)
-"DY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
+"DF" = (
+/mob/living/simple_animal/hostile/skeleton/templar{
+	faction = list("skeleton","mining");
+	loot = list(/obj/effect/decal/remains/human)
 	},
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/boss,
+/turf/open/indestructible/necropolis,
 /area/ruin/unpowered/dragonslair)
 "DZ" = (
 /obj/effect/turf_decal/bot,
@@ -2723,14 +2553,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"Ep" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/stack/sheet/mineral/mythril{
-	amount = 50
-	},
-/obj/structure/stone_tile/slab/cracked,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "Ez" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/seeds/onion,
@@ -2747,6 +2569,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"EG" = (
+/obj/item/dragon_egg,
+/obj/structure/stone_tile/surrounding,
+/turf/open/lava/smooth/lava_land_surface,
+/area/ruin/unpowered/dragonslair)
+"EH" = (
+/mob/living/simple_animal/hostile/megafauna/dragon{
+	desc = "Heart of the necropolis.";
+	move_to_delay = 30
+	},
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
 "EI" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -2773,6 +2607,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"FC" = (
+/obj/structure/stone_tile/cracked{
+	dir = 8
+	},
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
 "FP" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -2789,21 +2629,6 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/mine/laborcamp)
-"Gh" = (
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile,
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/skeleton,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "Gr" = (
 /obj/structure/sign/poster/official/do_not_question{
 	pixel_y = 32
@@ -2817,6 +2642,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"GB" = (
+/obj/structure/stone_tile/cracked,
+/mob/living/simple_animal/hostile/skeleton{
+	faction = list("skeleton","mining")
+	},
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
 "GK" = (
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
@@ -2827,29 +2659,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"GX" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/block/cracked,
-/obj/item/stack/sheet/mineral/gold,
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
-"GZ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile,
-/obj/structure/stone_tile/block/cracked{
-	dir = 1
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "Hr" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restroom"
@@ -2879,17 +2688,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"Ih" = (
-/obj/item/stack/sheet/mineral/gold,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/block/cracked{
-	dir = 1
+"Ib" = (
+/mob/living/simple_animal/hostile/drakeling{
+	faction = list("mining")
 	},
-/obj/structure/stone_tile/cracked{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/turf/open/indestructible/boss,
+/turf/open/indestructible/necropolis,
 /area/ruin/unpowered/dragonslair)
 "IC" = (
 /obj/effect/turf_decal/tile/blue{
@@ -2904,65 +2707,19 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/mine/laborcamp)
-"Jh" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
+"JX" = (
+/obj/effect/decal/cleanable/ash,
+/obj/item/reagent_containers/hypospray/medipen/survival{
+	pixel_x = -3;
+	pixel_y = 7
 	},
-/obj/structure/stone_tile,
-/obj/structure/stone_tile{
-	dir = 4
+/obj/item/sord{
+	desc = "The famous Dragons Layer, proof that fashion doesn't get you anywhere.";
+	name = "\improper Dragonslayer";
+	pixel_x = 11;
+	pixel_y = -5
 	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/skeleton/templar{
-	speak = list("THE NECROPOLIS WILLS IT!","DEUS VULT!","REMOVE KABAB!");
-	speak_chance = 0
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
-"Js" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile/block/cracked,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
-"Jw" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/skeleton,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
-"Kg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/indestructible/boss,
+/turf/open/indestructible/necropolis,
 /area/ruin/unpowered/dragonslair)
 "Km" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2971,20 +2728,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"Kn" = (
-/obj/item/stack/sheet/mineral/gold,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/obj/structure/stone_tile/cracked{
+"Kp" = (
+/obj/structure/stone_tile/surrounding_tile{
 	dir = 1
 	},
-/turf/open/indestructible/boss,
+/turf/open/indestructible/necropolis,
 /area/ruin/unpowered/dragonslair)
 "Kr" = (
 /obj/machinery/light/small,
@@ -3008,18 +2756,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/laborcamp)
-"KO" = (
-/obj/structure/stone_tile/block{
-	dir = 4
+"KE" = (
+/obj/structure/stone_tile/block/cracked,
+/obj/structure/stone_tile/cracked{
+	dir = 1
 	},
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/boss,
+/turf/open/lava/smooth/lava_land_surface,
 /area/ruin/unpowered/dragonslair)
 "Ld" = (
 /obj/structure/rack,
@@ -3027,11 +2769,6 @@
 /obj/item/analyzer,
 /turf/open/floor/plating,
 /area/mine/laborcamp)
-"Lo" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/block/burnt,
-/turf/open/lava/smooth/lava_land_surface,
-/area/ruin/unpowered/dragonslair)
 "Lq" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -3081,32 +2818,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/laborcamp)
-"LI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/block/cracked{
-	dir = 1
-	},
-/turf/open/lava/smooth/lava_land_surface,
-/area/ruin/unpowered/dragonslair)
-"LP" = (
-/obj/machinery/door/keycard/necropolis,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
-"LV" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/item/twohanded/spear,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "Md" = (
 /obj/machinery/door/airlock/external{
 	glass = 1;
@@ -3122,19 +2833,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"Ml" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
+"Mm" = (
+/obj/structure/stone_tile/cracked{
 	dir = 1
 	},
-/obj/structure/stone_tile{
-	dir = 4
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
+"MN" = (
+/obj/item/stack/sheet/mineral/mythril{
+	amount = 25;
+	pixel_x = -1;
+	pixel_y = 8
 	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile/burnt,
-/turf/open/indestructible/boss,
+/turf/open/indestructible/necropolis,
 /area/ruin/unpowered/dragonslair)
 "MW" = (
 /obj/effect/turf_decal/delivery,
@@ -3153,15 +2864,6 @@
 	},
 /turf/open/floor/plating,
 /area/mine/laborcamp)
-"Nh" = (
-/obj/effect/decal/remains/human{
-	desc = "They look like human remains. They appear to have short pants on them.";
-	name = "Rather Dashing"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/slab/burnt,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "NJ" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
@@ -3180,6 +2882,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"Od" = (
+/obj/structure/stone_tile/block/burnt,
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
 "Or" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -3230,6 +2936,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"PH" = (
+/obj/structure/stone_tile/cracked{
+	dir = 8
+	},
+/obj/item/coin/silver{
+	pixel_y = -7
+	},
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
+"PK" = (
+/obj/item/coin/silver{
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
 "PW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/holopad,
@@ -3258,21 +2980,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"Qp" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "Qw" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -3318,21 +3025,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"QI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "QU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/closed/wall/r_wall,
@@ -3382,32 +3074,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"RW" = (
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
-"RY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile/block/cracked,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "Sf" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/blue{
@@ -3458,6 +3124,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/mine/laborcamp)
+"SP" = (
+/obj/effect/decal/cleanable/blood/gibs/up,
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
 "SV" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -3470,6 +3140,14 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/plasteel/dark,
 /area/mine/laborcamp)
+"SZ" = (
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
+"Th" = (
+/obj/structure/stone_tile/surrounding,
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
 "Ts" = (
 /obj/machinery/vending/sustenance,
 /obj/effect/decal/cleanable/dirt,
@@ -3499,19 +3177,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"Ue" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/block/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 8
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "Up" = (
 /obj/machinery/status_display/evac{
 	pixel_x = -32
@@ -3542,35 +3207,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"UK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/block/cracked,
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
-/obj/item/stack/sheet/mineral/gold{
-	amount = 25
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
-"UL" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/stack/sheet/mineral/gold/fifty,
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "UM" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -3586,6 +3222,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/laborcamp)
+"UU" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 4
+	},
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
 "Vj" = (
 /obj/machinery/computer/secure_data{
 	dir = 4;
@@ -3610,25 +3252,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"VF" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/block/cracked{
-	dir = 1
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
-/obj/item/stack/sheet/mineral/gold{
-	amount = 25
-	},
-/turf/open/indestructible/boss,
+"VD" = (
+/obj/item/chair/bananium,
+/turf/open/indestructible/necropolis,
 /area/ruin/unpowered/dragonslair)
 "VP" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -3671,8 +3297,23 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/mine/laborcamp)
-"WJ" = (
-/obj/structure/stone_tile/surrounding/cracked,
+"WF" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/item/coin/adamantine,
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
+"WQ" = (
+/obj/structure/barricade/wooden,
+/obj/structure/mineral_door/silver,
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
+"WR" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
 /turf/open/lava/smooth/lava_land_surface,
 /area/ruin/unpowered/dragonslair)
 "WY" = (
@@ -3684,24 +3325,14 @@
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"Xg" = (
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/stone_tile,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "Xi" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/mine/laborcamp)
+"Xm" = (
+/obj/structure/stone_tile/cracked,
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
 "Xp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
@@ -3711,6 +3342,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"XB" = (
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
 "XC" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -3725,35 +3359,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"XI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile,
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/ash,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
-"Ya" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 8
-	},
-/obj/structure/stone_tile/cracked,
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/dragonslair)
 "Yj" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -3788,24 +3393,20 @@
 	},
 /turf/open/floor/plating,
 /area/mine/laborcamp)
-"Zg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/stone_tile/block/cracked,
-/turf/open/lava/smooth/lava_land_surface,
+"Zl" = (
+/mob/living/simple_animal/hostile/skeleton{
+	faction = list("skeleton","mining")
+	},
+/turf/open/indestructible/necropolis,
 /area/ruin/unpowered/dragonslair)
-"Zj" = (
-/obj/structure/stone_tile,
-/obj/structure/stone_tile{
-	dir = 1
-	},
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/boss,
+"ZC" = (
+/obj/structure/stone_tile/surrounding_tile,
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
+"ZD" = (
+/obj/structure/stone_tile/surrounding/cracked,
+/obj/structure/stone_tile/surrounding_tile,
+/turf/open/lava/smooth/lava_land_surface,
 /area/ruin/unpowered/dragonslair)
 "ZJ" = (
 /obj/machinery/door/airlock/public/glass{
@@ -3818,6 +3419,10 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"ZR" = (
+/obj/structure/stone_tile/slab,
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
 "ZT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -3826,6 +3431,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"ZW" = (
+/obj/item/fakeartefact,
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/dragonslair)
 "ZX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -37000,7 +36609,7 @@ aa
 aa
 aa
 aa
-LP
+gL
 aa
 aa
 aa
@@ -37254,13 +36863,13 @@ aj
 (131,1,1) = {"
 aa
 aa
-ts
-KO
-KO
-Zj
-KO
-KO
-KO
+XB
+XB
+BA
+ZR
+Od
+XB
+XB
 aa
 aa
 gR
@@ -37511,13 +37120,13 @@ aj
 (132,1,1) = {"
 aa
 aa
-Xg
-qY
-Bs
-Bs
-Bs
-Xg
-Xg
+XB
+Zl
+Kp
+UU
+ZC
+XB
+XB
 aa
 aa
 gR
@@ -37768,13 +37377,13 @@ aj
 (133,1,1) = {"
 aa
 aa
-Xg
-Xg
-kn
-Xg
-Xg
-qn
-Xg
+XB
+FC
+XB
+XB
+XB
+Mm
+XB
 aa
 aa
 ae
@@ -38025,13 +37634,13 @@ aj
 (134,1,1) = {"
 aa
 aa
-Xg
-Xg
-qn
-Gh
-zm
-Xg
-RW
+XB
+XB
+rC
+XB
+ri
+Zl
+XB
 aa
 aa
 aa
@@ -38282,13 +37891,13 @@ aj
 (135,1,1) = {"
 aa
 aa
-RW
-Xg
-Xg
-Xg
-Xg
-Xg
-Xg
+Mm
+ri
+XB
+FC
+XB
+XB
+XB
 aa
 aa
 aa
@@ -38539,13 +38148,13 @@ aj
 (136,1,1) = {"
 aa
 aa
-Xg
-Gh
-Xg
-Xg
-Gh
-qY
-Xg
+FC
+XB
+DF
+XB
+XB
+XB
+Xm
 aa
 aa
 aa
@@ -38796,13 +38405,13 @@ aj
 (137,1,1) = {"
 aa
 aa
-jC
-gg
-gg
-gu
-gg
-gg
-Lo
+ru
+XB
+FC
+XB
+XB
+kZ
+nv
 aa
 aa
 iK
@@ -39056,7 +38665,7 @@ aa
 aa
 aa
 aa
-gS
+XB
 aa
 aa
 aa
@@ -39310,13 +38919,13 @@ aj
 (139,1,1) = {"
 aa
 aa
-bX
-gS
+xY
+Th
 aa
-gS
+XB
 aa
-Cl
-Jw
+uZ
+eP
 aa
 aa
 ab
@@ -39567,13 +39176,13 @@ aj
 (140,1,1) = {"
 aa
 aa
-Kg
-Jw
-gS
-mg
-gS
-gS
-gS
+ii
+XB
+XB
+Zl
+XB
+BA
+GB
 aa
 aa
 ad
@@ -39825,12 +39434,12 @@ aj
 aa
 aa
 aa
-gS
+XB
 aa
 aa
 aa
 aa
-gS
+XB
 aa
 aa
 aa
@@ -40082,12 +39691,12 @@ aj
 aa
 aa
 aa
-gS
+DF
 aa
 aa
 aa
 aa
-qO
+XB
 aa
 aa
 aa
@@ -40338,13 +39947,13 @@ aj
 (143,1,1) = {"
 aa
 aa
-QI
-gS
-gS
-Jw
-gS
-gS
-LV
+Cd
+XB
+XB
+XB
+XB
+ri
+XB
 aa
 aa
 aa
@@ -40595,13 +40204,13 @@ aj
 (144,1,1) = {"
 aa
 aa
-Jw
-gS
+sH
+XB
 aa
 aa
 aa
-gS
-Jw
+XB
+kZ
 aa
 aa
 ad
@@ -40853,11 +40462,11 @@ aj
 aa
 aa
 aa
-gS
+XB
 aa
 aa
 aa
-gS
+ji
 aa
 aa
 aa
@@ -41110,11 +40719,11 @@ aj
 aa
 aa
 aa
-gS
-gS
-gS
-XI
-mg
+rC
+XB
+XB
+XB
+XB
 aa
 aa
 aa
@@ -41368,9 +40977,9 @@ aa
 aa
 aa
 aa
-gS
-DY
-gS
+XB
+XB
+FC
 aa
 aa
 aa
@@ -41624,11 +41233,11 @@ aj
 aa
 aa
 aa
-rt
-gS
-gS
-gS
-Da
+FC
+XB
+XB
+XB
+eP
 aa
 aa
 aa
@@ -41882,9 +41491,9 @@ aa
 aa
 aa
 nT
-gS
-Jh
-gS
+Zl
+Xm
+kZ
 lY
 aa
 aa
@@ -42138,11 +41747,11 @@ aj
 aa
 aa
 aa
-Js
-gS
-gS
-gS
-GZ
+Mm
+XB
+XB
+XB
+Mm
 aa
 aa
 aa
@@ -42396,9 +42005,9 @@ aa
 aa
 aa
 aa
-Jh
-oQ
-gS
+XB
+XB
+kZ
 aa
 aa
 aa
@@ -42652,11 +42261,11 @@ aj
 aa
 aa
 aa
-RY
-gS
-gS
-qO
-GZ
+eP
+FC
+XB
+XB
+XB
 aa
 aa
 aa
@@ -42910,10 +42519,10 @@ aa
 aa
 aa
 lY
-gS
-qO
-gS
-WJ
+XB
+eP
+DF
+ZD
 aa
 aa
 aa
@@ -43166,11 +42775,11 @@ aj
 aa
 aa
 aa
-RY
-gS
-gS
-gS
-GZ
+GB
+FC
+ar
+XB
+Mm
 aa
 aa
 aa
@@ -43424,9 +43033,9 @@ aa
 aa
 aa
 aa
-qO
-gS
-Qp
+SP
+XB
+Xm
 aa
 aa
 aa
@@ -43680,11 +43289,11 @@ aj
 aa
 aa
 aa
-wT
-gS
-Ml
-gS
-Da
+FC
+XB
+XB
+Zl
+eP
 aa
 aa
 aa
@@ -43937,10 +43546,10 @@ aj
 aa
 aa
 aa
-WJ
-mg
-gS
-gS
+ZD
+Mm
+XB
+XB
 nT
 aa
 aa
@@ -44194,11 +43803,11 @@ aj
 aa
 aa
 aa
-RY
-CJ
-Jh
-wl
-GZ
+xs
+XB
+XB
+FC
+Mm
 aa
 aa
 aa
@@ -44452,9 +44061,9 @@ aa
 aa
 aa
 aa
-kq
-pK
-cr
+WQ
+WQ
+WQ
 aa
 aa
 aa
@@ -44708,11 +44317,11 @@ aj
 aa
 aa
 aa
-qd
-Ue
-Ue
-Ue
-ow
+JX
+XB
+XB
+XB
+VD
 aa
 aa
 aa
@@ -44965,11 +44574,11 @@ aj
 aa
 aa
 aa
-qd
-Ya
-vO
-Ya
-ow
+eP
+XB
+XB
+XB
+ZW
 aa
 aa
 aa
@@ -45221,13 +44830,13 @@ aj
 (162,1,1) = {"
 aa
 aa
-qd
-Ya
-Ya
-Ya
-Ya
-Ya
-ow
+eA
+ar
+XB
+XB
+XB
+XB
+nR
 aa
 aa
 ab
@@ -45478,13 +45087,13 @@ aj
 (163,1,1) = {"
 aa
 aa
-qd
-wM
-Ya
-Ya
-Ya
-Ya
-ow
+SZ
+dA
+XB
+ri
+XB
+XB
+ar
 aa
 aa
 ab
@@ -45735,13 +45344,13 @@ aj
 (164,1,1) = {"
 aa
 aa
-qd
-LI
-Cx
-Cx
-Cx
-Zg
-ow
+XB
+KE
+FC
+XB
+kZ
+WR
+XB
 aa
 aa
 ab
@@ -45992,13 +45601,13 @@ aj
 (165,1,1) = {"
 aa
 aa
-qd
-LI
-Cx
-Nh
-Cx
-Zg
-ow
+kZ
+CG
+sE
+XB
+BA
+ig
+sE
 aa
 aa
 ab
@@ -46249,13 +45858,13 @@ aj
 (166,1,1) = {"
 aa
 aa
-qd
-LI
-Cx
-Cx
-Cx
-Zg
-ow
+ri
+BF
+Xm
+XB
+XB
+eY
+Xm
 aa
 aa
 ab
@@ -46506,13 +46115,13 @@ aj
 (167,1,1) = {"
 aa
 aa
-qd
-Ya
-Ya
-Ya
-Ya
-Ya
-ow
+XB
+XB
+XB
+XB
+XB
+XB
+XB
 aa
 aa
 ab
@@ -46763,13 +46372,13 @@ aj
 (168,1,1) = {"
 aa
 aa
-qd
-Ya
-Ya
-Ya
-Ya
-Ya
-ow
+XB
+XB
+XB
+XB
+XB
+XB
+ri
 aa
 aa
 ab
@@ -47021,11 +46630,11 @@ aj
 aa
 aa
 aa
-Ya
-Ya
-Ya
-Ya
-Ya
+XB
+XB
+ri
+XB
+XB
 aa
 aa
 aa
@@ -47277,13 +46886,13 @@ aj
 (170,1,1) = {"
 aa
 aa
-qd
-Ya
-Ya
-Ya
-Ya
-Ya
-ow
+WF
+XB
+XB
+XB
+vr
+XB
+rr
 aa
 aa
 ab
@@ -47534,13 +47143,13 @@ aj
 (171,1,1) = {"
 aa
 aa
-qd
-Ya
-Kn
-Ya
-Ya
-Kn
-ow
+Ib
+ri
+XB
+XB
+XB
+XB
+MN
 aa
 aa
 ab
@@ -47791,13 +47400,13 @@ aj
 (172,1,1) = {"
 aa
 aa
-nn
-Kn
-Ya
-Cb
-Kn
-Ya
-ow
+Aq
+of
+XB
+EH
+XB
+XB
+tQ
 aa
 aa
 ab
@@ -48048,13 +47657,13 @@ aj
 (173,1,1) = {"
 aa
 aa
-GX
-nM
-nM
-nM
-nM
-nM
-Ih
+AG
+iW
+XB
+XB
+XB
+Ib
+PK
 aa
 aa
 it
@@ -48306,11 +47915,11 @@ aj
 aa
 aa
 aa
-UK
-Aw
-UL
-UL
-VF
+oV
+FC
+ez
+PH
+kZ
 aa
 aa
 aa
@@ -48564,9 +48173,9 @@ aa
 aa
 aa
 aa
-uw
-Ep
-ce
+BP
+lL
+EG
 aa
 aa
 aa


### PR DESCRIPTION
# General Documentation
![obraz](https://user-images.githubusercontent.com/71487903/113160382-beff6100-923d-11eb-84a0-a679b84083f0.png)

### Intent of your Pull Request
Gives the ruin a (subjectively) better look, replaces floor with the necropolis floor, adds nice decals.
The drake now behaves more like Vasgrul (moves slower, but not as slow), and has 2 drakeling guardians. All the mobs inside ruin don't attack each other now. Added 2 tarantulas. There's now also a free drakeling egg behind it all. For the loot, there's piles of different coins, 25 mythril, 30 diamond and 35 gold stacks and a free survival medipen.

### Why is this change good for the game?
Makes it more interesting to traverse the ruin

# Wiki Documentation
### Briefly describe your PR and the impacts of it, in layman's terms. 
Changes the dragon lair a bit, the drake now has 2 drakeling protectors.

### What general grouping does this PR fall under? 
mining ruin change

# Changelog
:cl:  
tweak: Tweaks the lavaland ruin behind legion
/:cl: