### PR TITLE
Lavaland abandoned mech starts as a firefighter with a drill

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_random_ripley.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_random_ripley.dmm
@@ -8,16 +8,26 @@
 "c" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"d" = (
-/obj/mecha/working/ripley/mining{
+"u" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"w" = (
+/obj/item/clothing/under/rank/miner/lavaland,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"K" = (
+/obj/item/clothing/shoes/workboots/mining,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"O" = (
+/obj/mecha/working/ripley/firefighter{
 	ruin_mecha = 1
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"e" = (
-/obj/item/clothing/shoes/workboots/mining,
-/obj/item/clothing/under/rank/miner/lavaland,
-/obj/effect/decal/remains/human,
+"V" = (
+/obj/item/mecha_parts/mecha_equipment/drill,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 
@@ -32,20 +42,20 @@ a
 b
 c
 b
-c
+w
 b
 "}
 (3,1,1) = {"
 b
 c
-d
-e
+O
+u
 b
 "}
 (4,1,1) = {"
 b
-c
-c
+K
+V
 b
 b
 "}


### PR DESCRIPTION
# Github documenting your Pull Request
![vivaldi_EsWjLYRjS4](https://user-images.githubusercontent.com/48154165/126378791-b5048bea-506b-45da-a958-a36a94644cc5.png)
Promotes mech use on lavaland, might be strong but nobody uses the ripley mk1 anyway so this is possibly a good change

# Wiki Documentation

No idea if you have ruins listed but if you do you have to update the pictures

# Changelog

:cl:  
tweak: Lavaland abandoned mech starts as a firefighter with a drill
/:cl:
