### PR TITLE
Can now drag plasma tanks/parts into frames/collectors

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -280,7 +280,8 @@
 	..()
 
 /obj/structure/frame/machine/MouseDrop_T(atom/dropping, mob/user)
-	if(istype(dropping, /obj/item/circuitboard))
+	if(istype(dropping, /obj/item/circuitboard) || istype(dropping, /obj/item/stock_parts))
 		attackby(dropping, user)
 	else
 		..()
+

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -120,6 +120,12 @@
 	else
 		return ..()
 
+/obj/structure/frame/machine/MouseDrop_T(atom/dropping, mob/user)
+	if(istype(dropping, /obj/item/tank/internals/plasma))
+		attackby(dropping, user)
+	else
+		..()
+
 /obj/machinery/power/rad_collector/proc/togglelock(mob/user)
 	if(!user.canUseTopic(src, BE_CLOSE))
 		return


### PR DESCRIPTION
# Github documenting your Pull Request

Can now drag plasma tanks/parts into frames (borgs too)

# Wiki Documentation

n/a

# Changelog

:cl:  
rscadd: Can now drag plasma tanks/parts into frames/collectors.
/:cl:
