### PR TITLE
Fixes Cloning Error Message Issues (Mainly Lacking Biomass)

### DIFF
--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -492,6 +492,7 @@
 				playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
 			else
 				var/result = grow_clone_from_record(pod, C, empty)
+				temp = "[C.fields["name"]] => <font class='bad'>Initialisation failure.</font>"
 				if(result & CLONING_SUCCESS)
 					temp = "[C.fields["name"]] => <font class='good'>Cloning cycle in progress...</font>"
 					playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
@@ -508,10 +509,6 @@
 						active_record = null
 					menu = 1
 					records -= C
-
-			if(!success)
-				temp = "[C.fields["name"]] => <font class='bad'>Initialisation failure.</font>"
-				playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
 
 		else
 			temp = "<font class='bad'>Data corruption.</font>"

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -505,6 +505,7 @@
 					else
 						log_cloning("[key_name(usr)] initiated EMPTY cloning of [key_name(C.fields["mindref"])] via [src] at [AREACOORD(src)]. Pod: [pod] at [AREACOORD(pod)].")
 				if(result &	CLONING_DELETE_RECORD)
+					temp = "[C.fields["name"]] => <font class='bad'>Record deleted.</font>"
 					if(active_record == C)
 						active_record = null
 					menu = 1


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Fixes multiple issues with how if cloning fails sometimes it automatically spit out initialization error, I have tested this and confirmed it does indeed work.

### Why is this change good for the game?
Stops people from being round ended for cloner not having enough biomass. It also fixes some other error messages
### Briefly describe your PR and the impacts of it, in layman's terms. 
Makes the cloner spit out proper error messages when cloning
### What should players be aware of when it comes to the changes your PR is implementing?
This lets newer, and returning medical players have a better time understanding what the issue is while cloning
### What general grouping does this PR fall under? 
Bugfix

# Changelog
:cl:  
bugfix: fixed a few things  
/:cl:
