### PR TITLE
Escape Rework

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -6987,6 +6987,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"arH" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "arP" = (
 /turf/closed/wall,
 /area/maintenance/fore)
@@ -14546,20 +14561,6 @@
 /obj/machinery/computer/arcade,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"aOc" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
-"aOd" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "aOe" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Bay 1 South"
@@ -15586,19 +15587,6 @@
 "aRJ" = (
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"aRL" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Holding Area";
-	req_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "aRM" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -36813,14 +36801,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"eZE" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/food/snacks/grown/poppy,
-/obj/item/reagent_containers/food/snacks/grown/harebell,
-/turf/open/floor/plasteel/chapel{
-	dir = 4
-	},
-/area/escapepodbay)
 "eZN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -37609,6 +37589,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"fEv" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "fFo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -37895,6 +37884,31 @@
 /obj/item/stock_parts/subspace/analyzer,
 /turf/open/floor/plasteel/white,
 /area/storage/tech)
+"fQX" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Holding Area";
+	req_access_txt = "2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "fRa" = (
 /obj/item/twohanded/required/kirbyplants/photosynthetic,
 /obj/effect/turf_decal/tile/darkblue{
@@ -37928,6 +37942,16 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
+"fTL" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "fUl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -38209,6 +38233,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"gfl" = (
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/chapel,
+/area/chapel/main)
 "gfB" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -38238,16 +38266,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"ggH" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "ghA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -38793,6 +38811,31 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"gBB" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Office";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/service)
 "gBP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -38997,6 +39040,18 @@
 /obj/machinery/lapvend,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"gId" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "gIj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -40132,6 +40187,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"hBk" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "hBp" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -40769,11 +40830,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"hXW" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "hYC" = (
 /obj/effect/landmark/stationroom/maint/fivexthree,
 /turf/template_noop,
@@ -41480,6 +41536,12 @@
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"iuK" = (
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/chapel{
+	dir = 4
+	},
+/area/chapel/main)
 "ivp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -41791,6 +41853,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"iCC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "iCG" = (
 /obj/machinery/flasher{
 	id = "AI";
@@ -42212,12 +42289,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
-"iQR" = (
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/chapel{
-	dir = 4
-	},
-/area/escapepodbay)
 "iQY" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -42291,18 +42362,6 @@
 /obj/structure/chair,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"iTF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "iTR" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -43437,6 +43496,10 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"jHH" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "jHY" = (
 /obj/machinery/camera{
 	c_tag = "Holodeck"
@@ -44342,6 +44405,18 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
+"kmE" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "kmT" = (
 /obj/machinery/computer/med_data,
 /turf/open/floor/plasteel/grimy,
@@ -45254,15 +45329,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"kVO" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "kVQ" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -47360,15 +47426,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"mAm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "mAI" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -48715,19 +48772,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos_distro)
-"nsr" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Office";
-	req_access_txt = "63"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/service)
 "nsz" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -49036,6 +49080,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"nzQ" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "nzW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -49440,6 +49495,24 @@
 /obj/effect/landmark/stationroom/maint/tenxten,
 /turf/template_noop,
 /area/maintenance/port/aft)
+"nQm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "nQG" = (
 /obj/machinery/button/door{
 	id = "Dorm2";
@@ -51746,6 +51819,22 @@
 /obj/machinery/telecomms/server/presets/command,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
+"prU" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "psc" = (
 /obj/machinery/light,
 /obj/machinery/computer/aifixer{
@@ -52471,6 +52560,21 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
+"pQO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "pQP" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -54041,6 +54145,24 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"qUO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "qVe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -56039,18 +56161,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
-"smJ" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "smW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -56229,6 +56339,14 @@
 /obj/item/surgicaldrill,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"suo" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/food/snacks/grown/poppy,
+/obj/item/reagent_containers/food/snacks/grown/harebell,
+/turf/open/floor/plasteel/chapel{
+	dir = 4
+	},
+/area/chapel/main)
 "svw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -57640,10 +57758,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"ttZ" = (
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/chapel,
-/area/escapepodbay)
 "tuW" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -58174,6 +58288,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
+"tPC" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "tPS" = (
 /obj/structure/rack,
 /obj/structure/extinguisher_cabinet{
@@ -59103,6 +59232,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"uvn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "uvA" = (
 /obj/item/cigbutt/roach,
 /turf/open/floor/plating,
@@ -59350,6 +59491,12 @@
 /obj/structure/door_assembly/door_assembly_mhatch,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"uCG" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "uCN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59680,6 +59827,12 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"uOZ" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "uQe" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -114526,10 +114679,10 @@ atS
 aCR
 bfb
 aCR
-eZE
-ttZ
-iQR
-ttZ
+suo
+gfl
+iuK
+gfl
 aCR
 aNX
 aPo
@@ -115308,13 +115461,13 @@ dhY
 dhY
 rEn
 aPq
-aPq
-aPq
-rEn
-aPq
-aPq
-aPq
-aPq
+uOZ
+uOZ
+gId
+uOZ
+uOZ
+uOZ
+uOZ
 aPq
 rPu
 hoc
@@ -115562,19 +115715,19 @@ aMZ
 aMZ
 aMZ
 aMZ
-aNa
-rEn
+aMZ
+iCC
 aPq
-aPq
-aPq
-ggH
-aPq
-aPq
-aPq
-aPq
+uCG
+uCG
+kmE
+uCG
+uCG
+uCG
+uCG
 aPq
 imh
-nsr
+gBB
 ooz
 mkq
 hoc
@@ -115818,14 +115971,14 @@ aFR
 aMZ
 aOa
 tes
-smJ
+tPC
 aNa
-rEn
+iCC
 aPq
 aPq
 aPq
 rEn
-aPq
+jHH
 aPq
 aPq
 aPq
@@ -116073,19 +116226,19 @@ sHo
 sHo
 lsn
 aMZ
-aOd
-aWd
-kVO
-aRL
-hXW
+fTL
 aPq
+fEv
+aNa
+iCC
 aPq
-thb
-nWK
-lIE
-eDG
-edR
-xvY
+uOZ
+uOZ
+gId
+uOZ
+uOZ
+uOZ
+uOZ
 aPq
 wex
 ilH
@@ -116330,21 +116483,21 @@ sHo
 sHo
 sHo
 aMZ
-aOc
-iTF
-mAm
+fTL
+hBk
+fEv
 aNa
-mAm
-aPs
-aPs
-aXG
-ccT
-oDC
-hKY
-evF
-wSe
-aPs
-fcV
+iCC
+aPq
+uCG
+uCG
+uvn
+uCG
+uCG
+uCG
+uCG
+aPq
+wex
 ilH
 oGJ
 olb
@@ -116587,21 +116740,21 @@ sHo
 sHo
 sHo
 aMZ
-aRW
-aRW
-qOl
-aNa
-mmV
-aRW
-aRW
-aRW
-aRW
-aRW
-mXC
-aNa
-nxw
-aRW
-aRW
+fTL
+aWd
+arH
+fQX
+nzQ
+aPq
+aPq
+thb
+nWK
+lIE
+eDG
+edR
+xvY
+aPq
+wex
 hoc
 oUG
 dVX
@@ -116843,22 +116996,22 @@ sHo
 sHo
 sHo
 sHo
-ptH
-aaf
-aRW
-jOV
+aMZ
+prU
+nQm
+qUO
 aNa
-jOV
-aRW
-aaa
-aaf
-aaa
-aRW
-jOV
-aNa
-jOV
-aRW
-aaf
+pQO
+aPs
+aPs
+aXG
+ccT
+oDC
+hKY
+evF
+wSe
+aPs
+fcV
 hoc
 nzY
 qsO
@@ -117101,21 +117254,21 @@ iOa
 iOa
 rIf
 xnF
-aaa
-aMZ
-jrf
+aRW
+aRW
+qOl
 aNa
-pMt
-aMZ
-aaf
-aaf
-aaf
-aMZ
-jrf
+mmV
+aRW
+aRW
+aRW
+aRW
+aRW
+mXC
 aNa
-pMt
-aMZ
-aaa
+nxw
+aRW
+aRW
 hoc
 aEM
 aEM
@@ -117358,21 +117511,21 @@ uxv
 uxv
 uxv
 dgz
-aaa
-aRW
-jJQ
-aNa
-iHI
-aRW
-aaf
-aaa
 aaf
 aRW
-iHI
+jOV
 aNa
-hSf
+jOV
 aRW
 aaa
+aaf
+aaa
+aRW
+jOV
+aNa
+jOV
+aRW
+aaf
 aaa
 gXs
 aaa
@@ -117616,19 +117769,19 @@ aaa
 aaa
 aaa
 aaa
-aRW
-fOS
+aMZ
+jrf
 aNa
-fOS
-aRW
+pMt
+aMZ
 aaf
 aaf
 aaf
-aRW
-fOS
+aMZ
+jrf
 aNa
-fOS
-aRW
+pMt
+aMZ
 aaa
 aaa
 gXs
@@ -117874,17 +118027,17 @@ aaa
 aaa
 aaa
 aRW
-cyh
-bOH
-aTo
+jJQ
+aNa
+iHI
 aRW
-aaa
 aaf
 aaa
+aaf
 aRW
-aTo
-bOH
-cyr
+iHI
+aNa
+hSf
 aRW
 aaa
 aaa
@@ -118130,19 +118283,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-afa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aRW
+fOS
+aNa
+fOS
+aRW
+aaf
+aaf
+aaf
+aRW
+fOS
+aNa
+fOS
+aRW
 aaa
 aaa
 aaa
@@ -118387,19 +118540,19 @@ aaa
 aaa
 aaa
 aaa
+aRW
+cyh
+bOH
+aTo
+aRW
 aaa
+aaf
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aRW
+aTo
+bOH
+cyr
+aRW
 aaa
 aaa
 aaa
@@ -118647,7 +118800,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+afa
 aaa
 aaa
 aaa
@@ -122243,7 +122396,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+aoV
 aaa
 aaa
 aaa
@@ -123014,7 +123167,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cEB
 aaa
 aaa
 aaa


### PR DESCRIPTION
#### General Documentation

## Intent of your Pull Request

Reworks escape by adding chairs, and extends it out a little so that the chairs look better. This minorly extends the Holding Center.
![bpng](https://user-images.githubusercontent.com/62276730/118209617-f402f400-b436-11eb-9b1f-8d879a6f27da.png)
hell i was fine with the current bland escape nature which is just empty

## Why is this change good for the game?

This is to serve as an alternative to EIB0N's rework which uses the fake multi-z illusion using shadows and stairs. I'm personally still on the fence about it's use in an area as heavily trafficked as escape.

## Wiki Documentation

Wiki image will need to be updated.

# Changelog

:cl:  
tweak: reworks escape, making it and the Holding Center bigger. 
/:cl:
