### PR TITLE
Fixed husks not looking like husks

### DIFF
--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -425,17 +425,16 @@
 
 /mob/living/proc/cure_husk(list/sources)
 	REMOVE_TRAIT(src, TRAIT_HUSK, sources)
-	if(!HAS_TRAIT(src, TRAIT_HUSK))
-		REMOVE_TRAIT(src, TRAIT_DISFIGURED, "husk")
-		update_body()
-		return TRUE
+	REMOVE_TRAIT(src, TRAIT_DISFIGURED, "husk")
+	update_body()
+	return TRUE
 
 /mob/living/proc/become_husk(source)
 	if(!HAS_TRAIT(src, TRAIT_HUSK))
 		ADD_TRAIT(src, TRAIT_DISFIGURED, "husk")
-		update_body()
 		. = TRUE
 	ADD_TRAIT(src, TRAIT_HUSK, source)
+	update_body()
 
 /mob/living/proc/cure_fakedeath(list/sources)
 	REMOVE_TRAIT(src, TRAIT_FAKEDEATH, sources)

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -425,9 +425,10 @@
 
 /mob/living/proc/cure_husk(list/sources)
 	REMOVE_TRAIT(src, TRAIT_HUSK, sources)
-	REMOVE_TRAIT(src, TRAIT_DISFIGURED, "husk")
-	update_body()
-	return TRUE
+	if(!HAS_TRAIT(src, TRAIT_HUSK))
+		REMOVE_TRAIT(src, TRAIT_DISFIGURED, "husk")
+		update_body()
+		return TRUE
 
 /mob/living/proc/become_husk(source)
 	if(!HAS_TRAIT(src, TRAIT_HUSK))


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request
Husks now always look like husks and don't need slapped.

### Why is this change good for the game?
Husked people should look husked without being slapped.

# Changelog
Fixes #11448 

:cl:  
bugfix: fixed husks not getting the husk sprite
/:cl:
