### PR TITLE
Makes holdup more viable

### DIFF
--- a/code/datums/components/gunpoint.dm
+++ b/code/datums/components/gunpoint.dm
@@ -104,8 +104,6 @@
 		weapon.chambered.BB.stamina *= damage_mult
 
 	var/fired = weapon.process_fire(target, shooter)
-	if(!fired && weapon.chambered?.loaded_projectile)
-		weapon.chambered.loaded_projectile.damage /= damage_mult
 	qdel(src)
 
 /datum/component/gunpoint/proc/noshooted()

--- a/code/datums/components/gunpoint.dm
+++ b/code/datums/components/gunpoint.dm
@@ -103,7 +103,7 @@
 		weapon.chambered.BB.damage *= damage_mult
 		weapon.chambered.BB.stamina *= damage_mult
 
-	var/fired = weapon.process_fire(target, shooter)
+	weapon.process_fire(target, shooter)
 	qdel(src)
 
 /datum/component/gunpoint/proc/noshooted()

--- a/code/datums/components/gunpoint.dm
+++ b/code/datums/components/gunpoint.dm
@@ -1,6 +1,6 @@
 #define GUNPOINT_SHOOTER_STRAY_RANGE 3
-#define GUNPOINT_DELAY_STAGE_2 20
-#define GUNPOINT_DELAY_STAGE_3 80 // cumulative with past stages, so 100 deciseconds
+#define GUNPOINT_DELAY_STAGE_2 25
+#define GUNPOINT_DELAY_STAGE_3 85 // cumulative with past stages, so 100 deciseconds
 #define GUNPOINT_MULT_STAGE_1 1
 #define GUNPOINT_MULT_STAGE_2 2
 #define GUNPOINT_MULT_STAGE_3 2.5

--- a/code/datums/components/gunpoint.dm
+++ b/code/datums/components/gunpoint.dm
@@ -137,7 +137,7 @@
 	if(prob(flinch_chance))
 		shooter.visible_message("<span class='danger'>[shooter] flinches!</span>", \
 			"<span class='danger'>You flinch!</span>")
-		trigger_reaction(flinch = TRUE) //flinching will always result in firing at the target
+		trigger_reaction(TRUE) //flinching will always result in firing at the target
 
 /datum/component/gunpoint/proc/flinch_disarm(attacker,zone_targeted)
 	var/mob/living/shooter = parent
@@ -148,13 +148,13 @@
 	if(shooter.held_items[RIGHT_HANDS] == weapon)
 		gun_hand = RIGHT_HANDS
 
-	if((def_zone == BODY_ZONE_L_ARM && gun_hand == LEFT_HANDS) || (def_zone == BODY_ZONE_R_ARM && gun_hand == RIGHT_HANDS))
+	if((zone_targeted == BODY_ZONE_L_ARM && gun_hand == LEFT_HANDS) || (zone_targeted == BODY_ZONE_R_ARM && gun_hand == RIGHT_HANDS))
 		flinch_chance = 80
 
 	if(prob(flinch_chance))
 		shooter.visible_message("<span class='danger'>[shooter] flinches!</span>", \
 			"<span class='danger'>You flinch!</span>")
-		trigger_reaction(flinch = TRUE) //flinching will always result in firing at the target
+		trigger_reaction(TRUE) //flinching will always result in firing at the target
 
 #undef GUNPOINT_SHOOTER_STRAY_RANGE
 #undef GUNPOINT_DELAY_STAGE_2

--- a/code/datums/components/gunpoint.dm
+++ b/code/datums/components/gunpoint.dm
@@ -53,8 +53,8 @@
 
 /datum/component/gunpoint/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, .proc/check_deescalate)
-	RegisterSignal(parent, COMSIG_MOB_APPLY_DAMAGE), .proc/flinch)
-	RegisterSignal(parent, COMSIG_HUMAN_DISARM_HIT), .proc/flinch_disarm)
+	RegisterSignal(parent, COMSIG_MOB_APPLY_DAMAGE, .proc/flinch)
+	RegisterSignal(parent, COMSIG_HUMAN_DISARM_HIT, .proc/flinch_disarm)
 	RegisterSignal(parent, list(COMSIG_MOVABLE_BUMP, COMSIG_MOB_THROW, COMSIG_MOB_FIRED_GUN, COMSIG_MOB_TABLING), .proc/noshooted)
 
 /datum/component/gunpoint/UnregisterFromParent()


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

immobilize from 0.2 seconds to 1 second
added a check for disarms triggering flinching
makes any attacks from the target trigger holdup i.e. disarms or melee attacks rather than relying on flinching
holdup now applies to stamina secondary damage i.e. detective's revolver or beanbag rounds

### Why is this change good for the game?
improves a system meant to make people not shoot other people nearly as much

# Changelog

:cl:  
tweak: holdup is now more responsive and has a longer immobilize  
/:cl:
