### PR TITLE
Prevents code words in HTML tags from being highlighted

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -131,7 +131,7 @@ SUBSYSTEM_DEF(ticker)
 		GLOB.syndicate_code_response = generate_code_phrase(return_list=TRUE)
 
 		var/codewords = jointext(GLOB.syndicate_code_response, "|")
-		var/regex/codeword_match = new("([codewords])", "ig")
+		var/regex/codeword_match = new("([codewords])(?!\[^<\]*>)", "ig")
 
 		GLOB.syndicate_code_response_regex = codeword_match
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -123,7 +123,7 @@ SUBSYSTEM_DEF(ticker)
 		GLOB.syndicate_code_phrase	= generate_code_phrase(return_list=TRUE)
 
 		var/codewords = jointext(GLOB.syndicate_code_phrase, "|")
-		var/regex/codeword_match = new("([codewords])", "ig")
+		var/regex/codeword_match = new("([codewords])(?!\[^<\]*>)", "ig")
 
 		GLOB.syndicate_code_phrase_regex = codeword_match
 
@@ -131,7 +131,7 @@ SUBSYSTEM_DEF(ticker)
 		GLOB.syndicate_code_response = generate_code_phrase(return_list=TRUE)
 
 		var/codewords = jointext(GLOB.syndicate_code_response, "|")
-		var/regex/codeword_match = new("([codewords])", "ig")
+		var/regex/codeword_match = new("([codewords])(?!\[^<\]*>)", "ig")
 
 		GLOB.syndicate_code_response_regex = codeword_match
 


### PR DESCRIPTION
# Github documenting your Pull Request
If a code word appears in an html tag, it now won't be highlighted, because that breaks things

# Changelog

:cl:  
bugfix: fixed code words in html tags being highlighted
/:cl:
