### PR TITLE
adds regen slime pens to lavaland chemistry ruin

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_chemistry.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_chemistry.dmm
@@ -112,6 +112,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
+"s" = (
+/obj/structure/table,
+/obj/item/stack/sheet/mineral/silver,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/item/reagent_containers/hypospray/medipen/regenslime,
+/obj/item/reagent_containers/hypospray/medipen/regenslime,
+/turf/open/floor/plasteel/white,
+/area/ruin/powered)
 "t" = (
 /turf/open/floor/plating/lavaland_baseturf,
 /area/lavaland/surface/outdoors)
@@ -221,19 +236,6 @@
 /mob/living/simple_animal/hostile/pirate/ranged,
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
-"G" = (
-/obj/structure/table,
-/obj/item/stack/sheet/mineral/silver,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4;
-	icon_state = "tile_corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8;
-	icon_state = "tile_corner"
-	},
-/turf/open/floor/plasteel/white,
-/area/ruin/powered)
 "H" = (
 /obj/effect/mob_spawn/human/corpse/damaged,
 /obj/effect/turf_decal/tile/blue{
@@ -268,6 +270,7 @@
 	dir = 8;
 	icon_state = "tile_corner"
 	},
+/obj/item/reagent_containers/hypospray/medipen/regenslime,
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "K" = (
@@ -564,7 +567,7 @@ a
 A
 k
 B
-G
+s
 p
 J
 A

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -163,6 +163,11 @@
 	desc = "A rapid way to get you out of a tight situation and fast! You'll feel rather drowsy, though."
 	list_reagents = list(/datum/reagent/medicine/morphine = 10)
 
+/obj/item/reagent_containers/hypospray/medipen/regenslime
+	name = "regenerative jelly medipen"
+	desc = "A medipen filled with a experimental healing jelly"
+	list_reagents = list(/datum/reagent/medicine/regen_jelly = 10)
+
 /obj/item/reagent_containers/hypospray/medipen/tuberculosiscure
 	name = "BVAK autoinjector"
 	desc = "Bio Virus Antidote Kit autoinjector. Has a two use system for yourself, and someone else. Inject when infected."


### PR DESCRIPTION
thanks to mqiib for the idea
gives the ruin some much needed loot
changelog:
added slime pen
reason for adding it
i want more lavaland loot and variety
:cl:  
rscadd: Added regen slime medipens to lavaland chemistry ruin
/:cl:
