### PR TITLE
Prevents ghosts from buckling people to borgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1176,7 +1176,7 @@
 
 /mob/living/silicon/robot/MouseDrop_T(mob/living/M, mob/living/user)
 	. = ..()
-	if(!(M in buckled_mobs) && isliving(M))
+	if(!(M in buckled_mobs) && isliving(M) && user && user.can_buckle)
 		buckle_mob(M)
 
 /mob/living/silicon/robot/buckle_mob(mob/living/M, force = FALSE, check_loc = TRUE)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -698,7 +698,7 @@
 
 /mob/MouseDrop_T(atom/dropping, atom/user)
 	. = ..()
-	if(ismob(dropping) && dropping != user)
+	if(ismob(dropping) && dropping != user && user == src)
 		var/mob/M = dropping
 		M.show_inv(user)
 


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request
Prevent ghosts from buckling people to borgs

### Why is this change good for the game?
Ghosts should not be able to buckle people to borgs

# Changelog

Fixes #7244 

:cl:  
bugfix: Fixed ghosts being able to buckle people to borgs
/:cl:
