### PR TITLE
you can no longer cryopod others

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -364,11 +364,8 @@ GLOBAL_LIST_INIT(typecache_cryoitems, typecacheof(list(
 		to_chat(user, "<span class='notice'>This person cannot be put in cryogenic storage!</span>")
 		return
 
-	if(target.client && user != target)
-		if(iscyborg(target))
-			to_chat(user, "<span class='danger'>You can't put [target] into [src]. They're online.</span>")
-		else
-			to_chat(user, "<span class='danger'>You can't put [target] into [src]. They're conscious.</span>")
+	if(user != target)
+		to_chat(user, "<span class='danger'>You are unable to cryo others.</span>")
 		return
 	else if(target.client)
 		if(alert(target,"Would you like to enter cryosleep?",,"Yes","No") == "No")
@@ -399,8 +396,7 @@ GLOBAL_LIST_INIT(typecache_cryoitems, typecacheof(list(
 
 	if(target == user)
 		visible_message("[user] starts climbing into the cryo pod.")
-	else
-		visible_message("[user] starts putting [target] into the cryo pod.")
+	
 	close_machine(target)
 	to_chat(target, "<span class='boldnotice'>If you ghost, log out or close your client now, your character will shortly be permanently removed from the round.</span>")
 	name = "[name] ([occupant.name])"


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

cryoing other players is now impossible
admin-cryo will still work because it doesn't use the mousedrop-t proc
also fixes the bug where you can cryo catatonics because jamies code didn't work

### Why is this change good for the game?

prevents players from griefing each other

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
cryoing other players is now impossible

# Changelog

:cl:  
tweak: You can no longer put other players into cryopods
/:cl:
