### PR TITLE
Adds Computer Vendor and Deluxe Silicate Selections to Eclipse, Omega and Delta

### DIFF
--- a/_maps/map_files/EclipseStation/EclipseStation.dmm
+++ b/_maps/map_files/EclipseStation/EclipseStation.dmm
@@ -82260,6 +82260,10 @@
 	},
 /turf/open/floor/plating,
 /area/solar/port/fore)
+"fYM" = (
+/obj/machinery/vending/modularpc,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
 "fZl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -86309,6 +86313,10 @@
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
+"pep" = (
+/obj/machinery/lapvend,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
 "pez" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -86669,6 +86677,11 @@
 /obj/effect/spawner/lootdrop/costume,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"qht" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
 "qhE" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/camera{
@@ -121210,7 +121223,7 @@ alx
 bPI
 bQC
 cdQ
-bRC
+qht
 bRC
 bRC
 bWC
@@ -121467,7 +121480,7 @@ bOK
 bPJ
 bQD
 cdQ
-cFa
+cEh
 bRC
 bRC
 cgK
@@ -121981,7 +121994,7 @@ bHR
 bMV
 bMV
 bMV
-cEh
+fYM
 cSS
 cfU
 agE
@@ -122238,7 +122251,7 @@ bMV
 bMV
 bON
 jSj
-cEY
+pep
 aak
 cwz
 aez

--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -7352,17 +7352,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"akn" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "ako" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -15902,16 +15891,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
-"aHu" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot,
-/obj/structure/sign/departments/minsky/supply/mining{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "aHx" = (
 /obj/structure/cable/white{
 	icon_state = "0-4"
@@ -29737,6 +29716,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
+"hQk" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/sign/departments/minsky/supply/mining{
+	pixel_y = -32
+	},
+/obj/machinery/vending/modularpc,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "hQl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -45722,6 +45709,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"wYs" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/lapvend,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "wYt" = (
 /obj/machinery/bounty_board,
 /turf/closed/wall/r_wall,
@@ -94046,7 +94042,7 @@ ajK
 anm
 aGo
 adC
-akn
+wYs
 sqz
 bhk
 bhk
@@ -94303,7 +94299,7 @@ rER
 cTB
 bOf
 vLY
-aHu
+hQk
 sqz
 gwL
 bhk

--- a/_maps/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/map_files/YogsDelta/YogsDelta.dmm
@@ -94401,26 +94401,6 @@
 "cOV" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/science/research)
-"cOW" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/structure/sign/poster/official/science{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"cOX" = (
-/obj/structure/chair,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "cOY" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/purple{
@@ -94431,15 +94411,6 @@
 "cOZ" = (
 /obj/structure/chair,
 /obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"cPa" = (
-/obj/structure/table,
-/obj/item/folder/white,
-/obj/item/paicard,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -95431,15 +95402,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
-"cQH" = (
-/obj/structure/table,
-/obj/item/folder/white,
-/obj/item/assembly/infra,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "cQI" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
@@ -100356,21 +100318,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
-"cXr" = (
-/obj/structure/table,
-/obj/item/clipboard,
-/obj/item/electronics/airlock,
-/obj/item/stack/sheet/glass,
-/obj/item/assembly/signaler,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "cXs" = (
 /obj/machinery/door/airlock/research{
 	name = "Research Testing Range";
@@ -124904,6 +124851,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/locker)
+"fXI" = (
+/obj/structure/table,
+/obj/item/folder/white,
+/obj/item/paicard,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "gcN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -125148,6 +125106,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"hVY" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/machinery/lapvend,
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "hXk" = (
 /obj/structure/table,
 /obj/item/canvas/twentythreeXtwentythree,
@@ -126623,6 +126588,16 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"prJ" = (
+/obj/structure/sign/poster/official/science{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/machinery/vending/modularpc,
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "pwJ" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/latex,
@@ -127186,6 +127161,23 @@
 /obj/machinery/door/poddoor/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
+"sEc" = (
+/obj/structure/table,
+/obj/item/clipboard,
+/obj/item/electronics/airlock,
+/obj/item/stack/sheet/glass,
+/obj/item/assembly/signaler,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/item/assembly/infra,
+/obj/item/folder/white,
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "sFC" = (
 /obj/machinery/status_display/evac{
 	pixel_x = 32
@@ -163256,12 +163248,12 @@ bKh
 bZp
 aOl
 cNp
-cOW
-cQH
+prJ
+hVY
 cSp
 cUe
 cWb
-cXr
+sEc
 cOR
 daK
 cyY
@@ -163513,7 +163505,7 @@ aKY
 bZp
 bPf
 cNq
-cOX
+cOY
 cQI
 cQJ
 cnh
@@ -164541,7 +164533,7 @@ bKm
 bZw
 aOl
 cNp
-cPa
+fXI
 cQM
 cXA
 cBR


### PR DESCRIPTION
# генерал Documentation

# Intent of your Pull Request

Adds Computer Vendor to Deluxe Silicate Selections and Computer Vendors at either the Science Department Public Area or the Cargo Public Area should there be no public Science Area

# Why is this change good for the game?

Uniformity, people ought not to get screwed out of whatever the hell those vendors sell due to the map. they might get screwed out of the location but I'm just following Yogstation and Yogsmeta's precedent.

# Wiki Documentation

Science Department and Cargo Department on Eclipse, Omega and Delta may need to be rephotographed.

# Changelog

:cl:  
rscadd: Adds Deluxe Silicate Selections and Computer Vendors to Eclipse, Omega and Delta.
/:cl:
