### PR TITLE
Minor Changes to Tesla Mechanics

### DIFF
--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -14,12 +14,16 @@
 	circuit = /obj/item/circuitboard/machine/tesla_coil
 
 	var/tesla_flags = TESLA_MOB_DAMAGE | TESLA_OBJ_DAMAGE
-	var/power_loss = 2
-	var/input_power_multiplier = 1
+	var/percentage_power_loss = 0 // 0-1. Regular coils don't have power loss.
+	var/input_power_multiplier = 0
 	var/zap_cooldown = 100
-	var/last_zap = 0
 
 	var/datum/techweb/linked_techweb
+	var/research_points_per_zap = 2 // Research points gained per minute is indirectly buffed by having a lower zap cooldown.
+									// level 1 coil: 15/m, level coil 2: 20/m, level coil 3: 30/m, level coil 4: 60/m
+
+	var/datum/bank_account/linked_account
+	var/money_per_zap = 2 // This is tied to coil cooldown in the same way research points are.
 
 /obj/machinery/power/tesla_coil/power
 	circuit = /obj/item/circuitboard/machine/tesla_coil/power
@@ -28,14 +32,14 @@
 	. = ..()
 	wires = new /datum/wires/tesla_coil(src)
 	linked_techweb = SSresearch.science_tech
+	linked_account = SSeconomy.get_dep_account(ACCOUNT_ENG)
 
 /obj/machinery/power/tesla_coil/RefreshParts()
-	var/power_multiplier = 0
+	input_power_multiplier = 0
 	zap_cooldown = 100
 	for(var/obj/item/stock_parts/capacitor/C in component_parts)
-		power_multiplier += C.rating
-		zap_cooldown -= (C.rating * 20)
-	input_power_multiplier = power_multiplier
+		input_power_multiplier += C.rating // Each level increases power gain by 100%
+		zap_cooldown -= (C.rating * 20) // Each level decreases cooldown by 2 seconds
 
 /obj/machinery/power/tesla_coil/examine(mob/user)
 	. = ..()
@@ -77,27 +81,21 @@
 /obj/machinery/power/tesla_coil/tesla_act(power, tesla_flags, shocked_targets)
 	if(anchored && !panel_open)
 		obj_flags |= BEING_SHOCKED
-		//don't lose arc power when it's not connected to anything
-		//please place tesla coils all around the station to maximize effectiveness
-		var/power_produced = powernet ? power / power_loss : power
-		add_avail(power_produced*input_power_multiplier)
+		add_avail((power * (1 - percentage_power_loss))*input_power_multiplier)
 		flick("coilhit", src)
 		playsound(src.loc, 'sound/magic/lightningshock.ogg', 100, 1, extrarange = 5)
-		tesla_zap(src, 5, power_produced, tesla_flags, shocked_targets)
-		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_ENG)
-		if(D)
-			D.adjust_money(min(power_produced, 1))
+		if(istype(linked_account))
+			linked_account.adjust_money(money_per_zap)
 		if(istype(linked_techweb))
-			linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, min(power_produced, 1)) // x4 coils = ~240/m point bonus for R&D
-		addtimer(CALLBACK(src, .proc/reset_shocked), 10)
+			linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, research_points_per_zap)
+		addtimer(CALLBACK(src, .proc/reset_shocked), zap_cooldown)
 		tesla_buckle_check(power)
 	else
 		..()
 
 /obj/machinery/power/tesla_coil/proc/zap()
-	if((last_zap + zap_cooldown) > world.time || !powernet)
+	if(!powernet)
 		return FALSE
-	last_zap = world.time
 	var/coeff = (20 - ((input_power_multiplier - 1) * 3))
 	coeff = max(coeff, 10)
 	var/power = (powernet.avail/2)
@@ -112,22 +110,21 @@
 	desc = "A modified Tesla Coil used to study the effects of Edison's Bane for research."
 	icon_state = "rpcoil0"
 	circuit = /obj/item/circuitboard/machine/tesla_coil/research
-	power_loss = 20 // something something, high voltage + resistance
+	percentage_power_loss = 0.95 // Research coils lose 95% of the power (converting power to research or something idk)
+	research_points_per_zap = 6 // level 1 coil: 44/m, level coil 2: 60/m, level coil 3: 90/m, level coil 4: 180/m
+	money_per_zap = 6
 
 /obj/machinery/power/tesla_coil/research/tesla_act(power, tesla_flags, shocked_things)
 	if(anchored && !panel_open)
 		obj_flags |= BEING_SHOCKED
-		var/power_produced = powernet ? power / power_loss : power
-		add_avail(power_produced*input_power_multiplier)
+		add_avail((power * (1 - percentage_power_loss))*input_power_multiplier)
 		flick("rpcoilhit", src)
 		playsound(src.loc, 'sound/magic/lightningshock.ogg', 100, 1, extrarange = 5)
-		tesla_zap(src, 5, power_produced, tesla_flags, shocked_things)
-		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_ENG)
-		if(D)
-			D.adjust_money(min(power_produced, 3))
+		if(istype(linked_account))
+			linked_account.adjust_money(money_per_zap)
 		if(istype(linked_techweb))
-			linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, min(power_produced, 3)) // x4 coils with a pulse per second or so = ~720/m point bonus for R&D
-		addtimer(CALLBACK(src, .proc/reset_shocked), 10)
+			linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, research_points_per_zap)
+		addtimer(CALLBACK(src, .proc/reset_shocked), zap_cooldown)
 		tesla_buckle_check(power)
 	else
 		..()

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -72,8 +72,7 @@
 		for (var/ball in orbiting_balls)
 			if(prob(80))  //tesla nerf/reducing lag, each miniball now has only 20% to trigger the zap
 				continue
-			var/range = rand(1, clamp(orbiting_balls.len, 3, zap_range))
-			tesla_zap(ball, range, TESLA_MINI_POWER/7*range)
+			tesla_zap(ball, rand(2, zap_range), TESLA_MINI_POWER)
 	else
 		energy = 0 // ensure we dont have miniballs of miniballs
 
@@ -130,6 +129,11 @@
 /obj/singularity/energy_ball/proc/new_mini_ball()
 	if(!loc)
 		return
+	// Timers can be added fast enough that the max_balls check in handle_energy will "fail".
+	// Timers aren't accounted for in that check so it will add more timers to make more miniballs.
+	if(orbiting_balls.len >= max_balls)
+		return
+
 	var/obj/singularity/energy_ball/EB = new(loc, 0, TRUE)
 
 	EB.transform *= pick(0.3, 0.4, 0.5, 0.6, 0.7)
@@ -227,10 +231,13 @@
 		if(!(tesla_flags & TESLA_ALLOW_DUPLICATES) && LAZYACCESS(shocked_targets, A))
 			continue
 
+		var/dist = get_dist(source, A)
+		if(dist > zap_range)
+			continue
+
 		if(istype(A, /obj/machinery/power/tesla_coil))
-			var/dist = get_dist(source, A)
 			var/obj/machinery/power/tesla_coil/C = A
-			if(dist <= zap_range && (dist < closest_dist || !closest_tesla_coil) && !(C.obj_flags & BEING_SHOCKED))
+			if((dist < closest_dist || !closest_tesla_coil) && !(C.obj_flags & BEING_SHOCKED))
 				closest_dist = dist
 
 				//we use both of these to save on istype and typecasting overhead later on
@@ -238,13 +245,11 @@
 				closest_tesla_coil = C
 				closest_atom = C
 
-
 		else if(closest_tesla_coil)
 			continue //no need checking these other things
 
 		else if(istype(A, /obj/machinery/power/grounding_rod))
-			var/dist = get_dist(source, A)-2
-			if(dist <= zap_range && (dist < closest_dist || !closest_grounding_rod))
+			if((dist < closest_dist || !closest_grounding_rod))
 				closest_grounding_rod = A
 				closest_atom = A
 				closest_dist = dist
@@ -253,9 +258,8 @@
 			continue
 
 		else if(isliving(A))
-			var/dist = get_dist(source, A)
 			var/mob/living/L = A
-			if(dist <= zap_range && (dist < closest_dist || !closest_mob) && L.stat != DEAD && !(L.flags_1 & TESLA_IGNORE_1))
+			if((dist < closest_dist || !closest_mob) && L.stat != DEAD && !(L.flags_1 & TESLA_IGNORE_1))
 				closest_mob = L
 				closest_atom = A
 				closest_dist = dist
@@ -265,8 +269,7 @@
 
 		else if(ismachinery(A))
 			var/obj/machinery/M = A
-			var/dist = get_dist(source, A)
-			if(dist <= zap_range && (dist < closest_dist || !closest_machine) && !(M.obj_flags & BEING_SHOCKED))
+			if((dist < closest_dist || !closest_machine) && !(M.obj_flags & BEING_SHOCKED))
 				closest_machine = M
 				closest_atom = A
 				closest_dist = dist
@@ -276,8 +279,7 @@
 
 		else if(istype(A, /obj/structure/blob))
 			var/obj/structure/blob/B = A
-			var/dist = get_dist(source, A)
-			if(dist <= zap_range && (dist < closest_dist || !closest_tesla_coil) && !(B.obj_flags & BEING_SHOCKED))
+			if((dist < closest_dist || !closest_tesla_coil) && !(B.obj_flags & BEING_SHOCKED))
 				closest_blob = B
 				closest_atom = A
 				closest_dist = dist
@@ -287,8 +289,7 @@
 
 		else if(isstructure(A))
 			var/obj/structure/S = A
-			var/dist = get_dist(source, A)
-			if(dist <= zap_range && (dist < closest_dist || !closest_tesla_coil) && !(S.obj_flags & BEING_SHOCKED))
+			if((dist < closest_dist || !closest_tesla_coil) && !(S.obj_flags & BEING_SHOCKED))
 				closest_structure = S
 				closest_atom = A
 				closest_dist = dist

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -227,17 +227,16 @@
 										/obj/machinery/the_singularitygen/tesla,
 										/obj/structure/frame/machine))
 
-	for(var/A in typecache_filter_multi_list_exclusion(oview(source, zap_range+2), things_to_shock, blacklisted_tesla_types))
+	// +3 to range specifically to include grounding rods that are zap_range+2 away
+	for(var/A in typecache_filter_multi_list_exclusion(oview(source, zap_range+3), things_to_shock, blacklisted_tesla_types))
 		if(!(tesla_flags & TESLA_ALLOW_DUPLICATES) && LAZYACCESS(shocked_targets, A))
 			continue
 
 		var/dist = get_dist(source, A)
-		if(dist > zap_range)
-			continue
 
 		if(istype(A, /obj/machinery/power/tesla_coil))
 			var/obj/machinery/power/tesla_coil/C = A
-			if((dist < closest_dist || !closest_tesla_coil) && !(C.obj_flags & BEING_SHOCKED))
+			if(dist <= zap_range && (dist < closest_dist || !closest_tesla_coil) && !(C.obj_flags & BEING_SHOCKED))
 				closest_dist = dist
 
 				//we use both of these to save on istype and typecasting overhead later on
@@ -249,7 +248,7 @@
 			continue //no need checking these other things
 
 		else if(istype(A, /obj/machinery/power/grounding_rod))
-			if((dist < closest_dist || !closest_grounding_rod))
+			if(dist < closest_dist || !closest_grounding_rod)
 				closest_grounding_rod = A
 				closest_atom = A
 				closest_dist = dist
@@ -259,7 +258,7 @@
 
 		else if(isliving(A))
 			var/mob/living/L = A
-			if((dist < closest_dist || !closest_mob) && L.stat != DEAD && !(L.flags_1 & TESLA_IGNORE_1))
+			if(dist <= zap_range && (dist < closest_dist || !closest_mob) && L.stat != DEAD && !(L.flags_1 & TESLA_IGNORE_1))
 				closest_mob = L
 				closest_atom = A
 				closest_dist = dist
@@ -269,7 +268,7 @@
 
 		else if(ismachinery(A))
 			var/obj/machinery/M = A
-			if((dist < closest_dist || !closest_machine) && !(M.obj_flags & BEING_SHOCKED))
+			if((dist <= zap_range && dist < closest_dist || !closest_machine) && !(M.obj_flags & BEING_SHOCKED))
 				closest_machine = M
 				closest_atom = A
 				closest_dist = dist
@@ -279,7 +278,7 @@
 
 		else if(istype(A, /obj/structure/blob))
 			var/obj/structure/blob/B = A
-			if((dist < closest_dist || !closest_tesla_coil) && !(B.obj_flags & BEING_SHOCKED))
+			if(dist <= zap_range && (dist < closest_dist || !closest_tesla_coil) && !(B.obj_flags & BEING_SHOCKED))
 				closest_blob = B
 				closest_atom = A
 				closest_dist = dist
@@ -289,7 +288,7 @@
 
 		else if(isstructure(A))
 			var/obj/structure/S = A
-			if((dist < closest_dist || !closest_tesla_coil) && !(S.obj_flags & BEING_SHOCKED))
+			if(dist <= zap_range && (dist < closest_dist || !closest_tesla_coil) && !(S.obj_flags & BEING_SHOCKED))
 				closest_structure = S
 				closest_atom = A
 				closest_dist = dist

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -227,7 +227,7 @@
 										/obj/machinery/the_singularitygen/tesla,
 										/obj/structure/frame/machine))
 
-	// +3 to range specifically to include grounding rods that are zap_range+2 away
+	// +3 to range specifically to include grounding rods that are zap_range+3 away
 	for(var/A in typecache_filter_multi_list_exclusion(oview(source, zap_range+3), things_to_shock, blacklisted_tesla_types))
 		if(!(tesla_flags & TESLA_ALLOW_DUPLICATES) && LAZYACCESS(shocked_targets, A))
 			continue
@@ -268,7 +268,7 @@
 
 		else if(ismachinery(A))
 			var/obj/machinery/M = A
-			if((dist <= zap_range && dist < closest_dist || !closest_machine) && !(M.obj_flags & BEING_SHOCKED))
+			if(dist <= zap_range && (dist < closest_dist || !closest_machine) && !(M.obj_flags & BEING_SHOCKED))
 				closest_machine = M
 				closest_atom = A
 				closest_dist = dist


### PR DESCRIPTION
Tesla Miniball maximum now properly enforced.
Miniball power output no longer tied to zap range.
Minimum zap range increased to 2.
Grounding Rod bonus range increased by 1.
Tesla Coils no longer cause zaps to jump.
Coil cooldown restrictions actually work now.
Research/money gain adjusted to compensate for cooldown restrictions.

# General Documentation

### Intent of your Pull Request

This makes some of the Tesla's mechanics less weird, more predictable, and actually impactful. Currently you are extremely unlikely to ever see the Tesla's power output be above 1.7mW (unless you upgrade the Tesla Coils for a straight 100%/200%/etc bonus). This is because of some weird mechanics and decisions on how power generation is calculated. The changes in this PR will mean a roughly 50% increase in power output for the Tesla which will put it a bit under what a default TEG generates.
I've tested these changes and with the default setup power output is always at a minimum of 1.7mW with spikes up to 2.5mW and 3.4mW.

### Why is this change good for the game?
The Tesla's mechanics are easier to reason about and opportunities for experimenting with different Tesla setups are now possible.

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms.
The Tesla's mechanics are now more consistent and impactful. Miniball power generation has been increased because it is no longer tied to zap range. Tesla Coils that are zapped no longer cause a jump because that behavior was putting every coil onto cooldown with a single zap. Tesla Coils now go on cooldown when zapped and can't be zapped again until a short duration (8 seconds, decreased by better parts).

### What should players be aware of when it comes to the changes your PR is implementing?
Casual players who are just interested in having power be setup don't need to be concerned with this change. A default Tesla setup will still work perfectly fine for the station. However, enterprising players will be able to make changes to the Tesla's default setup and see improved results to power output.

### What general grouping does this PR fall under? 
Engineering rebalancing.

### Are there any aspects of the PR that you would like us not to mention on the Wiki?
No

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here.
Grounding Rods now work 1 tile further than they previously did making the default Tesla setup completely safe.
Standard Tesla Coils now generate the full amount of power per zap instead of anywhere from 1-50% of full power. This results in a roughly 50% increase in power output overall. Research Tesla Coils still incur a 95% power loss in exchange for increased research generation.
Tesla Coil cooldowns are now enforced. This means that when a coil is zapped it goes on cooldown and cannot be zapped before the cooldown is up. Level 1 coils have a cooldown of 8 seconds. Coils can be upgraded with capacitors to reduce the cooldown by 2 seconds per capacitor level.

# Changelog
Tesla mechanics tweaked to be more consistent, resulting in a roughly 50% increase in power output and more setup variety.

:cl:  
bugfix: Tesla Miniball maximum now properly enforced  
bugfix: Tesla Coil cooldowns now actually work
tweak: Miniball power output no longer tied to zap range
tweak: Minimum Miniball zap range increased to 2 (was 1)
tweak: Grounding Rod bonus range increase to 3 (was 2)
tweak: Tesla Coils no longer cause zaps to jump
/:cl:
