### PR TITLE
nerfs rezadone and buffs cloneoxadone, makes strange reagent heal all remaining physical damage but cause heavy clone damage

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1,5 +1,5 @@
 #define PERF_BASE_DAMAGE		0.5
-#define REAGENT_REVIVE_DAMAGE ((HEALTH_THRESHOLD_CRIT + HEALTH_THRESHOLD_DEAD) * 1.2)
+#define REAGENT_REVIVE_DAMAGE (HEALTH_THRESHOLD_CRIT + 20)
 
 /////////////////////////////////////////////////////////////////////////////////////////
 					// MEDICINE REAGENTS

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1,4 +1,5 @@
 #define PERF_BASE_DAMAGE		0.5
+#define HALFWAYCRITDEATH ((HEALTH_THRESHOLD_CRIT + HEALTH_THRESHOLD_DEAD) * 0.5)
 
 /////////////////////////////////////////////////////////////////////////////////////////
 					// MEDICINE REAGENTS
@@ -151,8 +152,8 @@
 	metabolization_rate = 1.5 * REAGENTS_METABOLISM
 
 /datum/reagent/medicine/clonexadone/on_mob_life(mob/living/carbon/M)
-	if(M.bodytemperature < T0C)
-		M.adjustCloneLoss(0.00006 * (M.bodytemperature ** 2) - 6, 0)
+	if(M.bodytemperature < T0C && M.IsUnconscious()) //yes you have to be in cryo shut up and drink your corn syrup
+		M.adjustCloneLoss(0.001 * (M.bodytemperature ** 2) - 100, 0)
 		REMOVE_TRAIT(M, TRAIT_DISFIGURED, TRAIT_GENERIC)
 		. = 1
 	metabolization_rate = REAGENTS_METABOLISM * (0.000015 * (M.bodytemperature ** 2) + 0.75)
@@ -195,7 +196,7 @@
 	taste_description = "fish"
 
 /datum/reagent/medicine/rezadone/on_mob_life(mob/living/carbon/M)
-	M.setCloneLoss(0) //Rezadone is almost never used in favor of cryoxadone. Hopefully this will change that.
+	M.adjustCloneLoss(-2) //Rezadone is almost always used over cryoxadone. Hopefully this will change that.
 	M.heal_bodypart_damage(1,1)
 	REMOVE_TRAIT(M, TRAIT_DISFIGURED, TRAIT_GENERIC)
 	..()
@@ -836,7 +837,7 @@
 
 /datum/reagent/medicine/strange_reagent
 	name = "Strange Reagent"
-	description = "A miracle drug capable of bringing the dead back to life. Only functions when applied by patch or spray, if the target has less than 100 brute and burn damage (independent of one another) and hasn't been husked. Causes slight damage to the living."
+	description = "A miracle drug capable of bringing the dead back to life, at a heavy cost to their cellular makeup. Only functions when applied by patch or spray, if the target has less than 100 brute and burn damage and hasn't been husked. Causes slight damage to the living."
 	reagent_state = LIQUID
 	color = "#A0E85E"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
@@ -847,7 +848,7 @@
 		if(M.suiciding || M.hellbound) //they are never coming back
 			M.visible_message("<span class='warning'>[M]'s body does not react...</span>")
 			return
-		if(M.getBruteLoss() >= 100 || M.getFireLoss() >= 100 || HAS_TRAIT(M, TRAIT_HUSK)) //body is too damaged to be revived
+		if(M.getBruteLoss() + M.getFireLoss() >= 100 || HAS_TRAIT(M, TRAIT_HUSK)) //body is too damaged to be revived
 			M.visible_message("<span class='warning'>[M]'s body convulses a bit, and then falls still once more.</span>")
 			M.do_jitter_animation(10)
 			return
@@ -863,8 +864,11 @@
 				for(var/organ in H.internal_organs)
 					var/obj/item/organ/O = organ
 					O.setOrganDamage(0)
+			M.adjustBruteLoss(-100)
+			M.adjustFireLoss(-100)
 			M.adjustOxyLoss(-20, 0)
 			M.adjustToxLoss(-20, 0)
+			M.adjustCloneLoss(max(HALFWAYCRITDEATH - M.getOxyLoss() - M.getToxLoss(), 0))
 			M.updatehealth()
 			if(M.revive())
 				M.emote("gasp")
@@ -1666,3 +1670,4 @@
 			movable_content.wash(clean_types)
 
 #undef PERF_BASE_DAMAGE
+#undef HALFWAYCRITDEATH

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -868,7 +868,7 @@
 			M.adjustFireLoss(-100)
 			M.adjustOxyLoss(-20, 0)
 			M.adjustToxLoss(-20, 0)
-			M.adjustCloneLoss(max(REAGENT_REVIVE_DAMAGE - M.getCloneLoss() - M.getOxyLoss() - M.getToxLoss(), 0))
+			M.adjustCloneLoss(max(M.health - REAGENT_REVIVE_DAMAGE - M.getCloneLoss() - M.getOxyLoss() - M.getToxLoss(), 0))
 			M.updatehealth()
 			if(M.revive())
 				M.emote("gasp")

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -196,7 +196,7 @@
 	taste_description = "fish"
 
 /datum/reagent/medicine/rezadone/on_mob_life(mob/living/carbon/M)
-	M.adjustCloneLoss(-2) //Rezadone is almost always used over cryoxadone. Hopefully this will change that.
+	M.adjustCloneLoss(-10) //Rezadone is almost always used over cryoxadone. Hopefully this will change that.
 	M.heal_bodypart_damage(1,1)
 	REMOVE_TRAIT(M, TRAIT_DISFIGURED, TRAIT_GENERIC)
 	..()
@@ -868,7 +868,7 @@
 			M.adjustFireLoss(-100)
 			M.adjustOxyLoss(-20, 0)
 			M.adjustToxLoss(-20, 0)
-			M.adjustCloneLoss(max(HALFWAYCRITDEATH - M.getOxyLoss() - M.getToxLoss(), 0))
+			M.adjustCloneLoss(max(HALFWAYCRITDEATH - M.getCloneLoss() - M.getOxyLoss() - M.getToxLoss(), 0))
 			M.updatehealth()
 			if(M.revive())
 				M.emote("gasp")

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1,5 +1,5 @@
 #define PERF_BASE_DAMAGE		0.5
-#define REAGENT_REVIVE_DAMAGE (HEALTH_THRESHOLD_CRIT + 20)
+#define REAGENT_REVIVE_MINIMUM_HEALTH (HEALTH_THRESHOLD_CRIT + 20)
 
 /////////////////////////////////////////////////////////////////////////////////////////
 					// MEDICINE REAGENTS
@@ -868,7 +868,7 @@
 			M.adjustFireLoss(-100)
 			M.adjustOxyLoss(-20, 0)
 			M.adjustToxLoss(-20, 0)
-			M.adjustCloneLoss(max(M.health - REAGENT_REVIVE_DAMAGE - M.getCloneLoss() - M.getOxyLoss() - M.getToxLoss(), 0))
+			M.adjustCloneLoss(max(M.health - REAGENT_REVIVE_MINIMUM_HEALTH - M.getCloneLoss() - M.getOxyLoss() - M.getToxLoss(), 0))
 			M.updatehealth()
 			if(M.revive())
 				M.emote("gasp")
@@ -1670,4 +1670,4 @@
 			movable_content.wash(clean_types)
 
 #undef PERF_BASE_DAMAGE
-#undef REAGENT_REVIVE_DAMAGE
+#undef REAGENT_REVIVE_MINIMUM_HEALTH

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1,5 +1,5 @@
 #define PERF_BASE_DAMAGE		0.5
-#define HALFWAYCRITDEATH ((HEALTH_THRESHOLD_CRIT + HEALTH_THRESHOLD_DEAD) * 0.5)
+#define REAGENT_REVIVE_DAMAGE ((HEALTH_THRESHOLD_CRIT + HEALTH_THRESHOLD_DEAD) * 1.2)
 
 /////////////////////////////////////////////////////////////////////////////////////////
 					// MEDICINE REAGENTS
@@ -868,7 +868,7 @@
 			M.adjustFireLoss(-100)
 			M.adjustOxyLoss(-20, 0)
 			M.adjustToxLoss(-20, 0)
-			M.adjustCloneLoss(max(HALFWAYCRITDEATH - M.getCloneLoss() - M.getOxyLoss() - M.getToxLoss(), 0))
+			M.adjustCloneLoss(max(REAGENT_REVIVE_DAMAGE - M.getCloneLoss() - M.getOxyLoss() - M.getToxLoss(), 0))
 			M.updatehealth()
 			if(M.revive())
 				M.emote("gasp")
@@ -1670,4 +1670,4 @@
 			movable_content.wash(clean_types)
 
 #undef PERF_BASE_DAMAGE
-#undef HALFWAYCRITDEATH
+#undef REAGENT_REVIVE_DAMAGE

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -152,7 +152,7 @@
 	metabolization_rate = 1.5 * REAGENTS_METABOLISM
 
 /datum/reagent/medicine/clonexadone/on_mob_life(mob/living/carbon/M)
-	if(M.bodytemperature < T0C && M.IsUnconscious()) //yes you have to be in cryo shut up and drink your corn syrup
+	if(M.bodytemperature < T0C && M.IsSleeping()) //yes you have to be in cryo shut up and drink your corn syrup
 		M.adjustCloneLoss(0.001 * (M.bodytemperature ** 2) - 100, 0)
 		REMOVE_TRAIT(M, TRAIT_DISFIGURED, TRAIT_GENERIC)
 		. = 1


### PR DESCRIPTION
# Github documenting your Pull Request

strange reagent is objectively better than other revival methods being:
irritating to get
easy to mass produce
easy to use
without a time limit (actually heals MORE damage when used later since it also fully heals organs and resets the defib timeout)
void of actual downsides

so I've decided to change that, changed chems:
Strange Reagent: will now only work if the body has less than 100 cumulative brute and burn (people already heal to full so this likely won't effect anyone), using strange reagent will heal the remaining brute and burn damage, as well as the 20 oxygen and toxin damage, but cause 80 cellular damage minus any cellular, oxygen or toxin damage, making it slightly harder to use effectively without other chemicals. This means instead of carrying around 200 patches of rezadone you have to carry around 100 patches of rezadone and 100 patches of cell damage healing chemicalss
Rezadone: will no longer heal all cellular damage with a single reagent metabolism cycle, instead healing 10 points per cycle.
Clonexadone: is now far more viable at healing clone damage, now healing up to 100 based on temperature up from 6 but does require you to be sleeping to work

# Wiki Documentation

Strange Reagent: will now only work if the body has less than 100 cumulative brute and burn (people already heal to full so this likely won't effect anyone), using strange reagent will heal the remaining brute and burn damage, as well as the 20 oxygen and toxin damage, but cause 80 cellular damage minus any cellular, oxygen or toxin damage.
Rezadone: will no longer heal all cellular damage with a single reagent metabolism cycle, instead healing 10 points per cycle.
Clonexadone: heals up to 100 cloneloss based on temperature up from 6 but does require you to be sleeping to work

# Changelog

:cl:  Coder Gun
tweak: strange reagent now deals heavy cellular damage on effective use
rezadone: now heals 10 cloneloss per reagent cycle instead of all at once
clonexadone: now heals up to 100 cloneloss based on temperature up from 6 but does require you to be sleeping to work
/:cl:
