### PR TITLE
inocybe shine helps with surgery

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2165,7 +2165,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/inocybeshine
 	name = "Inocybe Shine"
-	description = "A very strong, slightly toxic alcohol from fermented inocybe mycelium."
+	description = "A very strong, slightly toxic alcohol made from fermented inocybe mycelium. As a result of the fermentation process, the toxins inside the mushroom now work as a mild painkiller as well."
 	color = "#664300" // rgb: 102, 67, 0
 	nutriment_factor = 2 * REAGENTS_METABOLISM
 	boozepwr = 75

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -10,7 +10,7 @@
 	var/repeatable = FALSE				//can this step be repeated? Make shure it isn't last step, or it used in surgery with `can_cancel = 1`. Or surgion will be stuck in the loop
 	var/list/chems_needed = list()  //list of chems needed to complete the step. Even on success, the step will have no effect if there aren't the chems required in the mob.
 	var/require_all_chems = TRUE    //any on the list or all on the list?
-	var/list/ouchie_modifying_chems = list(/datum/reagent/consumable/ethanol/painkiller = 0.5, /datum/reagent/medicine/morphine = 0.5) //chems that will modify the chance for fuckups while operating on conscious patients, stacks.
+	var/list/ouchie_modifying_chems = list(/datum/reagent/consumable/ethanol/painkiller = 0.5, /datum/reagent/consumable/ethanol/inocybeshine = 0.5, /datum/reagent/medicine/morphine = 0.5) //chems that will modify the chance for fuckups while operating on conscious patients, stacks.
 	var/fuckup_damage = 10			//base damage dealt on a surgery being done without anesthetics on SURGERY_FUCKUP_CHANCE percent chance
 	var/fuckup_damage_type = BRUTE	//damage type fuckup_damage is dealt as
 


### PR DESCRIPTION

# General Documentation

### Intent of your Pull Request
inocybe shine, made from fermenting lavaland shroom caps, will now reduce the chance of a surgery step hurting someone. Primarily is for ashwalkers but other lavaland peoples can use it too.
description of inocybe shine was also slightly altered to reflect on this

### Why is this change good for the game?
lets ashwalkers have an easier time with surgery if they're resourceful.

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
This will be the basis of the Wiki entry for your PR, and more information / detail is better for Wiki editors to integrate.
inocybe shine, made from fermenting lavaland shroom caps, will now reduce the chance of a surgery step hurting someone. Primarily is for ashwalkers but other lavaland peoples can use it too.

### What should players be aware of when it comes to the changes your PR is implementing?
inocybe shine, made from fermenting lavaland shroom caps, will now reduce the chance of a surgery step hurting someone. Primarily is for ashwalkers but other lavaland peoples can use it too.

### What general grouping does this PR fall under? 
For example, Engineering changes, Medical rebalancing, TEG tweaks, etc.?
lavaland changes/surgery changes

### Are there any aspects of the PR that you would like us not to mention on the Wiki?
no
# Changelog

:cl:  
tweak: inocybe shine makes surgery easier if the person has it in their system. Also changes inocybe shine's description.
/:cl:
