### PR TITLE
allows you to mine with dark blessing and light eater and with a normal armblade

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -652,6 +652,7 @@
 	desc = "Particularly twisted deities grant gifts of dubious value."
 	icon_state = "arm_blade"
 	item_state = "arm_blade"
+	tool_behaviour = TOOL_MINING
 	lefthand_file = 'icons/mob/inhands/antag/changeling_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'
 	item_flags = ABSTRACT

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -155,6 +155,7 @@
 	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'
 	item_flags = NEEDS_PERMIT | ABSTRACT | DROPDEL
 	w_class = WEIGHT_CLASS_HUGE
+	tool_behaviour = TOOL_MINING
 	force = 25
 	throwforce = 0 //Just to be on the safe side
 	throw_range = 0

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -168,6 +168,7 @@
 	lefthand_file = 'icons/mob/inhands/antag/changeling_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'
 	item_flags = ABSTRACT | DROPDEL
+	tool_behaviour = TOOL_MINING
 	w_class = WEIGHT_CLASS_HUGE
 	sharpness = IS_SHARP
 	resistance_flags = ACID_PROOF


### PR DESCRIPTION
if you have one hand as a miner you just get screwed over if you picked this up, and if for some unknown reason a nightmare gets on lavaland they should be able to mine
:cl:  
rscadd: Added the ability to mine to dark blessing and light eater
/:cl:
