### PR TITLE
Removes necro stone from a lavaland ruin

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_I.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_I.dmm
@@ -23,12 +23,6 @@
 	},
 /turf/open/floor/mineral/diamond,
 /area/ruin/unpowered)
-"aA" = (
-/obj/structure/table,
-/obj/item/necromantic_stone,
-/obj/item/stack/sheet/mineral/diamond,
-/turf/open/floor/mineral/diamond,
-/area/ruin/unpowered)
 "aD" = (
 /obj/item/chair,
 /turf/open/floor/mineral/diamond,
@@ -262,6 +256,11 @@
 /obj/effect/decal/remains/human,
 /obj/item/coin/gold,
 /turf/open/floor/plasteel/dark/lavaland,
+/area/ruin/unpowered)
+"Wd" = (
+/obj/structure/table,
+/obj/item/stack/sheet/mineral/diamond,
+/turf/open/floor/mineral/diamond,
 /area/ruin/unpowered)
 "Xa" = (
 /obj/item/slimecross/industrial/silver,
@@ -685,7 +684,7 @@ aU
 aU
 vW
 rp
-aA
+Wd
 aE
 rp
 bm


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request
removes the wizard item that allows you to create thralls from a lavaland ruin

### Why is this change good for the game?
powergaming bad, wizard items shouldnt be available to miners

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
removes the wizard item that allows you to create thralls from a lavaland ruin

### What should players be aware of when it comes to the changes your PR is implementing?
removes the wizard item that allows you to create thralls from a lavaland ruin

### What general grouping does this PR fall under? 
mining

### Are there any aspects of the PR that you would like us not to mention on the Wiki?
nope

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
removes the wizard item that allows you to create thralls from a lavaland ruin

# Changelog

:cl:  
tweak: removes the wizard item that allows you to create thralls from a lavaland ruin
/:cl:
