### PR TITLE
Makes the shuttle catastrophe only happen if the shuttle is on the CC z-level

### DIFF
--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -5,7 +5,7 @@
 	max_occurrences = 1
 
 /datum/round_event_control/shuttle_catastrophe/canSpawnEvent(players, gamemode)
-	if((SSshuttle.emergency.name == "Build Your Own Shuttle") || (SSshuttle.emergency.name == "Build Your Own Shuttle, Jr.") || (SSshuttle.emergency.mode == SHUTTLE_CALL || SSshuttle.emergency.mode == SHUTTLE_RECALL || SSshuttle.emergency.mode == SHUTTLE_DOCKED || SSshuttle.emergency.mode == SHUTTLE_STRANDED))
+	if(SSshuttle.emergency.z != 1 || (SSshuttle.emergency.name == "Build Your Own Shuttle") || (SSshuttle.emergency.name == "Build Your Own Shuttle, Jr.") || (SSshuttle.emergency.mode == SHUTTLE_CALL || SSshuttle.emergency.mode == SHUTTLE_RECALL || SSshuttle.emergency.mode == SHUTTLE_DOCKED || SSshuttle.emergency.mode == SHUTTLE_STRANDED))
 		return FALSE // don't undo manual player engineering, it also would unload people and ghost them, there's just a lot of problems
 	return ..()
 


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Despite all the checks in place, the shuttle catastrophe can still happen with the BYO shuttle. This just puts in a check and won't fire the event unless its on the centcom z-level.

### Why is this change good for the game?

If the shuttle is replaced with people on it they get deleted, this is bad.

# Changelog

:cl:  
bugfix: The shuttle catastrophe can no longer happen when the shuttle is off the CC z-level
/:cl:
