### PR TITLE
changes bath salts to a actual drug name

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -269,7 +269,7 @@
 	. = 1
 
 /datum/reagent/drug/bath_salts
-	name = "Bath Salts"
+	name = "3-Methylmethcathinone"
 	description = "Makes you impervious to stuns and grants a stamina regeneration buff, but you will be a nearly uncontrollable tramp-bearded raving lunatic."
 	reagent_state = LIQUID
 	color = "#FAFAFA"


### PR DESCRIPTION
other drugs in game arent called by there street names so why should bath salts its been renamed to the most popular bath salt 3-mmc



:cl:  
tweak: changed named of bath salts
/:cl:
