### PR TITLE
Fixes gun pin removal spawning guns

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -115,7 +115,7 @@
 	if(G)
 		G.forceMove(loc)
 		var/pin = G.pin
-		if(G.pin.gun_remove()) //if this returns false the gun and pin are not going to exist
+		if(!G.pin || G.pin.gun_remove()) //if this returns false the gun and pin are not going to exist
 			visible_message("[G] can now fit a new pin, but the old one was destroyed in the process.", null, null, 3)
 			QDEL_NULL(pin)
 		qdel(src)


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Makes it so that attempting to remove a pin from a gun with no pin does not cause a gun to spawn

### Why is this change good for the game?
Spawning guns is bad

# Changelog

Fixes #11453 

:cl:  
bugfix: fixed guns spawning guns when their pins were removed multiple times
/:cl:
