### PR TITLE
rezadone now requires carpotoxin as it used to

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -15,7 +15,7 @@
 	name = "Rezadone"
 	id = /datum/reagent/medicine/rezadone
 	results = list(/datum/reagent/medicine/rezadone = 3)
-	required_reagents = list(/datum/reagent/consumable/capsaicin = 1, /datum/reagent/cryptobiolin = 1, /datum/reagent/copper = 1) //yogs: uses the yogs recipe that exchanges carpotoxin with capsaicin
+	required_reagents = list(/datum/reagent/toxin/carpotoxin = 1, /datum/reagent/cryptobiolin = 1, /datum/reagent/copper = 1) //yogs: uses the yogs recipe that exchanges carpotoxin with capsaicin
 
 /datum/chemical_reaction/spaceacillin
 	name = "Spaceacillin"

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -15,7 +15,7 @@
 	name = "Rezadone"
 	id = /datum/reagent/medicine/rezadone
 	results = list(/datum/reagent/medicine/rezadone = 3)
-	required_reagents = list(/datum/reagent/toxin/carpotoxin = 1, /datum/reagent/cryptobiolin = 1, /datum/reagent/copper = 1) //yogs: uses the yogs recipe that exchanges carpotoxin with capsaicin
+	required_reagents = list(/datum/reagent/toxin/carpotoxin = 1, /datum/reagent/cryptobiolin = 1, /datum/reagent/copper = 1)
 
 /datum/chemical_reaction/spaceacillin
 	name = "Spaceacillin"


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

rezadone now requires 1 part carpotoxin rather than 1 part capsaicin, this won't mean much now but it will later

### Why is this change good for the game?
makes an instant removal of all clone damage chem harder to get
# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
change the 1 part capsaicin to 1 part carpotoxin in rezadone recipe
### What general grouping does this PR fall under? 
chemistry


# Changelog
:cl:  
tweak: rezadone now requires carpotoxin rather than capsaicin as it used to
/:cl:
