### PR TITLE
Added sigdrobe to tcom on meta

### DIFF
--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -40074,9 +40074,7 @@
 /turf/open/space,
 /area/maintenance/disposal/incinerator)
 "bAY" = (
-/obj/structure/filingcabinet{
-	pixel_x = 3
-	},
+/obj/machinery/vending/wardrobe/sig_wardrobe,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bAZ" = (


### PR DESCRIPTION
# Github documenting your Pull Request

Metastation tcom didn't have a sigdrobe, placed it on top of the useless filing cabinet.

![image](https://user-images.githubusercontent.com/4607006/129072114-2ae21f94-6b0b-4081-9fca-56efb3dc19dc.png)


# Wiki Documentation
Tcom on meta will need new image

# Changelog

:cl:  
rscadd: Added sigdrobe to YogsMeta tcoms control room
/:cl:
