### PR TITLE
Fixes closing false walls while standing in them

### DIFF
--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -54,13 +54,12 @@
 	toggle(user)
 
 /obj/structure/falsewall/proc/toggle(mob/user)
-	opening = TRUE
-	update_icon()
 	if(!density)
 		var/srcturf = get_turf(src)
 		for(var/mob/living/obstacle in srcturf) //Stop people from using this as a shield
-			opening = FALSE
 			return
+	opening = TRUE
+	update_icon()
 	addtimer(CALLBACK(src, /obj/structure/falsewall/proc/toggle_open), 5)
 
 /obj/structure/falsewall/proc/toggle_open()


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request
Fixes the bug where standing in a fake wall and closing it leaves it in a half closed state.

### Why is this change good for the game?
It fixes the bug where standing in a fake wall and closing it leaves it in a half closed state

# Changelog

Fixes #9114 

:cl:  
bugfix: fixed fake walls being transparent if closed on someone
/:cl:
