### PR TITLE
ARDS nerf

### DIFF
--- a/code/datums/diseases/advance/symptoms/choking.dm
+++ b/code/datums/diseases/advance/symptoms/choking.dm
@@ -138,19 +138,19 @@ Bonus
 	return
 
 /datum/symptom/asphyxiation/proc/Asphyxiate_stage_3_4(mob/living/M, datum/disease/advance/A)
-	var/get_damage = rand(10,15) * power
+	var/get_damage = rand(5,8) * power
 	M.adjustOxyLoss(get_damage)
 	return 1
 
 /datum/symptom/asphyxiation/proc/Asphyxiate(mob/living/M, datum/disease/advance/A)
-	var/get_damage = rand(15,21) * power
+	var/get_damage = rand(8,11) * power
 	M.adjustOxyLoss(get_damage)
 	if(paralysis)
 		M.reagents.add_reagent_list(list(/datum/reagent/toxin/pancuronium = 3, /datum/reagent/toxin/sodium_thiopental = 3))
 	return 1
 
 /datum/symptom/asphyxiation/proc/Asphyxiate_death(mob/living/M, datum/disease/advance/A)
-	var/get_damage = rand(25,35) * power
+	var/get_damage = rand(11,18) * power
 	M.adjustOxyLoss(get_damage)
-	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, get_damage/2)
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, get_damage/3)
 	return 1


### PR DESCRIPTION


# General Documentation

Nerfs the Acute Respiratory Distress Syndrome virus symptom because it is blatantly op and is way too effective at killing people in an extremely short amount of time, even with use of perfleourodecalin. It's incredibly unfair as it is right now, and absolutely decimates almost everyone that gets a virus with this symptom.

### Why is this change good for the game?

A virologist releasing a virus with this symptom will not longer effectively guarantee the death of a large portion of the station if the cure takes more than a minute to make. This should help a bit with griefers, too.

# Wiki Documentation

Probably nothing if the damage numbers aren't explicitly listed in the wiki article.

### What should players be aware of when it comes to the changes your PR is implementing?

ARDS is significantly less lethal.

### What general grouping does this PR fall under? 

Virology rebalancing

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
For example, "This new chem will heal X brute damage". 

The symptom now deals 5-8 base damage at stages 3-4, 8-11 base damage at stage 5, and 11-18 base damage with 1/3 of that being dealt directly to the brain (why???) when oxyloss damage is greater than 120. This is approximately half the original values of 10-15, 15-21, 25-35, and 1/2 respectively. Note that the bonus damage threshold is untouched, so you can still double the damage that way.

# Changelog

:cl:  
tweak: ARDS symptom now deals about 1/2 as much damage

/:cl:
