### PR TITLE
Revert "removes dab"

### DIFF
--- a/code/__HELPERS/matrices.dm
+++ b/code/__HELPERS/matrices.dm
@@ -53,6 +53,7 @@
 		sleep(hold_seconds) // time to hold the dab before going back
 	if(!stay) // if stay param is true dab doesn't return
 		animate(src, transform = DAB_RETURN, time = speed * 1.5, loops ) // reverse dab to starting position , slower
+
 //Dumps the matrix data in format a-f
 /matrix/proc/tolist()
 	. = list()

--- a/code/datums/achievements/achievements.dm
+++ b/code/datums/achievements/achievements.dm
@@ -156,6 +156,12 @@
 	desc = "Trigger a keycard authentication device event, by yourself."
 	id = 23
 
+/datum/achievement/dab
+	name = "Brain Damage"
+	desc = "Dab."
+	id = 24
+	hidden = TRUE
+
 // The achievements that are basically just "greentext as this sort of antag"
 
 /datum/achievement/greentext

--- a/code/modules/mob/dead/emote.dm
+++ b/code/modules/mob/dead/emote.dm
@@ -1,0 +1,18 @@
+
+/* DEAD EMOTE DATUMS */
+/datum/emote/dead
+	mob_type_allowed_typecache = /mob/dead/observer
+
+/datum/emote/dead/dab
+	key = "dab"
+	key_third_person = "dabs"
+	message = "dabs."
+	message_param = "dabs on %t."
+	restraint_check = TRUE
+
+/datum/emote/dead/dab/run_emote(mob/user, params)
+	. = ..()
+	var/mob/dead/observer/H = user
+	var/light_dab_angle = rand(35,55)
+	var/light_dab_speed = rand(3,7)
+	H.DabAnimation(angle = light_dab_angle , speed = light_dab_speed)

--- a/yogstation/code/modules/mob/living/emote.dm
+++ b/yogstation/code/modules/mob/living/emote.dm
@@ -52,3 +52,20 @@
 	key = "smirk"
 	key_third_person = "smirks"
 	message = "smirks."
+
+/datum/emote/living/dab
+	key = "dab"
+	key_third_person = "dabs"
+	message = "dabs."
+	message_param = "dabs on %t."
+	restraint_check = TRUE
+
+/datum/emote/living/dab/run_emote(mob/user, params)
+	. = ..()
+	if(. && ishuman(user))
+		var/mob/living/carbon/human/H = user
+		var/light_dab_angle = rand(35,55)
+		var/light_dab_speed = rand(3,7)
+		H.DabAnimation(angle = light_dab_angle , speed = light_dab_speed)
+		H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
+		SSachievements.unlock_achievement(/datum/achievement/dab,H.client)

--- a/yogstation/code/modules/mob/living/emote.dm
+++ b/yogstation/code/modules/mob/living/emote.dm
@@ -67,5 +67,4 @@
 		var/light_dab_angle = rand(35,55)
 		var/light_dab_speed = rand(3,7)
 		H.DabAnimation(angle = light_dab_angle , speed = light_dab_speed)
-		H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
 		SSachievements.unlock_achievement(/datum/achievement/dab,H.client)


### PR DESCRIPTION
Reverts yogstation13/Yogstation#9733

hopek showed me where this button is and told me I need to "make a good reason"

seeing as our transition to mrp has fallen flat on its face and the RP rules document is probably accessed less then the space inbetween a nun's thighs, I believe its time to bring back dabbing as a way for our players to express how fucking stupid they are. (mainly me)

also, someone needs to add *cripwalk emote

(serious part)
The main reason this is being reverted is that its removal didn't do anything in the first place. It was touted as the beginning of the end of LRP and the first step on a path to usher in a great vision of MRP, but we all know how that went. I think it's time to face the reality of our low-to-medium-rp server and bring this back. 

Yogstation is, and always will be, this weird conglomeration of people that enjoy RP and people that enjoy doing things that aren't RP. Why can't we cater to both? If you want to do your RP, go ahead. If you want to dab every time you triumph over the local shitter clown, why not?