### PR TITLE
[EXPERIMENTAL] Traitors are assigned after 3 to 5 minutes

### DIFF
--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -101,7 +101,7 @@
 						add_latejoin_traitor(character.mind)
 
 /datum/game_mode/traitor/proc/add_traitor_delayed(datum/mind/traitor)
-	if(!traitor)
+	if(!traitor.current.client || (traitor.current.stat != CONSCIOUS))
 		create_new_traitor()
 		return
 	var/datum/antagonist/traitor/new_antag = new antag_datum()

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -131,6 +131,7 @@
 			continue
 		potential_candidates += applicant
 	if(!potential_candidates)
+		message_admins("Failed to find new antag after original one left! Check the antag balance please.")
 		return
 	var/mob/living/carbon/human/picked = pick(potential_candidates)
 	if(!picked || !picked.client)

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -77,14 +77,15 @@
 /datum/game_mode/traitor/post_setup()
 	for(var/datum/mind/traitor in pre_traitors)
 		var/datum/antagonist/traitor/new_antag = new antag_datum()
-		addtimer(CALLBACK(traitor, /datum/mind.proc/add_antag_datum, new_antag), rand(10,100))
+		addtimer(CALLBACK(src, /datum/game_mode/traitor.proc/add_traitor_delayed, traitor), rand(2 MINUTES, (2 MINUTES + 10 SECONDS)))
+		
 	if(!exchange_blue)
 		exchange_blue = -1 //Block latejoiners from getting exchange objectives
 	..()
 
 	//We're not actually ready until all traitors are assigned.
 	gamemode_ready = FALSE
-	addtimer(VARSET_CALLBACK(src, gamemode_ready, TRUE), 101)
+	addtimer(VARSET_CALLBACK(src, gamemode_ready, TRUE), (2 MINUTES + 11 SECONDS))
 	return TRUE
 
 /datum/game_mode/traitor/make_antag_chance(mob/living/carbon/human/character) //Assigns traitor to latejoiners
@@ -98,6 +99,46 @@
 				if(age_check(character.client))
 					if(!(character.job in restricted_jobs))
 						add_latejoin_traitor(character.mind)
+
+/datum/game_mode/traitor/proc/add_traitor_delayed(datum/mind/traitor)
+	if(!traitor)
+		create_new_traitor()
+		return
+	var/datum/antagonist/traitor/new_antag = new antag_datum()
+	traitor.add_antag_datum(new_antag)
+
+/datum/game_mode/traitor/proc/create_new_traitor()
+	var/list/potential_candidates = list()
+	for(var/mob/living/carbon/human/applicant in GLOB.player_list)
+		if(!applicant.client)
+			continue
+		if(!applicant.mind)
+			continue
+		if(!applicant.stat != CONSCIOUS)
+			continue
+		if(applicant.mind.assigned_role in protected_jobs) 
+			continue
+		if(applicant.mind.assigned_role in restricted_jobs) 
+			continue
+		if(applicant.mind.quiet_mode)
+			continue
+		if(HAS_TRAIT(applicant, TRAIT_MINDSHIELD))
+			continue
+		if(is_banned_from(applicant.ckey, list(antag_flag, ROLE_SYNDICATE)))
+			continue
+		if(!(role in applicant.client.prefs.be_special))
+			continue
+		if(!age_check(applicant.client))
+			continue
+		potential_candidates += applicant
+	if(!potential_candidates)
+		return
+	var/mob/living/carbon/human/picked = pick(potential_candidates)
+	if(!picked || !picked.client)
+		return
+	var/datum/antagonist/traitor/new_antag = new antag_datum()
+	picked.mind.add_antag_datum(new_antag)
+	picked.mind.special_role = traitor_name
 
 /datum/game_mode/traitor/proc/add_latejoin_traitor(datum/mind/character)
 	var/datum/antagonist/traitor/new_antag = new antag_datum()

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -119,6 +119,8 @@
 			continue
 		if(applicant.mind.assigned_role in restricted_jobs) 
 			continue
+		if(!(applicant.mind.assigned_role in GLOB.command_positions + GLOB.engineering_positions + GLOB.medical_positions + GLOB.science_positions + GLOB.supply_positions + GLOB.civilian_positions + GLOB.security_positions + list("AI", "Cyborg")))
+			continue
 		if(applicant.mind.quiet_round)
 			continue
 		if(HAS_TRAIT(applicant, TRAIT_MINDSHIELD))

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -76,7 +76,6 @@
 
 /datum/game_mode/traitor/post_setup()
 	for(var/datum/mind/traitor in pre_traitors)
-		var/datum/antagonist/traitor/new_antag = new antag_datum()
 		addtimer(CALLBACK(src, /datum/game_mode/traitor.proc/add_traitor_delayed, traitor), rand(2 MINUTES, (2 MINUTES + 10 SECONDS)))
 		
 	if(!exchange_blue)
@@ -120,13 +119,13 @@
 			continue
 		if(applicant.mind.assigned_role in restricted_jobs) 
 			continue
-		if(applicant.mind.quiet_mode)
+		if(applicant.mind.quiet_round)
 			continue
 		if(HAS_TRAIT(applicant, TRAIT_MINDSHIELD))
 			continue
 		if(is_banned_from(applicant.ckey, list(antag_flag, ROLE_SYNDICATE)))
 			continue
-		if(!(role in applicant.client.prefs.be_special))
+		if(!(antag_flag in applicant.client.prefs.be_special))
 			continue
 		if(!age_check(applicant.client))
 			continue

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -76,7 +76,7 @@
 
 /datum/game_mode/traitor/post_setup()
 	for(var/datum/mind/traitor in pre_traitors)
-		addtimer(CALLBACK(src, /datum/game_mode/traitor.proc/add_traitor_delayed, traitor), rand(3 MINUTES, 5 MINUTES))
+		addtimer(CALLBACK(src, /datum/game_mode/traitor.proc/add_traitor_delayed, traitor), rand(2 MINUTES, (2 MINUTES + 10 SECONDS)))
 		
 	if(!exchange_blue)
 		exchange_blue = -1 //Block latejoiners from getting exchange objectives

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -76,7 +76,7 @@
 
 /datum/game_mode/traitor/post_setup()
 	for(var/datum/mind/traitor in pre_traitors)
-		addtimer(CALLBACK(src, /datum/game_mode/traitor.proc/add_traitor_delayed, traitor), rand(2 MINUTES, (2 MINUTES + 10 SECONDS)))
+		addtimer(CALLBACK(src, /datum/game_mode/traitor.proc/add_traitor_delayed, traitor), rand(3 MINUTES, 5 MINUTES))
 		
 	if(!exchange_blue)
 		exchange_blue = -1 //Block latejoiners from getting exchange objectives

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -76,7 +76,7 @@
 
 /datum/game_mode/traitor/post_setup()
 	for(var/datum/mind/traitor in pre_traitors)
-		addtimer(CALLBACK(src, /datum/game_mode/traitor.proc/add_traitor_delayed, traitor), rand(2 MINUTES, (2 MINUTES + 10 SECONDS)))
+		addtimer(CALLBACK(src, /datum/game_mode/traitor.proc/add_traitor_delayed, traitor), rand(3 MINUTES, (5 MINUTES + 10 SECONDS)))
 		
 	if(!exchange_blue)
 		exchange_blue = -1 //Block latejoiners from getting exchange objectives
@@ -84,7 +84,7 @@
 
 	//We're not actually ready until all traitors are assigned.
 	gamemode_ready = FALSE
-	addtimer(VARSET_CALLBACK(src, gamemode_ready, TRUE), (2 MINUTES + 11 SECONDS))
+	addtimer(VARSET_CALLBACK(src, gamemode_ready, TRUE), (5 MINUTES + 11 SECONDS))
 	return TRUE
 
 /datum/game_mode/traitor/make_antag_chance(mob/living/carbon/human/character) //Assigns traitor to latejoiners

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -100,7 +100,7 @@
 						add_latejoin_traitor(character.mind)
 
 /datum/game_mode/traitor/proc/add_traitor_delayed(datum/mind/traitor)
-	if(!traitor.current.client || (traitor.current.stat != CONSCIOUS))
+	if(!traitor || !traitor.current || !traitor.current.client || (traitor.current.stat != CONSCIOUS) || istype(traitor.current.loc, /obj/machinery/cryopod))
 		create_new_traitor()
 		return
 	var/datum/antagonist/traitor/new_antag = new antag_datum()


### PR DESCRIPTION
# Github documenting your Pull Request

You're no longer safe from becoming a target if you latejoin.
Hopefully this helps increase the amount of people that ready up?

Untested and need to do other changes

- [x] Verify how objectives are picked
- [x] Testing everything

# Changelog

:cl:  
experimental: Traitors are only made aware of their traitor ways after approximately 2 minutes.
/:cl:
