### PR TITLE
Manually screaming is now audible

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -66,7 +66,7 @@
 	key_third_person = "screams"
 	message = "screams!"
 	emote_type = EMOTE_AUDIBLE
-	only_forced_audio = TRUE
+	cooldown = 10 SECONDS
 	vary = TRUE
 
 /datum/emote/living/carbon/human/scream/get_sound(mob/living/user)


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Allows players to create an audible scream when using the *scream emote instead of it only being triggered by code. It has a cooldown of ten seconds so cannot be spammed that much, do feel free to complain if you want it higher

### Why is this change good for the game?

More noises makes the game cooler. 

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
This will be the basis of the Wiki entry for your PR, and more information / detail is better for Wiki editors to integrate.

Players can audibly scream now

### What should players be aware of when it comes to the changes your PR is implementing?

Players can audibly scream now

### What general grouping does this PR fall under? 
For example, Engineering changes, Medical rebalancing, TEG tweaks, etc.?

Emotes

### Are there any aspects of the PR that you would like us not to mention on the Wiki?

Nyet

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
For example, "This new chem will heal X brute damage". 

Nah

# Changelog

:cl:  
soundadd: You can scream now
/:cl:
