### PR TITLE
Disables spark effect for quantum pads due to lag it generates

### DIFF
--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -118,10 +118,12 @@
 	add_fingerprint(user)
 	doteleport(user, target_pad)
 
+/* Disabled on 2021-08-02 due to lag caused by particles over time. This kills the server when the sparks are used alot over the course of the round.
 /obj/machinery/quantumpad/proc/sparks()
 	var/datum/effect_system/spark_spread/quantum/s = new /datum/effect_system/spark_spread/quantum
 	s.set_up(5, 1, get_turf(src))
 	s.start()
+*/
 
 /obj/machinery/quantumpad/attack_ghost(mob/dead/observer/ghost)
 	. = ..()
@@ -155,8 +157,8 @@
 
 			// use a lot of power
 			use_power(10000 / power_efficiency)
-			sparks()
-			target_pad.sparks()
+			//sparks()
+			//target_pad.sparks()
 
 			flick("qpad-beam", src)
 			playsound(get_turf(src), 'sound/weapons/emitter2.ogg', 25, 1, extrarange = 3, falloff = 5)


### PR DESCRIPTION
# Github documenting your Pull Request

Snip snip, spark effect on q pads is gone. Should probably remove it for the admin portals too 
This particle effect is neat i guess but it actually kills the server over time

Let's be honest this isn't a temporary measure, it's going to stay this way because ***rewrite and maintenance*** development is basically dead

# Wiki Documentation

Nope

# Changelog

:cl:  
rscdel: Removed quantum pad spark effect on teleport.
/:cl:
