### PR TITLE
Fixed reagent explosions inside people instantly clearing all chems

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -23,7 +23,8 @@
 	var/datum/effect_system/reagents_explosion/e = new()
 	e.set_up(modifier + round(created_volume/strengthdiv, 1), T, 0, 0)
 	e.start()
-	holder.clear_reagents()
+	if(!ismob(holder.my_atom))
+		holder.clear_reagents()
 
 
 /datum/chemical_reaction/reagent_explosion/nitroglycerin


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Makes reagent explosions in people no longer instantly clear all chems

### Why is this change good for the game?

Exploit nullified poisons and the volume restriction on synthflesh

# Changelog
Fixes #11604 

:cl:  
bugfix: Fixed reagent explosions instantly clearing chems in people
/:cl:
