### PR TITLE
[admin] Added a command to fix air on the whole zlevel, disabling atmos to do so safely - Alexkar598 better code edition

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -20,6 +20,7 @@ GLOBAL_PROTECT(admin_verbs_default)
 	/client/proc/cmd_admin_pm_panel,		/*admin-pm list*/
 	/client/proc/stop_sounds,
 	/client/proc/fix_air, // yogs - fix air verb
+	/client/proc/fix_air,
 	/client/proc/debugstatpanel
 	)
 GLOBAL_LIST_INIT(admin_verbs_admin, world.AVerbsAdmin())

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -20,7 +20,7 @@ GLOBAL_PROTECT(admin_verbs_default)
 	/client/proc/cmd_admin_pm_panel,		/*admin-pm list*/
 	/client/proc/stop_sounds,
 	/client/proc/fix_air, // yogs - fix air verb
-	/client/proc/fix_air,
+	/client/proc/fix_air_z,
 	/client/proc/debugstatpanel
 	)
 GLOBAL_LIST_INIT(admin_verbs_admin, world.AVerbsAdmin())

--- a/yogstation/code/modules/admin/verbs/fix_air.dm
+++ b/yogstation/code/modules/admin/verbs/fix_air.dm
@@ -19,33 +19,40 @@
 			F.copy_air(GM)
 			F.update_visuals()
 
-/client/proc/fix_air_z(var/turf/open/T in world)
-	set name = "Fix Air, Z-level"
+/client/proc/fix_air_z()
+	set name = "Fix Air on current Z-level"
 	set category = "Misc.Unused"
-	set desc = "Fixes air on the entire z-level, warning, laggy and temporarily disables atmos"
+	set desc = "Fixes air on the entire z-level, temporarily disables atmos"
 
 	if(!holder)
 		to_chat(src, "Only administrators may use this command.", confidential=TRUE)
 		return
 	if(!check_rights(R_ADMIN,1))
 		return
-	message_admins("[key_name_admin(usr)] fixed air on zlevel [T.z]")
-	log_game("[key_name_admin(usr)] fixed airon zlevel [T.z]")
+
+	if(alert("Do you want to reset air on the entire z level?", "Fix Air- Z level", "No", "Yes") != "Yes")
+		return
+
+	message_admins("[key_name_admin(usr)] fixed air on zlevel [mob.z]")
+	log_game("[key_name_admin(usr)] fixed air on zlevel [mob.z]")
 
 	var/atmos_enabled = SSair.can_fire
 	if(atmos_enabled)
 		message_admins("Disabling atmospherics to fix air on zlevel")
 		SSair.can_fire = FALSE
 
-	var/list/zlevel_turfs = block(locate(1, 1, T.z), locate(world.maxx, world.maxy, T.z))
-	var/datum/gas_mixture/GM = new
-	for(var/turf/open/F in zlevel_turfs)
-		if(F.blocks_air)
-		//skip walls
-			continue
-		GM.parse_gas_string(F.initial_gas_mix)
-		F.copy_air(GM)
-		F.update_visuals()
+	var/z = mob.z
+	for(var/x=1, x<=world.maxx, x++)
+		for(var/y=1, y<=world.maxy, y++)
+			//Not guarenteed to be an open turf, typecasted as an optimization, be careful how you use this variable
+			var/turf/open/T = locate(x, y, z)
+			//Not an early return to allow check_tick to do its thing
+			//Verfied to be an open turf here
+			//Uses a negation of a group of OR to improve performance
+			if(!istype(T, /turf/open/space) && T.is_openturf && !T.blocks_air)
+				T.air?.parse_gas_string(T.initial_gas_mix)
+				T.update_visuals()
+			CHECK_TICK
 
 	if(atmos_enabled)
 		message_admins("Re-enabling atmospherics, air on zlevel fixed")

--- a/yogstation/code/modules/admin/verbs/fix_air.dm
+++ b/yogstation/code/modules/admin/verbs/fix_air.dm
@@ -48,7 +48,6 @@
 			var/turf/open/T = locate(x, y, z)
 			//Not an early return to allow check_tick to do its thing
 			//Verfied to be an open turf here
-			//Uses a negation of a group of OR to improve performance
 			if(!istype(T, /turf/open/space) && T.is_openturf && !T.blocks_air)
 				T.air?.parse_gas_string(T.initial_gas_mix)
 				T.update_visuals()

--- a/yogstation/code/modules/admin/verbs/fix_air.dm
+++ b/yogstation/code/modules/admin/verbs/fix_air.dm
@@ -27,7 +27,7 @@
 	if(!holder)
 		to_chat(src, "Only administrators may use this command.", confidential=TRUE)
 		return
-	if(!check_rights(R_ADMIN,1))
+	if(!check_rights(R_ADMIN))
 		return
 
 	if(alert("Do you want to reset air on the entire z level?", "Fix Air- Z level", "No", "Yes") != "Yes")

--- a/yogstation/code/modules/admin/verbs/fix_air.dm
+++ b/yogstation/code/modules/admin/verbs/fix_air.dm
@@ -18,3 +18,35 @@
 			GM.parse_gas_string(F.initial_gas_mix)
 			F.copy_air(GM)
 			F.update_visuals()
+
+/client/proc/fix_air_z(var/turf/open/T in world)
+	set name = "Fix Air, Z-level"
+	set category = "Misc.Unused"
+	set desc = "Fixes air on the entire z-level, warning, laggy and temporarily disables atmos"
+
+	if(!holder)
+		to_chat(src, "Only administrators may use this command.", confidential=TRUE)
+		return
+	if(!check_rights(R_ADMIN,1))
+		return
+	message_admins("[key_name_admin(usr)] fixed air on zlevel [T.z]")
+	log_game("[key_name_admin(usr)] fixed airon zlevel [T.z]")
+
+	var/atmos_enabled = SSair.can_fire
+	if(atmos_enabled)
+		message_admins("Disabling atmospherics to fix air on zlevel")
+		SSair.can_fire = FALSE
+
+	var/list/zlevel_turfs = block(locate(1, 1, T.z), locate(world.maxx, world.maxy, T.z))
+	var/datum/gas_mixture/GM = new
+	for(var/turf/open/F in zlevel_turfs)
+		if(F.blocks_air)
+		//skip walls
+			continue
+		GM.parse_gas_string(F.initial_gas_mix)
+		F.copy_air(GM)
+		F.update_visuals()
+
+	if(atmos_enabled)
+		message_admins("Re-enabling atmospherics, air on zlevel fixed")
+		SSair.can_fire = atmos_enabled


### PR DESCRIPTION
Closes #11933 

Github documenting your Pull Request

Does what is says on the tin, fixes air for every turn on the zlevel. Turns off atmos if its on, then turns it back on at the end if it was on. Prevents atmos being strange mid fix.
Changelog

🆑 adamsong: Original Implementation | alexkar598: Improved Implementation
rscadd: Added fix air zlevel command.
/🆑

# Differences between the prs
Code is somewhat less readable here but theres comments
Code is faster
Code is actually accessible because adam added the wrong verb to the verb list(untested code mayhaps)
Verb isn't on right click menu but instead in the misc tab
Theres a confirmation box to prevent screwing over atmos techs by accident
Removes lag warning because this code takes 200ms to run, virtually impossible to notice

Other PR: 
![https://i.imgur.com/ZluPvkA.png](https://i.imgur.com/ZluPvkA.png)

This PR:
![https://i.imgur.com/M5GJ1aG.png](https://i.imgur.com/M5GJ1aG.png)

For those who don't know how to read profiler, self cpu is the time byond spent on this proc, total cpu is the time byond spent on this proc and all procs it called and real time is the IRL time byond spent(including confirmation boxes, sleeping procs such as stoplag() and other funny things)