### PR TITLE
Fixes felinid tabling

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -92,8 +92,8 @@
 	timeout = 1200
 
 /datum/mood_event/table/add_effects()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/H = owner
+	if(ishuman(owner.parent))
+		var/mob/living/carbon/human/H = owner.parent
 		if(iscatperson(H))
 			H.dna.species.start_wagging_tail(H)
 			addtimer(CALLBACK(H.dna.species, /datum/species.proc/stop_wagging_tail, H), 30)

--- a/code/datums/mood_events/mood_event.dm
+++ b/code/datums/mood_events/mood_event.dm
@@ -6,7 +6,7 @@
 	var/category //string of what category this mood was added in as
 	var/special_screen_obj //if it isn't null, it will replace or add onto the mood icon with this (same file). see happiness drug for example
 	var/special_screen_replace = TRUE //if false, it will be an overlay instead
-	var/mob/owner
+	var/datum/component/mood/owner
 
 /datum/mood_event/New(mob/M, param)
 	owner = M


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

fixes a bug where felinid tabling mood event doesn't work correctly because tg coders are FUCKING STUPID. WHY IN THE HELL IS THE OWNER VAR'S TYPE MOB IF IT GETS SET TO A MOOD COMPONENT DATUM

### Why is this change good for the game?

shitty tg code = bad. Also no bugs = good

# Changelog

:cl:  
fix: Felinid tabling now works properly
/:cl:
