### PR TITLE
Damaged borgs are 50% faster when there is no gravity.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -933,7 +933,10 @@
 	. = ..()
 	var/hd = maxHealth - health
 	if(hd > 50)
-		. += hd/100
+		if(has_gravity())
+			. += hd/100
+		else
+			. += hd/150
 
 /mob/living/silicon/robot/update_sight()
 	if(!client)


### PR DESCRIPTION
# Github documenting your Pull Request

Humans negate damage slowdown in space, but that is too much imo. 

Fixes https://github.com/yogstation13/Yogstation/issues/10490 (Or at least resolves it)

# Wiki Documentation

# Changelog

:cl:  
tweak: Damaged borgs are faster in zero gravity due to them requiring less mechanical work to move.
/:cl:
