### PR TITLE
Default age of IDs upped to 21, should avoid underage ghost roles

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -120,7 +120,7 @@
 	var/access_txt // mapping aid
 	var/datum/bank_account/registered_account
 	var/obj/machinery/paystand/my_store
-	var/registered_age = 13 // default age for ss13 players
+	var/registered_age = 18 // default age for ss13 players
 
 /obj/item/card/id/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -120,7 +120,7 @@
 	var/access_txt // mapping aid
 	var/datum/bank_account/registered_account
 	var/obj/machinery/paystand/my_store
-	var/registered_age = 18 // default age for ss13 players
+	var/registered_age = 21 // default age for ss13 players
 
 /obj/item/card/id/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
# Github documenting your Pull Request

:)

Fixes #11400 

# Wiki Documentation


# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
tweak: ID cards are now registered as being above 21 by default
tweak: The Free Miners are no longer ruled by 13 year old children.
/:cl:
