### PR TITLE
Moves the spare ID cabinet to the bridge

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -52637,10 +52637,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/port)
-"bHB" = (
-/obj/structure/sign/poster/official/help_others,
-/turf/closed/wall,
-/area/bridge)
 "bHC" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -93600,20 +93596,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard)
-"lpS" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/bridge)
 "lqM" = (
 /obj/structure/grille,
 /obj/structure/barricade/wooden,
@@ -94900,6 +94882,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"mSH" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/fireaxecabinet/spare{
+	pixel_y = -32;
+	req_access = list(20)
+	},
+/turf/open/floor/plasteel,
+/area/bridge)
 "mUm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -95728,6 +95725,17 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/port)
+"nPF" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/captains,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/captain)
 "nRc" = (
 /obj/structure/cable/yellow,
 /obj/effect/spawner/structure/window/reinforced/shutter,
@@ -99076,20 +99084,6 @@
 	},
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
-"seE" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/captains,
-/obj/effect/turf_decal/bot,
-/obj/structure/fireaxecabinet/spare{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/captain)
 "seX" = (
 /obj/machinery/door/airlock/command{
 	name = "Armoury";
@@ -99113,22 +99107,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"sfu" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/bridge)
 "shg" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -100583,6 +100561,25 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
+"tOk" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/item/radio/intercom{
+	pixel_y = -28
+	},
+/turf/open/floor/plasteel,
+/area/bridge)
 "tSG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -133813,8 +133810,8 @@ bvQ
 bwQ
 aqM
 bEN
-sfu
-bHB
+tOk
+atj
 erC
 auc
 atj
@@ -134841,7 +134838,7 @@ bvV
 bxb
 awh
 bBm
-lpS
+mSH
 atj
 aHU
 auc
@@ -137670,7 +137667,7 @@ bwk
 asx
 omq
 bCz
-seE
+nPF
 epd
 xlT
 brU

--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -724,21 +724,6 @@
 /obj/item/stack/ore/iron,
 /turf/open/floor/plating/asteroid,
 /area/asteroid/nearstation)
-"aaX" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet/blue,
-/area/bridge)
 "aaY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -2039,14 +2024,6 @@
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
-/turf/open/floor/plating,
-/area/ai_monitored/nuke_storage)
-"ada" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_x = 32
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/white,
 /turf/open/floor/plating,
 /area/ai_monitored/nuke_storage)
 "adb" = (
@@ -30385,6 +30362,25 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"iBz" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/fireaxecabinet/spare{
+	pixel_y = -32;
+	req_access = list(20)
+	},
+/turf/open/floor/carpet/blue,
+/area/bridge)
 "iDg" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -88707,7 +88703,7 @@ wqi
 abC
 aci
 aaT
-ada
+adb
 aeA
 sOA
 spw
@@ -88963,7 +88959,7 @@ mpl
 ggq
 ggq
 ach
-aaX
+iBz
 sOx
 aeB
 nEo

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -35828,12 +35828,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing/chamber)
-"eDw" = (
-/obj/structure/fireaxecabinet/spare{
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/blue,
-/area/crew_quarters/heads/captain)
 "eDG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
@@ -41255,6 +41249,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"irH" = (
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/captain)
 "irK" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -45743,6 +45740,27 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"lmQ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/item/storage/firstaid/regular{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = -4
+	},
+/obj/structure/fireaxecabinet/spare{
+	pixel_x = 32;
+	req_access = list(20)
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "lmY" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -63707,23 +63725,6 @@
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
-"xBl" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = -4
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "xBH" = (
 /obj/machinery/light{
 	dir = 1;
@@ -96829,7 +96830,7 @@ aJq
 epq
 aPX
 osa
-xBl
+lmQ
 vZH
 euq
 eHd
@@ -97872,7 +97873,7 @@ bfl
 bim
 bjG
 aZV
-eDw
+irH
 qWH
 kSk
 bqH

--- a/_maps/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/map_files/YogsDelta/YogsDelta.dmm
@@ -55952,21 +55952,6 @@
 /obj/machinery/status_display/ai,
 /turf/closed/wall,
 /area/bridge)
-"bIU" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "bIV" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/captain)
@@ -125949,16 +125934,6 @@
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"nkh" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/item/storage/secure/safe{
-	pixel_x = 32
-	},
-/obj/structure/fireaxecabinet/spare{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/grimy,
-/area/crew_quarters/heads/captain/private)
 "now" = (
 /turf/closed/wall,
 /area/storage/art)
@@ -127848,6 +127823,13 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"vKn" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/item/storage/secure/safe{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/heads/captain/private)
 "vKq" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -128363,6 +128345,25 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/research)
+"xOq" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/fireaxecabinet/spare{
+	pixel_y = -32;
+	req_access = list(20)
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "xOV" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/firedoor/border_only{
@@ -168465,7 +168466,7 @@ bzP
 bjk
 aXy
 bHi
-bIU
+xOq
 bKH
 bMF
 bOO
@@ -171302,7 +171303,7 @@ bUQ
 bVT
 dkH
 cbg
-nkh
+vKn
 ceL
 cgy
 bUQ

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -73038,6 +73038,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port/fore)
+"dXu" = (
+/obj/structure/table/wood,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain/private)
 "dXC" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -76390,16 +76397,6 @@
 /obj/structure/table/optable,
 /turf/open/floor/plasteel,
 /area/medical/surgery)
-"jYH" = (
-/obj/structure/table/wood,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/structure/fireaxecabinet/spare{
-	pixel_x = 32
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain/private)
 "kac" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/screwdriver{
@@ -81979,6 +81976,20 @@
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"uLS" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/fireaxecabinet/spare{
+	pixel_y = -32;
+	req_access = list(20)
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "uPd" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -112334,7 +112345,7 @@ bjf
 bkG
 blU
 boz
-boy
+uLS
 bsU
 bsU
 bsU
@@ -115156,7 +115167,7 @@ aMw
 bcj
 bdN
 yeQ
-jYH
+dXu
 bjk
 pim
 bjg


### PR DESCRIPTION
# Github documenting your Pull Request

- Moves the spare ID cabinet to the bridge
- Makes it require captain access instead of atmos tech access

# Wiki Documentation

Updated areas: Captain bedroom and Bridge

# Changelog

:cl:  
tweak: Moves the spare ID cabinet to the bridge so that heads may use it in the event the captain dies
/:cl:
