### PR TITLE
Enables aggressive changelog

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -278,7 +278,7 @@ NOTIFY_NEW_PLAYER_ACCOUNT_AGE 1
 #PANIC_SERVER_NAME [Put the name here]
 
 ## Uncomment to have the changelog file automatically open when a user connects and hasn't seen the latest changelog
-#AGGRESSIVE_CHANGELOG
+AGGRESSIVE_CHANGELOG
 
 ## Comment this out if you've used the mass conversion sql proc for notes or want to stop converting notes
 AUTOCONVERT_NOTES


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Enables aggressive changelog so it always pops up when you join and anything has changed

### Why is this change good for the game?

With a game that is under such active development it's good if the players stay updated on what changes instead of bothering the poor mentors or not knowing anything changed at all. If you don't want to read it, just close the window, it's not that hard.

# Wiki Documentation

does not apply

# Changelog


:cl:  
tweak: Enables aggressive changelog
/:cl:
