### PR TITLE
Pod people can now speak Sylvan

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -607,7 +607,7 @@
 /datum/quirk/sheltered/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	H.remove_language(/datum/language/common)
-	if(!H.can_speak_language(/datum/language/draconic) && !H.can_speak_language(/datum/language/machine))
+	if(!H.can_speak_language(/datum/language/draconic) && !H.can_speak_language(/datum/language/machine) && !H.can_speak_language(/datum/language/sylvan))
 		H.grant_language(/datum/language/japanese)
 
 /datum/quirk/allergic

--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -317,6 +317,12 @@ Key procs
 	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
 							/datum/language/sylvan = list(LANGUAGE_ATOM))
 
+/datum/language_holder/pod
+	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
+								/datum/language/sylvan = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
+							/datum/language/sylvan = list(LANGUAGE_ATOM))
+
 /datum/language_holder/preternis
 	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
 								/datum/language/machine = list(LANGUAGE_ATOM),)

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -16,6 +16,7 @@
 	disliked_food = MEAT | DAIRY
 	liked_food = VEGETABLES | FRUIT | GRAIN
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
+	species_language_holder = /datum/language_holder/pod
 
 /datum/species/pod/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -16,7 +16,6 @@
 	disliked_food = MEAT | DAIRY
 	liked_food = VEGETABLES | FRUIT | GRAIN
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
-	
 
 /datum/species/pod/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -16,7 +16,7 @@
 	disliked_food = MEAT | DAIRY
 	liked_food = VEGETABLES | FRUIT | GRAIN
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
-	species_language_holder = /datum/language_holder/pod
+	
 
 /datum/species/pod/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
@@ -18,7 +18,7 @@
 	disliked_food = MEAT | DAIRY
 	liked_food = VEGETABLES | FRUIT | GRAIN
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
-
+	species_language_holder = /datum/language_holder/pod
 	var/no_light_heal = FALSE
 	var/light_heal_multiplier = 1
 	var/dark_damage_multiplier = 1

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
@@ -19,6 +19,7 @@
 	liked_food = VEGETABLES | FRUIT | GRAIN
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/pod
+	
 	var/no_light_heal = FALSE
 	var/light_heal_multiplier = 1
 	var/dark_damage_multiplier = 1

--- a/yogstation/code/modules/scripting/Implementations/Telecomms.dm
+++ b/yogstation/code/modules/scripting/Implementations/Telecomms.dm
@@ -10,6 +10,7 @@
 #define POLYSMORPH 8
 #define DRACONIC 16
 #define BEACHTONGUE 32
+#define SYLVAN 64
 GLOBAL_LIST_INIT(allowed_custom_spans,list(SPAN_ROBOT,SPAN_YELL,SPAN_ITALICS,SPAN_SANS,SPAN_COMMAND,SPAN_CLOWN))//Span classes that players are allowed to set in a radio transmission.
 //this is fucking broken
 GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/common,/datum/language/machine,/datum/language/draconic))// language datums that players are allowed to translate to in a radio transmission.
@@ -115,7 +116,8 @@ GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/common,/datum/languag
 		"robot" = ROBOT,
 		"polysmorph" = POLYSMORPH,
 		"draconic" = DRACONIC,
-		"beachtounge" = BEACHTONGUE
+		"beachtounge" = BEACHTONGUE,
+		"sylvan" = SYLVAN
 	)))
 
 	interpreter.Run() // run the thing
@@ -153,6 +155,8 @@ GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/common,/datum/languag
 		oldlang = DRACONIC
 	else if(oldlang == /datum/language/beachbum)
 		oldlang = BEACHTONGUE
+	else if(oldlang == /datum/language/sylvan)
+		oldlang = SYLVAN
 
 	// Signal data
 
@@ -282,6 +286,8 @@ GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/common,/datum/languag
 			return /datum/language/draconic
 		if(BEACHTONGUE)
 			return /datum/language/beachbum
+		if(SYLVAN)
+			return /datum/language/sylvan
 
 /datum/n_function/default/mem
 	name = "mem"
@@ -451,3 +457,4 @@ GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/common,/datum/languag
 #undef POLYSMORPH
 #undef DRACONIC
 #undef BEACHTONGUE
+#undef SYLVAN


### PR DESCRIPTION
# Github documenting your Pull Request

The Sylvan language is "A complicated, ancient language spoken by sentient plants.", and it makes sense for natural born Phytosians to know it. In addition, a sheltered Phytosian will speak Sylvan instead of Space Japanese.

This isn't much more than a fun RP PR that gives pods some more flavor similar to Lizards being able to speak in their native tongue to one another.

# Wiki Documentation

Pod people will have Sylvan added to their spoken/understood languages

# Changelog


:cl:  
Pods can now speak Sylvan in addition to common
Sheltered Pods will speak only Sylvan instead of Space Japanese
Sylvan added to Tcomms recognition
/:cl:
