### PR TITLE
Added a suit-storage keybind

### DIFF
--- a/yogstation/code/modules/keybindings/bindings_human.dm
+++ b/yogstation/code/modules/keybindings/bindings_human.dm
@@ -85,7 +85,7 @@
 				var/obj/item/stored = equipped_suit.contents[equipped_suit.contents.len]
 				if(!stored || stored.on_found(src))
 					return
-				stored.attack_hand(src) // take out thing from backpack
+				stored.attack_hand(src) // take out thing from suit storage
 				return
 
 	return ..()

--- a/yogstation/code/modules/keybindings/bindings_human.dm
+++ b/yogstation/code/modules/keybindings/bindings_human.dm
@@ -59,7 +59,7 @@
 				stored.attack_hand(src) // take out thing from backpack
 				return
 
-			if(ACTION_DROP) // Put held thing in backpack or take out most recent thing from backpack
+			if(ACTION_DROP) // Put held thing in suit storage or take thing out of suit storage
 				var/obj/item/thing = get_active_held_item()
 				var/obj/item/equipped_suit = get_item_by_slot(SLOT_S_STORE)
 				if(!equipped_suit) 
@@ -75,7 +75,7 @@
 					else
 						to_chat(user, "<span class='notice'>You can't fit anything in.</span>")
 					return
-				if(thing) // put thing in backpack
+				if(thing) // put thing in suit storage
 					if(!SEND_SIGNAL(equipped_suit, COMSIG_TRY_STORAGE_INSERT, thing, user.mob))
 						to_chat(user, "<span class='notice'>You can't fit anything in.</span>")
 					return

--- a/yogstation/code/modules/keybindings/bindings_human.dm
+++ b/yogstation/code/modules/keybindings/bindings_human.dm
@@ -59,4 +59,33 @@
 				stored.attack_hand(src) // take out thing from backpack
 				return
 
+			if(ACTION_DROP) // Put held thing in backpack or take out most recent thing from backpack
+				var/obj/item/thing = get_active_held_item()
+				var/obj/item/equipped_suit = get_item_by_slot(SLOT_S_STORE)
+				if(!equipped_suit) 
+					if(!thing)
+						to_chat(user, "<span class='notice'>You have no suit storage to take something out of.</span>")
+						return
+					if(equip_to_slot_if_possible(thing, SLOT_S_STORE))
+						update_inv_hands()
+					return
+				if(!SEND_SIGNAL(equipped_suit, COMSIG_CONTAINS_STORAGE)) // not a storage item
+					if(!thing)
+						equipped_suit.attack_hand(src)
+					else
+						to_chat(user, "<span class='notice'>You can't fit anything in.</span>")
+					return
+				if(thing) // put thing in backpack
+					if(!SEND_SIGNAL(equipped_suit, COMSIG_TRY_STORAGE_INSERT, thing, user.mob))
+						to_chat(user, "<span class='notice'>You can't fit anything in.</span>")
+					return
+				if(!equipped_suit.contents.len) // nothing to take out
+					to_chat(user, "<span class='notice'>There's nothing in your suit storage to take out.</span>")
+					return
+				var/obj/item/stored = equipped_suit.contents[equipped_suit.contents.len]
+				if(!stored || stored.on_found(src))
+					return
+				stored.attack_hand(src) // take out thing from backpack
+				return
+
 	return ..()


### PR DESCRIPTION
#### Read our contributing.md if you haven't already: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md

# General Documentation

### Intent of your Pull Request

Shift + Drop-key (default Q) lets you take/remove items from your suit storage.

### Why is this change good for the game?
we have bindings for belt and backpack but not suit storage. cringe.
# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
i dont even think we have those keybinds on the wiki

### What should players be aware of when it comes to the changes your PR is implementing?
Press Shift + Q (or your drop key) to equip/remove items from your suit storage
### What general grouping does this PR fall under? 
tweak

### Are there any aspects of the PR that you would like us not to mention on the Wiki?

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 


# Changelog

Edit this changelog for changes that are noticeable by the players. Remove it if this isn't the case. If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. Prefix the PR title with [admin] if it's something admin related. Prefix the PR title with [s] if you are fixing an exploit so it is not announced on discord and the server.

:cl:  
rscadd: Added new keybind: pressing Shift + Drop key (default Q) lets you remove/add items to your suit storage.
/:cl:
