### PR TITLE
Fixes mech salvage including an invisible air tank

### DIFF
--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -387,8 +387,4 @@
 			cell.forceMove(WR)
 			cell.charge = rand(0, cell.charge)
 			cell = null
-		if(internal_tank)
-			WR.crowbar_salvage += internal_tank
-			internal_tank.forceMove(WR)
-			cell = null
 	. = ..()


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Fixes the bug where salvage might include an invisible unmovable air tank. Also, no mech requires one to build, so why are they salvageable?

### Why is this change good for the game?
The bug is annoying

# Changelog

Fixes #11358 

:cl:  
bugfix: fixed salvaging a mech with an airtank giving an invisible airtank
/:cl:
