### PR TITLE
makes borg spin be a knockdown instead of a stun

### DIFF
--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -262,7 +262,7 @@
 /datum/component/riding/human/force_dismount(mob/living/user)
 	var/atom/movable/AM = parent
 	AM.unbuckle_mob(user)
-	user.Paralyze(60)
+	user.Knockdown(60)
 	user.visible_message("<span class='warning'>[AM] pushes [user] off of [AM.p_them()]!</span>")
 
 /datum/component/riding/cyborg


### PR DESCRIPTION
makes borg spin knockdown people instead of stunning them

### Why is this change good for the game?
a near instant 6 second stuns pretty damn powerful in the right hands and was easily abusable
a 6 second knockdown is still decent but it's no longer OP.

### What should players be aware of when it comes to the changes your PR is implementing?
borg spins dont stun people anymore
players should also be aware that this isn't an ided

### What general grouping does this PR fall under? 
For example, Engineering changes, Medical rebalancing, TEG tweaks, etc.?
borg changes

:cl:  
tweak: borg spin doesn't stun anymore, instead it knocks down
/:cl:
