### PR TITLE
Enable crew hour requirements for several non-head jobs

### DIFF
--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -12,7 +12,7 @@
 	selection_color = "#ffdddd"
 	req_admin_notify = 1
 	minimal_player_age = 14
-	exp_requirements = 300
+	exp_requirements = 600
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SECURITY
 

--- a/code/modules/jobs/job_types/medical_doctor.dm
+++ b/code/modules/jobs/job_types/medical_doctor.dm
@@ -8,6 +8,8 @@
 	spawn_positions = 3
 	supervisors = "the chief medical officer"
 	selection_color = "#d4ebf2"
+	exp_requirements = 180
+	exp_type = EXP_TYPE_CREW
 
 	outfit = /datum/outfit/job/doctor
 

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -10,7 +10,7 @@
 	supervisors = "the head of security"
 	selection_color = "#ffeeee"
 	minimal_player_age = 7
-	exp_requirements = 300
+	exp_requirements = 600
 	exp_type = EXP_TYPE_CREW
 
 	outfit = /datum/outfit/job/warden

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -10,8 +10,9 @@
 	supervisors = "the head of security"
 	selection_color = "#ffeeee"
 	minimal_player_age = 7
-	exp_requirements = 600
+	exp_requirements = 300
 	exp_type = EXP_TYPE_CREW
+	exp_type_department = EXP_TYPE_SECURITY
 
 	outfit = /datum/outfit/job/warden
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -49,7 +49,7 @@ USE_EXP_RESTRICTIONS_HEADS
 ## Unhash this to change head jobs' playtime requirements so that they're based on department playtime, rather than crew playtime.
 USE_EXP_RESTRICTIONS_HEADS_DEPARTMENT
 ## Unhash this to enable playtime requirements for certain non-head jobs, like Engineer and Scientist.
-#USE_EXP_RESTRICTIONS_OTHER
+USE_EXP_RESTRICTIONS_OTHER
 ## Allows admins to bypass job playtime requirements.
 USE_EXP_RESTRICTIONS_ADMIN_BYPASS
 

--- a/yogstation/code/modules/jobs/job_types/security_officer.dm
+++ b/yogstation/code/modules/jobs/job_types/security_officer.dm
@@ -1,2 +1,2 @@
 /datum/job/officer
-	exp_requirements = 600
+	exp_requirements = 300


### PR DESCRIPTION
# Github documenting your Pull Request

Requires crew playtime for some non-head jobs

# Wiki Documentation
| Job | Requirement |
| --- | --- |
| Head of Security | 10 hours* |
| Warden | 5 hours* |
| Security Officer | 5 hours |
| Detective | 3 hours |
| Station Engineer | 3 hours |
| Atmospheric Technician | 3 hours |
| Cyborg | 2 hours |
| Scientist | 3 hours |
| Roboticist | 1 hour |
| Chemist | 2 hours |
| Geneticist | 1 hour |
| Virologist | 2 hours |
| Medical Doctor | 3 hours |

\* Warden and HoS hours are in security

# Changelog

:cl:  
rscadd: Added playtime requirement for several non-head roles
tweak: tweaked hour requirement for Warden and Security Officer 
/:cl:
