### PR TITLE
Ranged holoparasite shoots slower but deals more damage per shot

### DIFF
--- a/yogstation/code/modules/guardian/guardian.dm
+++ b/yogstation/code/modules/guardian/guardian.dm
@@ -338,7 +338,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	playsound(src, projectilesound, 100, 1)
 	if(namedatum)
 		P.color = namedatum.colour
-	P.damage = stats.damage * 1.5
+	P.damage = stats.damage * 3
 	P.starting = startloc
 	P.firer = src
 	P.fired_from = src
@@ -679,7 +679,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 
 /obj/item/projectile/guardian
 	name = "crystal spray"
-	icon_state = "guardian"
-	damage = 5
+	icon_state = "greyscale_bolt"
+	damage = 10
 	damage_type = BRUTE
 	armour_penetration = 100

--- a/yogstation/code/modules/guardian/guardian.dm
+++ b/yogstation/code/modules/guardian/guardian.dm
@@ -678,7 +678,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	return "F"
 
 /obj/item/projectile/guardian
-	name = "crystal spray"
+	name = "crystal bolt"
 	icon_state = "greyscale_bolt"
 	damage = 10
 	damage_type = BRUTE

--- a/yogstation/code/modules/guardian/guardianstats.dm
+++ b/yogstation/code/modules/guardian/guardianstats.dm
@@ -12,7 +12,7 @@
 	guardian.range = range * 2
 	if(ranged)
 		guardian.ranged = TRUE
-		guardian.ranged_cooldown_time = 5 / speed
+		guardian.ranged_cooldown_time = 20 / speed
 	else
 		guardian.melee_damage_lower = damage * 5
 		guardian.melee_damage_upper = damage * 5


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

damage per shot increased to 3*attack from 1.5*attack, making maximum damage per shot 15 at 5 attack
cooldown base increased to 20 deciseconds up from 5 deciseconds, making maximum attack speed 5 deciseconds at 5 speed
projectile icon changed to greyscale bolt from guardian crystal spray and renamed to reflect projectile behavior changes

### Why is this change good for the game?
removes another source of damage spam locking out movement unintentionally

# Changelog

:cl:  
tweak: ranged holoparasites deal twice the damage per shot, but shoot 75% slower to stop the attack speed from preventing movement
tweak: ranged holoparasite projectile icon and name changed to reflect their higher damage/lower speed
/:cl:
