### PR TITLE
Fix clown borgs being invisible after having a donor skin

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -193,6 +193,7 @@
 	if(!RM.be_transformed_to(src))
 		qdel(RM)
 		return
+	R.special_skin = FALSE
 	R.module = RM
 	R.update_module_innate()
 	RM.rebuild_modules()


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request
Make clown borgs not invisible after changing from a module with a donor skin.

### Why is this change good for the game?
Invisible borgs are bad

# Changelog

Fixes #11522 

:cl:  
bugfix: fixed clown borgs being invisible when changing from a donor skin
/:cl:
