### PR TITLE
makes WT-550 rifles obtainable again

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -654,17 +654,17 @@
 
 /datum/supply_pack/security/armory/wt550_single
 	name = "Surplus Security Autorifle Single-Pack"
-	desc = "Contains one high-powered, semiautomatic rifles chambered in 4.6x30mm rubber rounds. Requires Armory access to open."
+	desc = "Contains one high-powered, semiautomatic rifle chambered in 4.6x30mm rounds. Requires Armory access to open."
 	cost = 2000
-	contains = list(/obj/item/gun/ballistic/automatic/wt550/occupying)
+	contains = list(/obj/item/gun/ballistic/automatic/wt550)
 	small_item = TRUE
 
 /datum/supply_pack/security/armory/wt550
 	name = "Surplus Security Autorifle Crate"
-	desc = "Contains two high-powered, semiautomatic rifles chambered in 4.6x30mm rubber rounds. Requires Armory access to open."
+	desc = "Contains two high-powered, semiautomatic rifles chambered in 4.6x30mm rounds. Requires Armory access to open."
 	cost = 3500
-	contains = list(/obj/item/gun/ballistic/automatic/wt550/occupying,
-					/obj/item/gun/ballistic/automatic/wt550/occupying)
+	contains = list(/obj/item/gun/ballistic/automatic/wt550,
+					/obj/item/gun/ballistic/automatic/wt550)
 	crate_name = "auto rifle crate"
 
 /datum/supply_pack/security/armory/wt550ammo


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

somewhere sometime ago when WT550 rifles were being gutted and a rubber round version was made that couldnt accept lethal rounds for the Occupying Force, and then someone (i think it was swiss) made the cargo versions also this version

issue is cargo was the only way to get WT550 rifles
so in current state of game you cannot use lethal or any special WT rifle rounds

### Why is this change good for the game?

printable ammo types are now usable again

# Changelog

:cl:  
tweak: Cargo can now order normal WT-550 crates instead of the Occupying Force variants
spellcheck: fixed a typo in cargo WT-550 rifle crate description
/:cl:
