### PR TITLE
Allows medical borg to place organs into a smart organ storage

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -238,9 +238,8 @@
 
 		//Adding items from a bag
 		if(istype(O, /obj/item/storage/bag))
-			var/obj/item/storage/P = O
 			var/loaded = 0
-			for(var/obj/G in P.contents)
+			for(var/obj/G in O.contents)
 				if(contents.len >= max_n_of_items)
 					break
 				if(accept_check(G))
@@ -263,6 +262,21 @@
 			else
 				to_chat(user, "<span class='warning'>There is nothing in [O] to put in [src]!</span>")
 				return FALSE
+
+		//Adding items from a borg's organ storage
+		if(istype(O, /obj/item/organ_storage))
+			var/obj/item/organ_storage/OS = O
+			var/obj/organ = O.contents[1]
+			
+			if(accept_check(organ))
+				load(organ)
+				OS.clear_organ()
+				user.visible_message("[user] has added \the [organ] to \the [src].", "<span class='notice'>You add \the [organ] to \the [src].</span>")
+				update_icon()
+				updateUsrDialog()
+				if(contents.len >= max_n_of_items)
+					indicate_full()
+				return TRUE
 
 		if(user.a_intent != INTENT_HARM)
 			to_chat(user, "<span class='warning'>\The [src] smartly refuses [O].</span>")

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -224,6 +224,8 @@
 	. = ..()
 	if(!proximity)
 		return
+	if(istype(I, /obj/machinery/smartfridge))
+		return
 	if(contents.len)
 		to_chat(user, "<span class='notice'>[src] already has something inside it.</span>")
 		return
@@ -250,14 +252,17 @@
 /obj/item/organ_storage/attack_self(mob/user)
 	if(contents.len)
 		var/obj/item/I = contents[1]
+		clear_organ()
 		user.visible_message("[user] dumps [I] from [src].", "<span class='notice'>You dump [I] from [src].</span>")
-		cut_overlays()
 		I.forceMove(get_turf(src))
-		icon_state = "evidenceobj"
-		desc = "A container for holding body parts."
 	else
 		to_chat(user, "[src] is empty.")
 	return
+
+/obj/item/organ_storage/proc/clear_organ()
+	cut_overlays()
+	icon_state = "evidenceobj"
+	desc = "A container for holding body parts."
 
 /obj/item/surgical_processor //allows medical cyborgs to scan and initiate advanced surgeries
 	name = "\improper Surgical Processor"


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Allow medical borgs to place organs into a smart organ storage

### Why is this change good for the game?

Medical borgs can pick up organs, they should be able to place them into a fridge.

# Changelog

Fixes #6686 

:cl:  
bugfix: Medical borgs can place organs into a smart organ storage    
/:cl:
