### PR TITLE
fix the mindslave arrow not mindslaving

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -222,21 +222,20 @@
 			new /obj/item/slimecross/stabilized/green(src) //secret identity
 
 /obj/item/stand_arrow/boss
-	desc = "An arrow that can unleash <span class='holoparasite'>massive potential</span> from those stabbed by it. It has been laced with syndicate mindslave nanites."
+	desc = "An arrow that can unleash <span class='holoparasite'>massive potential</span> from those stabbed by it. It has been laced with syndicate mindslave nanites that will be linked to whoever first uses it in their hand."
 	kill_chance = 0
 	arrowtype = "tech"
 	var/datum/mind/owner
 	can_requiem = FALSE
 
-
-/obj/item/stand_arrow/boss/Initialize()
-	. = ..()
-	for(var/mob/living/M in range(0,src)) //this is probably a bad way of doing this help
-		if(M?.mind?.has_antag_datum(/datum/antagonist/traitor)) //don't think I have a better way of checking
-			owner = M.mind
+/obj/item/arrow/boss/attack_self(mob/user)
+	if(owner || !user.mind)
+		return
+	to_chat(user, <span class='notice'>You prick your finger on the arrow, linking the mindslave nanites to you!</span>")
+	owner = user.mind
 
 /obj/item/stand_arrow/boss/attack(mob/living/M, mob/living/user)
-	if(owner?.current && owner.current == user && owner.current == M) //you have a holoparasite injector for this exact purpose
+	if(owner && owner.current == M && user == M) //you have a holoparasite injector for this exact purpose
 		to_chat(M, "<span class='warning'>Implanting yourself with mindslave nanites is probably a bad idea...</span>")
 		return
 	. = ..()

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -228,7 +228,7 @@
 	var/datum/mind/owner
 	can_requiem = FALSE
 
-/obj/item/arrow/boss/attack_self(mob/user)
+/obj/item/stand_arrow/boss/attack_self(mob/user)
 	if(owner || !user.mind)
 		return
 	to_chat(user, "<span class='notice'>You prick your finger on the arrow, linking the mindslave nanites to you!</span>")

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -231,7 +231,7 @@
 /obj/item/arrow/boss/attack_self(mob/user)
 	if(owner || !user.mind)
 		return
-	to_chat(user, <span class='notice'>You prick your finger on the arrow, linking the mindslave nanites to you!</span>")
+	to_chat(user, "<span class='notice'>You prick your finger on the arrow, linking the mindslave nanites to you!</span>")
 	owner = user.mind
 
 /obj/item/stand_arrow/boss/attack(mob/living/M, mob/living/user)


### PR DESCRIPTION

fixes #12020

:cl:  
bugfix: syndicate mindslave stand arrow now actually mindslaves, use it in hand to link it to yourself then stab people to mindslave them
/:cl:
