### PR TITLE
Enables robocop as a roundstart AI lawset

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -424,7 +424,7 @@ LAW_WEIGHT asimov,6
 LAW_WEIGHT crewsimov,6
 LAW_WEIGHT asimovpp,0
 LAW_WEIGHT paladin,0
-LAW_WEIGHT robocop,0
+LAW_WEIGHT robocop,6
 LAW_WEIGHT corporate,0
 LAW_WEIGHT ceo,6
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -424,7 +424,7 @@ LAW_WEIGHT asimov,6
 LAW_WEIGHT crewsimov,6
 LAW_WEIGHT asimovpp,0
 LAW_WEIGHT paladin,0
-LAW_WEIGHT robocop,6
+LAW_WEIGHT robocop,3
 LAW_WEIGHT corporate,0
 LAW_WEIGHT ceo,6
 


### PR DESCRIPTION
# Github documenting your Pull Request

Enables robocop as a roundstart AI lawset with the same weight as CEO, Crewsimov, or Asimov

# Changelog

:cl:  
tweak: Enabled robocop as a roundstart AI lawset
/:cl: