### PR TITLE
Holoparasites healing structures now call their update_icon (Means cracked windows will un-crack if healed by them)

### DIFF
--- a/yogstation/code/modules/guardian/abilities/major/healing.dm
+++ b/yogstation/code/modules/guardian/abilities/major/healing.dm
@@ -45,6 +45,7 @@
 			guardian.do_attack_animation(O)
 			O.obj_integrity = min(O.obj_integrity + (O.max_integrity * 0.1), O.max_integrity)
 			var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal(get_turf(O))
+			O.update_icon()
 			if(guardian.namedatum)
 				H.color = guardian.namedatum.colour
 			guardian.changeNext_move(CLICK_CD_MELEE)


### PR DESCRIPTION
# Github documenting your Pull Request

Fixes https://github.com/yogstation13/Yogstation/issues/10692

# Wiki Documentation



# Changelog

:cl:  
bugfix: Structures healed by holoparasites will now display correctly
/:cl:
