### PR TITLE
Make unpowered ruins actually not have power

### DIFF
--- a/code/game/area/areas/ruins/_ruins.dm
+++ b/code/game/area/areas/ruins/_ruins.dm
@@ -11,6 +11,9 @@
 
 /area/ruin/unpowered
 	always_unpowered = FALSE
+	power_light = FALSE
+	power_equip = FALSE
+	power_environ = FALSE
 
 /area/ruin/unpowered/no_grav
 	has_gravity = FALSE


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Makes areas that should be unpowered not have power

### Why is this change good for the game?

If its not supposed to have power, it shouldn't have power

# Changelog

Fixes #6757

:cl:  
bugfix: Makes ruins unpowered
/:cl:
