### PR TITLE
Removes Firelocks from the gallery in Library, Resizes it, Adds Decals in the Rear.

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -9323,6 +9323,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"azd" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/wood,
+/area/library)
 "aze" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -12693,12 +12701,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
-"aIx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/wood,
-/area/library)
 "aIy" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -14164,18 +14166,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"aMU" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/library)
 "aMV" = (
 /obj/structure/bed,
 /obj/item/bedsheet/captain,
@@ -16277,11 +16267,6 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/wood,
 /area/vacant_room)
-"aUC" = (
-/obj/structure/chair/comfy/black,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/wood,
-/area/library)
 "aUD" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -21578,10 +21563,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/heads/captain)
-"bmB" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/wood,
-/area/library)
 "bmC" = (
 /obj/structure/sink{
 	dir = 4;
@@ -28731,6 +28712,17 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"bOi" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/library)
 "bOm" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -29573,6 +29565,17 @@
 /obj/structure/closet/l3closet/scientist,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"bSi" = (
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_y = 32
+	},
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_x = -32
+	},
+/turf/open/floor/carpet,
+/area/library)
 "bSj" = (
 /obj/machinery/light{
 	dir = 8
@@ -32273,6 +32276,11 @@
 /obj/structure/transit_tube/diagonal/topleft,
 /turf/open/space/basic,
 /area/space/nearstation)
+"css" = (
+/obj/machinery/vending/games,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/library)
 "csy" = (
 /obj/structure/table,
 /obj/item/weldingtool,
@@ -32992,6 +33000,21 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"cGo" = (
+/obj/structure/table/wood,
+/obj/item/pen{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/flashlight/lamp/green{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/library)
 "cGS" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
@@ -34278,6 +34301,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"dob" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/light/small,
+/turf/open/floor/wood,
+/area/library)
 "doh" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -35194,14 +35224,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
-"dTu" = (
-/obj/structure/chair/office/dark,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/library)
 "dTz" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -35255,6 +35277,10 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"dVK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/library)
 "dVR" = (
 /obj/machinery/computer/cloning{
 	dir = 8
@@ -35292,12 +35318,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"dXc" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/library)
 "dXk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -35382,11 +35402,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"ecA" = (
-/obj/machinery/vending/games,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/library)
 "edp" = (
 /obj/structure/chair{
 	dir = 4
@@ -35528,19 +35543,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"ekq" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/item/stack/packageWrap,
-/obj/machinery/camera{
-	c_tag = "Library North"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/library)
 "ekT" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -36356,12 +36358,6 @@
 "eLu" = (
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"eMj" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/library)
 "eMZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -36394,6 +36390,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"eNj" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/vending/coffee,
+/turf/open/floor/wood,
+/area/library)
 "eNr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -36587,16 +36590,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"eUp" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/wood,
-/area/library)
 "eUx" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -36677,13 +36670,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"eWm" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/library)
 "eWE" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -37095,12 +37081,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"fmk" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/library)
 "fmw" = (
 /obj/machinery/camera{
 	c_tag = "Bridge East Entrance"
@@ -37214,13 +37194,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/processing)
-"foV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/library)
 "fpj" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -37614,6 +37587,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
+"fGL" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/library)
 "fHi" = (
 /obj/machinery/computer/security/telescreen{
 	name = "Test Chamber Monitor";
@@ -38240,14 +38223,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
-"giF" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/turf/open/floor/wood,
-/area/library)
 "giN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -38873,6 +38848,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"gFh" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/library)
 "gFO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -39344,6 +39333,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"hcB" = (
+/obj/structure/table/wood,
+/obj/item/pen/red,
+/obj/item/pen/blue{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/library)
 "hcE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39457,6 +39456,10 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
+"hkb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall,
+/area/library)
 "hkX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -39632,6 +39635,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"hrV" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/library)
 "hsK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -40295,6 +40311,13 @@
 	},
 /turf/open/floor/plating,
 /area/security/processing)
+"hKu" = (
+/obj/structure/table/wood,
+/obj/item/camera_film,
+/obj/item/camera_film,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/library)
 "hKY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -41195,9 +41218,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"iqz" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
+"iqV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/carpet,
 /area/library)
 "irc" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -41744,6 +41768,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"iGK" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/chair/office/dark,
+/obj/effect/landmark/start/assistant,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/library)
 "iHb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -42425,6 +42456,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/tcoms)
+"jha" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/library)
 "jhe" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance";
@@ -43031,6 +43068,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos_distro)
+"jyJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/library)
 "jzb" = (
 /obj/effect/landmark/start/cyborg,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -43158,17 +43210,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"jFo" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/library)
 "jFA" = (
 /obj/structure/sign/departments/minsky/command/charge{
 	pixel_x = 32
@@ -44259,21 +44300,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"kvY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/wood,
-/area/library)
 "kvZ" = (
 /obj/machinery/button/door{
 	id = "AI Core shutters";
@@ -44619,18 +44645,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"kHi" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/turf/open/floor/wood,
-/area/library)
 "kHj" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/small{
@@ -44727,6 +44741,16 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/storage/tech)
+"kMF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/wood,
+/area/library)
 "kMZ" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable{
@@ -45401,6 +45425,11 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"ljK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/carpet,
+/area/library)
 "lkh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -45413,6 +45442,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"lkz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/wood,
+/area/library)
 "lkF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -45646,6 +45690,12 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"ltF" = (
+/obj/structure/table/wood,
+/obj/item/paper,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/library)
 "ltQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -47089,6 +47139,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"mBT" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/library)
 "mCg" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Port Quarter Solar Access";
@@ -47178,21 +47237,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/tcoms)
-"mDS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/library)
 "mEh" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -47362,6 +47406,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"mKS" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/library)
 "mLa" = (
 /obj/machinery/shower{
 	dir = 8
@@ -48268,6 +48322,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos_distro)
+"nkT" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/stack/packageWrap,
+/obj/machinery/camera{
+	c_tag = "Library North"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/library)
 "nlx" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -48712,19 +48779,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/service)
-"nAb" = (
-/obj/structure/table/wood,
-/obj/item/pen/red,
-/obj/item/pen/blue{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/turf/open/floor/wood,
-/area/library)
-"nAJ" = (
+"nAh" = (
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -26
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -48887,17 +48948,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
-"nGW" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/obj/structure/sign/painting{
-	persistence_id = "public";
-	pixel_x = -32
-	},
-/turf/open/floor/carpet,
-/area/library)
 "nHb" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -50568,21 +50618,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"oJe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/wood,
-/area/library)
 "oJh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -50602,8 +50637,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"oKP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+"oKO" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/library)
 "oLx" = (
@@ -51003,10 +51041,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"oWA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/carpet,
-/area/library)
 "oXp" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -51448,21 +51482,21 @@
 /obj/item/stamp/cmo,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"pvp" = (
-/obj/structure/sign/painting{
-	persistence_id = "public";
-	pixel_x = -32
-	},
-/obj/structure/sign/painting{
-	persistence_id = "public";
-	pixel_y = 32
-	},
-/turf/open/floor/carpet,
-/area/library)
 "pvF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"pvJ" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_x = -32
+	},
+/turf/open/floor/carpet,
+/area/library)
 "pwa" = (
 /obj/machinery/light{
 	dir = 8
@@ -54245,10 +54279,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"rpr" = (
-/obj/machinery/light/small,
-/turf/open/floor/wood,
-/area/library)
 "rqx" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow{
@@ -55886,13 +55916,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"szF" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/chair/office/dark,
-/obj/effect/landmark/start/assistant,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/library)
 "szP" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/britcup{
@@ -56432,6 +56455,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"sWQ" = (
+/obj/structure/chair/office/dark,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/library)
 "sWS" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -57192,6 +57223,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"two" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/wood,
+/area/library)
 "twv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -57420,6 +57466,13 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
+"tGM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/library)
 "tHl" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -58157,18 +58210,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"ueC" = (
-/obj/structure/table/wood,
-/obj/item/pen{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/obj/item/flashlight/lamp/green{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/turf/open/floor/wood,
-/area/library)
 "ueD" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -58196,6 +58237,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"ueN" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/library)
 "ufr" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -58223,15 +58276,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
-"uhO" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/wood,
-/area/library)
 "uhU" = (
 /obj/structure/sign/painting{
 	persistence_id = "public";
@@ -58289,11 +58333,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"ulp" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/carpet,
-/area/library)
 "ulz" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Three";
@@ -58943,6 +58982,12 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plating,
 /area/security/prison)
+"uFq" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/wood,
+/area/library)
 "uGQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -59616,11 +59661,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"vds" = (
-/obj/structure/table/wood,
-/obj/item/paper,
-/turf/open/floor/wood,
-/area/library)
 "vdA" = (
 /obj/structure/table,
 /obj/item/hand_labeler,
@@ -59912,6 +59952,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"von" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/library)
 "voB" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
@@ -60684,12 +60730,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"vSV" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/wood,
-/area/library)
 "vTi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -61328,6 +61368,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"woU" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/library)
 "wpY" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine/vacuum,
@@ -61678,12 +61727,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"wzv" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/library)
 "wAc" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/atmospherics/miner/toxins,
@@ -61864,12 +61907,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/janitor)
-"wFb" = (
-/obj/structure/table/wood,
-/obj/item/camera_film,
-/obj/item/camera_film,
-/turf/open/floor/wood,
-/area/library)
 "wFe" = (
 /obj/structure/transit_tube/junction{
 	dir = 4
@@ -62135,6 +62172,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"wSM" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/library)
 "wTx" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -62563,6 +62605,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"xml" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/library)
 "xne" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -63000,6 +63047,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"xCi" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/library)
+"xCm" = (
+/obj/machinery/vending/coffee,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/library)
 "xCq" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -108102,18 +108168,18 @@ gJh
 aGW
 aFu
 aPb
-eWm
+oKO
 aRN
-wzv
+oKO
 aPd
-jFo
-aFu
-pvp
+hkb
+bSi
 bLO
 idq
 idq
 idq
-nGW
+idq
+pvJ
 idq
 bbD
 aYV
@@ -108359,16 +108425,16 @@ aEH
 iAC
 aFu
 aPb
-iqz
+dVK
 aRN
 aIt
 aPd
-aIt
 aFu
 uhU
+aYW
 eBi
-oWA
-ulp
+iqV
+ljK
 bjK
 wxd
 wxd
@@ -108616,13 +108682,13 @@ aGW
 ioY
 aFu
 aIt
-aIt
 aKQ
 aIt
 jQY
 aIt
 aFu
 uhU
+aYW
 aYW
 aYW
 aYW
@@ -108873,13 +108939,13 @@ aFe
 aGQ
 bNw
 aPP
-aMU
 qbI
-aPP
+ueN
 qfi
-kvY
+lkz
 aFu
 uhU
+aYW
 wJG
 ffH
 aYW
@@ -109129,20 +109195,20 @@ aCC
 aFh
 aFu
 aFu
-szF
+iGK
 aLg
 aLg
 aOS
-aIt
-mDS
+jyJ
 aFu
-rpr
+von
+dob
 aFu
 aFu
-fmk
+mKS
 foa
 aYW
-bmB
+xCm
 aFu
 bTc
 pSv
@@ -109385,21 +109451,21 @@ alP
 alP
 aFh
 aFu
-ecA
-dTu
+css
+sWQ
 aLg
 aLg
 aOS
-aIt
-oJe
-kHi
+two
+gFh
+aPP
 aXX
 aXX
 aXX
-uhO
+fGL
 fIe
 aYW
-eUp
+hrV
 aFu
 qoE
 oUe
@@ -109642,21 +109708,21 @@ eCa
 alP
 aFh
 aFu
-ekq
-foV
+nkT
+tGM
 aJR
 aJR
 aIt
 aIt
 aIt
 aIt
+aLg
 aRO
 aRO
-aUC
-vds
+ltF
 bcl
 aYW
-ueC
+cGo
 bbD
 aYV
 oUe
@@ -109899,21 +109965,21 @@ syq
 qFC
 aFh
 aFu
-vSV
-aIx
+uFq
+kMF
 aJF
 aLh
 aIr
 aNV
 aNS
 aIt
+jha
 aRO
 aRO
-aIt
-dXc
+azd
 bcl
 aXV
-dXc
+mBT
 aFu
 lpU
 dSv
@@ -110167,10 +110233,10 @@ aQq
 aRP
 aIt
 aIt
-oKP
+xml
 bct
 aLL
-aIt
+eNj
 bbD
 aYV
 aXq
@@ -110424,10 +110490,10 @@ aFu
 aFu
 aTc
 aUD
-wFb
+hKu
 aYW
 aYW
-eMj
+woU
 aFu
 aYV
 aXq
@@ -110681,10 +110747,10 @@ aQr
 aFu
 aTb
 exz
-nAb
+hcB
 aYW
 aYW
-aUD
+bOi
 bbD
 aYV
 aXq
@@ -110938,10 +111004,10 @@ aQt
 aRQ
 aIt
 aUF
-aLg
+wSM
 aYW
 aYW
-dXc
+mBT
 aFu
 aYV
 aXq
@@ -111195,10 +111261,10 @@ aQs
 aFu
 aTd
 eUm
-giF
+xCi
 aYW
 aYW
-nAJ
+nAh
 aFu
 aYV
 aXq

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -12151,15 +12151,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"aHc" = (
-/obj/machinery/vending/games,
-/turf/open/floor/wood,
-/area/library)
-"aHd" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/wood,
-/area/library)
 "aHe" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical{
@@ -12702,12 +12693,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
-"aIv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/library)
 "aIx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -21593,6 +21578,10 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/heads/captain)
+"bmB" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/wood,
+/area/library)
 "bmC" = (
 /obj/structure/sink{
 	dir = 4;
@@ -28742,17 +28731,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"bOi" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/library)
 "bOm" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -32912,13 +32890,6 @@
 	},
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
-"cCy" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
-/area/library)
 "cCF" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -34242,12 +34213,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"dmj" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/library)
 "dmv" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -35229,6 +35194,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
+"dTu" = (
+/obj/structure/chair/office/dark,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/library)
 "dTz" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -35319,6 +35292,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"dXc" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/library)
 "dXk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -35403,6 +35382,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"ecA" = (
+/obj/machinery/vending/games,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/library)
 "edp" = (
 /obj/structure/chair{
 	dir = 4
@@ -35544,6 +35528,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"ekq" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/stack/packageWrap,
+/obj/machinery/camera{
+	c_tag = "Library North"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/library)
 "ekT" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -36359,6 +36356,12 @@
 "eLu" = (
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"eMj" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/library)
 "eMZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -36584,6 +36587,16 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"eUp" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/wood,
+/area/library)
 "eUx" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -36664,6 +36677,13 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"eWm" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/library)
 "eWE" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -37075,6 +37095,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"fmk" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/library)
 "fmw" = (
 /obj/machinery/camera{
 	c_tag = "Bridge East Entrance"
@@ -37188,6 +37214,13 @@
 	},
 /turf/open/floor/plating,
 /area/security/processing)
+"foV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/library)
 "fpj" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -37581,16 +37614,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
-"fGL" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
-/area/library)
 "fHi" = (
 /obj/machinery/computer/security/telescreen{
 	name = "Test Chamber Monitor";
@@ -38217,6 +38240,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"giF" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/turf/open/floor/wood,
+/area/library)
 "giN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -39313,16 +39344,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"hcB" = (
-/obj/structure/table/wood,
-/obj/item/pen/red,
-/obj/item/pen/blue{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
-/area/library)
 "hcE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39413,19 +39434,6 @@
 /obj/item/twohanded/rcl/pre_loaded,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"hhc" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/machinery/light/small,
-/turf/open/floor/wood,
-/area/library)
 "hhA" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -39624,19 +39632,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"hrV" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/library)
 "hsK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -40300,13 +40295,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/processing)
-"hKu" = (
-/obj/structure/table/wood,
-/obj/item/camera_film,
-/obj/item/camera_film,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
-/area/library)
 "hKY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -41034,18 +41022,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"ikC" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/item/stack/packageWrap,
-/obj/machinery/camera{
-	c_tag = "Library North"
-	},
-/turf/open/floor/wood,
-/area/library)
 "ild" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -41219,6 +41195,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"iqz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/library)
 "irc" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -42173,16 +42153,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"iVh" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/library)
 "iVk" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -43188,6 +43158,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"jFo" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/library)
 "jFA" = (
 /obj/structure/sign/departments/minsky/command/charge{
 	pixel_x = 32
@@ -45637,24 +45618,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"lsl" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/library)
 "lsn" = (
 /obj/machinery/light,
 /turf/open/floor/engine,
@@ -45683,12 +45646,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"ltF" = (
-/obj/structure/table/wood,
-/obj/item/paper,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
-/area/library)
 "ltQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -45776,13 +45733,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/detectives_office)
-"lxw" = (
-/obj/structure/chair/office/dark,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/library)
 "lxz" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -46357,27 +46307,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"lYq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/library)
 "lYK" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -47160,15 +47089,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"mBT" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/library)
 "mCg" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Port Quarter Solar Access";
@@ -48792,13 +48712,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/service)
-"nAh" = (
+"nAb" = (
+/obj/structure/table/wood,
+/obj/item/pen/red,
+/obj/item/pen/blue{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/wood,
+/area/library)
+"nAJ" = (
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -26
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -48961,6 +48887,17 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
+"nGW" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_x = -32
+	},
+/turf/open/floor/carpet,
+/area/library)
 "nHb" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -50665,6 +50602,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"oKP" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/wood,
+/area/library)
 "oLx" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
@@ -54205,19 +54146,6 @@
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"rld" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/turf/open/floor/wood,
-/area/library)
 "rlB" = (
 /obj/machinery/status_display/evac{
 	layer = 4;
@@ -54317,6 +54245,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"rpr" = (
+/obj/machinery/light/small,
+/turf/open/floor/wood,
+/area/library)
 "rqx" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow{
@@ -55954,6 +55886,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"szF" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/chair/office/dark,
+/obj/effect/landmark/start/assistant,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/library)
 "szP" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/britcup{
@@ -58218,6 +58157,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"ueC" = (
+/obj/structure/table/wood,
+/obj/item/pen{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/flashlight/lamp/green{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/turf/open/floor/wood,
+/area/library)
 "ueD" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -58272,6 +58223,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
+"uhO" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/wood,
+/area/library)
 "uhU" = (
 /obj/structure/sign/painting{
 	persistence_id = "public";
@@ -58824,15 +58784,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"uAw" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/library)
 "uAL" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -59665,6 +59616,11 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"vds" = (
+/obj/structure/table/wood,
+/obj/item/paper,
+/turf/open/floor/wood,
+/area/library)
 "vdA" = (
 /obj/structure/table,
 /obj/item/hand_labeler,
@@ -60384,21 +60340,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"vFn" = (
-/obj/structure/table/wood,
-/obj/item/pen{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/item/flashlight/lamp/green{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/turf/open/floor/wood,
-/area/library)
 "vFw" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
@@ -60743,6 +60684,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"vSV" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/wood,
+/area/library)
 "vTi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -61381,15 +61328,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"woU" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/library)
 "wpY" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine/vacuum,
@@ -61926,6 +61864,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/janitor)
+"wFb" = (
+/obj/structure/table/wood,
+/obj/item/camera_film,
+/obj/item/camera_film,
+/turf/open/floor/wood,
+/area/library)
 "wFe" = (
 /obj/structure/transit_tube/junction{
 	dir = 4
@@ -62191,11 +62135,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"wSM" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
-/area/library)
 "wTx" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -62624,11 +62563,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"xml" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
-/area/library)
 "xne" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -63066,15 +63000,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"xCi" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
-/area/library)
 "xCq" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -64024,12 +63949,6 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
-"yjc" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/chair/office/dark,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/wood,
-/area/library)
 "yjf" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -108183,18 +108102,18 @@ gJh
 aGW
 aFu
 aPb
-wzv
+eWm
 aRN
 wzv
 aPd
-iVh
+jFo
 aFu
 pvp
 bLO
 idq
 idq
 idq
-bLO
+nGW
 idq
 bbD
 aYV
@@ -108440,7 +108359,7 @@ aEH
 iAC
 aFu
 aPb
-aIt
+iqz
 aRN
 aIt
 aPd
@@ -109210,20 +109129,20 @@ aCC
 aFh
 aFu
 aFu
-yjc
+szF
 aLg
 aLg
 aOS
 aIt
 mDS
 aFu
-hhc
+rpr
 aFu
 aFu
-lsl
-lYq
-uAw
-rld
+fmk
+foa
+aYW
+bmB
 aFu
 bTc
 pSv
@@ -109466,8 +109385,8 @@ alP
 alP
 aFh
 aFu
-aHc
-lxw
+ecA
+dTu
 aLg
 aLg
 aOS
@@ -109477,10 +109396,10 @@ kHi
 aXX
 aXX
 aXX
-fGL
+uhO
 fIe
 aYW
-hrV
+eUp
 aFu
 qoE
 oUe
@@ -109723,8 +109642,8 @@ eCa
 alP
 aFh
 aFu
-ikC
-aIv
+ekq
+foV
 aJR
 aJR
 aIt
@@ -109734,10 +109653,10 @@ aIt
 aRO
 aRO
 aUC
-ltF
+vds
 bcl
 aYW
-vFn
+ueC
 bbD
 aYV
 oUe
@@ -109980,7 +109899,7 @@ syq
 qFC
 aFh
 aFu
-aHd
+vSV
 aIx
 aJF
 aLh
@@ -109991,10 +109910,10 @@ aIt
 aRO
 aRO
 aIt
-cCy
+dXc
 bcl
 aXV
-mBT
+dXc
 aFu
 lpU
 dSv
@@ -110248,10 +110167,10 @@ aQq
 aRP
 aIt
 aIt
-xml
+oKP
 bct
 aLL
-dmj
+aIt
 bbD
 aYV
 aXq
@@ -110505,10 +110424,10 @@ aFu
 aFu
 aTc
 aUD
-hKu
+wFb
 aYW
 aYW
-woU
+eMj
 aFu
 aYV
 aXq
@@ -110762,10 +110681,10 @@ aQr
 aFu
 aTb
 exz
-hcB
+nAb
 aYW
 aYW
-bOi
+aUD
 bbD
 aYV
 aXq
@@ -111019,10 +110938,10 @@ aQt
 aRQ
 aIt
 aUF
-wSM
+aLg
 aYW
 aYW
-mBT
+dXc
 aFu
 aYV
 aXq
@@ -111276,10 +111195,10 @@ aQs
 aFu
 aTd
 eUm
-xCi
+giF
 aYW
 aYW
-nAh
+nAJ
 aFu
 aYV
 aXq

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -9323,14 +9323,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"azd" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/wood,
-/area/library)
 "aze" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -11307,6 +11299,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"aES" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/wood,
+/area/library)
 "aEV" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -29565,17 +29572,6 @@
 /obj/structure/closet/l3closet/scientist,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"bSi" = (
-/obj/structure/sign/painting{
-	persistence_id = "public";
-	pixel_y = 32
-	},
-/obj/structure/sign/painting{
-	persistence_id = "public";
-	pixel_x = -32
-	},
-/turf/open/floor/carpet,
-/area/library)
 "bSj" = (
 /obj/machinery/light{
 	dir = 8
@@ -32276,11 +32272,6 @@
 /obj/structure/transit_tube/diagonal/topleft,
 /turf/open/space/basic,
 /area/space/nearstation)
-"css" = (
-/obj/machinery/vending/games,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/library)
 "csy" = (
 /obj/structure/table,
 /obj/item/weldingtool,
@@ -33000,21 +32991,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"cGo" = (
-/obj/structure/table/wood,
-/obj/item/pen{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/obj/item/flashlight/lamp/green{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/library)
 "cGS" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
@@ -33766,6 +33742,11 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"cTe" = (
+/obj/structure/table/wood,
+/obj/item/paper,
+/turf/open/floor/wood,
+/area/library)
 "cTn" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -34301,13 +34282,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"dob" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/machinery/light/small,
-/turf/open/floor/wood,
-/area/library)
 "doh" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -34435,6 +34409,21 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"dsh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/library)
 "dsr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -35083,6 +35072,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"dPy" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/library)
 "dQG" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -35277,10 +35273,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"dVK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/library)
 "dVR" = (
 /obj/machinery/computer/cloning{
 	dir = 8
@@ -36390,13 +36382,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"eNj" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/vending/coffee,
-/turf/open/floor/wood,
-/area/library)
 "eNr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -37587,16 +37572,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
-"fGL" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
-/area/library)
 "fHi" = (
 /obj/machinery/computer/security/telescreen{
 	name = "Test Chamber Monitor";
@@ -38848,20 +38823,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"gFh" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/library)
 "gFO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -39333,16 +39294,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"hcB" = (
-/obj/structure/table/wood,
-/obj/item/pen/red,
-/obj/item/pen/blue{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
-/area/library)
 "hcE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39456,10 +39407,6 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
-"hkb" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall,
-/area/library)
 "hkX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -39486,6 +39433,21 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
+"hmc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/wood,
+/area/library)
 "hmg" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -40311,13 +40273,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/processing)
-"hKu" = (
-/obj/structure/table/wood,
-/obj/item/camera_film,
-/obj/item/camera_film,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
-/area/library)
 "hKY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -40952,6 +40907,10 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
+"ihg" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/library)
 "ihF" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -41218,11 +41177,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"iqV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/carpet,
-/area/library)
 "irc" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -41768,13 +41722,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"iGK" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/chair/office/dark,
-/obj/effect/landmark/start/assistant,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/library)
 "iHb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41924,6 +41871,16 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"iMC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/wood,
+/area/library)
 "iMM" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -42456,12 +42413,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/tcoms)
-"jha" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/library)
 "jhe" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance";
@@ -43068,21 +43019,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos_distro)
-"jyJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood,
-/area/library)
 "jzb" = (
 /obj/effect/landmark/start/cyborg,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -43495,6 +43431,11 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"jRI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/carpet,
+/area/library)
 "jRV" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/slightlydarkerblue{
@@ -44014,6 +43955,13 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/fore)
+"kjw" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/chair/office/dark,
+/obj/effect/landmark/start/assistant,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/library)
 "kjA" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -44741,16 +44689,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/storage/tech)
-"kMF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/wood,
-/area/library)
 "kMZ" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable{
@@ -45425,11 +45363,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"ljK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/carpet,
-/area/library)
 "lkh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -45442,20 +45375,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"lkz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
+"lkq" = (
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/library)
 "lkF" = (
 /obj/structure/cable{
@@ -45532,6 +45461,12 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"lno" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/library)
 "lnU" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -45690,12 +45625,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"ltF" = (
-/obj/structure/table/wood,
-/obj/item/paper,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
-/area/library)
 "ltQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -45707,6 +45636,11 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"lvg" = (
+/obj/machinery/vending/games,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/library)
 "lvO" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -45958,6 +45892,21 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"lDw" = (
+/obj/structure/table/wood,
+/obj/item/pen{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/flashlight/lamp/green{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/library)
 "lDB" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -46221,6 +46170,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"lMr" = (
+/obj/structure/table/wood,
+/obj/item/pen/red,
+/obj/item/pen/blue{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/wood,
+/area/library)
 "lMK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -46727,6 +46685,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"mnw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/wood,
+/area/library)
 "mnB" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 1
@@ -47406,16 +47373,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"mKS" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
-/area/library)
 "mLa" = (
 /obj/machinery/shower{
 	dir = 8
@@ -48322,19 +48279,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos_distro)
-"nkT" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/item/stack/packageWrap,
-/obj/machinery/camera{
-	c_tag = "Library North"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/library)
 "nlx" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -49177,6 +49121,17 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/janitor)
+"nRE" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_x = -32
+	},
+/turf/open/floor/carpet,
+/area/library)
 "nSs" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -50479,6 +50434,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"oDD" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/turf/open/floor/wood,
+/area/library)
 "oEb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -50561,6 +50524,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/service)
+"oHC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall,
+/area/library)
 "oHG" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -50637,13 +50604,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"oKO" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/library)
 "oLx" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
@@ -50963,6 +50923,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"oUj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/wood,
+/area/library)
 "oUG" = (
 /obj/machinery/requests_console{
 	department = "Security";
@@ -51486,17 +51450,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"pvJ" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/obj/structure/sign/painting{
-	persistence_id = "public";
-	pixel_x = -32
-	},
-/turf/open/floor/carpet,
-/area/library)
 "pwa" = (
 /obj/machinery/light{
 	dir = 8
@@ -53624,6 +53577,13 @@
 "qQV" = (
 /turf/template_noop,
 /area/template_noop)
+"qRK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/library)
 "qRN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -54474,6 +54434,16 @@
 /obj/structure/sign/departments/minsky/research/research,
 /turf/closed/wall/r_wall,
 /area/science/lab)
+"rym" = (
+/obj/machinery/vending/coffee,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/library)
 "ryP" = (
 /obj/structure/chair/stool,
 /obj/item/clothing/under/lawyer/blacksuit,
@@ -55892,6 +55862,13 @@
 "syq" = (
 /turf/template_noop,
 /area/maintenance/starboard/fore)
+"syF" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/vending/coffee,
+/turf/open/floor/wood,
+/area/library)
 "syX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -56455,14 +56432,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"sWQ" = (
-/obj/structure/chair/office/dark,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/library)
 "sWS" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -57223,21 +57192,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"two" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/wood,
-/area/library)
 "twv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -57466,13 +57420,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
-"tGM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/library)
 "tHl" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -58179,6 +58126,12 @@
 /obj/effect/landmark/stationroom/maint/threexthree,
 /turf/template_noop,
 /area/maintenance/port)
+"ucr" = (
+/obj/structure/table/wood,
+/obj/item/camera_film,
+/obj/item/camera_film,
+/turf/open/floor/wood,
+/area/library)
 "ucZ" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -58237,18 +58190,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"ueN" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/library)
 "ufr" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -58306,6 +58247,18 @@
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
+"ujG" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/library)
 "ujZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -58333,6 +58286,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"ulu" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/wood,
+/area/library)
 "ulz" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Three";
@@ -58982,12 +58942,6 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plating,
 /area/security/prison)
-"uFq" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/wood,
-/area/library)
 "uGQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -59547,6 +59501,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"uZz" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/stack/packageWrap,
+/obj/machinery/camera{
+	c_tag = "Library North"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/library)
 "uZH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -59699,6 +59666,14 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
+"vem" = (
+/obj/structure/chair/office/dark,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/library)
 "vfF" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -59759,6 +59734,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"vhP" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/wood,
+/area/library)
 "vhQ" = (
 /obj/machinery/light_switch{
 	pixel_x = -3;
@@ -59952,12 +59933,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"von" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/library)
 "voB" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
@@ -60145,6 +60120,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"vvZ" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/library)
 "vwa" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
@@ -61548,6 +61537,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"wvr" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/library)
 "wvu" = (
 /obj/structure/table,
 /obj/item/stock_parts/cell/potato{
@@ -61935,6 +61930,11 @@
 /obj/item/stock_parts/cell/high/plus,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"wGr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/carpet,
+/area/library)
 "wHY" = (
 /obj/structure/cable/white{
 	icon_state = "1-8"
@@ -62172,11 +62172,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"wSM" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
-/area/library)
 "wTx" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -62605,11 +62600,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"xml" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
-/area/library)
 "xne" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -62874,6 +62864,10 @@
 /obj/effect/variation/box/sec/brig_cell/perma,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"xvM" = (
+/obj/machinery/light/small,
+/turf/open/floor/wood,
+/area/library)
 "xvY" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -63047,25 +63041,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"xCi" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
-/area/library)
-"xCm" = (
-/obj/machinery/vending/coffee,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/library)
 "xCq" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -108168,18 +108143,18 @@ gJh
 aGW
 aFu
 aPb
-oKO
+dPy
 aRN
-oKO
+dPy
 aPd
-hkb
-bSi
+oHC
+lkq
 bLO
 idq
 idq
 idq
 idq
-pvJ
+nRE
 idq
 bbD
 aYV
@@ -108425,7 +108400,7 @@ aEH
 iAC
 aFu
 aPb
-dVK
+ihg
 aRN
 aIt
 aPd
@@ -108433,8 +108408,8 @@ aFu
 uhU
 aYW
 eBi
-iqV
-ljK
+wGr
+jRI
 bjK
 wxd
 wxd
@@ -108940,9 +108915,9 @@ aGQ
 bNw
 aPP
 qbI
-ueN
+ujG
 qfi
-lkz
+aES
 aFu
 uhU
 aYW
@@ -109195,20 +109170,20 @@ aCC
 aFh
 aFu
 aFu
-iGK
+kjw
 aLg
 aLg
 aOS
-jyJ
+dsh
 aFu
-von
-dob
+aIt
+xvM
 aFu
 aFu
-mKS
+lno
 foa
 aYW
-xCm
+rym
 aFu
 bTc
 pSv
@@ -109451,18 +109426,18 @@ alP
 alP
 aFh
 aFu
-css
-sWQ
+lvg
+vem
 aLg
 aLg
 aOS
-two
-gFh
+hmc
+vvZ
 aPP
 aXX
 aXX
 aXX
-fGL
+mnw
 fIe
 aYW
 hrV
@@ -109708,21 +109683,21 @@ eCa
 alP
 aFh
 aFu
-nkT
-tGM
+uZz
+qRK
 aJR
 aJR
 aIt
 aIt
 aIt
 aIt
-aLg
-aRO
-aRO
-ltF
+wvr
+aIt
+aIt
+ulu
 bcl
 aYW
-cGo
+lDw
 bbD
 aYV
 oUe
@@ -109965,18 +109940,18 @@ syq
 qFC
 aFh
 aFu
-uFq
-kMF
+vhP
+iMC
 aJF
 aLh
 aIr
 aNV
 aNS
 aIt
-jha
+aLg
 aRO
 aRO
-azd
+cTe
 bcl
 aXV
 mBT
@@ -110233,10 +110208,10 @@ aQq
 aRP
 aIt
 aIt
-xml
+oUj
 bct
 aLL
-eNj
+syF
 bbD
 aYV
 aXq
@@ -110490,7 +110465,7 @@ aFu
 aFu
 aTc
 aUD
-hKu
+ucr
 aYW
 aYW
 woU
@@ -110747,7 +110722,7 @@ aQr
 aFu
 aTb
 exz
-hcB
+lMr
 aYW
 aYW
 bOi
@@ -111004,7 +110979,7 @@ aQt
 aRQ
 aIt
 aUF
-wSM
+aLg
 aYW
 aYW
 mBT
@@ -111261,7 +111236,7 @@ aQs
 aFu
 aTd
 eUm
-xCi
+oDD
 aYW
 aYW
 nAh

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -52441,13 +52441,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
-"qco" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/library)
 "qcs" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -57911,6 +57904,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"tVc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "tVl" = (
 /obj/structure/table/wood,
 /obj/machinery/camera{
@@ -59189,12 +59191,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos_distro)
-"uMn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "uMu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -61118,6 +61114,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"wdx" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_x = -32
+	},
+/turf/open/floor/carpet,
+/area/library)
 "wdT" = (
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff";
@@ -107934,7 +107941,7 @@ bfV
 bfV
 bfV
 bfV
-uMn
+tVc
 bnu
 bvB
 bzs
@@ -108173,9 +108180,9 @@ bLO
 idq
 idq
 idq
-aYW
-qco
-aYW
+idq
+wdx
+idq
 bbD
 aYV
 hoB

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -14495,10 +14495,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/hydroponics)
-"aNS" = (
-/obj/machinery/bookbinder,
-/turf/open/floor/wood,
-/area/library)
 "aNU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15188,12 +15184,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"aQq" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/library)
 "aQr" = (
 /obj/machinery/light/small,
 /obj/machinery/vending/wardrobe/curator_wardrobe,
@@ -15607,17 +15597,6 @@
 /area/engine/atmos_distro)
 "aRN" = (
 /obj/structure/bookcase/random/fiction,
-/turf/open/floor/wood,
-/area/library)
-"aRO" = (
-/obj/structure/displaycase/trophy,
-/turf/open/floor/wood,
-/area/library)
-"aRP" = (
-/obj/machinery/camera{
-	c_tag = "Library South";
-	dir = 8
-	},
 /turf/open/floor/wood,
 /area/library)
 "aRQ" = (
@@ -33742,11 +33721,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cTe" = (
-/obj/structure/table/wood,
-/obj/item/paper,
-/turf/open/floor/wood,
-/area/library)
 "cTn" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -34466,6 +34440,13 @@
 /obj/item/flashlight/lantern,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"dvd" = (
+/obj/machinery/light/small,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/library)
 "dvj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -37943,6 +37924,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"fXK" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/turf/open/floor/wood,
+/area/library)
 "fXY" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
@@ -39114,6 +39104,11 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"gTa" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/library)
 "gTO" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/structure/window/reinforced,
@@ -39196,6 +39191,16 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
+"gYw" = (
+/obj/effect/landmark/start/assistant,
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/library)
 "gYP" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -40752,6 +40757,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"idH" = (
+/obj/structure/table/wood,
+/obj/item/camera_film,
+/obj/item/camera_film,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/library)
 "idU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -43229,6 +43241,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
+"jIq" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/library)
 "jIM" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -44208,6 +44230,11 @@
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
+"kti" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/library)
 "kub" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45428,6 +45455,12 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"llW" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/library)
 "lmt" = (
 /obj/machinery/light{
 	dir = 1
@@ -45461,12 +45494,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"lno" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/library)
 "lnU" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -46170,15 +46197,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"lMr" = (
-/obj/structure/table/wood,
-/obj/item/pen/red,
-/obj/item/pen/blue{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/turf/open/floor/wood,
-/area/library)
 "lMK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -46410,6 +46428,14 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"maQ" = (
+/obj/machinery/camera{
+	c_tag = "Library South";
+	dir = 8
+	},
+/obj/machinery/bookbinder,
+/turf/open/floor/wood,
+/area/library)
 "maV" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/wood,
@@ -46685,15 +46711,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"mnw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/wood,
-/area/library)
 "mnB" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 1
@@ -47113,6 +47130,15 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/turf/open/floor/wood,
+/area/library)
+"mCb" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/library)
 "mCg" = (
@@ -49121,17 +49147,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/janitor)
-"nRE" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/obj/structure/sign/painting{
-	persistence_id = "public";
-	pixel_x = -32
-	},
-/turf/open/floor/carpet,
-/area/library)
 "nSs" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -50434,14 +50449,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"oDD" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/turf/open/floor/wood,
-/area/library)
 "oEb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -50923,10 +50930,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"oUj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/wood,
-/area/library)
 "oUG" = (
 /obj/machinery/requests_console{
 	department = "Security";
@@ -51101,6 +51104,16 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
+"pfS" = (
+/obj/structure/table/wood,
+/obj/item/pen/red,
+/obj/item/pen/blue{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/library)
 "phj" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
@@ -52428,6 +52441,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"qco" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/library)
 "qcs" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -53700,6 +53720,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"qVM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/displaycase/trophy,
+/turf/open/floor/wood,
+/area/library)
 "qVN" = (
 /obj/machinery/telecomms/server/presets/science,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -53788,6 +53818,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos_distro)
+"qYn" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/library)
 "qYw" = (
 /obj/machinery/light{
 	dir = 8
@@ -58126,12 +58160,6 @@
 /obj/effect/landmark/stationroom/maint/threexthree,
 /turf/template_noop,
 /area/maintenance/port)
-"ucr" = (
-/obj/structure/table/wood,
-/obj/item/camera_film,
-/obj/item/camera_film,
-/turf/open/floor/wood,
-/area/library)
 "ucZ" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -58286,13 +58314,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"ulu" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/wood,
-/area/library)
 "ulz" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Three";
@@ -59182,6 +59203,15 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"uMW" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/library)
 "uNi" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -61537,12 +61567,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"wvr" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/library)
 "wvu" = (
 /obj/structure/table,
 /obj/item/stock_parts/cell/potato{
@@ -62864,10 +62888,6 @@
 /obj/effect/variation/box/sec/brig_cell/perma,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"xvM" = (
-/obj/machinery/light/small,
-/turf/open/floor/wood,
-/area/library)
 "xvY" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -108153,9 +108173,9 @@ bLO
 idq
 idq
 idq
-idq
-nRE
-idq
+aYW
+qco
+aYW
 bbD
 aYV
 hoB
@@ -109176,11 +109196,11 @@ aLg
 aOS
 dsh
 aFu
-aIt
-xvM
+llW
+dvd
 aFu
 aFu
-lno
+uMW
 foa
 aYW
 rym
@@ -109435,9 +109455,9 @@ hmc
 vvZ
 aPP
 aXX
-aXX
-aXX
-mnw
+qVM
+qVM
+jIq
 fIe
 aYW
 hrV
@@ -109691,10 +109711,10 @@ aIt
 aIt
 aIt
 aIt
-wvr
 aIt
 aIt
-ulu
+aIt
+qYn
 bcl
 aYW
 lDw
@@ -109946,12 +109966,12 @@ aJF
 aLh
 aIr
 aNV
-aNS
+fXK
 aIt
-aLg
-aRO
-aRO
-cTe
+aIt
+aIt
+aIt
+qYn
 bcl
 aXV
 mBT
@@ -110204,11 +110224,11 @@ aFw
 aFw
 aFw
 aPf
-aQq
-aRP
+gYw
+maQ
 aIt
 aIt
-oUj
+gTa
 bct
 aLL
 syF
@@ -110465,7 +110485,7 @@ aFu
 aFu
 aTc
 aUD
-ucr
+idH
 aYW
 aYW
 woU
@@ -110722,7 +110742,7 @@ aQr
 aFu
 aTb
 exz
-lMr
+pfS
 aYW
 aYW
 bOi
@@ -110979,7 +110999,7 @@ aQt
 aRQ
 aIt
 aUF
-aLg
+kti
 aYW
 aYW
 mBT
@@ -111236,7 +111256,7 @@ aQs
 aFu
 aTd
 eUm
-oDD
+mCb
 aYW
 aYW
 nAh


### PR DESCRIPTION
### General Documentation

### Intent of your Pull Request

Removes firelocks from the new gallery in Library, makes it larger on top, and adds a few decals in the rear.
(PR has been hijacked and overruled, see Wej’s comments for the actual pic)
Removal of firelocks makes the Library more inline with other rooms and further reinforces the assertion that the secure art exhibit is an arbitrary construct (like a kiosk or a wall) and not a room defining wall.

Also removes 2 trophy display cases, man I wish those things worked.

### Why is this change good for the game?

Makes the gallery look better and the library more in line with the rest of the station (though I really only wanted to remove the firelocks and add dust to the back. God I hate those wood siding decals.)

# Wiki Documentation

Library image needs to be updated, sorry kettle

# Changelog

Why do people forget to remove the text that appears here?

:cl:  
tweak: Resizes the gallery in library somewhat along with removing firelocks.   
/:cl:
