### PR TITLE
[EXPERIMENTAL] People not readied up now count as half a readied up player. 

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -1,3 +1,6 @@
+///An unreadied player counts for this much compared to a readied one
+#define UNREADIED_PLAYER_MULTIPLIER 0.5
+
 #define NUKE_RESULT_FLUKE 0
 #define NUKE_RESULT_NUKE_WIN 1
 #define NUKE_RESULT_CREW_WIN 2

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -67,20 +67,24 @@
 ///Checks to see if the game can be setup and ran with the current number of players or whatnot.
 /datum/game_mode/proc/can_start()
 	var/playerC = 0
+	var/unreadiedPlayers = 0
 	for(var/mob/dead/new_player/player in GLOB.player_list)
-		if((player.client)&&(player.ready == PLAYER_READY_TO_PLAY))
+		if(player.client && (player.ready == PLAYER_READY_TO_PLAY))
 			playerC++
+		else if(player.client && (player.ready == PLAYER_NOT_READY) && !player.client.holder) //Admins don't count :)
+			unreadiedPlayers++
 	if(!GLOB.Debug2)
-		if(playerC < required_players || (maximum_players >= 0 && playerC > maximum_players))
-			return 0
+		var/adjustedPlayerCount = round(playerC + (unreadiedPlayers * UNREADIED_PLAYER_MULTIPLIER), 1)
+		if(adjustedPlayerCount < required_players || (maximum_players >= 0 && playerC > maximum_players))
+			return FALSE
 	antag_candidates = get_players_for_role(antag_flag)
 	if(!GLOB.Debug2)
 		if(antag_candidates.len < required_enemies)
-			return 0
-		return 1
+			return FALSE
+		return TRUE
 	else
 		message_admins("<span class='notice'>DEBUG: GAME STARTING WITHOUT PLAYER NUMBER CHECKS, THIS WILL PROBABLY BREAK SHIT.</span>")
-		return 1
+		return TRUE
 
 
 ///Attempts to select players for special roles the mode might have.

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -75,6 +75,7 @@
 			unreadiedPlayers++
 	if(!GLOB.Debug2)
 		var/adjustedPlayerCount = round(playerC + (unreadiedPlayers * UNREADIED_PLAYER_MULTIPLIER), 1)
+		log_game("Round can_start() with [adjustedPlayerCount] adjusted count, versus [playerC] regular player count. Requirement: [required_players] Gamemode: [name]")
 		if(adjustedPlayerCount < required_players || (maximum_players >= 0 && playerC > maximum_players))
 			return FALSE
 	antag_candidates = get_players_for_role(antag_flag)


### PR DESCRIPTION
# Github documenting your Pull Request

Will allow rounds with the population to run them, but not the readied up people ready. We're expecting around 25-50% of the un-readied players to midround join. Does not count admins nor people readied up to observe.

- [ ] Remove logging

# Wiki Documentation


# Changelog

:cl:  
experimental: For gamemode population calculations an unreadied player now counts as 50% of a readied one.
/:cl:
