### PR TITLE
makes ling gloves not check for antimagic

### DIFF
--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -244,6 +244,7 @@
 	ammo_type = /obj/item/ammo_casing/magic/tentacle
 	fire_sound = 'sound/effects/splat.ogg'
 	force = 0
+	checks_antimagic = FALSE
 	max_charges = 1
 	fire_delay = 1
 	throwforce = 0 //Just to be on the safe side


### PR DESCRIPTION
tentacles aren't magical unless they are from japan and these aren't the japanese tentacles

:cl:  
bugfix: ling tentacle is no longer blocked by antimagic
/:cl:
