### PR TITLE
Revert "Anvil's PR template changes n stuff"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,32 +1,29 @@
-#### Read our contributing.md if you haven't already: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
-
-# General Documentation
+########################################
+########################################
+# If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! This will ensure your PR is up to standards and get it merged more quickly! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
+########################################
+########################################
 
 ### Intent of your Pull Request
 
-Explain what the purpose of your PR is. Mention if you tested your changes. If you changed a map, make sure you used the mapmerge tool. Mention if your PR is related to an issue.
-You can type "Fixes issue #6" and issue 6 will be automatically closed when your pull request is merged.
+Explain what the purpose of your PR is.
+Mention if you tested your changes. If you changed a map, make sure you used the mapmerge tool.
 
-### Why is this change good for the game?
+Mention if your PR is related to an issue.
+You can type "Fixes issue #6" and issue 6 will be automatically closed when your pull request is merged. This is much easier for everyone.
 
-# Wiki Documentation
+Edit the changelog at the bottom for changes that are noticeable by the players. Remove it if this isn't the case.
+If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.
+Prefix the PR title with [admin] if it's something admin related.
+Prefix the PR title with [s] if you are fixing an exploit so it is not announced on discord and the server.
 
-### Briefly describe your PR and the impacts of it, in layman's terms. 
-This will be the basis of the Wiki entry for your PR, and more information / detail is better for Wiki editors to integrate.
+### Why is this good for the game?
 
-### What should players be aware of when it comes to the changes your PR is implementing?
+Explain why each change in your pr is beneficial to the server.
+This is less necessary for bugfixes and such, but it is always welcome.
+Remember: something that is self evident to you might not be to others. Explain your rationale, even if you feel it goes without saying.
 
-### What general grouping does this PR fall under? 
-For example, Engineering changes, Medical rebalancing, TEG tweaks, etc.?
-
-### Are there any aspects of the PR that you would like us not to mention on the Wiki?
-
-### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
-For example, "This new chem will heal X brute damage". 
-
-# Changelog
-
-Edit this changelog for changes that are noticeable by the players. Remove it if this isn't the case. If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. Prefix the PR title with [admin] if it's something admin related. Prefix the PR title with [s] if you are fixing an exploit so it is not announced on discord and the server.
+#### Changelog
 
 :cl:  
 rscadd: Added new things  


### PR DESCRIPTION
Reverts yogstation13/Yogstation#10704

**Why:**
The PR template is an ugly blob of text split up into way too many categories because of this change.

Adding this huge blob of text split up into 20 categories isn't the right way to go with presenting a PR in my opinion so it makes PR's harder to read and understand.

I've seen people not even fill out the template but leave the extra garbage anyway which makes it exhausting to read if you expect useful information in the PR description.