### PR TITLE
Mind-slaved syndicate crew can now use the stealth syndicate gear.

### DIFF
--- a/code/__DEFINES/~yogs_defines/is_helpers.dm
+++ b/code/__DEFINES/~yogs_defines/is_helpers.dm
@@ -8,7 +8,8 @@
 
 #define is_clockcult(M) (istype(M, /mob/living) && M.mind && M.mind.has_antag_datum(/datum/antagonist/clockcult))
 
-#define is_traitor(M) (istype(M, /mob/living) && M.mind && M.mind.has_antag_datum(/datum/antagonist/traitor))
+#define is_mindslaved(M) (istype(M, /mob/living) && M.mind && M.mind.has_antag_datum(/datum/antagonist/mindslave))
+#define is_traitor(M) (istype(M, /mob/living) && M.mind && M.mind.has_antag_datum(/datum/antagonist/traitor) || is_mindslaved(M))
 #define is_blood_brother(M) (istype(M, /mob/living) && M.mind && M.mind.has_antag_datum(/datum/antagonist/brother))
 #define is_nukeop(M) (M.mind && M.mind.has_antag_datum(/datum/antagonist/nukeop)) // also detects clownOP
 #define is_syndicate(M) (istype(M, /mob/living) && is_traitor(M) || is_blood_brother(M) || is_nukeop(M))


### PR DESCRIPTION
Apparently, implant traitor conversions don't actually make you a traitor.

![image](https://user-images.githubusercontent.com/24533979/115300156-3f223380-a125-11eb-8831-351e0dbc50a2.png)

Follow-up to #8144

:cl:  Hopek
bugfix: Mindslaved syndicate crew can now use the stealth syndicate gear.
/:cl:
