### PR TITLE
Fixed ghosts always hearing imaginary friends

### DIFF
--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -171,9 +171,11 @@
 		MA.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
 		INVOKE_ASYNC(GLOBAL_PROC, /proc/flick_overlay, MA, list(owner.client), 30)
 
-	for(var/mob/M in GLOB.dead_mob_list)
-		var/link = FOLLOW_LINK(M, owner)
-		to_chat(M, "[link] [dead_rendered]")
+	for(var/mob/dead/observer/M in GLOB.dead_mob_list)
+		if(M.client)
+			if(M.client.prefs.chat_toggles & CHAT_GHOSTEARS)
+				var/link = FOLLOW_LINK(M, owner)
+				to_chat(M, "[link] [dead_rendered]")
 
 /mob/camera/imaginary_friend/Move(NewLoc, Dir = 0)
 	if(world.time < move_delay)


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request
Ghosts can hear imaginary friends regardless of preferences, this fixes that

### Why is this change good for the game?
Preferences should work

# Changelog
Fixes #5138 

:cl:  
bugfix: Made imaginary friends respect preferences
/:cl:
