### PR TITLE
weak claymore nerf

### DIFF
--- a/code/game/objects/items/religion.dm
+++ b/code/game/objects/items/religion.dm
@@ -379,7 +379,8 @@
 /obj/item/claymore/weak
 	desc = "This one is rusted."
 	force = 30
-	armour_penetration = 15
+	block_chance = 30
+	armour_penetration = 5
 
 /obj/item/claymore/weak/ceremonial
 	desc = "A rusted claymore, once at the heart of a powerful scottish clan struck down and oppressed by tyrants, it has been passed down the ages as a symbol of defiance."

--- a/code/game/objects/items/religion.dm
+++ b/code/game/objects/items/religion.dm
@@ -385,5 +385,3 @@
 /obj/item/claymore/weak/ceremonial
 	desc = "A rusted claymore, once at the heart of a powerful scottish clan struck down and oppressed by tyrants, it has been passed down the ages as a symbol of defiance."
 	force = 15
-	block_chance = 30
-	armour_penetration = 5


### PR DESCRIPTION


### Intent of your Pull Request
weak claymore's block chance is reduced to 30 (instead of 50) and it's AP is reduced to 5 instead of 15

### Why is this change good for the game?
the weak claymore is really easy to get and currently has 30 damage, 15 AP, and a 50% block chance, which is pretty damn powerful. This PR makes it a little bit less powerful.

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
This will be the basis of the Wiki entry for your PR, and more information / detail is better for Wiki editors to integrate.
weak claymore's block chance is reduced to 30 (instead of 50) and it's AP is reduced to 5 instead of 15

### What should players be aware of when it comes to the changes your PR is implementing?
weak claymore's block chance is reduced to 30 (instead of 50) and it's AP is reduced to 5 instead of 15
### What general grouping does this PR fall under? 
For example, Engineering changes, Medical rebalancing, TEG tweaks, etc.?
lavaland loot change primarily

### Are there any aspects of the PR that you would like us not to mention on the Wiki?
no
### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
weak claymore's block chance is reduced to 30 (instead of 50) and it's AP is reduced to 5 instead of 15


:cl:  
tweak: reduced AP and block chance of the weak claymore.
/:cl:
