### PR TITLE
Reenables eclipse station. Depends on #11937

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -38,13 +38,13 @@ map kilostation
 	votable
 endmap
 
-map icebox
-	minplayers 25
-	disabled 
-endmap
-
 map eclipsestation
 	minplayers 60
+	votable 
+endmap
+
+map icebox
+	minplayers 25
 	disabled 
 endmap
 


### PR DESCRIPTION
Depends on #11937

# Github documenting your Pull Request

Eclipse was disabled by me due to crashes, #11937 should fix that so it should be safe to bring back eclipse. Needs to be test merged first.

# Wiki Documentation

Eclipsestation is reenabled

# Changelog

:cl:  
rscadd: Eclipse station has been reenabled
/:cl:
