### PR TITLE
[Admin] Removes heretics from rotation

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -94,7 +94,7 @@ ALERT_DELTA Destruction of the station is imminent. All crew are instructed to o
 
 # New
 PROBABILITY DARKSPAWN 6
-PROBABILITY HERESY 4
+PROBABILITY HERESY 0
 
 # Lowpop
 PROBABILITY TRAITOR 5


### PR DESCRIPTION
Let me preface this with: No, I haven't died due to heretics, this is not an ided.

Heretics is a gamemode where its core mechanic is killing people to gain points and using those points, you get abilities that mainly go into two categories:
- Damage
- Healing

Both of those very much encourage combat and the way you get them(by sacrificing dead people) makes killing people, in a semi permanant way mandatory.
Don't forget about the end ability of the heretics either, which is become a very high DPS enemy that is hard to kill AND on top of that, can still use items(except for flesh path I believe) which means they can stall the shuttle for a long amount of times.

Heretics can be fun in the right context but it doesn't fit yogs where murderbone is frowned upon unlike TG where crew is allowed to help fight back antags and antags are allowed to murderbone.

tl;dr; heretics encourages murderbone via game mechanics, good fit for tg not for yogs

:cl:  alexkar598
rscdel: Heretics are no longer in rotation.
/:cl:
