### PR TITLE
Removes a dead proc

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -896,10 +896,6 @@ GLOBAL_LIST_EMPTY(mentor_races)
 	stop_wagging_tail(H)
 	return
 
-/datum/species/proc/auto_equip(mob/living/carbon/human/H)
-	// handles the equipping of species-specific gear
-	return
-
 /datum/species/proc/can_equip(obj/item/I, slot, disable_warning, mob/living/carbon/human/H, bypass_equip_delay_self = FALSE)
 	if((slot in no_equip) || (slot in extra_no_equip))
 		if(!I.species_exception || !is_type_in_list(src, I.species_exception))


### PR DESCRIPTION
Dead code, called nowhere, implemented nowhere. Goodbye dead code