### PR TITLE
Moves mindshield firing pin to armory lathe

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -102,7 +102,7 @@
 	materials = list(/datum/material/silver = 600, /datum/material/diamond = 600, /datum/material/uranium = 200)
 	build_path = /obj/item/firing_pin/implant/mindshield
 	category = list("Firing Pins")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
 
 /datum/design/stunmine/sec //mines ported from BeeStation
 	name = "Stun Mine"


### PR DESCRIPTION

# Github documenting your Pull Request

Can't make guns outside of armory. Can't use pin without gun, no need for pin to be outside armory.

If anything this just encourages sec to go get guns somehow. There's a reason the Warden had all the normal firing pins in the first place.

# Wiki Documentation

Mindshield firing pins from security lathe to armory lathe 

# Changelog

:cl:  
tweak: Moved mindshield firing pin to Armory protolathe
/:cl:
