### PR TITLE
Changes YogsMeta to have 4500 kPa air to distro

### DIFF
--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -41044,12 +41044,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"bCr" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Waste to Filter"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "bCs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -41757,13 +41751,6 @@
 "bDW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"bDX" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Mix to Filter"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -73444,6 +73431,25 @@
 "eaC" = (
 /turf/open/space/basic,
 /area/space/nearstation)
+"eaN" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Air to Distro";
+	target_pressure = 4500
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics - Distro Loop"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/engine/atmos)
 "ebD" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 6
@@ -74414,6 +74420,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"fPJ" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Mix to Filter";
+	target_pressure = 4500
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "fQe" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -75715,6 +75729,28 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
+"inh" = (
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "O2 to Airmix";
+	target_pressure = 4500
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "ioB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -75973,25 +76009,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"iOP" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Air to Distro";
-	target_pressure = 4500
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics - Distro Loop"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
-/area/engine/atmos)
 "iPn" = (
 /obj/structure/chair{
 	dir = 4
@@ -77337,6 +77354,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"lDL" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "External Waste Ports to Filter";
+	target_pressure = 4500
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "lEu" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -77828,6 +77858,13 @@
 /obj/effect/landmark/stationroom/maint/fivexthree,
 /turf/template_noop,
 /area/maintenance/fore)
+"mRu" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Waste to Filter";
+	target_pressure = 4500
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "mTv" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -78063,6 +78100,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"nuF" = (
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Nitrogen Outlet";
+	target_pressure = 4500
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "nwS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -78086,28 +78145,6 @@
 /mob/living/simple_animal/sloth/citrus,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"nAf" = (
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Nitrogen Outlet";
-	target_pressure = 4500
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "nAo" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -79082,22 +79119,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"pFw" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Air to External Air Ports";
-	target_pressure = 4500
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
-/area/engine/atmos)
 "pGm" = (
 /obj/item/caution,
 /obj/effect/landmark/blobstart,
@@ -81620,20 +81641,6 @@
 /obj/machinery/vending/assist,
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
-"uxg" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "N2 to Airmix";
-	target_pressure = 4500
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "uyj" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -81718,18 +81725,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
-"uIx" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "External Waste Ports to Filter"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "uIZ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -82469,6 +82464,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"wiv" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "N2 to Airmix";
+	target_pressure = 4500
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "wiZ" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock";
@@ -83257,28 +83266,6 @@
 "xVl" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
-"xVK" = (
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "O2 to Airmix";
-	target_pressure = 4500
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "xYj" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/turf_decal/tile/neutral{
@@ -83320,6 +83307,22 @@
 /obj/effect/landmark/start/janitor,
 /turf/open/floor/plating,
 /area/janitor)
+"yar" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Air to External Air Ports";
+	target_pressure = 4500
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/engine/atmos)
 "yeQ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/captain,
@@ -124860,7 +124863,7 @@ bjA
 bet
 bCh
 bFL
-pFw
+yar
 bIO
 bKv
 bMb
@@ -125116,7 +125119,7 @@ ceP
 bIP
 ceT
 bHu
-uIx
+lDL
 bIT
 bKx
 bNQ
@@ -125131,7 +125134,7 @@ cex
 cey
 ebD
 bMg
-nAf
+nuF
 ccP
 czN
 cfv
@@ -125386,7 +125389,7 @@ bxd
 bUA
 bVK
 bXk
-uxg
+wiv
 bZH
 cbg
 ccQ
@@ -125886,7 +125889,7 @@ bxc
 kyR
 bkY
 bAJ
-bCr
+mRu
 bjB
 bza
 bKB
@@ -126159,7 +126162,7 @@ bFQ
 bXm
 myZ
 bZJ
-xVK
+inh
 ccP
 czN
 cfw
@@ -126400,7 +126403,7 @@ bxc
 ayG
 bAL
 ddF
-bDX
+fPJ
 bFR
 bHx
 bIU
@@ -127168,7 +127171,7 @@ aNC
 aTq
 iYE
 bxc
-iOP
+eaN
 bhF
 bCv
 bEa

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -29916,24 +29916,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"bgJ" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Air to Distro"
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics - Distro Loop"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
-/area/engine/atmos)
 "bgK" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -43454,21 +43436,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"bHt" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Air to External Air Ports"
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
-/area/engine/atmos)
 "bHu" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -52742,27 +52709,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"cbf" = (
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Nitrogen Outlet"
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "cbg" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -52800,27 +52746,6 @@
 /obj/structure/window/reinforced,
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"cbj" = (
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "O2 to Airmix"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -73318,19 +73243,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
-"dEP" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "N2 to Airmix"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "dFq" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -76061,6 +75973,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"iOP" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Air to Distro";
+	target_pressure = 4500
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics - Distro Loop"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/engine/atmos)
 "iPn" = (
 /obj/structure/chair{
 	dir = 4
@@ -78155,6 +78086,28 @@
 /mob/living/simple_animal/sloth/citrus,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"nAf" = (
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Nitrogen Outlet";
+	target_pressure = 4500
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "nAo" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -79129,6 +79082,22 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"pFw" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Air to External Air Ports";
+	target_pressure = 4500
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/engine/atmos)
 "pGm" = (
 /obj/item/caution,
 /obj/effect/landmark/blobstart,
@@ -81651,6 +81620,20 @@
 /obj/machinery/vending/assist,
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
+"uxg" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "N2 to Airmix";
+	target_pressure = 4500
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "uyj" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -83274,6 +83257,28 @@
 "xVl" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
+"xVK" = (
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "O2 to Airmix";
+	target_pressure = 4500
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "xYj" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/turf_decal/tile/neutral{
@@ -124855,7 +124860,7 @@ bjA
 bet
 bCh
 bFL
-bHt
+pFw
 bIO
 bKv
 bMb
@@ -125126,7 +125131,7 @@ cex
 cey
 ebD
 bMg
-cbf
+nAf
 ccP
 czN
 cfv
@@ -125381,7 +125386,7 @@ bxd
 bUA
 bVK
 bXk
-dEP
+uxg
 bZH
 cbg
 ccQ
@@ -126154,7 +126159,7 @@ bFQ
 bXm
 myZ
 bZJ
-cbj
+xVK
 ccP
 czN
 cfw
@@ -127163,7 +127168,7 @@ aNC
 aTq
 iYE
 bxc
-bgJ
+iOP
 bhF
 bCv
 bEa

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -74365,6 +74365,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"fKJ" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Waste to Filter";
+	target_pressure = 101.325
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "fNa" = (
 /obj/structure/chair{
 	dir = 4
@@ -74420,14 +74427,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"fPJ" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Mix to Filter";
-	target_pressure = 4500
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "fQe" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -75334,6 +75333,19 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/aisat)
+"hxX" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "External Waste Ports to Filter";
+	target_pressure = 101.325
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "hyP" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Two"
@@ -75916,6 +75928,14 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"iDI" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Mix to Filter";
+	target_pressure = 101.325
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "iDY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -77354,19 +77374,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"lDL" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "External Waste Ports to Filter";
-	target_pressure = 4500
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "lEu" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -77858,13 +77865,6 @@
 /obj/effect/landmark/stationroom/maint/fivexthree,
 /turf/template_noop,
 /area/maintenance/fore)
-"mRu" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Waste to Filter";
-	target_pressure = 4500
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "mTv" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -125119,7 +125119,7 @@ ceP
 bIP
 ceT
 bHu
-lDL
+hxX
 bIT
 bKx
 bNQ
@@ -125889,7 +125889,7 @@ bxc
 kyR
 bkY
 bAJ
-mRu
+fKJ
 bjB
 bza
 bKB
@@ -126403,7 +126403,7 @@ bxc
 ayG
 bAL
 ddF
-fPJ
+iDI
 bFR
 bHx
 bIU

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -74365,13 +74365,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"fKJ" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Waste to Filter";
-	target_pressure = 101.325
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "fNa" = (
 /obj/structure/chair{
 	dir = 4
@@ -75333,19 +75326,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/aisat)
-"hxX" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "External Waste Ports to Filter";
-	target_pressure = 101.325
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "hyP" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Two"
@@ -75579,6 +75559,18 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/toilet/auxiliary)
+"hVv" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "External Waste Ports to Filter"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "hWi" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -75928,14 +75920,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"iDI" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Mix to Filter";
-	target_pressure = 101.325
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "iDY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -81092,6 +81076,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopods)
+"tyH" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Waste to Filter"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "tzg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -81672,6 +81662,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"uGf" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Mix to Filter"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "uGm" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -125119,7 +125116,7 @@ ceP
 bIP
 ceT
 bHu
-hxX
+hVv
 bIT
 bKx
 bNQ
@@ -125889,7 +125886,7 @@ bxc
 kyR
 bkY
 bAJ
-fKJ
+tyH
 bjB
 bza
 bKB
@@ -126403,7 +126400,7 @@ bxc
 ayG
 bAL
 ddF
-iDI
+uGf
 bFR
 bHx
 bIU


### PR DESCRIPTION
#### Read our contributing.md if you haven't already: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md

# General Documentation

### Intent of your Pull Request

Brings YogsMeta further up to YogStation standards by having the distro be pressurized at 4500 kPa because it still had the "everything set to 101" pressure. Doesn't change ones that are not on at round start.

### Why is this change good for the game?

It isn't, YogsMeta sucks and I'm only helping change it so people dont cryo on round start.

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 

Maybe the atmos wiki entry but it's already not updated

### What should players be aware of when it comes to the changes your PR is implementing?

Nobody sets the distro pressure anyway because they dont have to on YogsStation, so nothing will change except the pipes will actually be PRESSURIZED.

### What general grouping does this PR fall under? 
Atmos tweak

# Changelog

:cl:  
tweak: set active pump pressure to 4500 in yogsmeta atmos distro
/:cl:
