### PR TITLE
[admin] Adds short forms for admin/mainterino combo roles in OOC

### DIFF
--- a/yogstation/code/modules/client/verbs/ooc.dm
+++ b/yogstation/code/modules/client/verbs/ooc.dm
@@ -21,6 +21,15 @@
 		if("RetiredAdmin")
 			return "\[Retmin\]"
 
+		if("Administrator-Mainterino")
+			return "\[Admin-tainer\]"
+
+		if("Moderator-Mainterino")
+			return "\[Mod-tainer\]"
+			
+		if("Retmin-Maintainerino")
+			return "\[Retmin-tainer\]"
+
 		else
 			return "\[[C.holder.rank.name]\]"
 


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

In OOC, Administrator-Mainterino -> Admin-tainer, Moderator-Mainterino -> Mod-tainer, Retmin-Maintainerino -> Retmin-tainer

### Why is this change good for the game?

Because shorter tags in OOC = better

# Changelog

:cl:  
tweak: In OOC, Administrator-Mainterino -> Admin-tainer, Moderator-Mainterino -> Mod-tainer, Retmin-Maintainerino -> Retmin-tainer
/:cl:
