### PR TITLE
Basic laser pointers are much worse at stunning borgs, with upgraded pointers becoming much more potent at the expense of how often they can be used.

### DIFF
--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -34,7 +34,7 @@
 	diode = new(src)
 	max_energy = initial(max_energy) - (diode.rating - 1)
 	if(energy >= max_energy)
-			energy = max_energy
+		energy = max_energy
 	if(!pointer_icon_state)
 		pointer_icon_state = pick("red_laser","green_laser","blue_laser","purple_laser")
 

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -126,7 +126,7 @@
 		var/mob/living/silicon/S = target
 		log_combat(user, S, "shone in the sensors", src)
 		//chance to actually hit the eyes depends on internal component, borgs are hard to stun :/
-		if(prob(effectchance * (diode.rating ** 0.75) * 0.75))
+		if(prob(effectchance * (diode.rating ** 1.35) * 0.75))
 			S.flash_act(affect_silicon = TRUE)
 			var/stun_modifier = diode.rating >= 4 ? 2 : 1
 			S.Paralyze(rand(2.5 SECONDS * stun_modifier, 5 SECONDS * stun_modifier))

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -128,7 +128,8 @@
 		//chance to actually hit the eyes depends on internal component, borgs are hard to stun :/
 		if(prob(effectchance * (diode.rating ** 0.75) * 0.75))
 			S.flash_act(affect_silicon = TRUE)
-			S.Paralyze(rand(2.5 SECONDS, 5 SECONDS))
+			var/stun_modifier = diode.rating >= 4 ? 2 : 1
+			S.Paralyze(rand(2.5 SECONDS * stun_modifier, 5 SECONDS * stun_modifier))
 			to_chat(S, "<span class='danger'>Your sensors were overloaded by a laser!</span>")
 			outmsg = "<span class='notice'>You overload [S] by shining [src] at [S.p_their()] sensors.</span>"
 		else

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -11,12 +11,18 @@
 	materials = list(/datum/material/iron=500, /datum/material/glass=500)
 	w_class = WEIGHT_CLASS_SMALL
 	var/turf/pointer_loc
+	///How many times the pointer can point
 	var/energy = 4
+	///Max energy we can store
 	var/max_energy = 4
+	///The chance of something happening when we shine at it in %
 	var/effectchance = 15
-	var/recharging = 0
+	///Are we currently recharging?
+	var/recharging = FALSE
+	///If we use all our energy we set this and have to wait for energy to equal max_energy to fire again
 	var/recharge_locked = FALSE
 	var/obj/item/stock_parts/micro_laser/diode //used for upgrading!
+	///Pseudo energy seperate from actual energy only used for recharging logic
 	var/lockout_charges = 0
 
 


### PR DESCRIPTION
# Github documenting your Pull Request

Max charges reduced to 4.

Every upgraded laser reduces the max charges by 1, with the max being 1 charge at level 4.

Stun reduced from 10-20 seconds to 2.5-5 seconds.

A standard laser pointer with 4 charges has a 11.25% chance of stunning a borg per hit. (38% chance of getting AT LEAST 1 stun.) 
(1% for 2 stuns, 0.1% for 3 stuns, 0.01% for 4 stuns)

Level 2 laser has a 28.68% chance of stunning with 3 charges. (64% chance of at least 1 stun) (8% for 2 stuns, 2% for 3 stuns.)

Level 3 laser has a 49.58% chance of stunning with 2 charges. (75% chance of at least 1 stun) (24.5% for 2 stuns)

Level 4 laser has a 73.1% chance of stunning with 1 charge. 

Level 4 laser has a lower overall probability but increases stun amount by 100%. (5-10 seconds) Why? Because when you use a level 4 laser once it overloads and requires 4 charge cycles (10% chance per process).

Best way to use this:
Shoot borg untill you have 1 charge left. Run the duck away unless you want to try your luck and get your skull bashed/flashed in by the borg.






# Wiki Documentation


# Changelog

:cl:  
tweak: Laser pointers are now much more potent at stunning borgs when upgraded using a better quality laser diodes. The increased power load does however mean that the max charges the laser pointer can hold will degrade by 1 per tier of upgraded diode.
/:cl:
