### PR TITLE
Made the devil contract not have a cooldown if you target a catatonic

### DIFF
--- a/code/modules/spells/spell_types/devil.dm
+++ b/code/modules/spells/spell_types/devil.dm
@@ -71,7 +71,9 @@
 				C.put_in_hands(contract)
 		else
 			to_chat(user, "<span class='notice'>[C] seems to not be sentient.  You cannot summon a contract for [C.p_them()].</span>")
-
+			action.UpdateButtonIcon()
+			charge_counter = charge_max
+			recharging = FALSE
 
 /obj/effect/proc_holder/spell/aimed/fireball/hellish
 	name = "Hellfire"


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request
Currently if a devil offers a contract to a devil, they must wait out the cooldown.

### Why is this change good for the game?
If a devil clicks the wrong person to give a contract to, they can try again immediately 

fixes #4642 

# Changelog
:cl:  
tweak: devil contract no long needs a cooldown 
/:cl:
