### PR TITLE
Fried non food will no longer generate the item as trash

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_bread.dm
+++ b/code/modules/food_and_drinks/food/snacks_bread.dm
@@ -268,6 +268,10 @@
 		QDEL_NULL(trash)
 	..()
 
+/obj/item/reagent_containers/food/snacks/deepfryholder/generate_trash(atom/location)
+	if(trash)
+		QDEL_NULL(trash)
+
 /obj/item/reagent_containers/food/snacks/deepfryholder/proc/fry(cook_time = 30)
 	switch(cook_time)
 		if(0 to 15)


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Fixes the bug where when adding fried non-food items to custom food it drops the item that was fried.

### Why is this change good for the game?

Fried foods shouldn't be un-fryable

# Changelog

Fixes #5505 

:cl:  
bugfix: fried foods no longer drop trash
/:cl:
