### PR TITLE
Raises the Price on Several Supply Crates

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1731,7 +1731,7 @@
 /datum/supply_pack/organic/randomized/chef
 	name = "Excellent Meat Crate"
 	desc = "The best cuts in the whole galaxy."
-	cost = 300
+	cost = 1000
 	small_item = TRUE
 	contains = list(/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/slime,
 					/obj/item/reagent_containers/food/snacks/meat/slab/killertomato,
@@ -2431,7 +2431,7 @@
 /datum/supply_pack/misc/artsupply
 	name = "Art Supplies"
 	desc = "Make some happy little accidents with six canvasses, two easels, and two rainbow crayons!"
-	cost = 300 //can get away with this since the crate is wooden and therefore cheap as hell
+	cost = 400 
 	contains = list(/obj/structure/easel,
 					/obj/structure/easel,
 					/obj/item/canvas/nineteenXnineteen,
@@ -2456,7 +2456,7 @@
 /datum/supply_pack/misc/bigband
 	name = "Big Band Instrument Collection"
 	desc = "Get your sad station movin' and groovin' with this fine collection! Contains ten different instruments!"
-	cost = 400
+	cost = 600
 	crate_name = "Big band musical instruments collection"
 	contains = list(/obj/item/instrument/violin,
 					/obj/item/instrument/guitar,


### PR DESCRIPTION
# General Documentation

# Intent of your Pull Request

Raise the price of the Art, Excellent Meats, and Big Band Crates.

# Why is this change good for the game?

300 is really goddamn cheap, especially for the excellent meat crate that used to be like 2000. How do you come to a figure like 300, let alone merge it?
 Art crate is raised with it to 400, which I'm pretty sure is still half of what it used to be, more to just move away from that 300 credit crate price.
Big Band crate raised to 600. You get 9 instruments which cost 50 from a conventional vendor, and ontop of that an entire piano so like 450+ value. 5k was steep for cheap instruments, but 400?

# Wiki Documentation

Values on https://wiki.yogstation.net/wiki/Supply_crates need to be changed.

# Changelog

:cl:    
tweak: raises the price on several supply crates  
/:cl:
