### PR TITLE
make time erasure prevent you from using stun weapons

### DIFF
--- a/yogstation/code/modules/guardian/abilities/major/time.dm
+++ b/yogstation/code/modules/guardian/abilities/major/time.dm
@@ -52,7 +52,7 @@
 			var/mob/living/simple_animal/hostile/guardian/G = L
 			G.erased_time = TRUE
 		ADD_TRAIT(L, TRAIT_PACIFISM, "king_crimson")
-		ADD_TRAIT(H, TRAIT_NO_STUN_WEAPONS, "king_crimson")
+		ADD_TRAIT(L, TRAIT_NO_STUN_WEAPONS, "king_crimson")
 		ADD_TRAIT(L, TRAIT_NOINTERACT, "king_crimson") // no touching anything ever
 		L.remove_alt_appearance("king_crimson")
 		L.add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/king_crimson, "king_crimson", I, NONE, immune)

--- a/yogstation/code/modules/guardian/abilities/major/time.dm
+++ b/yogstation/code/modules/guardian/abilities/major/time.dm
@@ -52,6 +52,7 @@
 			var/mob/living/simple_animal/hostile/guardian/G = L
 			G.erased_time = TRUE
 		ADD_TRAIT(L, TRAIT_PACIFISM, "king_crimson")
+		ADD_TRAIT(H, TRAIT_NO_STUN_WEAPONS, "king_crimson")
 		ADD_TRAIT(L, TRAIT_NOINTERACT, "king_crimson") // no touching anything ever
 		L.remove_alt_appearance("king_crimson")
 		L.add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/king_crimson, "king_crimson", I, NONE, immune)
@@ -73,6 +74,7 @@
 		L.alpha = initial(L.alpha)
 		L.remove_alt_appearance("king_crimson")
 		REMOVE_TRAIT(L, TRAIT_PACIFISM, "king_crimson")
+		REMOVE_TRAIT(L, TRAIT_NO_STUN_WEAPONS, "king_crimson")
 		REMOVE_TRAIT(L, TRAIT_NOINTERACT, "king_crimson")
 
 /datum/atom_hud/alternate_appearance/basic/king_crimson


### PR DESCRIPTION
if it doesnt already do this already
:cl:  
bugfix: time erasure stops you from using stun weapons alongside normal weapons
/:cl:
