### PR TITLE
Re-enables Darkspawn for dynamic roundstart.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -923,7 +923,7 @@
 //                                          //
 //////////////////////////////////////////////
 
-/*/datum/dynamic_ruleset/roundstart/darkspawn
+/datum/dynamic_ruleset/roundstart/darkspawn
 	name = "Darkspawn"
 	antag_flag = ROLE_DARKSPAWN
 	antag_datum = /datum/antagonist/darkspawn/
@@ -946,4 +946,4 @@
 		M.mind.special_role = ROLE_DARKSPAWN
 		M.mind.restricted_roles = restricted_roles
 		log_game("[key_name(M)] has been selected as a Darkspawn")
-	return TRUE */
+	return TRUE


### PR DESCRIPTION
# Github documenting your Pull Request

Re-enables the Darkspawn, since various changes have been made to properly fix some of their gameplay mechanics.

# Wiki Documentation

Darkspawn is now re-enabled for dynamic.

# Changelog

:cl:  Xoxeyos
tweak: Darkspawn has been re-enabled for dynamic.
/:cl:
