### PR TITLE
Fixes unintentional nerf to Tesla

### DIFF
--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -71,9 +71,9 @@
 
 		for (var/ball in orbiting_balls)
 			if(prob(80))  //tesla nerf/reducing lag, each miniball now has only 20% to trigger the zap
+				continue
 			var/range = rand(1, clamp(orbiting_balls.len, 3, zap_range))
 			tesla_zap(ball, range, TESLA_MINI_POWER/7*range)
-				continue
 	else
 		energy = 0 // ensure we dont have miniballs of miniballs
 

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -71,9 +71,9 @@
 
 		for (var/ball in orbiting_balls)
 			if(prob(80))  //tesla nerf/reducing lag, each miniball now has only 20% to trigger the zap
-				return
 			var/range = rand(1, clamp(orbiting_balls.len, 3, zap_range))
 			tesla_zap(ball, range, TESLA_MINI_POWER/7*range)
+				continue
 	else
 		energy = 0 // ensure we dont have miniballs of miniballs
 


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Fixes an issue introduced by #11278. There was a `return` where there should've been a `continue`.

### Why is this change good for the game?

It makes the miniballs not be super bad (but they're still pretty garbage).

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
Each miniball now independently now has a 20% chance to zap instead of all collectively only having a 20% chance to zap.

### What should players be aware of when it comes to the changes your PR is implementing?
Tesla miniballs will generate a tiny bit more power now that they can do work more often.

### What general grouping does this PR fall under? 
Engineering changes.

### Are there any aspects of the PR that you would like us not to mention on the Wiki?
No

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
Tesla as a whole generates a tiny bit more power.

# Changelog

:cl:  
bugfix: Telsa miniballs now properly trigger 20% of the time.
/:cl:
