### PR TITLE
Makes brand intelligence explosion not space rooms

### DIFF
--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -62,7 +62,7 @@
 				M.speak = rampant_speeches.Copy()
 				M.speak_chance = 7
 			else
-				explosion(upriser.loc, -1, 1, 2, 4, 0)
+				explosion(upriser.loc, -1, 0, 2, 4, 0)
 				qdel(upriser)
 
 		kill()


### PR DESCRIPTION
# Github documenting your Pull Request
Brand intelligence explosions won't space rooms anymore

# Changelog

:cl:  
tweak: tweaked brand intelligence explosion to not space rooms
/:cl:
