### PR TITLE
Lock offer to ghosts behind +ADMIN

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -643,7 +643,7 @@
 		C.debug_variables(thing)
 	// yogs start - offer control can now be used by mods
 	else if(href_list["offer_control"])
-		if(!check_rights(NONE))
+		if(!check_rights(R_ADMIN))
 			return
 
 		var/mob/M = locate(href_list["offer_control"]) in GLOB.mob_list


### PR DESCRIPTION
# Github documenting your Pull Request

AO shouldn't have access to this button, so they won't

# Changelog

:cl:  
tweak: tweaked required rights for offer to ghosts
/:cl:
