### PR TITLE
Instead of doubling the chance of the gravity event happening every time its triggered, it only doubles it if the gravity generator is active when the event ends

### DIFF
--- a/yogstation/code/modules/events/weightless.dm
+++ b/yogstation/code/modules/events/weightless.dm
@@ -19,8 +19,8 @@
 	for(var/obj/machinery/gravity_generator/main/station/A in GLOB.machines)
 		if(A)
 			A.set_state(0)
-	if(control)
-		control.weight *= 2
+			if(control && A.on)
+				control.weight *= 2		
 
 /datum/round_event/weightless/end()
 	for(var/obj/machinery/gravity_generator/main/station/A in GLOB.machines)

--- a/yogstation/code/modules/events/weightless.dm
+++ b/yogstation/code/modules/events/weightless.dm
@@ -19,12 +19,12 @@
 	for(var/obj/machinery/gravity_generator/main/station/A in GLOB.machines)
 		if(A)
 			A.set_state(0)
-			if(control && A.on)
-				control.weight *= 2		
 
 /datum/round_event/weightless/end()
 	for(var/obj/machinery/gravity_generator/main/station/A in GLOB.machines)
 		if(A)
 			A.set_state(1)
+			if(control && A.on)
+				control.weight *= 2		
 	if(announceWhen >= 0)
 		priority_announce("Artificial gravity arrays are now functioning within normal parameters. Please report any irregularities to your respective head of staff.")


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Discourages rebooting the gravity generator, bypassing the event completly

### Why is this change good for the game?

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
Instead of doubling the chance of the gravity event happening every time its triggered, it only doubles it if the gravity generator is active when the event ends

### What should players be aware of when it comes to the changes your PR is implementing?
Instead of doubling the chance of the gravity event happening every time its triggered, it only doubles it if the gravity generator is active when the event ends

### What general grouping does this PR fall under? 
Events

### Are there any aspects of the PR that you would like us not to mention on the Wiki?
No

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
For example, "This new chem will heal X brute damage". 
Doubling = original value * 2
Alternatively if youre feeling spicy, you can do original value / 0.5

# Changelog
:cl:  
tweak: Instead of doubling the chance of the gravity event happening every time its triggered, it only doubles it if the gravity generator is active when the event ends
/:cl:
