### PR TITLE
Rebalance AI law weights

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -420,14 +420,14 @@ RANDOM_LAWS reporter
 LAW_WEIGHT custom,0
 
 ## standard-ish laws. These are fairly ok to run
-LAW_WEIGHT asimov,6
-LAW_WEIGHT crewsimov,6
+LAW_WEIGHT asimov,5
+LAW_WEIGHT crewsimov,5
 LAW_WEIGHT asimovpp,0
 LAW_WEIGHT paladin,0
 LAW_WEIGHT robocop,0
 LAW_WEIGHT corporate,0
-LAW_WEIGHT ceo,6
-LAW_WEIGHT cowboy,6
+LAW_WEIGHT ceo,5
+LAW_WEIGHT cowboy,2
 
 ## Quirky laws. Shouldn't cause too much harm
 LAW_WEIGHT hippocratic,0

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -427,7 +427,6 @@ LAW_WEIGHT paladin,0
 LAW_WEIGHT robocop,0
 LAW_WEIGHT corporate,0
 LAW_WEIGHT ceo,5
-LAW_WEIGHT cowboy,2
 
 ## Quirky laws. Shouldn't cause too much harm
 LAW_WEIGHT hippocratic,0
@@ -436,6 +435,7 @@ LAW_WEIGHT drone,0
 LAW_WEIGHT liveandletlive,0
 LAW_WEIGHT peacekeeper,0
 LAW_WEIGHT reporter,3
+LAW_WEIGHT cowboy,2
 
 ## Bad idea laws. Probably shouldn't enable these
 LAW_WEIGHT syndie,0


### PR DESCRIPTION
# Github documenting your Pull Request

Changes crewsmov, asimov, and corprate to roll 25% each (so 75% for one of the three) , with reporter getting 15% and cowboy getting 10%

# Changelog

:cl: 
tweak: tweaked AI law weights
/:cl:
