### PR TITLE
Reduce the weight of asimov and crewsimov

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -420,8 +420,8 @@ RANDOM_LAWS reporter
 LAW_WEIGHT custom,0
 
 ## standard-ish laws. These are fairly ok to run
-LAW_WEIGHT asimov,6
-LAW_WEIGHT crewsimov,6
+LAW_WEIGHT asimov,3
+LAW_WEIGHT crewsimov,3
 LAW_WEIGHT asimovpp,0
 LAW_WEIGHT paladin,0
 LAW_WEIGHT robocop,0


### PR DESCRIPTION
# Github documenting your Pull Request

Reduces the spawn weight of crewsimov and asimov, as they are very similar laws. Currently an AI will get one 57% of the time, this reduces that to 40%, the same as CEO.

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
tweak: tweaked weight of asimov and crewsimov
/:cl:
