### PR TITLE
Fixes the access on the spare ID cabinet and bridge fire axe cabinet

### DIFF
--- a/_maps/map_files/EclipseStation/EclipseStation.dmm
+++ b/_maps/map_files/EclipseStation/EclipseStation.dmm
@@ -83668,7 +83668,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "jfR" = (
-/obj/structure/fireaxecabinet/spare{
+/obj/structure/fireaxecabinet/bridge/spare{
 	pixel_y = 32
 	},
 /turf/open/floor/wood,

--- a/_maps/map_files/IceBox/IceBox.dmm
+++ b/_maps/map_files/IceBox/IceBox.dmm
@@ -23646,8 +23646,8 @@
 	c_tag = "Bridge Center";
 	dir = 1
 	},
-/obj/structure/fireaxecabinet{
-	pixel_y = -32
+/obj/structure/fireaxecabinet/bridge{
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 0
@@ -58808,7 +58808,7 @@
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
-/obj/structure/fireaxecabinet/spare{
+/obj/structure/fireaxecabinet/bridge/spare{
 	pixel_x = 2;
 	pixel_y = 32
 	},

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -9874,7 +9874,7 @@
 /obj/item/crowbar/red,
 /obj/item/flashlight,
 /obj/item/flashlight,
-/obj/structure/fireaxecabinet{
+/obj/structure/fireaxecabinet/bridge{
 	pixel_y = -30
 	},
 /obj/machinery/door/window/northright{
@@ -99085,7 +99085,7 @@
 	},
 /obj/structure/closet/secure_closet/captains,
 /obj/effect/turf_decal/bot,
-/obj/structure/fireaxecabinet/spare{
+/obj/structure/fireaxecabinet/bridge/spare{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/dark,

--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -20347,7 +20347,7 @@
 	},
 /obj/structure/table/wood,
 /obj/item/phone/real,
-/obj/structure/fireaxecabinet/spare{
+/obj/structure/fireaxecabinet/bridge/spare{
 	pixel_x = 32
 	},
 /turf/open/floor/wood,
@@ -26552,7 +26552,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
-/obj/structure/fireaxecabinet{
+/obj/structure/fireaxecabinet/bridge{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/neutral{

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -35829,7 +35829,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing/chamber)
 "eDw" = (
-/obj/structure/fireaxecabinet/spare{
+/obj/structure/fireaxecabinet/bridge/spare{
 	pixel_y = 32
 	},
 /turf/open/floor/carpet/blue,
@@ -40898,7 +40898,7 @@
 "igi" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/fireaxecabinet{
+/obj/structure/fireaxecabinet/bridge{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/caution/white{

--- a/_maps/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/map_files/YogsDelta/YogsDelta.dmm
@@ -54714,8 +54714,8 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bGZ" = (
-/obj/structure/fireaxecabinet{
-	pixel_y = -28
+/obj/structure/fireaxecabinet/bridge{
+	pixel_y = -32
 	},
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/blue,
@@ -125954,7 +125954,7 @@
 /obj/item/storage/secure/safe{
 	pixel_x = 32
 	},
-/obj/structure/fireaxecabinet/spare{
+/obj/structure/fireaxecabinet/bridge/spare{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/grimy,

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -35357,7 +35357,7 @@
 /turf/open/space,
 /area/aisat)
 "bqU" = (
-/obj/structure/fireaxecabinet{
+/obj/structure/fireaxecabinet/bridge{
 	pixel_y = -32
 	},
 /obj/item/paper_bin{
@@ -76395,7 +76395,7 @@
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
-/obj/structure/fireaxecabinet/spare{
+/obj/structure/fireaxecabinet/bridge/spare{
 	pixel_x = 32
 	},
 /turf/open/floor/wood,

--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -240,7 +240,7 @@
 		alarmed.burglaralert(src)
 		playsound(src, 'sound/effects/alert.ogg', 50, TRUE)
 
-/obj/structure/fireaxecabinet/spare
+/obj/structure/fireaxecabinet/bridge/spare
 	name = "spare id cabinet"
 	desc = "There is a small label that reads \"For Emergency use only\". <BR>There are bolts under it's glass cover for easy disassembly using a wrench."
 	icon = 'icons/obj/wallmounts.dmi'
@@ -249,7 +249,7 @@
 	armor = list("melee" = 30, "bullet" = 20, "laser" = 0, "energy" = 100, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 50)
 	axe = FALSE
 
-/obj/structure/fireaxecabinet/spare/Initialize()
+/obj/structure/fireaxecabinet/bridge/spare/Initialize()
 	. = ..()
 	fireaxe = null
 	spareid = new(src)

--- a/yogstation/code/game/objects/structures/fireaxe.dm
+++ b/yogstation/code/game/objects/structures/fireaxe.dm
@@ -2,6 +2,9 @@
 	req_access = list(ACCESS_ATMOSPHERICS) //adds ATMOSPHERICS access requirement for the lock on the cabinet.
 	var/datum/effect_system/spark_spread/spark_system	//the spark system, used for generating... sparks?
 
+/obj/structure/fireaxecabinet/bridge
+	req_access = list(ACCESS_CAPTAIN)
+
 /obj/structure/fireaxecabinet/Initialize()//<-- mirrored/overwritten proc
 	. = ..()
 	fireaxe = new


### PR DESCRIPTION
# Github documenting your Pull Request

The bridge fire axe cabinet, and spare ID cabinet will now have captain access, instead of atmos tech access.

# Changelog

:cl:  
bugfix: fixed the access on the spare ID cabinet
bugfix: fixed the access on the bridge fire axe cabinet
/:cl:
