### PR TITLE
Hypospray starts filled with basic chems instead of omnizine

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -69,7 +69,9 @@
 				log_game("[user.real_name] ([user.ckey]) injected [M.real_name] ([M.ckey]) with [viruslist]")
 // yogs end
 /obj/item/reagent_containers/hypospray/CMO
-	list_reagents = list(/datum/reagent/medicine/omnizine = 30)
+	list_reagents = list(/datum/reagent/medicine/c2/libital = 10,
+						/datum/reagent/medicine/c2/aiuri = 10,
+						/datum/reagent/medicine/salbutamol = 10)
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
 /obj/item/reagent_containers/hypospray/combat


### PR DESCRIPTION
Hypospray payload at initialization changed from 30u Omnizine to 10u Aiuri + 10u Libital + 10u Salbutamol.

# Github documenting your Pull Request

Rebalances the Hypospray to have an evenly split mixture of normally attainable chemicals on object initialization, which can address most major types of damage. 

Overall, this buffs the power and usefulness of the Hypospray right out of the locker by giving it a more intense burst healing effect on patients (see: Airui, Libital, Salbutamol having heal rates of 3 / 2 / 3 for their respective damage values per tick), rather than necessitating waiting for omnizine (.5 to all per tick) to slowly mend the patient's health back together. This also serves to reduce the amount of omnizine immediately available in the map for Medical to use in a rush for Strange Reagent.

# Wiki Documentation

Hypospray Changes (initial generation):
30u Omnizine -> 10u Aiuri + 10u Libital + 10u Salbutamol

# Changelog

:cl:  
tweak: Hypospray starting configuration: 30u Omnizine -> 10u Aiuri + 10u Libital + 10u Salbutamol
/:cl:
