### PR TITLE
adds energy cutlass to lavaland pirate ruin

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_chemistry.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_chemistry.dmm
@@ -112,6 +112,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
+"s" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/item/melee/transforming/energy/sword/pirate,
+/turf/open/floor/plasteel/white,
+/area/ruin/powered)
 "t" = (
 /turf/open/floor/plating/lavaland_baseturf,
 /area/lavaland/surface/outdoors)
@@ -566,7 +579,7 @@ k
 B
 G
 p
-J
+s
 A
 a
 a


### PR DESCRIPTION
when the pr that made pirates drop normal cutlasses and not drop energy gun unintentionally messed up this ruin loot so this brings it to slightly worse then it used to be loot wise 
:cl:  
rscadd: Added cutlass 
/:cl:
