### PR TITLE
Adds armory protolathe for printing lethal weapons

### DIFF
--- a/_maps/map_files/EclipseStation/EclipseStation.dmm
+++ b/_maps/map_files/EclipseStation/EclipseStation.dmm
@@ -1113,6 +1113,7 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/bot_red,
+/obj/item/circuitboard/machine/techfab/department/security,
 /obj/item/card/id/departmental_budget/sec,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -83454,6 +83455,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"iwD" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/rnd/production/techfab/department/armory,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "ixv" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -120877,7 +120888,7 @@ adD
 adD
 aeA
 adD
-adD
+iwD
 agl
 agP
 ahs

--- a/_maps/map_files/IceBox/IceBox.dmm
+++ b/_maps/map_files/IceBox/IceBox.dmm
@@ -8296,7 +8296,13 @@
 /turf/open/floor/plating,
 /area/medical/sleeper)
 "arc" = (
-/obj/item/twohanded/required/kirbyplants/random,
+/obj/structure/rack,
+/obj/item/storage/box/trackimp{
+	pixel_x = -3
+	},
+/obj/item/storage/box/chemimp{
+	pixel_x = 6
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ard" = (
@@ -14483,13 +14489,7 @@
 /area/crew_quarters/heads/cmo)
 "aDu" = (
 /obj/effect/turf_decal/bot_red,
-/obj/structure/rack,
-/obj/item/storage/box/chemimp{
-	pixel_x = 6
-	},
-/obj/item/storage/box/trackimp{
-	pixel_x = -3
-	},
+/obj/machinery/rnd/production/techfab/department/armory,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aDv" = (
@@ -59050,6 +59050,7 @@
 "jQA" = (
 /obj/structure/rack,
 /obj/item/storage/lockbox/loyalty,
+/obj/item/circuitboard/machine/techfab/department/security,
 /obj/item/card/id/departmental_budget/sec,
 /obj/item/reagent_containers/syringe/lethal/execution,
 /turf/open/floor/plasteel/dark,

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -18203,13 +18203,6 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port)
 "aFh" = (
-/obj/machinery/recharger{
-	pixel_x = -7
-	},
-/obj/machinery/recharger{
-	pixel_x = 7
-	},
-/obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -18221,6 +18214,7 @@
 	pixel_x = 24;
 	pixel_y = -6
 	},
+/obj/machinery/rnd/production/techfab/department/armory,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aFk" = (
@@ -51776,7 +51770,6 @@
 /area/hydroponics)
 "bFK" = (
 /obj/structure/table,
-/obj/machinery/recharger,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -51787,11 +51780,16 @@
 /obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
+/obj/machinery/recharger{
+	pixel_x = 7
+	},
+/obj/machinery/recharger{
+	pixel_x = -7
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bFL" = (
 /obj/structure/table,
-/obj/machinery/recharger,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -51800,6 +51798,12 @@
 	},
 /obj/structure/sign/warning/electricshock{
 	pixel_y = -32
+	},
+/obj/machinery/recharger{
+	pixel_x = 7
+	},
+/obj/machinery/recharger{
+	pixel_x = -7
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -94157,6 +94161,7 @@
 	pixel_y = -23
 	},
 /obj/structure/cable/yellow,
+/obj/item/circuitboard/machine/techfab/department/security,
 /obj/item/card/id/departmental_budget/sec,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)

--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -6469,13 +6469,13 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "aiV" = (
-/obj/machinery/rnd/production/techfab/department/security,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/rnd/production/techfab/department/armory,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aiW" = (

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -6924,7 +6924,7 @@
 /turf/closed/wall,
 /area/maintenance/fore)
 "arQ" = (
-/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/rnd/production/techfab/department/armory,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "arR" = (
@@ -61185,6 +61185,7 @@
 /area/ai_monitored/turret_protected/ai)
 "vPf" = (
 /obj/structure/rack,
+/obj/item/circuitboard/machine/techfab/department/security,
 /obj/item/storage/lockbox/loyalty,
 /obj/item/card/id/departmental_budget/sec,
 /obj/item/reagent_containers/syringe/lethal/execution,

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -6771,7 +6771,13 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "arc" = (
-/obj/item/twohanded/required/kirbyplants/random,
+/obj/structure/rack,
+/obj/item/storage/box/trackimp{
+	pixel_x = -3
+	},
+/obj/item/storage/box/chemimp{
+	pixel_x = 6
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ard" = (
@@ -6924,7 +6930,7 @@
 /turf/closed/wall,
 /area/maintenance/fore)
 "arQ" = (
-/obj/machinery/rnd/production/techfab/department/armory,
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "arR" = (
@@ -10704,13 +10710,7 @@
 /area/hallway/primary/central)
 "aDu" = (
 /obj/effect/turf_decal/bot_red,
-/obj/structure/rack,
-/obj/item/storage/box/chemimp{
-	pixel_x = 6
-	},
-/obj/item/storage/box/trackimp{
-	pixel_x = -3
-	},
+/obj/machinery/rnd/production/techfab/department/armory,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aDw" = (

--- a/_maps/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/map_files/YogsDelta/YogsDelta.dmm
@@ -21281,6 +21281,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/circuitboard/machine/techfab/department/security,
 /obj/item/card/id/departmental_budget/sec,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -41613,11 +41614,10 @@
 /turf/closed/wall/r_wall,
 /area/security/execution/transfer)
 "bnH" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/rnd/production/techfab/department/armory,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "bnI" = (
@@ -64815,7 +64815,9 @@
 /area/crew_quarters/dorms)
 "bVl" = (
 /obj/structure/table/reinforced,
-/obj/machinery/recharger,
+/obj/machinery/recharger{
+	pixel_x = -7
+	},
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -32
 	},
@@ -64824,6 +64826,9 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/recharger{
+	pixel_x = 7
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -1133,6 +1133,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/circuitboard/machine/techfab/department/security,
 /obj/item/card/id/departmental_budget/sec,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -3152,14 +3153,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/mob/living/simple_animal/bot/secbot{
-	arrest_type = 1;
-	health = 45;
-	icon_state = "secbot1";
-	idcheck = 1;
-	name = "Sergeant-at-Armsky";
-	weaponscheck = 1
-	},
+/obj/machinery/rnd/production/techfab/department/armory,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agc" = (
@@ -3547,6 +3541,14 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/mob/living/simple_animal/bot/secbot{
+	arrest_type = 1;
+	health = 45;
+	icon_state = "secbot1";
+	idcheck = 1;
+	name = "Sergeant-at-Armsky";
+	weaponscheck = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)

--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -57,8 +57,9 @@
 #define DEPARTMENTAL_FLAG_SCIENCE		(1<<3)
 #define DEPARTMENTAL_FLAG_ENGINEERING	(1<<4)
 #define DEPARTMENTAL_FLAG_SERVICE		(1<<5)
-#define DEPARTMENTAL_FLAG_ALL			(1<<6)			//NO THIS DOESN'T ALLOW YOU TO PRINT EVERYTHING, IT'S FOR ALL DEPARTMENTS!
-//#define DEPARTMENTAL_FLAG_MINING		(1<<7)			//I swear I'm actually going to use this eventually leave it here
+#define DEPARTMENTAL_FLAG_ARMORY		(1<<6)
+#define DEPARTMENTAL_FLAG_ALL			(1<<7)			//NO THIS DOESN'T ALLOW YOU TO PRINT EVERYTHING, IT'S FOR ALL DEPARTMENTS!
+//#define DEPARTMENTAL_FLAG_MINING		(1<<8)			//I swear I'm actually going to use this eventually leave it here
 
 #define DESIGN_ID_IGNORE "IGNORE_THIS_DESIGN"			///For instances where we don't want a design showing up due to it being for debug/sanity purposes
 

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -971,6 +971,11 @@
 	icon_state = "security"
 	build_path = /obj/machinery/rnd/production/techfab/department/security
 
+/obj/item/circuitboard/machine/techfab/department/armory
+	name = "\improper Departmental Techfab (Machine Board) - Armory"
+	icon_state = "security"
+	build_path = /obj/machinery/rnd/production/techfab/department/armory
+
 //Service
 
 /obj/item/circuitboard/machine/biogenerator

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -65,7 +65,7 @@
 	new /obj/item/gun/energy/e_gun/hos(src)
 	new /obj/item/flashlight/seclite(src)
 	new /obj/item/pinpointer/nuke(src)
-	new /obj/item/circuitboard/machine/techfab/department/security(src)
+	new /obj/item/circuitboard/machine/techfab/department/armory(src)
 	new /obj/item/storage/photo_album/HoS(src)
 	new /obj/item/clipboard/yog/paperwork/hos(src)
 	new /obj/item/radio/security(src)

--- a/code/modules/research/designs/mecha_designs.dm
+++ b/code/modules/research/designs/mecha_designs.dm
@@ -156,7 +156,7 @@
 	materials = list(/datum/material/iron=6000)
 	construction_time = 20
 	category = list("Exosuit Ammunition", "Ammo")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
 
 /datum/design/mech_carbine
 	name = "Exosuit Weapon (FNX-99 \"Hades\" Carbine)"
@@ -177,7 +177,7 @@
 	materials = list(/datum/material/iron=6000)
 	construction_time = 20
 	category = list("Exosuit Ammunition", "Ammo")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
 
 /datum/design/mech_ion
 	name = "Exosuit Weapon (MKIV Ion Heavy Cannon)"
@@ -258,7 +258,7 @@
 	materials = list(/datum/material/iron=4000,/datum/material/gold=500,/datum/material/silver=500)
 	construction_time = 20
 	category = list("Exosuit Ammunition", "Ammo")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
 
 /datum/design/mech_missile_rack
 	name = "Exosuit Weapon (BRM-6 Missile Rack)"
@@ -279,7 +279,7 @@
 	materials = list(/datum/material/iron=8000,/datum/material/gold=500,/datum/material/silver=500)
 	construction_time = 20
 	category = list("Exosuit Ammunition", "Ammo")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
 
 /datum/design/clusterbang_launcher
 	name = "Exosuit Weapon (SOB-3 Clusterbang Launcher)"
@@ -431,7 +431,7 @@
 	materials = list(/datum/material/iron=4000)
 	construction_time = 20
 	category = list("Exosuit Ammunition", "Ammo")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
 
 /datum/design/mech_sleeper
 	name = "Exosuit Medical (Mounted Sleeper)"

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -26,7 +26,7 @@
 	materials = list(/datum/material/iron = 20000, /datum/material/plasma = 5000)
 	build_path = /obj/item/ammo_box/c38/hotshot
 	category = list("Ammo")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
 
 /datum/design/c38_iceblox
 	name = "Speed Loader (.38 Iceblox)"
@@ -36,7 +36,7 @@
 	materials = list(/datum/material/iron = 20000, /datum/material/plasma = 5000)
 	build_path = /obj/item/ammo_box/c38/iceblox
 	category = list("Ammo")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
 
 /datum/design/rubbershot/sec
 	id = "sec_rshot"
@@ -54,25 +54,25 @@
 	id = "sec_slug"
 	build_type = PROTOLATHE
 	category = list("Ammo")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
 
 /datum/design/buckshot_shell/sec
 	id = "sec_bshot"
 	build_type = PROTOLATHE
 	category = list("Ammo")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
 
 /datum/design/shotgun_dart/sec
 	id = "sec_dart"
 	build_type = PROTOLATHE
 	category = list("Ammo")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
 
 /datum/design/incendiary_slug/sec
 	id = "sec_Islug"
 	build_type = PROTOLATHE
 	category = list("Ammo")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
 
 /datum/design/breaching_slug/sec
 	name = "Breaching Slug"
@@ -102,7 +102,7 @@
 	materials = list(/datum/material/silver = 600, /datum/material/diamond = 600, /datum/material/uranium = 200)
 	build_path = /obj/item/firing_pin/implant/mindshield
 	category = list("Firing Pins")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
 
 /datum/design/stunmine/sec //mines ported from BeeStation
 	name = "Stun Mine"
@@ -172,7 +172,7 @@
 	materials = list(/datum/material/iron = 10000, /datum/material/glass = 2000, /datum/material/uranium = 3000, /datum/material/titanium = 1000)
 	build_path = /obj/item/gun/energy/e_gun/nuclear
 	category = list("Weapons")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
 
 /datum/design/tele_shield
 	name = "Telescopic Riot Shield"
@@ -192,7 +192,7 @@
 	materials = list(/datum/material/iron = 10000, /datum/material/glass = 5000, /datum/material/diamond = 5000, /datum/material/uranium = 8000, /datum/material/silver = 4500, /datum/material/gold = 5000)
 	build_path = /obj/item/gun/energy/beam_rifle
 	category = list("Weapons")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
 
 /datum/design/decloner
 	name = "Decloner"
@@ -203,7 +203,7 @@
 	reagents_list = list(/datum/reagent/toxin/mutagen = 40)
 	build_path = /obj/item/gun/energy/decloner
 	category = list("Weapons")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
 
 /datum/design/rapidsyringe
 	name = "Rapid Syringe Gun"
@@ -284,7 +284,7 @@
 	materials = list(/datum/material/gold = 5000, /datum/material/uranium = 4000, /datum/material/iron = 5000, /datum/material/titanium = 2000, /datum/material/bluespace = 2000)
 	build_path = /obj/item/gun/energy/xray
 	category = list("Weapons")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
 
 /datum/design/ioncarbine
 	name = "Ion Carbine"
@@ -316,7 +316,7 @@
 	materials = list(/datum/material/iron = 4000)
 	build_path = /obj/item/ammo_box/magazine/wt550m9
 	category = list("Ammo")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
 
 /datum/design/mag_oldsmg/ap_mag
 	name = "WT-550 Auto Gun Armour Piercing Magazine (4.6x30mm AP)"
@@ -324,7 +324,7 @@
 	id = "mag_oldsmg_ap"
 	materials = list(/datum/material/iron = 6000, /datum/material/silver = 600)
 	build_path = /obj/item/ammo_box/magazine/wt550m9/wtap
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
 
 /datum/design/mag_oldsmg/ic_mag
 	name = "WT-550 Auto Gun Incendiary Magazine (4.6x30mm IC)"
@@ -332,7 +332,7 @@
 	id = "mag_oldsmg_ic"
 	materials = list(/datum/material/iron = 6000, /datum/material/silver = 600, /datum/material/glass = 1000)
 	build_path = /obj/item/ammo_box/magazine/wt550m9/wtic
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
 
 /datum/design/mag_oldsmg/rubber_mag
 	name = "WT-550 Auto Gun Rubber Bullet Magazine (4.6x30mm Rubber)"
@@ -390,7 +390,7 @@
 	materials = list(/datum/material/iron = 5000, /datum/material/glass = 1500, /datum/material/uranium = 1500, /datum/material/silver = 1500)
 	build_path = /obj/item/gun/energy/kinetic_accelerator/crossbow/large
 	category = list("Weapons")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
 
 /datum/design/cryostatis_shotgun_dart
 	name = "Cryostatis Shotgun Dart"

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -102,7 +102,7 @@
 	materials = list(/datum/material/silver = 600, /datum/material/diamond = 600, /datum/material/uranium = 200)
 	build_path = /obj/item/firing_pin/implant/mindshield
 	category = list("Firing Pins")
-	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/stunmine/sec //mines ported from BeeStation
 	name = "Stun Mine"

--- a/code/modules/research/machinery/departmental_techfab.dm
+++ b/code/modules/research/machinery/departmental_techfab.dm
@@ -39,3 +39,9 @@
 	allowed_department_flags = DEPARTMENTAL_FLAG_ALL|DEPARTMENTAL_FLAG_SECURITY
 	department_tag = "Security"
 	circuit = /obj/item/circuitboard/machine/techfab/department/security
+
+/obj/machinery/rnd/production/techfab/department/armory
+	name = "department techfab (Armory)"
+	allowed_department_flags = DEPARTMENTAL_FLAG_ALL|DEPARTMENTAL_FLAG_SECURITY|DEPARTMENTAL_FLAG_ARMORY
+	department_tag = "Armory"
+	circuit = /obj/item/circuitboard/machine/techfab/department/armory


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request
Adds an armory protolathe for printing lethal weapons and ammo, removing those items from the security protolathe.

### Why is this change good for the game?
It defeats the purpose of the warden for sec officers to just print guns, bypassing the need to have them issued by the warden.

# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
Lethal weapons and ammo are removed from the sec protolathe, and added to the armory protolathe, located in the back of the armory. The table of what items can be printed in which protolathe will need to be updated to reflect the addition of a new protolathe and the moving of some items to it.

### What general grouping does this PR fall under? 
Security changes

# Changelog

:cl:  
rscadd: Added armory protolathe
/:cl:
