### PR TITLE
Fixes all ghost random events (blob, loneop, revenant, etc)

### DIFF
--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -57,7 +57,7 @@
 		return FALSE
 	if(holidayID && (!SSevents.holidays || !SSevents.holidays[holidayID]))
 		return FALSE
-	if(ispath(typepath, /datum/round_event/ghost_role) && GHOSTROLE_MIDROUND_EVENT)
+	if(ispath(typepath, /datum/round_event/ghost_role) && !(GLOB.ghost_role_flags & GHOSTROLE_MIDROUND_EVENT))
 		return FALSE
 
 	var/datum/game_mode/dynamic/dynamic = SSticker.mode


### PR DESCRIPTION
It’s a bitflag, it’s a static value

:cl:  
bugfix: Random Ghost Role events can once again happen
/:cl:
