### PR TITLE
You no longer need to steal an entire paper bin to make paper frames.

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -445,7 +445,7 @@
 	name = "Paper Frames"
 	result = /obj/item/stack/sheet/paperframes/five
 	time = 1 SECONDS
-	reqs = list(/obj/item/stack/sheet/mineral/wood = 5, /obj/item/paper = 20)
+	reqs = list(/obj/item/stack/sheet/mineral/wood = 5, /obj/item/paper = 5)
 	category = CAT_MISC
 
 /datum/crafting_recipe/naturalpaper


### PR DESCRIPTION

# General Documentation
The Player wants to use paper frames to make something. The Player now needs to run around the station and slowly dump paper bins empty to get a small number of paper frames. This is cringe because emptying paper bins is slow as fuck.
### Intent of your Pull Request

i fucking hate this template. look at all the stuff I need to fill out to say "paper frames now take 5 paper instead of 20"

### Why is this change good for the game?
Paper frames look pretty cool. It's a shame you need to sit there clicking a paper bin 20 times to make...5 paper frames? Enough for 2 entire tiles! Hope you brought a lot of paper bins.
# Wiki Documentation
Paper frames aren't documented
### Briefly describe your PR and the impacts of it, in layman's terms. 
Player's can make paper frames with less paper, so you don't have to click a paper bin 20 times. Slowly. Because there's a cooldown on removing paper from a paper bin. 

### What should players be aware of when it comes to the changes your PR is implementing?
Crafting paper frames takes less paper
### What general grouping does this PR fall under? 
Tweaks

### Are there any aspects of the PR that you would like us not to mention on the Wiki?
yeah don't mention im making myself host
### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
20 paper to 5 paper in recipe

# Changelog

:cl:  
tweak: Paper frame recipe tweaked to require 5 paper instead of 20. Rejoice, as no you longer need to click a paper bin 20 times for 5 frames!
/:cl:
