### PR TITLE
adds the C.L.U.W.N.E. to the clown uplink and makes simple clowns hostile

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/stalwart.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/stalwart.dm
@@ -28,14 +28,14 @@
 	var/revving_charge = FALSE
 
 /mob/living/simple_animal/hostile/megafauna/stalwart/OpenFire()
-	ranged_cooldown = world.time + 30
+	ranged_cooldown = world.time + 50
 	anger_modifier = clamp(((maxHealth - health)/50),0,20)
 	if(prob(20+anger_modifier)) //Major attack
 		stalnade()
-	else if(prob(50))
+	else if(prob(20))
 		charge()
 	else
-		if(prob(20))
+		if(prob(70))
 			backup()
 		else
 			energy_pike()
@@ -77,7 +77,7 @@
 	visible_message("<span class='danger'>[src] constructs a flock of mini mechanoid!</span>")
 	for(var/turf/open/H in range(src, 2))
 		if(prob(25))
-			new /mob/living/simple_animal/hostile/asteroid/staldrone(H.loc)
+			new /mob/living/simple_animal/hostile/asteroid/hivelordbrood/staldrone(H.loc)
 
 /mob/living/simple_animal/hostile/megafauna/stalwart/proc/energy_pike()
 	ranged_cooldown = world.time + 40
@@ -125,34 +125,12 @@
 	
 //Projectiles and such
 
-/mob/living/simple_animal/hostile/asteroid/staldrone
+/mob/living/simple_animal/hostile/asteroid/hivelordbrood/staldrone
 	name = "mini mechanoid"
-	desc = "A still hot, newly formed spawn of an automaton. It seems upset with you."
-	icon = 'icons/mob/drone.dmi'
+	desc = "It's staring at you intently. Do not taunt."
 	icon_state = "drone_gem"
-	icon_living = "drone_gem"
-	icon_aggro = "drone_gem"
-	icon_dead = "drone_gem"
-	icon_gib = "syndicate_gib"
-	mouse_opacity = MOUSE_OPACITY_OPAQUE
-	move_to_delay = 1
-	friendly = "buzzes near"
-	vision_range = 10
-	speed = 3
-	maxHealth = 1
-	health = 1
-	movement_type = FLYING
-	harm_intent_damage = 5
-	melee_damage_lower = 8
-	melee_damage_upper = 8
-	attacktext = "slashes"
-	speak_emote = list("telepathically cries")
-	attack_sound = 'sound/weapons/pierce.ogg'
-	throw_message = "falls right through the strange body of the"
-	obj_damage = 0
-	environment_smash = ENVIRONMENT_SMASH_NONE
-	pass_flags = PASSTABLE
-	del_on_death = 1
+	faction = list("mining")
+	weather_immunities = list("lava","ash")
 
 /obj/item/gps/internal/stalwart
 	icon_state = null

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/stalwart.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/stalwart.dm
@@ -28,14 +28,14 @@
 	var/revving_charge = FALSE
 
 /mob/living/simple_animal/hostile/megafauna/stalwart/OpenFire()
-	ranged_cooldown = world.time + 50
+	ranged_cooldown = world.time + 30
 	anger_modifier = clamp(((maxHealth - health)/50),0,20)
 	if(prob(20+anger_modifier)) //Major attack
 		stalnade()
-	else if(prob(20))
+	else if(prob(50))
 		charge()
 	else
-		if(prob(70))
+		if(prob(20))
 			backup()
 		else
 			energy_pike()
@@ -77,7 +77,7 @@
 	visible_message("<span class='danger'>[src] constructs a flock of mini mechanoid!</span>")
 	for(var/turf/open/H in range(src, 2))
 		if(prob(25))
-			new /mob/living/simple_animal/hostile/asteroid/hivelordbrood/staldrone(H.loc)
+			new /mob/living/simple_animal/hostile/asteroid/staldrone(H.loc)
 
 /mob/living/simple_animal/hostile/megafauna/stalwart/proc/energy_pike()
 	ranged_cooldown = world.time + 40
@@ -125,12 +125,34 @@
 	
 //Projectiles and such
 
-/mob/living/simple_animal/hostile/asteroid/hivelordbrood/staldrone
+/mob/living/simple_animal/hostile/asteroid/staldrone
 	name = "mini mechanoid"
-	desc = "It's staring at you intently. Do not taunt."
+	desc = "A still hot, newly formed spawn of an automaton. It seems upset with you."
+	icon = 'icons/mob/drone.dmi'
 	icon_state = "drone_gem"
-	faction = list("mining")
-	weather_immunities = list("lava","ash")
+	icon_living = "drone_gem"
+	icon_aggro = "drone_gem"
+	icon_dead = "drone_gem"
+	icon_gib = "syndicate_gib"
+	mouse_opacity = MOUSE_OPACITY_OPAQUE
+	move_to_delay = 1
+	friendly = "buzzes near"
+	vision_range = 10
+	speed = 3
+	maxHealth = 1
+	health = 1
+	movement_type = FLYING
+	harm_intent_damage = 5
+	melee_damage_lower = 8
+	melee_damage_upper = 8
+	attacktext = "slashes"
+	speak_emote = list("telepathically cries")
+	attack_sound = 'sound/weapons/pierce.ogg'
+	throw_message = "falls right through the strange body of the"
+	obj_damage = 0
+	environment_smash = ENVIRONMENT_SMASH_NONE
+	pass_flags = PASSTABLE
+	del_on_death = 1
 
 /obj/item/gps/internal/stalwart
 	icon_state = null

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -23,6 +23,7 @@
 	melee_damage_upper = 10
 	attacktext = "attacks"
 	attack_sound = 'sound/items/bikehorn.ogg'
+	faction = list("creature")
 	obj_damage = 0
 	environment_smash = ENVIRONMENT_SMASH_NONE
 	del_on_death = 1

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1884,7 +1884,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	
 /datum/uplink_item/role_restricted/clowngrenade
 	name = "C.L.U.W.N.E. Grenade"
-	desc = "A tactical clown grenade which conjures a clown from the netherworlds. Be careful, it may attack you too! Not guaranteed to be useful in the slightest."
+	desc = "A tactical clown grenade which conjures a clown from the netherworlds. Be careful; it may attack you too! Not guaranteed to be useful in the slightest."
 	item = /obj/item/grenade/spawnergrenade/clown
 	cost = 7
 	restricted_roles = list("Clown")

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1882,12 +1882,12 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	manufacturer = /datum/corporation/traitor/donkco
 	restricted_roles = list("Roboticist", "Research Director")
 	
-/datum/uplink_item/role_restricted/syndicate_basket
+/datum/uplink_item/role_restricted/clowngrenade
 	name = "C.L.U.W.N.E. Grenade"
-	desc = "A tactical clown grenade which conjures a clown from the netherworlds. Be careful, it may attack you too!"
+	desc = "A tactical clown grenade which conjures a clown from the netherworlds. Be careful, it may attack you too! Not guaranteed to be useful in the slightest."
 	item = /obj/item/grenade/spawnergrenade/clown
-	cost = 3
-	restricted_roles = list("Cook")
+	cost = 7
+	restricted_roles = list("Clown")
 
 /datum/uplink_item/role_restricted/haunted_magic_eightball
 	name = "Haunted Magic Eightball"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1881,6 +1881,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 3
 	manufacturer = /datum/corporation/traitor/donkco
 	restricted_roles = list("Roboticist", "Research Director")
+	
+/datum/uplink_item/role_restricted/syndicate_basket
+	name = "C.L.U.W.N.E. Grenade"
+	desc = "A tactical clown grenade which conjures a clown from the netherworlds. Be careful, it may attack you too!"
+	item = /obj/item/grenade/spawnergrenade/clown
+	cost = 3
+	restricted_roles = list("Cook")
 
 /datum/uplink_item/role_restricted/haunted_magic_eightball
 	name = "Haunted Magic Eightball"


### PR DESCRIPTION
### Intent of your Pull Request

these funny clowns are never used, and i think this could add a bit of spice to the round, and fits the whole style of the clown in that it's completely chaotic, either being incredible or absolutely useless. also, i made the simple clowns hostile to everyone as to not make it just a free 500 health bodyguard for the tot clown, and also not something you can just avoid instead of fighting, as youd have to start the fight.

### Why is this change good for the game?

i like these funny clowners, could be fun to see these doods run around the station

### Briefly describe your PR and the impacts of it, in layman's terms. 
adds a clown spawner grenade to the traitor uplink for 7 tc, it spawns a random clown mob that is hostile to all people

### What general grouping does this PR fall under? 
syndicate items

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
the item costs 7 telecrystals 

:cl:  
rscadd: clown spawner grenade put into uplink  
tweak: clown mobs are now innately hostile
/:cl:
