### PR TITLE
BoH bombing the bluespace locker no longer bombs the outside of the locker

### DIFF
--- a/code/datums/components/storage/concrete/bag_of_holding.dm
+++ b/code/datums/components/storage/concrete/bag_of_holding.dm
@@ -14,7 +14,7 @@
 	var/safety = alert(user, "Doing this will have extremely dire consequences for the station and its crew. Be sure you know what you're doing.", "Put in [A.name]?", "Abort", "Proceed")
 	if(safety != "Proceed" || QDELETED(A) || QDELETED(W) || QDELETED(user) || !user.canUseTopic(A, BE_CLOSE, iscarbon(user)))
 		return
-	var/turf/loccheck = get_turf_global(A)
+	var/turf/loccheck = get_turf(A)
 	if(is_reebe(loccheck.z))
 		user.visible_message("<span class='warning'>An unseen force knocks [user] to the ground!</span>", "<span class='big_brass'>\"I think not!\"</span>")
 		user.Paralyze(60)


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request
Changes the BoH bomb code so it no longer uses the outside of the bluespace locker.

### Why is this change good for the game?
When BoH bombing the bluespace locker before, it would bomb the tile the locker is sitting on, destroy the locker, and move it, therefore being perfectly safe for anyone inside. This makes it so the bomb only affects the inside.

# Changelog
Fixes #11525 

:cl:  
bugfix: fixed boh bomb bombing the outside of the bluespace locker
/:cl:
