### PR TITLE
Makes borgs able to deconstruct racks and tables

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -179,13 +179,13 @@
 	if(istype(I, /obj/item/rsf)) // Stops RSF from placing itself instead of glasses
 		return
 	if(!(flags_1 & NODECONSTRUCT_1))
-		if(I.tool_behaviour == TOOL_SCREWDRIVER && deconstruction_ready && user.a_intent != INTENT_HELP && user.a_intent != INTENT_HARM)
+		if(I.tool_behaviour == TOOL_SCREWDRIVER && deconstruction_ready && (user.a_intent != INTENT_HELP && user.a_intent != INTENT_HARM || iscyborg(user)))
 			to_chat(user, "<span class='notice'>You start disassembling [src]...</span>")
 			if(I.use_tool(src, user, 20, volume=50))
 				deconstruct(TRUE)
 			return
 
-		if(I.tool_behaviour == TOOL_WRENCH && deconstruction_ready && user.a_intent != INTENT_HELP && user.a_intent != INTENT_HARM)
+		if(I.tool_behaviour == TOOL_WRENCH && deconstruction_ready && (user.a_intent != INTENT_HELP && user.a_intent != INTENT_HARM || iscyborg(user)))
 			to_chat(user, "<span class='notice'>You start deconstructing [src]...</span>")
 			if(I.use_tool(src, user, 40, volume=50))
 				playsound(src.loc, 'sound/items/deconstruct.ogg', 50, 1)
@@ -600,7 +600,7 @@
 		step(O, get_dir(O, src))
 
 /obj/structure/rack/attackby(obj/item/W, mob/user, params)
-	if (W.tool_behaviour == TOOL_WRENCH && !(flags_1&NODECONSTRUCT_1) && user.a_intent != INTENT_HELP && user.a_intent != INTENT_HARM)
+	if (W.tool_behaviour == TOOL_WRENCH && !(flags_1&NODECONSTRUCT_1) && (user.a_intent != INTENT_HELP && user.a_intent != INTENT_HARM || iscyborg(user)))
 		W.play_tool_sound(src)
 		deconstruct(TRUE)
 		return


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Makes it so that borgs can deconstruct racks and tables

### Why is this change good for the game?

Because borgs should be able to deconstruct racks and tables

# Changelog

Fixes #11659 

:cl:  
bugfix: Fixes borgs being unable to deconstruct racks and tables
/:cl:
