### PR TITLE
so tcomms were still generating heat and calculating speed even when offline

### DIFF
--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -144,14 +144,8 @@ GLOBAL_LIST_EMPTY(telecomms_list)
 	else
 		on = FALSE
 
-/obj/machinery/telecomms/process()
-	update_power()
 
-	// Update the icon
-	update_icon()
-	update_speed()
-
-/obj/machinery/telecomms/update_speed()
+/obj/machinery/telecomms/proc/update_speed()
 	if(!on)
 		return
 	var/turf/T = get_turf(src) //yogs
@@ -168,8 +162,6 @@ GLOBAL_LIST_EMPTY(telecomms_list)
 			var/ratio = 1000/netspeed			// temp per one unit of speedloss
 			speedloss = round((temperature - 150)/ratio)	// exact speedloss
 			net_efective = 100 - speedloss/netspeed		// percantage speedloss ui use only
-	//yogs end
-
 
 	if(traffic > 0)
 		var/deltaT = netspeed - speedloss  //yogs start
@@ -180,6 +172,14 @@ GLOBAL_LIST_EMPTY(telecomms_list)
 			traffic -= deltaT
 		if(generates_heat && env.heat_capacity())
 			env.set_temperature(env.return_temperature() + deltaT * heatoutput / env.heat_capacity())   //yogs end
+
+/obj/machinery/telecomms/process()
+	update_power()
+
+	// Update the icon
+	update_icon()
+	update_speed()
+
 
 
 /obj/machinery/telecomms/emp_act(severity)

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -149,7 +149,11 @@ GLOBAL_LIST_EMPTY(telecomms_list)
 
 	// Update the icon
 	update_icon()
+	update_speed()
 
+/obj/machinery/telecomms/update_speed()
+	if(!on)
+		return
 	var/turf/T = get_turf(src) //yogs
 	var/speedloss = 0
 	var/datum/gas_mixture/env = T.return_air()


### PR DESCRIPTION
so i'm back and since i remmember that someone complained that my kentucky fried tcomms code was borked i decided to take a look at it and fix it.
the new calculation should be more resistant to rounding errors
also the calculation is also skipped if the machine is turned off 

:cl:  
bugfix: tcomms no longer do kentucky fried tcomms when offline
tweak: changed the speed calculation between 150K and 1150K to make more consistent
/:cl:
