### PR TITLE
Wiping down things with a rag will now apply the reagents in the rag to the item

### DIFF
--- a/code/modules/detectivework/footprints_and_rag.dm
+++ b/code/modules/detectivework/footprints_and_rag.dm
@@ -42,3 +42,6 @@
 		if(do_after(user,30, target = A))
 			user.visible_message("[user] finishes wiping off [A]!", "<span class='notice'>You finish wiping off [A].</span>")
 			A.wash(CLEAN_SCRUB)
+			reagents.reaction(A, TOUCH)
+			reagents.clear_reagents()
+


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

When wiping down objects and turfs with a wet rag, the reagents in the rag will be applied to the object or turf.

### Why is this change good for the game?

The rag already causes a person being wiped down to absorb/ingest the reagents, so now it also applies to items.

# Changelog
Fixes #6292

:cl:  
bugfix: Damp rag now applies reagents to objects and turfs
/:cl:
