### PR TITLE
Removes blackout station trait.

### DIFF
--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -25,20 +25,6 @@
 	report_message = "Sorry for that, we missed your station by a few miles, so we just launched you towards your station in pods. Hope you don't mind!"
 	trait_to_give = STATION_TRAIT_RANDOM_ARRIVALS
 
-/datum/station_trait/blackout
-	name = "Blackout"
-	trait_type = STATION_TRAIT_NEGATIVE
-	weight = 3
-	show_in_report = TRUE
-	report_message = "Station lights seem to be damaged, be safe when starting your shift today."
-
-/datum/station_trait/blackout/on_round_start()
-	. = ..()
-	for(var/a in GLOB.apcs_list)
-		var/obj/machinery/power/apc/current_apc = a
-		if(prob(60))
-			current_apc.overload_lighting()
-
 /datum/station_trait/empty_maint
 	name = "Cleaned out maintenance"
 	trait_type = STATION_TRAIT_NEGATIVE


### PR DESCRIPTION
# Github documenting your Pull Request

This is the most annoying station trait, talked to a few people that agree.

Doesn't add anything to the gamer other than actual pain and suffering

# Wiki Documentation

May have to remove from wiki if it's on there.

# Changelog

:cl:  
tweak: NanoTrasen has installed more durable lightbulbs are you should no longer encounter half of the stations lights being destroyed when you arrive.
/:cl:
