### PR TITLE
digitalcamo now hides ling's hud from silicons as well 

### DIFF
--- a/code/__DEFINES/atom_hud.dm
+++ b/code/__DEFINES/atom_hud.dm
@@ -51,15 +51,15 @@
 
 //data HUD (medhud, sechud) defines
 //Don't forget to update human/New() if you change these!
-#define DATA_HUD_SECURITY_BASIC			1
-#define DATA_HUD_SECURITY_ADVANCED		2
-#define DATA_HUD_MEDICAL_BASIC			3
-#define DATA_HUD_MEDICAL_ADVANCED		4
-#define DATA_HUD_DIAGNOSTIC_BASIC		5
-#define DATA_HUD_DIAGNOSTIC_ADVANCED	6
-#define DATA_HUD_ABDUCTOR				7
-#define DATA_HUD_SENTIENT_DISEASE		8
-#define DATA_HUD_AI_DETECT				9
+#define DATA_HUD_SECURITY_BASIC				1
+#define DATA_HUD_SECURITY_ADVANCED			2
+#define DATA_HUD_MEDICAL_BASIC				3
+#define DATA_HUD_MEDICAL_ADVANCED			4
+#define DATA_HUD_DIAGNOSTIC_BASIC			5
+#define DATA_HUD_DIAGNOSTIC_ADVANCED		6
+#define DATA_HUD_ABDUCTOR					7
+#define DATA_HUD_SENTIENT_DISEASE			8
+#define DATA_HUD_AI_DETECT					9
 
 //antag HUD defines
 #define ANTAG_HUD_CULT			10

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -111,7 +111,14 @@ GLOBAL_LIST_INIT(huds, list(
 	if(!A)
 		return FALSE
 	hudatoms |= A
+	var/mob/B = null
+	if(istype(A, /mob))
+		B = A
 	for(var/mob/M in hudusers)
+		if(istype(M, /mob/living/silicon))
+			if(B)
+				if(B.digitalcamo)
+					return
 		if(!queued_to_see[M])
 			add_to_single_hud(M, A)
 	return TRUE
@@ -119,11 +126,6 @@ GLOBAL_LIST_INIT(huds, list(
 /datum/atom_hud/proc/add_to_single_hud(mob/M, atom/A) //unsafe, no sanity apart from client
 	if(!M || !M.client || !A)
 		return
-	if(istype(M, /mob/living/silicon))
-		if(istype(A, /mob))
-			var/mob/B = A
-			if(B.digitalcamo)
-				return
 	for(var/i in hud_icons)
 		if(A.hud_list[i])
 			M.client.images |= A.hud_list[i]

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -48,6 +48,8 @@ GLOBAL_LIST_INIT(huds, list(
 	var/list/next_time_allowed = list() //mobs associated with the next time this hud can be added to them
 	var/list/queued_to_see = list() //mobs that have triggered the cooldown and are queued to see the hud, but do not yet
 
+	var/do_silicon_check = FALSE // true for medical and sec advanced and diagnostic basic HUDs
+
 /datum/atom_hud/New()
 	GLOB.all_huds += src
 
@@ -63,17 +65,30 @@ GLOBAL_LIST_INIT(huds, list(
 	if(!M || !hudusers[M])
 		return
 	if (!--hudusers[M])
+		var/M_is_silicon = FALSE
+		if(do_silicon_check && istype(A, /mob/silicon))
+			M_is_silicon = TRUE
 		hudusers -= M
 		if(queued_to_see[M])
 			queued_to_see -= M
 		else
 			for(var/atom/A in hudatoms)
+				if(M_is_silicon)
+					continue
 				remove_from_single_hud(M, A)
 
 /datum/atom_hud/proc/remove_from_hud(atom/A)	//this is called when some stops existing or needs HUD removed
 	if(!A)
 		return FALSE
+	var/has_camo = FALSE
+	if(do_silicon_check && istype(A, /mob))
+		var/mob/B = A
+		if(B.digitalcamo)
+			has_camo = TRUE
 	for(var/mob/M in hudusers)
+		if(has_camo)
+			if(istype(A, /mob/silicon))
+				continue
 		remove_from_single_hud(M, A)
 	hudatoms -= A
 	return TRUE
@@ -89,42 +104,55 @@ GLOBAL_LIST_INIT(huds, list(
 		return
 	if(!hudusers[M])
 		hudusers[M] = 1
+		var/M_is_silicon = FALSE
+		if(do_silicon_check && istype(A, /mob/silicon))
+			M_is_silicon = TRUE
 		if(next_time_allowed[M] > world.time)
 			if(!queued_to_see[M])
-				addtimer(CALLBACK(src, .proc/show_hud_images_after_cooldown, M), next_time_allowed[M] - world.time)
+				addtimer(CALLBACK(src, .proc/show_hud_images_after_cooldown, M, M_is_silicon), next_time_allowed[M] - world.time)
 				queued_to_see[M] = TRUE
 		else
 			next_time_allowed[M] = world.time + ADD_HUD_TO_COOLDOWN
 			for(var/atom/A in hudatoms)
+				if(M_is_silicon)
+					if(istype(A, /mob))
+						var/mob/B = A
+						if(B.digitalcamo)
+							continue
 				add_to_single_hud(M, A)
 	else
-		hudusers[M]++
+		hudusers[M]++		// the hell does this do?
 
-/datum/atom_hud/proc/show_hud_images_after_cooldown(M)
+/datum/atom_hud/proc/show_hud_images_after_cooldown(M, M_is_silicon)
 	if(queued_to_see[M])
 		queued_to_see -= M
 		next_time_allowed[M] = world.time + ADD_HUD_TO_COOLDOWN
 		for(var/atom/A in hudatoms)
+			if(M_is_silicon)
+				if(istype(A, /mob))
+					var/mob/B = A
+					if(B.digitalcamo)
+						continue
 			add_to_single_hud(M, A)
 
-/datum/atom_hud/proc/add_to_hud(atom/A)	// something new starts existing or is in a need of a HUD	this is used to show hud A to mob M
+/datum/atom_hud/proc/add_to_hud(atom/A)	// something new starts existing or is in a need of a HUD
 	if(!A)
 		return FALSE
 	hudatoms |= A
 	var/has_camo = FALSE
-	if(istype(A, /mob))
+	if(do_silicon_check && istype(A, /mob))
 		var/mob/B = A
 		if(B.digitalcamo)
 			has_camo = TRUE
 	for(var/mob/M in hudusers)
 		if(has_camo)
 			if(istype(M, /mob/living/silicon))
-				return
+				continue
 		if(!queued_to_see[M])
-			add_to_single_hud(M, A)
+			add_to_single_hud(M, A, has_camo)
 	return TRUE
 
-/datum/atom_hud/proc/add_to_single_hud(mob/M, atom/A) //unsafe, no sanity apart from client
+/datum/atom_hud/proc/add_to_single_hud(mob/M, atom/A) //unsafe, no sanity apart from client		this is used to show hud A to mob M
 	if(!M || !M.client || !A)
 		return
 	for(var/i in hud_icons)
@@ -132,7 +160,7 @@ GLOBAL_LIST_INIT(huds, list(
 			M.client.images |= A.hud_list[i]
 
 //MOB PROCS
-/mob/proc/reload_huds()
+/mob/proc/reload_huds()		// used when you need to readd all aplicable huds to user (for instance on reconnect)
 	for(var/datum/atom_hud/hud in GLOB.all_huds)
 		if(hud && hud.hudusers[src])
 			for(var/atom/A in hud.hudatoms)

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -119,6 +119,11 @@ GLOBAL_LIST_INIT(huds, list(
 /datum/atom_hud/proc/add_to_single_hud(mob/M, atom/A) //unsafe, no sanity apart from client
 	if(!M || !M.client || !A)
 		return
+	if(istype(M, /mob/living/silicon))
+		if(istype(A, /mob))
+			mob/B = A
+			if(B.digitalcamo)
+				return
 	for(var/i in hud_icons)
 		if(A.hud_list[i])
 			M.client.images |= A.hud_list[i]

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -111,14 +111,15 @@ GLOBAL_LIST_INIT(huds, list(
 	if(!A)
 		return FALSE
 	hudatoms |= A
-	var/mob/B = null
+	var/has_camo = FALSE
 	if(istype(A, /mob))
-		B = A
+		var/mob/B = A
+		if(B.digitalcamo)
+			has_camo = TRUE
 	for(var/mob/M in hudusers)
 		if(istype(M, /mob/living/silicon))
-			if(B)
-				if(B.digitalcamo)
-					return
+			if(has_camo)
+				return
 		if(!queued_to_see[M])
 			add_to_single_hud(M, A)
 	return TRUE

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -66,7 +66,7 @@ GLOBAL_LIST_INIT(huds, list(
 		return
 	if (!--hudusers[M])
 		var/M_is_silicon = FALSE
-		if(do_silicon_check && istype(A, /mob/silicon))
+		if(do_silicon_check && istype(M, /mob/living/silicon))
 			M_is_silicon = TRUE
 		hudusers -= M
 		if(queued_to_see[M])
@@ -74,7 +74,10 @@ GLOBAL_LIST_INIT(huds, list(
 		else
 			for(var/atom/A in hudatoms)
 				if(M_is_silicon)
-					continue
+					if (istype(A, /mob))
+						var/mob/B = A
+						if(B.digitalcamo)
+							continue
 				remove_from_single_hud(M, A)
 
 /datum/atom_hud/proc/remove_from_hud(atom/A)	//this is called when some stops existing or needs HUD removed
@@ -87,7 +90,7 @@ GLOBAL_LIST_INIT(huds, list(
 			has_camo = TRUE
 	for(var/mob/M in hudusers)
 		if(has_camo)
-			if(istype(A, /mob/silicon))
+			if(istype(M, /mob/living/silicon))
 				continue
 		remove_from_single_hud(M, A)
 	hudatoms -= A
@@ -105,7 +108,7 @@ GLOBAL_LIST_INIT(huds, list(
 	if(!hudusers[M])
 		hudusers[M] = 1
 		var/M_is_silicon = FALSE
-		if(do_silicon_check && istype(A, /mob/silicon))
+		if(do_silicon_check && istype(M, /mob/living/silicon))
 			M_is_silicon = TRUE
 		if(next_time_allowed[M] > world.time)
 			if(!queued_to_see[M])
@@ -149,7 +152,7 @@ GLOBAL_LIST_INIT(huds, list(
 			if(istype(M, /mob/living/silicon))
 				continue
 		if(!queued_to_see[M])
-			add_to_single_hud(M, A, has_camo)
+			add_to_single_hud(M, A)
 	return TRUE
 
 /datum/atom_hud/proc/add_to_single_hud(mob/M, atom/A) //unsafe, no sanity apart from client		this is used to show hud A to mob M

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -121,7 +121,7 @@ GLOBAL_LIST_INIT(huds, list(
 		return
 	if(istype(M, /mob/living/silicon))
 		if(istype(A, /mob))
-			mob/B = A
+			var/mob/B = A
 			if(B.digitalcamo)
 				return
 	for(var/i in hud_icons)

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -117,8 +117,8 @@ GLOBAL_LIST_INIT(huds, list(
 		if(B.digitalcamo)
 			has_camo = TRUE
 	for(var/mob/M in hudusers)
-		if(istype(M, /mob/living/silicon))
-			if(has_camo)
+		if(has_camo)
+			if(istype(M, /mob/living/silicon))
 				return
 		if(!queued_to_see[M])
 			add_to_single_hud(M, A)

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -59,7 +59,7 @@ GLOBAL_LIST_INIT(huds, list(
 	GLOB.all_huds -= src
 	return ..()
 
-/datum/atom_hud/proc/remove_hud_from(mob/M)
+/datum/atom_hud/proc/remove_hud_from(mob/M)	// this is called when something disables HUD
 	if(!M || !hudusers[M])
 		return
 	if (!--hudusers[M])
@@ -70,7 +70,7 @@ GLOBAL_LIST_INIT(huds, list(
 			for(var/atom/A in hudatoms)
 				remove_from_single_hud(M, A)
 
-/datum/atom_hud/proc/remove_from_hud(atom/A)
+/datum/atom_hud/proc/remove_from_hud(atom/A)	//this is called when some stops existing or needs HUD removed
 	if(!A)
 		return FALSE
 	for(var/mob/M in hudusers)
@@ -78,13 +78,13 @@ GLOBAL_LIST_INIT(huds, list(
 	hudatoms -= A
 	return TRUE
 
-/datum/atom_hud/proc/remove_from_single_hud(mob/M, atom/A) //unsafe, no sanity apart from client
+/datum/atom_hud/proc/remove_from_single_hud(mob/M, atom/A) //unsafe, no sanity apart from client	this is used to Hide HUD A from mob M
 	if(!M || !M.client || !A)
 		return
 	for(var/i in hud_icons)
 		M.client.images -= A.hud_list[i]
 
-/datum/atom_hud/proc/add_hud_to(mob/M)
+/datum/atom_hud/proc/add_hud_to(mob/M)	// this is called when something activates HUD
 	if(!M)
 		return
 	if(!hudusers[M])
@@ -107,7 +107,7 @@ GLOBAL_LIST_INIT(huds, list(
 		for(var/atom/A in hudatoms)
 			add_to_single_hud(M, A)
 
-/datum/atom_hud/proc/add_to_hud(atom/A)
+/datum/atom_hud/proc/add_to_hud(atom/A)	// something new starts existing or is in a need of a HUD	this is used to show hud A to mob M
 	if(!A)
 		return FALSE
 	hudatoms |= A

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -40,6 +40,7 @@
 	check_sensors(H) ? add_to_hud(H) : remove_from_hud(H)
 
 /datum/atom_hud/data/human/medical/advanced
+	do_silicon_check = TRUE
 
 /datum/atom_hud/data/human/security
 
@@ -48,11 +49,13 @@
 
 /datum/atom_hud/data/human/security/advanced
 	hud_icons = list(ID_HUD, IMPTRACK_HUD, IMPLOYAL_HUD, IMPCHEM_HUD, WANTED_HUD, NANITE_HUD)
+	do_silicon_check = TRUE
 
 /datum/atom_hud/data/diagnostic
 
 /datum/atom_hud/data/diagnostic/basic
 	hud_icons = list(DIAG_HUD, DIAG_STAT_HUD, DIAG_BATT_HUD, DIAG_MECH_HUD, DIAG_BOT_HUD, DIAG_CIRCUIT_HUD, DIAG_TRACK_HUD, DIAG_AIRLOCK_HUD, DIAG_NANITE_FULL_HUD, DIAG_LAUNCHPAD_HUD)
+	do_silicon_check = TRUE
 
 /datum/atom_hud/data/diagnostic/advanced
 	hud_icons = list(DIAG_HUD, DIAG_STAT_HUD, DIAG_BATT_HUD, DIAG_MECH_HUD, DIAG_BOT_HUD, DIAG_CIRCUIT_HUD, DIAG_TRACK_HUD, DIAG_AIRLOCK_HUD, DIAG_NANITE_FULL_HUD, DIAG_LAUNCHPAD_HUD, DIAG_PATH_HUD)


### PR DESCRIPTION
so digital camo hid the person using it from the sillicons but didnt hide the hud thus aloving AI to see theese lings even when it was not supposed to
:cl:  
bugfix: Silicons can no longer see ling's hud if the ling is using digital camo
/:cl: