### PR TITLE
[admin] Added a command to fix air on the whole zlevel, disabling atmos to do so safely

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -20,6 +20,7 @@ GLOBAL_PROTECT(admin_verbs_default)
 	/client/proc/cmd_admin_pm_panel,		/*admin-pm list*/
 	/client/proc/stop_sounds,
 	/client/proc/fix_air, // yogs - fix air verb
+	/client/proc/fix_air,
 	/client/proc/debugstatpanel
 	)
 GLOBAL_LIST_INIT(admin_verbs_admin, world.AVerbsAdmin())

--- a/yogstation/code/modules/admin/verbs/fix_air.dm
+++ b/yogstation/code/modules/admin/verbs/fix_air.dm
@@ -18,3 +18,35 @@
 			GM.parse_gas_string(F.initial_gas_mix)
 			F.copy_air(GM)
 			F.update_visuals()
+
+/client/proc/fix_air_z(var/turf/open/T in world)
+	set name = "Fix Air, Z-level"
+	set category = "Misc.Unused"
+	set desc = "Fixes air on the entire z-level, warning, laggy and temporarily disables atmos"
+
+	if(!holder)
+		to_chat(src, "Only administrators may use this command.", confidential=TRUE)
+		return
+	if(!check_rights(R_ADMIN,1))
+		return
+	message_admins("[key_name_admin(usr)] fixed air on zlevel [T.z]")
+	log_game("[key_name_admin(usr)] fixed airon zlevel [T.z]")
+
+	var/atmos_enabled = SSair.can_fire
+	if(atmos_enabled)
+		message_admins("Disabling atmospherics to fix air on zlevel")
+		SSair.can_fire = FALSE
+
+	var/list/zlevel_turfs = block(locate(1, 1, T.z), locate(world.maxx, world.maxy, T.z))
+	var/datum/gas_mixture/GM = new
+	for(var/turf/open/F in zlevel_turfs)
+		if(F.blocks_air)
+		//skip walls
+			continue
+		GM.parse_gas_string(F.initial_gas_mix)
+		F.copy_air(GM)
+		F.update_visuals()
+
+	if(atmos_enabled)
+		message_admins("Re-enabling atmospherics, air on zlevel fixed")
+		SSair.can_fire = atmos_enabled

--- a/yogstation/code/modules/admin/verbs/fix_air.dm
+++ b/yogstation/code/modules/admin/verbs/fix_air.dm
@@ -37,15 +37,15 @@
 		message_admins("Disabling atmospherics to fix air on zlevel")
 		SSair.can_fire = FALSE
 
-	var/list/zlevel_turfs = block(locate(1, 1, T.z), locate(world.maxx, world.maxy, T.z))
-	var/datum/gas_mixture/GM = new
-	for(var/turf/open/F in zlevel_turfs)
-		if(F.blocks_air)
-		//skip walls
-			continue
-		GM.parse_gas_string(F.initial_gas_mix)
-		F.copy_air(GM)
-		F.update_visuals()
+	for(var/x = 1; x <= world.maxx; x++)
+		for(var/y = 1; y <= world.maxy; y++)
+			var/turf/open/F = locate(x, y, T.z)
+			if(F.blocks_air)
+			//skip walls
+				continue
+			F.air.parse_gas_string(F.initial_gas_mix)
+			F.update_visuals()
+			CHECK_TICK 
 
 	if(atmos_enabled)
 		message_admins("Re-enabling atmospherics, air on zlevel fixed")


### PR DESCRIPTION
# Github documenting your Pull Request

Does what is says on the tin, fixes air for every turn on the zlevel. Turns off atmos if its on, then turns it back on at the end if it was on. Prevents atmos being strange mid fix.

# Changelog

:cl:  
rscadd: Added fix air zlevel command.
/:cl:
