### PR TITLE
RCD cartridges now refill the RCD in a single cartridge vs having to use 4

### DIFF
--- a/_maps/map_files/debug/multiz.dmm
+++ b/_maps/map_files/debug/multiz.dmm
@@ -579,9 +579,9 @@
 /area/bridge)
 "bL" = (
 /obj/structure/table,
-/obj/item/rcd_ammo/large,
-/obj/item/rcd_ammo/large,
-/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo,
+/obj/item/rcd_ammo,
+/obj/item/rcd_ammo,
 /obj/item/construction/rcd,
 /turf/open/floor/plasteel,
 /area/bridge)

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -591,9 +591,9 @@
 /area/bridge)
 "bL" = (
 /obj/structure/table,
-/obj/item/rcd_ammo/large,
-/obj/item/rcd_ammo/large,
-/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo,
+/obj/item/rcd_ammo,
+/obj/item/rcd_ammo,
 /obj/item/construction/rcd/combat,
 /turf/open/floor/plasteel,
 /area/bridge)

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -729,12 +729,8 @@ RLD
 	w_class = WEIGHT_CLASS_TINY
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
-	materials = list(/datum/material/iron=12000, /datum/material/glass=8000)
-	var/ammoamt = 40
-
-/obj/item/rcd_ammo/large
 	materials = list(/datum/material/iron=48000, /datum/material/glass=32000)
-	ammoamt = 160
+	var/ammoamt = 160
 
 
 /obj/item/construction/rcd/combat/admin

--- a/code/game/objects/structures/crates_lockers/closets/secure/misc.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/misc.dm
@@ -64,4 +64,4 @@
 	new /obj/item/clothing/shoes/magboots(src)
 	new /obj/item/storage/box/smart_metal_foam(src)
 	for(var/i in 1 to 3)
-		new /obj/item/rcd_ammo/large(src)
+		new /obj/item/rcd_ammo(src)

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -152,8 +152,8 @@
 	back = /obj/item/storage/backpack/ert/engineer
 	belt = /obj/item/storage/belt/utility/full
 	mask = /obj/item/clothing/mask/gas/sechailer
-	l_pocket = /obj/item/rcd_ammo/large
-	r_pocket= /obj/item/rcd_ammo/large
+	l_pocket = /obj/item/rcd_ammo
+	r_pocket= /obj/item/rcd_ammo
 	backpack_contents = list(
 		/obj/item/reagent_containers/hypospray/medipen=1,
 		/obj/item/melee/classic_baton/telescopic=1,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24533979/129646273-fb4741f1-f0d3-4e6c-9f63-25f1603e7d94.png)

The RCD cartridges suck compared to just grabbing mats which is weird because the cartridge item is meant to reload the RCD almost as if the RCD cartridges were coded first before you could add mats to the RCD.

The RCD cartridges now refill the RCD in a single unit vs before where you needed to put in 4 separate RCD ammo cartridges into the RCD.

The large RCD cartridge doesn't even have its own sprite so I think it just makes more sense to exist as a single item that refills the base level RCD. 
The large one seemed to only really exist for the sake of being put in an ERT engineer's pocket so this standardizes it as well.

Does not conflict with #12032

:cl:  Hopek
tweak: RCD cartridges now refill the standard RCD in a single cartridge vs having to use 4.
/:cl:
