### PR TITLE
Revert "makes science's greytide gun unobtainable" and makes it not pass tables or windows

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -169,7 +169,7 @@
 			new /obj/item/assembly/signaler(src) // 0 tc
 			new /obj/item/storage/toolbox/syndicate(src) // 1 tc
 			new /obj/item/pen/edagger(src)
-			new /obj/item/gun/energy/wormhole_projector(src) //mooorttyyyy
+			new /obj/item/gun/energy/wormhole_projector/upgraded(src) //mooorttyyyy
 			new /obj/item/gun/energy/decloner/unrestricted(src)
 
 		if("bee")

--- a/code/modules/projectiles/ammunition/energy/portal.dm
+++ b/code/modules/projectiles/ammunition/energy/portal.dm
@@ -10,10 +10,10 @@
 	projectile_type = /obj/item/projectile/beam/wormhole/orange
 	select_name = "orange"
 
-/obj/item/ammo_casing/energy/wormhole
+/obj/item/ammo_casing/energy/wormhole/upgraded
 	projectile_type = /obj/item/projectile/beam/wormhole/upgraded
 
-/obj/item/ammo_casing/energy/wormhole/orange
+/obj/item/ammo_casing/energy/wormhole/orange/upgraded
 	projectile_type = /obj/item/projectile/beam/wormhole/orange/upgraded
 
 /obj/item/ammo_casing/energy/wormhole/Initialize(mapload, obj/item/gun/energy/wormhole_projector/wh)

--- a/code/modules/projectiles/ammunition/energy/portal.dm
+++ b/code/modules/projectiles/ammunition/energy/portal.dm
@@ -10,6 +10,12 @@
 	projectile_type = /obj/item/projectile/beam/wormhole/orange
 	select_name = "orange"
 
+/obj/item/ammo_casing/energy/wormhole
+	projectile_type = /obj/item/projectile/beam/wormhole/upgraded
+
+/obj/item/ammo_casing/energy/wormhole/orange
+	projectile_type = /obj/item/projectile/beam/wormhole/orange/upgraded
+
 /obj/item/ammo_casing/energy/wormhole/Initialize(mapload, obj/item/gun/energy/wormhole_projector/wh)
 	. = ..()
 	gun = wh

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -271,6 +271,10 @@
 	var/obj/effect/portal/p_orange
 	var/atmos_link = FALSE
 
+/obj/item/gun/energy/wormhole_projector/upgraded
+	desc = "A projector that emits high density quantum-coupled bluespace beams. This one seems to be modified to go through glass."
+	ammo_type = list(/obj/item/ammo_casing/energy/wormhole/upgraded, /obj/item/ammo_casing/energy/wormhole/orange/upgraded)
+
 /obj/item/gun/energy/wormhole_projector/update_icon()
 	icon_state = "[initial(icon_state)][select]"
 	item_state = icon_state

--- a/code/modules/projectiles/projectile/special/wormhole.dm
+++ b/code/modules/projectiles/projectile/special/wormhole.dm
@@ -4,7 +4,7 @@
 	hitsound = "sparks"
 	damage = 0
 	nodamage = TRUE
-	pass_flags = PASSGLASS | PASSTABLE | PASSGRILLE | PASSMOB
+	pass_flags = PASSGRILLE | PASSMOB
 	var/obj/item/gun/energy/wormhole_projector/gun
 	color = "#33CCFF"
 	tracer_type = /obj/effect/projectile/tracer/wormhole

--- a/code/modules/projectiles/projectile/special/wormhole.dm
+++ b/code/modules/projectiles/projectile/special/wormhole.dm
@@ -16,6 +16,13 @@
 	name = "orange bluespace beam"
 	color = "#FF6600"
 
+//muh OOP, wheres my traits/implements/extends lummox 
+/obj/item/projectile/beam/wormhole/upgraded
+	pass_flags = PASSGLASS | PASSTABLE | PASSGRILLE | PASSMOB
+
+/obj/item/projectile/beam/wormhole/orange/upgraded
+	pass_flags = PASSGLASS | PASSTABLE | PASSGRILLE | PASSMOB
+
 /obj/item/projectile/beam/wormhole/Initialize(mapload, obj/item/ammo_casing/energy/wormhole/casing)
 	. = ..()
 	if(casing)

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -296,6 +296,16 @@
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
+/datum/design/wormhole_projector
+	name = "Bluespace Wormhole Projector"
+	desc = "A projector that emits high density quantum-coupled bluespace beams."
+	id = "wormholeprojector"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/silver = 2000, /datum/material/iron = 5000, /datum/material/diamond = 2000, /datum/material/bluespace = 3000)
+	build_path = /obj/item/gun/energy/wormhole_projector
+	category = list("Weapons")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+
 //WT550 Mags
 
 /datum/design/mag_oldsmg

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -212,7 +212,7 @@
 	display_name = "Miniaturized Bluespace Research"
 	description = "Extreme reduction in space required for bluespace engines, leading to portable bluespace technology."
 	prereq_ids = list("bluespace_travel", "practical_bluespace", "high_efficiency")
-	design_ids = list("bluespace_matter_bin", "femto_mani", "bluespacebodybag", "triphasic_scanning", "quantum_keycard")
+	design_ids = list("bluespace_matter_bin", "femto_mani", "bluespacebodybag", "triphasic_scanning", "quantum_keycard", "wormholeprojector")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	export_price = 5000
 

--- a/yogstation/code/game/gamemodes/battle_royale/loot.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/loot.dm
@@ -54,7 +54,7 @@
 					new /obj/item/storage/box/syndie_kit/throwing_weapons(src)
 					return
 				if(8)
-					new /obj/item/gun/energy/wormhole_projector(src)
+					new /obj/item/gun/energy/wormhole_projector/upgraded(src)
 					return
 		else if(prob(25))
 			var/num = rand(1,8)


### PR DESCRIPTION
*sigh*

Why is the first reaction to everything to just remove it? It still has potential for neat stuff and greytiding is one component of it which can easily be severely nerfed without impacting the ability to do neat stuff too much



Haven't seen many complaints about the portal gun except for the greytiding part

Now for the questions:
### but why not table, i get that this pr is supposed to stop people breaking into like kitchen with portal gun but this is unrealistic!!!!
You are talking about a handheld device that can warp time and space and yet doesnt need a power source, realism has been thrown out the window a long time ago

### Now this is useless, i cant find any use for this
its not because your mind is restricted to greytiding with shit that noone else can make neat stuff with it, just dont print it if you cant find any use for it

### bruh
bruh

:cl:
rscadd: portal gun is back
tweak: portal gun can no longer fire through windows or tables
/:cl: