### PR TITLE
Variable charge rate for Potato Batteries with Electrical Activity trait

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -343,9 +343,8 @@
 			var/datum/plant_gene/trait/cell_charge/CG = G.seed.get_gene(/datum/plant_gene/trait/cell_charge)
 			if(CG) // Cell charge max is now 40MJ or otherwise known as 400KJ (Same as bluespace powercells)
 				pocell.maxcharge *= CG.rate*100
-				pocell.maxrate *=CG.rate*100
+				pocell.chargerate = G.seed.potency * 40
 			pocell.charge = pocell.maxcharge
-			pocell.rate = pocell.maxrate
 			pocell.name = "[G.name] battery"
 			pocell.desc = "A rechargeable plant-based power cell. This one has a rating of [DisplayEnergy(pocell.maxcharge)], and you should not swallow it."
 

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -343,7 +343,9 @@
 			var/datum/plant_gene/trait/cell_charge/CG = G.seed.get_gene(/datum/plant_gene/trait/cell_charge)
 			if(CG) // Cell charge max is now 40MJ or otherwise known as 400KJ (Same as bluespace powercells)
 				pocell.maxcharge *= CG.rate*100
+				pocell.maxrate *=CG.rate*100
 			pocell.charge = pocell.maxcharge
+			pocell.rate = pocell.maxrate
 			pocell.name = "[G.name] battery"
 			pocell.desc = "A rechargeable plant-based power cell. This one has a rating of [DisplayEnergy(pocell.maxcharge)], and you should not swallow it."
 


### PR DESCRIPTION
# Github documenting your Pull Request

Plants with both capacitive cells and electrical activity that get turned into batteries get a variable charge rate that better matches the max charge.

# Wiki Documentation

Potatoes, or any plant grown with both capacitive cells and electrical activity can be turned into organic batteries that match bluespace batteries if the potency is maxed. However, only the max charge benefits from this combination, and the charge rate remains capped at the stock 100 value, meaning if you ever tried to charge the bluespace potato battery, it would take around 400 ticks (over 10 minutes), and neuters their ability power SMESes because you can't charge them faster than they output. Now the charge rate will be about 1/10th of the max charge.

# Changelog

:cl:  
rscadd: Plant batteries made from plants with Capacitive Cells and Electrical Activity have better potential charge rates
/:cl:

Thank you, Jamie for helping me understand what the buffer was in cells and why potato batteries suck even with bluespace charge. Someday, potato batteries might actually save the station