### PR TITLE
darkspawn progenitors are immune to magic

### DIFF
--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_progenitor.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_progenitor.dm
@@ -33,6 +33,7 @@
 
 /mob/living/simple_animal/hostile/darkspawn_progenitor/Initialize()
 	. = ..()
+	ADD_TRAIT(src, TRAIT_ANTIMAGIC, "ohgodohfuck")
 	ADD_TRAIT(src, TRAIT_HOLY, "ohgodohfuck") //sorry no magic
 	alpha = 0
 	animate(src, alpha = 255, time = 10)


### PR DESCRIPTION
intended, somehow added holy instead like a doofus
:cl:  
bugfix: darkspawn progenitors can no longer be mindswapped or staff of died
/:cl:
