### PR TITLE
gives science research points for augments

### DIFF
--- a/code/modules/surgery/limb_augmentation.dm
+++ b/code/modules/surgery/limb_augmentation.dm
@@ -67,6 +67,7 @@
 		log_combat(user, target, "augmented", addition="by giving him new [parse_zone(target_zone)] INTENT: [uppertext(user.a_intent)]")
 		var/points = 150 * (target.client ? 1 : 0.1)
 		SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = points))
+		to_chat(user, "<span class = 'notice'>The augment uploads diagnostic data to the research cloud, giving a bonus of research points!</span>")
 	else
 		to_chat(user, "<span class='warning'>[target] has no organic [parse_zone(target_zone)] there!</span>")
 	target.update_disabled_bodyparts()

--- a/code/modules/surgery/limb_augmentation.dm
+++ b/code/modules/surgery/limb_augmentation.dm
@@ -65,6 +65,8 @@
 			"[user] successfully augments [target]'s [parse_zone(target_zone)] with [tool]!",
 			"[user] successfully augments [target]'s [parse_zone(target_zone)]!")
 		log_combat(user, target, "augmented", addition="by giving him new [parse_zone(target_zone)] INTENT: [uppertext(user.a_intent)]")
+		var/points = 150 * (target.client ? 1 : 0.1)
+		SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = points))
 	else
 		to_chat(user, "<span class='warning'>[target] has no organic [parse_zone(target_zone)] there!</span>")
 	target.update_disabled_bodyparts()


### PR DESCRIPTION
# Github documenting your Pull Request

you now get 150 points for finishing an augmentation surgery, with 6 bodyparts to augment this is worth 900 points per person
using this on a braindead or catatonic will only give 15 points per part

# Wiki Documentation

augmentation surgery gives 150 points on success, 15 points if the target isn't an active player

# Changelog

:cl:  
tweak: you now get research points for doing augmentation surgeries 
/:cl:
