### PR TITLE
Points charcoal stylus icon to the correct file

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -238,6 +238,7 @@
 /obj/item/pen/charcoal
 	name = "charcoal stylus"
 	desc = "It's just a wooden stick with some compressed ash on the end. At least it can write."
+	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "pen-charcoal"
 	colour = "dimgray"
 	font = CHARCOAL_FONT


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Gives the charcoal stylus an actual icon

### Why is this change good for the game?
Invisible items bad

# Changelog

Fixes #11600 

:cl:  
bugfix: fixes charcoal stylus not having a sprite
/:cl:
