### PR TITLE
Reverts my unnecessary ebow nerf

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -613,8 +613,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	slur as if inebriated. It can produce an infinite number \
 	of bolts, but takes time to automatically recharge after each shot."
 	item = /obj/item/gun/energy/kinetic_accelerator/crossbow
-	cost = 11
+	cost = 10
 	surplus = 50
+	limited_stock = 1
 	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_weapons/origami_kit


### PR DESCRIPTION
# Github documenting your Pull Request

My intention in increasing the ebow price was to prevent people from using two. I only now realized the limited_stock var and that I should have done this from the start. Making the ebow 11TC has the side effect of making it incompatible with certain loadouts which was not my intention.

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
tweak: Miniature energy crossbow costs 10TC again
/:cl:
