### PR TITLE
Religio-Capitalist golem buff

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -1157,7 +1157,7 @@
 	playsound(source, 'sound/misc/mymoney.ogg', 25, 0)
 	speech_args[SPEECH_MESSAGE] = "Hello, I like money!"
 
-/datum/species/golem/church_capitalist
+/datum/species/golem/church_capitalist //slightly faster reskinned iron golem gained from a cult of st credit rite
 	name = "Churchgoing Capitalist Golem"
 	id = "church_capitalist golem"
 	prefix = "Religio-Capitalist"
@@ -1166,6 +1166,7 @@
 	special_names = list("John D. Rockefeller","Rich Uncle Pennybags","Commodore Vanderbilt","Entrepreneur","Mr. Moneybags", "Adam Smith")
 	species_traits = list(NOBLOOD,NO_UNDERWEAR,NOEYESPRITES)
 	fixed_mut_color = null
+	speedmod = 1.5
 	inherent_traits = list(TRAIT_RESISTHEAT,TRAIT_NOBREATH,TRAIT_RESISTCOLD,TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE,TRAIT_NOFIRE,TRAIT_RADIMMUNE,TRAIT_GENELESS,TRAIT_PIERCEIMMUNE,TRAIT_NODISMEMBER)
 	info_text = "As a <span class='danger'>Churchgoing Capitalist Golem</span>, your god-given right is to make fat stacks of money!"
 	changesource_flags = MIRROR_BADMIN


### PR DESCRIPTION
### Intent of your Pull Request
to slightly buff the move speed of the cult of st. credit cash golem that chaplains can make with a rite.

### Why is this change good for the game?
It costs a whole 10,000 credits to get enough favor to become this golem, but it has the same stats as an iron golem, which are pretty bad all in all. To help encourage chaps to stay in this cool cash golem form instead of just going to xenobio for an upgrade to plasteel golem or something, they will be slightly faster to help make that 10,000 credits seem more worth it.

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
For example, "This new chem will heal X brute damage". 
changes the golem's speed to 1.5 instead of 2, which makes it slightly faster

:cl:  
tweak: church of st.credit golem is faster
/:cl:
