### PR TITLE
unfucks a blast door i was supposed to turn into a shutter but forgot to (bar)

### DIFF
--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_box.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_box.dmm
@@ -1234,19 +1234,6 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"dF" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/smartfridge/drinks,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "ge" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -1276,6 +1263,19 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"rY" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "sb" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets{
@@ -1696,7 +1696,7 @@ bJ
 bx
 cq
 bx
-dF
+rY
 bx
 SG
 ag


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

i forgot to turn it into a shutter lol

its a blast door now

### Why is this change good for the game?

consistency

# Wiki Documentation

None needed

# Changelog

:cl:  
tweak: blast door in one of the bar templates is now a shutter
/:cl:
