### PR TITLE
You can no longer scrub the cold of space to cool down gasses by scrubbing space

### DIFF
--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -77,6 +77,10 @@
 /turf/open/space/Assimilate_Air()
 	return
 
+//IT SHOULD RETURN NULL YOU MONKEY, WHY IN TARNATION WHAT THE FUCKING FUCK
+/turf/open/space/remove_air(amount)
+	return null
+
 /turf/open/space/proc/update_starlight()
 	if(CONFIG_GET(flag/starlight))
 		for(var/t in RANGE_TURFS(1,src)) //RANGE_TURFS is in code\__HELPERS\game.dm


### PR DESCRIPTION
Ports tgstation/tgstation#51091

🆑 LemonInTheDark, with thanks to ArcaneDefence for the pointer
fix: Scrubbers no longer cool pipenets attached to them when scrubbing space
/🆑