### PR TITLE
lowers instability of antenna and removes it's access to command and sec channels

### DIFF
--- a/code/datums/mutations/antenna.dm
+++ b/code/datums/mutations/antenna.dm
@@ -4,7 +4,7 @@
 	quality = POSITIVE
 	text_gain_indication = "<span class='notice'>You feel an antenna sprout from your forehead.</span>"
 	text_lose_indication = "<span class='notice'>Your antenna shrinks back down.</span>"
-	instability = 15
+	instability = 10
 	difficulty = 8
 	var/obj/item/implant/radio/antenna/radio
 

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -131,5 +131,5 @@
 /obj/item/encryptionkey/secbot
 	channels = list(RADIO_CHANNEL_AI_PRIVATE = 1, RADIO_CHANNEL_SECURITY = 1)
 
-/obj/item/encryptionkey/antenna //for antenna mutation and it's unique demands. hopefully it wont be pulled out somehow.
+/obj/item/encryptionkey/antenna //for antenna mutation and it's unique demands. hopefully, it won't be pulled out somehow.
 	channels = list(RADIO_CHANNEL_ENGINEERING = 1, RADIO_CHANNEL_SCIENCE = 1, RADIO_CHANNEL_MEDICAL = 1, RADIO_CHANNEL_SUPPLY = 1, RADIO_CHANNEL_SERVICE = 1)

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -130,3 +130,6 @@
 
 /obj/item/encryptionkey/secbot
 	channels = list(RADIO_CHANNEL_AI_PRIVATE = 1, RADIO_CHANNEL_SECURITY = 1)
+
+/obj/item/encryptionkey/antenna //for antenna mutation and it's unique demands. hopefully it wont be pulled out somehow.
+	channels = list(RADIO_CHANNEL_ENGINEERING = 1, RADIO_CHANNEL_SCIENCE = 1, RADIO_CHANNEL_MEDICAL = 1, RADIO_CHANNEL_SUPPLY = 1, RADIO_CHANNEL_SERVICE = 1)

--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -128,7 +128,7 @@
 /obj/item/implant/radio/antenna
 	name = "internal antenna"
 	desc = "The internal organ part of the antenna. Science has not yet given it a good name."
-	radio_key = /obj/item/encryptionkey/heads/captain
+	radio_key = /obj/item/encryptionkey/antenna
 	subspace_transmission = TRUE
 
 /obj/item/implant/radio/slime


### PR DESCRIPTION

### Intent of your Pull Request
lowers instability of antenna and removes it's access to command and sec channels

### Why is this change good for the game?
invalidates the privacy of sec and command comms way too easily, this fixes that

### What should players be aware of when it comes to the changes your PR is implementing?
antenna doesn't let people access sec and command channels now
also it's instability is 10 instead of 15 now since it's most powerful feature of having sec and command comms was removed.

### What general grouping does this PR fall under? 
mutation/genetics changes

### Are there any aspects of the PR that you would like us not to mention on the Wiki?
no?

:cl:  
rscdel: Removes antenna's access to the sec and command channels  
tweak: antenna mutation instability lowered to 10
/:cl:
