### PR TITLE
fix directional x4

### DIFF
--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -57,16 +57,18 @@
 
 /obj/item/grenade/plastic/prime()
 	var/turf/location
+	var/density_check = FALSE
 	if(target)
 		if(!QDELETED(target))
 			location = get_turf(target)
+			density_check = target.density //since turfs getting exploded makes this a bit fucky wucky we need to assert whether we should go directional before that part
 			target.cut_overlay(plastic_overlay, TRUE)
 			if(!ismob(target) || full_damage_on_mobs)
 				target.ex_act(2, target)
 	else
 		location = get_turf(src)
 	if(location)
-		if(directional && target && target.density)
+		if(directional && target && density_check)
 			var/turf/T = get_step(location, aim_dir)
 			explosion(get_step(T, aim_dir), boom_sizes[1], boom_sizes[2], boom_sizes[3])
 		else


### PR DESCRIPTION
fixes #7417
for a while x4 wouldn't apply its offset when breaching a wall which kills the ENTIRE POINT of using it as a breaching charge over c4 the bit where you blow a nice large hole in the room and don't have to run as far from the initial breaching point to not eat shit
turns out it's because the wall is considered a floor after being exploded which makes it not trigger the directional check since it's no longer dense when that happens

:cl:  
bugfix: x4 now explodes properly when placed on walls 
/:cl:
