### PR TITLE
russian bounty hunters now have the correct mag in their pocket

### DIFF
--- a/code/modules/antagonists/fugitive/fugitive_outfits.dm
+++ b/code/modules/antagonists/fugitive/fugitive_outfits.dm
@@ -100,7 +100,7 @@
 	gloves = /obj/item/clothing/gloves/color/black
 	mask = /obj/item/clothing/mask/gas
 	r_hand = /obj/item/gun/ballistic/rifle/boltaction
-	r_pocket = /obj/item/ammo_box/magazine/internal/boltaction
+	r_pocket = /obj/item/ammo_box/a762 
 	mask = /obj/item/clothing/mask/gas
 	back = /obj/item/storage/backpack
 	box = /obj/item/storage/box/survival


### PR DESCRIPTION
so somebody put the INTERNAL magazine which is supposed to be coded inside the gun instead of the ACTUAL magazine in the space russian outfit thingy, good job
closes #11460
:cl:  
bugfix: the mosin magazine in the russian outfit no longer has the internal magazine
/:cl:
