### PR TITLE
Adds an oxy tank dispenser in security equipment room

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -33117,6 +33117,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"cME" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "cMX" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/tile/neutral{
@@ -97200,7 +97204,7 @@ abP
 aco
 acO
 abl
-abO
+cME
 abO
 afc
 afQ


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request
Adds a dispenser of full size oxygen tanks for use with the sec hardsuits.

<details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/4607006/124166736-388f3100-da71-11eb-95dc-2859322ea0f2.png)
</details>

### Why is this change good for the game?
The small internals tank is not good for jetpack and breathing for long periods, this allows sec an easy source of bigger tanks.

# Changelog

:cl:  
rscadd: Added an oxy tank dispenser to the security equipment room.
/:cl:
