### PR TITLE
Enables late join heretics, lowers their weight, etc.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -63,7 +63,7 @@
 	restricted_roles = list("AI","Cyborg")
 	required_candidates = 1
 	weight = 7
-	cost = 15
+	cost = 10
 	requirements = list(40,30,20,10,10,10,10,10,10,10)
 	repeatable = TRUE
 
@@ -198,7 +198,7 @@
 	required_candidates = 1
 	weight = 4
 	cost = 15
-	requirements = list(80,70,60,50,50,45,30,30,20,25)
+	requirements = list(45,40,40,35,30,30,20,20,20,20)
 	minimum_players = 30
 	repeatable = TRUE
 
@@ -209,14 +209,15 @@
 //                                          //
 //////////////////////////////////////////////
 
-/*/datum/dynamic_ruleset/latejoin/heretic_smuggler
+/datum/dynamic_ruleset/latejoin/heretic_smuggler
 	name = "Heretic Smuggler"
 	antag_datum = /datum/antagonist/heretic
 	antag_flag = ROLE_HERETIC
 	protected_roles = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director")
 	restricted_roles = list("AI","Cyborg")
 	required_candidates = 1
-	weight = 3
+	weight = 2
 	cost = 15
-	requirements = list(101,101,101,10,10,10,10,10,10,10)
-	repeatable = TRUE */
+	requirements = list(45,40,30,30,20,20,15,10,10,10)
+	minimum_players = 36
+	repeatable = TRUE


### PR DESCRIPTION
# General Description

Heretics are now enabled for latejoin dynamic, with a lower weight, which means they appear less, they need 36 players in order to spawn. Traitors also have a lower cost now, from 15 down to 10, and the vampire requirements for player scaling have been lowered, and ordered correctly.

# Wiki Documentation

Heretics can now join in late, during a dynamic shift.

:cl:  Xoxeyos
rscadd: Heretics are now enabled for dynamic latejoin.
tweak: Tweaked heretic weights, traitor costs, and gamemode requirements.
/:cl:
