### PR TITLE
Makes the code team own the code, as they should

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,6 +21,8 @@
 /yogstation/SQL/ @yogstation13/head-coders
 /yogstation/icons/ @yogstation13/art
 /yogstation/sound/ @yogstation13/art
+/code/ @yogstation13/code
+/yogstation/code/ @yogstation13/code
 
 #monster860
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,6 +38,6 @@
 
 /code/controllers/subsystem/ticker.dm @yogstation13/art
 /yogstation/code/controllers/subsystem/ticker.dm @yogstation13/art
-/code/modules/holidays/holidays.dm @yogstation13/art
-/yogstation/code/modules/holidays/holidays.dm @yogstation13/art
+/code/modules/holidays/holidays.dm
+/yogstation/code/modules/holidays/holidays.dm
 


### PR DESCRIPTION
Does as the title says, makes `/code` and `/yogstation/code` owned by the code team.