### PR TITLE
rename SRM-6 rocket ammo to BRM-6

### DIFF
--- a/code/modules/research/designs/mecha_designs.dm
+++ b/code/modules/research/designs/mecha_designs.dm
@@ -271,8 +271,8 @@
 	category = list("Exosuit Equipment")
 
 /datum/design/mech_missile_rack_ammo
-	name = "SRM-8 Missile Rack Ammunition"
-	desc = "Ammunition for the SRM-8 Missile Rack."
+	name = "BRM-8 Missile Rack Ammunition"
+	desc = "Ammunition for the BRM-8 Missile Rack."
 	id = "mech_missile_rack_ammo"
 	build_type = PROTOLATHE | MECHFAB
 	build_path = /obj/item/mecha_ammo/missiles_br


### PR DESCRIPTION
also #11485 is no longer a problem
:cl:  
spellcheck: renamed SRM-6 ammo to BRM-6 to keep it consistent
/:cl:
