### PR TITLE
Enable support for 514.1556

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -58,17 +58,9 @@
 
 #define EXTOOLS (world.system_type == MS_WINDOWS ? "byond-extools.dll" : "libbyond-extools.so")
 
-#if (DM_VERSION == 513) && (DM_BUILD == 1537)
-#error ============WARNING===============
-#error BYOND version 513.1537 contains a bug that prevents the codebase from compiling properly. Please upgrade/downgrade your BYOND version
-#error BYOND version 513.1537 contains a bug that prevents the codebase from compiling properly. Please upgrade/downgrade your BYOND version
-#error BYOND version 513.1537 contains a bug that prevents the codebase from compiling properly. Please upgrade/downgrade your BYOND version
-#error ==================================
-#endif
-
 //If you update these values, update the message in the #error
 #define MAX_BYOND_MAJOR 514
-#define MAX_BYOND_MINOR 1554
+#define MAX_BYOND_MINOR 1556
 
 ///Uncomment to bypass the max version check. Note: This will likely break the game, only use if you know what you're doing
 //#define IGNORE_MAX_BYOND_VERSION


### PR DESCRIPTION
No major known issues with the new build. Also removed the 513.1537 check as 514 is the minimum version now
