### PR TITLE
Paraplegics can move faster in wheelchairs then their leg-having crewmembers

### DIFF
--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -45,7 +45,7 @@
 		//1.5 (movespeed as of this change) multiplied by 4 gets 6, which gives you a delay of 3 assuming the user has two arms,
 		//getting the speed of the wheelchair roughly equal to the speed of a scooter based on testing.
 		//if that made no sense this simply makes the wheelchair speed change along with movement speed delay
-		D.vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * 4) / min(user.get_num_arms(), 2)
+		D.vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * 3) / min(user.get_num_arms(), 2)
 	return ..()
 
 /obj/vehicle/ridden/wheelchair/Moved()

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -9,6 +9,7 @@
 	legs_required = 0	//You'll probably be using this if you don't have legs
 	canmove = TRUE
 	density = FALSE		//Thought I couldn't fix this one easily, phew
+	movedelay = 4
 
 /obj/vehicle/ridden/wheelchair/Initialize()
 	. = ..()
@@ -45,7 +46,11 @@
 		//1.5 (movespeed as of this change) multiplied by 4 gets 6, which gives you a delay of 3 assuming the user has two arms,
 		//getting the speed of the wheelchair roughly equal to the speed of a scooter based on testing.
 		//if that made no sense this simply makes the wheelchair speed change along with movement speed delay
-		D.vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * 3) / min(user.get_num_arms(), 2)
+		if(user.has_quirk(/datum/quirk/paraplegic))
+			movedelay = 2
+		else
+			movedelay = 4
+		D.vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * movedelay) / min(user.get_num_arms(), 2)
 	return ..()
 
 /obj/vehicle/ridden/wheelchair/Moved()

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -46,6 +46,7 @@
 		//1.5 (movespeed as of this change) multiplied by 4 gets 6, which gives you a delay of 3 assuming the user has two arms,
 		//getting the speed of the wheelchair roughly equal to the speed of a scooter based on testing.
 		//if that made no sense this simply makes the wheelchair speed change along with movement speed delay
+		//paraplegic quirk users get a halved movedelay to model their life of wheelchair useage - yogs
 		if(user.has_quirk(/datum/quirk/paraplegic))
 			movedelay = 2
 		else

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -45,7 +45,7 @@
 		//1.5 (movespeed as of this change) multiplied by 4 gets 6, which gives you a delay of 3 assuming the user has two arms,
 		//getting the speed of the wheelchair roughly equal to the speed of a scooter based on testing.
 		//if that made no sense this simply makes the wheelchair speed change along with movement speed delay
-		D.vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * 3) / min(user.get_num_arms(), 2)
+		D.vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * 4) / min(user.get_num_arms(), 2)
 	return ..()
 
 /obj/vehicle/ridden/wheelchair/Moved()


### PR DESCRIPTION
# Github Documentation

Paraplegics now have less of a move speed penalty when compared to normal crewmembers, and can use wheelchairs approximately twice as fast. This still isn't very fast, but you won't be waiting forever to move from medbay to cargo. 

This is for the quirk only to prevent people from gaming the system. If you want fast wheelchairs you better pulverize that fucking spine.
# Wiki Documentation

not sure we have quirks in wiki but if we do then paraplegics move faster in wheelchairs

# Changelog
:cl:  
tweak: Paraplegics can now move twice as fast in a wheelchair when compared to normal crewmembers. This isn't very fast still, because wheelchairs are slow as shit, but now anyone choosing the quirk won't be forced to use fire extinguishers to get anywhere in a reasonable amount of time.
/:cl:
