### PR TITLE
Fixes notes and photos pinned on airlocks

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -622,7 +622,7 @@
 	if(show_lights && lights && hasPower())
 		base.add_overlay(get_airlock_overlay("lights_[side]", overlays_file))
 
-	if(note && note_attachment == "left")
+	if(note && note_attachment == side)
 		var/notetype = note_type()
 		base.add_overlay(get_airlock_overlay(notetype, note_overlay_file))
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -622,7 +622,7 @@
 	if(show_lights && lights && hasPower())
 		base.add_overlay(get_airlock_overlay("lights_[side]", overlays_file))
 
-	if(note && note_attachment == "side")
+	if(note && note_attachment == "left")
 		var/notetype = note_type()
 		base.add_overlay(get_airlock_overlay(notetype, note_overlay_file))
 


### PR DESCRIPTION
# Github documenting your Pull Request

Thanks monster, simple fix

Fixes #11381 

# Wiki Documentation


# Changelog


:cl:  
bugfix: You can now pin papers on airlocks
/:cl:
