### PR TITLE
should fix the byos not accounting for byos specific things

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -166,18 +166,18 @@
 	admin_notes = "No brig and no medical facilities. Build YOUR own."
 	credit_cost = 5000
 
-/datum/map_template/shuttle/emergency/construction_small
+/datum/map_template/shuttle/emergency/construction/small
 	suffix = "construction_small"
 	name = "Build Your Own Shuttle, Jr."
 	description = "The full-size BYOS too big for your taste? Aside from the reduced size and cost, this has the all same (lack of) amenities as its full-sized sibling."
 	admin_notes = "No brig and no medical facilities. Build YOUR own."
 	credit_cost = 2000
 
-/datum/map_template/shuttle/emergency/airless/prerequisites_met()
+/datum/map_template/shuttle/emergency/construction/prerequisites_met()
 	// first 10 minutes only
 	return world.time - SSticker.round_start_time < 6000
 
-/datum/map_template/shuttle/emergency/airless/post_load()
+/datum/map_template/shuttle/emergency/construction/post_load()
 	. = ..()
 	//enable buying engines from cargo
 	var/datum/supply_pack/P = SSshuttle.supply_packs[/datum/supply_pack/engineering/shuttle_engine]

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -175,7 +175,7 @@
 
 /datum/map_template/shuttle/emergency/construction/prerequisites_met()
 	// first 10 minutes only
-	return world.time - SSticker.round_start_time < 6000
+	return world.time - SSticker.round_start_time < 12000
 
 /datum/map_template/shuttle/emergency/construction/post_load()
 	. = ..()


### PR DESCRIPTION
airless
:cl:  
bugfix: you can now buy engines for the byos and it will only be purchasable in thef irst 10 minutes of the round as intended
tweak: BYOS purchase window increased from 10 to 20 minutes
/:cl:
