### PR TITLE
buffs specific tend wounds by giving them a 2.5 base healing boost per level (total of 10 at experimental)

### DIFF
--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -22,7 +22,7 @@
 	name = "repair body"
 	implements = list(/obj/item/hemostat = 100, TOOL_SCREWDRIVER = 65, /obj/item/pen = 55)
 	repeatable = TRUE
-	time = 25
+	time = 2 SECONDS
 	fuckup_damage = 0
 	var/brutehealing = 0
 	var/burnhealing = 0
@@ -158,11 +158,11 @@
 	missinghpbonus = 15
 
 /datum/surgery_step/heal/brute/upgraded
-	brutehealing = 5
+	brutehealing = 7.5
 	missinghpbonus = 10
 
 /datum/surgery_step/heal/brute/upgraded/femto
-	brutehealing = 5
+	brutehealing = 10
 	missinghpbonus = 5
 
 /***************************BURN***************************/
@@ -223,11 +223,11 @@
 	missinghpbonus = 15
 
 /datum/surgery_step/heal/burn/upgraded
-	burnhealing = 5
+	burnhealing = 7.5
 	missinghpbonus = 10
 
 /datum/surgery_step/heal/burn/upgraded/femto
-	burnhealing = 5
+	burnhealing = 10
 	missinghpbonus = 5
 
 /***************************COMBO***************************/
@@ -291,7 +291,7 @@
 	brutehealing = 3
 	burnhealing = 3
 	missinghpbonus = 15
-	time = 10
+	time = 1 SECONDS
 
 /datum/surgery_step/heal/combo/upgraded
 	brutehealing = 3


### PR DESCRIPTION
# Github documenting your Pull Request

testing shows mixture tend wounds to be objectively better at healing specific damage even when it's the only damage so I am changing that
the base healing of each surgery has now been increased by 2.5 at advanced and another 2.5 at experimental, bringing the base at advanced to 7.5 and the base at experimental to 10, experimental tend brute/burn should now heal almost twice as fast as the available level of mixture
additionally, the step now only takes 2 seconds for specific down from 2.5

# Wiki Documentation

tend wounds brute/burn adv now heals 7.5 of its damage type
tend wounds brute/burn experimental now heals 10 of its damage type

# Changelog

:cl:  
tweak: tend wounds brute and burn now heal more base damage per cycle, and have had their step time reduced by half a second to 2 seconds flat
/:cl:
