### PR TITLE
should fix progenitor roar spam

### DIFF
--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_progenitor.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_progenitor.dm
@@ -29,7 +29,7 @@
 	mob_size = MOB_SIZE_LARGE
 	layer = LARGE_MOB_LAYER
 	movement_type = FLYING
-	var/time_since_last_roar = 0
+	var/time_to_next_roar = 0
 
 /mob/living/simple_animal/hostile/darkspawn_progenitor/Initialize()
 	. = ..()
@@ -52,18 +52,17 @@
 	I.pixel_x -= pixel_x
 	I.pixel_y -= pixel_y
 	add_alt_appearance(/datum/atom_hud/alternate_appearance/basic, "smolgenitor", I)
-	time_since_last_roar = world.time + 300
+	time_to_next_roar = world.time + 30 SECONDS
 
 /mob/living/simple_animal/hostile/darkspawn_progenitor/Life()
 	..()
-	if(time_since_last_roar <= world.time)
+	if(time_to_next_roar + 10 SECONDS <= world.time) //gives time to roar manually if you like want to do that
 		roar()
 
 /mob/living/simple_animal/hostile/darkspawn_progenitor/say(message, bubble_type,var/list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
 	..()
-	if(time_since_last_roar > world.time + 350) //at least give it SOME time
-		return
-	roar()
+	if(time_to_next_roar <= world.time)
+		roar()
 
 /mob/living/simple_animal/hostile/darkspawn_progenitor/Process_Spacemove()
 	return TRUE
@@ -78,7 +77,7 @@
 			if(L != src) //OH GOD OH FUCK I'M SCARING MYSELF
 				to_chat(M, "<span class='boldannounce'>You stand paralyzed in the shadow of the cold as it descends from on high.</span>")
 				L.Stun(20)
-	time_since_last_roar = world.time + 400
+	time_to_next_roar = world.time + 30 SECONDS
 
 /obj/effect/proc_holder/spell/targeted/progenitor_curse
 	name = "Viscerate Mind"


### PR DESCRIPTION
redoes progenitor screaming code a bit so it's less terrible and more readable
every roar sets the cooldown to 30 seconds, with a roar automatically occuring if 10 seconds elapse after the cooldown is over to give time to roar manually not like that's important
variables renamed to make it more readable and using time defines
:cl:  
bugfix: progenitors should no longer be able to spam the super loud and annoying scream noise so it's more t h e m a t i c
/:cl:
