### PR TITLE
Removes Cohiba Robusto Cigars from Possible Smoker Quirk Roundstart Cigarettes and Adds A Warning Label to the Cohiba Robusto Case

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -538,7 +538,6 @@
 		/obj/item/storage/box/fancy/cigarettes/cigpack_robustgold,
 		/obj/item/storage/box/fancy/cigarettes/cigpack_carp,
 		/obj/item/storage/box/fancy/cigarettes/cigars,
-		/obj/item/storage/box/fancy/cigarettes/cigars/cohiba,
 		/obj/item/storage/box/fancy/cigarettes/cigars/havana)
 	. = ..()
 

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -329,7 +329,7 @@
 
 /obj/item/storage/box/fancy/cigarettes/cigars/cohiba
 	name = "\improper Cohiba Robusto cigar case"
-	desc = "A case of imported Cohiba cigars, renowned for their strong flavor. The warning label states that the cigar is extremely potent"
+	desc = "A case of imported Cohiba cigars, renowned for their strong flavor. The warning label states that the cigar is extremely potent."
 	icon_state = "cohibacase"
 	spawn_type = /obj/item/clothing/mask/cigarette/cigar/cohiba
 

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -329,7 +329,7 @@
 
 /obj/item/storage/box/fancy/cigarettes/cigars/cohiba
 	name = "\improper Cohiba Robusto cigar case"
-	desc = "A case of imported Cohiba cigars, renowned for their strong flavor."
+	desc = "A case of imported Cohiba cigars, renowned for their strong flavor. The warning label states that the cigar is extremely potent"
 	icon_state = "cohibacase"
 	spawn_type = /obj/item/clothing/mask/cigarette/cigar/cohiba
 


### PR DESCRIPTION
#### Read catcher in the rye if you haven't already: 
https://www.uzickagimnazija.edu.rs/files/Catcher%20in%20the%20Rye.pdf

# General Documentation

### Intent of your Pull Request

Removes Cohiba Robusto cigars from the roundstart Smoker Quirk pool cigarettes and adds a warning label to the Cohiba Robusto case.

### Why is this change good for the game?

All other cigars and cigarettes can be smoked constantly and frequently with little consequence. Cohiba Robusta is dramatically different in that regard as it is significantly more potent while offering no warning (strong taste isn't a warning, its flavor text) and looking exactly like a regular cigar, as well as being sold next to all of the regular ones. Warning label helps curve this easy beginners trap at no cost to anything (or atleast gives a more definite warning to Cohiba Robusta's potency besides just having to die or get a lung transplant to figure something as small as what cigars are safe out).

# Wiki Documentation

None

# Changelog

:cl:  
rscadd: Adds warning label, damn Surgeon General.
rscdel: Removes Cohiba Robusto from roundstart Smoker Quirk pool  
/:cl:
