### PR TITLE
Makes the space heater not need APC power

### DIFF
--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -13,6 +13,7 @@
 	max_integrity = 250
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 10)
 	circuit = /obj/item/circuitboard/machine/space_heater
+	use_power = NO_POWER_USE
 	var/obj/item/stock_parts/cell/cell
 	var/on = FALSE
 	var/mode = HEATER_MODE_STANDBY


### PR DESCRIPTION
# Github documenting your Pull Request
Space heater no longer turn off when the room they are in has no power, fixes #11890 

# Changelog

:cl:  
bugfix: fixed space heaters turning off in unpowered rooms
/:cl:
