### PR TITLE
Reduces the Hypertool's brain damage and armor penetration

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -480,10 +480,12 @@
 	item_state = "hypertool"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
+	force = 7
+	throwforce = 5
 	slot_flags = ITEM_SLOT_BELT
 	name = "hypertool"
 	desc = "A tool so powerful even you cannot perfectly use it."
-	armour_penetration = 35
+	armour_penetration = 10
 	damtype = BRAIN
 	attack_verb = list("pulsed", "mended", "cut")
 	hitsound = 'sound/effects/sparks4.ogg'

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -480,7 +480,7 @@
 	item_state = "hypertool"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
-	force = 7
+	force = 9
 	throwforce = 5
 	slot_flags = ITEM_SLOT_BELT
 	name = "hypertool"


### PR DESCRIPTION
Pares the Chaplain's nullrod morph, the Hypertool, back from 18 melee / 10 thrown brain damage force and 35 Armor Pen.
Applied Force is now 9 brain damage for a melee hit, and 5 for a thrown hit, half the original values, with 10 Armor Pen. 
Direct Brain Damage applications in game are rare, and are potentially abusable, both in weaponized form against other people, and in respect to trauma rolling (see original dab emote); this PR seeks to rebalance this in regards to the hypertool. Suggested tweaks to the modified values are welcome.

# Github documenting your Pull Request

Hypertool hypertuning, see statblock below.

# Wiki Documentation

**Hypertool proposed changes:**
Melee [Brain Damage] Force: 18 (default) -> 9
Thrown [Brain Damage] Force: 10 (default) -> 5
Armor Penetration: 35 -> 10

# Changelog

:cl:  
tweak: Adjusts statline of the Hypertool from 18/10(t)/35AP to 9/5(t)/10AP
experimental: Statline adjustments subject to change.
/:cl:
