### PR TITLE
Enables map rotation

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -302,7 +302,7 @@ PREFERENCE_MAP_VOTING 1
 ## This is the chance of map rotation factored to the round length.
 ## A value of 1 would mean the map rotation chance is the round length in minutes (hour long round == 60% rotation chance)
 ## A value of 0.5 would mean the map rotation chance is half of the round length in minutes (hour long round == 30% rotation chance)
-MAPROTATIONCHANCEDELTA 0.5
+MAPROTATIONCHANCEDELTA 1
 
 ## AUTOADMIN
 ## The default admin rank

--- a/config/config.txt
+++ b/config/config.txt
@@ -302,7 +302,7 @@ PREFERENCE_MAP_VOTING 1
 ## This is the chance of map rotation factored to the round length.
 ## A value of 1 would mean the map rotation chance is the round length in minutes (hour long round == 60% rotation chance)
 ## A value of 0.5 would mean the map rotation chance is half of the round length in minutes (hour long round == 30% rotation chance)
-MAPROTATIONCHANCEDELTA 0
+MAPROTATIONCHANCEDELTA 0.5
 
 ## AUTOADMIN
 ## The default admin rank


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request
Enables map rotation, how it works is explained below:
![image](https://user-images.githubusercontent.com/48154165/121805745-bd461680-cc4c-11eb-915b-27a40fec5766.png)
then it rolls a random map that fulfills the pop reqs.

### Why is this change good for the game?
Enables some map variation, if someone really really doesn't want it, they can always do a map vote to change it back to box.
So I wouldn't say this is forcing anything

# Wiki Documentation
does not apply, config change

# Changelog
:cl:  
tweak: enables map rotation
/:cl:
