### PR TITLE
adds a small minimum playercount to  heretics since it doesn't work work well on hyperlowpop

### DIFF
--- a/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
+++ b/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
@@ -6,7 +6,7 @@
 	false_report_weight = 5
 	protected_jobs = list("Chaplain","Security Officer", "Warden", "Detective", "Head of Security", "Captain")
 	restricted_jobs = list("AI", "Cyborg")
-	required_players = 0
+	required_players = 10
 	required_enemies = 1
 	recommended_enemies = 4
 	reroll_friendly = 1


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

what are you gonna do for your sacrifice 6 dude objective if there are not 6 dude

### Why is this change good for the game?
gamemodes should be completable at the population they are able to roll at

# Changelog

:cl:  
tweak: heretics can now only be rolled at pop counts of 10 and above
/:cl:
