### PR TITLE
Doubles Jukebox hearing range for more vibing potential

### DIFF
--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -449,14 +449,14 @@
 	if(world.time < stop && active)
 		var/sound/song_played = sound(selection.song_path)
 
-		for(var/mob/M in range(10,src))
+		for(var/mob/M in range(20,src))
 			if(!M.client || !(M.client.prefs.toggles & SOUND_JUKEBOX))
 				continue
 			if(!(M in rangers))
 				rangers[M] = TRUE
 				M.playsound_local(get_turf(M), null, volume, channel = CHANNEL_JUKEBOX, S = song_played)
 		for(var/mob/L in rangers)
-			if(get_dist(src,L) > 10)
+			if(get_dist(src,L) > 20)
 				rangers -= L
 				if(!L || !L.client)
 					continue


### PR DESCRIPTION
I just want to be able to leave the jukeboxes sight while still being able to vibe.
# Changelog
:cl:  
tweak: Jukebox ranged upped from a measly 10 tiles to 20
/:cl:
