### PR TITLE
[box]Adds a 2% xeno egg spawner to xenobio

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -38841,6 +38841,11 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"gML" = (
+/obj/structure/alien/weeds,
+/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "gNi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -110362,7 +110367,7 @@ bKS
 bAC
 bBW
 bDb
-xwZ
+gML
 egr
 bEm
 bDb


### PR DESCRIPTION
### Intent of your Pull Request

title,
The thing exists as on object so I figure we might as well use it.
Mainly making this to see if people think this is a horrible or a good idea

it's just 2%, remember

### Why is this change good for the game?
Variety is the spice of life
also makes for some interesting science action

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
title

### What should players be aware of when it comes to the changes your PR is implementing?

### What general grouping does this PR fall under? 
xenobio

### Are there any aspects of the PR that you would like us not to mention on the Wiki?
uuh
### If there are any numerical values involved in your PR that will be relevant to a player, 2% spawn chance

# Changelog


:cl:  
rsctweak: Adds a 2% xeno egg spawner to xenobio in boxstation
/:cl:
