### PR TITLE
Removes unused lines from the CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,11 +27,6 @@
 /code/modules/atmospherics/ @monster860
 /yogstation/code/modules/atmospherics/ @monster860
 
-#alexkar598
-/rust_g @alexkar598
-*.so @alexkar598
-*.dll @alexkar598
-
 #Art stuff
 
 /code/controllers/subsystem/ticker.dm @yogstation13/art


### PR DESCRIPTION
# Github documenting your Pull Request
Since alexkar can no longer cannot approve prs, github doesn't count him as a codeowner anymore, evidenced by pr #11988 