### PR TITLE
Fixed and Tweaked Some Stuff With the Crew Console Interface

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -105,15 +105,6 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		z = T.z
 	var/list/zdata = update_data(z)
 	. = list()
-	var/datum/minimap/M = SSmapping.station_minimaps[1]
-	.["sensors"] = zdata
-	.["link_allowed"] = isAI(user)
-	.["z"] = z
-	.["minx"] = M.minx
-	.["miny"] = M.miny
-	.["maxx"] = M.maxx
-	.["maxy"] = M.maxy
-	.["map_filename"] = SSassets.transport.get_asset_url("minimap-1.png")
 
 /datum/crewmonitor/proc/update_data(z)
 	if(data_by_z["[z]"] && last_update["[z]"] && world.time <= last_update["[z]"] + SENSORS_UPDATE_PERIOD)

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -103,7 +103,6 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 	if(!z)
 		var/turf/T = get_turf(user)
 		z = T.z
-	var/list/zdata = update_data(z)
 	. = list()
 
 /datum/crewmonitor/proc/update_data(z)

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -42,12 +42,16 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 	jobs["Geneticist"] = 22
 	jobs["Virologist"] = 23
 	jobs["Medical Doctor"] = 24
+	jobs["Paramedic"] = 25 //Yogs: Added IDs for this job
+	jobs["Psychiatrist"] = 26 //Yogs: Added IDs for this job
+	jobs["Mining Medic"] = 27 //Yogs: Added IDs for this job
 	jobs["Research Director"] = 30
 	jobs["Scientist"] = 31
 	jobs["Roboticist"] = 32
 	jobs["Chief Engineer"] = 40
 	jobs["Station Engineer"] = 41
 	jobs["Atmospheric Technician"] = 42
+	jobs["Signal Technician"] = 43 //Yogs: Added IDs for this job
 	jobs["Quartermaster"] = 51
 	jobs["Shaft Miner"] = 52
 	jobs["Cargo Technician"] = 53
@@ -60,6 +64,9 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 	jobs["Mime"] = 67
 	jobs["Janitor"] = 68
 	jobs["Lawyer"] = 69
+	jobs["Clerk"] = 71 //Yogs: Added IDs for this job, also need to skip 70 or it clerk would be considered a head job
+	jobs["Tourist"] = 72 //Yogs: Added IDs for this job
+	jobs["Artist"] = 73 //Yogs: Added IDs for this job
 	jobs["Admiral"] = 200
 	jobs["CentCom Commander"] = 210
 	jobs["Custodian"] = 211

--- a/tgui/packages/tgui/constants.js
+++ b/tgui/packages/tgui/constants.js
@@ -20,6 +20,7 @@ export const COLORS = {
     science: '#9b59b6',
     engineering: '#f1c40f',
     cargo: '#f39c12',
+    civilian: '#535353', // Yogs: Added new civilian color
     centcom: '#00c100',
     other: '#c38312',
   },

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -39,7 +39,7 @@ const jobToColor = jobId => {
   if (jobId >= 200 && jobId < 230) {
     return COLORS.department.centcom;
   }
-  if (jobId == 999) { // Yogs Start: Assistants need the new color too
+  if (jobId === 999) { // Yogs Start: Assistants need the new color too
     return COLORS.department.civilian;
   } // Yogs End
   return COLORS.department.other;

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -33,9 +33,15 @@ const jobToColor = jobId => {
   if (jobId >= 50 && jobId < 60) {
     return COLORS.department.cargo;
   }
+  if (jobId >= 60 && jobId < 80) { // Yogs: Extended this to 80 as we have more than 9 civilian jobs
+    return COLORS.department.civilian; // Yogs: Also added a new civilian color
+  }
   if (jobId >= 200 && jobId < 230) {
     return COLORS.department.centcom;
   }
+  if (jobId == 999) { // Yogs Start: Assistants need the new color too
+    return COLORS.department.civilian;
+  } // Yogs End
   return COLORS.department.other;
 };
 
@@ -70,26 +76,6 @@ export const CrewConsole = (props, context) => {
       resizable>
       <Window.Content scrollable>
         <Flex>
-          <Flex.Item>
-            <Section>
-              {data.z === 2 && (
-                <div className="map">
-                  {data["sensors"].map(sensor => (
-                    sensor.pos_x && (
-                      <div className="blip" style={
-                        `left:${
-                          (sensor.pos_x-data.minx)*(600/(data.maxx-data.minx))}px;
-                    top:${
-                      (data.maxy-sensor.pos_y)*(600/(data.maxx-data.minx))}px`
-                      } />
-                    )
-                  ))}
-                  <img src={data.map_filename} width="600px"
-                    style={`-ms-interpolation-mode: nearest-neighbor`} />
-                </div>
-              )}
-            </Section>
-          </Flex.Item>
           <Flex.Item>
             <Section minHeight={90}>
               <Table>


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Added IDs for job that didn't have them (Paramedic, Psychiatrist, Mining Medic, Signal Technician, Clerk, Tourist, an Artist), now they will appear in the right place and have the correct color. Additionally, I removed the map from the interface and added a new civilian color that civilians use in the crew console (#535353).

### Why is this change good for the game?

The missing job IDs are a mistake I assume and it causes the layout to look wrong. The map serves little purpose and I've that seen some people dislike it. The new color is just to help the list easier to comprehend at a glance.

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
This will be the basis of the Wiki entry for your PR, and more information / detail is better for Wiki editors to integrate.

Fixed and tweaked some stuff with the crew console interface

### What should players be aware of when it comes to the changes your PR is implementing?
The crew console looks better I guess
### What general grouping does this PR fall under? 
TGUI fixes
### Are there any aspects of the PR that you would like us not to mention on the Wiki?
How long it took me to find where ijob was stored
### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
Nope

# Changelog

:cl:  
bugfix: fixed some jobs missing IDs in the crew console
tweak: Removed the map an gave civilians their own color on the crew console 
/:cl:
