### PR TITLE
Starts the deprecation cycle for omegastation in favour of kilostation

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -19,7 +19,6 @@ endmap
 
 map omegastation
 	maxplayers 35
-	votable
 endmap
 
 map yogsmeta


### PR DESCRIPTION
It makes absolutely no sense to maintain a shitton of maps because we can barely maintain our current set. Also the bounty clearly said
![img](https://i.imgur.com/iQgo6EQ.png)
Not "Add kilo alongside omega"

Omega should later be completly disabled and then finally removed from the codebase

:cl:  
rscdel: Omegastation has been removed from rotation
/:cl:
