### PR TITLE
shuttles move after the round ends

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -5,7 +5,6 @@ SUBSYSTEM_DEF(shuttle)
 	wait = 10
 	init_order = INIT_ORDER_SHUTTLE
 	flags = SS_KEEP_TIMING|SS_NO_TICK_CHECK
-	runlevels = RUNLEVEL_SETUP | RUNLEVEL_GAME
 
 	var/list/mobile = list()
 	var/list/stationary = list()


### PR DESCRIPTION
# Github documenting your Pull Request

this can't POSSIBLY break anything can it
allows shuttles to move and dock after the round ends

# Changelog

:cl:  
tweak: shuttles can now move post-round end
/:cl:
