### PR TITLE
slightly decreases the armor on the juggernaut suit and helmet because apparently giving miners deathsquad tier armor is a bad idea

### DIFF
--- a/yogstation/code/modules/clothing/head/misc.dm
+++ b/yogstation/code/modules/clothing/head/misc.dm
@@ -33,7 +33,7 @@
 	icon = 'yogstation/icons/obj/clothing/hats.dmi'
 	icon_state = "juggernauthelm"
 	item_state = "juggernauthelm"
-	armor = list("melee" = 80, "bullet" = 80, "laser" = 50, "energy" = 50, "bomb" = 100, "bio" = 100, "rad" = 100, "fire" = 40, "acid" = 90)
+	armor = list("melee" = 60, "bullet" = 50, "laser" = 30, "energy" = 50, "bomb" = 80, "bio" = 100, "rad" = 0, "fire" = 90, "acid" = 90)
 	strip_delay = 120
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	flash_protect = TRUE

--- a/yogstation/code/modules/clothing/suits/armor.dm
+++ b/yogstation/code/modules/clothing/suits/armor.dm
@@ -94,7 +94,7 @@
 	icon_state = "juggernaut"
 	item_state = "juggernaut"
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS|FEET
-	armor = list("melee" = 80, "bullet" = 80, "laser" = 50, "energy" = 50, "bomb" = 100, "bio" = 100, "rad" = 100, "fire" = 40, "acid" = 90)
+	armor = list("melee" = 60, "bullet" = 50, "laser" = 30, "energy" = 50, "bomb" = 80, "bio" = 100, "rad" = 0, "fire" = 90, "acid" = 90)
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	cold_protection = CHEST|GROIN|LEGS|ARMS|FEET
 	heat_protection = CHEST|GROIN|LEGS|ARMS|FEET


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

same level of armor as adamantine shit from xenobio except it has a helmet so it is still better

### Why is this change good for the game?
too easy to hit 100 armor on several categories

# Changelog

:cl:  
tweak: reduced armor on the juggernaut suit to be in line with xenobio endgame gear making miners more powerful than science again
/:cl:
