### PR TITLE
adds bulletproof helmet crate

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -441,6 +441,15 @@
 					/obj/item/clothing/suit/armor/bulletproof)
 	crate_name = "bulletproof armor crate"
 
+/datum/supply_pack/security/armory/bullethelmets
+	name = "Bulletproof Helmet Crate"
+	desc = "Contains three bulletproof helmets, perfect for protecting the void inside your skull. Requires Armory access to open."
+	cost = 1500
+	contains = list(/obj/item/clothing/head/helmet/alt,
+					/obj/item/clothing/head/helmet/alt,
+					/obj/item/clothing/head/helmet/alt)
+	crate_name = "bulletproof helmet crate"
+
 /datum/supply_pack/security/armory/chemimp
 	name = "Chemical Implants Crate"
 	desc = "Contains five Remote Chemical implants. Requires Armory access to open."


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

adds a bulletproof helmet crate for 1500 credits for 3 helmets to cargo, allowing people to get full antiballistic armor aside from whoever gets the like two or three helmets in the armory, making having ballistic armor actually matter and not just be a "did they target the head"

### Why is this change good for the game?
targetting the head != skill
# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
cargo crate ballistic helmet crate 1500 credits contains 3 bulletproof helmets requires armory access to open

### What general grouping does this PR fall under? 
cargo

# Changelog

:cl:  
rscadd: bulletproof helmets are now available for sale to cargo
/:cl:
