### PR TITLE
he cabinet for the Captains spare ID now triggers the area theft alarm when multi-tooled and emagged.

### DIFF
--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -254,3 +254,25 @@
 	fireaxe = null
 	spareid = new(src)
 	update_icon()
+	
+/obj/structure/fireaxecabinet/bridge/spare/reset_lock(mob/user)
+	//this happens when you hack the lock as a synthetic/AI, or with a multitool.
+	if(obj_flags & EMAGGED)
+		to_chat(user, "<span class='notice'>You try to reset the [name]'s circuits, but they're completely burnt out.</span>")
+		return
+	if(!open)
+		to_chat(user, "<span class = 'caution'>Resetting circuitry...</span>")
+		if(alert)
+			to_chat(user, "<span class='danger'>This will trigger the built in burglary alarm!</span>")
+		if(do_after(user, 15 SECONDS, target = src))
+			to_chat(user, "<span class='caution'>You [locked ? "disable" : "re-enable"] the locking modules.</span>")
+			src.add_fingerprint(user)
+			if(locked)
+				trigger_alarm() //already checks for alert var
+			toggle_lock(user)
+
+/obj/structure/fireaxecabinet/bridge/spare/emag_act(mob/user)
+	. = ..()
+	if(!.)
+		return
+	trigger_alarm()


### PR DESCRIPTION
Github documenting your Pull Request
See title

Wiki Documentation
Changelog
Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

🆑
tweak: The cabinet for the Captains spare ID now triggers the area theft alarm when multi-tooled and emagged.
/🆑