### PR TITLE
Fake armblade nerf

### DIFF
--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -115,7 +115,7 @@
 /datum/action/changeling/sting/false_armblade
 	name = "False Armblade Sting"
 	desc = "We silently sting a human, injecting a retrovirus that mutates their arm to temporarily appear as an armblade. Costs 20 chemicals."
-	helptext = "The victim will form an armblade much like a changeling would, except the armblade is dull and useless."
+	helptext = "The victim will form an armblade much like a changeling would, except the armblade is less sharp and powerful."
 	button_icon_state = "sting_armblade"
 	sting_icon = "sting_armblade"
 	chemical_cost = 20
@@ -123,7 +123,7 @@
 
 /obj/item/melee/arm_blade/false
 	desc = "A grotesque mass of flesh that used to be your arm. On the bright side, at least you can cut wood with this."
-	force = 30 //yogs -- Prevents dual-stinging people with this sting to render them defenseless.
+	force = 20 //yogs -- worse than armblade but still not terrible
 	//daily reminder that xantam is a closet furry
 	fake = TRUE
 


### PR DESCRIPTION

### Intent of your Pull Request
nerfs the fake armblade's damage to 20 instead of 30. Fake armblade is something lings can give people via the armblade sting. 30 damage is simply too much power for the plebs.

### Why is this change good for the game?
armblade stinging your victim as a ling is no longer your unmaking

### Briefly describe your PR and the impacts of it, in layman's terms. 
This will be the basis of the Wiki entry for your PR, and more information / detail is better for Wiki editors to integrate.

### What should players be aware of when it comes to the changes your PR is implementing?
fake armblade is no longer OP

### What general grouping does this PR fall under? 
For example, Engineering changes, Medical rebalancing, TEG tweaks, etc.?
antag changes

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
For example, "This new chem will heal X brute damage". 
fake armblade now deals 20 damage instead of 30

:cl:  
tweak: fake armblade damage nerfed to 20. Armblade sting ability description changed to be more fitting.
/:cl:
