### PR TITLE
Removes borg *Spin stunlock I guess

### DIFF
--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -262,7 +262,7 @@
 /datum/component/riding/human/force_dismount(mob/living/user)
 	var/atom/movable/AM = parent
 	AM.unbuckle_mob(user)
-	user.Paralyze(60)
+	user.Paralyze(41)
 	user.visible_message("<span class='warning'>[AM] pushes [user] off of [AM.p_them()]!</span>")
 
 /datum/component/riding/cyborg

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -45,7 +45,7 @@
 	restraint_check = TRUE
 	mob_type_allowed_typecache = list(/mob/living, /mob/dead/observer)
 	mob_type_ignore_stat_typecache = list(/mob/dead/observer)
-	cooldown = 0 SECONDS
+	cooldown = 4 SECONDS
 
 /datum/emote/spin/run_emote(mob/user, params ,  type_override, intentional)
 	. = ..()


### PR DESCRIPTION
### Intent of your Pull Request

this was complained about in dev public by Steamed, so I did a thing. *spin now has a 4 second cooldown, and the person is knocked down for 4.1 seconds instead of the previous 6 seconds. 

### Why is this change good for the game?

stunlock bad

:cl:  
tweak: borg spin stun now paralyzes for 4.1 seconds
tweak: *spin has a 4 second cooldown
/:cl:
