### PR TITLE
Replaces security and warden plasmaman masks with sec mask

### DIFF
--- a/code/modules/clothing/outfits/plasmaman.dm
+++ b/code/modules/clothing/outfits/plasmaman.dm
@@ -85,7 +85,7 @@
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/security
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
-	mask = /obj/item/clothing/mask/breath
+	mask = /obj/item/clothing/mask/gas/sechailer
 	uniform = /obj/item/clothing/under/plasmaman/security
 	ears = /obj/item/radio/headset/headset_sec/alt
 	gloves = /obj/item/clothing/gloves/color/black
@@ -121,7 +121,7 @@
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/security
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
-	mask = /obj/item/clothing/mask/breath
+	mask = /obj/item/clothing/mask/gas/sechailer
 	uniform = /obj/item/clothing/under/plasmaman/security/warden
 	ears = /obj/item/radio/headset/headset_sec/alt
 	shoes = /obj/item/clothing/shoes/jackboots


### PR DESCRIPTION
### Intent of your Pull Request

Gives plasmamen sec and warden outfits the sec gas mask instead of the standard mask, because they need to be wearing a mask, might as well make it the sec mask.

### Why is this change good for the game?
Most sec officers spawn with the sec mask, plasmamen don't this applies the standard to plasmamen, but equips it because they need a mask.
# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
Plasmaman sec officers will now spawn with the sec gas mask

# Changelog

Fixes #11598 

:cl:  
bugfix: gives the sec and warden plasma uniforms sec masks
/:cl:
