### PR TITLE
Fixes incorrect uses of UnregisterSignal

### DIFF
--- a/code/modules/antagonists/ninja/ninja.dm
+++ b/code/modules/antagonists/ninja/ninja.dm
@@ -27,7 +27,7 @@ GLOBAL_LIST_EMPTY(ninja_capture)
 	var/mob/living/M = mob_override || owner.current
 	for(var/obj/item/implant/explosive/E in M.implants)
 		if(E)
-			UnregisterSignal(M, COMSIG_IMPLANT_ACTIVATED, .proc/on_death)
+			UnregisterSignal(M, COMSIG_IMPLANT_ACTIVATED)
 	update_ninja_icons_removed(M)
 
 /datum/antagonist/ninja/proc/equip_space_ninja(mob/living/carbon/human/H = owner.current)

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -60,7 +60,7 @@
 			A.malf_picker.remove_malf_verbs(A)
 			qdel(A.malf_picker)
 	owner.remove_employee(company)
-	UnregisterSignal(owner.current, COMSIG_MOVABLE_HEAR, .proc/handle_hearing)
+	UnregisterSignal(owner.current, COMSIG_MOVABLE_HEAR)
 	SSticker.mode.traitors -= owner
 	if(!silent && owner.current)
 		to_chat(owner.current,"<span class='userdanger'> You are no longer the [special_role]! </span>")

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -1215,7 +1215,7 @@
 	. = ..()
 	for(var/obj/effect/proc_holder/spell/aoe_turf/knock/spell in C.mob_spell_list)
 		C.RemoveSpell(spell)
-	UnregisterSignal(C, COMSIG_MOB_SAY, .proc/handle_speech)
+	UnregisterSignal(C, COMSIG_MOB_SAY)
 	var/datum/antagonist/golem/communist/CU = C.mind.has_antag_datum(/datum/antagonist/golem/communist)
 	if(CU && !CU.removing)
 		C.mind.remove_antag_datum(/datum/antagonist/golem/communist)

--- a/code/modules/research/nanites/nanite_programs/sensor.dm
+++ b/code/modules/research/nanites/nanite_programs/sensor.dm
@@ -350,7 +350,7 @@
 	RegisterSignal(host_mob, COMSIG_MOVABLE_HEAR, .proc/on_hear)
 
 /datum/nanite_program/sensor/voice/on_mob_remove()
-	UnregisterSignal(host_mob, COMSIG_MOVABLE_HEAR, .proc/on_hear)
+	UnregisterSignal(host_mob, COMSIG_MOVABLE_HEAR)
 
 /datum/nanite_program/sensor/voice/set_extra_setting(user, setting)
 	if(setting == "Sent Code")

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -44,7 +44,7 @@
 	..()
 	if(say_mod && M.dna && M.dna.species)
 		M.dna.species.say_mod = initial(M.dna.species.say_mod)
-	UnregisterSignal(M, COMSIG_MOB_SAY, .proc/handle_speech)
+	UnregisterSignal(M, COMSIG_MOB_SAY)
 	M.RegisterSignal(M, COMSIG_MOB_SAY, /mob/living/carbon/.proc/handle_tongueless_speech)
 
 /obj/item/organ/tongue/could_speak_language(language)

--- a/yogstation/code/datums/components/crawl.dm
+++ b/yogstation/code/datums/components/crawl.dm
@@ -384,7 +384,7 @@
 		for(var/obj/item/vomitcrawl/B in C)
 			qdel(B)
 	..()
-	UnregisterSignal(enteredvomit, COMSIG_PARENT_PREQDELETED, .proc/throw_out)
+	UnregisterSignal(enteredvomit, COMSIG_PARENT_PREQDELETED)
 	enteredvomit = null
 	user.visible_message("<span class='warning'><B>[user] rises out of the pool of vomit!?</B></span>")
 	exit_vomit_effect(target, user)

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -1,5 +1,5 @@
 /datum/species/jelly/slime/on_species_loss(mob/living/carbon/C)
-	UnregisterSignal(C, COMSIG_ALT_CLICK_ON, .proc/handle_altclick)
+	UnregisterSignal(C, COMSIG_ALT_CLICK_ON)
 	..()
 
 /datum/species/jelly/slime/on_species_gain(mob/living/carbon/C)


### PR DESCRIPTION
## Intent of your Pull Request

Fixes incorrect uses of UnregisterSignal. (Removes unneeded proc parameters).
This can cause runtimes with signals getting overridden.

Ran some regex to find them all so I shouldn't have missed any.

## Why is this change good for the game?

Runtimes bad

## Changelog

:cl:  
bugfix: Signals will no longer sometimes runtime when unregistering
/:cl: