### PR TITLE
Blob Buff?? (Up for discussion)

### DIFF
--- a/code/modules/antagonists/blob/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob_mobs.dm
@@ -201,7 +201,7 @@
 	icon_living = "blobbernaut"
 	icon_dead = "blobbernaut_dead"
 	health = 200
-	maxHealth = 200
+	maxHealth = 300
 	damage_coeff = list(BRUTE = 0.5, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
 	melee_damage_lower = 20
 	melee_damage_upper = 20

--- a/code/modules/antagonists/blob/powers.dm
+++ b/code/modules/antagonists/blob/powers.dm
@@ -338,9 +338,9 @@
 
 /mob/camera/blob/verb/strain_reroll()
 	set category = "Blob"
-	set name = "Reactive Strain Adaptation (40)"
+	set name = "Reactive Strain Adaptation (15)"
 	set desc = "Replaces your strain with a random, different one."
-	if(!rerolling && (free_strain_rerolls || can_buy(40)))
+	if(!rerolling && (free_strain_rerolls || can_buy(15)))
 		rerolling = TRUE
 		reroll_strain()
 		rerolling = FALSE


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

To buff the bob. Blob was a start of the round antagonist then was moved to mid-round. Blob has a hard time going up against crew when blob appears. This is due to blob appearing after the crew has mechs and the entire tech tree at their disposal. Max health increased for blobernaught from 200 to 300 meaning that blobernaught will need to stay in the blob to get to his full health. Strain re-roll cost 15 down from 40 is pretty self-explanatory

Other ideas I have are things such as making the message of level 5 biohazard take longer to appear based of how long the round has been going on and other factors. No idea how to do this though

### Why is this change good for the game?

Blob is underpowered and this is my attempt to change that.

# Wiki Documentation

Max health increased for blobernaught to 300 from 200.
Strain re-roll cost 15 down from 40

### What general grouping does this PR fall under? 

Antag rebalance

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 

Max health increased for blobernaught to 300 from 200
Strain re-roll cost 15 down from 40

# Changelog

:cl:  
experimental: Max health increased for blobernaught from 200 to 300
experimental: Strain re-roll cost 15 down from 40
/:cl:
