### PR TITLE
Alternative Fixes gun pin removal spawning guns

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -115,7 +115,9 @@
 	if(G)
 		G.forceMove(loc)
 		var/pin = G.pin
-		if(G.pin.gun_remove()) //if this returns false the gun and pin are not going to exist
+		if(!pin)
+			visible_message("[G] has no pin to remove.", null, null, 3)
+		if(pin && G.pin.gun_remove()) //if this returns false the gun and pin are not going to exist
 			visible_message("[G] can now fit a new pin, but the old one was destroyed in the process.", null, null, 3)
 			QDEL_NULL(pin)
 		qdel(src)


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request
Fixes #11453

Makes it so that attempting to remove a pin from a gun with no pin does not runtime and does not create a the base gun type.

### Why is this change good for the game?
Spawning guns is bad


# Changelog

:cl:  
bugfix: Removing firing pins from firing-pin-less guns no longer makes the game panic.
/:cl:
