### PR TITLE
massively buffs genetics by making the strength mutation remove slowdown from having people buckled rather than reducing it

### DIFF
--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -226,7 +226,7 @@
 /datum/component/riding/human/vehicle_mob_buckle(datum/source, mob/living/M, force = FALSE)
 	. = ..()
 	var/mob/living/carbon/human/AM = parent
-	var/slowdown = HUMAN_CARRY_SLOWDOWN - (AM.dna.check_mutation(STRONG) ? 0.2 : 0)
+	var/slowdown = AM.dna.check_mutation(STRONG) ? 0 : HUMAN_CARRY_SLOWDOWN
 	AM.add_movespeed_modifier(MOVESPEED_ID_HUMAN_CARRYING, multiplicative_slowdown = slowdown)
 
 /datum/component/riding/human/proc/on_host_unarmed_melee(atom/target)


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

slight reduction is still a reduction which is probably less than enough to warrant getting it

### Why is this change good for the game?
make genetics slightly more useful to non-tiders

:cl:  
tweak: strength mutation now completely removes slowdown from carrying people rather than reducing it
/:cl:
