### PR TITLE
Makes felinids show up as human on health scanner and remove felinid scan on nanites and scanner gates

### DIFF
--- a/code/controllers/subsystem/traumas.dm
+++ b/code/controllers/subsystem/traumas.dm
@@ -160,7 +160,8 @@ SUBSYSTEM_DEF(traumas)
 						  "robots" = typecacheof(list(/datum/species/android)),
 						  "the supernatural" = typecacheof(list(/datum/species/golem/clockwork, /datum/species/golem/runic)),
 						  "aliens" = typecacheof(list(/datum/species/abductor, /datum/species/jelly, /datum/species/pod,
-						  /datum/species/shadow, /datum/species/polysmorph))
+						  /datum/species/shadow, /datum/species/polysmorph)),
+						  "anime" = typecacheof(list(/datum/species/human/felinid))
 						 )
 
 	return ..()

--- a/code/controllers/subsystem/traumas.dm
+++ b/code/controllers/subsystem/traumas.dm
@@ -160,8 +160,7 @@ SUBSYSTEM_DEF(traumas)
 						  "robots" = typecacheof(list(/datum/species/android)),
 						  "the supernatural" = typecacheof(list(/datum/species/golem/clockwork, /datum/species/golem/runic)),
 						  "aliens" = typecacheof(list(/datum/species/abductor, /datum/species/jelly, /datum/species/pod,
-						  /datum/species/shadow, /datum/species/polysmorph)),
-						  "anime" = typecacheof(list(/datum/species/human/felinid))
+						  /datum/species/shadow, /datum/species/polysmorph))
 						 )
 
 	return ..()

--- a/code/game/machinery/scan_gate.dm
+++ b/code/game/machinery/scan_gate.dm
@@ -9,7 +9,6 @@
 
 #define SCANGATE_HUMAN			"human"
 #define SCANGATE_LIZARD			"lizard"
-#define SCANGATE_FELINID		"felinid"
 #define SCANGATE_FLY			"fly"
 #define SCANGATE_PLASMAMAN		"plasma"
 #define SCANGATE_POLYSMORPH		"polysmorph"
@@ -127,8 +126,6 @@
 						scan_species = /datum/species/lizard
 					if(SCANGATE_FLY)
 						scan_species = /datum/species/fly
-					if(SCANGATE_FELINID)
-						scan_species = /datum/species/human/felinid
 					if(SCANGATE_PLASMAMAN)
 						scan_species = /datum/species/plasmaman
 					if(SCANGATE_POLYSMORPH)
@@ -251,7 +248,6 @@
 
 #undef SCANGATE_HUMAN
 #undef SCANGATE_LIZARD
-#undef SCANGATE_FELINID
 #undef SCANGATE_FLY
 #undef SCANGATE_PLASMAMAN
 #undef SCANGATE_MOTH

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -1,6 +1,6 @@
 //Subtype of human
 /datum/species/human/felinid
-	name = "Felinid"
+	name = "Human" // Felinids are human
 	id = "felinid"
 	limbs_id = "human"
 

--- a/code/modules/research/nanites/nanite_programs/sensor.dm
+++ b/code/modules/research/nanites/nanite_programs/sensor.dm
@@ -411,7 +411,6 @@
 		"Ethereal" = /datum/species/ethereal,
 		"Pod" = /datum/species/pod,
 		"Fly" = /datum/species/fly,
-		"Felinid" = /datum/species/human/felinid,
 		"Jelly" = /datum/species/jelly,
 		"Preternis" = /datum/species/preternis
 	)

--- a/tgui/packages/tgui/interfaces/ScannerGate.js
+++ b/tgui/packages/tgui/interfaces/ScannerGate.js
@@ -28,10 +28,6 @@ const TARGET_SPECIES_LIST = [
     value: 'fly',
   },
   {
-    name: 'Felinid',
-    value: 'felinid',
-  },
-  {
     name: 'Plasmaman',
     value: 'plasma',
   },


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request
Make it such that scanners cannot identify felinids as different from humans because they are the same species, and remove felinids from anime phobia.

# Changelog

Fixes #11248 

:cl:  
rscdel: Removed the ability for scanner gates and nanites to scan for felinids
tweak: Tweaked the health scanner to show felinids as human
/:cl:
