### PR TITLE
Makes wikibooks not entirely shit

### DIFF
--- a/code/game/objects/items/manuals.dm
+++ b/code/game/objects/items/manuals.dm
@@ -210,27 +210,27 @@
 	var/wikiurl = CONFIG_GET(string/wikiurl)
 	if(wikiurl)
 		dat = {"
-
-			<html><head>
+			<iframe 
+				id='ext_frame' 
+				src='[wikiurl]/frame.html' 
+				style='border: none; width: 100vw; height: 100vh;'>
+			</iframe>
 			<style>
-				iframe {
-					display: none;
+			html, body { 
+				height: 100vh;
+				width: 100vw; 
+				margin: 0;
+				overflow: hidden;
+			}
+			body > :not(iframe) {
+				display: none;
 				}
 			</style>
-			</head>
-			<body>
-			<script type="text/javascript">
-				function pageloaded(myframe) {
-					document.getElementById("loading").style.display = "none";
-					myframe.style.display = "inline";
-    			}
+			<script>
+				window.onmessage = function() {
+					document.getElementById('ext_frame').contentWindow.postMessage('[page_link]', '*')
+				}
 			</script>
-			<p id='loading'>You start skimming through the manual...</p>
-			<iframe width='100%' height='97%' onload="pageloaded(this)" src="[wikiurl]/[page_link]?printable=yes&remove_links=1" frameborder="0" id="main_frame"></iframe>
-			</body>
-
-			</html>
-
 			"}
 
 /obj/item/book/manual/wiki/chemistry
@@ -238,21 +238,21 @@
 	icon_state ="chemistrybook"
 	author = "Nanotrasen"
 	title = "Chemistry Textbook"
-	page_link = "Guide_to_chemistry"
+	page_link = "Guide_to_Chemistry"
 
 /obj/item/book/manual/wiki/engineering_construction
 	name = "Station Repairs and Construction"
 	icon_state ="bookEngineering"
 	author = "Engineering Encyclopedia"
 	title = "Station Repairs and Construction"
-	page_link = "Guide_to_construction"
+	page_link = "Guide_to_Construction"
 
 /obj/item/book/manual/wiki/engineering_guide
 	name = "Engineering Textbook"
 	icon_state ="bookEngineering2"
 	author = "Engineering Encyclopedia"
 	title = "Engineering Textbook"
-	page_link = "Guide_to_engineering"
+	page_link = "Guide_to_Engineering"
 
 /obj/item/book/manual/wiki/engineering_singulo_tesla
 	name = "Singularity and Tesla for Dummies"
@@ -306,7 +306,7 @@
 	icon_state = "barbook"
 	author = "Sir John Rose"
 	title = "Barman Recipes: Mixing Drinks and Changing Lives"
-	page_link = "Guide_to_drinks"
+	page_link = "Guide_to_Drinks"
 
 /obj/item/book/manual/wiki/hydroponicsguide
 	name = "Botany: An Introduction"
@@ -341,21 +341,21 @@
 	icon_state = "rdbook"
 	author = "Dr. H.P. Kritz"
 	title = "Mentoring your Experiments"
-	page_link = "Experimentor"
+	page_link = "E.X.P.E.R.I-MENTOR"
 
 /obj/item/book/manual/wiki/medical_cloning
 	name = "Cloning techniques of the 26th century"
 	icon_state ="bookCloning"
 	author = "Medical Journal, volume 3"
 	title = "Cloning techniques of the 26th century"
-	page_link = "Guide_to_genetics#Cloning"
+	page_link = "Guide_to_Genetics"
 
 /obj/item/book/manual/wiki/medical_genetics
 	name = "Genetics of the 26th century"
 	icon_state ="bookCloning"
 	author = "Dr. Likes-The-Powers "
 	title = "Genetics of the 26th century"
-	page_link = "Guide_to_genetics"
+	page_link = "Guide_to_Genetics"
 
 /obj/item/book/manual/wiki/cooking_to_serve_man
 	name = "To Serve Man"

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -202,7 +202,7 @@
 	if(!user.can_read(src))
 		return
 	if(dat)
-		user << browse("<HTML><HEAD><meta charset='UTF-8'></HEAD><BODY><TT><I>Penned by [author].</I></TT> <BR>" + "[dat]", "window=book[window_size != null ? ";size=[window_size]" : ""]</BODY></HTML>")
+		user << browse("<HTML><HEAD><meta http-equiv='X-UA-Compatible' content='IE=Edge'/><meta charset='UTF-8'><title>[title]</title></HEAD><BODY><TT><I>Penned by [author].</I></TT> <BR>[dat]</BODY></HTML>", "window=book[window_size != null ? ";size=[window_size]" : ""]")
 		user.visible_message("[user] opens a book titled \"[title]\" and begins reading intently.")
 		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "book_nerd", /datum/mood_event/book_nerd)
 		onclose(user, "book")


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Makes wikibooks not shit by using the mediawiki api instead of using deprecated shit.

The rest of the code is at https://wiki.yogstation.net/frame.html . It has to be there because BYOND is an insecure context and internet explorer will refuse to let BYOND speak to our HTTPS wiki. STONKS.

### Why is this change good for the game?

Because wiki books sucks

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
Rn wikibooks = cringe and never used
After this pr, wikibooks = never used

### What should players be aware of when it comes to the changes your PR is implementing?
That wikibooks are slightly less shit

### What general grouping does this PR fall under? 
Gaming

### Are there any aspects of the PR that you would like us not to mention on the Wiki?
Gaming

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
Gaming x2

# Changelog

:cl:  
tweak: Wikibooks have been improved to suck less
/:cl:


# Note to wiki men
This brings two new css classes to the wiki
game-only : Will not be displayed on the wiki, only in game books
wiki-only: Will be displayed on the wiki, not in in game books, currently used to hide shit in space law so it doesnt look awful in game.

By default, elements are displayed in both the wiki and in the in game books