### PR TITLE
veil mind costs 6 lucidity up from 1 to unlock

### DIFF
--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/veil_mind.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/veil_mind.dm
@@ -6,7 +6,7 @@
 	button_icon_state = "veil_mind"
 	check_flags = AB_CHECK_STUN|AB_CHECK_CONSCIOUS
 	psi_cost = 60 //since this is only useful when cast directly after a succ it should be pretty expensive
-	lucidity_price = 1 //Yep, thralling is optional! It's just one of many possible playstyles.
+	lucidity_price = 6 //Yep, thralling is optional! It's just one of many possible playstyles.
 
 /datum/action/innate/darkspawn/veil_mind/Activate()
 	var/mob/living/carbon/human/H = owner


### PR DESCRIPTION
# Github documenting your Pull Request

Stop taking it first you unoriginal fucks you might learn something

# Wiki Documentation

veil mind lucidity cost is now 6

# Changelog

:cl:  
tweak: veil mind now costs 6 lucidity points to unlock up from 1
/:cl:
