### PR TITLE
Ports /tg/ tend wounds time estimation

### DIFF
--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -28,6 +28,9 @@
 	var/burnhealing = 0
 	var/missinghpbonus = 0 //heals an extra point of damager per X missing damage of type (burn damage for burn healing, brute for brute). Smaller Number = More Healing!
 
+/datum/surgery_step/heal/proc/get_progress(mob/user, mob/living/carbon/target, brute_healed, burn_healed)
+	return
+
 /datum/surgery_step/heal/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/woundtype
 	if(brutehealing && burnhealing)
@@ -67,6 +70,8 @@
 		umsg += " as best as you can while they have clothing on"
 		tmsg += " as best as they can while [target] has clothing on"
 	target.heal_bodypart_damage(urhealedamt_brute,urhealedamt_burn)
+	umsg += get_progress(user, target, urhealedamt_brute, urhealedamt_burn)
+
 	display_results(user, target, "<span class='notice'>[umsg].</span>",
 		"[tmsg].",
 		"[tmsg].")
@@ -113,6 +118,33 @@
 	desc = "A surgical procedure that provides experimental treatment for a patient's brute traumas. Heals considerably more when the patient is severely injured."
 
 /********************BRUTE STEPS********************/
+/datum/surgery_step/heal/brute/get_progress(mob/user, mob/living/carbon/target, brute_healed, burn_healed)
+	if(!brute_healed)
+		return
+
+	var/estimated_remaining_steps = target.getBruteLoss() / brute_healed
+	var/progress_text
+	if(locate(/obj/item/healthanalyzer) in user.held_items)
+		progress_text = ". Remaining brute: <font color='#ff3333'>[target.getBruteLoss()]</font>"
+	else
+		switch(estimated_remaining_steps)
+			if(-INFINITY to 1)
+				return
+			if(1 to 3)
+				progress_text = ", stitching up the last few scrapes"
+			if(3 to 6)
+				progress_text = ", counting down the last few bruises left to treat"
+			if(6 to 9)
+				progress_text = ", continuing to plug away at [target.p_their()] extensive rupturing"
+			if(9 to 12)
+				progress_text = ", steadying yourself for the long surgery ahead"
+			if(12 to 15)
+				progress_text = ", though [target.p_they()] still look[target.p_s()] more like ground beef than a person"
+			if(15 to INFINITY)
+				progress_text = ", though you feel like you're barely making a dent in treating [target.p_their()] pulped body"
+
+	return progress_text
+
 /datum/surgery_step/heal/brute/basic
 	name = "tend bruises"
 	brutehealing = 5
@@ -151,6 +183,33 @@
 	desc = "A surgical procedure that provides experimental treatment for a patient's burns. Heals considerably more when the patient is severely injured."
 
 /********************BURN STEPS********************/
+/datum/surgery_step/heal/burn/get_progress(mob/user, mob/living/carbon/target, brute_healed, burn_healed)
+	if(!burn_healed)
+		return
+
+	var/estimated_remaining_steps = target.getFireLoss() / burn_healed
+	var/progress_text
+	if(locate(/obj/item/healthanalyzer) in user.held_items)
+		progress_text = ". Remaining brute: <font color='#ff9933'>[target.getFireLoss()]</font>"
+	else
+		switch(estimated_remaining_steps)
+			if(-INFINITY to 1)
+				return
+			if(1 to 3)
+				progress_text = ", finishing up the last few singe marks"
+			if(3 to 6)
+				progress_text = ", counting down the last few blisters left to treat"
+			if(6 to 9)
+				progress_text = ", continuing to plug away at [target.p_their()] thorough roasting"
+			if(9 to 12)
+				progress_text = ", steadying yourself for the long surgery ahead"
+			if(12 to 15)
+				progress_text = ", though [target.p_they()] still look[target.p_s()] more like burnt steak than a person"
+			if(15 to INFINITY)
+				progress_text = ", though you feel like you're barely making a dent in treating [target.p_their()] charred body"
+
+	return progress_text
+
 /datum/surgery_step/heal/burn/basic
 	name = "tend burn wounds"
 	burnhealing = 5
@@ -165,8 +224,6 @@
 	missinghpbonus = 5
 
 /***************************COMBO***************************/
-/datum/surgery/healing/combo
-
 
 /datum/surgery/healing/combo
 	name = "Tend Wounds (Mixture, Basic)"
@@ -189,6 +246,39 @@
 	desc = "A surgical procedure that provides experimental treatment for a patient's burns and brute traumas. Heals considerably more when the patient is severely injured."
 
 /********************COMBO STEPS********************/
+/datum/surgery_step/heal/combo/get_progress(mob/user, mob/living/carbon/target, brute_healed, burn_healed)
+	var/estimated_remaining_steps = 0
+	if(brute_healed > 0)
+		estimated_remaining_steps = max(0, (target.getBruteLoss() / brute_healed))
+	if(burn_healed > 0)
+		estimated_remaining_steps = max(estimated_remaining_steps, (target.getFireLoss() / burn_healed)) // whichever is higher between brute or burn steps
+
+	var/progress_text
+
+	if(locate(/obj/item/healthanalyzer) in user.held_items)
+		if(target.getBruteLoss())
+			progress_text = ". Remaining brute: <font color='#ff3333'>[target.getBruteLoss()]</font>"
+		if(target.getFireLoss())
+			progress_text += ". Remaining burn: <font color='#ff9933'>[target.getFireLoss()]</font>"
+	else
+		switch(estimated_remaining_steps)
+			if(-INFINITY to 1)
+				return
+			if(1 to 3)
+				progress_text = ", finishing up the last few signs of damage"
+			if(3 to 6)
+				progress_text = ", counting down the last few patches of trauma"
+			if(6 to 9)
+				progress_text = ", continuing to plug away at [target.p_their()] extensive injuries"
+			if(9 to 12)
+				progress_text = ", steadying yourself for the long surgery ahead"
+			if(12 to 15)
+				progress_text = ", though [target.p_they()] still look[target.p_s()] more like smooshed baby food than a person"
+			if(15 to INFINITY)
+				progress_text = ", though you feel like you're barely making a dent in treating [target.p_their()] broken body"
+
+	return progress_text
+
 /datum/surgery_step/heal/combo
 	name = "tend physical wounds"
 	brutehealing = 3


### PR DESCRIPTION
#### Read our contributing.md if you haven't already: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md

# General Documentation

### Intent of your Pull Request
This PR makes it so during tend-wounds, you get messages that allow you to estimate how much more surgery you have before the patient is completely fixed. If you are holding a health analyzer in your off-hand, then you are shown damage numbers instead.
### Why is this change good for the game?
With health-scanning being weird during surgery, and operating computers sometimes not working or taking up screenspace, this will allow estimates to be done on if its worth doing the surgery.
# Wiki Documentation
n/a
### Briefly describe your PR and the impacts of it, in layman's terms. 
see above

### What should players be aware of when it comes to the changes your PR is implementing?
see above
### What general grouping does this PR fall under? 
tweaks

### Are there any aspects of the PR that you would like us not to mention on the Wiki?
n/a
### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
At 1 to 3 steps of damage, you are "finishing up"
at 3 to 6 steps of damage, you are "counting down the last bits of damage"
at 6 to 9 steps of damage, you are "plugging away"
at 9 to 12 steps, you are "steadying yourself"
at 12 to 15 the target will "look like x"
anything bigger and you "feel like you are barely making a dent"


# Changelog

Edit this changelog for changes that are noticeable by the players. Remove it if this isn't the case. If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. Prefix the PR title with [admin] if it's something admin related. Prefix the PR title with [s] if you are fixing an exploit so it is not announced on discord and the server.

:cl:  
tweak: Tend-wounds surgery now gives time estimates in the form of messages. Holding a health analyzer in your off-hand during surgery gives exact damage numbers now.
/:cl:
