### PR TITLE
Remove debug hardsuit slowdown

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -1118,4 +1118,4 @@
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	resistance_flags = FIRE_PROOF | ACID_PROOF
-	slowdown = -1
+	slowdown = 0

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -1118,3 +1118,4 @@
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	resistance_flags = FIRE_PROOF | ACID_PROOF
+	slowdown = -1


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Removes the slowdown from the debug hardsuit

### Why is this change good for the game?

The debug hardsuit has the same slowdown as the regular space suit, which is annoying when testing. This removes that

# Changelog

:cl:   
tweak: Removes the slowdown from the debug suit
/:cl:
