### PR TITLE
Reduces the priority of the explosion subsystem so mobs still process while meteors are overflowing everything else

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -165,6 +165,7 @@
 #define FIRE_PRIORITY_DEFAULT		50
 #define FIRE_PRIORITY_PARALLAX		65
 #define FIRE_PRIORITY_INSTRUMENTS	80
+#define FIRE_PRIORITY_EXPLOSIONS	96
 #define FIRE_PRIORITY_MOBS			100
 #define FIRE_PRIORITY_TGUI			110
 #define FIRE_PRIORITY_TICKER		200
@@ -172,7 +173,6 @@
 #define FIRE_PRIORITY_CHAT			400
 #define FIRE_PRIORITY_RUNECHAT		410
 #define FIRE_PRIORITY_OVERLAYS		500
-#define FIRE_PRIORITY_EXPLOSIONS	666
 #define FIRE_PRIORITY_INPUT			1000 // This must always always be the max highest priority. Player input must never be lost.
 
 // SS runlevels


### PR DESCRIPTION
# Github documenting your Pull Request

This may be a bad idea but it also may be an extremely good idea

# Changelog
:cl:  
tweak: stuns will no longer last 200 years when there's meteors beating up the station probably
/:cl:
