### PR TITLE
Reinforces walls around hos office

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -13,30 +13,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
-"aac" = (
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	pixel_x = -30
-	},
-/obj/machinery/camera{
-	c_tag = "Brig Control Room";
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/bed/dogbed{
-	desc = "Jacob's bed! Looks comfy";
-	name = "Jacob's bed"
-	},
-/mob/living/simple_animal/pet/dog/pug{
-	desc = "Much better at protecting the armory than your average warden.";
-	name = "Warden Jacob";
-	real_name = "Warden Jacob"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "aad" = (
 /obj/machinery/gulag_processor,
 /turf/open/floor/plasteel,
@@ -103,22 +79,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aan" = (
-/obj/structure/bed/dogbed/ian,
-/obj/structure/sign/painting{
-	persistence_id = "public";
-	pixel_y = 32
-	},
-/obj/item/toy/figure/hop{
-	layer = 2.89;
-	pixel_x = 8;
-	pixel_y = -5
-	},
-/mob/living/simple_animal/pet/dog/corgi/Ian{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
 "aao" = (
 /obj/machinery/light{
 	dir = 4
@@ -147,32 +107,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"aar" = (
-/obj/structure/flora/junglebush,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/item/toy/figure/geneticist,
-/mob/living/carbon/monkey,
-/turf/open/floor/grass,
-/area/medical/genetics)
-"aas" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	department = "Janitorial";
-	departmentType = 1;
-	pixel_y = -32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/lizard{
-	name = "Wags-His-Tail";
-	real_name = "Wags-His-Tail"
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "aat" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -300,22 +234,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
-"aaF" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/item/toy/figure/ce,
-/mob/living/simple_animal/parrot/Poly,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "aaG" = (
 /obj/structure/window/reinforced,
 /obj/structure/chair{
@@ -539,7 +457,7 @@
 /turf/closed/wall,
 /area/security/main)
 "abq" = (
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hos)
 "abr" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -21753,6 +21671,19 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"bnw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "QMLoad2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
 "bnx" = (
 /obj/machinery/door/airlock/research{
 	name = "Genetics Research Access";
@@ -22020,6 +21951,19 @@
 "bou" = (
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
+"bov" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/posialert{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "bow" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Biohazard";
@@ -22114,19 +22058,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"boJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "QMLoad2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/quartermaster/storage)
 "boK" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -22439,12 +22370,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/lab)
-"bps" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "QMLoad2"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "bpz" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -23392,6 +23317,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"bsW" = (
+/obj/machinery/vending/wardrobe/robo_wardrobe,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 30;
+	pixel_y = -9
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "bta" = (
 /obj/machinery/camera{
 	c_tag = "Research Division North"
@@ -27248,6 +27182,25 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"bGQ" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorm3";
+	name = "Dorm 3"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "bGS" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -32687,6 +32640,25 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"cDz" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorm2";
+	name = "Dorm 2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "cDB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32743,6 +32715,30 @@
 "cFl" = (
 /turf/closed/wall,
 /area/maintenance/solars/port/aft)
+"cFx" = (
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 5;
+	pixel_x = -30
+	},
+/obj/machinery/camera{
+	c_tag = "Brig Control Room";
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/bed/dogbed{
+	desc = "Jacob's bed! Looks comfy";
+	name = "Jacob's bed"
+	},
+/mob/living/simple_animal/pet/dog/pug{
+	desc = "Much better at protecting the armory than your average warden.";
+	name = "Warden Jacob";
+	real_name = "Warden Jacob"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "cFH" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -33121,6 +33117,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"cMX" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/toy/figure/ce,
+/mob/living/simple_animal/parrot/Poly,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "cNa" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -33858,10 +33870,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"ddh" = (
-/obj/effect/landmark/stationroom/box/execution,
-/turf/template_noop,
-/area/security/execution/transfer)
 "ddt" = (
 /obj/structure/table,
 /obj/item/clipboard,
@@ -35222,12 +35230,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"eeH" = (
-/obj/machinery/modular_computer/console/preset/curator{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/library)
 "eeI" = (
 /obj/structure/table/wood,
 /obj/item/canvas/twentythreeXnineteen{
@@ -35280,6 +35282,12 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"egk" = (
+/obj/machinery/modular_computer/console/preset/curator{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/library)
 "egr" = (
 /obj/structure/alien/weeds,
 /obj/structure/alien/resin/membrane,
@@ -37385,9 +37393,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"fEb" = (
-/turf/template_noop,
-/area/crew_quarters/dorms)
 "fFo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -38610,6 +38615,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"gCp" = (
+/obj/effect/landmark/stationroom/box/medbay/morgue,
+/turf/template_noop,
+/area/medical/morgue)
 "gCr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38872,11 +38881,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"gML" = (
-/obj/structure/alien/weeds,
-/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
-/turf/open/floor/engine,
-/area/science/xenobiology)
 "gNi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39069,10 +39073,6 @@
 /obj/effect/spawner/lootdrop/gloves,
 /turf/open/floor/plasteel,
 /area/clerk)
-"gUE" = (
-/obj/effect/landmark/stationroom/box/medbay/morgue,
-/turf/template_noop,
-/area/medical/morgue)
 "gUZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -39223,9 +39223,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"hah" = (
-/turf/template_noop,
-/area/medical/morgue)
 "haw" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 4;
@@ -40644,6 +40641,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/storage/tech)
+"ias" = (
+/obj/effect/landmark/stationroom/box/execution,
+/turf/template_noop,
+/area/security/execution/transfer)
 "iay" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -40736,12 +40737,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"idF" = (
-/obj/machinery/camera{
-	c_tag = "Hydroponics North"
-	},
-/turf/template_noop,
-/area/hydroponics)
 "idG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -42784,6 +42779,25 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"jrd" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Janitorial";
+	departmentType = 1;
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/lizard{
+	name = "Wags-His-Tail";
+	real_name = "Wags-His-Tail"
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "jrf" = (
 /obj/machinery/advanced_airlock_controller{
 	pixel_y = 24
@@ -43191,19 +43205,6 @@
 /obj/item/camera,
 /turf/open/floor/wood,
 /area/vacant_room)
-"jDe" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/posialert{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
 "jDm" = (
 /obj/machinery/vending/assist,
 /obj/machinery/airalarm{
@@ -44021,13 +44022,6 @@
 	dir = 4
 	},
 /area/chapel/main)
-"kgK" = (
-/obj/machinery/camera{
-	c_tag = "Hydroponics South";
-	dir = 8
-	},
-/turf/template_noop,
-/area/hydroponics)
 "kgV" = (
 /obj/machinery/camera{
 	c_tag = "Bridge West Entrance";
@@ -44570,6 +44564,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"kBl" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorm4";
+	name = "Dorm 4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "kBu" = (
 /obj/machinery/camera{
 	c_tag = "Gravity Generator";
@@ -45549,10 +45562,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"ljM" = (
-/obj/effect/landmark/stationroom/box/testingsite,
-/turf/open/space/basic,
-/area/space)
 "lkh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -46005,6 +46014,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"lzl" = (
+/obj/machinery/button/door{
+	id = "Dorm3";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 25;
+	specialfunctions = 4
+	},
+/turf/template_noop,
+/area/crew_quarters/dorms)
 "lzr" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -47792,9 +47811,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"mPz" = (
-/turf/template_noop,
-/area/hydroponics)
 "mRf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -48493,6 +48509,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"nia" = (
+/turf/template_noop,
+/area/hydroponics)
 "niv" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 8
@@ -49416,6 +49435,13 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"nPI" = (
+/obj/structure/flora/junglebush,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/item/toy/figure/geneticist,
+/mob/living/carbon/monkey,
+/turf/open/floor/grass,
+/area/medical/genetics)
 "nQh" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
@@ -49427,6 +49453,19 @@
 /obj/effect/landmark/stationroom/maint/tenxten,
 /turf/template_noop,
 /area/maintenance/port/aft)
+"nQl" = (
+/turf/template_noop,
+/area/science/test_area)
+"nQG" = (
+/obj/machinery/button/door{
+	id = "Dorm2";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 25;
+	specialfunctions = 4
+	},
+/turf/template_noop,
+/area/crew_quarters/dorms)
 "nRp" = (
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /obj/effect/turf_decal/trimline/blue,
@@ -50444,6 +50483,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"ouI" = (
+/obj/effect/landmark/stationroom/box/testingsite,
+/turf/open/space/basic,
+/area/space)
 "ouJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -52035,15 +52078,6 @@
 	},
 /turf/open/floor/engine/air,
 /area/engine/atmos_distro)
-"pAG" = (
-/obj/machinery/vending/wardrobe/robo_wardrobe,
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 30;
-	pixel_y = -9
-	},
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
 "pAL" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -52184,9 +52218,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"pFY" = (
-/turf/template_noop,
-/area/security/execution/transfer)
 "pGm" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
@@ -52390,6 +52421,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"pMe" = (
+/obj/machinery/camera{
+	c_tag = "Hydroponics North"
+	},
+/turf/template_noop,
+/area/hydroponics)
 "pMt" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 1;
@@ -52732,11 +52769,24 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"pXx" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "QMLoad2"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "pXS" = (
 /obj/structure/transit_tube/crossing,
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"pXY" = (
+/obj/machinery/camera{
+	c_tag = "Hydroponics South";
+	dir = 8
+	},
+/turf/template_noop,
+/area/hydroponics)
 "pYf" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
@@ -52813,12 +52863,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"qbA" = (
-/obj/machinery/light_switch{
-	pixel_y = -25
-	},
-/turf/template_noop,
-/area/medical/morgue)
 "qbE" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -53466,10 +53510,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/sleeper)
-"qwq" = (
-/obj/effect/landmark/stationroom/box/dorm_edoor,
-/turf/template_noop,
-/area/crew_quarters/dorms)
 "qwE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -53678,6 +53718,22 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"qGm" = (
+/obj/structure/bed/dogbed/ian,
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_y = 32
+	},
+/obj/item/toy/figure/hop{
+	layer = 2.89;
+	pixel_x = 8;
+	pixel_y = -5
+	},
+/mob/living/simple_animal/pet/dog/corgi/Ian{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
 "qGp" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -54636,6 +54692,10 @@
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"rlj" = (
+/obj/effect/landmark/stationroom/box/dorm_edoor,
+/turf/template_noop,
+/area/crew_quarters/dorms)
 "rlB" = (
 /obj/machinery/status_display/evac{
 	layer = 4;
@@ -54686,6 +54746,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"rnS" = (
+/turf/template_noop,
+/area/security/execution/transfer)
 "rnX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -54800,16 +54863,6 @@
 /obj/item/soap/nanotrasen,
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
-"rsr" = (
-/obj/machinery/button/door{
-	id = "Dorm4";
-	name = "Dorm Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
-	},
-/turf/template_noop,
-/area/crew_quarters/dorms)
 "rsV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -55138,14 +55191,6 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"rEL" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/obj/effect/landmark/stationroom/box/hydroponics,
-/turf/template_noop,
-/area/hydroponics)
 "rEY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -55383,25 +55428,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"rOY" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock{
-	id_tag = "Dorm4";
-	name = "Dorm 4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "rPb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -55978,6 +56004,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"shN" = (
+/obj/machinery/requests_console{
+	department = "Hydroponics";
+	departmentType = 2;
+	pixel_y = 30
+	},
+/turf/template_noop,
+/area/hydroponics)
 "sia" = (
 /obj/effect/landmark/stationroom/maint/threexthree,
 /turf/template_noop,
@@ -56706,6 +56740,12 @@
 /obj/effect/turf_decal/trimline/blue,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"sKm" = (
+/obj/machinery/light_switch{
+	pixel_y = -25
+	},
+/turf/template_noop,
+/area/medical/morgue)
 "sKs" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -57731,6 +57771,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"tvb" = (
+/obj/structure/alien/weeds,
+/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "tvA" = (
 /obj/structure/chair{
 	dir = 4
@@ -58802,6 +58847,9 @@
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
+"ujv" = (
+/turf/template_noop,
+/area/crew_quarters/dorms)
 "ujG" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -58840,16 +58888,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"ukR" = (
-/obj/machinery/button/door{
-	id = "Dorm2";
-	name = "Dorm Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
-	},
-/turf/template_noop,
-/area/crew_quarters/dorms)
 "ulD" = (
 /obj/structure/tank_dispenser,
 /obj/effect/turf_decal/bot{
@@ -60915,25 +60953,6 @@
 /obj/machinery/power/tracker,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/fore)
-"vFZ" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock{
-	id_tag = "Dorm2";
-	name = "Dorm 2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "vGx" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -61035,16 +61054,6 @@
 /obj/effect/landmark/stationroom/maint/threexthree,
 /turf/template_noop,
 /area/maintenance/port/aft)
-"vJz" = (
-/obj/machinery/button/door{
-	id = "Dorm3";
-	name = "Dorm Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
-	},
-/turf/template_noop,
-/area/crew_quarters/dorms)
 "vJO" = (
 /obj/structure/table/reinforced,
 /obj/item/aiModule/core/full/custom,
@@ -61676,6 +61685,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"wec" = (
+/turf/template_noop,
+/area/medical/morgue)
 "wex" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -62293,9 +62305,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"wzi" = (
-/turf/template_noop,
-/area/science/test_area)
 "wzt" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -62350,6 +62359,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"wBr" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/obj/effect/landmark/stationroom/box/hydroponics,
+/turf/template_noop,
+/area/hydroponics)
 "wBx" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
@@ -62406,25 +62423,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"wDq" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock{
-	id_tag = "Dorm3";
-	name = "Dorm 3"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "wDB" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -62653,14 +62651,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"wLm" = (
-/obj/machinery/requests_console{
-	department = "Hydroponics";
-	departmentType = 2;
-	pixel_y = 30
-	},
-/turf/template_noop,
-/area/hydroponics)
 "wLC" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -63894,6 +63884,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"xKy" = (
+/obj/machinery/button/door{
+	id = "Dorm4";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 25;
+	specialfunctions = 4
+	},
+/turf/template_noop,
+/area/crew_quarters/dorms)
 "xKE" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet,
@@ -84923,8 +84923,8 @@ rOP
 bgT
 aZE
 blY
-boJ
-boJ
+bnw
+bnw
 bql
 rGf
 btr
@@ -85181,7 +85181,7 @@ xND
 aZE
 bkj
 bjr
-bps
+pXx
 bjr
 blT
 bjr
@@ -89486,15 +89486,15 @@ pEf
 pEf
 pEf
 aaa
-pFY
-pFY
-pFY
-pFY
-pFY
-pFY
-pFY
-pFY
-ddh
+rnS
+rnS
+rnS
+rnS
+rnS
+rnS
+rnS
+rnS
+ias
 aaa
 aaa
 aaa
@@ -89743,15 +89743,15 @@ aaa
 gXs
 aaa
 aaa
-pFY
-pFY
-pFY
-pFY
-pFY
-pFY
-pFY
-pFY
-pFY
+rnS
+rnS
+rnS
+rnS
+rnS
+rnS
+rnS
+rnS
+rnS
 aaa
 aaa
 aaa
@@ -90000,15 +90000,15 @@ aSM
 aap
 aai
 afA
-pFY
-pFY
-pFY
-pFY
-pFY
-pFY
-pFY
-pFY
-pFY
+rnS
+rnS
+rnS
+rnS
+rnS
+rnS
+rnS
+rnS
+rnS
 afA
 aaf
 aaa
@@ -90257,15 +90257,15 @@ uNu
 aat
 xrc
 sQI
-pFY
-pFY
-pFY
-pFY
-pFY
-pFY
-pFY
-pFY
-pFY
+rnS
+rnS
+rnS
+rnS
+rnS
+rnS
+rnS
+rnS
+rnS
 afA
 aaf
 aaa
@@ -90514,15 +90514,15 @@ aat
 aat
 olh
 sQI
-pFY
-pFY
-pFY
-pFY
-pFY
-pFY
-pFY
-pFY
-pFY
+rnS
+rnS
+rnS
+rnS
+rnS
+rnS
+rnS
+rnS
+rnS
 afA
 aaf
 aaa
@@ -90771,15 +90771,15 @@ aat
 aat
 ozw
 sQI
-pFY
-pFY
-pFY
-pFY
-pFY
-pFY
-pFY
-pFY
-pFY
+rnS
+rnS
+rnS
+rnS
+rnS
+rnS
+rnS
+rnS
+rnS
 afA
 aaf
 aaa
@@ -93404,7 +93404,7 @@ bjE
 knP
 bbX
 bmo
-aan
+qGm
 bpb
 bqz
 blt
@@ -94891,7 +94891,7 @@ aEq
 aEw
 oJs
 aHt
-aac
+cFx
 agQ
 ahv
 ahQ
@@ -96502,7 +96502,7 @@ bBt
 bCv
 dNs
 mKr
-aas
+jrd
 bCv
 bBR
 eEO
@@ -96708,14 +96708,14 @@ ajb
 bNR
 gDj
 arf
-fEb
-qwq
+ujv
+rlj
 arf
-fEb
-qwq
+ujv
+rlj
 arf
-fEb
-qwq
+ujv
+rlj
 arf
 rcJ
 eTl
@@ -96783,7 +96783,7 @@ alp
 amX
 aiv
 bZD
-aaF
+cMX
 ccj
 cdm
 bCR
@@ -96965,14 +96965,14 @@ aoz
 bNR
 gDj
 arf
-fEb
-fEb
+ujv
+ujv
 arf
-fEb
-fEb
+ujv
+ujv
 arf
-fEb
-fEb
+ujv
+ujv
 arf
 nWl
 fNs
@@ -97222,14 +97222,14 @@ iiN
 bNR
 gDj
 arf
-rsr
-fEb
+xKy
+ujv
 arf
-vJz
-fEb
+lzl
+ujv
 arf
-ukR
-fEb
+nQG
+ujv
 arf
 pEh
 dUv
@@ -97480,13 +97480,13 @@ bNR
 gDj
 arf
 arf
-rOY
+kBl
 arf
 arf
-wDq
+bGQ
 arf
 arf
-vFZ
+cDz
 arf
 iwi
 osc
@@ -106249,11 +106249,11 @@ oXu
 oXu
 oXu
 bfL
-hah
-hah
-hah
-hah
-gUE
+wec
+wec
+wec
+wec
+gCp
 bfL
 tlm
 bJa
@@ -106492,25 +106492,25 @@ aIp
 aKH
 iiE
 aIp
-mPz
-mPz
-mPz
-mPz
-mPz
-mPz
-mPz
-mPz
-rEL
+nia
+nia
+nia
+nia
+nia
+nia
+nia
+nia
+wBr
 bam
 aYV
 aYV
 mWK
 bfL
-hah
-hah
-hah
-hah
-hah
+wec
+wec
+wec
+wec
+wec
 tEa
 pwz
 rPb
@@ -106749,25 +106749,25 @@ aJB
 aKD
 aTC
 aIp
-wLm
-mPz
-mPz
-mPz
-mPz
-mPz
-mPz
-mPz
-mPz
+shN
+nia
+nia
+nia
+nia
+nia
+nia
+nia
+nia
 bbB
 aYV
 aYV
 jTR
 bfL
-hah
-hah
-hah
-hah
-qbA
+wec
+wec
+wec
+wec
+sKm
 bfL
 czn
 tIW
@@ -107006,25 +107006,25 @@ aIp
 skk
 aUh
 aIp
-mPz
-mPz
-mPz
-mPz
-mPz
-mPz
-mPz
-mPz
-mPz
+nia
+nia
+nia
+nia
+nia
+nia
+nia
+nia
+nia
 bbB
 aYV
 aYV
 jTR
 gHo
-hah
-hah
-hah
-hah
-hah
+wec
+wec
+wec
+wec
+wec
 bfL
 ipN
 bon
@@ -107263,29 +107263,29 @@ aIp
 aKI
 aUn
 aIp
-idF
-mPz
-mPz
-mPz
-mPz
-mPz
-mPz
-mPz
+pMe
+nia
+nia
+nia
+nia
+nia
+nia
+nia
 cBg
 bam
 aYV
 aYV
 jTR
 bfL
-hah
-hah
-hah
-hah
-hah
+wec
+wec
+wec
+wec
+wec
 bfL
 cDK
 bon
-aar
+nPI
 sMx
 auz
 hZk
@@ -107520,25 +107520,25 @@ aIp
 lZq
 aOo
 aIp
-mPz
-mPz
-mPz
-mPz
-mPz
-mPz
-mPz
-mPz
+nia
+nia
+nia
+nia
+nia
+nia
+nia
+nia
 bam
 aYV
 aYV
 aYV
 fDx
 bfL
-hah
-hah
-hah
-hah
-hah
+wec
+wec
+wec
+wec
+wec
 bfL
 cDK
 bon
@@ -107777,14 +107777,14 @@ aIp
 aKL
 aUh
 aNQ
-mPz
-mPz
-mPz
-mPz
-mPz
-mPz
-mPz
-mPz
+nia
+nia
+nia
+nia
+nia
+nia
+nia
+nia
 ban
 aYV
 aYV
@@ -108034,14 +108034,14 @@ aJO
 aRJ
 aUS
 aNN
-mPz
-mPz
-mPz
-mPz
-mPz
-mPz
-mPz
-mPz
+nia
+nia
+nia
+nia
+nia
+nia
+nia
+nia
 bap
 aYV
 aYV
@@ -108291,14 +108291,14 @@ mDD
 aLd
 aMN
 aNQ
-mPz
-mPz
-mPz
-mPz
-mPz
-mPz
-mPz
-kgK
+nia
+nia
+nia
+nia
+nia
+nia
+nia
+pXY
 bam
 bfO
 aYV
@@ -110378,7 +110378,7 @@ bKS
 bAC
 bBW
 bDb
-gML
+tvb
 egr
 bEm
 bDb
@@ -111379,7 +111379,7 @@ aPg
 aQr
 aFu
 aTb
-eeH
+egk
 pfS
 aYW
 aYW
@@ -111908,10 +111908,10 @@ fGE
 taB
 uDm
 idl
-jDe
+bov
 bpU
 brq
-pAG
+bsW
 wci
 bgp
 bxe
@@ -124003,12 +124003,12 @@ aaa
 aaa
 gXs
 gXs
-wzi
-wzi
-wzi
+nQl
+nQl
+nQl
 gXs
 gXs
-ljM
+ouI
 aaa
 aaa
 aaa
@@ -124259,11 +124259,11 @@ aaa
 aaa
 gXs
 gXs
-wzi
-wzi
-wzi
-wzi
-wzi
+nQl
+nQl
+nQl
+nQl
+nQl
 gXs
 gXs
 aaa
@@ -124515,13 +124515,13 @@ aaa
 aaa
 aaf
 gXs
-wzi
-wzi
-wzi
-wzi
-wzi
-wzi
-wzi
+nQl
+nQl
+nQl
+nQl
+nQl
+nQl
+nQl
 gXs
 aaf
 aaa
@@ -124771,15 +124771,15 @@ aaa
 aaa
 aaa
 aaf
-wzi
-wzi
-wzi
-wzi
-wzi
-wzi
-wzi
-wzi
-wzi
+nQl
+nQl
+nQl
+nQl
+nQl
+nQl
+nQl
+nQl
+nQl
 aaf
 aaa
 aaa
@@ -125028,15 +125028,15 @@ aaa
 aaf
 aaf
 aaf
-wzi
-wzi
-wzi
-wzi
-wzi
-wzi
-wzi
-wzi
-wzi
+nQl
+nQl
+nQl
+nQl
+nQl
+nQl
+nQl
+nQl
+nQl
 aaf
 aaf
 aaf
@@ -125285,15 +125285,15 @@ aaa
 aaa
 aaa
 aaf
-wzi
-wzi
-wzi
-wzi
-wzi
-wzi
-wzi
-wzi
-wzi
+nQl
+nQl
+nQl
+nQl
+nQl
+nQl
+nQl
+nQl
+nQl
 aaf
 aaa
 aaa
@@ -125543,13 +125543,13 @@ aaa
 aaa
 aaf
 gXs
-wzi
-wzi
-wzi
-wzi
-wzi
-wzi
-wzi
+nQl
+nQl
+nQl
+nQl
+nQl
+nQl
+nQl
 gXs
 aaf
 aaa
@@ -125801,11 +125801,11 @@ aaa
 aaa
 gXs
 gXs
-wzi
-wzi
-wzi
-wzi
-wzi
+nQl
+nQl
+nQl
+nQl
+nQl
 gXs
 gXs
 aaa
@@ -126059,9 +126059,9 @@ aaa
 aaa
 gXs
 gXs
-wzi
-wzi
-wzi
+nQl
+nQl
+nQl
 gXs
 gXs
 aaa


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

every other head of staff office has rwalls except the hos office like why it is DIRECTLY next to space ?????

### Why is this change good for the game?
reinforcing thing that should be reinforced


# Changelog

:cl:  
tweak: walls around hos office are now reinforced
/:cl:
