### PR TITLE
Enables mother drone as a roundstart AI lawset

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -431,7 +431,7 @@ LAW_WEIGHT ceo,6
 ## Quirky laws. Shouldn't cause too much harm
 LAW_WEIGHT hippocratic,0
 LAW_WEIGHT maintain,0
-LAW_WEIGHT drone,0
+LAW_WEIGHT drone,3
 LAW_WEIGHT liveandletlive,0
 LAW_WEIGHT peacekeeper,0
 LAW_WEIGHT reporter,3


### PR DESCRIPTION
# Github documenting your Pull Request

Enables Mother drone as a roundstart AI lawset with the same weight as reporter

# Changelog

:cl:  
tweak: Enabled mother drone as a roundstart AI lawset
/:cl: