### PR TITLE
[Admin] People who are non consentually put into cryo no longer get offered to ghosts automatically and prevents using cryo as an indestructible safe spot by using the offer to ghost prompt to delay the cryo forever

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -170,7 +170,8 @@ GLOBAL_LIST_INIT(typecache_cryoitems, typecacheof(list(
 	var/on_store_name = "Cryogenic Oversight"
 
 	// 5 minutes-ish safe period before being despawned.
-	var/time_till_despawn = 5 MINUTES // This is reduced to 30 seconds if a player manually enters cryo
+	var/time_till_despawn = 15 MINUTES // Time if a player gets forced into cryo
+	var/time_till_despawn_online = 30 SECONDS // Time if a player manually enters cryo
 
 	var/obj/machinery/computer/cryopod/control_computer
 	var/cooldown = FALSE
@@ -216,7 +217,7 @@ GLOBAL_LIST_INIT(typecache_cryoitems, typecacheof(list(
 		if(!occupant) //Check they still exist
 			return
 		if(mob_occupant.client)//if they're logged in
-			var/offertimer = addtimer(VARSET_CALLBACK(src, ready, TRUE), (time_till_despawn * 0.1), TIMER_STOPPABLE) // This gives them 30 seconds
+			var/offertimer = addtimer(VARSET_CALLBACK(src, ready, TRUE), time_till_despawn_online, TIMER_STOPPABLE)
 			if(alert(mob_occupant, "Do you want to offer yourself to ghosts?", "Ghost Offer", "Yes", "No"))
 				deltimer(offertimer) //Player wants to offer, cancel the timer
 				if(!offer_control(occupant))

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -213,15 +213,17 @@ GLOBAL_LIST_INIT(typecache_cryoitems, typecacheof(list(
 		var/mob/living/mob_occupant = occupant
 		if(mob_occupant && mob_occupant.stat != DEAD)
 			to_chat(occupant, "<span class='boldnotice'>You feel cool air surround you. You go numb as your senses turn inward.</span>")
-		var/offer = alert(mob_occupant, "Do you want to offer yourself to ghosts?", "Ghost Offer", "Yes", "No")
-		if(offer == "Yes" && offer_control(occupant))
-			return
 		if(!occupant) //Check they still exist
 			return
 		if(mob_occupant.client)//if they're logged in
 			addtimer(VARSET_CALLBACK(src, ready, TRUE), (time_till_despawn * 0.1)) // This gives them 30 seconds
 		else
 			addtimer(VARSET_CALLBACK(src, ready, TRUE), time_till_despawn)
+
+		if(mob_occupant.client)
+			var/offer = alert(mob_occupant, "Do you want to offer yourself to ghosts?", "Ghost Offer", "Yes", "No")
+			if(offer == "Yes" && offer_control(occupant))
+				return
 
 /obj/machinery/cryopod/open_machine()
 	..()

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -218,7 +218,7 @@ GLOBAL_LIST_INIT(typecache_cryoitems, typecacheof(list(
 			return
 		if(mob_occupant.client)//if they're logged in
 			var/offertimer = addtimer(VARSET_CALLBACK(src, ready, TRUE), time_till_despawn_online, TIMER_STOPPABLE)
-			if(alert(mob_occupant, "Do you want to offer yourself to ghosts?", "Ghost Offer", "Yes", "No"))
+			if(alert(mob_occupant, "Do you want to offer yourself to ghosts?", "Ghost Offer", "Yes", "No") == "Yes")
 				deltimer(offertimer) //Player wants to offer, cancel the timer
 				if(!offer_control(occupant))
 					//Player is a jackass that noone wants the body of, restart the timer

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -170,7 +170,7 @@ GLOBAL_LIST_INIT(typecache_cryoitems, typecacheof(list(
 	var/on_store_name = "Cryogenic Oversight"
 
 	// 5 minutes-ish safe period before being despawned.
-	var/time_till_despawn = 5 MINUTES // This is reduced to 60 seconds if a player manually enters cryo
+	var/time_till_despawn = 5 MINUTES // This is reduced to 30 seconds if a player manually enters cryo
 
 	var/obj/machinery/computer/cryopod/control_computer
 	var/cooldown = FALSE
@@ -216,14 +216,12 @@ GLOBAL_LIST_INIT(typecache_cryoitems, typecacheof(list(
 		if(!occupant) //Check they still exist
 			return
 		if(mob_occupant.client)//if they're logged in
-			addtimer(VARSET_CALLBACK(src, ready, TRUE), (time_till_despawn * 0.2)) // This gives them 60 seconds
+			var/offertimer = addtimer(VARSET_CALLBACK(src, ready, TRUE), (time_till_despawn * 0.1), TIMER_STOPPABLE) // This gives them 30 seconds
+			if(alert(mob_occupant, "Do you want to offer yourself to ghosts?", "Ghost Offer", "Yes", "No"))
+				deltimer(offertimer)
+				offer_control(occupant)
 		else
 			addtimer(VARSET_CALLBACK(src, ready, TRUE), time_till_despawn)
-
-		if(mob_occupant.client)
-			var/offer = alert(mob_occupant, "Do you want to offer yourself to ghosts?", "Ghost Offer", "Yes", "No")
-			if(offer == "Yes" && offer_control(occupant))
-				return
 
 /obj/machinery/cryopod/open_machine()
 	..()

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -170,7 +170,7 @@ GLOBAL_LIST_INIT(typecache_cryoitems, typecacheof(list(
 	var/on_store_name = "Cryogenic Oversight"
 
 	// 5 minutes-ish safe period before being despawned.
-	var/time_till_despawn = 5 MINUTES // This is reduced to 30 seconds if a player manually enters cryo
+	var/time_till_despawn = 5 MINUTES // This is reduced to 60 seconds if a player manually enters cryo
 
 	var/obj/machinery/computer/cryopod/control_computer
 	var/cooldown = FALSE
@@ -216,7 +216,7 @@ GLOBAL_LIST_INIT(typecache_cryoitems, typecacheof(list(
 		if(!occupant) //Check they still exist
 			return
 		if(mob_occupant.client)//if they're logged in
-			addtimer(VARSET_CALLBACK(src, ready, TRUE), (time_till_despawn * 0.1)) // This gives them 30 seconds
+			addtimer(VARSET_CALLBACK(src, ready, TRUE), (time_till_despawn * 0.2)) // This gives them 60 seconds
 		else
 			addtimer(VARSET_CALLBACK(src, ready, TRUE), time_till_despawn)
 

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -218,8 +218,10 @@ GLOBAL_LIST_INIT(typecache_cryoitems, typecacheof(list(
 		if(mob_occupant.client)//if they're logged in
 			var/offertimer = addtimer(VARSET_CALLBACK(src, ready, TRUE), (time_till_despawn * 0.1), TIMER_STOPPABLE) // This gives them 30 seconds
 			if(alert(mob_occupant, "Do you want to offer yourself to ghosts?", "Ghost Offer", "Yes", "No"))
-				deltimer(offertimer)
-				offer_control(occupant)
+				deltimer(offertimer) //Player wants to offer, cancel the timer
+				if(!offer_control(occupant))
+					//Player is a jackass that noone wants the body of, restart the timer
+					addtimer(VARSET_CALLBACK(src, ready, TRUE), (time_till_despawn * 0.1))
 		else
 			addtimer(VARSET_CALLBACK(src, ready, TRUE), time_till_despawn)
 


### PR DESCRIPTION
Let's end this stupid shit of admins bwoinking people for making use of cryo pods as they should be used because of a bug

Technical details:
Alert will return the first option automatically if the mob does not have a client set, this made people autoconsent to ghost, which was a bug
Also moved the ghost prompt down so it starts the despawn timer before asking people if thye wanna take control but that despawn timer is cancelled if the person says yes

:cl:  
bugfix: You can no longer offer people to ghosts by cryoing them forcibly, players who cryo themselves are still able to offer themselves
bugfix: You can no longer delay the cryo despawn timer indefinetly by keeping the offer to ghost prompt open indefinetly
/:cl:
