### PR TITLE
Transit tubes are no longer 2x stronger than reinforced windows

### DIFF
--- a/code/game/objects/structures/transit_tubes/transit_tube.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube.dm
@@ -13,6 +13,7 @@
 	var/exit_delay = 1
 	var/enter_delay = 0
 	var/const/time_to_unwrench = 2 SECONDS
+	max_integrity = 75
 
 /obj/structure/transit_tube/CanAllowThrough(atom/movable/mover, turf/target)
 	. = ..()


### PR DESCRIPTION


# Github documenting your Pull Request

Don't need to incentivize using as barricades. Strength lies between normal full-tile window and reinforced one.

# Wiki Documentation


# Changelog

:cl:  
tweak: Transit tubes are much weaker
/:cl:
