### PR TITLE
Adds Deluxe Agent ID

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -297,6 +297,9 @@ update_label("John Doe", "Clowny")
 	var/anyone = FALSE //Can anyone forge the ID or just syndicate?
 	var/forged = FALSE //have we set a custom name and job assignment, or will we use what we're given when we chameleon change?
 
+/obj/item/card/id/syndicate/deluxe
+	access = get_all_accesses() + ACCESS_SYNDICATE
+
 /obj/item/card/id/syndicate/Initialize()
 	. = ..()
 	var/datum/action/item_action/chameleon/change/chameleon_action = new(src)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -297,7 +297,8 @@ update_label("John Doe", "Clowny")
 	var/anyone = FALSE //Can anyone forge the ID or just syndicate?
 	var/forged = FALSE //have we set a custom name and job assignment, or will we use what we're given when we chameleon change?
 
-/obj/item/card/id/syndicate/deluxe
+/obj/item/card/id/syndicate/deluxe/Initialize()
+	. = ..()
 	access = get_all_accesses() + ACCESS_SYNDICATE
 
 /obj/item/card/id/syndicate/Initialize()

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1168,6 +1168,16 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/card/id/syndicate
 	cost = 2
 
+/datum/uplink_item/stealthy_tools/agent_card/deluxe
+	name = "Deluxe Agent Identification Card"
+	desc = "Agent cards prevent artificial intelligences from tracking the wearer, and can copy access \
+			from other identification cards. The access is cumulative, so scanning one card does not erase the \
+			access gained from another. In addition, they can be forged to display a new assignment and name. \
+			This can be done an unlimited amount of times. Some Syndicate areas and devices can only be accessed \
+			with these cards. This one ships with full access to the station."
+	item = /obj/item/card/id/syndicate/deluxe
+	cost = 10
+
 /datum/uplink_item/stealthy_tools/ai_detector
 	name = "Artificial Intelligence Detector"
 	desc = "A functional multitool that turns red when it detects an artificial intelligence watching it, and can be \


### PR DESCRIPTION
# Github documenting your Pull Request

10TC item from uplink, deluxe agent ID, comes with AA. 

# Changelog

:cl:  
rscadd: Added deluxe agent ID to the traitor uplink, comes with AA
/:cl:
