### PR TITLE
does something REALLY FUCKING SMART with sparks and makes their sleep a QDEL_IN

### DIFF
--- a/code/game/objects/effects/effect_system/effects_sparks.dm
+++ b/code/game/objects/effects/effect_system/effects_sparks.dm
@@ -34,8 +34,7 @@
 	var/turf/T = loc
 	if(isturf(T))
 		T.hotspot_expose(1000,100)
-	sleep(20)
-	qdel(src)
+	QDEL_IN(src, 2 SECONDS)
 
 /obj/effect/particle_effect/sparks/Destroy()
 	var/turf/T = loc


### PR DESCRIPTION
# Github documenting your Pull Request

sleep bad

# Wiki Documentation

# Changelog
:cl:  
bugfix: sparks no longer call sleep when late initializing, this might fix some stuff
/:cl:
