### PR TITLE
Space adapt nerf (prevents passive cooling if space adapt is active)

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -156,6 +156,8 @@
 #define TRAIT_PRESERVED_ORGANS	"preserved_organs"
 #define TRAIT_SKINNY			"skinny"  //For those with a slightly thinner torso sprite
 #define TRAIT_SURGERY_PREPARED	"surgery_prepared"
+#define TRAIT_NO_NATURAL_COOLING "no-natural-cooling"
+#define TRAIT_NO_NATURAL_HEATING "no-natural-heating"
 
 //non-mob traits
 #define TRAIT_PARALYSIS			"paralysis" //Used for limb-based paralysis, where replacing the limb will fix it

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -156,8 +156,8 @@
 #define TRAIT_PRESERVED_ORGANS	"preserved_organs"
 #define TRAIT_SKINNY			"skinny"  //For those with a slightly thinner torso sprite
 #define TRAIT_SURGERY_PREPARED	"surgery_prepared"
-#define TRAIT_NO_NATURAL_COOLING "no-natural-cooling"
-#define TRAIT_NO_NATURAL_HEATING "no-natural-heating"
+#define TRAIT_NO_PASSIVE_COOLING "no-passive-cooling"
+#define TRAIT_NO_PASSIVE_HEATING "no-passive-heating"
 
 //non-mob traits
 #define TRAIT_PARALYSIS			"paralysis" //Used for limb-based paralysis, where replacing the limb will fix it

--- a/code/datums/mutations/space_adaptation.dm
+++ b/code/datums/mutations/space_adaptation.dm
@@ -21,12 +21,12 @@
 		return
 	ADD_TRAIT(owner, TRAIT_RESISTCOLD, "space_adaptation")
 	ADD_TRAIT(owner, TRAIT_RESISTLOWPRESSURE, "space_adaptation")
-	ADD_TRAIT(owner, TRAIT_NO_NATURAL_COOLING, "space_adaptation")
+	ADD_TRAIT(owner, TRAIT_NO_PASSIVE_COOLING, "space_adaptation")
 
 /datum/mutation/human/space_adaptation/on_losing(mob/living/carbon/human/owner)
 	if(..())
 		return
 	REMOVE_TRAIT(owner, TRAIT_RESISTCOLD, "space_adaptation")
 	REMOVE_TRAIT(owner, TRAIT_RESISTLOWPRESSURE, "space_adaptation")
-	REMOVE_TRAIT(owner, TRAIT_NO_NATURAL_COOLING, "space_adaptation")
+	REMOVE_TRAIT(owner, TRAIT_NO_PASSIVE_COOLING, "space_adaptation")
 

--- a/code/datums/mutations/space_adaptation.dm
+++ b/code/datums/mutations/space_adaptation.dm
@@ -21,10 +21,12 @@
 		return
 	ADD_TRAIT(owner, TRAIT_RESISTCOLD, "space_adaptation")
 	ADD_TRAIT(owner, TRAIT_RESISTLOWPRESSURE, "space_adaptation")
+	ADD_TRAIT(owner, TRAIT_NO_NATURAL_COOLING, "space_adaptation")
 
 /datum/mutation/human/space_adaptation/on_losing(mob/living/carbon/human/owner)
 	if(..())
 		return
 	REMOVE_TRAIT(owner, TRAIT_RESISTCOLD, "space_adaptation")
 	REMOVE_TRAIT(owner, TRAIT_RESISTLOWPRESSURE, "space_adaptation")
+	REMOVE_TRAIT(owner, TRAIT_NO_NATURAL_COOLING, "space_adaptation")
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1749,10 +1749,11 @@ GLOBAL_LIST_EMPTY(mentor_races)
 		if(loc_temp < H.bodytemperature) //Place is colder than we are
 			thermal_protection -= H.get_cold_protection(loc_temp) //This returns a 0 - 1 value, which corresponds to the percentage of protection based on what you're wearing and what you're exposed to.
 			thermal_protection *= heat_capacity_factor
-			if(H.bodytemperature < BODYTEMP_NORMAL) //we're cold, insulation helps us retain body heat and will reduce the heat we lose to the environment
-				H.adjust_bodytemperature((thermal_protection+1)*natural + max(thermal_protection * (loc_temp - H.bodytemperature) / BODYTEMP_COLD_DIVISOR, BODYTEMP_COOLING_MAX))
-			else //we're sweating, insulation hinders our ability to reduce heat - and it will reduce the amount of cooling you get from the environment
-				H.adjust_bodytemperature(natural*(1/(thermal_protection+1)) + max((thermal_protection * (loc_temp - H.bodytemperature) + BODYTEMP_NORMAL - H.bodytemperature) / BODYTEMP_COLD_DIVISOR , BODYTEMP_COOLING_MAX)) //Extra calculation for hardsuits to bleed off heat
+			if(!HAS_TRAIT(H, TRAIT_NO_PASSIVE_COOLING))
+				if(H.bodytemperature < BODYTEMP_NORMAL) //we're cold, insulation helps us retain body heat and will reduce the heat we lose to the environment
+					H.adjust_bodytemperature((thermal_protection+1)*natural + max(thermal_protection * (loc_temp - H.bodytemperature) / BODYTEMP_COLD_DIVISOR, BODYTEMP_COOLING_MAX))
+				else //we're sweating, insulation hinders our ability to reduce heat - and it will reduce the amount of cooling you get from the environment
+					H.adjust_bodytemperature(natural*(1/(thermal_protection+1)) + max((thermal_protection * (loc_temp - H.bodytemperature) + BODYTEMP_NORMAL - H.bodytemperature) / BODYTEMP_COLD_DIVISOR , BODYTEMP_COOLING_MAX)) //Extra calculation for hardsuits to bleed off heat
 	if (loc_temp > H.bodytemperature) //Place is hotter than we are
 		var/natural = 0
 		if(H.stat != DEAD)
@@ -1760,10 +1761,11 @@ GLOBAL_LIST_EMPTY(mentor_races)
 		var/thermal_protection = 1
 		thermal_protection -= H.get_heat_protection(loc_temp) //This returns a 0 - 1 value, which corresponds to the percentage of protection based on what you're wearing and what you're exposed to.
 		thermal_protection *= heat_capacity_factor
-		if(H.bodytemperature < BODYTEMP_NORMAL) //and we're cold, insulation enhances our ability to retain body heat but reduces the heat we get from the environment
-			H.adjust_bodytemperature((thermal_protection+1)*natural + min(thermal_protection * (loc_temp - H.bodytemperature) / BODYTEMP_HEAT_DIVISOR, BODYTEMP_HEATING_MAX))
-		else //we're sweating, insulation hinders out ability to reduce heat - but will reduce the amount of heat we get from the environment
-			H.adjust_bodytemperature(natural*(1/(thermal_protection+1)) + min(thermal_protection * (loc_temp - H.bodytemperature) / BODYTEMP_HEAT_DIVISOR, BODYTEMP_HEATING_MAX))
+		if(!HAS_TRAIT(H, TRAIT_NO_PASSIVE_HEATING))
+			if(H.bodytemperature < BODYTEMP_NORMAL) //and we're cold, insulation enhances our ability to retain body heat but reduces the heat we get from the environment
+				H.adjust_bodytemperature((thermal_protection+1)*natural + min(thermal_protection * (loc_temp - H.bodytemperature) / BODYTEMP_HEAT_DIVISOR, BODYTEMP_HEATING_MAX))
+			else //we're sweating, insulation hinders out ability to reduce heat - but will reduce the amount of heat we get from the environment
+				H.adjust_bodytemperature(natural*(1/(thermal_protection+1)) + min(thermal_protection * (loc_temp - H.bodytemperature) / BODYTEMP_HEAT_DIVISOR, BODYTEMP_HEATING_MAX))
 
 	// +/- 50 degrees from 310K is the 'safe' zone, where no damage is dealt.
 	if(H.bodytemperature > BODYTEMP_HEAT_DAMAGE_LIMIT && !HAS_TRAIT(H, TRAIT_RESISTHEAT))

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -596,20 +596,12 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 	var/body_temperature_difference = BODYTEMP_NORMAL - bodytemperature
 	switch(bodytemperature)
 		if(-INFINITY to BODYTEMP_COLD_DAMAGE_LIMIT) //Cold damage limit is 50 below the default, the temperature where you start to feel effects.
-			if(HAS_TRAIT(src, TRAIT_NO_NATURAL_HEATING))
-				return 0
 			return max((body_temperature_difference * metabolism_efficiency / BODYTEMP_AUTORECOVERY_DIVISOR), BODYTEMP_AUTORECOVERY_MINIMUM)
 		if(BODYTEMP_COLD_DAMAGE_LIMIT to BODYTEMP_NORMAL)
-			if(HAS_TRAIT(src, TRAIT_NO_NATURAL_HEATING))
-				return 0
 			return max(body_temperature_difference * metabolism_efficiency / BODYTEMP_AUTORECOVERY_DIVISOR, min(body_temperature_difference, BODYTEMP_AUTORECOVERY_MINIMUM/4))
 		if(BODYTEMP_NORMAL to BODYTEMP_HEAT_DAMAGE_LIMIT) // Heat damage limit is 50 above the default, the temperature where you start to feel effects.
-			if(HAS_TRAIT(src, TRAIT_NO_NATURAL_COOLING))
-				return 0
 			return min(body_temperature_difference * metabolism_efficiency / BODYTEMP_AUTORECOVERY_DIVISOR, max(body_temperature_difference, -BODYTEMP_AUTORECOVERY_MINIMUM/4))
 		if(BODYTEMP_HEAT_DAMAGE_LIMIT to INFINITY)
-			if(HAS_TRAIT(src, TRAIT_NO_NATURAL_COOLING))
-				return 0
 			return min((body_temperature_difference / BODYTEMP_AUTORECOVERY_DIVISOR), -BODYTEMP_AUTORECOVERY_MINIMUM)	//We're dealing with negative numbers
 
 /////////

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -596,12 +596,20 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 	var/body_temperature_difference = BODYTEMP_NORMAL - bodytemperature
 	switch(bodytemperature)
 		if(-INFINITY to BODYTEMP_COLD_DAMAGE_LIMIT) //Cold damage limit is 50 below the default, the temperature where you start to feel effects.
+			if(HAS_TRAIT(src, TRAIT_NO_NATURAL_HEATING))
+				return 0
 			return max((body_temperature_difference * metabolism_efficiency / BODYTEMP_AUTORECOVERY_DIVISOR), BODYTEMP_AUTORECOVERY_MINIMUM)
 		if(BODYTEMP_COLD_DAMAGE_LIMIT to BODYTEMP_NORMAL)
+			if(HAS_TRAIT(src, TRAIT_NO_NATURAL_HEATING))
+				return 0
 			return max(body_temperature_difference * metabolism_efficiency / BODYTEMP_AUTORECOVERY_DIVISOR, min(body_temperature_difference, BODYTEMP_AUTORECOVERY_MINIMUM/4))
 		if(BODYTEMP_NORMAL to BODYTEMP_HEAT_DAMAGE_LIMIT) // Heat damage limit is 50 above the default, the temperature where you start to feel effects.
+			if(HAS_TRAIT(src, TRAIT_NO_NATURAL_COOLING))
+				return 0
 			return min(body_temperature_difference * metabolism_efficiency / BODYTEMP_AUTORECOVERY_DIVISOR, max(body_temperature_difference, -BODYTEMP_AUTORECOVERY_MINIMUM/4))
 		if(BODYTEMP_HEAT_DAMAGE_LIMIT to INFINITY)
+			if(HAS_TRAIT(src, TRAIT_NO_NATURAL_COOLING))
+				return 0
 			return min((body_temperature_difference / BODYTEMP_AUTORECOVERY_DIVISOR), -BODYTEMP_AUTORECOVERY_MINIMUM)	//We're dealing with negative numbers
 
 /////////


### PR DESCRIPTION
# Github documenting your Pull Request

Added 2 new traits:
TRAIT_NO_PASSIVE_COOLING
TRAIT_NO_PASSIVE_HEATING

The first one prevents the bodytemperature from stabilizing naturally or to cool down from the environment. THe second one is the opposite, preventing you from heating up

Space adaptation now gives the no passive cooling trait, preventing someone with space adapt from cooling down if overheated.

# Wiki Documentation

Space adaptation has a downside of preventing you from losing body temperature, even if its too high.

# Changelog

:cl:  
tweak: Space adaptation has a downside of preventing you from losing body temperature, even if its too high.
/:cl:

temp gun
55s slowdown
2 min 17 sec crit

Being set on fire for 15 seconds
20 seconds slodown
40 seconds crit

Lizard tempgun
1 min 40 slowdown
3 min 30 crit

Lizard set on fire for 15 seconds
20 seconds slowdown
1 minute crit
