### PR TITLE
Enable cowboy as a roundstart AI lawset

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -427,6 +427,7 @@ LAW_WEIGHT paladin,0
 LAW_WEIGHT robocop,0
 LAW_WEIGHT corporate,0
 LAW_WEIGHT ceo,6
+LAW_WEIGHT cowboy,6
 
 ## Quirky laws. Shouldn't cause too much harm
 LAW_WEIGHT hippocratic,0


### PR DESCRIPTION
# Github documenting your Pull Request

Enables Cowboy as a roundstart AI lawset with the same weight as CEO, Crewsimov, or Asimov

# Changelog

:cl:  
tweak: Enabled cowboy as a roundstart AI lawset
/:cl: