### PR TITLE
Fix EMT green hat becoming blue when flipped

### DIFF
--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -134,5 +134,5 @@
 	name = "green EMT cap"
 	desc = "It's a baseball hat with a green color and a reflective cross on the top."
 	icon_state = "emtgrsoft"
-	item_color = "emt"
+	item_color = "emtgr"
 	dog_fashion = null


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Green EMT cap will now stay green when flipped

### Why is this change good for the game?
Dripstation


# Changelog

Fixes #11002 

:cl:  
bugfix: fixed green emt cap becoming blue when flipped 
/:cl:
