### PR TITLE
[boring] Map template cleanup

### DIFF
--- a/_maps/RandomRuins/StationRuins/BoxStation/dorms_edoor1.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/dorms_edoor1.dmm
@@ -1,5 +1,20 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"c" = (
+"j" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/template_noop)
+"k" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/carpet,
+/area/template_noop)
+"z" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -8,31 +23,7 @@
 	dir = 6
 	},
 /turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"e" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"E" = (
-/turf/closed/wall,
-/area/crew_quarters/dorms)
-"I" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
+/area/template_noop)
 "J" = (
 /obj/structure/table,
 /obj/machinery/light/small{
@@ -42,59 +33,38 @@
 	dir = 4
 	},
 /turf/open/floor/carpet,
-/area/crew_quarters/dorms)
+/area/template_noop)
 "L" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/structure/bed,
+/obj/item/bedsheet,
+/obj/machinery/airalarm{
+	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"R" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"X" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
+/area/template_noop)
+"Q" = (
+/obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
 	},
 /turf/open/floor/carpet,
-/area/crew_quarters/dorms)
+/area/template_noop)
 
 (1,1,1) = {"
-E
-E
-E
-E
+J
+k
 "}
 (2,1,1) = {"
-E
-J
-X
-E
+z
+Q
 "}
 (3,1,1) = {"
-E
-c
-e
-E
-"}
-(4,1,1) = {"
-E
-I
-R
-E
-"}
-(5,1,1) = {"
-E
-E
 L
-E
+j
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/dorms_edoor2.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/dorms_edoor2.dmm
@@ -1,14 +1,5 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"y" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/turf/open/floor/carpet/blue,
-/area/crew_quarters/dorms)
-"E" = (
-/turf/closed/wall,
-/area/crew_quarters/dorms)
-"G" = (
+"d" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -17,8 +8,27 @@
 	},
 /obj/structure/table/glass,
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/dorms)
-"L" = (
+/area/template_noop)
+"i" = (
+/obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/carpet/blue,
+/area/template_noop)
+"k" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/carpet/blue,
+/area/template_noop)
+"u" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
@@ -28,17 +38,8 @@
 /obj/structure/bed,
 /obj/item/bedsheet/blue,
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/dorms)
-"T" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"U" = (
+/area/template_noop)
+"F" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
@@ -47,54 +48,23 @@
 	},
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/dorms)
-"X" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/carpet/blue,
-/area/crew_quarters/dorms)
+/area/template_noop)
 "Y" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
+/obj/structure/chair/stool{
+	pixel_y = 8
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/dorms)
+/area/template_noop)
 
 (1,1,1) = {"
-E
-E
-E
-E
+d
+Y
 "}
 (2,1,1) = {"
-E
-G
-y
-E
+F
+i
 "}
 (3,1,1) = {"
-E
-U
-Y
-E
-"}
-(4,1,1) = {"
-E
-L
-X
-E
-"}
-(5,1,1) = {"
-E
-E
-T
-E
+u
+k
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/dorms_edoor3.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/dorms_edoor3.dmm
@@ -1,5 +1,11 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "c" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"d" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -8,17 +14,28 @@
 	dir = 5
 	},
 /turf/open/floor/wood,
-/area/crew_quarters/dorms)
-"j" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/area/template_noop)
+"n" = (
+/obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/structure/table/wood,
 /turf/open/floor/wood,
-/area/crew_quarters/dorms)
+/area/template_noop)
 "s" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"G" = (
 /obj/structure/bed,
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -28,64 +45,26 @@
 	},
 /obj/item/bedsheet/brown,
 /turf/open/floor/wood,
-/area/crew_quarters/dorms)
-"E" = (
-/turf/closed/wall,
-/area/crew_quarters/dorms)
-"H" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/area/template_noop)
+"L" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/crew_quarters/dorms)
-"I" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+	dir = 8
 	},
 /turf/open/floor/wood,
-/area/crew_quarters/dorms)
-"Q" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/dorms)
+/area/template_noop)
 
 (1,1,1) = {"
-E
-E
-E
-E
+n
+c
 "}
 (2,1,1) = {"
-E
-H
-Q
-E
+s
+d
 "}
 (3,1,1) = {"
-E
-I
-c
-E
-"}
-(4,1,1) = {"
-E
-s
-j
-E
-"}
-(5,1,1) = {"
-E
-E
-j
-E
+G
+L
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/dorms_edoor4.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/dorms_edoor4.dmm
@@ -1,43 +1,11 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"h" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/carpet/royalblack,
-/area/crew_quarters/dorms)
-"w" = (
+"b" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
 	},
 /turf/open/floor/carpet/royalblack,
-/area/crew_quarters/dorms)
-"E" = (
-/turf/closed/wall,
-/area/crew_quarters/dorms)
-"H" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/carpet/royalblack,
-/area/crew_quarters/dorms)
-"O" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblack,
-/area/crew_quarters/dorms)
-"R" = (
+/area/template_noop)
+"c" = (
 /obj/structure/bed,
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -47,17 +15,37 @@
 	},
 /obj/item/bedsheet/black,
 /turf/open/floor/carpet/royalblack,
-/area/crew_quarters/dorms)
-"X" = (
+/area/template_noop)
+"B" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/carpet/royalblack,
+/area/template_noop)
+"L" = (
+/obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/carpet/royalblack,
+/area/template_noop)
+"W" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"Z" = (
+/turf/open/floor/carpet/royalblack,
+/area/template_noop)
+"X" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -66,35 +54,17 @@
 	},
 /obj/structure/table,
 /turf/open/floor/carpet/royalblack,
-/area/crew_quarters/dorms)
+/area/template_noop)
 
 (1,1,1) = {"
-E
-E
-E
-E
+X
+b
 "}
 (2,1,1) = {"
-E
-Z
-w
-E
+B
+L
 "}
 (3,1,1) = {"
-E
-h
-H
-E
-"}
-(4,1,1) = {"
-E
-R
-O
-E
-"}
-(5,1,1) = {"
-E
-E
-X
-E
+c
+W
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/dorms_edoor5.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/dorms_edoor5.dmm
@@ -1,14 +1,15 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"c" = (
+"a" = (
+/obj/structure/closet/secure_closet/personal,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
+	dir = 6
 	},
 /turf/open/floor/carpet/exoticpurple,
-/area/crew_quarters/dorms)
-"u" = (
+/area/template_noop)
+"b" = (
 /obj/structure/bed,
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -18,30 +19,8 @@
 	},
 /obj/item/bedsheet/purple,
 /turf/open/floor/carpet/exoticpurple,
-/area/crew_quarters/dorms)
-"v" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/carpet/exoticpurple,
-/area/crew_quarters/dorms)
-"A" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"E" = (
-/turf/closed/wall,
-/area/crew_quarters/dorms)
-"J" = (
+/area/template_noop)
+"n" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -50,8 +29,14 @@
 	},
 /obj/structure/table/glass,
 /turf/open/floor/carpet/exoticpurple,
-/area/crew_quarters/dorms)
-"O" = (
+/area/template_noop)
+"F" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/carpet/exoticpurple,
+/area/template_noop)
+"U" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -60,41 +45,26 @@
 	dir = 5
 	},
 /turf/open/floor/carpet/exoticpurple,
-/area/crew_quarters/dorms)
-"Q" = (
-/obj/structure/chair/office/dark{
-	dir = 1
+/area/template_noop)
+"Z" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/carpet/exoticpurple,
-/area/crew_quarters/dorms)
+/area/template_noop)
 
 (1,1,1) = {"
-E
-E
-E
-E
+n
+F
 "}
 (2,1,1) = {"
-E
-J
-Q
-E
+a
+U
 "}
 (3,1,1) = {"
-E
-v
-O
-E
-"}
-(4,1,1) = {"
-E
-u
-c
-E
-"}
-(5,1,1) = {"
-E
-E
-A
-E
+b
+Z
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/dorms_edoor6.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/dorms_edoor6.dmm
@@ -1,62 +1,20 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"d" = (
-/obj/structure/closet/secure_closet/personal,
+"m" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+	dir = 8
 	},
 /turf/open/floor/carpet/exoticblue,
-/area/crew_quarters/dorms)
-"g" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/carpet/exoticblue,
-/area/crew_quarters/dorms)
-"n" = (
+/area/template_noop)
+"o" = (
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
 /turf/open/floor/carpet/exoticblue,
-/area/crew_quarters/dorms)
-"v" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"E" = (
-/turf/closed/wall,
-/area/crew_quarters/dorms)
-"I" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/obj/structure/table,
-/turf/open/floor/carpet/exoticblue,
-/area/crew_quarters/dorms)
-"S" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/carpet/exoticblue,
-/area/crew_quarters/dorms)
-"X" = (
+/area/template_noop)
+"x" = (
 /obj/structure/bed,
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -66,35 +24,47 @@
 	},
 /obj/item/bedsheet/nanotrasen,
 /turf/open/floor/carpet/exoticblue,
-/area/crew_quarters/dorms)
+/area/template_noop)
+"y" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/structure/table,
+/turf/open/floor/carpet/exoticblue,
+/area/template_noop)
+"D" = (
+/obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/carpet/exoticblue,
+/area/template_noop)
+"H" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/carpet/exoticblue,
+/area/template_noop)
 
 (1,1,1) = {"
-E
-E
-E
-E
+y
+o
 "}
 (2,1,1) = {"
-E
-I
-n
-E
+H
+D
 "}
 (3,1,1) = {"
-E
-d
-g
-E
-"}
-(4,1,1) = {"
-E
-X
-S
-E
-"}
-(5,1,1) = {"
-E
-E
-v
-E
+x
+m
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/dorms_edoor7.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/dorms_edoor7.dmm
@@ -1,28 +1,5 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
-/obj/structure/table,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet/orange,
-/area/crew_quarters/dorms)
-"o" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/carpet/orange,
-/area/crew_quarters/dorms)
-"E" = (
-/turf/closed/wall,
-/area/crew_quarters/dorms)
-"K" = (
+"c" = (
 /obj/structure/bed,
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -32,23 +9,24 @@
 	},
 /obj/item/bedsheet/orange,
 /turf/open/floor/carpet/orange,
-/area/crew_quarters/dorms)
-"L" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/area/template_noop)
+"h" = (
+/obj/structure/table,
+/obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"M" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet/orange,
+/area/template_noop)
+"C" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
 	},
 /turf/open/floor/carpet/orange,
-/area/crew_quarters/dorms)
-"W" = (
+/area/template_noop)
+"D" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -57,8 +35,8 @@
 	dir = 5
 	},
 /turf/open/floor/carpet/orange,
-/area/crew_quarters/dorms)
-"X" = (
+/area/template_noop)
+"H" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -66,35 +44,27 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/orange,
-/area/crew_quarters/dorms)
+/area/template_noop)
+"S" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/carpet/orange,
+/area/template_noop)
 
 (1,1,1) = {"
-E
-E
-E
-E
+h
+C
 "}
 (2,1,1) = {"
-E
-a
-M
-E
+S
+D
 "}
 (3,1,1) = {"
-E
-o
-W
-E
-"}
-(4,1,1) = {"
-E
-K
-X
-E
-"}
-(5,1,1) = {"
-E
-E
-L
-E
+c
+H
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/dorms_edoor8.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/dorms_edoor8.dmm
@@ -1,39 +1,15 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"d" = (
-/obj/structure/table,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/crew_quarters/dorms)
-"i" = (
+"a" = (
+/obj/structure/closet/secure_closet/personal,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"j" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
+	dir = 6
 	},
 /turf/open/floor/carpet/black,
-/area/crew_quarters/dorms)
-"k" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/crew_quarters/dorms)
-"s" = (
+/area/template_noop)
+"y" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/machinery/airalarm{
@@ -44,8 +20,33 @@
 	},
 /obj/item/bedsheet/black,
 /turf/open/floor/carpet/black,
-/area/crew_quarters/dorms)
-"y" = (
+/area/template_noop)
+"C" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/black,
+/area/template_noop)
+"D" = (
+/obj/structure/table,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/template_noop)
+"O" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/template_noop)
+"Y" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -54,48 +55,17 @@
 	dir = 5
 	},
 /turf/open/floor/carpet/black,
-/area/crew_quarters/dorms)
-"E" = (
-/turf/closed/wall,
-/area/crew_quarters/dorms)
-"H" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/carpet/black,
-/area/crew_quarters/dorms)
+/area/template_noop)
 
 (1,1,1) = {"
-E
-E
-E
-E
+D
+C
 "}
 (2,1,1) = {"
-E
-d
-j
-E
+a
+Y
 "}
 (3,1,1) = {"
-E
-H
 y
-E
-"}
-(4,1,1) = {"
-E
-s
-k
-E
-"}
-(5,1,1) = {"
-E
-E
-i
-E
+O
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/dorms_edoor9.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/dorms_edoor9.dmm
@@ -1,26 +1,5 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"i" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"j" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"x" = (
+"l" = (
 /obj/structure/bed,
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -31,11 +10,29 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/bedsheet/prisoner,
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"E" = (
-/turf/closed/wall,
-/area/crew_quarters/dorms)
-"H" = (
+/area/template_noop)
+"u" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"z" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"I" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -45,8 +42,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"L" = (
+/area/template_noop)
+"Q" = (
 /obj/structure/table,
 /obj/machinery/light/small{
 	dir = 8
@@ -58,42 +55,24 @@
 /obj/item/paper,
 /obj/item/pen,
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"M" = (
+/area/template_noop)
+"R" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/template_noop)
 
 (1,1,1) = {"
-E
-E
-E
-E
+Q
+R
 "}
 (2,1,1) = {"
-E
-L
-M
-E
+u
+I
 "}
 (3,1,1) = {"
-E
-j
-H
-E
-"}
-(4,1,1) = {"
-E
-x
-i
-E
-"}
-(5,1,1) = {"
-E
-E
-i
-E
+l
+z
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/hydro1.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/hydro1.dmm
@@ -1,25 +1,169 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/black{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/black{
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"b" = (
+/obj/structure/table/glass,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"c" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"d" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"e" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"f" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"g" = (
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"i" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"l" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"m" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"n" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"o" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"p" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"r" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"s" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"t" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"w" = (
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"y" = (
+/obj/effect/landmark/start/botanist,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"z" = (
+/obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/black{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/black,
-/turf/template_noop,
-/area/hydroponics)
-"b" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/effect/turf_decal/tile/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/black{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"A" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/turf/template_noop,
-/area/hydroponics)
-"c" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"B" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/black{
 	dir = 8
@@ -34,68 +178,87 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/template_noop,
-/area/hydroponics)
-"d" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"D" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"E" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"F" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/machinery/camera{
+	c_tag = "Hydroponics South";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"G" = (
+/obj/effect/landmark/start/botanist,
+/obj/structure/chair/stool,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/template_noop,
-/area/hydroponics)
-"e" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"H" = (
 /obj/machinery/vending/hydroseeds{
 	slogan_delay = 700
 	},
-/turf/template_noop,
-/area/hydroponics)
-"f" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"I" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/black{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/black{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/black,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"K" = (
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"N" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/template_noop,
-/area/hydroponics)
-"h" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/template_noop,
-/area/hydroponics)
-"i" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/template_noop,
-/area/hydroponics)
-"j" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/turf/template_noop,
-/area/hydroponics)
-"l" = (
 /obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
-"p" = (
-/obj/machinery/biogenerator,
-/turf/template_noop,
-/area/hydroponics)
-"q" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"O" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -108,173 +271,51 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
-"r" = (
-/obj/effect/landmark/start/botanist,
-/obj/structure/chair/stool,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/template_noop,
-/area/hydroponics)
-"s" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
-"t" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/template_noop,
-/area/hydroponics)
-"u" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/item/reagent_containers/glass/bucket,
-/turf/template_noop,
-/area/hydroponics)
-"v" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
-"w" = (
-/obj/machinery/seed_extractor,
-/turf/template_noop,
-/area/hydroponics)
-"x" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"Q" = (
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/turf/template_noop,
-/area/hydroponics)
-"y" = (
-/turf/template_noop,
-/area/hydroponics)
-"A" = (
-/obj/structure/table/glass,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/turf/template_noop,
-/area/hydroponics)
-"C" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
-"E" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/template_noop,
-/area/hydroponics)
-"H" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/item/reagent_containers/glass/bucket,
-/turf/template_noop,
-/area/hydroponics)
-"J" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/template_noop,
-/area/hydroponics)
-"K" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
-"L" = (
-/obj/effect/landmark/start/botanist,
-/turf/template_noop,
-/area/hydroponics)
-"M" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
-"N" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
-"O" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/black{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/black,
-/obj/effect/turf_decal/tile/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/black{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
+/turf/open/floor/plasteel,
+/area/template_noop)
 "R" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"S" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
+/turf/open/floor/plasteel,
+/area/template_noop)
+"T" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
 "U" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"W" = (
+/turf/template_noop,
+/area/template_noop)
+"X" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/black{
 	dir = 8
@@ -286,134 +327,117 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/black,
-/obj/machinery/light{
+/obj/machinery/camera{
+	c_tag = "Hydroponics North"
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"Y" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"Z" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/black{
 	dir = 8
 	},
-/turf/template_noop,
-/area/hydroponics)
-"V" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
-"W" = (
-/obj/machinery/vending/hydronutrients,
-/turf/template_noop,
-/area/hydroponics)
-"X" = (
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/black{
 	dir = 1
 	},
-/turf/template_noop,
-/area/hydroponics)
-"Y" = (
-/obj/machinery/holopad,
-/turf/template_noop,
-/area/hydroponics)
-"Z" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/black{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
+/obj/effect/turf_decal/tile/black,
+/turf/open/floor/plasteel,
+/area/template_noop)
 
 (1,1,1) = {"
-R
-U
-a
-i
-K
-U
-a
-H
-x
+N
+I
+Z
+E
+n
+I
+Z
+r
+Q
 "}
 (2,1,1) = {"
-v
-f
-J
-h
-d
-t
-t
-X
-y
+S
+A
+e
+R
+o
+U
+U
+p
+T
 "}
 (3,1,1) = {"
-a
-i
-b
-j
-A
-L
-l
-s
+Z
 E
+f
+s
+b
+y
+g
+d
+Y
 "}
 (4,1,1) = {"
-a
-i
-b
-w
+X
+E
+f
+D
+K
+T
+m
+z
 W
-y
-N
-O
-y
 "}
 (5,1,1) = {"
+Z
+E
+f
+w
+H
 a
-i
-b
-p
-e
-Y
-N
-O
-y
+m
+z
+W
 "}
 (6,1,1) = {"
-a
-i
-b
-y
-y
-y
-d
-r
-y
+Z
+E
+f
+T
+T
+T
+o
+G
+W
 "}
 (7,1,1) = {"
-q
-Z
-V
-M
-s
-s
-s
-E
-y
+O
+c
+t
+i
+d
+d
+d
+Y
+W
 "}
 (8,1,1) = {"
-C
-c
-a
-a
-a
-c
-a
-u
-y
+l
+B
+Z
+Z
+Z
+B
+Z
+F
+W
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/hydro2.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/hydro2.dmm
@@ -1,20 +1,13 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/template_noop)
 "b" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/template_noop,
-/area/hydroponics)
-"d" = (
-/obj/structure/table/glass,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/turf/template_noop,
-/area/hydroponics)
-"e" = (
+/obj/effect/landmark/start/botanist,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
@@ -25,45 +18,44 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/template_noop,
-/area/hydroponics)
+/turf/open/floor/plasteel,
+/area/template_noop)
 "f" = (
-/obj/machinery/vending/hydronutrients,
-/turf/template_noop,
-/area/hydroponics)
-"h" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
-"i" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/item/reagent_containers/glass/bucket,
-/turf/template_noop,
-/area/hydroponics)
-"j" = (
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/botanist,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel,
+/area/template_noop)
+"g" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/black{
 	dir = 8
 	},
-/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/black,
+/obj/effect/turf_decal/tile/black{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/black{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"h" = (
 /turf/template_noop,
-/area/hydroponics)
-"m" = (
+/area/template_noop)
+"i" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"n" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/tile/green{
@@ -72,22 +64,9 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/template_noop,
-/area/hydroponics)
+/turf/open/floor/plasteel,
+/area/template_noop)
 "o" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
-"q" = (
-/obj/effect/landmark/start/botanist,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
@@ -98,155 +77,26 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/template_noop,
-/area/hydroponics)
-"r" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
-"v" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/start/botanist,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/template_noop,
-/area/hydroponics)
-"y" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/structure/chair/stool,
-/turf/template_noop,
-/area/hydroponics)
-"A" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/template_noop,
-/area/hydroponics)
-"B" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/item/reagent_containers/glass/bucket,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
-"C" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/black{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/black,
-/obj/effect/turf_decal/tile/black{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/black{
-	dir = 1
-	},
-/turf/template_noop,
-/area/hydroponics)
-"D" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
-"E" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
-"F" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/template_noop,
-/area/hydroponics)
-"G" = (
-/turf/template_noop,
-/area/hydroponics)
-"H" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"p" = (
 /obj/machinery/seed_extractor,
-/turf/template_noop,
-/area/hydroponics)
-"J" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/structure/sink{
-	pixel_y = 20
-	},
-/turf/template_noop,
-/area/hydroponics)
-"K" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/black{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/black,
-/obj/effect/turf_decal/tile/black{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/black{
-	dir = 1
-	},
-/turf/template_noop,
-/area/hydroponics)
-"M" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"q" = (
 /obj/machinery/vending/hydroseeds{
 	slogan_delay = 700
 	},
-/turf/template_noop,
-/area/hydroponics)
-"N" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
-"R" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/black{
+/turf/open/floor/plasteel,
+/area/template_noop)
+"r" = (
+/obj/machinery/camera{
+	c_tag = "Hydroponics South";
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/black,
-/obj/effect/turf_decal/tile/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/black{
-	dir = 4
-	},
-/turf/template_noop,
-/area/hydroponics)
-"T" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"t" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -258,126 +108,303 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/template_noop,
-/area/hydroponics)
-"U" = (
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel,
+/area/template_noop)
+"u" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"v" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"w" = (
+/obj/machinery/light{
 	dir = 4
 	},
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"x" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/turf/template_noop,
-/area/hydroponics)
-"V" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"z" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"A" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"B" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/template_noop,
-/area/hydroponics)
-"X" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"C" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/black{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/black,
+/obj/effect/turf_decal/tile/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/black{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"D" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"E" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"F" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
-"Z" = (
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"H" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"J" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"O" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/black{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/black,
+/obj/effect/turf_decal/tile/black{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/black{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"P" = (
+/obj/structure/table/glass,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"R" = (
 /obj/machinery/biogenerator,
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/template_noop,
-/area/hydroponics)
+/turf/open/floor/plasteel,
+/area/template_noop)
+"S" = (
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"T" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/black{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/black,
+/obj/effect/turf_decal/tile/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/black{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Hydroponics North"
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"U" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"V" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"X" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/item/reagent_containers/glass/bucket,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"Z" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/template_noop)
 
 (1,1,1) = {"
-i
-B
-G
-G
-G
-r
-d
-G
-b
+u
+X
+v
+v
+v
+z
+P
+v
+E
 "}
 (2,1,1) = {"
-J
-X
-N
-E
-X
-X
-X
 F
-G
+a
+H
+J
+a
+a
+a
+A
+v
 "}
 (3,1,1) = {"
-R
-e
 C
-e
-K
-e
-K
-U
-G
+o
+O
+o
+g
+o
+g
+D
+v
 "}
 (4,1,1) = {"
-R
-e
-C
-q
-K
-e
-K
-U
-G
+T
+o
+O
+b
+g
+o
+g
+D
+h
 "}
 (5,1,1) = {"
-R
-e
 C
-e
-K
-j
-K
-U
-G
+o
+O
+o
+g
+Z
+g
+D
+h
 "}
 (6,1,1) = {"
-R
-e
 C
-e
-K
-e
-K
-v
-G
+o
+O
+o
+g
+o
+g
+f
+h
 "}
 (7,1,1) = {"
-T
-m
+t
+n
+B
+V
+U
+U
+U
+x
 h
-o
-V
-V
-V
-y
-G
 "}
 (8,1,1) = {"
-D
-Z
-H
-M
-f
-A
-G
-G
-G
+i
+R
+p
+q
+S
+w
+v
+r
+h
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/hydro3.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/hydro3.dmm
@@ -1,5 +1,29 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"b" = (
+"a" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"c" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/black{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/black,
+/obj/effect/turf_decal/tile/black{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"e" = (
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = -12;
@@ -11,34 +35,35 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/turf/template_noop,
-/area/hydroponics)
-"c" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"f" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
-"d" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/turf/open/floor/plasteel,
+/area/template_noop)
+"g" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/black{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/black,
+/obj/effect/turf_decal/tile/black{
 	dir = 8
 	},
-/turf/template_noop,
-/area/hydroponics)
-"f" = (
-/obj/machinery/vending/hydronutrients,
-/turf/template_noop,
-/area/hydroponics)
-"k" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"h" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -51,19 +76,163 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/turf/template_noop,
-/area/hydroponics)
+/turf/open/floor/plasteel,
+/area/template_noop)
+"k" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/black{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/black,
+/obj/effect/turf_decal/tile/black{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Hydroponics North"
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
 "l" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"m" = (
+/obj/effect/landmark/start/botanist,
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"n" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"o" = (
+/obj/effect/landmark/start/botanist,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"p" = (
+/turf/template_noop,
+/area/template_noop)
+"q" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/machinery/camera{
+	c_tag = "Hydroponics South";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"r" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"s" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"t" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"v" = (
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"x" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
-"m" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"y" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"B" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"C" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"D" = (
+/obj/machinery/biogenerator,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"E" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"H" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"I" = (
+/obj/structure/table/glass,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"J" = (
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = -12;
@@ -73,18 +242,9 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/template_noop,
-/area/hydroponics)
-"n" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/template_noop,
-/area/hydroponics)
-"o" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"K" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/black{
 	dir = 1
@@ -96,204 +256,9 @@
 /obj/effect/turf_decal/tile/black{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
-"p" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
-"q" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/holopad,
-/turf/template_noop,
-/area/hydroponics)
-"r" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
-"s" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/black{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/black,
-/obj/effect/turf_decal/tile/black{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/template_noop,
-/area/hydroponics)
-"t" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/item/reagent_containers/glass/bucket,
-/turf/template_noop,
-/area/hydroponics)
-"u" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/template_noop,
-/area/hydroponics)
-"v" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/turf/template_noop,
-/area/hydroponics)
-"w" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/item/reagent_containers/glass/bucket,
-/turf/template_noop,
-/area/hydroponics)
-"A" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
-"C" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
-"E" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
-"F" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
-"G" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
-"I" = (
-/obj/effect/landmark/start/botanist,
-/obj/structure/chair/stool,
-/turf/template_noop,
-/area/hydroponics)
-"J" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/black{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/black,
-/obj/effect/turf_decal/tile/black{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
-"M" = (
-/obj/machinery/biogenerator,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
-"N" = (
-/turf/template_noop,
-/area/hydroponics)
-"O" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/template_noop,
-/area/hydroponics)
-"P" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
-"S" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
-"T" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/template_noop,
-/area/hydroponics)
-"W" = (
-/obj/effect/landmark/start/botanist,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/template_noop,
-/area/hydroponics)
-"X" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"L" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -304,104 +269,163 @@
 	pixel_x = 2;
 	pixel_y = 2
 	},
-/turf/template_noop,
-/area/hydroponics)
-"Y" = (
-/obj/machinery/seed_extractor,
-/turf/template_noop,
-/area/hydroponics)
-"Z" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"N" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"O" = (
 /obj/machinery/vending/hydroseeds{
 	slogan_delay = 700
 	},
-/turf/template_noop,
-/area/hydroponics)
+/turf/open/floor/plasteel,
+/area/template_noop)
+"R" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"S" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"U" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"W" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"X" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"Y" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/template_noop)
 
 (1,1,1) = {"
-t
-m
-o
-n
-F
-o
+y
 J
-J
-b
+g
+f
+a
+g
+K
+K
+e
 "}
 (2,1,1) = {"
-Y
-G
-C
-T
-G
-P
-P
-P
-u
+r
+S
+W
+U
+S
+R
+R
+R
+n
 "}
 (3,1,1) = {"
-M
-O
-S
-X
-v
-W
-N
-N
-N
+D
+l
+t
+L
+I
+o
+E
+E
+E
 "}
 (4,1,1) = {"
-J
-n
-E
-J
-J
-n
-N
+k
 f
-N
+B
+K
+K
+f
+E
+v
+p
 "}
 (5,1,1) = {"
-J
-n
+K
+f
+B
+K
+K
+N
 E
-J
-J
-q
-N
-Z
-N
+O
+p
 "}
 (6,1,1) = {"
-J
+K
+f
+C
+R
+R
 n
-d
-P
-P
-u
-N
-I
-N
+E
+m
+p
 "}
 (7,1,1) = {"
-k
-c
-p
+h
+x
+s
+X
+Y
+Y
+Y
 l
-A
-A
-A
-O
-N
+p
 "}
 (8,1,1) = {"
-r
-s
-J
-J
-J
-s
-J
-w
-N
+H
+c
+K
+K
+K
+c
+K
+q
+p
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/hydro4.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/hydro4.dmm
@@ -1,164 +1,11 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
-/turf/template_noop,
-/area/hydroponics)
+/turf/open/floor/plasteel,
+/area/template_noop)
 "b" = (
-/obj/effect/landmark/start/botanist,
-/obj/structure/chair/stool,
-/turf/template_noop,
-/area/hydroponics)
-"e" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/black{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/black{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/black,
-/turf/template_noop,
-/area/hydroponics)
-"f" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
-"g" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
-"h" = (
-/obj/machinery/vending/hydroseeds{
-	slogan_delay = 700
-	},
-/turf/template_noop,
-/area/hydroponics)
-"k" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
-"m" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
-"n" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/item/reagent_containers/glass/bucket,
-/turf/template_noop,
-/area/hydroponics)
-"o" = (
-/turf/template_noop,
-/area/hydroponics)
-"q" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/item/reagent_containers/glass/bucket,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/template_noop,
-/area/hydroponics)
-"r" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/template_noop,
-/area/hydroponics)
-"t" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/template_noop,
-/area/hydroponics)
-"u" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/machinery/holopad,
-/turf/template_noop,
-/area/hydroponics)
-"w" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/turf/template_noop,
-/area/hydroponics)
-"x" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
-"z" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/black{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/black{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/black,
-/turf/template_noop,
-/area/hydroponics)
-"C" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/template_noop,
-/area/hydroponics)
-"D" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/template_noop,
-/area/hydroponics)
-"E" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
@@ -168,23 +15,274 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/template_noop,
-/area/hydroponics)
-"F" = (
-/obj/structure/table/glass,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/turf/template_noop,
-/area/hydroponics)
-"H" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"d" = (
+/obj/machinery/vending/hydroseeds{
+	slogan_delay = 700
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"f" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"g" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"h" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"i" = (
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"j" = (
+/obj/structure/table/glass,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"k" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"m" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"n" = (
+/obj/machinery/biogenerator,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"o" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/item/reagent_containers/glass/bucket,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"p" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/black{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/black{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/black,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"q" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"s" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/black{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/black{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/black,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"t" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"u" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"v" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"w" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"x" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"y" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"A" = (
+/obj/effect/landmark/start/botanist,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"D" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/black{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/black{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/black,
+/obj/machinery/camera{
+	c_tag = "Hydroponics North"
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"E" = (
+/obj/machinery/camera{
+	c_tag = "Hydroponics South";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"G" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"H" = (
+/obj/effect/landmark/start/botanist,
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"J" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"L" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"N" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"P" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"Q" = (
 /turf/template_noop,
-/area/hydroponics)
-"I" = (
+/area/template_noop)
+"R" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"S" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"V" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"X" = (
+/obj/structure/table/glass,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"Y" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"Z" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/black{
 	dir = 1
@@ -199,165 +297,94 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/template_noop,
-/area/hydroponics)
-"K" = (
-/obj/effect/landmark/start/botanist,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
-"L" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/template_noop,
-/area/hydroponics)
-"N" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
-"P" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/template_noop,
-/area/hydroponics)
-"R" = (
-/obj/machinery/seed_extractor,
-/turf/template_noop,
-/area/hydroponics)
-"S" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/template_noop,
-/area/hydroponics)
-"T" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/template_noop,
-/area/hydroponics)
-"U" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/template_noop,
-/area/hydroponics)
-"V" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
-"W" = (
-/obj/machinery/vending/hydronutrients,
-/turf/template_noop,
-/area/hydroponics)
-"Y" = (
-/obj/machinery/biogenerator,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/template_noop,
-/area/hydroponics)
+/turf/open/floor/plasteel,
+/area/template_noop)
 
 (1,1,1) = {"
-k
-I
-e
-D
-g
-I
-e
-n
-r
+j
+Z
+s
+x
+y
+Z
+s
+N
+w
 "}
 (2,1,1) = {"
-K
-f
-E
+A
+u
+b
+V
 L
-m
+u
+u
 f
-f
-C
-o
+P
 "}
 (3,1,1) = {"
-H
-H
-N
-H
-H
-u
-t
-o
-o
+q
+q
+J
+q
+q
+h
+a
+P
+P
 "}
 (4,1,1) = {"
-e
-e
-z
-e
-e
-e
 D
-F
-o
+s
+p
+s
+s
+s
+x
+X
+Q
 "}
 (5,1,1) = {"
-e
-e
-z
-e
-e
-e
-D
-w
-o
+s
+s
+p
+s
+s
+s
+x
+m
+Q
 "}
 (6,1,1) = {"
+u
+u
+v
+u
+u
+u
 f
-f
-x
-f
-f
-f
-C
-b
-o
+H
+Q
 "}
 (7,1,1) = {"
-U
+g
+t
+G
+R
 P
-a
-S
-o
-o
-o
-o
-o
+P
+P
+P
+Q
 "}
 (8,1,1) = {"
-V
+k
+n
+S
+d
+i
+o
 Y
-R
-h
-W
-q
-T
-o
-o
+E
+Q
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/hydro5.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/hydro5.dmm
@@ -1,161 +1,20 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/turf/template_noop,
-/area/hydroponics)
-"d" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/template_noop,
-/area/hydroponics)
-"e" = (
-/obj/structure/table/glass,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/turf/template_noop,
-/area/hydroponics)
-"f" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/template_noop,
-/area/hydroponics)
-"g" = (
-/obj/machinery/biogenerator,
-/turf/template_noop,
-/area/hydroponics)
-"h" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/black{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/black,
-/obj/effect/turf_decal/tile/black{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
-"j" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/black{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/black,
-/obj/effect/turf_decal/tile/black{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
-"l" = (
-/obj/effect/landmark/start/botanist,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/template_noop,
-/area/hydroponics)
-"m" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/item/reagent_containers/glass/bucket,
-/turf/template_noop,
-/area/hydroponics)
-"n" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/template_noop,
-/area/hydroponics)
-"r" = (
-/obj/machinery/seed_extractor,
-/turf/template_noop,
-/area/hydroponics)
-"s" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/template_noop,
-/area/hydroponics)
-"v" = (
-/obj/structure/sink{
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/turf/template_noop,
-/area/hydroponics)
-"w" = (
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel,
+/area/template_noop)
+"b" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
-"x" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/template_noop,
-/area/hydroponics)
-"y" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
-"A" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/template_noop,
-/area/hydroponics)
-"B" = (
 /obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/black{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/black{
 	dir = 4
 	},
@@ -163,12 +22,33 @@
 /obj/effect/turf_decal/tile/black{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"c" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"d" = (
+/obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/black{
 	dir = 1
 	},
-/turf/template_noop,
-/area/hydroponics)
-"C" = (
+/obj/effect/turf_decal/tile/black{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/black,
+/obj/effect/turf_decal/tile/black{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"e" = (
 /obj/machinery/light{
 	dir = 4
 	},
@@ -182,13 +62,65 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/turf/template_noop,
-/area/hydroponics)
-"E" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"f" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/black{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/black,
+/obj/effect/turf_decal/tile/black{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/black{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"g" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"h" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"k" = (
 /obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"m" = (
 /turf/template_noop,
-/area/hydroponics)
-"G" = (
+/area/template_noop)
+"n" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"p" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/tile/green{
@@ -203,21 +135,61 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/turf/template_noop,
-/area/hydroponics)
-"H" = (
-/obj/structure/chair/stool,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"s" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"t" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"u" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"v" = (
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"w" = (
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"x" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"z" = (
 /obj/effect/landmark/start/botanist,
-/turf/template_noop,
-/area/hydroponics)
-"K" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/turf/template_noop,
-/area/hydroponics)
-"M" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"C" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"D" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/black{
 	dir = 1
@@ -229,79 +201,9 @@
 /obj/effect/turf_decal/tile/black{
 	dir = 8
 	},
-/turf/template_noop,
-/area/hydroponics)
-"O" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/template_noop,
-/area/hydroponics)
-"P" = (
-/obj/machinery/vending/hydronutrients,
-/turf/template_noop,
-/area/hydroponics)
-"Q" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
-"R" = (
-/turf/template_noop,
-/area/hydroponics)
-"S" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/holopad,
-/turf/template_noop,
-/area/hydroponics)
-"T" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/template_noop,
-/area/hydroponics)
-"U" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/template_noop,
-/area/hydroponics)
-"X" = (
-/obj/machinery/vending/hydroseeds{
-	slogan_delay = 700
-	},
-/turf/template_noop,
-/area/hydroponics)
-"Y" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"F" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/tile/green{
@@ -317,94 +219,221 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
+/turf/open/floor/plasteel,
+/area/template_noop)
+"G" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"H" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"I" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"K" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"L" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/item/reagent_containers/glass/bucket,
+/obj/machinery/camera{
+	c_tag = "Hydroponics South";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"N" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/black{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/black,
+/obj/effect/turf_decal/tile/black{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Hydroponics North"
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"O" = (
+/obj/machinery/vending/hydroseeds{
+	slogan_delay = 700
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"P" = (
+/obj/structure/table/glass,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"Q" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"R" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"T" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"W" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"X" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"Y" = (
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/botanist,
+/turf/open/floor/plasteel,
+/area/template_noop)
 
 (1,1,1) = {"
-M
-Q
-w
-f
-R
-y
+d
+I
+H
+x
+C
+W
+a
+O
 v
-X
-P
 "}
 (2,1,1) = {"
-M
-l
-h
-A
-K
-f
+d
+z
+D
+n
 R
-R
-R
+x
+C
+C
+C
 "}
 (3,1,1) = {"
-M
-n
-j
-n
-M
-x
-R
-R
-R
+d
+G
+b
+G
+d
+X
+C
+C
+C
 "}
 (4,1,1) = {"
-M
-n
-j
-n
-M
-x
-R
-g
-R
+N
+G
+b
+G
+d
+X
+C
+w
+m
 "}
 (5,1,1) = {"
-M
-n
-j
-n
-M
-S
-R
-r
-R
+d
+G
+b
+G
+d
+c
+C
+Q
+m
 "}
 (6,1,1) = {"
-M
-n
-j
-n
-M
-x
-R
-H
-R
+d
+G
+b
+G
+d
+X
+C
+Y
+m
 "}
 (7,1,1) = {"
-Y
-G
+F
+p
+g
 T
-d
-U
+h
 s
-R
-R
-R
+C
+C
+m
 "}
 (8,1,1) = {"
-B
-C
-E
-a
+f
 e
-O
+k
+u
+P
+K
+t
+L
 m
-m
-R
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/hydro6.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/hydro6.dmm
@@ -1,13 +1,103 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
+"c" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"d" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"e" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/black{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/black{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/black,
+/obj/machinery/camera{
+	c_tag = "Hydroponics North"
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"f" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"g" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"h" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
-"b" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"i" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"j" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"m" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"o" = (
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"q" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/black{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/black{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/black,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"r" = (
 /obj/structure/sink{
 	pixel_y = 20
 	},
@@ -17,17 +107,129 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/template_noop,
-/area/hydroponics)
-"c" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"s" = (
+/obj/effect/landmark/start/botanist,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"u" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"v" = (
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/botanist,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"w" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"x" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"y" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"z" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"A" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"B" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/black{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/black{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/black,
+/obj/machinery/camera{
+	c_tag = "Hydroponics South";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"C" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"D" = (
 /turf/template_noop,
-/area/hydroponics)
-"j" = (
+/area/template_noop)
+"E" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"H" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"I" = (
+/obj/structure/table/glass,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"K" = (
+/obj/machinery/vending/hydroseeds{
+	slogan_delay = 700
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"M" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"N" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/syringes,
 /obj/item/storage/box/beakers{
@@ -37,220 +239,16 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/template_noop,
-/area/hydroponics)
-"k" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/black{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/black{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/black,
-/turf/template_noop,
-/area/hydroponics)
-"l" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/template_noop,
-/area/hydroponics)
-"m" = (
-/obj/machinery/vending/hydroseeds{
-	slogan_delay = 700
-	},
-/turf/template_noop,
-/area/hydroponics)
-"o" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/item/reagent_containers/glass/bucket,
-/turf/template_noop,
-/area/hydroponics)
-"p" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
-"r" = (
-/obj/machinery/seed_extractor,
-/turf/template_noop,
-/area/hydroponics)
-"s" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
-"t" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
-"u" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/black{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/black{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/black,
-/turf/template_noop,
-/area/hydroponics)
-"v" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/template_noop,
-/area/hydroponics)
-"w" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/item/reagent_containers/glass/bucket,
-/turf/template_noop,
-/area/hydroponics)
-"y" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/template_noop,
-/area/hydroponics)
-"z" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/template_noop,
-/area/hydroponics)
-"A" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/template_noop,
-/area/hydroponics)
-"D" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/template_noop,
-/area/hydroponics)
-"F" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/template_noop,
-/area/hydroponics)
-"G" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/template_noop,
-/area/hydroponics)
-"H" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/start/botanist,
-/turf/template_noop,
-/area/hydroponics)
-"I" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
-"J" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/template_noop,
-/area/hydroponics)
-"L" = (
-/obj/effect/landmark/start/botanist,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
-"M" = (
-/obj/machinery/biogenerator,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/template_noop,
-/area/hydroponics)
-"N" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/template_noop,
-/area/hydroponics)
-"O" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
+/turf/open/floor/plasteel,
+/area/template_noop)
 "P" = (
-/obj/machinery/vending/hydronutrients,
-/turf/template_noop,
-/area/hydroponics)
-"Q" = (
-/obj/machinery/holopad,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/template_noop,
-/area/hydroponics)
-"R" = (
-/turf/template_noop,
-/area/hydroponics)
-"S" = (
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"Q" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
@@ -260,110 +258,150 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/template_noop,
-/area/hydroponics)
-"T" = (
-/obj/structure/table/glass,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/turf/template_noop,
-/area/hydroponics)
-"Y" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"R" = (
+/obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/template_noop,
-/area/hydroponics)
+/turf/open/floor/plasteel,
+/area/template_noop)
+"S" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"T" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"V" = (
+/obj/machinery/biogenerator,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"X" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/black{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/black{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/black,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"Z" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
 
 (1,1,1) = {"
-k
-u
-k
-J
-R
-j
+q
+X
+q
+y
+z
+N
+I
 T
-w
-v
+x
 "}
 (2,1,1) = {"
-b
-O
-S
-t
-p
-p
-G
-R
-R
-"}
-(3,1,1) = {"
-p
-p
-y
-s
-k
-k
-J
-R
-R
-"}
-(4,1,1) = {"
-k
-k
-l
-L
-k
-k
-J
-R
-R
-"}
-(5,1,1) = {"
-k
-k
-l
-s
-k
-k
-Q
-R
-R
-"}
-(6,1,1) = {"
-O
-O
-N
-s
-k
-k
-J
-H
-R
-"}
-(7,1,1) = {"
-A
-z
-D
-Y
-O
-O
-F
-a
-G
-"}
-(8,1,1) = {"
-I
-M
 r
 m
+Q
+i
+d
+d
+A
+z
+z
+"}
+(3,1,1) = {"
+d
+d
+C
+R
+q
+q
+y
+z
+z
+"}
+(4,1,1) = {"
+e
+q
+Z
+s
+q
+q
+y
+z
+D
+"}
+(5,1,1) = {"
+q
+q
+Z
+R
+q
+q
+E
+z
+D
+"}
+(6,1,1) = {"
+m
+m
+f
+R
+q
+q
+y
+v
+D
+"}
+(7,1,1) = {"
+H
+g
+j
+M
+m
+m
 P
+h
+D
+"}
+(8,1,1) = {"
+w
+V
+u
+K
 o
+S
 c
-k
-J
+B
+D
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/medbay_morgue1.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/medbay_morgue1.dmm
@@ -1,71 +1,134 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"G" = (
-/turf/template_noop,
-/area/medical/morgue)
-"H" = (
+"h" = (
+/obj/structure/bodycontainer/morgue,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"i" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"j" = (
+/obj/machinery/light/small,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"r" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"v" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"C" = (
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"D" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"E" = (
+/obj/structure/table,
+/obj/item/storage/box/bodybags,
+/obj/item/pen,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"I" = (
+/obj/machinery/camera{
+	c_tag = "Medbay Morgue";
+	dir = 8;
+	network = list("ss13","medbay")
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"P" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"S" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"U" = (
 /obj/structure/table,
 /obj/item/paper/guides/jobs/medical/morgue{
 	pixel_x = 5;
 	pixel_y = 4
 	},
-/turf/template_noop,
-/area/medical/morgue)
-"L" = (
-/obj/structure/table,
-/obj/item/storage/box/bodybags,
-/obj/item/pen,
-/turf/template_noop,
-/area/medical/morgue)
-"T" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 8
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"Z" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/template_noop,
-/area/medical/morgue)
-"W" = (
-/obj/structure/bodycontainer/morgue,
-/turf/template_noop,
-/area/medical/morgue)
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
 
 (1,1,1) = {"
-L
-W
-W
-W
-H
+E
+h
+h
+h
+U
 "}
 (2,1,1) = {"
-G
-G
-G
-G
-G
+C
+S
+i
+P
+r
 "}
 (3,1,1) = {"
-G
-G
-G
-G
-G
+C
+C
+C
+C
+Z
 "}
 (4,1,1) = {"
-G
-T
-T
-T
-G
+C
+D
+D
+D
+j
 "}
 (5,1,1) = {"
-G
-W
-W
-W
-G
+C
+h
+h
+h
+Z
 "}
 (6,1,1) = {"
-G
-G
-G
-G
-G
+C
+v
+I
+C
+Z
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/medbay_morgue2.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/medbay_morgue2.dmm
@@ -1,83 +1,170 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"e" = (
+/obj/structure/table,
+/obj/item/storage/box/bodybags,
+/obj/item/pen,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
 "h" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 2
-	},
-/turf/template_noop,
-/area/medical/morgue)
-"i" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 1
-	},
-/turf/template_noop,
-/area/medical/morgue)
-"G" = (
-/turf/template_noop,
-/area/medical/morgue)
-"H" = (
+/obj/structure/bodycontainer/morgue,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"m" = (
 /obj/structure/table,
 /obj/item/paper/guides/jobs/medical/morgue{
 	pixel_x = 5;
 	pixel_y = 4
 	},
-/turf/template_noop,
-/area/medical/morgue)
-"L" = (
-/obj/structure/table,
-/obj/item/storage/box/bodybags,
-/obj/item/pen,
-/turf/template_noop,
-/area/medical/morgue)
-"T" = (
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"o" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"q" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
 	},
-/turf/template_noop,
-/area/medical/morgue)
-"W" = (
-/obj/structure/bodycontainer/morgue,
-/turf/template_noop,
-/area/medical/morgue)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"r" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"t" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 2
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"u" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"v" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"A" = (
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"C" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"D" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"E" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"S" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"T" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"U" = (
+/obj/machinery/camera{
+	c_tag = "Medbay Morgue";
+	dir = 8;
+	network = list("ss13","medbay")
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"V" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 2
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"Y" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 1
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
 
 (1,1,1) = {"
-h
-G
-G
-L
-H
+V
+A
+A
+e
+m
 "}
 (2,1,1) = {"
-h
-G
-G
-G
-G
+t
+D
+E
+v
+u
 "}
 (3,1,1) = {"
-h
-G
-T
-G
-i
+t
+A
+C
+o
+S
 "}
 (4,1,1) = {"
-G
-G
-W
-G
-i
+A
+A
+h
+o
+Y
 "}
 (5,1,1) = {"
-G
-G
-G
-G
-i
+A
+A
+A
+o
+S
 "}
 (6,1,1) = {"
-G
+A
+q
+U
 T
-G
-G
-G
+r
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/medbay_morgue3.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/medbay_morgue3.dmm
@@ -1,83 +1,167 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"c" = (
+/obj/structure/table,
+/obj/item/storage/box/bodybags,
+/obj/item/pen,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
 "f" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 1
-	},
-/turf/template_noop,
-/area/medical/morgue)
-"A" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 2
-	},
-/turf/template_noop,
-/area/medical/morgue)
-"G" = (
-/turf/template_noop,
-/area/medical/morgue)
-"H" = (
 /obj/structure/table,
 /obj/item/paper/guides/jobs/medical/morgue{
 	pixel_x = 5;
 	pixel_y = 4
 	},
-/turf/template_noop,
-/area/medical/morgue)
-"L" = (
-/obj/structure/table,
-/obj/item/storage/box/bodybags,
-/obj/item/pen,
-/turf/template_noop,
-/area/medical/morgue)
-"T" = (
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"i" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
 	},
-/turf/template_noop,
-/area/medical/morgue)
-"W" = (
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"l" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Medbay Morgue";
+	dir = 8;
+	network = list("ss13","medbay")
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"q" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"r" = (
 /obj/structure/bodycontainer/morgue,
-/turf/template_noop,
-/area/medical/morgue)
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"s" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"t" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"x" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"I" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"L" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 1
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"N" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 2
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"O" = (
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"Q" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"S" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"W" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"Z" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
 
 (1,1,1) = {"
-L
-W
-W
-W
-H
+c
+r
+r
+r
+f
 "}
 (2,1,1) = {"
-G
-G
-G
-G
-G
+O
+W
+S
+I
+s
 "}
 (3,1,1) = {"
-A
-G
-G
-G
-f
+N
+O
+O
+q
+Z
 "}
 (4,1,1) = {"
-G
-G
-G
-G
-f
+O
+O
+O
+q
+L
 "}
 (5,1,1) = {"
-G
-G
-G
-G
-G
+O
+O
+O
+Q
+x
 "}
 (6,1,1) = {"
-G
-T
-T
-T
-G
+O
+t
+l
+i
+q
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/medbay_morgue4.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/medbay_morgue4.dmm
@@ -1,17 +1,114 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"o" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 2
-	},
-/turf/template_noop,
-/area/medical/morgue)
-"q" = (
+"a" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 1
 	},
-/turf/template_noop,
-/area/medical/morgue)
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"d" = (
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"h" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 2
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"i" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"m" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 2
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"n" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"o" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"r" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
 "v" = (
+/obj/machinery/camera{
+	c_tag = "Medbay Morgue";
+	dir = 8;
+	network = list("ss13","medbay")
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"x" = (
+/obj/structure/bodycontainer/morgue,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"y" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"A" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"E" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"K" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 1
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"P" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"R" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"X" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
 /obj/item/paper/guides/jobs/medical/morgue{
@@ -19,61 +116,48 @@
 	pixel_y = 4
 	},
 /obj/item/pen,
-/turf/template_noop,
-/area/medical/morgue)
-"G" = (
-/turf/template_noop,
-/area/medical/morgue)
-"T" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 8
-	},
-/turf/template_noop,
-/area/medical/morgue)
-"W" = (
-/obj/structure/bodycontainer/morgue,
-/turf/template_noop,
-/area/medical/morgue)
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
 
 (1,1,1) = {"
-o
-G
-W
-G
-q
+m
+d
+x
+d
+a
 "}
 (2,1,1) = {"
-o
-G
-G
-G
-G
+h
+R
+E
+r
+n
 "}
 (3,1,1) = {"
-G
-G
-G
-G
-q
+d
+d
+d
+i
+a
 "}
 (4,1,1) = {"
-G
-T
-T
-G
-q
+d
+y
+y
+i
+K
 "}
 (5,1,1) = {"
-G
-v
-W
-G
-G
+d
+X
+x
+P
+o
 "}
 (6,1,1) = {"
-G
-G
-G
-G
-G
+d
+A
+v
+d
+i
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/medbay_morgue5.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/medbay_morgue5.dmm
@@ -1,83 +1,164 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"l" = (
+"f" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Medbay Morgue";
+	dir = 8;
+	network = list("ss13","medbay")
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"h" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 1
 	},
-/turf/template_noop,
-/area/medical/morgue)
-"z" = (
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"k" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"n" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"o" = (
+/obj/structure/table,
+/obj/item/storage/box/bodybags,
+/obj/item/pen,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"r" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"A" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"C" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"F" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"H" = (
+/obj/structure/bodycontainer/morgue,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"J" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 2
 	},
-/turf/template_noop,
-/area/medical/morgue)
-"G" = (
-/turf/template_noop,
-/area/medical/morgue)
-"H" = (
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"L" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"M" = (
 /obj/structure/table,
 /obj/item/paper/guides/jobs/medical/morgue{
 	pixel_x = 5;
 	pixel_y = 4
 	},
-/turf/template_noop,
-/area/medical/morgue)
-"L" = (
-/obj/structure/table,
-/obj/item/storage/box/bodybags,
-/obj/item/pen,
-/turf/template_noop,
-/area/medical/morgue)
-"T" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"Q" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
 	},
-/turf/template_noop,
-/area/medical/morgue)
-"W" = (
-/obj/structure/bodycontainer/morgue,
-/turf/template_noop,
-/area/medical/morgue)
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"R" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"V" = (
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
 
 (1,1,1) = {"
-G
-G
-G
-G
-G
+L
+V
+V
+V
+V
 "}
 (2,1,1) = {"
-G
-L
-H
-G
-G
+C
+o
+M
+n
+F
 "}
 (3,1,1) = {"
-G
-l
-z
-G
-T
+V
+h
+J
+R
+Q
 "}
 (4,1,1) = {"
-G
-l
-z
-G
-W
+V
+h
+J
+R
+H
 "}
 (5,1,1) = {"
-G
-G
-G
-G
-G
+V
+V
+V
+r
+k
 "}
 (6,1,1) = {"
-G
-T
-T
-T
-G
+V
+A
+f
+Q
+R
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/testingsite_range1.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/testingsite_range1.dmm
@@ -1,9 +1,5 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "c" = (
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
-"d" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -12,53 +8,20 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/science/test_area)
-"e" = (
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'BOMB RANGE";
-	name = "BOMB RANGE"
+/area/template_noop)
+"d" = (
+/obj/item/target,
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/closed/wall,
-/area/science/test_area)
+/turf/open/floor/plating/airless,
+/area/template_noop)
 "f" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
-/area/science/test_area)
+/area/template_noop)
 "h" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"j" = (
-/turf/open/space/basic,
-/area/space)
-"k" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"l" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"m" = (
-/turf/closed/indestructible{
-	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
-	icon_state = "riveted";
-	name = "hyper-reinforced wall"
-	},
-/area/science/test_area)
-"p" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"s" = (
 /obj/structure/chair{
 	dir = 8
 	},
@@ -76,80 +39,30 @@
 	use_power = 0
 	},
 /turf/open/floor/plating/airless,
-/area/science/test_area)
-"t" = (
-/turf/closed/wall,
-/area/science/test_area)
-"u" = (
-/obj/item/target,
-/obj/structure/window/reinforced{
+/area/template_noop)
+"i" = (
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
-/area/science/test_area)
-"w" = (
-/obj/item/beacon,
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"y" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"A" = (
-/obj/structure/table,
-/obj/item/storage/box/mre,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"B" = (
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"E" = (
-/obj/item/target,
-/obj/structure/window/reinforced,
+/area/template_noop)
+"l" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/science/test_area)
-"H" = (
-/obj/structure/chair{
+/area/template_noop)
+"m" = (
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /turf/open/floor/plating/airless,
-/area/science/test_area)
-"I" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp,
-/obj/effect/turf_decal/stripes/corner,
+/area/template_noop)
+"n" = (
+/obj/item/beacon,
 /turf/open/floor/plating/airless,
-/area/science/test_area)
-"J" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"N" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"O" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"P" = (
+/area/template_noop)
+"p" = (
 /obj/structure/chair{
 	dir = 1
 	},
@@ -157,272 +70,199 @@
 	dir = 6
 	},
 /turf/open/floor/plating/airless,
-/area/science/test_area)
+/area/template_noop)
+"r" = (
+/turf/template_noop,
+/area/template_noop)
+"u" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"v" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"z" = (
+/obj/item/target,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"C" = (
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"D" = (
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'BOMB RANGE";
+	name = "BOMB RANGE"
+	},
+/turf/closed/wall,
+/area/template_noop)
+"E" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"G" = (
+/turf/closed/wall,
+/area/template_noop)
+"J" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"M" = (
+/turf/closed/indestructible{
+	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
+	icon_state = "riveted";
+	name = "hyper-reinforced wall"
+	},
+/area/template_noop)
+"O" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"P" = (
+/obj/structure/table,
+/obj/item/flashlight/lamp,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"S" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
 "T" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/science/test_area)
+/area/template_noop)
+"V" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
 "Y" = (
+/obj/structure/table,
+/obj/item/storage/box/mre,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/science/test_area)
+/area/template_noop)
 
 (1,1,1) = {"
-j
-j
-j
-j
-j
-j
-c
-j
-c
-j
-j
-j
-j
-j
-j
+r
+r
+r
+G
+J
+G
+r
+r
+r
 "}
 (2,1,1) = {"
-j
-j
-j
-j
-j
-c
-c
-j
-c
-c
-j
-j
-j
-j
-j
+r
+r
+D
+G
+T
+G
+D
+r
+r
 "}
 (3,1,1) = {"
-j
-j
-j
-j
-c
-c
-t
-h
-t
-c
-c
-j
-j
-j
-j
+r
+G
+G
+v
+J
+V
+G
+G
+r
 "}
 (4,1,1) = {"
-j
-j
-j
-c
-c
-e
-t
-f
-t
-e
-c
-c
-j
-j
-j
+G
+G
+v
+i
+C
+m
+V
+G
+G
 "}
 (5,1,1) = {"
-j
-j
-c
-c
-t
-t
+f
+d
 l
-h
+S
+n
+S
 O
-t
-t
-c
-c
-j
-j
+z
+f
 "}
 (6,1,1) = {"
-j
-j
-c
-t
-t
-l
+G
+G
+u
 Y
-B
-k
-O
-t
-t
-c
-j
-j
+C
+P
+p
+G
+G
 "}
 (7,1,1) = {"
-c
-c
-c
-J
+r
+G
+G
 E
 T
-y
-w
-y
-p
-u
-J
-c
-c
-c
+h
+G
+G
+r
 "}
 (8,1,1) = {"
-j
-j
+r
+r
+D
+G
 c
-t
-t
-N
-A
-B
-I
-P
-t
-t
-c
-j
-j
+G
+D
+r
+r
 "}
 (9,1,1) = {"
-j
-j
-c
-c
-t
-t
-H
-f
-s
-t
-t
-c
-c
-j
-j
-"}
-(10,1,1) = {"
-j
-j
-j
-c
-c
-e
-t
-d
-t
-e
-c
-c
-j
-j
-j
-"}
-(11,1,1) = {"
-j
-j
-j
-j
-c
-c
-t
-m
-t
-c
-c
-j
-j
-j
-j
-"}
-(12,1,1) = {"
-j
-j
-j
-j
-j
-c
-c
-c
-c
-c
-j
-j
-j
-j
-j
-"}
-(13,1,1) = {"
-j
-j
-j
-j
-j
-j
-c
-c
-c
-j
-j
-j
-j
-j
-j
-"}
-(14,1,1) = {"
-j
-j
-j
-j
-j
-j
-j
-c
-j
-j
-j
-j
-j
-j
-j
-"}
-(15,1,1) = {"
-j
-j
-j
-j
-j
-j
-j
-c
-j
-j
-j
-j
-j
-j
-j
+r
+r
+r
+G
+M
+G
+r
+r
+r
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/testingsite_range2.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/testingsite_range2.dmm
@@ -1,5 +1,66 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"b" = (
+"a" = (
+/obj/item/toy/nuke,
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"d" = (
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/flashlight/lamp,
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"f" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"h" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/item/flashlight/lamp,
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"i" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"k" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"l" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"m" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"n" = (
+/obj/item/beacon,
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"p" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"q" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -7,31 +68,17 @@
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/science/test_area)
-"c" = (
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
-"d" = (
+/area/template_noop)
+"r" = (
+/turf/template_noop,
+/area/template_noop)
+"v" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 9
 	},
 /turf/open/floor/plating/airless,
-/area/science/test_area)
-"e" = (
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'BOMB RANGE";
-	name = "BOMB RANGE"
-	},
-/turf/closed/wall,
-/area/science/test_area)
-"f" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"g" = (
+/area/template_noop)
+"w" = (
 /obj/machinery/camera{
 	active_power_usage = 0;
 	c_tag = "Bomb Test Site";
@@ -47,387 +94,180 @@
 	},
 /obj/item/target/syndicate,
 /turf/open/floor/plating/airless,
-/area/science/test_area)
-"h" = (
+/area/template_noop)
+"A" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"C" = (
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"D" = (
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'BOMB RANGE";
+	name = "BOMB RANGE"
+	},
+/turf/closed/wall,
+/area/template_noop)
+"G" = (
+/turf/closed/wall,
+/area/template_noop)
+"I" = (
+/obj/item/target/syndicate,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"J" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/science/test_area)
-"i" = (
-/obj/item/target/syndicate,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"j" = (
-/turf/open/space/basic,
-/area/space)
-"l" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"m" = (
+/area/template_noop)
+"M" = (
 /turf/closed/indestructible{
 	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
 	icon_state = "riveted";
 	name = "hyper-reinforced wall"
 	},
-/area/science/test_area)
-"n" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/area/template_noop)
+"O" = (
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
-/area/science/test_area)
-"r" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"t" = (
-/turf/closed/wall,
-/area/science/test_area)
-"w" = (
-/obj/item/beacon,
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"y" = (
+/area/template_noop)
+"S" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /obj/structure/chair,
 /turf/open/floor/plating/airless,
-/area/science/test_area)
-"A" = (
+/area/template_noop)
+"T" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/science/test_area)
-"B" = (
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"C" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"G" = (
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/item/flashlight/lamp,
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"I" = (
-/obj/item/toy/nuke,
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"J" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"K" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"O" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"R" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/item/flashlight/lamp,
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"S" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/science/test_area)
+/area/template_noop)
 "V" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"X" = (
 /obj/item/target/syndicate,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/science/test_area)
-"W" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/area/template_noop)
+"Y" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
 /turf/open/floor/plating/airless,
-/area/science/test_area)
+/area/template_noop)
 
 (1,1,1) = {"
-j
-j
-j
-j
-j
-j
-c
-j
-c
-j
-j
-j
-j
-j
-j
+r
+r
+r
+f
+J
+f
+r
+r
+r
 "}
 (2,1,1) = {"
-j
-j
-j
-j
-j
-c
-c
-j
-c
-c
-j
-j
-j
-j
-j
+r
+r
+D
+f
+T
+f
+D
+r
+r
 "}
 (3,1,1) = {"
-j
-j
-j
-j
-c
-c
-S
-h
-S
-c
-c
-j
-j
-j
-j
+r
+f
+f
+v
+J
+V
+f
+f
+r
 "}
 (4,1,1) = {"
-j
-j
-j
-c
-c
-e
+G
+G
 S
-f
-S
-e
-c
-c
-j
-j
-j
+i
+C
+m
+p
+G
+G
 "}
 (5,1,1) = {"
-j
-j
-c
-c
-S
-S
+f
+d
 l
-h
+C
+n
+C
 O
-S
-S
-c
-c
-j
-j
+h
+f
 "}
 (6,1,1) = {"
-j
-j
-c
-t
-t
-y
-r
-B
-W
-C
-t
-t
-c
-j
-j
+G
+G
+Y
+X
+a
+I
+k
+G
+G
 "}
 (7,1,1) = {"
-c
-c
-c
-S
-G
-d
-B
+r
+f
+f
+q
 w
-B
-K
-R
-S
-c
-c
-c
+A
+f
+f
+r
 "}
 (8,1,1) = {"
-j
-j
-c
-t
-t
-A
-V
-I
-i
-n
-t
-t
-c
-j
-j
+r
+r
+D
+f
+M
+f
+D
+r
+r
 "}
 (9,1,1) = {"
-j
-j
-c
-c
-S
-S
-b
-g
-J
-S
-S
-c
-c
-j
-j
-"}
-(10,1,1) = {"
-j
-j
-j
-c
-c
-e
-S
-m
-S
-e
-c
-c
-j
-j
-j
-"}
-(11,1,1) = {"
-j
-j
-j
-j
-c
-c
-S
-t
-S
-c
-c
-j
-j
-j
-j
-"}
-(12,1,1) = {"
-j
-j
-j
-j
-j
-c
-c
-c
-c
-c
-j
-j
-j
-j
-j
-"}
-(13,1,1) = {"
-j
-j
-j
-j
-j
-j
-c
-c
-c
-j
-j
-j
-j
-j
-j
-"}
-(14,1,1) = {"
-j
-j
-j
-j
-j
-j
-j
-c
-j
-j
-j
-j
-j
-j
-j
-"}
-(15,1,1) = {"
-j
-j
-j
-j
-j
-j
-j
-c
-j
-j
-j
-j
-j
-j
-j
+r
+r
+r
+f
+G
+f
+r
+r
+r
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/testingsite_range3.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/testingsite_range3.dmm
@@ -1,72 +1,29 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"c" = (
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
-"e" = (
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'BOMB RANGE";
-	name = "BOMB RANGE"
-	},
-/turf/closed/wall,
-/area/science/test_area)
-"f" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"h" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"j" = (
-/turf/open/space/basic,
-/area/space)
-"k" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"l" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"m" = (
-/turf/closed/indestructible{
-	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
-	icon_state = "riveted";
-	name = "hyper-reinforced wall"
-	},
-/area/science/test_area)
-"n" = (
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/stripes/line{
+"d" = (
+/obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line,
 /obj/item/target/clown,
 /turf/open/floor/plating/airless,
-/area/science/test_area)
-"o" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/item/grown/bananapeel,
+/area/template_noop)
+"f" = (
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
-/area/science/test_area)
-"p" = (
-/obj/structure/chair{
+/area/template_noop)
+"h" = (
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"j" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plating/airless,
-/area/science/test_area)
-"q" = (
+/area/template_noop)
+"k" = (
 /obj/machinery/camera{
 	active_power_usage = 0;
 	c_tag = "Bomb Test Site";
@@ -84,8 +41,23 @@
 	pixel_y = 3
 	},
 /turf/open/floor/plating/airless,
-/area/science/test_area)
-"r" = (
+/area/template_noop)
+"l" = (
+/obj/item/beacon,
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"n" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/grown/bananapeel,
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"o" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"p" = (
 /obj/structure/chair{
 	dir = 8
 	},
@@ -93,69 +65,115 @@
 	dir = 6
 	},
 /turf/open/floor/plating/airless,
-/area/science/test_area)
-"t" = (
-/turf/closed/wall,
-/area/science/test_area)
-"w" = (
-/obj/item/beacon,
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"x" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"B" = (
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"G" = (
-/obj/item/target/clown,
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"H" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"I" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/item/target/clown,
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"J" = (
+/area/template_noop)
+"q" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/plating/airless,
-/area/science/test_area)
-"L" = (
-/obj/effect/turf_decal/stripes/corner{
+/area/template_noop)
+"r" = (
+/turf/template_noop,
+/area/template_noop)
+"w" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"y" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"B" = (
+/obj/item/target/clown,
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"C" = (
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"E" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"F" = (
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/target/clown,
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"G" = (
+/turf/closed/wall,
+/area/template_noop)
+"H" = (
+/turf/closed/indestructible{
+	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
+	icon_state = "riveted";
+	name = "hyper-reinforced wall"
+	},
+/area/template_noop)
+"I" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"J" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/science/test_area)
+/area/template_noop)
+"K" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
 "N" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"O" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /turf/open/floor/plating/airless,
-/area/science/test_area)
-"O" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/area/template_noop)
+"P" = (
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'BOMB RANGE";
+	name = "BOMB RANGE"
+	},
+/turf/closed/wall,
+/area/template_noop)
+"U" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/science/test_area)
-"P" = (
+/area/template_noop)
+"V" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"Y" = (
 /obj/structure/chair{
 	dir = 1
 	},
@@ -163,282 +181,104 @@
 	dir = 6
 	},
 /turf/open/floor/plating/airless,
-/area/science/test_area)
-"S" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"T" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"U" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"W" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
+/area/template_noop)
 
 (1,1,1) = {"
-j
-j
-j
-j
-j
-j
-c
-j
-c
-j
-j
-j
-j
-j
-j
+r
+r
+r
+f
+E
+f
+r
+r
+r
 "}
 (2,1,1) = {"
-j
-j
-j
-j
-j
-c
-c
-j
-c
-c
-j
-j
-j
-j
-j
+r
+r
+P
+f
+N
+f
+P
+r
+r
 "}
 (3,1,1) = {"
+r
+f
+f
+y
+n
 j
-j
-j
-j
-c
-c
-S
-h
-S
-c
-c
-j
-j
-j
-j
+f
+f
+r
 "}
 (4,1,1) = {"
-j
-j
-j
-c
-c
-e
-S
-f
-S
-e
-c
-c
-j
-j
-j
+G
+G
+q
+h
+B
+K
+w
+G
+G
 "}
 (5,1,1) = {"
-j
-j
-c
-c
-S
-S
+f
+F
+J
+C
 l
+C
 o
-O
-S
-S
-c
-c
-j
-j
+d
+f
 "}
 (6,1,1) = {"
-j
-j
-c
-t
-t
-J
-L
 G
-W
-p
-t
-t
-c
-j
-j
+G
+O
+U
+C
+I
+Y
+G
+G
 "}
 (7,1,1) = {"
-c
-c
-c
-S
-n
-U
-B
-w
-B
+r
+f
+f
+V
 k
-I
-S
-c
-c
-c
+p
+f
+f
+r
 "}
 (8,1,1) = {"
-j
-j
-c
-t
-t
-N
-T
-B
-x
+r
+r
 P
-t
-t
-c
-j
-j
+f
+H
+f
+P
+r
+r
 "}
 (9,1,1) = {"
-j
-j
-c
-c
-S
-S
-H
-q
 r
-S
-S
-c
-c
-j
-j
-"}
-(10,1,1) = {"
-j
-j
-j
-c
-c
-e
-S
-m
-S
-e
-c
-c
-j
-j
-j
-"}
-(11,1,1) = {"
-j
-j
-j
-j
-c
-c
-S
-t
-S
-c
-c
-j
-j
-j
-j
-"}
-(12,1,1) = {"
-j
-j
-j
-j
-j
-c
-c
-c
-c
-c
-j
-j
-j
-j
-j
-"}
-(13,1,1) = {"
-j
-j
-j
-j
-j
-j
-c
-c
-c
-j
-j
-j
-j
-j
-j
-"}
-(14,1,1) = {"
-j
-j
-j
-j
-j
-j
-j
-c
-j
-j
-j
-j
-j
-j
-j
-"}
-(15,1,1) = {"
-j
-j
-j
-j
-j
-j
-j
-c
-j
-j
-j
-j
-j
-j
-j
+r
+r
+f
+G
+f
+r
+r
+r
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/testingsite_range4.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/testingsite_range4.dmm
@@ -1,61 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/door/window/eastright{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/test_area)
 "c" = (
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
-"e" = (
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'BOMB RANGE";
-	name = "BOMB RANGE"
-	},
-/turf/closed/wall,
-/area/science/test_area)
-"f" = (
-/obj/item/beacon,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/science/test_area)
-"g" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/structure/table,
-/obj/item/flashlight/lamp,
-/turf/open/floor/plasteel,
-/area/science/test_area)
-"h" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -66,15 +11,12 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/door/window/eastright{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/machinery/paystand/register{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/science/test_area)
-"i" = (
+/area/template_noop)
+"e" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -85,12 +27,15 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/end,
+/obj/structure/statue/sandstone/assistant,
 /turf/open/floor/plasteel,
-/area/science/test_area)
+/area/template_noop)
+"f" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/template_noop)
 "j" = (
-/turf/open/space/basic,
-/area/space)
-"k" = (
 /obj/structure/table_frame,
 /obj/item/stack/sheet/metal,
 /obj/effect/turf_decal/tile/yellow{
@@ -105,52 +50,8 @@
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel,
-/area/science/test_area)
-"m" = (
-/turf/closed/indestructible{
-	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
-	icon_state = "riveted";
-	name = "hyper-reinforced wall"
-	},
-/area/science/test_area)
-"q" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/item/a_gift,
-/obj/item/a_gift,
-/turf/open/floor/plasteel,
-/area/science/test_area)
-"s" = (
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/science/test_area)
-"t" = (
-/turf/closed/wall,
-/area/science/test_area)
-"v" = (
+/area/template_noop)
+"k" = (
 /obj/machinery/camera{
 	active_power_usage = 0;
 	c_tag = "Bomb Test Site";
@@ -173,8 +74,75 @@
 	},
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/plasteel,
-/area/science/test_area)
-"z" = (
+/area/template_noop)
+"r" = (
+/turf/template_noop,
+/area/template_noop)
+"s" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"t" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/door/window/eastright{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"x" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"y" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/flashlight/lamp,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"A" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -199,63 +167,27 @@
 	pixel_y = 1
 	},
 /turf/open/floor/plasteel,
-/area/science/test_area)
-"E" = (
+/area/template_noop)
+"B" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/door/window/eastright{
+	dir = 1
+	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/science/test_area)
-"H" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/science/test_area)
-"J" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"M" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/end,
-/obj/structure/statue/sandstone/assistant,
-/turf/open/floor/plasteel,
-/area/science/test_area)
-"N" = (
+/area/template_noop)
+"C" = (
 /obj/structure/chair{
 	dir = 8
 	},
@@ -271,12 +203,16 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/science/test_area)
-"S" = (
-/obj/structure/closet/crate,
-/obj/item/target/syndicate,
-/obj/item/target,
-/obj/item/target/alien,
+/area/template_noop)
+"D" = (
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'BOMB RANGE";
+	name = "BOMB RANGE"
+	},
+/turf/closed/wall,
+/area/template_noop)
+"F" = (
+/obj/item/beacon,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -288,10 +224,20 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/science/test_area)
-"U" = (
+/area/template_noop)
+"G" = (
+/turf/closed/wall,
+/area/template_noop)
+"M" = (
+/turf/closed/indestructible{
+	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
+	icon_state = "riveted";
+	name = "hyper-reinforced wall"
+	},
+/area/template_noop)
+"P" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -304,25 +250,8 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/science/test_area)
-"W" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/paystand/register{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/test_area)
-"Y" = (
+/area/template_noop)
+"R" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -341,8 +270,25 @@
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
-/area/science/test_area)
-"Z" = (
+/area/template_noop)
+"S" = (
+/obj/structure/closet/crate,
+/obj/item/target/syndicate,
+/obj/item/target,
+/obj/item/target/alien,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"T" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -360,260 +306,154 @@
 	pixel_y = -1
 	},
 /turf/open/floor/plasteel,
-/area/science/test_area)
+/area/template_noop)
+"U" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/item/a_gift,
+/obj/item/a_gift,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"V" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"X" = (
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/template_noop)
 
 (1,1,1) = {"
-j
-j
-j
-j
-j
-j
-c
-j
-c
-j
-j
-j
-j
-j
-j
+r
+r
+r
+G
+V
+G
+r
+r
+r
 "}
 (2,1,1) = {"
-j
-j
-j
-j
-j
-c
-c
-j
-c
-c
-j
-j
-j
-j
-j
+r
+r
+D
+G
+P
+G
+D
+r
+r
 "}
 (3,1,1) = {"
-j
-j
-j
-j
-c
-c
+r
+G
+G
+s
+s
 t
-U
-t
-c
-c
-j
-j
-j
-j
+G
+G
+r
 "}
 (4,1,1) = {"
-j
-j
-j
-c
-c
-e
-t
-E
-t
-e
-c
+G
+G
+U
 c
 j
-j
-j
+s
+A
+G
+G
 "}
 (5,1,1) = {"
-j
-j
-c
-c
-t
-t
-i
-i
-a
-t
-t
-c
-c
-j
-j
+f
+X
+T
+C
+F
+s
+x
+e
+f
 "}
 (6,1,1) = {"
-j
-j
-c
-t
-t
-q
-W
-k
-i
-z
-t
-t
-c
-j
-j
+G
+G
+y
+s
+s
+s
+B
+G
+G
 "}
 (7,1,1) = {"
-c
-c
-c
-J
+r
+G
+G
+S
 s
-Z
-N
-f
-i
-H
-M
-J
-c
-c
-c
+k
+G
+G
+r
 "}
 (8,1,1) = {"
-j
-j
-c
-t
-t
-g
-i
-i
-i
-h
-t
-t
-c
-j
-j
+r
+r
+D
+G
+R
+G
+D
+r
+r
 "}
 (9,1,1) = {"
-j
-j
-c
-c
-t
-t
-S
-i
-v
-t
-t
-c
-c
-j
-j
-"}
-(10,1,1) = {"
-j
-j
-j
-c
-c
-e
-t
-Y
-t
-e
-c
-c
-j
-j
-j
-"}
-(11,1,1) = {"
-j
-j
-j
-j
-c
-c
-t
-m
-t
-c
-c
-j
-j
-j
-j
-"}
-(12,1,1) = {"
-j
-j
-j
-j
-j
-c
-c
-c
-c
-c
-j
-j
-j
-j
-j
-"}
-(13,1,1) = {"
-j
-j
-j
-j
-j
-j
-c
-c
-c
-j
-j
-j
-j
-j
-j
-"}
-(14,1,1) = {"
-j
-j
-j
-j
-j
-j
-j
-c
-j
-j
-j
-j
-j
-j
-j
-"}
-(15,1,1) = {"
-j
-j
-j
-j
-j
-j
-j
-c
-j
-j
-j
-j
-j
-j
-j
+r
+r
+r
+G
+M
+G
+r
+r
+r
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/transfer1.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/transfer1.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "c" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -9,21 +9,21 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "d" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "f" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "h" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/sec/surgery{
@@ -40,7 +40,7 @@
 	pixel_y = -1
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "k" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -50,7 +50,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "l" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -59,7 +59,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "o" = (
 /obj/structure/chair{
 	dir = 1
@@ -86,13 +86,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "p" = (
 /turf/closed/wall/r_wall,
-/area/security/execution/transfer)
+/area/template_noop)
 "q" = (
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "r" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -111,7 +111,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "s" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/spray/cleaner{
@@ -136,7 +136,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "t" = (
 /obj/structure/bed,
 /obj/machinery/flasher{
@@ -147,7 +147,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "v" = (
 /obj/structure/chair{
 	dir = 1
@@ -168,7 +168,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "y" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast";
@@ -183,7 +183,7 @@
 	},
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "z" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -192,7 +192,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "B" = (
 /obj/structure/chair{
 	dir = 1
@@ -205,7 +205,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "C" = (
 /obj/structure/chair{
 	dir = 1
@@ -221,11 +221,11 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "D" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "E" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -237,7 +237,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "G" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast";
@@ -255,7 +255,7 @@
 	req_access_txt = "2"
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "H" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -270,7 +270,7 @@
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "I" = (
 /obj/structure/table,
 /obj/item/folder/red{
@@ -283,19 +283,19 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "K" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "L" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "N" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/execution/transfer";
@@ -308,7 +308,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "O" = (
 /obj/structure/closet/secure_closet/injection,
 /obj/effect/turf_decal/tile/red{
@@ -319,7 +319,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "Q" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -331,11 +331,11 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "R" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "S" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -344,7 +344,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "T" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp{
@@ -363,7 +363,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "U" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/syringe/lethal/execution,
@@ -380,13 +380,13 @@
 	pixel_y = 18
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "Y" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "Z" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -395,7 +395,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 
 (1,1,1) = {"
 a

--- a/_maps/RandomRuins/StationRuins/BoxStation/transfer2.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/transfer2.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "b" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast";
@@ -19,7 +19,7 @@
 	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 "c" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -27,14 +27,14 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "d" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "h" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/sec/surgery{
@@ -51,7 +51,7 @@
 	pixel_y = -1
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "i" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/red{
@@ -81,10 +81,10 @@
 	pixel_y = -5
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "j" = (
 /turf/closed/wall/r_wall,
-/area/security/execution/transfer)
+/area/template_noop)
 "k" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -94,7 +94,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "o" = (
 /obj/structure/chair{
 	dir = 1
@@ -121,14 +121,14 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "p" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 "q" = (
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "r" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -147,7 +147,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "s" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/spray/cleaner{
@@ -172,7 +172,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "u" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -185,7 +185,7 @@
 	pixel_y = 25
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 "v" = (
 /obj/structure/chair{
 	dir = 1
@@ -206,7 +206,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "w" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -215,7 +215,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "x" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -230,7 +230,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "y" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast";
@@ -245,7 +245,7 @@
 	},
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "B" = (
 /obj/structure/chair{
 	dir = 1
@@ -258,7 +258,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "C" = (
 /obj/structure/chair{
 	dir = 1
@@ -274,11 +274,11 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "D" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "E" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -290,14 +290,14 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "G" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 "I" = (
 /obj/structure/table,
 /obj/item/folder/red{
@@ -310,14 +310,14 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "L" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 "N" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/execution/transfer";
@@ -330,13 +330,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "O" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "Q" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -348,14 +348,14 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "R" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/structure/guillotine,
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 "T" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp{
@@ -374,7 +374,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "U" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -383,7 +383,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "V" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -392,13 +392,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 "Y" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "Z" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -410,7 +410,7 @@
 /obj/item/mop,
 /obj/structure/mopbucket,
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 
 (1,1,1) = {"
 a

--- a/_maps/RandomRuins/StationRuins/BoxStation/transfer3.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/transfer3.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "b" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -10,7 +10,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "c" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -18,21 +18,21 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "d" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "f" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "h" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/sec/surgery{
@@ -49,7 +49,7 @@
 	pixel_y = -1
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "i" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -64,14 +64,14 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "n" = (
 /obj/machinery/door/poddoor{
 	id = "executionspaceblast";
 	name = "blast door"
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "p" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -86,10 +86,10 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "q" = (
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "r" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -108,7 +108,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "s" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/spray/cleaner{
@@ -133,7 +133,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "t" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast";
@@ -154,7 +154,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "v" = (
 /obj/structure/chair{
 	dir = 1
@@ -175,7 +175,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "w" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -184,7 +184,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "y" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast";
@@ -199,7 +199,7 @@
 	},
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "A" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -208,7 +208,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "B" = (
 /obj/structure/chair{
 	dir = 1
@@ -221,7 +221,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "C" = (
 /obj/structure/chair{
 	dir = 1
@@ -237,7 +237,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "D" = (
 /obj/structure/chair{
 	dir = 1
@@ -271,7 +271,7 @@
 	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "E" = (
 /obj/structure/bed,
 /obj/machinery/flasher{
@@ -283,7 +283,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "F" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -292,12 +292,12 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "G" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "I" = (
 /obj/structure/table,
 /obj/item/folder/red{
@@ -310,7 +310,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "J" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -320,13 +320,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "K" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "N" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/execution/transfer";
@@ -339,7 +339,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "P" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -349,14 +349,14 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "R" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "S" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -365,7 +365,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "T" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp{
@@ -384,7 +384,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "V" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -395,7 +395,7 @@
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "W" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/red{
@@ -421,16 +421,16 @@
 /obj/item/clothing/suit/space/fragile,
 /obj/item/clothing/head/helmet/space/fragile,
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "X" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "Y" = (
 /turf/closed/wall/r_wall,
-/area/security/execution/transfer)
+/area/template_noop)
 
 (1,1,1) = {"
 a

--- a/_maps/RandomRuins/StationRuins/BoxStation/transfer4.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/transfer4.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "b" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -10,7 +10,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "c" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -18,21 +18,21 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "d" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "f" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "g" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/red{
@@ -67,7 +67,7 @@
 	pixel_y = -3
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "h" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/sec/surgery{
@@ -84,7 +84,7 @@
 	pixel_y = -1
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "i" = (
 /obj/machinery/flasher{
 	id = "executionflash";
@@ -98,7 +98,7 @@
 	},
 /obj/structure/chair,
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "l" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -118,7 +118,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "o" = (
 /obj/structure/chair{
 	dir = 1
@@ -145,17 +145,17 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "p" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "q" = (
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "r" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -174,7 +174,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "s" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/spray/cleaner{
@@ -199,7 +199,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "u" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -209,7 +209,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "v" = (
 /obj/structure/chair{
 	dir = 1
@@ -230,7 +230,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "y" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast";
@@ -245,7 +245,7 @@
 	},
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "B" = (
 /obj/structure/chair{
 	dir = 1
@@ -258,7 +258,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "C" = (
 /obj/structure/chair{
 	dir = 1
@@ -274,14 +274,14 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "D" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "E" = (
 /turf/closed/wall/r_wall,
-/area/security/execution/transfer)
+/area/template_noop)
 "F" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -296,7 +296,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "I" = (
 /obj/structure/table,
 /obj/item/folder/red{
@@ -309,13 +309,13 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "K" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "L" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast";
@@ -336,7 +336,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "N" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/execution/transfer";
@@ -349,7 +349,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "Q" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -361,7 +361,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "S" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -370,7 +370,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "T" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp{
@@ -389,7 +389,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "U" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -398,13 +398,13 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "V" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "X" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -419,13 +419,13 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "Y" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "Z" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -434,7 +434,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 
 (1,1,1) = {"
 a

--- a/_maps/RandomRuins/StationRuins/BoxStation/transfer5.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/transfer5.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "c" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -9,21 +9,21 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "d" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "f" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "h" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/sec/surgery{
@@ -40,7 +40,7 @@
 	pixel_y = -1
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "j" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -56,7 +56,7 @@
 	},
 /obj/item/stack/cable_coil/red,
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "l" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/red{
@@ -73,7 +73,7 @@
 	},
 /obj/item/storage/firstaid/fire,
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "o" = (
 /obj/structure/chair{
 	dir = 1
@@ -100,10 +100,10 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "q" = (
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "r" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -122,7 +122,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "s" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/spray/cleaner{
@@ -147,7 +147,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "u" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -156,7 +156,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "v" = (
 /obj/structure/chair{
 	dir = 1
@@ -177,7 +177,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "w" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -192,13 +192,13 @@
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "x" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "y" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast";
@@ -213,7 +213,7 @@
 	},
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "B" = (
 /obj/structure/chair{
 	dir = 1
@@ -226,14 +226,14 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "C" = (
 /turf/closed/wall/r_wall,
-/area/security/execution/transfer)
+/area/template_noop)
 "D" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "G" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast";
@@ -251,7 +251,7 @@
 	req_access_txt = "2"
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "H" = (
 /obj/structure/chair{
 	dir = 1
@@ -270,7 +270,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "I" = (
 /obj/structure/table,
 /obj/item/folder/red{
@@ -283,7 +283,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "J" = (
 /obj/machinery/flasher{
 	id = "executionflash";
@@ -294,13 +294,13 @@
 	},
 /obj/structure/chair,
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "K" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "N" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/execution/transfer";
@@ -313,7 +313,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "P" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -323,7 +323,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "Q" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -335,11 +335,11 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "R" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "S" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -348,7 +348,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "T" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp{
@@ -367,7 +367,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "V" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -379,7 +379,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "X" = (
 /obj/machinery/power/emitter/anchored{
 	dir = 1;
@@ -390,7 +390,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "Y" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -399,7 +399,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "Z" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -408,7 +408,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 
 (1,1,1) = {"
 a

--- a/_maps/RandomRuins/StationRuins/BoxStation/transfer6.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/transfer6.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "c" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -9,14 +9,14 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "d" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "g" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/light/small{
@@ -26,7 +26,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 "h" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/sec/surgery{
@@ -43,7 +43,7 @@
 	pixel_y = -1
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "j" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -53,7 +53,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "k" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -62,7 +62,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 "n" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -71,10 +71,10 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "q" = (
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "r" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -93,7 +93,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "s" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/spray/cleaner{
@@ -118,7 +118,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "v" = (
 /obj/structure/chair{
 	dir = 1
@@ -139,7 +139,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "w" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "executioncrush"
@@ -148,10 +148,10 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 "x" = (
 /turf/closed/wall/r_wall,
-/area/security/execution/transfer)
+/area/template_noop)
 "y" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast";
@@ -166,13 +166,13 @@
 	},
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "z" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "B" = (
 /obj/structure/chair{
 	dir = 1
@@ -185,7 +185,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "C" = (
 /obj/structure/chair{
 	dir = 1
@@ -201,11 +201,11 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "D" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "E" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -217,7 +217,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "G" = (
 /obj/structure/bed,
 /obj/machinery/flasher{
@@ -232,7 +232,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 "H" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/red{
@@ -249,7 +249,7 @@
 	},
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "I" = (
 /obj/structure/table,
 /obj/item/folder/red{
@@ -262,7 +262,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "J" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast";
@@ -280,11 +280,11 @@
 	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 "K" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 "N" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/execution/transfer";
@@ -297,7 +297,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "P" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -312,7 +312,7 @@
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "Q" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -324,7 +324,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "S" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -333,7 +333,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "T" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp{
@@ -352,7 +352,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "U" = (
 /obj/structure/chair{
 	dir = 1
@@ -386,7 +386,7 @@
 	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "W" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "executioncrush"
@@ -395,13 +395,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 "Y" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "Z" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -413,7 +413,7 @@
 /obj/structure/mopbucket,
 /obj/item/mop,
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 
 (1,1,1) = {"
 a

--- a/_maps/RandomRuins/StationRuins/BoxStation/transfer7.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/transfer7.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "b" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/red{
@@ -19,7 +19,7 @@
 /obj/item/storage/firstaid/fire,
 /obj/item/wrench,
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "c" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -27,21 +27,21 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "d" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "e" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/engine,
-/area/security/execution/transfer)
+/area/template_noop)
 "f" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -53,7 +53,7 @@
 	id = "transfer"
 	},
 /turf/open/floor/engine,
-/area/security/execution/transfer)
+/area/template_noop)
 "h" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/sec/surgery{
@@ -70,7 +70,7 @@
 	pixel_y = -1
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "i" = (
 /obj/structure/bed,
 /obj/machinery/flasher{
@@ -82,7 +82,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/engine,
-/area/security/execution/transfer)
+/area/template_noop)
 "j" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -95,7 +95,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "k" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -104,7 +104,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "m" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
@@ -112,7 +112,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/security/execution/transfer)
+/area/template_noop)
 "n" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/execution/transfer";
@@ -126,13 +126,13 @@
 	},
 /obj/machinery/space_heater,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "p" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "r" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -151,7 +151,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "s" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/spray/cleaner{
@@ -176,7 +176,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "u" = (
 /obj/structure/grille,
 /obj/machinery/door/poddoor{
@@ -184,7 +184,7 @@
 	name = "blast door"
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "v" = (
 /obj/structure/chair{
 	dir = 1
@@ -205,7 +205,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "y" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast";
@@ -229,7 +229,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/security/execution/transfer)
+/area/template_noop)
 "A" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -241,7 +241,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "B" = (
 /obj/structure/chair{
 	dir = 1
@@ -254,7 +254,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "C" = (
 /obj/structure/chair{
 	dir = 1
@@ -270,13 +270,13 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "D" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/engine,
-/area/security/execution/transfer)
+/area/template_noop)
 "E" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast";
@@ -291,7 +291,7 @@
 	},
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "F" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -309,7 +309,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "G" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -318,7 +318,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "H" = (
 /obj/structure/chair{
 	dir = 1
@@ -357,7 +357,7 @@
 	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "I" = (
 /obj/structure/table,
 /obj/item/folder/red{
@@ -370,7 +370,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "J" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -383,7 +383,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "L" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -398,13 +398,13 @@
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "O" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "P" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -416,7 +416,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/security/execution/transfer)
+/area/template_noop)
 "R" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -426,7 +426,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "S" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -440,7 +440,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "T" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp{
@@ -459,16 +459,16 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "U" = (
 /turf/closed/wall/r_wall,
-/area/security/execution/transfer)
+/area/template_noop)
 "W" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 
 (1,1,1) = {"
 a

--- a/_maps/RandomRuins/StationRuins/BoxStation/transfer8.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/transfer8.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "c" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -9,14 +9,14 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "d" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "h" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/sec/surgery{
@@ -33,7 +33,7 @@
 	pixel_y = -1
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "i" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/red{
@@ -53,11 +53,11 @@
 	},
 /obj/item/clothing/mask/balaclava,
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "l" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 "m" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -67,7 +67,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "n" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -81,7 +81,7 @@
 	name = "execution sabre"
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "o" = (
 /obj/structure/chair{
 	dir = 1
@@ -108,7 +108,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "p" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -117,10 +117,10 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 "q" = (
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "r" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -139,7 +139,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "s" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/spray/cleaner{
@@ -164,7 +164,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "t" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -173,7 +173,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 "v" = (
 /obj/structure/chair{
 	dir = 1
@@ -194,7 +194,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "x" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -203,7 +203,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "y" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast";
@@ -218,7 +218,7 @@
 	},
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "z" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -233,7 +233,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "B" = (
 /obj/structure/chair{
 	dir = 1
@@ -246,7 +246,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "C" = (
 /obj/structure/chair{
 	dir = 1
@@ -262,11 +262,11 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "D" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "E" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -278,7 +278,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "I" = (
 /obj/structure/table,
 /obj/item/folder/red{
@@ -291,7 +291,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "K" = (
 /obj/structure/bed,
 /obj/machinery/flasher{
@@ -302,7 +302,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 "N" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/execution/transfer";
@@ -315,7 +315,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "O" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -324,7 +324,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "Q" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -336,14 +336,14 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "S" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 "T" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp{
@@ -362,13 +362,13 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "U" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "V" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast";
@@ -386,23 +386,23 @@
 	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 "X" = (
 /turf/closed/wall/r_wall,
-/area/security/execution/transfer)
+/area/template_noop)
 "Y" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "Z" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 
 (1,1,1) = {"
 a

--- a/_maps/RandomRuins/StationRuins/BoxStation/transfer9.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/transfer9.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "c" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -9,14 +9,14 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "d" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "g" = (
 /obj/machinery/flasher{
 	id = "executionflash";
@@ -27,7 +27,7 @@
 	},
 /obj/structure/chair,
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 "h" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/sec/surgery{
@@ -44,7 +44,7 @@
 	pixel_y = -1
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "i" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast";
@@ -62,18 +62,18 @@
 	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 "j" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 "k" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 "l" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -82,13 +82,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "m" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 "o" = (
 /obj/structure/chair{
 	dir = 1
@@ -115,10 +115,10 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "q" = (
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "r" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -137,7 +137,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "s" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/spray/cleaner{
@@ -162,7 +162,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "t" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/red{
@@ -179,7 +179,7 @@
 	},
 /obj/item/soap/nanotrasen,
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "v" = (
 /obj/structure/chair{
 	dir = 1
@@ -200,7 +200,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "y" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast";
@@ -215,10 +215,10 @@
 	},
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/security/execution/transfer)
+/area/template_noop)
 "z" = (
 /turf/closed/wall/r_wall,
-/area/security/execution/transfer)
+/area/template_noop)
 "B" = (
 /obj/structure/chair{
 	dir = 1
@@ -231,7 +231,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "C" = (
 /obj/structure/chair{
 	dir = 1
@@ -247,11 +247,11 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "D" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "E" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -263,7 +263,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "G" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -272,7 +272,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 "I" = (
 /obj/structure/table,
 /obj/item/folder/red{
@@ -285,7 +285,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "J" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -300,7 +300,7 @@
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "K" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -310,7 +310,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "N" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/execution/transfer";
@@ -323,7 +323,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "O" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -332,7 +332,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/security/execution/transfer)
+/area/template_noop)
 "Q" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -344,7 +344,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "T" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp{
@@ -363,7 +363,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "U" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -372,13 +372,13 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "V" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 "W" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -398,13 +398,13 @@
 	pixel_y = -8
 	},
 /turf/open/floor/plasteel/white,
-/area/security/execution/transfer)
+/area/template_noop)
 "Y" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
+/area/template_noop)
 
 (1,1,1) = {"
 a

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -9299,12 +9299,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"azk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
 "azl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -10195,13 +10189,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"aBV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
 "aBW" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -13962,10 +13949,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"aMJ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
 "aMK" = (
 /obj/machinery/shower{
 	dir = 8
@@ -19883,9 +19866,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"bhm" = (
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
 "bhq" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -27203,19 +27183,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"bGQ" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock{
-	id_tag = "Dorm3";
-	name = "Dorm 3"
-	},
-/turf/template_noop,
-/area/template_noop)
 "bGS" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -32655,19 +32622,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"cDz" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock{
-	id_tag = "Dorm2";
-	name = "Dorm 2"
-	},
-/turf/template_noop,
-/area/template_noop)
 "cDB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33879,6 +33833,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ddh" = (
+/obj/effect/landmark/stationroom/box/execution,
+/turf/template_noop,
+/area/security/execution/transfer)
 "ddt" = (
 /obj/structure/table,
 /obj/item/clipboard,
@@ -37396,6 +37354,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"fEb" = (
+/turf/template_noop,
+/area/crew_quarters/dorms)
 "fFo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -38618,10 +38579,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"gCp" = (
-/obj/effect/landmark/stationroom/box/medbay/morgue,
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
 "gCr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39076,6 +39033,10 @@
 /obj/effect/spawner/lootdrop/gloves,
 /turf/open/floor/plasteel,
 /area/clerk)
+"gUE" = (
+/obj/effect/landmark/stationroom/box/medbay/morgue,
+/turf/template_noop,
+/area/medical/morgue)
 "gUZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -39226,6 +39187,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"hah" = (
+/turf/template_noop,
+/area/medical/morgue)
 "haw" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 4;
@@ -40644,10 +40608,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/storage/tech)
-"ias" = (
-/obj/effect/landmark/stationroom/box/execution,
-/turf/template_noop,
-/area/template_noop)
 "iay" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -40740,6 +40700,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"idF" = (
+/obj/machinery/camera{
+	c_tag = "Hydroponics North"
+	},
+/turf/template_noop,
+/area/hydroponics)
 "idG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -41401,10 +41367,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"ixf" = (
-/obj/effect/landmark/stationroom/box/dorm_edoor,
-/turf/template_noop,
-/area/template_noop)
 "ixh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -44029,6 +43991,13 @@
 	dir = 4
 	},
 /area/chapel/main)
+"kgK" = (
+/obj/machinery/camera{
+	c_tag = "Hydroponics South";
+	dir = 8
+	},
+/turf/template_noop,
+/area/hydroponics)
 "kgV" = (
 /obj/machinery/camera{
 	c_tag = "Bridge West Entrance";
@@ -44571,19 +44540,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"kBl" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock{
-	id_tag = "Dorm4";
-	name = "Dorm 4"
-	},
-/turf/template_noop,
-/area/template_noop)
 "kBu" = (
 /obj/machinery/camera{
 	c_tag = "Gravity Generator";
@@ -45563,6 +45519,10 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"ljM" = (
+/obj/effect/landmark/stationroom/box/testingsite,
+/turf/open/space/basic,
+/area/space)
 "lkh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -46015,16 +45975,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"lzl" = (
-/obj/machinery/button/door{
-	id = "Dorm3";
-	name = "Dorm Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
-	},
-/turf/template_noop,
-/area/template_noop)
 "lzr" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -47812,6 +47762,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"mPz" = (
+/turf/template_noop,
+/area/hydroponics)
 "mRf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -49266,12 +49219,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"nIx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
 "nJu" = (
 /obj/machinery/smartfridge/drying_rack,
 /obj/effect/decal/cleanable/cobweb,
@@ -49387,12 +49334,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"nMv" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
 "nMN" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -49463,16 +49404,6 @@
 /obj/effect/landmark/stationroom/maint/tenxten,
 /turf/template_noop,
 /area/maintenance/port/aft)
-"nQG" = (
-/obj/machinery/button/door{
-	id = "Dorm2";
-	name = "Dorm Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
-	},
-/turf/template_noop,
-/area/template_noop)
 "nRp" = (
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /obj/effect/turf_decal/trimline/blue,
@@ -51750,18 +51681,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"pqp" = (
-/obj/machinery/camera{
-	c_tag = "Medbay Morgue";
-	dir = 8;
-	network = list("ss13","medbay")
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
 "pqK" = (
 /turf/closed/wall,
 /area/maintenance/department/medical/morgue)
@@ -52233,6 +52152,9 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"pFY" = (
+/turf/template_noop,
+/area/security/execution/transfer)
 "pGm" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
@@ -52436,12 +52358,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"pMe" = (
-/obj/machinery/camera{
-	c_tag = "Hydroponics North"
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "pMt" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 1;
@@ -52789,13 +52705,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"pXY" = (
-/obj/machinery/camera{
-	c_tag = "Hydroponics South";
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "pYf" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
@@ -52872,6 +52781,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"qbA" = (
+/obj/machinery/light_switch{
+	pixel_y = -25
+	},
+/turf/template_noop,
+/area/medical/morgue)
 "qbE" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -53519,6 +53434,10 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/sleeper)
+"qwq" = (
+/obj/effect/landmark/stationroom/box/dorm_edoor,
+/turf/template_noop,
+/area/crew_quarters/dorms)
 "qwE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -54865,6 +54784,16 @@
 /obj/item/soap/nanotrasen,
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
+"rsr" = (
+/obj/machinery/button/door{
+	id = "Dorm4";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 25;
+	specialfunctions = 4
+	},
+/turf/template_noop,
+/area/crew_quarters/dorms)
 "rsV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -55193,6 +55122,14 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"rEL" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/obj/effect/landmark/stationroom/box/hydroponics,
+/turf/template_noop,
+/area/hydroponics)
 "rEY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -55430,6 +55367,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"rOY" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorm4";
+	name = "Dorm 4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "rPb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -56006,14 +55962,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"shN" = (
-/obj/machinery/requests_console{
-	department = "Hydroponics";
-	departmentType = 2;
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "sia" = (
 /obj/effect/landmark/stationroom/maint/threexthree,
 /turf/template_noop,
@@ -56609,10 +56557,6 @@
 /obj/effect/landmark/stationroom/maint/threexthree,
 /turf/template_noop,
 /area/maintenance/fore)
-"sER" = (
-/obj/effect/landmark/stationroom/box/testingsite,
-/turf/template_noop,
-/area/template_noop)
 "sFG" = (
 /obj/machinery/status_display/ai{
 	pixel_x = -32
@@ -56746,15 +56690,6 @@
 /obj/effect/turf_decal/trimline/blue,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"sKm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_y = -25
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
 "sKs" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -57717,18 +57652,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"ttj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
 "ttn" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -58901,6 +58824,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"ukR" = (
+/obj/machinery/button/door{
+	id = "Dorm2";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 25;
+	specialfunctions = 4
+	},
+/turf/template_noop,
+/area/crew_quarters/dorms)
 "ulD" = (
 /obj/structure/tank_dispenser,
 /obj/effect/turf_decal/bot{
@@ -60966,6 +60899,25 @@
 /obj/machinery/power/tracker,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/fore)
+"vFZ" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorm2";
+	name = "Dorm 2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "vGx" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -61067,6 +61019,16 @@
 /obj/effect/landmark/stationroom/maint/threexthree,
 /turf/template_noop,
 /area/maintenance/port/aft)
+"vJz" = (
+/obj/machinery/button/door{
+	id = "Dorm3";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 25;
+	specialfunctions = 4
+	},
+/turf/template_noop,
+/area/crew_quarters/dorms)
 "vJO" = (
 /obj/structure/table/reinforced,
 /obj/item/aiModule/core/full/custom,
@@ -61698,12 +61660,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"wec" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
 "wex" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -62321,6 +62277,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"wzi" = (
+/turf/template_noop,
+/area/science/test_area)
 "wzt" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -62375,14 +62334,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"wBr" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/obj/effect/landmark/stationroom/box/hydroponics,
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "wBx" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
@@ -62439,6 +62390,25 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"wDq" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorm3";
+	name = "Dorm 3"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "wDB" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -62667,6 +62637,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"wLm" = (
+/obj/machinery/requests_console{
+	department = "Hydroponics";
+	departmentType = 2;
+	pixel_y = 30
+	},
+/turf/template_noop,
+/area/hydroponics)
 "wLC" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -63900,16 +63878,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"xKy" = (
-/obj/machinery/button/door{
-	id = "Dorm4";
-	name = "Dorm Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
-	},
-/turf/template_noop,
-/area/template_noop)
 "xKE" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet,
@@ -64383,13 +64351,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
-"yba" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
 "ydd" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -89509,15 +89470,15 @@ pEf
 pEf
 pEf
 aaa
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-ias
+pFY
+pFY
+pFY
+pFY
+pFY
+pFY
+pFY
+pFY
+ddh
 aaa
 aaa
 aaa
@@ -89766,15 +89727,15 @@ aaa
 gXs
 aaa
 aaa
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
+pFY
+pFY
+pFY
+pFY
+pFY
+pFY
+pFY
+pFY
+pFY
 aaa
 aaa
 aaa
@@ -90023,15 +89984,15 @@ aSM
 aap
 aai
 afA
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
+pFY
+pFY
+pFY
+pFY
+pFY
+pFY
+pFY
+pFY
+pFY
 afA
 aaf
 aaa
@@ -90280,15 +90241,15 @@ uNu
 aat
 xrc
 sQI
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
+pFY
+pFY
+pFY
+pFY
+pFY
+pFY
+pFY
+pFY
+pFY
 afA
 aaf
 aaa
@@ -90537,15 +90498,15 @@ aat
 aat
 olh
 sQI
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
+pFY
+pFY
+pFY
+pFY
+pFY
+pFY
+pFY
+pFY
+pFY
 afA
 aaf
 aaa
@@ -90794,15 +90755,15 @@ aat
 aat
 ozw
 sQI
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
+pFY
+pFY
+pFY
+pFY
+pFY
+pFY
+pFY
+pFY
+pFY
 afA
 aaf
 aaa
@@ -96473,16 +96434,16 @@ anv
 aoA
 bNR
 gDj
-qQV
-qQV
-qQV
-ixf
-qQV
-qQV
-ixf
-qQV
-qQV
-ixf
+arf
+arf
+arf
+arf
+arf
+arf
+arf
+arf
+arf
+arf
 mxN
 mxN
 mxN
@@ -96730,16 +96691,16 @@ anv
 ajb
 bNR
 gDj
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
+arf
+fEb
+qwq
+arf
+fEb
+qwq
+arf
+fEb
+qwq
+arf
 rcJ
 eTl
 eTl
@@ -96987,16 +96948,16 @@ anv
 aoz
 bNR
 gDj
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
+arf
+fEb
+fEb
+arf
+fEb
+fEb
+arf
+fEb
+fEb
+arf
 nWl
 fNs
 kCr
@@ -97244,16 +97205,16 @@ anD
 iiN
 bNR
 gDj
-qQV
-xKy
-qQV
-qQV
-lzl
-qQV
-qQV
-nQG
-qQV
-qQV
+arf
+rsr
+fEb
+arf
+vJz
+fEb
+arf
+ukR
+fEb
+arf
 pEh
 dUv
 vwz
@@ -97501,16 +97462,16 @@ anz
 aoC
 bNR
 gDj
-qQV
-qQV
-kBl
-qQV
-qQV
-bGQ
-qQV
-qQV
-cDz
-qQV
+arf
+arf
+rOY
+arf
+arf
+wDq
+arf
+arf
+vFZ
+arf
 iwi
 osc
 goe
@@ -106272,11 +106233,11 @@ oXu
 oXu
 oXu
 bfL
-wec
-bhm
-bhm
-bhm
-gCp
+hah
+hah
+hah
+hah
+gUE
 bfL
 tlm
 bJa
@@ -106515,25 +106476,25 @@ aIp
 aKH
 iiE
 aIp
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
-wBr
+mPz
+mPz
+mPz
+mPz
+mPz
+mPz
+mPz
+mPz
+rEL
 bam
 aYV
 aYV
 mWK
 bfL
-bhm
-aMJ
-azk
-aBV
-ttj
+hah
+hah
+hah
+hah
+hah
 tEa
 pwz
 rPb
@@ -106772,25 +106733,25 @@ aJB
 aKD
 aTC
 aIp
-shN
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
+wLm
+mPz
+mPz
+mPz
+mPz
+mPz
+mPz
+mPz
+mPz
 bbB
 aYV
 aYV
 jTR
 bfL
-bhm
-bhm
-bhm
-bhm
-sKm
+hah
+hah
+hah
+hah
+qbA
 bfL
 czn
 tIW
@@ -107029,25 +106990,25 @@ aIp
 skk
 aUh
 aIp
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
+mPz
+mPz
+mPz
+mPz
+mPz
+mPz
+mPz
+mPz
+mPz
 bbB
 aYV
 aYV
 jTR
 gHo
-bhm
-bhm
-bhm
-bhm
-yba
+hah
+hah
+hah
+hah
+hah
 bfL
 ipN
 bon
@@ -107286,25 +107247,25 @@ aIp
 aKI
 aUn
 aIp
-pMe
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
+idF
+mPz
+mPz
+mPz
+mPz
+mPz
+mPz
+mPz
 cBg
 bam
 aYV
 aYV
 jTR
 bfL
-bhm
-bhm
-bhm
-bhm
-nIx
+hah
+hah
+hah
+hah
+hah
 bfL
 cDK
 bon
@@ -107543,25 +107504,25 @@ aIp
 lZq
 aOo
 aIp
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
+mPz
+mPz
+mPz
+mPz
+mPz
+mPz
+mPz
+mPz
 bam
 aYV
 aYV
 aYV
 fDx
 bfL
-bhm
-nMv
-pqp
-bhm
-nIx
+hah
+hah
+hah
+hah
+hah
 bfL
 cDK
 bon
@@ -107800,14 +107761,14 @@ aIp
 aKL
 aUh
 aNQ
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
+mPz
+mPz
+mPz
+mPz
+mPz
+mPz
+mPz
+mPz
 ban
 aYV
 aYV
@@ -108057,14 +108018,14 @@ aJO
 aRJ
 aUS
 aNN
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
+mPz
+mPz
+mPz
+mPz
+mPz
+mPz
+mPz
+mPz
 bap
 aYV
 aYV
@@ -108314,14 +108275,14 @@ mDD
 aLd
 aMN
 aNQ
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
-aRJ
-pXY
+mPz
+mPz
+mPz
+mPz
+mPz
+mPz
+mPz
+kgK
 bam
 bfO
 aYV
@@ -123506,21 +123467,21 @@ aaa
 aaa
 aaa
 aaa
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-sER
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
+aaa
+aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -123763,21 +123724,21 @@ aaa
 aaa
 aaa
 aaa
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
+aaf
+aaa
+aaf
+aaf
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -124020,21 +123981,21 @@ aaa
 aaa
 aaa
 aaa
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
+aaa
+aaa
+aaa
+aaa
+gXs
+gXs
+wzi
+wzi
+wzi
+gXs
+gXs
+ljM
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -124277,21 +124238,21 @@ aaa
 aaa
 aaa
 aaa
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
+aaa
+aaa
+aaa
+gXs
+gXs
+wzi
+wzi
+wzi
+wzi
+wzi
+gXs
+gXs
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -124534,21 +124495,21 @@ aaa
 aaa
 aaa
 aaa
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
+aaa
+aaa
+aaf
+gXs
+wzi
+wzi
+wzi
+wzi
+wzi
+wzi
+wzi
+gXs
+aaf
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -124791,21 +124752,21 @@ aaa
 aaa
 aaa
 aaa
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
+aaa
+aaa
+aaf
+wzi
+wzi
+wzi
+wzi
+wzi
+wzi
+wzi
+wzi
+wzi
+aaf
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -125048,21 +125009,21 @@ aaa
 aaa
 aaa
 aaa
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
+aaf
+aaf
+aaf
+wzi
+wzi
+wzi
+wzi
+wzi
+wzi
+wzi
+wzi
+wzi
+aaf
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -125305,21 +125266,21 @@ aaa
 aaa
 aaa
 aaa
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
+aaa
+aaa
+aaf
+wzi
+wzi
+wzi
+wzi
+wzi
+wzi
+wzi
+wzi
+wzi
+aaf
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -125562,21 +125523,21 @@ aaa
 aaa
 aaa
 aaa
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
+aaa
+aaa
+aaf
+gXs
+wzi
+wzi
+wzi
+wzi
+wzi
+wzi
+wzi
+gXs
+aaf
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -125819,21 +125780,21 @@ aaa
 aaa
 aaa
 aaa
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
+aaa
+aaa
+aaa
+gXs
+gXs
+wzi
+wzi
+wzi
+wzi
+wzi
+gXs
+gXs
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -126076,21 +126037,21 @@ aaa
 aaa
 aaa
 aaa
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
+aaa
+aaa
+aaa
+aaa
+gXs
+gXs
+wzi
+wzi
+wzi
+gXs
+gXs
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -126333,21 +126294,21 @@ aaa
 aaa
 aaa
 aaa
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
+aaf
+aaf
+aaf
+aaf
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -126590,21 +126551,21 @@ aaa
 aaa
 aaa
 aaa
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
+aaf
+aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -126847,21 +126808,21 @@ aaa
 aaa
 aaa
 aaa
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -127104,21 +127065,21 @@ aaa
 aaa
 aaa
 aaa
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
-qQV
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request
The following excludes engine and bar templates because they are too flexible with areas and room shape
Cleans up all our station templates to follow a certain standard,
Also shrinks the dorms and testsite templates to not include the parts that don't change

The station file:

no objects within template space
areas designated, no template areas
template turfs where needed, no same turfs over same turfs

The template files:

template area (this is to allow pasting of templates anywhere without having to worry about areas)
turfs are set and all objects are inside of the template
space is always a template turf (to allow for pasting of space templates into places that shouldn't have space)


### Why is this change good for the game?
Consistency,
ease of porting templates to other maps, 
ability to paste templates anywhere during a round without worrying about areas and missing objects

# Wiki Documentation

nothing from the player side has changed

# Changelog

:cl:  
tweak: standardizes our map templates
/:cl:
