### PR TITLE
No longer resets account to zero when adjusting money while it is negative

### DIFF
--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -32,9 +32,7 @@
 
 /datum/bank_account/proc/_adjust_money(amt)
 	account_balance += amt
-	if(account_balance < 0)
-		account_balance = 0
-	else if(account_balance > 1000000 && !is_bourgeois) // if we are now a millionaire, give the achievement
+	if(account_balance > 1000000 && !is_bourgeois) // if we are now a millionaire, give the achievement
 		//So we currently only know what is *supposed* to be the real_name of the client's mob. If we can find them, we can get them this achievement.
 		for(var/x in GLOB.player_list)
 			var/mob/M = x


### PR DESCRIPTION
# Github documenting your Pull Request

Currently if an admin were to reduce an account below zero for bus reasons, the next time that account got money it would be reset to zero. This removes that check, so if a negative account receives money it will just be less negative. A different proc already checks to see if the purchase can be afforded if money is being withdrawn, so this will not break that.

# Changelog

:cl:  
tweak: tweaked economy to properly support negative balances
/:cl:
