### PR TITLE
Fixes the gas drain code for research rad collectors

### DIFF
--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -53,11 +53,13 @@
 			add_avail(power_produced)
 			stored_power-=power_produced
 	else if(is_station_level(z) && SSresearch.science_tech)
-		if(!loaded_tank.air_contents.get_moles(/datum/gas/tritium) || !loaded_tank.air_contents.get_moles(/datum/gas/oxygen))
+		var/trit_amount = loaded_tank.air_contents.get_moles(/datum/gas/tritium)
+		var/oxy_amount = loaded_tank.air_contents.get_moles(/datum/gas/oxygen)
+		if(!trit_amount || !oxy_amount)
 			playsound(src, 'sound/machines/ding.ogg', 50, 1)
 			eject()
 		else
-			var/gasdrained = bitcoinproduction_drain*drainratio
+			var/gasdrained = min(bitcoinproduction_drain*drainratio, min(trit_amount, oxy_amount))
 			loaded_tank.air_contents.adjust_moles(/datum/gas/tritium, -gasdrained)
 			loaded_tank.air_contents.adjust_moles(/datum/gas/oxygen, -gasdrained)
 			loaded_tank.air_contents.adjust_moles(/datum/gas/carbon_dioxide, gasdrained*2)


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Research rad collectors no longer have effectively infinite gas due to the rad collectors not consuming gas if the gas was low enough

### Why is this change good for the game?

Research rad collectors should work as intended

# Changelog
Fixes #11579 

:cl:  
bugfix: fixed research rad collectors not running out of gas
/:cl:
