### PR TITLE
throw emitter

### DIFF
--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -44,6 +44,9 @@
 	var/charge = 0
 	var/last_projectile_params
 
+	var/throwing_range = 5
+	var/throwing_speed = 3
+
 
 /obj/machinery/power/emitter/anchored
 	anchored = TRUE
@@ -202,7 +205,20 @@
 		fire_beam()
 
 /obj/machinery/power/emitter/proc/fire_beam(mob/user)
-	var/obj/item/projectile/P = new projectile_type(get_turf(src))
+	var/obj/item/K = new projectile_type(get_turf(src))
+
+	/// If it isn't a projectile, throw it
+	if(!istype(K, /obj/item/projectile))
+		if(istype(K, /obj/item/grenade))
+			var/obj/item/grenade/I = K
+			I.preprime()
+		K.throw_at(get_edge_target_turf(src, dir), throwing_range, throwing_speed)
+		playsound(get_turf(src), projectile_sound, 50, TRUE)
+		if(prob(35))
+			sparks.start()
+		return K
+
+	var/obj/item/projectile/P = K
 	playsound(get_turf(src), projectile_sound, 50, TRUE)
 	if(prob(35))
 		sparks.start()


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

emitters, if a non-projectile is loaded into the projectile_type, will throw it instead of firing it
if a grenade is loaded, it will preprime it first then throw it
![VagueHospitableAustralianshelduck-max-1mb](https://user-images.githubusercontent.com/28408322/114770054-ffc8a100-9d38-11eb-925e-d8befda64ca1.gif)

### Why is this change good for the game?

for moja
![image](https://user-images.githubusercontent.com/28408322/114769823-b0827080-9d38-11eb-8e17-77efdfe88350.png)
catching edge cases
better functionality
modularization
other buzz words that make maints like me

# Changelog

:cl:  
tweak: Emitters now properly handle non-projectiles
/:cl:
