### PR TITLE
Silicons s no longer spawn a skillcape on the floor

### DIFF
--- a/yogstation/code/modules/jobs/job_types/_job.dm
+++ b/yogstation/code/modules/jobs/job_types/_job.dm
@@ -51,6 +51,9 @@
 		C = H.client
 		if(!C)
 			return
+	if(issilicon(H) || issilicon(M))
+		return
+
 	var/S = C.prefs.skillcape
 	if(S != 1)
 		var/datum/skillcape/A = GLOB.skillcapes[S]


### PR DESCRIPTION
# Github documenting your Pull Request

See title, AI's don't have hands, neither do borg

# Wiki Documentation


# Changelog

:cl:  
bugfix: Silicons no longer get a skill cape
/:cl:
