### PR TITLE
Fixes space adap so it prevents passive heating as well as passive cooling

### DIFF
--- a/code/datums/mutations/space_adaptation.dm
+++ b/code/datums/mutations/space_adaptation.dm
@@ -22,6 +22,7 @@
 	ADD_TRAIT(owner, TRAIT_RESISTCOLD, "space_adaptation")
 	ADD_TRAIT(owner, TRAIT_RESISTLOWPRESSURE, "space_adaptation")
 	ADD_TRAIT(owner, TRAIT_NO_PASSIVE_COOLING, "space_adaptation")
+	ADD_TRAIT(owner, TRAIT_NO_PASSIVE_HEATING, "space_adaptation")
 
 /datum/mutation/human/space_adaptation/on_losing(mob/living/carbon/human/owner)
 	if(..())
@@ -29,4 +30,5 @@
 	REMOVE_TRAIT(owner, TRAIT_RESISTCOLD, "space_adaptation")
 	REMOVE_TRAIT(owner, TRAIT_RESISTLOWPRESSURE, "space_adaptation")
 	REMOVE_TRAIT(owner, TRAIT_NO_PASSIVE_COOLING, "space_adaptation")
+	REMOVE_TRAIT(owner, TRAIT_NO_PASSIVE_HEATING, "space_adaptation")
 


### PR DESCRIPTION
# Github documenting your Pull Request

Walking through a hot room is no longer a death sentence with space adap.

# Wiki Documentation

Space adap not prevents heating from hot air

# Changelog

:cl:  
tweak: tweaked space adaptation to make it not kill you from being in a slightly warm room
/:cl:
