### PR TITLE
Adds Wiki-linked Guide to Medicine book to Medical staff starting first aid kits

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -93,6 +93,7 @@
 		/obj/item/implanter,
 		/obj/item/pinpointer/crew,
 		/obj/item/holosign_creator/medical
+		/obj/item/book/manual/wiki/medicine
 		))
 
 /obj/item/storage/firstaid/medical/PopulateContents()
@@ -107,7 +108,8 @@
 		/obj/item/surgical_drapes = 1,
 		/obj/item/scalpel = 1,
 		/obj/item/hemostat = 1,
-		/obj/item/cautery = 1)
+		/obj/item/cautery = 1,
+		/obj/item/book/manual/wiki/medicine = 1)
 	generate_items_inside(items_inside,src)
 
 /obj/item/storage/firstaid/ancient

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -92,7 +92,7 @@
 		/obj/item/implant,
 		/obj/item/implanter,
 		/obj/item/pinpointer/crew,
-		/obj/item/holosign_creator/medical
+		/obj/item/holosign_creator/medical,
 		/obj/item/book/manual/wiki/medicine
 		))
 


### PR DESCRIPTION
NOTE: this shouldn't be implemented until #11654 is in, as that shrinks the size/weight class of the Wiki-linked books which should help this work. Without it the book will successfully spawn in the kit, but it can't be put back in the kit because it's too large.

# General Documentation

### Intent of your Pull Request

Adds a copy of the Wiki-Linked Guide to Medicine book to Medical staff's starting first aid kit.

### Why is this change good for the game?

Now Medical players (MD + CMO) will have the Wiki in their starting first aid kit, allowing them to crack the guide open and actually try to read and learn about their job. Good for new players starting out, good for veteran players that need a refresher.

# Wiki Documentation

### What should players be aware of when it comes to the changes your PR is implementing?
Behold! A book inside a kit!
First aid kit inventory listing will need updated on the Wiki.

# Changelog

:cl:  
rscadd: Wiki-linked Guide to Medicine book will generate in Medical staff starting First Aid Kits
experimental: System could be expanded to add a Surgery book to the kit as well, if people would like that too.
/:cl:
