### PR TITLE
repeated healing surgeries no longer have a chance to be penalized by lack of anesthetics because they are short

### DIFF
--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -16,7 +16,7 @@
 	if(healing_step_type)
 		steps = list(/datum/surgery_step/incise/nobleed,
 					healing_step_type, //hehe cheeky
-					/datum/surgery_step/close)
+					/datum/surgery_step/close/nofail)
 
 /datum/surgery_step/heal
 	name = "repair body"

--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -1,8 +1,5 @@
 /datum/surgery/healing
 	steps = list(/datum/surgery_step/incise,
-				/datum/surgery_step/retract_skin,
-				/datum/surgery_step/incise,
-				/datum/surgery_step/clamp_bleeders,
 				/datum/surgery_step/heal,
 				/datum/surgery_step/close)
 
@@ -17,7 +14,7 @@
 /datum/surgery/healing/New(surgery_target, surgery_location, surgery_bodypart)
 	..()
 	if(healing_step_type)
-		steps = list(/datum/surgery_step/incise,
+		steps = list(/datum/surgery_step/incise/nobleed,
 					healing_step_type, //hehe cheeky
 					/datum/surgery_step/close)
 

--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -96,7 +96,8 @@
 		H.bleed_rate = max( (H.bleed_rate - 3), 0)
 	return ..()
 
-
+/datum/surgery_step/close/nofail
+	fuckup_damage = 0
 
 //saw bone
 /datum/surgery_step/saw

--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -5,6 +5,7 @@
 	implements = list(/obj/item/scalpel = 100, /obj/item/melee/transforming/energy/sword = 75, /obj/item/kitchen/knife = 65,
 		/obj/item/shard = 45, /obj/item = 30) // 30% success with any sharp item.
 	time = 16
+	var/bleeding = 3 //how much bleeding you get from this being done
 
 /datum/surgery_step/incise/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, "<span class='notice'>You begin to make an incision in [target]'s [parse_zone(target_zone)]...</span>",
@@ -20,12 +21,21 @@
 /datum/surgery_step/incise/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if ishuman(target)
 		var/mob/living/carbon/human/H = target
-		if (!(NOBLOOD in H.dna.species.species_traits))
+		if (!(NOBLOOD in H.dna.species.species_traits) && bleeding)
 			display_results(user, target, "<span class='notice'>Blood pools around the incision in [H]'s [parse_zone(target_zone)].</span>",
 				"Blood pools around the incision in [H]'s [parse_zone(target_zone)].",
 				"")
-			H.bleed_rate += 3
+			H.bleed_rate += bleeding
 	return TRUE
+
+/datum/surgery_step/incise/nobleed
+	fuckup_damage = 0
+	bleeding = 0
+
+/datum/surgery_step/incise/nobleed/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	display_results(user, target, "<span class='notice'>You begin to <i>carefully</i> make an incision in [target]'s [parse_zone(target_zone)]...</span>",
+		"<span class='notice'>[user] begins to <i>carefully</i> make an incision in [target]'s [parse_zone(target_zone)].</span>",
+		"<span class='notice'>[user] begins to <i>carefully</i> make an incision in [target]'s [parse_zone(target_zone)].</span>")
 
 //clamp bleeders
 /datum/surgery_step/clamp_bleeders


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

more counterintuitive than a punishment due to the lack of steps

### Why is this change good for the game?
healing surgeries are too short to demand anesthetics

# Changelog


:cl:  
tweak: repeating healing surgeries no longer cause damage with lack of anesthetic since they are short
/:cl:
