### PR TITLE
replaces the sepia major luminescent with a deja vu effect

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -589,10 +589,10 @@
 			return 150
 
 		if(SLIME_ACTIVATE_MAJOR)
-			to_chat(user, "<span class='warning'>You feel time slow down...</span>")
-			if(do_after(user, 30, target = user))
-				new /obj/effect/timestop(get_turf(user), 2, 50, list(user))
-				return 900
+			to_chat(user, "<span class='warning'>You begin to anchor yourself to your current chronicity...</span>")
+			if(do_after(user, 10, target = user))
+				user.AddComponent(/datum/component/dejavu)
+				return 300
 
 /obj/item/slime_extract/rainbow
 	name = "rainbow slime extract"


### PR DESCRIPTION
# Github documenting your Pull Request

Repalces the timestop major luminescent activation effect for sepia extracts with a 1 second warmup deja vu effect, like the nostalgia camera or whatever it's called and some other sepia related stuff because
haha funny 5x5 stun with no tell or counters

# Wiki Documentation

sepia major luminescent activation is now deja vu, like the burning sepia crossbreed nostalgic camera. Deja vu will return you to your state and location at the time it was added after 10 seconds
# Changelog
:cl:  
tweak: the luminescent sepia major effect will now give you a deja vu effect that returns you to your position and health at the time of use after a 1  second channel rather than stopping time in a 5x5 square after a 3 second channel
tweak: luminescent sepia major now has a 30 second cooldown down from 90 seconds since it's not as directly useful
/:cl:
