### PR TITLE
riot armor slowdown reduce

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -128,7 +128,7 @@
 	blocks_shove_knockdown = TRUE
 	strip_delay = 80
 	equip_delay_other = 60
-	slowdown = 0.5
+	slowdown = 0.33
 
 /obj/item/clothing/suit/armor/bone
 	name = "bone armor"


### PR DESCRIPTION
Reduces the slowdown for the riot suit to 0.33
Previously it was 0.5
The riot suit is decent enough but doesn't really get used often since melee is generally not used or melee is used in conjunction with a stunning weapon, which at the point your armor really doesn't matter much. Also, the riot suit makes you way too slow, which is bad when dealing with foes using melee since then it lets them catch up to you easier.

:cl:  
tweak: changes riot suit slowdown to 0.33
/:cl:
