### PR TITLE
chef cqc checks defender for being in the kitchen

### DIFF
--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -192,7 +192,7 @@
 
 ///CQC grab, stuns for 1.5 seconds on use
 /datum/martial_art/cqc/grab_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	if(A.a_intent == INTENT_GRAB && A!=D && (can_use(A) && can_use(D)) // A!=D prevents grabbing yourself
+	if(A.a_intent == INTENT_GRAB && A!=D && (can_use(A) && can_use(D))) // A!=D prevents grabbing yourself
 		add_to_streak("G",D)
 		if(check_streak(A,D)) //if a combo is made no grab upgrade is done
 			return TRUE

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -51,7 +51,7 @@
   * otherwise returns false
   */
 /datum/martial_art/cqc/proc/check_streak(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	if(!(can_use(A) || can_use(D))
+	if(!(can_use(A) || can_use(D)))
 		return FALSE
 	if(findtext(streak,SLAM_COMBO))
 		streak = ""

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -206,7 +206,7 @@
 
 ///CQC harm intent, deals 15 stamina damage and immobilizes for 1.5 seconds, if the attacker is prone, they knock the defender down and stand up
 /datum/martial_art/cqc/harm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	if(!(can_use(A) || can_use(D))
+	if(!(can_use(A) || can_use(D)))
 		return FALSE
 	add_to_streak("H",D)
 	if(check_streak(A,D))
@@ -234,7 +234,7 @@
 
 ///CQC disarm, 65% chance to instantly pick up the opponent's weapon and deal 5 stamina damage, also used for choke attack
 /datum/martial_art/cqc/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	if(!(can_use(A) || can_use(D))
+	if(!(can_use(A) || can_use(D)))
 		return FALSE
 	add_to_streak("D",D)
 	var/obj/item/I = null

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -51,7 +51,7 @@
   * otherwise returns false
   */
 /datum/martial_art/cqc/proc/check_streak(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	if(!can_use(A))
+	if(!(can_use(A) || can_use(D))
 		return FALSE
 	if(findtext(streak,SLAM_COMBO))
 		streak = ""
@@ -192,7 +192,7 @@
 
 ///CQC grab, stuns for 1.5 seconds on use
 /datum/martial_art/cqc/grab_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	if(A.a_intent == INTENT_GRAB && A!=D && can_use(A)) // A!=D prevents grabbing yourself
+	if(A.a_intent == INTENT_GRAB && A!=D && (can_use(A) && can_use(D)) // A!=D prevents grabbing yourself
 		add_to_streak("G",D)
 		if(check_streak(A,D)) //if a combo is made no grab upgrade is done
 			return TRUE
@@ -206,7 +206,7 @@
 
 ///CQC harm intent, deals 15 stamina damage and immobilizes for 1.5 seconds, if the attacker is prone, they knock the defender down and stand up
 /datum/martial_art/cqc/harm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	if(!can_use(A))
+	if(!(can_use(A) || can_use(D))
 		return FALSE
 	add_to_streak("H",D)
 	if(check_streak(A,D))
@@ -234,7 +234,7 @@
 
 ///CQC disarm, 65% chance to instantly pick up the opponent's weapon and deal 5 stamina damage, also used for choke attack
 /datum/martial_art/cqc/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	if(!can_use(A))
+	if(!(can_use(A) || can_use(D))
 		return FALSE
 	add_to_streak("D",D)
 	var/obj/item/I = null


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

this is gonna turn into a thing and I don't want it to turn into a thing

### Why is this change good for the game?

prevents chefs from using their turf defense ability outside their turf


:cl:  
tweak: chef cqc will no longer work if the person being assailed is not trespassing
/:cl:
