### PR TITLE
[box] Adds all the job figurines to the station

### DIFF
--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_arcade.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_arcade.dmm
@@ -33,13 +33,6 @@
 "ag" = (
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"ah" = (
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/structure/table/wood,
-/obj/item/stack/spacecash/c10,
-/obj/item/stack/spacecash/c100,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "ai" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Kitchen Maintenance";
@@ -115,10 +108,6 @@
 "aB" = (
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"aC" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
 "aE" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -486,25 +475,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"de" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/fancy/donut_box,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"df" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "dh" = (
 /obj/structure/sign/barsign,
 /turf/closed/wall,
@@ -766,6 +736,11 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"Af" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/item/toy/figure/chef,
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen)
 "Ak" = (
 /obj/machinery/light,
 /obj/machinery/firealarm{
@@ -774,6 +749,18 @@
 	},
 /turf/open/floor/eighties,
 /area/crew_quarters/bar)
+"BB" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "CV" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only,
@@ -811,6 +798,14 @@
 /obj/structure/chair{
 	dir = 4
 	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"Hw" = (
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/structure/table/wood,
+/obj/item/stack/spacecash/c10,
+/obj/item/stack/spacecash/c100,
+/obj/item/toy/figure/bartender,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "HX" = (
@@ -901,6 +896,19 @@
 /obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"Px" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/fancy/donut_box,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "PU" = (
 /obj/structure/table,
 /obj/machinery/light,
@@ -1277,7 +1285,7 @@ yM
 ag
 "}
 (13,1,1) = {"
-ah
+Hw
 ay
 aE
 Nf
@@ -1374,7 +1382,7 @@ aa
 "}
 (19,1,1) = {"
 al
-aC
+Af
 aS
 bg
 bq
@@ -1385,7 +1393,7 @@ cr
 cz
 ce
 ce
-de
+Px
 aa
 "}
 (20,1,1) = {"
@@ -1401,7 +1409,7 @@ xI
 sb
 cI
 ce
-df
+BB
 aa
 "}
 (21,1,1) = {"
@@ -1417,7 +1425,7 @@ QH
 cB
 ce
 cR
-df
+BB
 aa
 "}
 (22,1,1) = {"
@@ -1433,7 +1441,7 @@ bP
 cB
 ce
 ce
-df
+BB
 aa
 "}
 (23,1,1) = {"

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_box.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_box.dmm
@@ -33,13 +33,6 @@
 "ag" = (
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"ah" = (
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/structure/table/wood,
-/obj/item/stack/spacecash/c10,
-/obj/item/stack/spacecash/c100,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "ai" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Kitchen Maintenance";
@@ -202,10 +195,6 @@
 "aB" = (
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"aC" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
 "aD" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/tile/bar,
@@ -748,6 +737,19 @@
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"bT" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/fancy/donut_box,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "bU" = (
 /obj/structure/chair{
 	dir = 4
@@ -1218,25 +1220,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"de" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/fancy/donut_box,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"df" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "dg" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Diner"
@@ -1263,6 +1246,26 @@
 	name = "privacy shutters"
 	},
 /turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"ge" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"gL" = (
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/structure/table/wood,
+/obj/item/stack/spacecash/c10,
+/obj/item/stack/spacecash/c100,
+/obj/item/toy/figure/bartender,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "jO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -1353,6 +1356,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"DS" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/item/toy/figure/chef,
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen)
 "IS" = (
 /obj/machinery/disposal/bin,
 /obj/structure/sign/warning/securearea{
@@ -1646,7 +1654,7 @@ db
 ag
 "}
 (13,1,1) = {"
-ah
+gL
 ay
 aE
 bd
@@ -1743,7 +1751,7 @@ aa
 "}
 (19,1,1) = {"
 al
-aC
+DS
 aS
 bg
 bq
@@ -1754,7 +1762,7 @@ cr
 cz
 ce
 ce
-de
+bT
 aa
 "}
 (20,1,1) = {"
@@ -1770,7 +1778,7 @@ xI
 sb
 cI
 ce
-df
+ge
 aa
 "}
 (21,1,1) = {"
@@ -1786,7 +1794,7 @@ QH
 cB
 ce
 cR
-df
+ge
 aa
 "}
 (22,1,1) = {"
@@ -1802,7 +1810,7 @@ bP
 cB
 ce
 ce
-df
+ge
 aa
 "}
 (23,1,1) = {"

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_casino.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_casino.dmm
@@ -41,18 +41,6 @@
 	icon_state = "r_wall"
 	},
 /area/crew_quarters/bar)
-"ah" = (
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/structure/table/wood,
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/stack/cable_coil,
-/turf/open/floor/plasteel/rockvault,
-/area/crew_quarters/bar)
 "ai" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/rockvault,
@@ -177,12 +165,6 @@
 	},
 /turf/open/floor/plasteel/rockvault,
 /area/crew_quarters/bar)
-"aA" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/turf/open/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/crew_quarters/kitchen)
 "aB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -630,41 +612,12 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
-"bK" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/item/storage/box/fancy/donut_box,
-/turf/open/floor/plasteel/ameridiner,
-/area/crew_quarters/kitchen)
-"bL" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/item/reagent_containers/food/snacks/mint,
-/turf/open/floor/plasteel/ameridiner,
-/area/crew_quarters/kitchen)
 "bM" = (
 /mob/living/carbon/monkey{
 	name = "Pun Pun"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"bN" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/crew_quarters/kitchen)
 "bO" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Bar"
@@ -923,6 +876,18 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
+"Ax" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/crew_quarters/kitchen)
 "AK" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/enzyme{
@@ -953,6 +918,19 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"Dw" = (
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/structure/table/wood,
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/stack/cable_coil,
+/obj/item/toy/figure/bartender,
+/turf/open/floor/plasteel/rockvault,
+/area/crew_quarters/bar)
 "Fj" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets{
@@ -969,6 +947,19 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
+"Kb" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/item/storage/box/fancy/donut_box,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/crew_quarters/kitchen)
 "LT" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel{
@@ -1041,6 +1032,26 @@
 "TA" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/mint,
+/turf/open/floor/plasteel/ameridiner,
+/area/crew_quarters/kitchen)
+"Uk" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/item/toy/figure/chef,
+/turf/open/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/crew_quarters/kitchen)
+"Ul" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/item/reagent_containers/food/snacks/mint,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/kitchen)
 "Up" = (
@@ -1271,7 +1282,7 @@ ap
 Nq
 "}
 (13,1,1) = {"
-ah
+Dw
 ax
 aK
 aW
@@ -1368,7 +1379,7 @@ aa
 "}
 (19,1,1) = {"
 am
-aA
+Uk
 aO
 aY
 bi
@@ -1379,7 +1390,7 @@ TA
 AK
 co
 co
-bK
+Kb
 aa
 "}
 (20,1,1) = {"
@@ -1395,7 +1406,7 @@ cg
 Fj
 cq
 co
-bL
+Ul
 aa
 "}
 (21,1,1) = {"
@@ -1411,7 +1422,7 @@ ge
 cf
 co
 cP
-bN
+Ax
 aa
 "}
 (22,1,1) = {"
@@ -1427,7 +1438,7 @@ bm
 cf
 co
 co
-bN
+Ax
 aa
 "}
 (23,1,1) = {"

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_cheese.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_cheese.dmm
@@ -252,21 +252,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"aN" = (
-/obj/structure/table/wood,
-/obj/structure/sign/poster/official/fruit_bowl{
-	pixel_x = 32
-	},
-/obj/item/reagent_containers/food/snacks/grown/grapes{
-	pixel_x = -2;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/food/snacks/grown/grapes/green{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "aP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -511,12 +496,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"bH" = (
-/obj/structure/closet/secure_closet/freezer/meat{
-	name = "cured meat fridge"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "bI" = (
 /obj/machinery/light{
 	dir = 8
@@ -756,16 +735,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"cB" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/item/reagent_containers/food/snacks/baguette,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "cC" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Diner"
@@ -824,15 +793,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"df" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "dh" = (
 /obj/structure/sign/barsign,
 /turf/closed/wall,
@@ -887,6 +847,13 @@
 /obj/item/reagent_containers/food/condiment/enzyme{
 	layer = 5
 	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"kA" = (
+/obj/structure/closet/secure_closet/freezer/meat{
+	name = "cured meat fridge"
+	},
+/obj/item/toy/figure/chef,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "kC" = (
@@ -960,6 +927,22 @@
 /obj/machinery/food_cart,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"tV" = (
+/obj/structure/table/wood,
+/obj/structure/sign/poster/official/fruit_bowl{
+	pixel_x = 32
+	},
+/obj/item/reagent_containers/food/snacks/grown/grapes{
+	pixel_x = -2;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/snacks/grown/grapes/green{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/toy/figure/bartender,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "ul" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/wood,
@@ -975,6 +958,18 @@
 /area/crew_quarters/bar)
 "we" = (
 /obj/machinery/deepfryer,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"zN" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "BJ" = (
@@ -1101,6 +1096,19 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"XV" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/item/reagent_containers/food/snacks/baguette,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "ZP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -1369,7 +1377,7 @@ ag
 (17,1,1) = {"
 ak
 BJ
-aN
+tV
 ag
 rA
 al
@@ -1411,7 +1419,7 @@ bP
 jQ
 ce
 by
-cB
+XV
 aa
 "}
 (20,1,1) = {"
@@ -1427,7 +1435,7 @@ ca
 Ux
 cv
 ct
-df
+zN
 aa
 "}
 (21,1,1) = {"
@@ -1443,7 +1451,7 @@ ce
 ce
 cI
 ce
-df
+zN
 aa
 "}
 (22,1,1) = {"
@@ -1459,7 +1467,7 @@ cb
 ci
 cm
 ce
-df
+zN
 aa
 "}
 (23,1,1) = {"
@@ -1485,7 +1493,7 @@ al
 al
 al
 al
-bH
+kA
 ce
 ce
 rk

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_citadel.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_citadel.dmm
@@ -709,6 +709,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"wY" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/item/toy/figure/chef,
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen)
 "wZ" = (
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -769,19 +774,6 @@
 /obj/structure/window{
 	dir = 1
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"Al" = (
-/obj/structure/table/wood,
-/obj/item/paper/fluff{
-	info = "<b>Renovation Notice</b><br><br>The bar layout for the station is very old. We've decided to give it a facelift after our partnership with IKEA Intergalactic?.</li><li>We added some sweet retro arcade machines and much more seating area. We removed the stage since it hasn't ever been used.</li><li>You can run this place like a restaurant now that you have tables. Go whip up a menu with the Chef. You have a condiments table and your Requests Console has been moved so a noticeboard can be placed there. Take tickets from customers and pin them on the noticeboard for the Chef.</li><li><b>We hope you like the new bar!</ b>";
-	name = "Renovation Notice - Bar";
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/stack/spacecash/c100,
-/obj/item/stack/spacecash/c100,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "AN" = (
@@ -1208,10 +1200,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"NB" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
 "OC" = (
 /turf/closed/wall,
 /area/crew_quarters/bar)
@@ -1374,6 +1362,20 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"VK" = (
+/obj/structure/table/wood,
+/obj/item/paper/fluff{
+	info = "<b>Renovation Notice</b><br><br>The bar layout for the station is very old. We've decided to give it a facelift after our partnership with IKEA Intergalactic?.</li><li>We added some sweet retro arcade machines and much more seating area. We removed the stage since it hasn't ever been used.</li><li>You can run this place like a restaurant now that you have tables. Go whip up a menu with the Chef. You have a condiments table and your Requests Console has been moved so a noticeboard can be placed there. Take tickets from customers and pin them on the noticeboard for the Chef.</li><li><b>We hope you like the new bar!</ b>";
+	name = "Renovation Notice - Bar";
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/stack/spacecash/c100,
+/obj/item/stack/spacecash/c100,
+/obj/item/toy/figure/bartender,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "WX" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -1680,7 +1682,7 @@ OC
 Gu
 RL
 Ic
-Al
+VK
 OC
 PT
 kk
@@ -1774,7 +1776,7 @@ uY
 "}
 (19,1,1) = {"
 tx
-NB
+wY
 Mo
 dZ
 JA

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_clock.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_clock.dmm
@@ -96,10 +96,6 @@
 	},
 /turf/open/floor/bronze,
 /area/crew_quarters/bar)
-"aC" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
 "aF" = (
 /obj/machinery/door/window/southleft{
 	base_state = "left";
@@ -231,6 +227,18 @@
 /obj/machinery/deepfryer,
 /turf/open/floor/bronze,
 /area/crew_quarters/kitchen)
+"eX" = (
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/stack/spacecash/c10,
+/obj/item/stack/spacecash/c100,
+/obj/item/clothing/head/bronze,
+/obj/item/clothing/shoes/bronze,
+/obj/item/clothing/suit/bronze,
+/obj/item/toy/clockwork_watch,
+/obj/structure/table/bronze,
+/obj/item/toy/figure/bartender,
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
 "fa" = (
 /obj/structure/table/bronze,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -408,6 +416,19 @@
 /obj/item/clockwork/alloy_shards/clockgolem_remains,
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
+"oO" = (
+/obj/item/storage/box/fancy/donut_box,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/structure/table/bronze,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/kitchen)
 "pv" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -542,6 +563,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/bronze,
 /area/crew_quarters/theatre)
+"wp" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/structure/table/bronze,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/kitchen)
 "wz" = (
 /mob/living/carbon/monkey/punpun,
 /turf/open/floor/bronze/reebe,
@@ -559,6 +592,11 @@
 	},
 /turf/open/floor/bronze,
 /area/crew_quarters/bar)
+"xO" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/item/toy/figure/chef,
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen)
 "xV" = (
 /obj/machinery/airalarm{
 	dir = 2;
@@ -586,16 +624,6 @@
 	req_access_txt = "28"
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
-"yv" = (
-/obj/item/storage/box/fancy/donut_box,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/structure/table/bronze,
-/turf/open/floor/bronze/reebe,
 /area/crew_quarters/kitchen)
 "yE" = (
 /obj/item/radio/intercom{
@@ -703,15 +731,6 @@
 	pixel_y = 6
 	},
 /turf/open/floor/bronze,
-/area/crew_quarters/kitchen)
-"CJ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/structure/table/bronze,
-/turf/open/floor/bronze/reebe,
 /area/crew_quarters/kitchen)
 "CO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -859,17 +878,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"Lp" = (
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/stack/spacecash/c10,
-/obj/item/stack/spacecash/c100,
-/obj/item/clothing/head/bronze,
-/obj/item/clothing/shoes/bronze,
-/obj/item/clothing/suit/bronze,
-/obj/item/toy/clockwork_watch,
-/obj/structure/table/bronze,
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
 "LL" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -1397,7 +1405,7 @@ Re
 Ws
 "}
 (13,1,1) = {"
-Lp
+eX
 QK
 Xj
 jf
@@ -1494,7 +1502,7 @@ aa
 "}
 (19,1,1) = {"
 al
-aC
+xO
 aS
 bg
 bq
@@ -1505,7 +1513,7 @@ gL
 SM
 eu
 CT
-yv
+oO
 aa
 "}
 (20,1,1) = {"
@@ -1521,7 +1529,7 @@ vK
 Nx
 Mg
 CT
-CJ
+wp
 aa
 "}
 (21,1,1) = {"
@@ -1537,7 +1545,7 @@ Cz
 eP
 eu
 rZ
-CJ
+wp
 aa
 "}
 (22,1,1) = {"
@@ -1553,7 +1561,7 @@ HF
 eP
 eu
 CT
-CJ
+wp
 aa
 "}
 (23,1,1) = {"

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_conveyor.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_conveyor.dmm
@@ -30,18 +30,6 @@
 /obj/structure/musician/piano,
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
-"ah" = (
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/structure/table/wood,
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/stack/cable_coil,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "ai" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
@@ -144,12 +132,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"az" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/turf/open/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/crew_quarters/kitchen)
 "aA" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -730,16 +712,6 @@
 /mob/living/simple_animal/hostile/lizard,
 /turf/open/floor/plating/beach/sand,
 /area/crew_quarters/bar)
-"ct" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/item/storage/box/fancy/donut_box,
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/kitchen)
 "cu" = (
 /obj/effect/landmark/start/bartender,
 /turf/open/floor/plasteel/vaporwave,
@@ -750,25 +722,6 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
-"cw" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/item/reagent_containers/food/snacks/mint,
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/kitchen)
-"cx" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/kitchen)
 "cy" = (
 /obj/machinery/requests_console{
 	department = "Bar";
@@ -1008,6 +961,22 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/bar)
+"gS" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/item/reagent_containers/food/snacks/butterdog{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/kitchen)
 "hc" = (
 /obj/structure/table/reinforced,
 /obj/structure/plasticflaps,
@@ -1059,6 +1028,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/kitchen)
+"kH" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/item/toy/figure/chef,
+/turf/open/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
 /area/crew_quarters/kitchen)
 "kM" = (
 /obj/machinery/holopad,
@@ -1183,6 +1159,19 @@
 	},
 /turf/closed/wall,
 /area/crew_quarters/bar)
+"yR" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/item/storage/box/fancy/donut_box,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/kitchen)
 "BP" = (
 /obj/effect/spawner/xmastree,
 /turf/open/floor/plasteel/vaporwave,
@@ -1241,6 +1230,31 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/kitchen)
+"MC" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/item/reagent_containers/food/snacks/mint,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/kitchen)
+"Nj" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/crew_quarters/kitchen)
 "Rl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1283,19 +1297,19 @@
 /obj/item/stack/packageWrap,
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/kitchen)
-"XW" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
+"Yu" = (
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/structure/table/wood,
+/obj/item/stack/sheet/metal{
+	amount = 50
 	},
-/obj/item/reagent_containers/food/snacks/butterdog{
-	pixel_x = -1;
-	pixel_y = 3
+/obj/item/stack/sheet/glass{
+	amount = 50
 	},
-/turf/open/floor/plasteel/vaporwave,
-/area/crew_quarters/kitchen)
+/obj/item/stack/cable_coil,
+/obj/item/toy/figure/bartender,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 
 (1,1,1) = {"
 aa
@@ -1490,7 +1504,7 @@ ao
 cG
 "}
 (13,1,1) = {"
-ah
+Yu
 aw
 aJ
 aW
@@ -1587,7 +1601,7 @@ aa
 "}
 (19,1,1) = {"
 al
-az
+kH
 aM
 aY
 bn
@@ -1598,7 +1612,7 @@ wu
 Wr
 bN
 bN
-ct
+yR
 aa
 "}
 (20,1,1) = {"
@@ -1614,7 +1628,7 @@ VM
 Mi
 cf
 bN
-cw
+MC
 aa
 "}
 (21,1,1) = {"
@@ -1630,7 +1644,7 @@ ow
 bU
 bN
 cl
-cx
+Nj
 aa
 "}
 (22,1,1) = {"
@@ -1646,7 +1660,7 @@ ca
 bU
 bN
 bN
-XW
+gS
 aa
 "}
 (23,1,1) = {"

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_diner.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_diner.dmm
@@ -19,18 +19,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
-"af" = (
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/structure/table/wood,
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/stack/cable_coil,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "ag" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
@@ -147,12 +135,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"aw" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/turf/open/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/crew_quarters/kitchen)
 "ax" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -906,18 +888,6 @@
 /obj/effect/turf_decal/ameritard,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"di" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/item/storage/box/fancy/donut_box,
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/kitchen)
 "dj" = (
 /obj/structure/sign/barsign,
 /turf/closed/wall,
@@ -933,6 +903,13 @@
 	},
 /turf/open/floor/plasteel{
 	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
+"gu" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/item/toy/figure/chef,
+/turf/open/floor/plasteel{
+	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
 "hl" = (
@@ -1036,7 +1013,7 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/bar)
-"pQ" = (
+"pL" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -1044,6 +1021,9 @@
 	name = "kitchen shutters"
 	},
 /obj/item/reagent_containers/food/snacks/mint,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -1090,6 +1070,21 @@
 /obj/item/reagent_containers/food/snacks/burger/plain,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
+"zm" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/item/reagent_containers/food/snacks/burger/plain,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
 "Aw" = (
 /obj/structure/table,
 /obj/machinery/requests_console{
@@ -1104,18 +1099,19 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
-"Dn" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
+"BA" = (
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/structure/table/wood,
+/obj/item/stack/sheet/metal{
+	amount = 50
 	},
-/obj/item/reagent_containers/food/snacks/burger/superbite,
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
+/obj/item/stack/sheet/glass{
+	amount = 50
 	},
-/area/crew_quarters/kitchen)
+/obj/item/stack/cable_coil,
+/obj/item/toy/figure/bartender,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "Dt" = (
 /obj/machinery/smartfridge/drinks,
 /obj/machinery/door/poddoor/preopen{
@@ -1162,6 +1158,21 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/bar)
+"JW" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/item/storage/box/fancy/donut_box,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
 "Ku" = (
 /obj/structure/table/american,
 /obj/item/reagent_containers/food/snacks/burger/plain,
@@ -1180,6 +1191,21 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/bar)
+"MR" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/item/reagent_containers/food/snacks/burger/superbite,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/crew_quarters/kitchen)
 "Ns" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -1225,18 +1251,6 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/bar)
-"Tm" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/item/reagent_containers/food/snacks/burger/plain,
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/kitchen)
 "Tv" = (
 /obj/effect/turf_decal/ameritard,
 /obj/machinery/holopad,
@@ -1484,7 +1498,7 @@ az
 ab
 "}
 (13,1,1) = {"
-af
+BA
 at
 aG
 aV
@@ -1581,7 +1595,7 @@ aa
 "}
 (19,1,1) = {"
 aj
-aw
+gu
 aK
 aX
 bi
@@ -1592,7 +1606,7 @@ if
 Up
 bD
 bD
-di
+JW
 aa
 "}
 (20,1,1) = {"
@@ -1608,7 +1622,7 @@ bO
 Vc
 bU
 bD
-pQ
+pL
 aa
 "}
 (21,1,1) = {"
@@ -1624,7 +1638,7 @@ vo
 bM
 bD
 ck
-Dn
+MR
 aa
 "}
 (22,1,1) = {"
@@ -1640,7 +1654,7 @@ bB
 bM
 bD
 bD
-Tm
+zm
 aa
 "}
 (23,1,1) = {"

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_disco.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_disco.dmm
@@ -2,18 +2,6 @@
 "aa" = (
 /turf/template_noop,
 /area/template_noop)
-"ab" = (
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/structure/table/wood,
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/stack/cable_coil,
-/turf/open/floor/plasteel/ameridiner,
-/area/crew_quarters/bar)
 "ac" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
@@ -159,12 +147,6 @@
 	},
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/bar)
-"ax" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/turf/open/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/crew_quarters/kitchen)
 "ay" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -527,16 +509,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"bx" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/item/storage/box/fancy/donut_box,
-/turf/open/floor/plasteel/ameridiner,
-/area/crew_quarters/kitchen)
 "by" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/light/colour_cycle/dancefloor_a,
@@ -549,25 +521,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"bA" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/item/reagent_containers/food/snacks/mint,
-/turf/open/floor/plasteel/ameridiner,
-/area/crew_quarters/kitchen)
-"bB" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/crew_quarters/kitchen)
 "bC" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Diner"
@@ -861,6 +814,19 @@
 /obj/effect/spawner/xmastree,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"li" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/item/storage/box/fancy/donut_box,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/crew_quarters/kitchen)
 "nK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -869,6 +835,19 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"pp" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/item/reagent_containers/food/snacks/mint,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/crew_quarters/kitchen)
 "pw" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -926,6 +905,18 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"DX" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/crew_quarters/kitchen)
 "Eq" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/head/that,
@@ -948,6 +939,22 @@
 /obj/item/reagent_containers/food/condiment/saltshaker{
 	pixel_x = -8;
 	pixel_y = 4
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/crew_quarters/kitchen)
+"Gr" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/item/reagent_containers/food/snacks/salad/fruit{
+	pixel_x = 1;
+	pixel_y = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/kitchen)
@@ -982,6 +989,19 @@
 	},
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/kitchen)
+"Lk" = (
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/structure/table/wood,
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/stack/cable_coil,
+/obj/item/toy/figure/bartender,
+/turf/open/floor/plasteel/ameridiner,
+/area/crew_quarters/bar)
 "Mm" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/barman_recipes,
@@ -1015,18 +1035,12 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
-"RL" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
+"OZ" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/item/toy/figure/chef,
+/turf/open/floor/plasteel{
+	icon_state = "showroomfloor"
 	},
-/obj/item/reagent_containers/food/snacks/salad/fruit{
-	pixel_x = 1;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/kitchen)
 "SI" = (
 /obj/machinery/door/airlock{
@@ -1264,7 +1278,7 @@ HK
 ai
 "}
 (13,1,1) = {"
-ab
+Lk
 au
 aI
 aW
@@ -1361,7 +1375,7 @@ aa
 "}
 (19,1,1) = {"
 ak
-ax
+OZ
 aL
 aY
 bj
@@ -1372,7 +1386,7 @@ xw
 Zg
 cy
 cy
-bx
+li
 aa
 "}
 (20,1,1) = {"
@@ -1388,7 +1402,7 @@ cp
 BD
 cA
 cy
-bA
+pp
 aa
 "}
 (21,1,1) = {"
@@ -1404,7 +1418,7 @@ FH
 co
 cy
 cU
-bB
+DX
 aa
 "}
 (22,1,1) = {"
@@ -1420,7 +1434,7 @@ bn
 co
 cy
 cy
-RL
+Gr
 aa
 "}
 (23,1,1) = {"

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_irish.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_irish.dmm
@@ -21,13 +21,6 @@
 "ad" = (
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"af" = (
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/structure/table/wood,
-/obj/item/stack/spacecash/c10,
-/obj/item/stack/spacecash/c100,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "ag" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -198,10 +191,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"ay" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
 "az" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -1527,16 +1516,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"cV" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/fancy/donut_box,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "cW" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -1587,15 +1566,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"cZ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "db" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Diner"
@@ -1610,6 +1580,11 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/crew_quarters/bar)
+"du" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/item/toy/figure/chef,
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen)
 "hD" = (
 /obj/structure/table,
 /obj/machinery/requests_console{
@@ -1647,6 +1622,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"nx" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "pI" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/mixbowl{
@@ -1705,6 +1692,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"FU" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/fancy/donut_box,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "IS" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -1755,6 +1755,14 @@
 	req_access_txt = "25"
 	},
 /turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"Lb" = (
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/structure/table/wood,
+/obj/item/stack/spacecash/c10,
+/obj/item/stack/spacecash/c100,
+/obj/item/toy/figure/bartender,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "MM" = (
 /obj/structure/table,
@@ -2034,7 +2042,7 @@ cW
 ad
 "}
 (13,1,1) = {"
-af
+Lb
 au
 aL
 bb
@@ -2131,7 +2139,7 @@ aa
 "}
 (19,1,1) = {"
 aj
-ay
+du
 aQ
 be
 bp
@@ -2142,7 +2150,7 @@ ck
 cu
 bX
 bX
-cV
+FU
 aa
 "}
 (20,1,1) = {"
@@ -2158,7 +2166,7 @@ pI
 iw
 cE
 bX
-cZ
+nx
 aa
 "}
 (21,1,1) = {"
@@ -2174,7 +2182,7 @@ MM
 cw
 bX
 cM
-cZ
+nx
 aa
 "}
 (22,1,1) = {"
@@ -2190,7 +2198,7 @@ cn
 cw
 bX
 bX
-cZ
+nx
 aa
 "}
 (23,1,1) = {"

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_purple.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_purple.dmm
@@ -28,18 +28,6 @@
 /obj/item/radio/intercom,
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"ag" = (
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/structure/table/wood,
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/stack/cable_coil,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "ah" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/purple{
@@ -182,23 +170,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"ay" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4;
-	icon_state = "tile_corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/kitchen)
 "az" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -782,18 +753,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"bN" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/structure/table/reinforced{
-	color = "purple"
-	},
-/obj/item/reagent_containers/food/snacks/burger/purple,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/kitchen)
 "bO" = (
 /obj/machinery/vending/boozeomat,
 /obj/effect/turf_decal/tile/purple{
@@ -895,30 +854,6 @@
 	dir = 8;
 	icon_state = "tile_corner"
 	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/kitchen)
-"bX" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/structure/table/reinforced{
-	color = "purple"
-	},
-/obj/item/storage/box/fancy/donut_box,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/kitchen)
-"bY" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/structure/table/reinforced{
-	color = "purple"
-	},
-/obj/item/reagent_containers/food/snacks/mint,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
 "bZ" = (
@@ -1305,6 +1240,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"mp" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/structure/table/reinforced{
+	color = "purple"
+	},
+/obj/item/reagent_containers/food/snacks/burger/purple,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/kitchen)
 "vD" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin{
@@ -1333,12 +1283,45 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"Be" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/structure/table/reinforced{
+	color = "purple"
+	},
+/obj/item/storage/box/fancy/donut_box,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/kitchen)
 "BD" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"CX" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/item/toy/figure/chef,
+/turf/open/floor/plasteel,
+/area/crew_quarters/kitchen)
 "Dl" = (
 /obj/item/clothing/gloves/color/purple,
 /obj/item/clothing/head/soft/purple,
@@ -1362,6 +1345,21 @@
 	},
 /obj/item/stack/packageWrap,
 /turf/open/floor/mineral/titanium/purple,
+/area/crew_quarters/kitchen)
+"Ef" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/structure/table/reinforced{
+	color = "purple"
+	},
+/obj/item/reagent_containers/food/snacks/mint,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
 "Eq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -1459,6 +1457,19 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
+"OF" = (
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/structure/table/wood,
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/stack/cable_coil,
+/obj/item/toy/figure/bartender,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "Px" = (
@@ -1779,7 +1790,7 @@ ar
 ab
 "}
 (13,1,1) = {"
-ag
+OF
 au
 aK
 ba
@@ -1876,7 +1887,7 @@ aa
 "}
 (19,1,1) = {"
 ak
-ay
+CX
 aO
 bd
 br
@@ -1887,7 +1898,7 @@ Jf
 DJ
 db
 do
-bN
+mp
 aa
 "}
 (20,1,1) = {"
@@ -1903,7 +1914,7 @@ cE
 Hw
 cP
 do
-bX
+Be
 aa
 "}
 (21,1,1) = {"
@@ -1919,7 +1930,7 @@ vD
 cD
 db
 dp
-bY
+Ef
 aa
 "}
 (22,1,1) = {"
@@ -1935,7 +1946,7 @@ cc
 cD
 db
 do
-bN
+mp
 aa
 "}
 (23,1,1) = {"

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_spacious.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_spacious.dmm
@@ -15,13 +15,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"af" = (
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/structure/table/wood,
-/obj/item/stack/spacecash/c10,
-/obj/item/stack/spacecash/c100,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "ag" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -169,10 +162,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"ax" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
 "ay" = (
 /obj/machinery/camera{
 	c_tag = "Kitchen Cold Room"
@@ -596,25 +585,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"bF" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/fancy/donut_box,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"bG" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "bJ" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -939,6 +909,18 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/bar)
+"et" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "gP" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -1034,6 +1016,14 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/bar)
+"yS" = (
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/structure/table/wood,
+/obj/item/stack/spacecash/c10,
+/obj/item/stack/spacecash/c100,
+/obj/item/toy/figure/bartender,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "Eu" = (
 /obj/structure/sign/plaques/deempisi,
 /turf/closed/wall,
@@ -1067,6 +1057,19 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/bar)
+"FR" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/fancy/donut_box,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "Ij" = (
 /obj/machinery/chem_dispenser/drinks,
 /obj/structure/table/reinforced,
@@ -1134,6 +1137,11 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"YV" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/item/toy/figure/chef,
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen)
 
 (1,1,1) = {"
 aa
@@ -1328,7 +1336,7 @@ co
 ab
 "}
 (13,1,1) = {"
-af
+yS
 ao
 as
 aD
@@ -1425,7 +1433,7 @@ aa
 "}
 (19,1,1) = {"
 aj
-ax
+YV
 aK
 aW
 bd
@@ -1436,7 +1444,7 @@ bL
 bS
 bC
 bC
-bF
+FR
 aa
 "}
 (20,1,1) = {"
@@ -1452,7 +1460,7 @@ pB
 Fq
 bX
 bC
-bG
+et
 aa
 "}
 (21,1,1) = {"
@@ -1468,7 +1476,7 @@ nP
 bU
 bC
 ce
-bG
+et
 aa
 "}
 (22,1,1) = {"
@@ -1484,7 +1492,7 @@ bf
 bU
 bC
 bC
-bG
+et
 aa
 "}
 (23,1,1) = {"

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_trek.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_trek.dmm
@@ -2,13 +2,6 @@
 "aa" = (
 /turf/template_noop,
 /area/template_noop)
-"ac" = (
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/stack/spacecash/c10,
-/obj/item/stack/spacecash/c100,
-/obj/structure/table,
-/turf/open/floor/mineral/titanium,
-/area/crew_quarters/bar)
 "ad" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
@@ -563,13 +556,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
-"bg" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "bh" = (
@@ -1214,25 +1200,6 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/crew_quarters/bar)
-"cJ" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/fancy/donut_box,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel,
-/area/crew_quarters/kitchen)
-"cK" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel,
-/area/crew_quarters/kitchen)
 "cL" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -1279,6 +1246,26 @@
 	pixel_y = 3
 	},
 /turf/open/floor/mineral/titanium,
+/area/crew_quarters/kitchen)
+"nE" = (
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/stack/spacecash/c10,
+/obj/item/stack/spacecash/c100,
+/obj/structure/table,
+/obj/item/toy/figure/bartender,
+/turf/open/floor/mineral/titanium,
+/area/crew_quarters/bar)
+"nZ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "oK" = (
 /obj/structure/grille,
@@ -1416,6 +1403,14 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/crew_quarters/bar)
+"JG" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/item/toy/figure/chef,
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen)
 "MN" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin{
@@ -1460,6 +1455,19 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/crew_quarters/bar)
+"Nw" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/fancy/donut_box,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/kitchen)
 "Pz" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -1706,7 +1714,7 @@ cE
 ag
 "}
 (13,1,1) = {"
-ac
+nE
 ay
 aP
 aZ
@@ -1805,7 +1813,7 @@ aa
 al
 aF
 aQ
-bg
+JG
 bo
 al
 bF
@@ -1814,7 +1822,7 @@ cc
 cj
 bQ
 bQ
-cJ
+Nw
 aa
 "}
 (20,1,1) = {"
@@ -1830,7 +1838,7 @@ MS
 ni
 cq
 bQ
-cK
+nZ
 aa
 "}
 (21,1,1) = {"
@@ -1846,7 +1854,7 @@ MN
 cm
 bQ
 cy
-cK
+nZ
 aa
 "}
 (22,1,1) = {"
@@ -1862,7 +1870,7 @@ cf
 cm
 bQ
 bQ
-cK
+nZ
 aa
 "}
 (23,1,1) = {"

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -435,16 +435,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"abk" = (
-/obj/machinery/keycard_auth{
-	pixel_x = 24;
-	pixel_y = 10
-	},
-/obj/structure/table/wood,
-/obj/item/radio/off,
-/obj/item/taperecorder,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "abl" = (
 /obj/machinery/vending/security,
 /turf/open/floor/plasteel/showroomfloor,
@@ -1843,31 +1833,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aeW" = (
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	pixel_x = -30
-	},
-/obj/machinery/camera{
-	c_tag = "Brig Control Room";
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/rack,
-/obj/item/clothing/mask/gas/sechailer{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "aeX" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -2114,18 +2079,6 @@
 	dir = 8
 	},
 /obj/item/storage/box/prisoner,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"afG" = (
-/obj/structure/table,
-/obj/item/storage/box/hug,
-/obj/item/razor{
-	pixel_x = -6
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "afH" = (
@@ -6138,14 +6091,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
-"aoK" = (
-/mob/living/simple_animal/pet/dog/pug{
-	desc = "Much better at protecting the armory than your average warden.";
-	name = "Warden Jacob";
-	real_name = "Warden Jacob"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "aoL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -6558,19 +6503,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"aqb" = (
-/obj/machinery/button/door{
-	id = "kanyewest";
-	name = "Privacy Shutters";
-	pixel_y = 24
-	},
-/obj/item/storage/briefcase,
-/obj/structure/rack,
-/obj/machinery/light_switch{
-	pixel_x = 27
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
 "aqc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -11091,34 +11023,11 @@
 /obj/machinery/flasher/portable,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"aEr" = (
-/obj/effect/turf_decal/bot_white,
-/obj/structure/table,
-/obj/item/grenade/barrier{
-	pixel_x = -4
-	},
-/obj/item/grenade/barrier,
-/obj/item/grenade/barrier{
-	pixel_x = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "aEs" = (
 /obj/effect/turf_decal/bot_white,
 /obj/structure/rack,
 /obj/item/storage/box/firingpins,
 /obj/item/storage/box/firingpins,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
-"aEt" = (
-/obj/effect/turf_decal/bot_white,
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/structure/rack,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aEu" = (
@@ -12431,19 +12340,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aHS" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Storage Maintenance";
-	req_access_txt = "25"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "aHT" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Dormitory"
@@ -12492,24 +12388,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"aHZ" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/closet/crate/wooden/toy,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/theatre)
 "aIb" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/theatre";
@@ -14818,15 +14696,6 @@
 	},
 /turf/open/floor/engine/cult,
 /area/library)
-"aPh" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen/invisible,
-/turf/open/floor/engine/cult,
-/area/library)
 "aPi" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder,
@@ -15438,13 +15307,6 @@
 /obj/structure/table,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
-"aRD" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -19479,24 +19341,6 @@
 "bfv" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
-"bfw" = (
-/obj/structure/table/wood,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/item/camera,
-/obj/item/storage/photo_album{
-	pixel_y = -10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
 "bfy" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -23081,16 +22925,6 @@
 /obj/structure/closet/l3closet/scientist,
 /turf/open/floor/plasteel/white/side,
 /area/science/explab)
-"brC" = (
-/obj/structure/table,
-/obj/item/folder/white,
-/obj/item/folder/white,
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/item/radio/off,
-/turf/open/floor/plasteel/white/side,
-/area/science/explab)
 "brD" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/white/corner{
@@ -25139,20 +24973,6 @@
 "byf" = (
 /turf/closed/wall/r_wall,
 /area/science/server)
-"byg" = (
-/obj/structure/table,
-/obj/item/clipboard,
-/obj/item/stamp/qm,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "byi" = (
 /turf/closed/wall,
 /area/security/checkpoint/science)
@@ -26420,28 +26240,6 @@
 	pixel_x = 24
 	},
 /obj/item/twohanded/required/kirbyplants/dead,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
-"bCg" = (
-/obj/structure/table,
-/obj/item/cartridge/signal/toxins,
-/obj/item/cartridge/signal/toxins{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/item/cartridge/signal/toxins{
-	pixel_x = 4;
-	pixel_y = 6
-	},
-/obj/machinery/camera{
-	c_tag = "Research Director's Office";
-	dir = 1;
-	network = list("ss13","rd")
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "bCh" = (
@@ -27928,10 +27726,6 @@
 /area/quartermaster/miningdock)
 "bKo" = (
 /obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"bKp" = (
-/obj/structure/closet/crate,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bKq" = (
@@ -30307,21 +30101,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
-"cbq" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/mob/living/simple_animal/parrot/Poly,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "cbt" = (
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway 1";
@@ -31173,19 +30952,6 @@
 /area/maintenance/port/aft)
 "ciW" = (
 /obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"ciX" = (
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 30
-	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ciY" = (
@@ -32762,16 +32528,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/security/main)
-"cBZ" = (
-/obj/structure/table/wood,
-/obj/item/clothing/under/burial,
-/obj/item/clothing/under/burial,
-/obj/item/clothing/under/burial,
-/obj/item/clothing/under/burial,
-/obj/item/clothing/under/burial,
-/obj/item/clothing/under/burial,
-/turf/open/floor/plasteel/grimy,
-/area/chapel/office)
 "cCb" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil{
@@ -32898,6 +32654,30 @@
 "cFl" = (
 /turf/closed/wall,
 /area/maintenance/solars/port/aft)
+"cFx" = (
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 5;
+	pixel_x = -30
+	},
+/obj/machinery/camera{
+	c_tag = "Brig Control Room";
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/mob/living/simple_animal/pet/dog/pug{
+	desc = "Much better at protecting the armory than your average warden.";
+	name = "Warden Jacob";
+	real_name = "Warden Jacob"
+	},
+/obj/structure/bed/dogbed{
+	desc = "Jacob's bed! Looks comfy";
+	name = "Jacob's bed"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "cFH" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -33003,37 +32783,6 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
-"cIe" = (
-/obj/structure/table,
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/crowbar,
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stock_parts/cell/high/plus,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cIf" = (
@@ -33286,6 +33035,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"cMX" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/mob/living/simple_animal/parrot/Poly,
+/obj/item/toy/figure/ce,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "cNa" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -34023,6 +33788,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ddt" = (
+/obj/structure/table,
+/obj/item/clipboard,
+/obj/item/stamp/qm,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/item/toy/figure/qm,
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "ddA" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/plasteel/white,
@@ -35999,36 +35779,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/tcoms)
-"eDN" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/stack/sheet/cardboard{
-	pixel_x = 2;
-	pixel_y = 1
-	},
-/obj/item/stack/packageWrap{
-	pixel_x = 1;
-	pixel_y = 1
-	},
-/obj/item/stack/wrapping_paper{
-	pixel_x = 3;
-	pixel_y = 8
-	},
-/obj/item/hand_labeler{
-	pixel_x = 8;
-	pixel_y = -7
-	},
-/turf/open/floor/plasteel,
-/area/clerk)
 "eDT" = (
 /obj/machinery/vending/cola/random,
 /obj/machinery/light{
@@ -37219,6 +36969,38 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"fsN" = (
+/obj/structure/table,
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/toy/figure/roboticist,
+/obj/item/crowbar,
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "fsW" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel,
@@ -37412,6 +37194,17 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/wood,
 /area/vacant_room)
+"fAH" = (
+/obj/structure/table/wood,
+/obj/item/toy/figure/chaplain,
+/obj/item/clothing/under/burial,
+/obj/item/clothing/under/burial,
+/obj/item/clothing/under/burial,
+/obj/item/clothing/under/burial,
+/obj/item/clothing/under/burial,
+/obj/item/clothing/under/burial,
+/turf/open/floor/plasteel/grimy,
+/area/chapel/office)
 "fBG" = (
 /obj/effect/landmark/stationroom/maint/threexfive,
 /turf/template_noop,
@@ -37827,6 +37620,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
+"fUQ" = (
+/obj/structure/closet/crate,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/figure/cargotech,
+/turf/open/floor/plasteel,
+/area/quartermaster/warehouse)
 "fUR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 8
@@ -38261,6 +38060,37 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"gnJ" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/toy/figure/clerk,
+/obj/item/stack/sheet/cardboard{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/item/stack/wrapping_paper{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/stack/packageWrap{
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/obj/item/hand_labeler{
+	pixel_x = 8;
+	pixel_y = -7
+	},
+/turf/open/floor/plasteel,
+/area/clerk)
 "gnZ" = (
 /obj/machinery/disposal/bin,
 /obj/structure/sign/warning/deathsposal{
@@ -38594,12 +38424,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"gyF" = (
-/obj/structure/flora/junglebush,
-/obj/structure/flora/ausbushes/sparsegrass,
-/mob/living/carbon/monkey,
-/turf/open/floor/grass,
-/area/medical/genetics)
 "gzz" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Fitness"
@@ -38713,6 +38537,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"gDl" = (
+/obj/structure/table,
+/obj/item/folder/white,
+/obj/item/folder/white,
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/item/radio/off,
+/obj/item/toy/figure/scientist{
+	pixel_x = -11;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/white/side,
+/area/science/explab)
 "gDG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -39912,19 +39750,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"hAt" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/cmo)
 "hAK" = (
 /obj/machinery/door/airlock{
 	name = "Gift Shop";
@@ -40470,6 +40295,16 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"hSv" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/machinery/chem_dispenser,
+/obj/item/toy/figure/chemist{
+	layer = 2.89
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "hSA" = (
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms Maintenance";
@@ -40615,6 +40450,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"hWK" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/rods/ten,
+/obj/item/toy/figure/atmos,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "hXz" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -40968,6 +40814,16 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"iiE" = (
+/obj/machinery/light/small,
+/obj/structure/closet/crate/hydroponics,
+/obj/item/wrench,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/wirecutters,
+/obj/item/toy/figure/botanist,
+/obj/item/shovel/spade,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "iiN" = (
 /obj/machinery/camera{
 	c_tag = "Fore Primary Hallway East";
@@ -41105,6 +40961,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"imA" = (
+/obj/structure/closet/toolcloset,
+/obj/item/toy/figure/assistant,
+/turf/open/floor/plasteel,
+/area/storage/tools)
 "imV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -43559,6 +43420,22 @@
 /obj/structure/altar_of_gods,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"jUA" = (
+/obj/effect/turf_decal/bot_white,
+/obj/structure/table,
+/obj/item/grenade/barrier{
+	pixel_x = -4
+	},
+/obj/item/grenade/barrier,
+/obj/item/toy/figure/warden{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "jUX" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/morgue";
@@ -43949,16 +43826,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
-"kgS" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/rods/ten,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "kgV" = (
 /obj/machinery/camera{
 	c_tag = "Bridge West Entrance";
@@ -44771,6 +44638,16 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
+"kKq" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen/invisible,
+/obj/item/toy/figure/curator,
+/turf/open/floor/engine/cult,
+/area/library)
 "kLy" = (
 /obj/structure/toilet{
 	dir = 1
@@ -45349,6 +45226,20 @@
 	},
 /turf/closed/wall,
 /area/engine/atmos_distro)
+"lgq" = (
+/obj/structure/rack,
+/obj/item/storage/box/lights/mixed,
+/obj/item/storage/box/lights/mixed,
+/obj/item/restraints/legcuffs/beartrap,
+/obj/item/restraints/legcuffs/beartrap,
+/obj/item/storage/box/mousetraps,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/item/toy/figure/janitor,
+/obj/item/storage/box/mousetraps,
+/turf/open/floor/plasteel,
+/area/janitor)
 "lhk" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/donkpockets{
@@ -46515,6 +46406,29 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"maZ" = (
+/obj/structure/table,
+/obj/item/cartridge/signal/toxins,
+/obj/item/cartridge/signal/toxins{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/cartridge/signal/toxins{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/machinery/camera{
+	c_tag = "Research Director's Office";
+	dir = 1;
+	network = list("ss13","rd")
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/obj/item/toy/figure/rd,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
 "mck" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -47726,6 +47640,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"mTY" = (
+/obj/structure/table/wood,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/item/camera,
+/obj/item/storage/photo_album{
+	pixel_y = -10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/item/toy/figure/captain,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
 "mUk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -48315,6 +48248,18 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"niQ" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/toy/figure/lawyer{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/turf/open/floor/wood,
+/area/lawoffice)
 "njh" = (
 /obj/structure/sink{
 	dir = 4;
@@ -49099,6 +49044,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"nKB" = (
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/toy/figure/engineer,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 30
+	},
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "nLo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -49206,6 +49165,13 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"nPI" = (
+/obj/structure/flora/junglebush,
+/obj/structure/flora/ausbushes/sparsegrass,
+/mob/living/carbon/monkey,
+/obj/item/toy/figure/geneticist,
+/turf/open/floor/grass,
+/area/medical/genetics)
 "nQh" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
@@ -50562,6 +50528,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"oED" = (
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/structure/rack,
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "oET" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/camera{
@@ -51171,6 +51154,26 @@
 	},
 /turf/open/space/basic,
 /area/engine/atmos_distro)
+"pbv" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/structure/closet/crate/wooden/toy,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/item/toy/figure/clown,
+/obj/item/toy/figure/mime,
+/turf/open/floor/plasteel,
+/area/crew_quarters/theatre)
 "pbM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/white,
@@ -52664,6 +52667,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"qel" = (
+/obj/machinery/button/door{
+	id = "kanyewest";
+	name = "Privacy Shutters";
+	pixel_y = 24
+	},
+/obj/structure/rack,
+/obj/machinery/light_switch{
+	pixel_x = 27
+	},
+/obj/item/toy/figure/detective,
+/obj/item/storage/briefcase,
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
 "qeE" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -53356,6 +53373,22 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"qGm" = (
+/obj/structure/bed/dogbed/ian,
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_y = 32
+	},
+/mob/living/simple_animal/pet/dog/corgi/Ian{
+	dir = 8
+	},
+/obj/item/toy/figure/hop{
+	layer = 2.89;
+	pixel_x = 8;
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
 "qGp" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -54035,6 +54068,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"rbj" = (
+/obj/machinery/keycard_auth{
+	pixel_x = 24;
+	pixel_y = 10
+	},
+/obj/structure/table/wood,
+/obj/item/radio/off,
+/obj/item/toy/figure/hos,
+/obj/item/taperecorder,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/hos)
 "rbs" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -54688,6 +54732,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"rDi" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Storage Maintenance";
+	req_access_txt = "25"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "rDX" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -57040,19 +57098,6 @@
 /obj/structure/sign/departments/minsky/medical/medical1,
 /turf/closed/wall,
 /area/medical/paramedic)
-"tlC" = (
-/obj/structure/rack,
-/obj/item/storage/box/lights/mixed,
-/obj/item/storage/box/lights/mixed,
-/obj/item/restraints/legcuffs/beartrap,
-/obj/item/restraints/legcuffs/beartrap,
-/obj/item/storage/box/mousetraps,
-/obj/item/storage/box/mousetraps,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "tmG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -57339,13 +57384,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"ttJ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/machinery/chem_dispenser,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "ttK" = (
 /obj/effect/landmark/stationroom/maint/threexfive,
 /turf/template_noop,
@@ -58401,17 +58439,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"uhJ" = (
-/obj/structure/bed/dogbed/ian,
-/obj/structure/sign/painting{
-	persistence_id = "public";
-	pixel_y = 32
-	},
-/mob/living/simple_animal/pet/dog/corgi/Ian{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
 "uhU" = (
 /obj/structure/sign/painting{
 	persistence_id = "public";
@@ -59153,24 +59180,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"uHe" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/item/hand_labeler,
-/obj/item/book/manual/wiki/medicine,
-/obj/machinery/requests_console{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC";
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
 "uHh" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance";
@@ -59396,14 +59405,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"uQe" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/turf/open/floor/wood,
-/area/lawoffice)
 "uQw" = (
 /obj/item/storage/toolbox/mechanical,
 /obj/structure/rack,
@@ -59465,15 +59466,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"uRs" = (
-/obj/machinery/light/small,
-/obj/structure/closet/crate/hydroponics,
-/obj/item/shovel/spade,
-/obj/item/wrench,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/wirecutters,
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "uRv" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -61143,6 +61135,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"vZn" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/item/toy/figure/virologist{
+	layer = 2.79;
+	pixel_x = -6;
+	pixel_y = -7
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "vZH" = (
 /obj/item/aicard{
 	pixel_x = 6;
@@ -61396,6 +61400,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"whN" = (
+/obj/structure/table,
+/obj/item/storage/box/hug,
+/obj/item/razor{
+	pixel_x = -6
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/item/toy/figure/secofficer{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "wil" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -62121,6 +62141,29 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/carpet,
 /area/library)
+"wHA" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/item/hand_labeler,
+/obj/item/book/manual/wiki/medicine,
+/obj/machinery/requests_console{
+	department = "Medbay";
+	departmentType = 1;
+	name = "Medbay RC";
+	pixel_y = -32
+	},
+/obj/item/toy/figure/md{
+	layer = 2.79;
+	pixel_x = -9;
+	pixel_y = 16
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "wHY" = (
 /obj/structure/cable/white{
 	icon_state = "1-8"
@@ -63331,6 +63374,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"xEg" = (
+/obj/structure/closet/crate,
+/obj/item/toy/figure/miner,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "xFh" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
@@ -63745,6 +63793,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"xUb" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/item/toy/figure/cmo,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/cmo)
 "xUV" = (
 /obj/structure/window/reinforced,
 /obj/structure/cable{
@@ -86496,7 +86558,7 @@ gXs
 aaa
 aaf
 aWa
-aWF
+imA
 aWF
 aGb
 tCH
@@ -87304,7 +87366,7 @@ bvY
 bxx
 byB
 boH
-byg
+ddt
 aJn
 aaa
 aaa
@@ -87546,7 +87608,7 @@ bbS
 baS
 baS
 baS
-bbS
+fUQ
 gjl
 aZE
 bkJ
@@ -88596,7 +88658,7 @@ bBG
 bBG
 rGe
 pSY
-bKp
+xEg
 bGi
 aaf
 bPr
@@ -91704,7 +91766,7 @@ bCq
 cay
 ccw
 chY
-ciX
+nKB
 cjM
 ckB
 ckB
@@ -92121,7 +92183,7 @@ acv
 adI
 aei
 aeO
-afG
+whN
 acd
 agK
 agK
@@ -92138,7 +92200,7 @@ aiX
 anQ
 anZ
 ard
-uQe
+niQ
 arT
 avG
 atc
@@ -92948,7 +93010,7 @@ bjE
 knP
 bbX
 bmo
-uhJ
+qGm
 bpb
 bqz
 blt
@@ -94194,7 +94256,7 @@ any
 anz
 aov
 apd
-aqb
+qel
 are
 arZ
 ixi
@@ -94435,7 +94497,7 @@ aEq
 aEw
 oJs
 aHt
-aeW
+cFx
 agQ
 ahv
 ahQ
@@ -94688,7 +94750,7 @@ awX
 adl
 aBZ
 atk
-aEr
+jUA
 aEx
 aFF
 aHt
@@ -95202,12 +95264,12 @@ adl
 acl
 adl
 aEo
-aEt
+oED
 aeM
 aGK
 aIi
 agr
-aoK
+agt
 ayd
 ahX
 aiL
@@ -96303,7 +96365,7 @@ qkv
 bCv
 tcL
 ggi
-tlC
+lgq
 bCv
 bCv
 eEO
@@ -96327,7 +96389,7 @@ alp
 amX
 aiv
 bZD
-cbq
+cMX
 ccj
 cdm
 bCR
@@ -98340,7 +98402,7 @@ bcn
 maV
 ben
 bfE
-bfw
+mTY
 bdk
 bjJ
 bld
@@ -99311,7 +99373,7 @@ aaa
 aaf
 abq
 abW
-abk
+rbj
 acj
 acn
 akw
@@ -99654,7 +99716,7 @@ gaW
 ugv
 bvr
 jhU
-kgS
+hWK
 aId
 avy
 odT
@@ -99860,7 +99922,7 @@ avx
 ayG
 fUP
 mAL
-eDN
+gnJ
 ayG
 qvH
 dWr
@@ -100377,7 +100439,7 @@ iSq
 ayz
 aFl
 nJB
-aHZ
+pbv
 qQV
 qQV
 qQV
@@ -100653,7 +100715,7 @@ aYV
 aYV
 aYV
 bfF
-ttJ
+hSv
 bip
 djy
 bip
@@ -101701,7 +101763,7 @@ shz
 daW
 dCe
 obb
-uHe
+wHA
 jdO
 btU
 avy
@@ -102947,7 +103009,7 @@ aAh
 aAh
 aAh
 aFv
-aHS
+rDi
 qQV
 qQV
 qQV
@@ -104511,7 +104573,7 @@ kiy
 wte
 bCY
 pve
-hAt
+xUb
 qsL
 bEi
 sxa
@@ -106034,7 +106096,7 @@ cVb
 aLb
 aIp
 aKH
-uRs
+iiE
 aIp
 aRJ
 aRJ
@@ -106829,7 +106891,7 @@ nIx
 bfL
 cDK
 bon
-gyF
+nPI
 sMx
 auz
 hZk
@@ -107111,7 +107173,7 @@ dRm
 bwh
 qbE
 aSI
-aRD
+vZn
 aFq
 bNd
 bZU
@@ -109399,7 +109461,7 @@ blA
 sUL
 jna
 cIb
-cIe
+fsN
 wci
 bgp
 sRl
@@ -111431,9 +111493,9 @@ aHf
 aIz
 aJM
 aRI
-cBZ
+fAH
 aFw
-aPh
+kKq
 aQs
 aFu
 aTd
@@ -113518,7 +113580,7 @@ bxi
 byp
 bzJ
 aDa
-bCg
+maZ
 bvK
 bEu
 tbz
@@ -115823,7 +115885,7 @@ iJg
 hoc
 bjT
 bqe
-brC
+gDl
 blN
 bvO
 bvO

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -32383,6 +32383,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"cAY" = (
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/chapel{
+	dir = 4
+	},
+/area/chapel/main)
 "cBg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/effect/landmark/event_spawn,
@@ -36446,14 +36452,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"eZE" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/food/snacks/grown/poppy,
-/obj/item/reagent_containers/food/snacks/grown/harebell,
-/turf/open/floor/plasteel/chapel{
-	dir = 4
-	},
-/area/escapepodbay)
 "eZN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41910,12 +41908,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
-"iQR" = (
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/chapel{
-	dir = 4
-	},
-/area/escapepodbay)
 "iQY" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -43826,6 +43818,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
+"kfF" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/food/snacks/grown/poppy,
+/obj/item/reagent_containers/food/snacks/grown/harebell,
+/turf/open/floor/plasteel/chapel{
+	dir = 4
+	},
+/area/chapel/main)
 "kgV" = (
 /obj/machinery/camera{
 	c_tag = "Bridge West Entrance";
@@ -49655,6 +49655,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"ohr" = (
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/chapel,
+/area/chapel/main)
 "ohL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -57397,10 +57401,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"ttZ" = (
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/chapel,
-/area/escapepodbay)
 "tuW" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -114316,10 +114316,10 @@ atS
 aCR
 bfb
 aCR
-eZE
-ttZ
-iQR
-ttZ
+kfF
+ohr
+cAY
+ohr
 aCR
 aNX
 aPo


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request
Adds every job figurine to box, some of them are in plain sight, some of them are hidden a bit.

Also gave warden Jacob a bed because screw atomization on map pr's and it's a good change, 
Also fixed the kitchen still having pre-monstermos airlocks because I was touching kitchens to add bartender & chef

### Why is this change good for the game?
Allows people to go on scavenger hunts to collect figurines because now every single one of them is on the map somewhere

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
Adds every job figurine to box, some of them are in plain sight, some of them are hidden a bit.

### What should players be aware of when it comes to the changes your PR is implementing?
Adds every job figurine to box, some of them are in plain sight, some of them are hidden a bit.

### What general grouping does this PR fall under? 
figurine grouping

### Are there any aspects of the PR that you would like us not to mention on the Wiki?
Don't mention where they are specifically so people learn it over time

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
nope

# Changelog

:cl:  
rscadd: Added all the job figurines to the station [box]
bugfix: fixed firelocks in kitchens
tweak: warden jacob gets a bed
/:cl:
