### PR TITLE
Defib's now force ghosts back into their body

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -22,7 +22,7 @@
 	var/obj/item/twohanded/shockpaddles/paddles
 	var/obj/item/stock_parts/cell/high/cell
 	var/combat = FALSE //can we revive through space suits?
-	var/grab_ghost = FALSE // Do we pull the ghost back into their body?
+	var/grab_ghost = TRUE // Do we pull the ghost back into their body?
 
 /obj/item/defibrillator/get_cell()
 	return cell
@@ -305,7 +305,7 @@
 	var/obj/item/defibrillator/defib
 	var/req_defib = TRUE
 	var/combat = FALSE //If it penetrates armor and gives additional functionality
-	var/grab_ghost = FALSE
+	var/grab_ghost = TRUE
 	var/tlimit = DEFIB_TIME_LIMIT * 10
 
 	var/mob/listeningTo

--- a/code/modules/surgery/advanced/revival.dm
+++ b/code/modules/surgery/advanced/revival.dm
@@ -54,13 +54,14 @@
 	display_results(user, target, "<span class='notice'>You prepare to give [target]'s brain the spark of life with [tool].</span>",
 		"[user] prepares to shock [target]'s brain with [tool].",
 		"[user] prepares to shock [target]'s brain with [tool].")
-	target.notify_ghost_cloning("Someone is trying to zap your brain. Re-enter your corpse if you want to be revived!", source = target)
+	target.notify_ghost_cloning("Someone is trying to zap your brain.", source = target)
 
 /datum/surgery_step/revive/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, "<span class='notice'>You successfully shock [target]'s brain with [tool]...</span>",
 		"[user] send a powerful shock to [target]'s brain with [tool]...",
 		"[user] send a powerful shock to [target]'s brain with [tool]...")
 	playsound(get_turf(target), 'sound/magic/lightningbolt.ogg', 50, 1)
+	target.grab_ghost()
 	target.adjustOxyLoss(-50, 0)
 	target.updatehealth()
 	if(target.revive())


### PR DESCRIPTION
#### Read our contributing.md if you haven't already: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md

# General Documentation

### Intent of your Pull Request

When defibbing, you get forced back into your body. If you don't want to be defibbed, hit that DNR button.

### Why is this change good for the game?
Im stick and tired of defibbing motherfuckers who just go AFK as a ghost and wasting time
# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
Defibs will bring you back to life, kicking and screaming and shitting even if you are a ghost

### What should players be aware of when it comes to the changes your PR is implementing?

### What general grouping does this PR fall under? 
For example, Engineering changes, Medical rebalancing, TEG tweaks, etc.?

### Are there any aspects of the PR that you would like us not to mention on the Wiki?

### If there are any numerical values involved in your PR that will be relevant to a player, please note them here. 
For example, "This new chem will heal X brute damage". 

# Changelog


:cl:  
tweak: Defibs now drag ghosts back to their bodies by force. Use that DNR button under your "Ghost" tab if you don't want to come back.
/:cl:
