### PR TITLE
lizard martial changes

### DIFF
--- a/code/datums/martial/flying_fang.dm
+++ b/code/datums/martial/flying_fang.dm
@@ -1,4 +1,3 @@
-#define HEADBUTT_COMBO "DH"
 #define CHOMP_COMBO "GH"
 #define TAIL_COMBO_START "DD"
 #define TAIL_COMBO "TD"
@@ -30,10 +29,6 @@
 	if(findtext(streak, CHOMP_COMBO))
 		streak = ""
 		Chomp(A,D)
-		return TRUE
-	if(findtext(streak, HEADBUTT_COMBO))
-		streak = ""
-		Headbutt(A,D)
 		return TRUE
 
 ///second attack of the tail slap combo, deals high stamina damage, low brute damage, and causes a short slowdown
@@ -84,27 +79,6 @@
 					  "<span class='userdanger'>[A] tail slaps you!</span>")
 	log_combat(A, D, "tail slapped (Flying Fang)")
 
-//headbutt, deals moderate brute and stamina damage with a short stun and eye blur, causes poor aim for a few seconds to the target if they have no helmet on with a chance to concuss
-/datum/martial_art/flyingfang/proc/Headbutt(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	if(!can_use(A))
-		return
-	var/obj/item/bodypart/affecting = D.get_bodypart(check_zone(BODY_ZONE_HEAD))
-	var/armor_block = D.run_armor_check(affecting, "melee")
-	A.do_attack_animation(D, ATTACK_EFFECT_SMASH)
-	playsound(D, 'sound/weapons/genhit1.ogg', 50, TRUE, -1)
-	D.apply_damage(20, STAMINA, BODY_ZONE_HEAD, armor_block)
-	D.apply_damage(15, A.dna.species.attack_type, BODY_ZONE_HEAD, armor_block)
-	D.Stun(1 SECONDS)
-	D.blur_eyes(4)
-	if(!istype(D.head, /obj/item/clothing/head/helmet))
-		if(prob(10))
-			D.gain_trauma(/datum/brain_trauma/mild/concussion)
-		ADD_TRAIT(D, TRAIT_POOR_AIM, "martial")
-		addtimer(CALLBACK(src, .proc/remove_bonk, D), 10 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE)
-	D.visible_message("<span class='danger'>[A] headbutts [D]!</span>", \
-					  "<span class='userdanger'>[A] headbutts you!</span>")
-	log_combat(A, D, "headbutted (Flying Fang)")
-
 /datum/martial_art/flyingfang/proc/remove_bonk(mob/living/carbon/human/D)
 	REMOVE_TRAIT(D, TRAIT_POOR_AIM, "martial")
 
@@ -130,11 +104,26 @@
 	D.Stun(2 SECONDS)
 	log_combat(A, D, "neck chomped (Flying Fang)")
 
+//headbutt, deals moderate brute and stamina damage with an eye blur, causes poor aim for a few seconds to the target if they have no helmet on
 /datum/martial_art/flyingfang/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	add_to_streak("D",D)
 	if(check_streak(A,D))
 		return TRUE
-	return FALSE //nothing special here
+	if(!can_use(A))
+		return
+	var/obj/item/bodypart/affecting = D.get_bodypart(check_zone(BODY_ZONE_HEAD))
+	var/armor_block = D.run_armor_check(affecting, "melee")
+	A.do_attack_animation(D, ATTACK_EFFECT_SMASH)
+	playsound(D, 'sound/weapons/genhit1.ogg', 50, TRUE, -1)
+	D.apply_damage(5, STAMINA, BODY_ZONE_HEAD, armor_block)
+	D.apply_damage(5, A.dna.species.attack_type, BODY_ZONE_HEAD, armor_block)
+	D.blur_eyes(4)
+	if(!istype(D.head, /obj/item/clothing/head/helmet))
+		ADD_TRAIT(D, TRAIT_POOR_AIM, "martial")
+		addtimer(CALLBACK(src, .proc/remove_bonk, D), 10 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE)
+	D.visible_message("<span class='danger'>[A] headbutts [D]!</span>", \
+					  "<span class='userdanger'>[A] headbutts you!</span>")
+	log_combat(A, D, "headbutted (Flying Fang)")
 
 /datum/martial_art/flyingfang/grab_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	add_to_streak("G",D)
@@ -202,7 +191,7 @@
 	if(linked_martial.leaping)
 		return
 	linked_martial.leaping = TRUE
-	A.Knockdown(10 SECONDS)
+	A.Knockdown(5 SECONDS)
 	A.Immobilize(30 SECONDS) //prevents you from breaking out of your pounce
 	A.throw_at(target, get_dist(A,target)+1, 1, A, FALSE, TRUE, callback = CALLBACK(src, .proc/leap_end, A))
 	Deactivate()
@@ -253,9 +242,10 @@
 	to_chat(usr, "<span class='notice'>Your training has rendered you more resistant to pain, allowing you to keep fighting effectively for longer and reducing the effectiveness of stun and stamina weapons by about a third.</span>")
 	to_chat(usr, "<span class='warning'>However, the primitive instincts gained through this training prevent you from using guns, stun weapons, or armor.</span>")
 	to_chat(usr, "<span class='notice'><b>All of your unarmed attacks deal increased brute damage with a small amount of armor piercing</b></span>")
+	
+	to_chat(usr, "<span class='notice'>Disarm Intent</span>: Headbutt your enemy, Deals minor stamina and brute damage, as well as causing eye blurryness. Prevents the target from using ranged weapons effectively for a few seconds if they are not wearing a helmet.")
 
 	to_chat(usr, "<span class='notice'>Tail Slap</span>: Disarm Disarm Disarm. High armor piercing attack that causes a short slow followed by a knockdown. Deals heavy stamina damage.")
-	to_chat(usr, "<span class='notice'>Headbutt</span>: Disarm Harm. Deals moderate stamina and brute damage with a short stun, as well as causing eye blurryness. Prevents the target from using ranged weapons effectively for a few seconds if they are not wearing a helmet.")
 	to_chat(usr, "<span class='notice'>Neck Bite</span>: Grab Harm. Target must be prone. Stuns you and your target for a short period, dealing heavy brute damage and bleeding. If the target is not in crit, this attack will heal you.")
 	to_chat(usr, "<spna class='notice'>Leap</span>: Action: Jump at a target, with a successful hit stunning them and preventing you from moving for a few seconds.")
 

--- a/code/datums/martial/flying_fang.dm
+++ b/code/datums/martial/flying_fang.dm
@@ -243,7 +243,7 @@
 	to_chat(usr, "<span class='warning'>However, the primitive instincts gained through this training prevent you from using guns, stun weapons, or armor.</span>")
 	to_chat(usr, "<span class='notice'><b>All of your unarmed attacks deal increased brute damage with a small amount of armor piercing</b></span>")
 	
-	to_chat(usr, "<span class='notice'>Disarm Intent</span>: Headbutt your enemy, Deals minor stamina and brute damage, as well as causing eye blurryness. Prevents the target from using ranged weapons effectively for a few seconds if they are not wearing a helmet.")
+	to_chat(usr, "<span class='notice'>Disarm Intent</span>: Headbutt your enemy, Deals minor stamina and brute damage, as well as causing eye blurriness. Prevents the target from using ranged weapons effectively for a few seconds if they are not wearing a helmet.")
 
 	to_chat(usr, "<span class='notice'>Tail Slap</span>: Disarm Disarm Disarm. High armor piercing attack that causes a short slow followed by a knockdown. Deals heavy stamina damage.")
 	to_chat(usr, "<span class='notice'>Neck Bite</span>: Grab Harm. Target must be prone. Stuns you and your target for a short period, dealing heavy brute damage and bleeding. If the target is not in crit, this attack will heal you.")


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

compactifies the headbutt  combo into disarm intent, you can no longer directly disarm people of stuff but you do force them to be worse at using guns on disarming them. This is because the headbutt combo is probably entirely unused due to its lack of synchronicity with other combos. Headbutt no longer has a stun or chance to concuss as a result of being a single attack and its damage has been reduced.

Pounce cool/knockdown on miss reduced to base 5 seconds (actually ~3 due to stun reduction) since base 10 seconds (6 seconds accounting for stun reduction) was a bit high

### Why is this change good for the game?

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
flying fang headbutt combo removed, disarm intent now does most of the stuff the combo would do aside from the concussion and stun bits and it deals 5 brute down from 10
knockdown on failing to connect a pounce halved

# Changelog

:cl:  
tweak: lizard martial art headbutt combo effects moved to disarm intent and nerfed slightly
tweak: lizard martial art pounce slightly less punishing when simply missing
/:cl:
