### PR TITLE
Re-adds comments to the security records console, plus some other records changes

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -60,7 +60,7 @@
 	var/datum/data/comment/C = new /datum/data/comment
 	C.commentText = commentText
 	C.author = author
-	C.time = time != "" ? time : text("[] [], []", station_time_timestamp(), time2text(world.realtime, "MMM DD"), GLOB.year_integer+540)
+	C.time = time || station_time_timestamp()
 	C.dataId = ++securityCommentCounter
 	return C
 

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -6,6 +6,7 @@
 	var/list/security = list()
 	var/securityPrintCount = 0
 	var/securityCrimeCounter = 0
+	var/securityCommentCounter = 0
 	//This list tracks characters spawned in the world and cannot be modified in-game. Currently referenced by respawn_character().
 	var/list/locked = list()
 
@@ -37,6 +38,13 @@
 	var/paid = 0
 	var/dataId = 0
 
+/datum/data/comment
+	name = "comment"
+	var/commentText = ""
+	var/author = ""
+	var/time = ""
+	var/dataId = 0
+
 /datum/datacore/proc/createCrimeEntry(cname = "", cdetails = "", author = "", time = "", fine = 0)
 	var/datum/data/crime/c = new /datum/data/crime
 	c.crimeName = cname
@@ -47,6 +55,14 @@
 	c.paid = 0
 	c.dataId = ++securityCrimeCounter
 	return c
+
+/datum/datacore/proc/createCommentEntry(commentText = "", author = "", time = "")
+	var/datum/data/comment/C = new /datum/data/comment
+	C.commentText = commentText
+	C.author = author
+	C.time = time != "" ? time : text("[] [], []", station_time_timestamp(), time2text(world.realtime, "MMM DD"), GLOB.year_integer+540)
+	C.dataId = ++securityCommentCounter
+	return C
 
 /datum/datacore/proc/addCitation(id = "", datum/data/crime/crime)
 	for(var/datum/data/record/R in security)
@@ -89,6 +105,22 @@
 			for(var/datum/data/crime/crime in crimes)
 				if(crime.dataId == text2num(cDataId))
 					crimes -= crime
+					return
+
+/datum/datacore/proc/addComment(id = "", datum/data/comment/comment)
+	for(var/datum/data/record/R in security)
+		if(R.fields["id"] == id)
+			var/list/comments = R.fields["comments"]
+			comments |= comment
+			return
+
+/datum/datacore/proc/removeComment(id, cDataId)
+	for(var/datum/data/record/R in security)
+		if(R.fields["id"] == id)
+			var/list/comments = R.fields["comments"]
+			for(var/datum/data/comment/comment in comments)
+				if(comment.dataId == text2num(cDataId))
+					comments -= comment
 					return
 
 /datum/datacore/proc/manifest()
@@ -319,8 +351,8 @@
 		S.fields["name"]		= H.real_name
 		S.fields["criminal"]	= "None"
 		S.fields["citation"]	= list()
-		S.fields["mi_crim"]		= list()
-		S.fields["ma_crim"]		= list()
+		S.fields["crimes"]		= list()
+		S.fields["comments"]	= list()
 		S.fields["notes"]		= "No notes."
 		security += S
 

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -75,37 +75,21 @@
 					D.adjust_money(amount)
 					return
 
-/datum/datacore/proc/addMinorCrime(id = "", datum/data/crime/crime)
+/datum/datacore/proc/addCrime(id = "", datum/data/crime/crime)
 	for(var/datum/data/record/R in security)
 		if(R.fields["id"] == id)
-			var/list/crimes = R.fields["mi_crim"]
+			var/list/crimes = R.fields["crimes"]
 			crimes |= crime
 			return
 
-/datum/datacore/proc/removeMinorCrime(id, cDataId)
+/datum/datacore/proc/removeCrime(id, cDataId)
 	for(var/datum/data/record/R in security)
 		if(R.fields["id"] == id)
-			var/list/crimes = R.fields["mi_crim"]
+			var/list/crimes = R.fields["crimes"]
 			for(var/datum/data/crime/crime in crimes)
 				if(crime.dataId == text2num(cDataId))
 					crimes -= crime
 					return
-
-/datum/datacore/proc/removeMajorCrime(id, cDataId)
-	for(var/datum/data/record/R in security)
-		if(R.fields["id"] == id)
-			var/list/crimes = R.fields["ma_crim"]
-			for(var/datum/data/crime/crime in crimes)
-				if(crime.dataId == text2num(cDataId))
-					crimes -= crime
-					return
-
-/datum/datacore/proc/addMajorCrime(id = "", datum/data/crime/crime)
-	for(var/datum/data/record/R in security)
-		if(R.fields["id"] == id)
-			var/list/crimes = R.fields["ma_crim"]
-			crimes |= crime
-			return
 
 /datum/datacore/proc/manifest()
 	for(var/mob/dead/new_player/N in GLOB.player_list)

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -217,29 +217,17 @@
 
 				record["citations"] += list(citation)
 
-			record["minor_crimes"] = list()
+			record["crimes"] = list()
 
-			for(var/datum/data/crime/C in active_security_record.fields["mi_crim"])
-				var/list/minor_crime = list()
-				minor_crime["name"] = C.crimeName
-				minor_crime["details"] = C.crimeDetails
-				minor_crime["author"] = C.author
-				minor_crime["time"] = C.time
-				minor_crime["id"] = C.dataId
+			for(var/datum/data/crime/C in active_security_record.fields["crimes"])
+				var/list/crime = list()
+				crime["name"] = C.crimeName
+				crime["details"] = C.crimeDetails
+				crime["author"] = C.author
+				crime["time"] = C.time
+				crime["id"] = C.dataId
 
-				record["minor_crimes"] += list(minor_crime)
-
-			record["major_crimes"] = list()
-
-			for(var/datum/data/crime/C in active_security_record.fields["ma_crim"])
-				var/list/major_crime = list()
-				major_crime["name"] = C.crimeName
-				major_crime["details"] = C.crimeDetails
-				major_crime["author"] = C.author
-				major_crime["time"] = C.time
-				major_crime["id"] = C.dataId
-
-				record["major_crimes"] += list(major_crime)
+				record["crimes"] += list(crime)
 
 			record["notes"] = active_security_record.fields["notes"]
 
@@ -627,39 +615,22 @@
 							var/obj/item/photo/P = active_general_record.fields["photo_side"]
 							print_photo(P.picture.picture_image, active_general_record.fields["name"])
 
-				if("minor_crime_add")
+				if("crime_add")
 					if(istype(active_general_record, /datum/data/record))
-						var/name = stripped_input(usr, "Please input minor crime names:", "Security Records", "", null)
-						var/details = stripped_input(usr, "Please input minor crime details:", "Security Records", "", null)
+						var/name = stripped_input(usr, "Please input crime names:", "Security Records", "", null)
+						var/details = stripped_input(usr, "Please input crime details:", "Security Records", "", null)
 						if(!valid_record_change(usr, name, null, active_security_record))
 							return
 						var/crime = GLOB.data_core.createCrimeEntry(name, details, logged_in, station_time_timestamp())
-						GLOB.data_core.addMinorCrime(active_general_record.fields["id"], crime)
-						investigate_log("New Minor Crime: <strong>[name]</strong>: [details] | Added to [active_general_record.fields["name"]] by [key_name(usr)]", INVESTIGATE_RECORDS)
+						GLOB.data_core.addCrime(active_general_record.fields["id"], crime)
+						investigate_log("New Crime: <strong>[name]</strong>: [details] | Added to [active_general_record.fields["name"]] by [key_name(usr)]", INVESTIGATE_RECORDS)
 
-				if("minor_crime_delete")
+				if("crime_delete")
 					if(istype(active_general_record, /datum/data/record))
 						if(params["id"])
 							if(!valid_record_change(usr, "delete", null, active_security_record))
 								return
-							GLOB.data_core.removeMinorCrime(active_general_record.fields["id"], params["id"])
-
-				if("major_crime_add")
-					if(istype(active_general_record, /datum/data/record))
-						var/name = stripped_input(usr, "Please input major crime names:", "Security Records", "", null)
-						var/details = stripped_input(usr, "Please input major crime details:", "Security Records", "", null)
-						if(!valid_record_change(usr, name, null, active_security_record))
-							return
-						var/crime = GLOB.data_core.createCrimeEntry(name, details, logged_in, station_time_timestamp())
-						GLOB.data_core.addMajorCrime(active_general_record.fields["id"], crime)
-						investigate_log("New Major Crime: <strong>[name]</strong>: [details] | Added to [active_general_record.fields["name"]] by [key_name(usr)]", INVESTIGATE_RECORDS)
-
-				if("major_crime_delete")
-					if(istype(active_general_record, /datum/data/record))
-						if(params["id"])
-							if(!valid_record_change(usr, "delete", null, active_security_record))
-								return
-							GLOB.data_core.removeMajorCrime(active_general_record.fields["id"], params["id"])
+							GLOB.data_core.removeCrime(active_general_record.fields["id"], params["id"])
 
 				if("citation_add")
 					if(istype(active_general_record, /datum/data/record))

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -565,7 +565,7 @@
 
 				if("id")
 					if(istype(active_security_record, /datum/data/record) || istype(active_general_record, /datum/data/record))
-						var/id = stripped_input(usr, "Please input ID:", "Security Records", active_general_record.fields["id"], null)
+						var/id = stripped_input(usr, "Please input ID:", "Security Records", active_general_record.fields["id"])
 						if(!valid_record_change(usr, id, general_record))
 							return
 						if(istype(active_general_record, /datum/data/record))
@@ -575,7 +575,7 @@
 
 				if("fingerprint")
 					if(istype(active_general_record, /datum/data/record))
-						var/fingerprint = stripped_input(usr, "Please input fingerprint hash:", "Security Records", active_general_record.fields["fingerprint"], null)
+						var/fingerprint = stripped_input(usr, "Please input fingerprint hash:", "Security Records", active_general_record.fields["fingerprint"])
 						if(!valid_record_change(usr, fingerprint, general_record))
 							return
 						active_general_record.fields["fingerprint"] = fingerprint
@@ -626,8 +626,8 @@
 
 				if("crime_add")
 					if(istype(active_general_record, /datum/data/record))
-						var/name = stripped_input(usr, "Please input crime name:", "Security Records", "", null)
-						var/details = stripped_input(usr, "Please input crime details:", "Security Records", "", null)
+						var/name = stripped_input(usr, "Please input crime name:", "Security Records", "")
+						var/details = stripped_input(usr, "Please input crime details:", "Security Records", "")
 						if(!valid_record_change(usr, name, null, active_security_record))
 							return
 						var/crime = GLOB.data_core.createCrimeEntry(name, details, logged_in, station_time_timestamp())
@@ -643,17 +643,17 @@
 
 				if("comment_add")
 					if(istype(active_general_record, /datum/data/record))
-						var/t1 = stripped_multiline_input("Add Comment:", "Secure. records", null, null)
+						var/t1 = stripped_multiline_input(usr, "Add Comment:", "Security records")
 						if(!valid_record_change(usr, name, null, active_security_record))
 							return
-						var/crime = GLOB.data_core.createCommentEntry(t1, logged_in)
-						GLOB.data_core.addComment(active_general_record.fields["id"], crime)
+						var/comment = GLOB.data_core.createCommentEntry(t1, logged_in)
+						GLOB.data_core.addComment(active_general_record.fields["id"], comment)
 						investigate_log("New Comment: [t1] | Added to [active_general_record.fields["name"]] by [key_name(usr)]", INVESTIGATE_RECORDS)
 
 
 				if("citation_add")
 					if(istype(active_general_record, /datum/data/record))
-						var/name = stripped_input(usr, "Please input citation crime:", "Security Records", "", null)
+						var/name = stripped_input(usr, "Please input citation crime:", "Security Records", "")
 						var/fine = FLOOR(input(usr, "Please input citation fine:", "Security Records", 50) as num, 1)
 						if(!fine || fine < 0)
 							to_chat(usr, "<span class='warning'>You're pretty sure that's not how money works.</span>")
@@ -685,7 +685,7 @@
 
 				if("edit_note")
 					if(istype(active_security_record, /datum/data/record))
-						var/name = stripped_input(usr, "Please summarize notes:", "Security Records", active_security_record.fields["notes"], null)
+						var/name = stripped_input(usr, "Please summarize notes:", "Security Records", active_security_record.fields["notes"])
 						if(!valid_record_change(usr, name, null, active_security_record))
 							return
 						active_security_record.fields["notes"] = name

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -231,11 +231,13 @@
 
 			record["comments"] = list()
 
-			for(var/datum/data/comment/C in active_security_record.fields["crimes"])
+			for(var/datum/data/comment/C in active_security_record.fields["comments"])
 				var/list/comment = list()
 				comment["content"] = C.commentText
 				comment["author"] = C.author
 				comment["time"] = C.time
+				comment["id"] = C.dataId
+
 				record["comments"] += list(comment)
 
 			record["notes"] = active_security_record.fields["notes"]
@@ -615,9 +617,16 @@
 							var/obj/item/photo/P = active_general_record.fields["photo_side"]
 							print_photo(P.picture.picture_image, active_general_record.fields["name"])
 
+				if("crime_delete")
+					if(istype(active_general_record, /datum/data/record))
+						if(params["id"])
+							if(!valid_record_change(usr, "delete", null, active_security_record))
+								return
+							GLOB.data_core.removeCrime(active_general_record.fields["id"], params["id"])
+
 				if("crime_add")
 					if(istype(active_general_record, /datum/data/record))
-						var/name = stripped_input(usr, "Please input crime names:", "Security Records", "", null)
+						var/name = stripped_input(usr, "Please input crime name:", "Security Records", "", null)
 						var/details = stripped_input(usr, "Please input crime details:", "Security Records", "", null)
 						if(!valid_record_change(usr, name, null, active_security_record))
 							return
@@ -641,12 +650,6 @@
 						GLOB.data_core.addComment(active_general_record.fields["id"], crime)
 						investigate_log("New Comment: [t1] | Added to [active_general_record.fields["name"]] by [key_name(usr)]", INVESTIGATE_RECORDS)
 
-				if("crime_delete")
-					if(istype(active_general_record, /datum/data/record))
-						if(params["id"])
-							if(!valid_record_change(usr, "delete", null, active_security_record))
-								return
-							GLOB.data_core.removeCrime(active_general_record.fields["id"], params["id"])
 
 				if("citation_add")
 					if(istype(active_general_record, /datum/data/record))

--- a/code/game/machinery/computer/warrant.dm
+++ b/code/game/machinery/computer/warrant.dm
@@ -68,7 +68,7 @@
 				dat += "</tr>"
 			dat += "</table>"
 
-			dat += "<br>Minor Crimes:"
+			dat += "<br>Crimes:"
 			dat +={"<table style="text-align:center;" border="1" cellspacing="0" width="100%">
 			<tr>
 			<th>Crime</th>
@@ -76,23 +76,7 @@
 			<th>Author</th>
 			<th>Time Added</th>
 			</tr>"}
-			for(var/datum/data/crime/c in current.fields["mi_crim"])
-				dat += {"<tr><td>[c.crimeName]</td>
-				<td>[c.crimeDetails]</td>
-				<td>[c.author]</td>
-				<td>[c.time]</td>
-				</tr>"}
-			dat += "</table>"
-
-			dat += "<br>Major Crimes:"
-			dat +={"<table style="text-align:center;" border="1" cellspacing="0" width="100%">
-			<tr>
-			<th>Crime</th>
-			<th>Details</th>
-			<th>Author</th>
-			<th>Time Added</th>
-			</tr>"}
-			for(var/datum/data/crime/c in current.fields["ma_crim"])
+			for(var/datum/data/crime/c in current.fields["crimes"])
 				dat += {"<tr><td>[c.crimeName]</td>
 				<td>[c.crimeDetails]</td>
 				<td>[c.author]</td>

--- a/code/game/objects/effects/contraband.dm
+++ b/code/game/objects/effects/contraband.dm
@@ -190,18 +190,11 @@
 	var/obj/item/photo/photo = R.fields["photo_front"]
 	var/wanted_name = R.fields["name"]
 	var/description = "A poster declaring [wanted_name] to be a dangerous individual, wanted by Nanotrasen. Report any sightings to security immediately."
-	var/list/major_crimes = S.fields["ma_crim"]
-	var/list/minor_crimes = S.fields["mi_crim"]
-	if(major_crimes.len || minor_crimes.len)
+	var/list/crimes = S.fields["crimes"]
+	if(crimes.len)
 		description += "\n[wanted_name] is wanted for the following crimes:\n"
-	if(minor_crimes.len)
 		description += "\nMinor Crimes:"
-		for(var/datum/data/crime/c in S.fields["mi_crim"])
-			description += "\n[c.crimeName]\n"
-			description += "[c.crimeDetails]\n"
-	if(major_crimes.len)
-		description += "\nMajor Crimes:"
-		for(var/datum/data/crime/c in S.fields["ma_crim"])
+		for(var/datum/data/crime/c in S.fields["crimes"])
 			description += "\n[c.crimeName]\n"
 			description += "[c.crimeDetails]\n"
 	var/obj/structure/sign/poster/wanted/D = new(P, photo.picture.picture_image, wanted_name, description, "WANTED", "#FF0000", "wanted_background", "wanted poster", "A wanted poster for")

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -382,7 +382,7 @@ Code:
 			if(active3 in GLOB.data_core.security)
 				menu += "Criminal Status: [active3.fields["criminal"]]<br>"
 
-				menu += text("<BR>\nMinor Crimes:")
+				menu += text("<BR>\nCrimes:")
 
 				menu +={"<table style="text-align:center;" border="1" cellspacing="0" width="100%">
 <tr>
@@ -391,7 +391,7 @@ Code:
 <th>Author</th>
 <th>Time Added</th>
 </tr>"}
-				for(var/datum/data/crime/c in active3.fields["mi_crim"])
+				for(var/datum/data/crime/c in active3.fields["crimes"])
 					menu += "<tr><td>[c.crimeName]</td>"
 					menu += "<td>[c.crimeDetails]</td>"
 					menu += "<td>[c.author]</td>"
@@ -399,18 +399,16 @@ Code:
 					menu += "</tr>"
 				menu += "</table>"
 
-				menu += text("<BR>\nMajor Crimes:")
+				menu += text("<BR>\nComments:")
 
 				menu +={"<table style="text-align:center;" border="1" cellspacing="0" width="100%">
 <tr>
-<th>Crime</th>
-<th>Details</th>
+<th>Comment</th>
 <th>Author</th>
 <th>Time Added</th>
 </tr>"}
-				for(var/datum/data/crime/c in active3.fields["ma_crim"])
-					menu += "<tr><td>[c.crimeName]</td>"
-					menu += "<td>[c.crimeDetails]</td>"
+				for(var/datum/data/comment/c in active3.fields["comments"])
+					menu += "<tr><td>[c.commentText]</td>"
 					menu += "<td>[c.author]</td>"
 					menu += "<td>[c.time]</td>"
 					menu += "</tr>"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -430,38 +430,20 @@
 									return
 
 								if(href_list["add_crime"])
-									switch(alert("What crime would you like to add?","Security HUD","Minor Crime","Major Crime","Cancel"))
-										if("Minor Crime")
-											if(R)
-												var/t1 = stripped_input("Please input minor crime names:", "Security HUD", "", null)
-												var/t2 = stripped_multiline_input("Please input minor crime details:", "Security HUD", "", null)
-												if(R)
-													if (!t1 || !t2 || !allowed_access)
-														return
-													else if(!H.canUseHUD())
-														return
-													else if(!istype(H.glasses, /obj/item/clothing/glasses/hud/security) && !istype(H.getorganslot(ORGAN_SLOT_HUD), /obj/item/organ/cyberimp/eyes/hud/security))
-														return
-													var/crime = GLOB.data_core.createCrimeEntry(t1, t2, allowed_access, station_time_timestamp())
-													GLOB.data_core.addMinorCrime(R.fields["id"], crime)
-													investigate_log("New Minor Crime: <strong>[t1]</strong>: [t2] | Added to [R.fields["name"]] by [key_name(usr)]", INVESTIGATE_RECORDS)
-													to_chat(usr, "<span class='notice'>Successfully added a minor crime.</span>")
-													return
-										if("Major Crime")
-											if(R)
-												var/t1 = stripped_input("Please input major crime names:", "Security HUD", "", null)
-												var/t2 = stripped_multiline_input("Please input major crime details:", "Security HUD", "", null)
-												if(R)
-													if (!t1 || !t2 || !allowed_access)
-														return
-													else if (!H.canUseHUD())
-														return
-													else if (!istype(H.glasses, /obj/item/clothing/glasses/hud/security) && !istype(H.getorganslot(ORGAN_SLOT_HUD), /obj/item/organ/cyberimp/eyes/hud/security))
-														return
-													var/crime = GLOB.data_core.createCrimeEntry(t1, t2, allowed_access, station_time_timestamp())
-													GLOB.data_core.addMajorCrime(R.fields["id"], crime)
-													investigate_log("New Major Crime: <strong>[t1]</strong>: [t2] | Added to [R.fields["name"]] by [key_name(usr)]", INVESTIGATE_RECORDS)
-													to_chat(usr, "<span class='notice'>Successfully added a major crime.</span>")
+									if(R)
+										var/t1 = stripped_input("Please input crime names:", "Security HUD", "", null)
+										var/t2 = stripped_multiline_input("Please input crime details:", "Security HUD", "", null)
+										if(R)
+											if (!t1 || !t2 || !allowed_access)
+												return
+											else if(!H.canUseHUD())
+												return
+											else if(!istype(H.glasses, /obj/item/clothing/glasses/hud/security) && !istype(H.getorganslot(ORGAN_SLOT_HUD), /obj/item/organ/cyberimp/eyes/hud/security))
+												return
+											var/crime = GLOB.data_core.createCrimeEntry(t1, t2, allowed_access, station_time_timestamp())
+											GLOB.data_core.addCrime(R.fields["id"], crime)
+											investigate_log("New Crime: <strong>[t1]</strong>: [t2] | Added to [R.fields["name"]] by [key_name(usr)]", INVESTIGATE_RECORDS)
+											to_chat(usr, "<span class='notice'>Successfully added a crime.</span>")
 									return
 
 								if(href_list["view_comment"])

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -430,18 +430,18 @@
 
 								if(href_list["add_crime"])
 									if(R)
-										var/t1 = stripped_input("Please input crime names:", "Security HUD", "", null)
-										var/t2 = stripped_multiline_input("Please input crime details:", "Security HUD", "", null)
+										var/crimeName = stripped_input("Please input crime name:", "Security HUD", "")
+										var/crimeDetails = stripped_multiline_input("Please input crime details:", "Security HUD", "")
 										if(R)
-											if (!t1 || !t2 || !allowed_access)
+											if (!crimeName || !crimeDetails || !allowed_access)
 												return
 											else if(!H.canUseHUD())
 												return
 											else if(!istype(H.glasses, /obj/item/clothing/glasses/hud/security) && !istype(H.getorganslot(ORGAN_SLOT_HUD), /obj/item/organ/cyberimp/eyes/hud/security))
 												return
-											var/crime = GLOB.data_core.createCrimeEntry(t1, t2, allowed_access, station_time_timestamp())
+											var/crime = GLOB.data_core.createCrimeEntry(crimeName, crimeDetails, allowed_access, station_time_timestamp())
 											GLOB.data_core.addCrime(R.fields["id"], crime)
-											investigate_log("New Crime: <strong>[t1]</strong>: [t2] | Added to [R.fields["name"]] by [key_name(usr)]", INVESTIGATE_RECORDS)
+											investigate_log("New Crime: <strong>[crimeName]</strong>: [crimeDetails] | Added to [R.fields["name"]] by [key_name(usr)]", INVESTIGATE_RECORDS)
 											to_chat(usr, "<span class='notice'>Successfully added a crime.</span>")
 									return
 
@@ -459,15 +459,15 @@
 
 								if(href_list["add_comment"])
 									if(R)
-										var/t1 = stripped_multiline_input("Add Comment:", "Secure. records", null, null)
+										var/commentValue = stripped_multiline_input("Add Comment:", "Security records")
 										if(R)
-											if (!t1 || !allowed_access)
+											if (!commentValue || !allowed_access)
 												return
 											else if(!H.canUseHUD())
 												return
 											else if(!istype(H.glasses, /obj/item/clothing/glasses/hud/security) && !istype(H.getorganslot(ORGAN_SLOT_HUD), /obj/item/organ/cyberimp/eyes/hud/security))
 												return
-											var/comment = GLOB.data_core.createCommentEntry(t1, allowed_access)
+											var/comment = GLOB.data_core.createCommentEntry(commentValue, allowed_access)
 											GLOB.data_core.addComment(R.fields["id"], comment)
 											to_chat(usr, "<span class='notice'>Successfully added comment.</span>")
 											return

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -414,16 +414,15 @@
 										else if(!istype(H.glasses, /obj/item/clothing/glasses/hud/security) && !istype(H.getorganslot(ORGAN_SLOT_HUD), /obj/item/organ/cyberimp/eyes/hud/security))
 											return
 										to_chat(usr, "<b>Name:</b> [R.fields["name"]]	<b>Criminal Status:</b> [R.fields["criminal"]]")
-										to_chat(usr, "<b>Minor Crimes:</b>")
-										for(var/datum/data/crime/c in R.fields["mi_crim"])
+										to_chat(usr, "<b>Crimes:</b>")
+										for(var/datum/data/crime/c in R.fields["crimes"])
 											to_chat(usr, "<b>Crime:</b> [c.crimeName]")
 											to_chat(usr, "<b>Details:</b> [c.crimeDetails]")
 											to_chat(usr, "Added by [c.author] at [c.time]")
 											to_chat(usr, "----------")
-										to_chat(usr, "<b>Major Crimes:</b>")
-										for(var/datum/data/crime/c in R.fields["ma_crim"])
-											to_chat(usr, "<b>Crime:</b> [c.crimeName]")
-											to_chat(usr, "<b>Details:</b> [c.crimeDetails]")
+										to_chat(usr, "<b>Comments:</b>")
+										for(var/datum/data/comment/c in R.fields["comments"])
+											to_chat(usr, "<b>Comment:</b> [c.commentText]")
 											to_chat(usr, "Added by [c.author] at [c.time]")
 											to_chat(usr, "----------")
 										to_chat(usr, "<b>Notes:</b> [R.fields["notes"]]")
@@ -453,11 +452,9 @@
 										else if(!istype(H.glasses, /obj/item/clothing/glasses/hud/security) && !istype(H.getorganslot(ORGAN_SLOT_HUD), /obj/item/organ/cyberimp/eyes/hud/security))
 											return
 										to_chat(usr, "<b>Comments/Log:</b>")
-										var/counter = 1
-										while(R.fields[text("com_[]", counter)])
-											to_chat(usr, R.fields[text("com_[]", counter)])
+										for(var/datum/data/comment/C in R.fields["comments"])
+											to_chat(usr, text("Made by [] on []<BR>[]", C.author, C.time, C.commentText))
 											to_chat(usr, "----------")
-											counter++
 										return
 
 								if(href_list["add_comment"])
@@ -470,10 +467,8 @@
 												return
 											else if(!istype(H.glasses, /obj/item/clothing/glasses/hud/security) && !istype(H.getorganslot(ORGAN_SLOT_HUD), /obj/item/organ/cyberimp/eyes/hud/security))
 												return
-											var/counter = 1
-											while(R.fields[text("com_[]", counter)])
-												counter++
-											R.fields[text("com_[]", counter)] = text("Made by [] on [] [], []<BR>[]", allowed_access, station_time_timestamp(), time2text(world.realtime, "MMM DD"), GLOB.year_integer+540, t1)
+											var/comment = GLOB.data_core.createCommentEntry(t1, allowed_access)
+											GLOB.data_core.addComment(R.fields["id"], comment)
 											to_chat(usr, "<span class='notice'>Successfully added comment.</span>")
 											return
 							to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -492,7 +492,18 @@
 			else
 				. += "<pre>Requested security record not found,</pre><BR>"
 			if(securityActive2 in GLOB.data_core.security)
-				. += "<BR>\nSecurity Data<BR>\nCriminal Status: [securityActive2.fields["criminal"]]<BR>\n<BR>\nMinor Crimes: <A href='?src=[REF(src)];field=mi_crim'>[securityActive2.fields["mi_crim"]]</A><BR>\nDetails: <A href='?src=[REF(src)];field=mi_crim_d'>[securityActive2.fields["mi_crim_d"]]</A><BR>\n<BR>\nMajor Crimes: <A href='?src=[REF(src)];field=ma_crim'>[securityActive2.fields["ma_crim"]]</A><BR>\nDetails: <A href='?src=[REF(src)];field=ma_crim_d'>[securityActive2.fields["ma_crim_d"]]</A><BR>\n<BR>\nImportant Notes:<BR>\n\t<A href='?src=[REF(src)];field=notes'>[securityActive2.fields["notes"]]</A><BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>"
+				. += "<BR>"
+				. += "Security Data<BR>"
+				. += "Criminal Status: [securityActive2.fields["criminal"]]<BR><BR>"
+				. += "Crimes:<BR>"
+				for(var/datum/data/crime/crime in securityActive2.fields["crimes"])
+					. += "\t[crime.crimeName]: [crime.crimeDetails]<BR>"
+				. += "<BR>"
+				. += "Important Notes:<BR>"
+				. += "\t[securityActive2.fields["notes"]]<BR><BR>"
+				. += "<CENTER><B>Comments/Log</B></CENTER><BR>"
+				for(var/datum/data/comment/comment in securityActive2.fields["comments"])
+					. += "\t[comment.commentText] - [comment.author] [comment.time]<BR>"
 			else
 				. += "<pre>Requested security record not found,</pre><BR>"
 			. += "<BR>\n<A href='?src=[REF(src)];software=securityrecord;sub=0'>Back</A><BR>"

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -203,12 +203,23 @@
 				continue
 			var/obj/item/paper/P = new /obj/item/paper(src)
 			P.info = "<CENTER><B>Security Record</B></CENTER><BR>"
-			P.info += "Name: [G.fields["name"]] ID: [G.fields["id"]]<BR>\nGender: [G.fields["gender"]]<BR>\nAge: [G.fields["age"]]<BR>\nFingerprint: [G.fields["fingerprint"]]<BR>\nPhysical Status: [G.fields["p_stat"]]<BR>\nMental Status: [G.fields["m_stat"]]<BR>"
-			P.info += "<BR>\n<CENTER><B>Security Data</B></CENTER><BR>\nCriminal Status: [S.fields["criminal"]]<BR>\n<BR>\nMinor Crimes: [S.fields["mi_crim"]]<BR>\nDetails: [S.fields["mi_crim_d"]]<BR>\n<BR>\nMajor Crimes: [S.fields["ma_crim"]]<BR>\nDetails: [S.fields["ma_crim_d"]]<BR>\n<BR>\nImportant Notes:<BR>\n\t[S.fields["notes"]]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>"
-			var/counter = 1
-			while(S.fields["com_[counter]"])
-				P.info += "[S.fields["com_[counter]"]]<BR>"
-				counter++
+			P.info += "Name: [G.fields["name"]] ID: [G.fields["id"]]<BR>"
+			P.info += "Gender: [G.fields["gender"]]<BR>"
+			P.info += "Age: [G.fields["age"]]<BR>"
+			P.info += "Fingerprint: [G.fields["fingerprint"]]<BR>"
+			P.info += "Physical Status: [G.fields["p_stat"]]<BR>"
+			P.info += "Mental Status: [G.fields["m_stat"]]<BR><BR>"
+			P.info += "<CENTER><B>Security Data</B></CENTER><BR>"
+			P.info += "Criminal Status: [S.fields["criminal"]]<BR><BR>"
+			P.info += "Crimes:<BR>"
+			for(var/datum/data/crime/crime in S.fields["crimes"])
+				P.info += "\t[crime.crimeName]: [crime.crimeDetails]<BR>"
+			P.info += "<BR>"
+			P.info += "Important Notes:<BR>"
+			P.info += "\t[S.fields["notes"]]<BR><BR>"
+			P.info += "<CENTER><B>Comments/Log</B></CENTER><BR>"
+			for(var/datum/data/comment/comment in S.fields["comments"])
+				P.info += "\t[comment.commentText] - [comment.author] [comment.time]<BR>"
 			P.info += "</TT>"
 			P.name = "paper - '[G.fields["name"]]'"
 			virgin = 0	//tabbing here is correct- it's possible for people to try and use it

--- a/tgui/packages/tgui/interfaces/SecurityConsole.js
+++ b/tgui/packages/tgui/interfaces/SecurityConsole.js
@@ -355,7 +355,6 @@ export const SecurityConsole = (props, context) => {
                       <TableCell>
                         Time Added
                       </TableCell>
-                        <TableCell>ID</TableCell> 
                       <TableCell collapsing>
                         Delete
                       </TableCell>
@@ -372,7 +371,6 @@ export const SecurityConsole = (props, context) => {
                         <TableCell>
                           {comment.time}
                         </TableCell>
-                        <TableCell>{comment.id}</TableCell>
                         <TableCell collapsing>
                           <Button color="bad" onClick={() => act("edit_field", {
                             field: "comment_delete",

--- a/tgui/packages/tgui/interfaces/SecurityConsole.js
+++ b/tgui/packages/tgui/interfaces/SecurityConsole.js
@@ -337,6 +337,52 @@ export const SecurityConsole = (props, context) => {
                     ))}
                   </Table>
                 </Section>
+                <Section title="Comments" buttons={(
+                  <Button color="good" icon="plus" onClick={() => act("edit_field", {
+                    field: "comment_add",
+                  })}>
+                    Add Comment
+                  </Button>
+                )}>
+                  <Table>
+                    <TableRow color="label">
+                      <TableCell>
+                        Comment
+                      </TableCell>
+                      <TableCell>
+                        Author
+                      </TableCell>
+                      <TableCell>
+                        Time Added
+                      </TableCell>
+                      <TableCell collapsing>
+                        Delete
+                      </TableCell>
+                    </TableRow>
+                    {data.active_record.comments
+                    && data.active_record.comments.map(crime => (
+                      <TableRow key={crime.id}>
+                        <TableCell>
+                          {crime.name}
+                        </TableCell>
+                        <TableCell>
+                          {crime.author}
+                        </TableCell>
+                        <TableCell>
+                          {crime.time}
+                        </TableCell>
+                        <TableCell collapsing>
+                          <Button color="bad" onClick={() => act("edit_field", {
+                            field: "comment_delete",
+                            id: crime.id,
+                          })}>Delete
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </Table>
+                </Section>
+
 
                 <LabeledList>
                   <LabeledList.Item label="Important Notes">

--- a/tgui/packages/tgui/interfaces/SecurityConsole.js
+++ b/tgui/packages/tgui/interfaces/SecurityConsole.js
@@ -286,9 +286,9 @@ export const SecurityConsole = (props, context) => {
                     ))}
                   </Table>
                 </Section>
-                <Section title="Major Crimes" buttons={(
+                <Section title="Crimes" buttons={(
                   <Button color="good" icon="plus" onClick={() => act("edit_field", {
-                    field: "major_crime_add",
+                    field: "crime_add",
                   })}>
                     Add Crime
                   </Button>
@@ -311,8 +311,8 @@ export const SecurityConsole = (props, context) => {
                         Delete
                       </TableCell>
                     </TableRow>
-                    {data.active_record.major_crimes
-                    && data.active_record.major_crimes.map(crime => (
+                    {data.active_record.crimes
+                    && data.active_record.crimes.map(crime => (
                       <TableRow key={crime.id}>
                         <TableCell>
                           {crime.name}
@@ -328,58 +328,7 @@ export const SecurityConsole = (props, context) => {
                         </TableCell>
                         <TableCell collapsing>
                           <Button color="bad" onClick={() => act("edit_field", {
-                            field: "major_crime_delete",
-                            id: crime.id,
-                          })}>Delete
-                          </Button>
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </Table>
-                </Section>
-                <Section title="Minor Crimes" buttons={(
-                  <Button color="good" icon="plus" onClick={() => act("edit_field", {
-                    field: "minor_crime_add",
-                  })}>
-                    Add Crime
-                  </Button>
-                )}>
-                  <Table>
-                    <TableRow color="label">
-                      <TableCell>
-                        Crime
-                      </TableCell>
-                      <TableCell>
-                        Details
-                      </TableCell>
-                      <TableCell>
-                        Author
-                      </TableCell>
-                      <TableCell>
-                        Time Added
-                      </TableCell>
-                      <TableCell collapsing>
-                        Delete
-                      </TableCell>
-                    </TableRow>
-                    {data.active_record.minor_crimes
-                    && data.active_record.minor_crimes.map(crime => (
-                      <TableRow key={crime.id}>
-                        <TableCell>
-                          {crime.name}
-                        </TableCell>
-                        <TableCell>
-                          {crime.details}
-                        </TableCell>
-                        <TableCell>
-                          {crime.author}
-                        </TableCell>
-                        <TableCell>
-                          {crime.time}
-                        </TableCell>
-                        <TableCell collapsing>
-                          <Button color="bad" onClick={() => act("edit_field", {
-                            field: "minor_crime_delete",
+                            field: "crime_delete",
                             id: crime.id,
                           })}>Delete
                           </Button>

--- a/tgui/packages/tgui/interfaces/SecurityConsole.js
+++ b/tgui/packages/tgui/interfaces/SecurityConsole.js
@@ -355,26 +355,28 @@ export const SecurityConsole = (props, context) => {
                       <TableCell>
                         Time Added
                       </TableCell>
+                        <TableCell>ID</TableCell> 
                       <TableCell collapsing>
                         Delete
                       </TableCell>
                     </TableRow>
                     {data.active_record.comments
-                    && data.active_record.comments.map(crime => (
-                      <TableRow key={crime.id}>
+                    && data.active_record.comments.map(comment => (
+                      <TableRow key={comment.id}>
                         <TableCell>
-                          {crime.name}
+                          {comment.content}
                         </TableCell>
                         <TableCell>
-                          {crime.author}
+                          {comment.author}
                         </TableCell>
                         <TableCell>
-                          {crime.time}
+                          {comment.time}
                         </TableCell>
+                        <TableCell>{comment.id}</TableCell>
                         <TableCell collapsing>
                           <Button color="bad" onClick={() => act("edit_field", {
                             field: "comment_delete",
-                            id: crime.id,
+                            id: comment.id,
                           })}>Delete
                           </Button>
                         </TableCell>


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

Re-adds comments to the security records console that were not implemented with the last UI update, while also redoing the comment storage internally to work better.
Combined major and minor crime categories due to the lack of need for the distinction, and the need for UI space for the comments. 
Fixed the security filing cabinet and pAI security records not working properly.

<details>
<summary>Image</summary>

![image](https://user-images.githubusercontent.com/4607006/124605152-9fc63000-de39-11eb-8b8c-cd356fecda28.png)


</details>

### Why is this change good for the game?
A lot of people like comments, and wanted them added back, this does that.

# Changelog

Fixes #11723 
Fixes #11316 
Adds feature https://forums.yogstation.net/threads/if-security-records-do-not-get-comments-back-then-please-revert-the-ui-change.23664/

:cl:  
rscadd: Added security comments to security records console
bugfix: fixed security filing cabinet
bugfix: fixed pAI security records
tweak: tweaked how security comments are stored 
tweak: removed the distinction between major and minor crimes in the sec records
/:cl:
