### PR TITLE
Makes accessories get deleted less

### DIFF
--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -163,6 +163,10 @@
 			H.update_inv_w_uniform()
 			H.update_inv_wear_suit()
 
+/obj/item/clothing/under/Destroy()
+	if(attached_accessory)
+		remove_accessory(loc)
+	return ..()
 
 /obj/item/clothing/under/examine(mob/user)
 	. = ..()


### PR DESCRIPTION


# Github documenting your Pull Request

Makes accessories detach when the thing they're attached to gets destroyed rather than just ceasing to exist.

# Wiki Documentation

not needed

# Changelog


:cl:  

bugfix: accessories get deleted less

/:cl:
