### PR TITLE
Mosins are no longer able to be fired while holding stuff in the offhand BUT are back to 60 damage

### DIFF
--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -61,7 +61,7 @@ obj/item/gun/ballistic/rifle/attackby(obj/item/A, mob/user, params)
 	knife_x_offset = 27
 	knife_y_offset = 13
 	can_be_sawn_off = TRUE
-	weapon_weight = WEAPON_MEDIUM
+	weapon_weight = WEAPON_HEAVY
 
 /obj/item/gun/ballistic/rifle/boltaction/sawoff(mob/user)
 	. = ..()

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -8,7 +8,7 @@
 
 /obj/item/projectile/bullet/a762
 	name = "7.62 bullet"
-	damage = 40
+	damage = 60
 
 /obj/item/projectile/bullet/a762_enchanted
 	name = "enchanted 7.62 bullet"


### PR DESCRIPTION
# General Documentation

### Intent of your Pull Request

takes forever to chamber a round in one might as well be worth shooting it compared to a shotgun
### Why is this change good for the game?
it's not
# Wiki Documentation

### Briefly describe your PR and the impacts of it, in layman's terms. 
7.62 rounds deal 60 damage up from 40, mosins require offhand free to fire

# Changelog

:cl:  
tweak: 7.62 rounds now deal 60 damage up from 40
tweak: mosins now require the offhand to be free to fire
/:cl:
