### PR TITLE
Banned team antags are no longer allowed to play even if there are no ghosts to replace them.

### DIFF
--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -106,6 +106,11 @@ GLOBAL_LIST_EMPTY(antagonists)
 		message_admins("[key_name_admin(C)] has taken control of ([key_name_admin(owner)]) to replace a jobbanned player.")
 		owner.current.ghostize(0)
 		owner.current.key = C.key
+	else
+		to_chat(owner, "Your mob has been taken over by a ghost! Appeal your job ban if you want to avoid this in the future!")
+		message_admins(" [key_name_admin(owner)] is banned from [job_rank] and was unable to be replaced!")
+		owner.current.ghostize(0)
+		owner.current.key = null
 
 //Called by the remove_antag_datum() and remove_all_antag_datums() mind procs for the antag datum to handle its own removal and deletion.
 /datum/antagonist/proc/on_removal()

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -106,9 +106,9 @@ GLOBAL_LIST_EMPTY(antagonists)
 	
 	owner.current.ghostize(0)
 	owner.current.key = null
-	
+	var/mob/dead/observer/C
 	if(LAZYLEN(candidates))
-		var/mob/dead/observer/C = pick(candidates)
+		C = pick(candidates)
 	message_admins(" [key_name_admin(owner)] [C ? "has been replaced by [key_name_admin(C)]" : "is banned from [job_rank] and was unable to be replaced!"]")
 	owner.current.key = C.key ? C.key : null
 	

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -100,17 +100,18 @@ GLOBAL_LIST_EMPTY(antagonists)
 	set waitfor = FALSE
 
 	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a [name]?", "[name]", null, job_rank, 50, owner.current)
+	
+	owner.current.ghostize(0)
+	to_chat(owner, "Your mob has been taken over by a ghost! Appeal your job ban if you want to avoid this in the future!")
+	
+	owner.current.ghostize(0)
+	owner.current.key = null
+	
 	if(LAZYLEN(candidates))
 		var/mob/dead/observer/C = pick(candidates)
-		to_chat(owner, "Your mob has been taken over by a ghost! Appeal your job ban if you want to avoid this in the future!")
-		message_admins("[key_name_admin(C)] has taken control of ([key_name_admin(owner)]) to replace a jobbanned player.")
-		owner.current.ghostize(0)
-		owner.current.key = C.key
-	else
-		to_chat(owner, "Your mob has been taken over by a ghost! Appeal your job ban if you want to avoid this in the future!")
-		message_admins(" [key_name_admin(owner)] is banned from [job_rank] and was unable to be replaced!")
-		owner.current.ghostize(0)
-		owner.current.key = null
+	message_admins(" [key_name_admin(owner)] [C ? "has been replaced by [key_name_admin(C)]" : "is banned from [job_rank] and was unable to be replaced!"]")
+	owner.current.key = C.key ? C.key : null
+	
 
 //Called by the remove_antag_datum() and remove_all_antag_datums() mind procs for the antag datum to handle its own removal and deletion.
 /datum/antagonist/proc/on_removal()

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -100,17 +100,15 @@ GLOBAL_LIST_EMPTY(antagonists)
 	set waitfor = FALSE
 
 	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a [name]?", "[name]", null, job_rank, 50, owner.current)
-	
-	owner.current.ghostize(0)
-	to_chat(owner, "Your mob has been taken over by a ghost! Appeal your job ban if you want to avoid this in the future!")
-	
-	owner.current.ghostize(0)
-	owner.current.key = null
 	var/mob/dead/observer/C
+	
+	to_chat(owner, "Your mob has been taken over by a ghost! Appeal your job ban if you want to avoid this in the future!")
 	if(LAZYLEN(candidates))
 		C = pick(candidates)
+		
 	message_admins(" [key_name_admin(owner)] [C ? "has been replaced by [key_name_admin(C)]" : "is banned from [job_rank] and was unable to be replaced!"]")
-	owner.current.key = C.key ? C.key : null
+	owner.current.ghostize(0)
+	owner.current.key = C ? C.key : null
 	
 
 //Called by the remove_antag_datum() and remove_all_antag_datums() mind procs for the antag datum to handle its own removal and deletion.


### PR DESCRIPTION
# Github documenting your Pull Request

Fixes https://github.com/yogstation13/Yogstation/issues/8307

# Wiki Documentation


# Changelog


:cl:   
bugfix: Antag banned players can no longer play that antag even if there are no ghosts to replace them
/:cl:
