### PR TITLE
Gives Oldstation Ruin Atmospherics area gravity

### DIFF
--- a/code/game/area/areas/ruins/space.dm
+++ b/code/game/area/areas/ruins/space.dm
@@ -247,7 +247,6 @@
 /area/ruin/space/has_grav/ancientstation/atmo
 	name = "Beta Station Atmospherics"
 	icon_state = "red"
-	has_gravity = FALSE
 
 /area/ruin/space/has_grav/ancientstation/betanorth
 	name = "Beta Station North Corridor"


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Why doesn't this have gravity? It's still attached to the station, barely bit into, and without an actual gravity generator on the station it will never have gravity even if you restore the entire station. It should just have gravity. also it's literally called /area/ruin/space/**has_grav**/ancientstation/atmo

could you please put "Fixes #11560" in the body thanks


### Why is this change good for the game?

m*ppers

# Wiki Documentation

there is none

# Changelog

:cl:  
bugfix: gives oldstation atmos gravity
/:cl:
