### PR TITLE
Extendoarm can no longer grab intercoms and safes off of the walls

### DIFF
--- a/yogstation/code/datums/mutations/extendoarm.dm
+++ b/yogstation/code/datums/mutations/extendoarm.dm
@@ -96,8 +96,10 @@
 	else
 		if(grabbed)
 			ungrab()
-		else if(isitem(target) && !target.anchored)
-			grab(target)
+		else if(isitem(target))
+			var/obj/item/I = target
+			if(!I.anchored)
+				grab(target)
 		go_home()
 
 /obj/item/projectile/bullet/arm/proc/go_home()

--- a/yogstation/code/datums/mutations/extendoarm.dm
+++ b/yogstation/code/datums/mutations/extendoarm.dm
@@ -96,7 +96,7 @@
 	else
 		if(grabbed)
 			ungrab()
-		else if(isitem(target))
+		else if(isitem(target) && !target.anchored)
 			grab(target)
 		go_home()
 


### PR DESCRIPTION

# Github documenting your Pull Request

Or anything anchored for that matter

# Wiki Documentation

# Changelog

:cl:  
tweak: Extendoarm can no longer grab intercoms and safes off of the walls
/:cl:
