### PR TITLE
switches nuka cola to use reduced slowdown from resisted slowdown so it's viable

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -480,7 +480,7 @@
 	ADD_TRAIT(L, TRAIT_REDUCED_DAMAGE_SLOWDOWN, type)
 
 /datum/reagent/consumable/nuka_cola/on_mob_end_metabolize(mob/living/L)
-	REMOVE_TRAIT(H, TRAIT_REDUCED_DAMAGE_SLOWDOWN, type)
+	REMOVE_TRAIT(L, TRAIT_REDUCED_DAMAGE_SLOWDOWN, type)
 	..()
 
 /datum/reagent/consumable/nuka_cola/on_mob_life(mob/living/carbon/M)

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -477,10 +477,10 @@
 
 /datum/reagent/consumable/nuka_cola/on_mob_metabolize(mob/living/L)
 	..()
-	ADD_TRAIT(L, TRAIT_RESISTDAMAGESLOWDOWN, type)
+	ADD_TRAIT(L, TRAIT_REDUCED_DAMAGE_SLOWDOWN, type)
 
 /datum/reagent/consumable/nuka_cola/on_mob_end_metabolize(mob/living/L)
-	REMOVE_TRAIT(L, TRAIT_RESISTDAMAGESLOWDOWN, type)
+	REMOVE_TRAIT(H, TRAIT_REDUCED_DAMAGE_SLOWDOWN, type)
 	..()
 
 /datum/reagent/consumable/nuka_cola/on_mob_life(mob/living/carbon/M)


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

nuka cola causes you to resist the first 20% of damage slowdown you receive rather than reducing the slowdown you get by a %

### Why is this change good for the game?
makes thing that was not viable for much of anything slightly viable for something
:cl:  
tweak: nuka cola will now cause damage slowdown amounts to  be reduced by 20%, taking your initial damage slowdown from being caused at 40 damage to being caused at 60
/:cl:
