### PR TITLE
Adds the anniversary of 24605 as a holiday

### DIFF
--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -671,3 +671,13 @@ Since Ramadan is an entire month that lasts 29.5 days on average, the start and 
 		"https://www.youtube.com/watch?v=61MR40PG8K4", // What Do You Do with an Innsmouth Sailor? - H. P. Lovecraft Historical Society - A Shoggoth on the Roof
 		"https://www.youtube.com/watch?v=P2csnVNai-o"  // Tentacles! - H. P. Lovecraft Historical Society - A Shoggoth on the Roof
 		)
+
+/datum/holiday/twofoursixohfive
+	name = "24605 Anniversary"
+	begin_day = 2
+	begin_month = AUGUST
+	drone_hat = /obj/item/clothing/head/beret/atmos
+	lobby_music = list("https://www.youtube.com/watch?v=5WyLhwYFgmk") // Johnny Cash - Ring Of Fire
+
+/datum/holiday/twofoursixohfive/getStationPrefix()
+	return pick("Class-O","Class-B","Class-A","Class-F","Class-G","Class-K","Class-M","Dwarf","Main Sequence","Giant","Atmospheric")


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

There's already a poster, so why not a holiday, too?

Like most of the other holidays, there isn't too much to it. A drone hat (the atmos tech beret), a specific lobby song ([Johnny Cash's "Ring Of Fire"](https://www.youtube.com/watch?v=5WyLhwYFgmk), feel free to suggest more), and a new set of star-related station prefixes..

# Changelog
:cl:  
rscadd: Adds the anniversary of 24605 (August 2nd) as a holiday.  
/:cl:
