### PR TITLE
Assistant pager for the PDA

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -555,7 +555,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 					_alert_drones(msg, TRUE, U)
 					to_chat(U, msg)
 			if("Assistant Pager")
-				PingAssistants(U)
+				ping_assistants(U)
 
 
 
@@ -804,6 +804,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 
 	update_icon()
 	add_overlay(icon_alert)
+
 /obj/item/pda/proc/receive_ping(message)
 	if (!silent)
 		if(HAS_TRAIT(SSstation, STATION_TRAIT_PDA_GLITCHED))
@@ -828,7 +829,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 		return
 	send_message(U,get_viewable_pdas(), TRUE)
 
-/obj/item/pda/proc/PingAssistants (mob/living/U)
+/obj/item/pda/proc/ping_assistants(mob/living/U)
 	if (last_everyone && world.time < last_everyone + PDA_SPAM_DELAY)
 		to_chat(U,"<span class='warning'>Function is still on cooldown.</span>")
 		return
@@ -838,13 +839,12 @@ GLOBAL_LIST_EMPTY(PDAs)
 
 	if(!toSend)
 		return
+
 	toSend = "Assistant requested by [owner] at [A]! Reason: [toSend]"
 
 	last_everyone = world.time
-	for(var/i in get_viewable_assistant_pdas())
-		receive_ping(toSend)
-
-
+	for(var/obj/item/pda/P in get_viewable_assistant_pdas())
+		P.receive_ping(toSend)
 
 /obj/item/pda/proc/create_message(mob/living/U, obj/item/pda/P)
 	send_message(U,list(P))
@@ -1240,3 +1240,4 @@ GLOBAL_LIST_EMPTY(PDAs)
 #undef PDA_PRINTING_RESEARCH_REQUEST
 #undef PDA_PRINTING_MECH_REQUEST
 #undef PDA_PRINTING_JOB_REASSIGNMENT_CERTIFICATE
+

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -835,7 +835,12 @@ GLOBAL_LIST_EMPTY(PDAs)
 
 	var/area/A = get_area(U)
 	var toSend = stripped_input(U, "Please enter your issue.")
+
+	if(!toSend)
+		return
 	toSend = "Assistant requested by [owner] at [A]! Reason: [toSend]"
+
+	last_everyone = world.time
 	for(var/i in get_viewable_assistant_pdas())
 		receive_ping(toSend)
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -834,7 +834,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 		return
 
 	var/area/A = get_area(U)
-	var toSend = stripped_input(U, "Please enter your issue.")
+	var/toSend = stripped_input(U, "Please enter your issue.")
 
 	if(!toSend)
 		return
@@ -1240,4 +1240,3 @@ GLOBAL_LIST_EMPTY(PDAs)
 #undef PDA_PRINTING_RESEARCH_REQUEST
 #undef PDA_PRINTING_MECH_REQUEST
 #undef PDA_PRINTING_JOB_REASSIGNMENT_CERTIFICATE
-


### PR DESCRIPTION
### Intent of your Pull Request
Adds the ability to page assistants from your PDA. Any job that is not assistant can use this and it does not require a special cartridge. 

### Why is this change good for the game?
Allows assistants to be more useful while also not filling up the common chat with your requests.
# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
Adds a new feautre to the PDA which allows any non-assistant to send an alert to all assistants on the station.

### What should players be aware of when it comes to the changes your PR is implementing?
Just a new feature for the PDA
### What general grouping does this PR fall under? 
PDA tweak

### Are there any aspects of the PR that you would like us not to mention on the Wiki?

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
The pager has a two minute delay so it may not be spammed.

# Changelog

:cl:  
rscadd: Added a pager feature to the PDA

/:cl:
