### PR TITLE
Makes syndicate borgs explode self destruct like emagged borgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -652,7 +652,7 @@
 	update_fire()
 
 /mob/living/silicon/robot/proc/self_destruct()
-	if(emagged || istype(src, /mob/living/silicon/robot/modules/syndicate))
+	if(emagged || module.syndicate_module)
 		if(mmi)
 			qdel(mmi)
 		explosion(src.loc,1,2,4,flame_range = 2)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -6,14 +6,14 @@
 	maxHealth = 100
 	health = 100
 	bubble_icon = "robot"
-	designation = "Default" //used for displaying the prefix & getting the current module of cyborg
+	designation = "Default" ///used for displaying the prefix & getting the current module of cyborg
 	has_limbs = 1
 	hud_type = /datum/hud/robot
 	blocks_emissive = EMISSIVE_BLOCK_GENERIC
 
 	var/custom_name = ""
 	var/braintype = "Cyborg"
-	var/obj/item/robot_suit/robot_suit = null //Used for deconstruction to remember what the borg was constructed out of..
+	var/obj/item/robot_suit/robot_suit = null ///Used for deconstruction to remember what the borg was constructed out of..
 	var/obj/item/mmi/mmi = null
 
 	var/shell = FALSE
@@ -32,7 +32,7 @@
 	var/obj/screen/thruster_button = null
 	var/obj/screen/hands = null
 
-	var/shown_robot_modules = 0	//Used to determine whether they have the module menu shown or not
+	var/shown_robot_modules = 0	///Used to determine whether they have the module menu shown or not
 	var/obj/screen/robot_modules_background
 
 //3 Modules can be activated at any one time.
@@ -59,25 +59,25 @@
 
 	var/alarms = list("Motion"=list(), "Fire"=list(), "Atmosphere"=list(), "Power"=list(), "Camera"=list(), "Burglar"=list())
 
-	var/speed = 0 // VTEC speed boost.
-	var/magpulse = FALSE // Magboot-like effect.
-	var/ionpulse = FALSE // Jetpack-like effect.
-	var/ionpulse_on = FALSE // Jetpack-like effect.
-	var/datum/effect_system/trail_follow/ion/ion_trail // Ionpulse effect.
+	var/speed = 0 /// VTEC speed boost.
+	var/magpulse = FALSE /// Magboot-like effect.
+	var/ionpulse = FALSE /// Jetpack-like effect.
+	var/ionpulse_on = FALSE /// Jetpack-like effect.
+	var/datum/effect_system/trail_follow/ion/ion_trail /// Ionpulse effect.
 
-	var/low_power_mode = FALSE //whether the robot has no charge left.
-	var/datum/effect_system/spark_spread/spark_system // So they can initialize sparks whenever/N
+	var/low_power_mode = FALSE ///whether the robot has no charge left.
+	var/datum/effect_system/spark_spread/spark_system /// So they can initialize sparks whenever/N
 
-	var/lawupdate = TRUE //Cyborgs will sync their laws with their AI by default
-	var/scrambledcodes = FALSE // Used to determine if a borg shows up on the robotics console.  Setting to true hides them.
-	var/lockcharge //Boolean of whether the borg is locked down or not
+	var/lawupdate = TRUE ///Cyborgs will sync their laws with their AI by default
+	var/scrambledcodes = FALSE /// Used to determine if a borg shows up on the robotics console.  Setting to true hides them.
+	var/lockcharge ///Boolean of whether the borg is locked down or not
 
 	var/toner = 0
 	var/tonermax = 40
 
-	var/lamp_max = 10 //Maximum brightness of a borg lamp. Set as a var for easy adjusting.
-	var/lamp_intensity = 0 //Luminosity of the headlamp. 0 is off. Higher settings than the minimum require power.
-	var/lamp_cooldown = 0 //Flag for if the lamp is on cooldown after being forcibly disabled.
+	var/lamp_max = 10 ///Maximum brightness of a borg lamp. Set as a var for easy adjusting.
+	var/lamp_intensity = 0 ///Luminosity of the headlamp. 0 is off. Higher settings than the minimum require power.
+	var/lamp_cooldown = 0 ///Flag for if the lamp is on cooldown after being forcibly disabled.
 
 	var/sight_mode = 0
 	hud_possible = list(ANTAG_HUD, DIAG_STAT_HUD, DIAG_HUD, DIAG_BATT_HUD, DIAG_TRACK_HUD)
@@ -87,10 +87,10 @@
 	var/expansion_count = 0
 	var/obj/item/hat
 	var/hat_offset = -3
-	var/list/blacklisted_hats = list( //Hats that don't really work on borgos
+	var/list/blacklisted_hats = list( ///Hats that don't really work on borgos
 	/obj/item/clothing/head/helmet/space/santahat,
 	/obj/item/clothing/head/welding,
-	/obj/item/clothing/head/mob_holder, //I am so very upset that this breaks things
+	/obj/item/clothing/head/mob_holder, ///I am so very upset that this breaks things
 	/obj/item/clothing/head/helmet/space,
 	)
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -652,7 +652,7 @@
 	update_fire()
 
 /mob/living/silicon/robot/proc/self_destruct()
-	if(emagged)
+	if(emagged || istype(src, /mob/living/silicon/robot/modules/syndicate))
 		if(mmi)
 			qdel(mmi)
 		explosion(src.loc,1,2,4,flame_range = 2)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -8,17 +8,17 @@
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	flags_1 = CONDUCT_1
 
-	var/list/basic_modules = list() //a list of paths, converted to a list of instances on New()
-	var/list/emag_modules = list() //ditto
-	var/list/ratvar_modules = list() //ditto ditto
-	var/list/modules = list() //holds all the usable modules
-	var/list/added_modules = list() //modules not inherient to the robot module, are kept when the module changes
+	var/list/basic_modules = list() ///a list of paths, converted to a list of instances on New()
+	var/list/emag_modules = list() ///ditto
+	var/list/ratvar_modules = list() ///ditto ditto
+	var/list/modules = list() ///holds all the usable modules
+	var/list/added_modules = list() ///modules not inherient to the robot module, are kept when the module changes
 	var/list/storages = list()
 
 	var/list/radio_channels = list()
 
-	var/cyborg_base_icon = "robot" //produces the icon for the borg and, if no special_light_key is set, the lights
-	var/special_light_key //if we want specific lights, use this instead of copying lights in the dmi
+	var/cyborg_base_icon = "robot" ///produces the icon for the borg and, if no special_light_key is set, the lights
+	var/special_light_key ///if we want specific lights, use this instead of copying lights in the dmi
 
 	var/moduleselect_icon = "nomod"
 
@@ -34,9 +34,9 @@
 	var/list/ride_offset_y = list("north" = 4, "south" = 4, "east" = 3, "west" = 3)
 	var/ride_allow_incapacitated = TRUE
 	var/allow_riding = TRUE
-	var/canDispose = FALSE // Whether the borg can stuff itself into disposal
+	var/canDispose = FALSE /// Whether the borg can stuff itself into disposal
 
-	var/syndicate_module = FALSE // If the borg should blow emag size regardless of emag state
+	var/syndicate_module = FALSE /// If the borg should blow emag size regardless of emag state
 
 /obj/item/robot_module/Initialize()
 	. = ..()
@@ -163,7 +163,7 @@
 
 	R.toner = R.tonermax
 
-/obj/item/robot_module/proc/rebuild_modules() //builds the usable module list from the modules we have
+/obj/item/robot_module/proc/rebuild_modules() ///builds the usable module list from the modules we have
 	var/mob/living/silicon/robot/R = loc
 	var/list/held_modules = R.held_items.Copy()
 	var/active_module = R.module_active

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -36,6 +36,8 @@
 	var/allow_riding = TRUE
 	var/canDispose = FALSE // Whether the borg can stuff itself into disposal
 
+	var/syndicate_module = FALSE // If the borg should blow emag size regardless of emag state
+
 /obj/item/robot_module/Initialize()
 	. = ..()
 	for(var/i in basic_modules)
@@ -608,6 +610,7 @@
 	moduleselect_icon = "malf"
 	can_be_pushed = FALSE
 	hat_offset = 3
+	syndicate_module = TRUE
 
 /obj/item/robot_module/syndicate/rebuild_modules()
 	..()
@@ -648,6 +651,7 @@
 	moduleselect_icon = "malf"
 	can_be_pushed = FALSE
 	hat_offset = 3
+	syndicate_module = TRUE
 
 /obj/item/robot_module/saboteur
 	name = "Syndicate Saboteur"
@@ -682,6 +686,7 @@
 	magpulsing = TRUE
 	hat_offset = -4
 	canDispose = TRUE
+	syndicate_module = TRUE
 
 /datum/robot_energy_storage
 	var/name = "Generic energy storage"


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Make it so that syndicate borgs self destruct with the same intensity of emagged borgs

### Why is this change good for the game?
People who play syndicate borg will self destruct expecting big boom and get small boom, this removes sad boom from syndicate borg players.

# Changelog
Fixes #11578 

:cl:  
tweak: Makes the syndicate borgs self destruct like emagged borgs
/:cl:
