### PR TITLE
Reduces the weight of yogstation, removes the weight on meta, lowering it in the process

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -13,7 +13,7 @@ Format:
 	votable (is this map votable)
 
 map yogstation
-	voteweight 0.9
+	voteweight 0.7
 	votable
 endmap
 
@@ -24,7 +24,6 @@ endmap
 
 map yogsmeta
 	minplayers 25
-	voteweight 1.3
 	votable
 endmap
 


### PR DESCRIPTION
# Github documenting your Pull Request

Yogstation vote weight is down to 0.7 from 0.9. Yogsmeta was at 1.3, its back to zero.

# Changelog

:cl:  
tweak: nerfed yogstation vote
/:cl:
