### PR TITLE
Alien weeds now only pass their click if you are on help intent.

### DIFF
--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -145,7 +145,10 @@
 /obj/structure/alien/weeds/Click(var/atom/A)
 	var/turf/T = loc
 	if(T)
-		T.Click(A)
+		if(istype(A, /mob/living/carbon))
+			var/mob/living/carbon/C = A
+			if(C.a_intent == INTENT_HELP)
+				T.Click(A)
 	. = ..()
 
 /obj/structure/alien/weeds/proc/expand()


### PR DESCRIPTION
# Github documenting your Pull Request

Allows you to bash the weeds to bits

# Wiki Documentation


# Changelog

:cl:  
bugfix: Alien Weeds are now once again interactable, but only on non-help intent.
/:cl:
