### PR TITLE
Tweaks and Overdoses for Libital, Aiuri

### DIFF
--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -10,7 +10,7 @@
 	name = "Libital"
 	description = "A bruise reliever. Does minor liver damage."
 	color = "#ECEC8D" // rgb: 236 236 141
-	overdose_threshold = 25
+	overdose_threshold = 30
 	taste_description = "bitter with a hint of alcohol"
 	reagent_state = SOLID
 
@@ -93,7 +93,7 @@
 	name = "Aiuri"
 	description = "Used to treat burns. Does minor eye damage."
 	color = "#8C93FF"
-	overdose_threshold = 25
+	overdose_threshold = 30
 	taste_description = "ammonia with a bit of acid"
 	reagent_state = LIQUID
 

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -10,6 +10,7 @@
 	name = "Libital"
 	description = "A bruise reliever. Does minor liver damage."
 	color = "#ECEC8D" // rgb: 236 236 141
+	overdose_threshold = 25
 	taste_description = "bitter with a hint of alcohol"
 	reagent_state = SOLID
 
@@ -18,6 +19,12 @@
 	M.adjustBruteLoss(-3 * REM)
 	..()
 	return TRUE
+
+/datum/reagent/medicine/c2/libital/overdose_process(mob/living/M)
+	M.adjustOrganLoss(ORGAN_SLOT_LIVER, 0.9 * REM)
+	M.adjustOrganLoss(ORGAN_SLOT_STOMACH, 0.5 * REM)
+	..()
+	. = TRUE
 
 /datum/reagent/medicine/c2/probital
 	name = "Probital"
@@ -85,14 +92,22 @@
 /datum/reagent/medicine/c2/aiuri
 	name = "Aiuri"
 	description = "Used to treat burns. Does minor eye damage."
-	reagent_state = LIQUID
 	color = "#8C93FF"
+	overdose_threshold = 25
+	taste_description = "ammonia with a bit of acid"
+	reagent_state = LIQUID
 
 /datum/reagent/medicine/c2/aiuri/on_mob_life(mob/living/carbon/M)
 	M.adjustFireLoss(-2 * REM)
 	M.adjustOrganLoss(ORGAN_SLOT_EYES, 0.25 * REM)
 	..()
 	return TRUE
+
+/datum/reagent/medicine/c2/aiuri/overdose_process(mob/living/M)
+	M.adjustOrganLoss(ORGAN_SLOT_EYES, 0.75 * REM)
+	M.adjustOrganLoss(ORGAN_SLOT_STOMACH, 0.4 * REM)
+	..()
+	. = TRUE
 
 /datum/reagent/medicine/c2/rhigoxane
 	name = "Rhigoxane"

--- a/code/modules/reagents/chemistry/recipes/cat2_medicines.dm
+++ b/code/modules/reagents/chemistry/recipes/cat2_medicines.dm
@@ -4,8 +4,8 @@
 /datum/chemical_reaction/medicine/libital
 	name = "libital"
 	id = /datum/reagent/medicine/c2/libital
-	results = list(/datum/reagent/medicine/c2/libital = 3)
-	required_reagents = list(/datum/reagent/phenol = 1, /datum/reagent/oxygen = 1, /datum/reagent/nitrogen = 1)
+	results = list(/datum/reagent/medicine/c2/libital = 5)
+	required_reagents = list(/datum/reagent/phenol = 3, /datum/reagent/oxygen = 1, /datum/reagent/nitrogen = 1)
 
 /datum/chemical_reaction/medicine/probital
 	name = "probital"
@@ -24,8 +24,8 @@
 /datum/chemical_reaction/medicine/aiuri
 	name = "aiuri"
 	id = /datum/reagent/medicine/c2/aiuri
-	results = list(/datum/reagent/medicine/c2/aiuri = 4)
-	required_reagents = list(/datum/reagent/ammonia = 1, /datum/reagent/toxin/acid = 1, /datum/reagent/hydrogen = 2)
+	results = list(/datum/reagent/medicine/c2/aiuri = 5)
+	required_reagents = list(/datum/reagent/ammonia = 2, /datum/reagent/toxin/acid = 1, /datum/reagent/hydrogen = 2)
 
 /datum/chemical_reaction/medicine/rhigoxane
 	name = "rhigoxane"


### PR DESCRIPTION
Adjusted Libital, Aiuri recipes to produce 5u batches for 5u of components. Adds a taste descriptor for Aiuri.
Adds overdoses for both chemicals, which nullify the healing and amp up their respective organ damages, and applies stomach damage as well.
Changes have been partially tested due to my messed up BYOND. The recipe adjustments, taste change, and overdose initializing works, but I haven't been able to gauge if the organ damage is applying, though it should be.

# Github documenting your Pull Request

This PR adjusts the recipes of Libital and Aiuri as follows:

**OLD**
- Libital: 3u; 1u of Phenol, 1u of Oxygen, 1u of Nitrogen
- Aiuri: 4u; 1u of Ammonia, 1u of Acid, 2u of Hydrogen

**NEW**
- Libital: _5u_; _3u_ of Phenol, 1u of Oxygen, 1u of Nitrogen
- Aiuri: _5u_; _2u_ of Ammonia, 1u of Acid, 2u of Hydrogen

This PR also adds overdoses to Libital and Aiuri at 30u

- Libital overdose: .9 Liver Damage, .5 Stomach Damage per tick
- Aiuri overdose: .75 Liver Damage, .4 Stomach Damage per tick

Aiuri now has a taste of "ammonia with a bit of acid."

# Wiki Documentation

Adjustments to be reflected on the Guide to Chemistry.

# Changelog

:cl:  
rscadd: Overdoses for Libital, Aiuri at 30u
rscadd: Aiuri now tastes like ammonia and acid 
tweak: Aiuri and Libital recipes now take 5u of components and make 5u of product
experimental: Numbers subject to change
/:cl:
