### PR TITLE
alien queen shuttle call no longer causes a recall lock so you degenerates can keep one in science

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -56,9 +56,8 @@
 	if(stat != DEAD)
 		SSshuttle.clearHostileEnvironment(src)
 		if(EMERGENCY_IDLE_OR_RECALLED)
-			priority_announce("Xenomorph infestation detected: crisis shuttle protocols activated - jamming recall signals across all frequencies. P.S.: Bring back a live one please.")
+			priority_announce("Xenomorph infestation detected: Emergency shuttle will be sent to recover any survivors, if this is in error feel free to recall.")
 			SSshuttle.emergency.request(null, set_coefficient=0.5)
-			SSshuttle.emergencyNoRecall = TRUE
 
 /mob/living/carbon/alien/humanoid/royal/queen/death()//yogs start: dead queen doesnt stop shuttle
 	SSshuttle.clearHostileEnvironment(src)


### PR DESCRIPTION
# Github documenting your Pull Request

see title

# Changelog

:cl:  
tweak: emergency shuttle will no longer be un-recallable if it is called due to a xeno queen existing since you sick fucks like to keep those
/:cl:
