### PR TITLE
Makes the SM surge event even more powerful

### DIFF
--- a/code/modules/events/supermatter_surge.dm
+++ b/code/modules/events/supermatter_surge.dm
@@ -16,8 +16,7 @@
 	power = rand(1000,100000)
 
 /datum/round_event/supermatter_surge/announce()
-	if(power > 800 || prob(round(power/8)))
-		priority_announce("Class [round(power/500) + 1] supermatter surge detected. Intervention may be required.", "Anomaly Alert")
+	priority_announce("Class [round(power/500) + 1] supermatter surge detected. Intervention may be required.", "Anomaly Alert")
 
 /datum/round_event/supermatter_surge/start()
 	GLOB.main_supermatter_engine.matter_power += power

--- a/code/modules/events/supermatter_surge.dm
+++ b/code/modules/events/supermatter_surge.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/supermatter_surge
 	name = "Supermatter Surge"
 	typepath = /datum/round_event/supermatter_surge
-	weight = 20
+	weight = 15
 	max_occurrences = 4
 	earliest_start = 10 MINUTES
 
@@ -13,7 +13,7 @@
 	var/power = 2000
 
 /datum/round_event/supermatter_surge/setup()
-	power = rand(400,8000)
+	power = rand(1000,50000)
 
 /datum/round_event/supermatter_surge/announce()
 	if(power > 800 || prob(round(power/8)))

--- a/code/modules/events/supermatter_surge.dm
+++ b/code/modules/events/supermatter_surge.dm
@@ -13,7 +13,7 @@
 	var/power = 2000
 
 /datum/round_event/supermatter_surge/setup()
-	power = rand(1000,50000)
+	power = rand(1000,100000)
 
 /datum/round_event/supermatter_surge/announce()
 	if(power > 800 || prob(round(power/8)))


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

After the latest changes it's still wet farts. What I did is raise the maximum random powerup to as high as 100 000.
This may seem like a lot compared to what we have now(8k) but from what I understand, the way this code works is just set it to the power value for a split second, making even values up to 10k insignificant on a default engine setup.
Made it a bit more rare to balance it out.

Tested it by getting a simple straight pipe setup and setting the SM power level to 100k via varediting. What happened was it just burned for a little while but didn't even start delaminating.

### Why is this change good for the game?

As it is right now it still does nothing and only fills up the events.

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
What I did is raise the maximum random powerup to as high as 100 000.
This may seem like a lot compared to what we have now(8k) but from what I understand, the way this code works is just set it to the power value for a split second, making even values up to 10k insignificant on a default engine setup.
Made it a bit more rare to balance it out.

### What should players be aware of when it comes to the changes your PR is implementing?
The SM surge event is now a bit more rare but more powerful

### What general grouping does this PR fall under? 
Engineering

### Are there any aspects of the PR that you would like us not to mention on the Wiki?
Not really

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
The earliest start for it is 10 minutes in and the SM crystal has to has been powered.

# Changelog

:cl:  
tweak: Makes the SM surge event even more powerful, lowers its chance to appear
/:cl:
