### PR TITLE
Enable peacekeeper as a roundstart AI lawset

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -433,7 +433,7 @@ LAW_WEIGHT hippocratic,0
 LAW_WEIGHT maintain,0
 LAW_WEIGHT drone,0
 LAW_WEIGHT liveandletlive,0
-LAW_WEIGHT peacekeeper,0
+LAW_WEIGHT peacekeeper,3
 LAW_WEIGHT reporter,3
 
 ## Bad idea laws. Probably shouldn't enable these


### PR DESCRIPTION
# Github documenting your Pull Request

Enables Peacekeeper as a roundstart AI lawset with the same weight as reporter

# Changelog

:cl:  
tweak: Enabled peacekeeper as a roundstart AI lawset
/:cl: