### PR TITLE
Increases the probability for random electric shocks to revive people from 25% to 80%

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -242,12 +242,11 @@
 		if((!tesla_shock || (tesla_shock && siemens_coeff > 0.5)) && stun)
 			Paralyze(60)
 	if(stat == DEAD && can_defib()) //yogs: ZZAPP
-		if(!illusion && (shock_damage * siemens_coeff >= 1) && prob(25))
+		if(!illusion && (shock_damage * siemens_coeff >= 1) && prob(80))
 			set_heartattack(FALSE)
 			revive()
 			INVOKE_ASYNC(src, .proc/emote, "gasp")
 			Jitter(100)
-			SEND_SIGNAL(src, COMSIG_LIVING_MINOR_SHOCK)
 			adjustOrganLoss(ORGAN_SLOT_BRAIN, 100, 199) //yogs end
 	if(override)
 		return override


### PR DESCRIPTION
# Github documenting your Pull Request

the body still has to be survivable and have functioning organs for this to work
also removes a signal for minor shock from a normal sized shock since it was copypastad code and is likely redundant

# Changelog

:cl:  
tweak: electric shocks now have an 80% chance up from 25% to revive a dead person if the body is in survivable condition
/:cl:
