### PR TITLE
Chance for antagonists to spawn less when threat is less than or equal to 30.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -109,7 +109,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	var/higher_injection_chance = 15
 
 	/// If below this threat, decrease the chance of injection
-	var/lower_injection_chance_minimum_threat = 10
+	var/lower_injection_chance_minimum_threat = 30
 
 	/// The chance of injection decrease when above lower_injection_chance_minimum_threat
 	var/lower_injection_chance = 15


### PR DESCRIPTION
# Github documenting your Pull Request

So what lower_injection_chance_minimum_threat does when interacting with lower_injection_chance is basically going "Hey, if the current dynamic threat level is less than or equal to 30, there is a chance lower_injection_chance will lower the chance to inject by 15%"; It's now 30 because only traitors have a threat of 10 or less, meanwhile there are atleast five other modes that have a threat above 15.

TL;DR; Raised lower_injection_chance_minimum because it could only work with ten threat, which only traitors and nightmares take up, **additional antagonists have less of a chance of spawning at threats below or equal to 30.**

# Changelog

Antagonists have less of a chance of spawning at threats below or equal to 30.


:cl:  Xoxeyos
tweak: Antagonists have less of a chance of spawning at threats below or equal to 30.
/:cl:
