### PR TITLE
Self aware trait no longer shows health while screwyhud is active

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -740,7 +740,7 @@
 			if(prob(30))
 				burndamage += rand(30,40)
 
-		if(HAS_TRAIT(src, TRAIT_SELF_AWARE) && hal_screwyhud != SCREWYHUD_NONE)
+		if(HAS_TRAIT(src, TRAIT_SELF_AWARE) && hal_screwyhud == SCREWYHUD_NONE)
 			status = "[brutedamage] brute damage and [burndamage] burn damage"
 			if(!brutedamage && !burndamage)
 				status = "no damage"

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -740,7 +740,7 @@
 			if(prob(30))
 				burndamage += rand(30,40)
 
-		if(HAS_TRAIT(src, TRAIT_SELF_AWARE))
+		if(HAS_TRAIT(src, TRAIT_SELF_AWARE) && hal_screwyhud != SCREWYHUD_NONE)
 			status = "[brutedamage] brute damage and [burndamage] burn damage"
 			if(!brutedamage && !burndamage)
 				status = "no damage"


### PR DESCRIPTION
# Github documenting your Pull Request

The self aware trait no longer works if something is overriding the health hud display like a hallucination or brain trauma.

# Changelog
Fixes #11240 

:cl:  
bugfix: fixed screwyhud not working with self aware
/:cl:
