### PR TITLE
AI is no longer trackable after they've been removed from the AI core

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -802,6 +802,7 @@
 			to_chat(user, "<span class='warning'>No intelligence patterns detected.</span>"    )
 			return
 		ShutOffDoomsdayDevice()
+		builtInCamera.toggle_cam(user)
 		var/obj/structure/AIcore/new_core = new /obj/structure/AIcore/deactivated(loc)//Spawns a deactivated terminal at AI location.
 		new_core.circuit.battery = battery
 		ai_restore_power()//So the AI initially has power.


### PR DESCRIPTION
# Github documenting your Pull Request

Need to figure out a way to re-enable it when they're slotted back n

# Wiki Documentation


# Changelog


:cl:  
bugfix: You can no longer see through the dead AIs camera
/:cl:
