### PR TITLE
Fixes Perma Shambler's Vendor Not Being Usable by Perma Prisoners

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -16274,11 +16274,6 @@
 "aTQ" = (
 /turf/closed/wall,
 /area/bridge)
-"aUg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/cola/shamblers/prison,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aUh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62588,6 +62583,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"xrc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/cola/shamblers/prison{
+	onstation = 0
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "xrs" = (
 /obj/machinery/requests_console{
 	department = "AI";
@@ -89450,7 +89452,7 @@ aYN
 dxV
 uNu
 aat
-aUg
+xrc
 sQI
 qQV
 qQV


### PR DESCRIPTION
# Heerführer Documentation

### Intent of your Pull Request

Fixes perma Shambler's Vendor not being usable by Perma Prisoners.

### Why is this change good for the game?

Makes it usable. I think they shouldn't have gotten any damn vending machine other than the sustenance vendor imo but bugs are bugs.

# Wiki Documentation

Image of perma has to be updated. Not because of changes made in this PR, the picture is just fucking out of date!

# Changelog

:cl:  
bugfix: Makes perma shambler's juice machine usable.  
/:cl:
