### PR TITLE
Sets deathsquad name to numbers and matches voice to accomodate

### DIFF
--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -378,15 +378,8 @@
 	W.icon_state = "centcom"
 	W.access = get_all_accesses()//They get full station access.
 	W.access += get_centcom_access("Death Commando")//Let's add their alloted CentCom access.
-
-	// Take "mob_###" (from H.tag) and turn it into "###"
-	var/newassignment = ""
-	for(var/i = 1, i <= length(H.tag), i += 1)
-		if(i > 4)
-			newassignment += H.tag[i]
-	W.assignment = newassignment // Unknown's ID Card (###) so DS can identify each other by their IDs
-	
-	W.registered_name = "Unknown"
+	W.assignment = "Death Commando"
+	W.registered_name = splittext(H.tag, "_")[2] // 412's ID Card (Death Commando); deathsquad are so edgy they are just numbers
 	W.update_label(W.registered_name, W.assignment)
 
 /datum/outfit/death_commando/officer

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -378,8 +378,15 @@
 	W.icon_state = "centcom"
 	W.access = get_all_accesses()//They get full station access.
 	W.access += get_centcom_access("Death Commando")//Let's add their alloted CentCom access.
-	W.assignment = "Death Commando"
-	W.registered_name = H.real_name
+
+	// Take "mob_###" (from H.tag) and turn it into "###"
+	var/newassignment = ""
+	for(var/i = 1, i <= length(H.tag), i += 1)
+		if(i > 4)
+			newassignment += H.tag[i]
+	W.assignment = newassignment // Unknown's ID Card (###) so DS can identify each other by their IDs
+	
+	W.registered_name = "Unknown"
 	W.update_label(W.registered_name, W.assignment)
 
 /datum/outfit/death_commando/officer

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -17,7 +17,7 @@
 		else
 			return real_name
 	if(istype(wear_mask, /obj/item/clothing/mask/gas/sechailer/swat/encrypted))
-		return "Unknown"
+		return splittext(src.tag, "_")[2] // Voice name will show up as their tag numbers to match ID
 	if(mind)
 		var/datum/antagonist/changeling/changeling = mind.has_antag_datum(/datum/antagonist/changeling)
 		if(changeling && changeling.mimicing )


### PR DESCRIPTION
# Github documenting your Pull Request

Encrypted mask now sets name to numbers in speech
This change will also make ID say numbers to accomodate
Numbers are 3 numbers pulled from mob tag
![image](https://i.imgur.com/TwZSkCK.png)

# Changelog

:cl:  
tweak: Deathsquad are now identified strictly by number tags
/:cl:
