### PR TITLE
remove burst fire from WT  rifle

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -89,7 +89,6 @@
 	mag_type = /obj/item/ammo_box/magazine/wt550m9
 	fire_delay = 2
 	can_suppress = FALSE
-	burst_size = 2
 	can_bayonet = TRUE
 	knife_x_offset = 25
 	knife_y_offset = 12


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

waa

### Why is this change good for the game?
I can't touch this shit without people starting bonfires so fine it goes back to being "balanced" with the ammo being the important bit
# Wiki Documentation
WT-550 rifle is back to no burst fire if anyone bothered to update that

# Changelog


:cl:  
tweak: WT rifles no longer have a 2 round burst
/:cl:
