### PR TITLE
Only one high impact ruleset will spawn during dynamic per round. (Nukies, Clock Cult, Etc.)

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -5,7 +5,7 @@
 #define REPORT_POS_DIVERGENCE 15
 
 // Are HIGH_IMPACT_RULESETs allowed to stack?
-GLOBAL_VAR_INIT(dynamic_no_stacking, FALSE)
+GLOBAL_VAR_INIT(dynamic_no_stacking, TRUE)
 // If enabled does not accept or execute any rulesets.
 GLOBAL_VAR_INIT(dynamic_forced_extended, FALSE)
 // How high threat is required for HIGH_IMPACT_RULESETs stacking.


### PR DESCRIPTION
# Github documenting your Pull Request

High Impact Rulesets can easily take a round that's ten minutes in and spin it out of control, I am turning it off multiple spawning at a time, so that I can balance some of the other, more easy-going game modes better.

# Changelog

Only one High Impact Ruleset spawns in a dynamic round, this can be configured in game using the game panel before the round starts.

:cl:  Xoxeyos
tweak: Only one High Impact Ruleset can spawn at the start of a round.
/:cl:
