### PR TITLE
adds forbidden lore to emagged library consoles

### DIFF
--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -329,7 +329,7 @@ GLOBAL_LIST(cachedbooks) // List of our cached book datums
 			new /obj/item/melee/cultblade/dagger(get_turf(src))
 			to_chat(user, "<span class='warning'>Your sanity barely endures the seconds spent in the vault's browsing window. The only thing to remind you of this when you stop browsing is a sinister dagger sitting on the desk. You don't even remember where it came from...</span>")
 		if(2)
-			new /obj/item/clockwork/clockwork_slab(get_turf(src))
+			new /obj/item/clockwork/slab(get_turf(src))
 			to_chat(user, "<span class='warning'>Your sanity barely endures the seconds spent in the vault's browsing window. The only thing to remind you of this when you stop browsing is a strange metal tablet sitting on the desk. You don't even remember where it came from...</span>")
 		if(3)
 			new /obj/item/forbidden_book(get_turf(src))

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -324,13 +324,16 @@ GLOBAL_LIST(cachedbooks) // List of our cached book datums
 	return null
 
 /obj/machinery/computer/libraryconsole/bookmanagement/proc/print_forbidden_lore(mob/user)
-	if (prob(50))
-		new /obj/item/melee/cultblade/dagger(get_turf(src))
-		to_chat(user, "<span class='warning'>Your sanity barely endures the seconds spent in the vault's browsing window. The only thing to remind you of this when you stop browsing is a sinister dagger sitting on the desk. You don't even remember where it came from...</span>")
-	else
-		new /obj/item/clockwork/slab(get_turf(src))
-		to_chat(user, "<span class='warning'>Your sanity barely endures the seconds spent in the vault's browsing window. The only thing to remind you of this when you stop browsing is a strange metal tablet sitting on the desk. You don't even remember where it came from...</span>")
-
+	switch(rand(1,3))
+		if(1)
+			new /obj/item/melee/cultblade/dagger(get_turf(src))
+			to_chat(user, "<span class='warning'>Your sanity barely endures the seconds spent in the vault's browsing window. The only thing to remind you of this when you stop browsing is a sinister dagger sitting on the desk. You don't even remember where it came from...</span>")
+		if(2)
+			new /obj/item/clockwork/clockwork_slab(get_turf(src))
+			to_chat(user, "<span class='warning'>Your sanity barely endures the seconds spent in the vault's browsing window. The only thing to remind you of this when you stop browsing is a strange metal tablet sitting on the desk. You don't even remember where it came from...</span>")
+		if(3)
+			new /obj/item/forbidden_book(get_turf(src))
+			to_chat(user, "<span class='warning'>You lose your train of thought, the longer you stare into the vault's browsing window, the deeper you reach into timeless eons. You tear away from the screen, and a book fashioned in a strange leather, bound in chains, appears before you...</span>")
 	user.visible_message("[user] stares at the blank screen for a few moments, [user.p_their()] expression frozen in fear. When [user.p_they()] finally awaken[user.p_s()] from it, [user.p_they()] look[user.p_s()] a lot older.", 2)
 
 /obj/machinery/computer/libraryconsole/bookmanagement/attackby(obj/item/W, mob/user, params)


### PR DESCRIPTION
### Intent of your Pull Request

Adds the heretic's book of forbidden knowledge to the library console.

### Why is this change good for the game?

The clockwork slab and cultists blade are also accessible in the library console, the book for forbidden knowledge should be aswell.

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 

When you emag the library console, you can now get the book of forbidden knowledge.

### What should players be aware of when it comes to the changes your PR is implementing?

You can now obtain the book of forbidden knowledge when emagging a library console.

### What general grouping does this PR fall under? 
Library additions.

### Are there any aspects of the PR that you would like us not to mention on the Wiki?

Nope.

:cl:  Xoxeyos
rscadd: Emagged library console can now make heretic books.
/:cl:
