### PR TITLE
Engineers use tools slightly faster

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -727,7 +727,6 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	// Run the start check here so we wouldn't have to call it manually.
 	if(!delay && !tool_start_check(user, amount))
 		return
-	
 	delay *= toolspeed
 
 	if(IS_ENGINEERING(user) && tool_behaviour != TOOL_MINING) //if the user is an engineer, they'll use the tool faster. Doesn't apply to mining tools.

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -730,7 +730,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	
 	delay *= toolspeed
 
-	if(IS_ENGINEERING(user) & tool_behaviour != TOOL_MINING) //if the user is an engineer, they'll use the tool faster. Doesn't apply to mining tools.
+	if(IS_ENGINEERING(user) && tool_behaviour != TOOL_MINING) //if the user is an engineer, they'll use the tool faster. Doesn't apply to mining tools.
 		delay *= 0.8
 
 	// Play tool sound at the beginning of tool usage.

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -727,8 +727,11 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	// Run the start check here so we wouldn't have to call it manually.
 	if(!delay && !tool_start_check(user, amount))
 		return
-
+	
 	delay *= toolspeed
+
+	if(IS_ENGINEERING(user)) //if the user is an engineer, they'll use the tool faster.
+		delay *= 0.8
 
 	// Play tool sound at the beginning of tool usage.
 	play_tool_sound(target, volume)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -730,7 +730,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	
 	delay *= toolspeed
 
-	if(IS_ENGINEERING(user)) //if the user is an engineer, they'll use the tool faster.
+	if(IS_ENGINEERING(user) & tool_behaviour != TOOL_MINING) //if the user is an engineer, they'll use the tool faster. Doesn't apply to mining tools.
 		delay *= 0.8
 
 	// Play tool sound at the beginning of tool usage.


### PR DESCRIPTION
Engineers use all tools (except surgery and mining tools) slightly faster. To be specific, the delay for using the tool which is determined by the  toolspeed is then multiplied by 0.8 to reduce the delay if the user is an engineer.

:cl:  
rscadd: Thanks to years of elite marine combat training, engineers use tools slightly faster.
/:cl:
