### PR TITLE
Darkspawn can now only have 10 concurrent veils down from infinite

### DIFF
--- a/yogstation/code/game/gamemodes/darkspawn/darkspawn.dm
+++ b/yogstation/code/game/gamemodes/darkspawn/darkspawn.dm
@@ -1,3 +1,4 @@
+#define DARKSPAWN_VEIL_MAXIMUM 10
 /datum/game_mode
 	var/list/datum/mind/darkspawn = list()
 	var/list/datum/mind/veils = list()
@@ -122,6 +123,14 @@
 		Eyes filled with stars.</b>\n\
 		<span class='boldwarning'>It needs to die.</span>")
 		return FALSE
+	if(LAZYLEN(veils) > DARKSPAWN_VEIL_MAXIMUM)
+		src.visible_message("<span class='warning'>[src] seems to resist an unseen force!</span>")
+		to_chat(src, "<b>Your mind falters. Your thoughts hitch. You feel empty. \n\
+		You feel another mind. You dream.\n\
+		Of a vast patch of nothingness.\n\
+		Something sleeps in the darkness. Old. Strange. It watches you with tired eyes.</b>\n\
+		<span class='boldwarning'>You feel no different.</span>")
+		return FALSE
 	return mind.add_antag_datum(/datum/antagonist/veil)
 
 /mob/living/proc/remove_veil()
@@ -143,3 +152,5 @@
 
 	round_credits += ..()
 	return round_credits
+
+#undef DARKSPAWN_VEIL_MAXIMUM

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/veil_mind.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/veil_mind.dm
@@ -36,9 +36,8 @@
 				to_chat(L, "<span class='warning'>...but you can't hear it!</span>")
 			else
 				if(L.has_status_effect(STATUS_EFFECT_BROKEN_WILL))
-					if(L.add_veil(darkspawn))
+					if(L.add_veil())
 						to_chat(owner, "<span class='velvet'><b>[L.real_name]</b> has become a veil!</span>")
-						darkspawn.veilcount++
 				else
 					to_chat(L, "<span class='boldwarning'>...and it scrambles your thoughts!</span>")
 					L.dir = pick(GLOB.cardinals)

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/veil_mind.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/veil_mind.dm
@@ -1,3 +1,4 @@
+#define DARKSPAWN_VEIL_MAXIMUM 3 //maximum number of veils per darkspawn
 //Converts people within three tiles of the caster into veils. Also confuses noneligible targets and stuns silicons.
 /datum/action/innate/darkspawn/veil_mind
 	name = "Veil Mind"
@@ -36,10 +37,13 @@
 				to_chat(L, "<span class='warning'>...but you can't hear it!</span>")
 			else
 				if(L.has_status_effect(STATUS_EFFECT_BROKEN_WILL))
-					if(L.add_veil())
+					if(darkspawn?.veilcount < DARKSPAWN_VEIL_MAXIMUM && L.add_veil(darkspawn))
 						to_chat(owner, "<span class='velvet'><b>[L.real_name]</b> has become a veil!</span>")
+						darkspawn.veilcount++
 				else
 					to_chat(L, "<span class='boldwarning'>...and it scrambles your thoughts!</span>")
 					L.dir = pick(GLOB.cardinals)
 					L.confused += 2
 	return TRUE
+
+#undef DARKSPAWN_VEIL_MAXIMUM

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/veil_mind.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/veil_mind.dm
@@ -1,4 +1,3 @@
-#define DARKSPAWN_VEIL_MAXIMUM 3 //maximum number of veils per darkspawn
 //Converts people within three tiles of the caster into veils. Also confuses noneligible targets and stuns silicons.
 /datum/action/innate/darkspawn/veil_mind
 	name = "Veil Mind"
@@ -37,7 +36,7 @@
 				to_chat(L, "<span class='warning'>...but you can't hear it!</span>")
 			else
 				if(L.has_status_effect(STATUS_EFFECT_BROKEN_WILL))
-					if(darkspawn?.veilcount < DARKSPAWN_VEIL_MAXIMUM && L.add_veil(darkspawn))
+					if(L.add_veil(darkspawn))
 						to_chat(owner, "<span class='velvet'><b>[L.real_name]</b> has become a veil!</span>")
 						darkspawn.veilcount++
 				else
@@ -45,5 +44,3 @@
 					L.dir = pick(GLOB.cardinals)
 					L.confused += 2
 	return TRUE
-
-#undef DARKSPAWN_VEIL_MAXIMUM


### PR DESCRIPTION
# Github documenting your Pull Request

Turning into ghetto shadowlings has a tendency to drag the round on as darkspawn aren't mechanically supported even with my changes to convert the entire fucking station

# Wiki Documentation

darkspawn veil mind can now only work on 10 people at a time TOTAL, this is SHARED between darkspawn.

# Changelog

:cl:  
tweak: darkspawn can now only convert 10 people at any time, down from infinite
/:cl:
