### PR TITLE
Removes flash protection from plasmaman helmet, can still wear welding goggles or sunglasses

### DIFF
--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -47,6 +47,7 @@
 	var/brightness_on = 4 //luminosity when the light is on
 	var/on = FALSE
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
+	flash_protect = 0
 
 /obj/item/clothing/head/helmet/space/plasmaman/attack_self(mob/user)
 	on = !on


### PR DESCRIPTION
# Github documenting your Pull Request
Removes flash protection from plasmaman helmets 

# Wiki Documentation
Plasmaman helmets no longer provide flash protection

# Changelog


:cl:  
rscdel: Removed plasmaman helmet flash protections    
/:cl:
