### PR TITLE
chitin plate changes

### DIFF
--- a/yogstation/code/modules/clothing/suits/armor.dm
+++ b/yogstation/code/modules/clothing/suits/armor.dm
@@ -5,9 +5,9 @@
 	item_state = "chitenplate"
 	blood_overlay_type = "armor"
 	resistance_flags = FIRE_PROOF
-	armor = list(melee = 65, bullet = 35, laser = 15, energy = 10, bomb = 35, fire = 50, bio = 0, rad = 0)
+	armor = list("melee" = 65, "bullet" = 35, "laser" = 25, "energy" = 10, "bomb" = 35, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
-	allowed = list(/obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman) // allows ling armor to carry the usual space suit tanks.
+	allowed = list(/obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/gun/energy/kinetic_accelerator)
 
 /obj/item/clothing/suit/armor/vest/rycliesarmour
 	name = "war armour"


### PR DESCRIPTION
real tired of that dumbass unnecessarily long template

this changes chitin plate's laser armor to be up to par with bone armor (25 laser armor) rather than being worse, and adds in acid resistance since it... didn't have it before? Removes the comment about ling chitin armor too since thats not what this is, and lets the armor hold PKAs since bone armor can do that, so why cant chitin armor.

this is good for the game since it removes any pitfalls of the chitin armor since its supposed to be a direct upgrade

:cl:    
tweak: tweaks some armor stats of chitin plate and lets it hold PKAs
/:cl:
