### PR TITLE
Revert "#9147 (Belt tweaks) Hotfix"

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -38,6 +38,7 @@
 /obj/item/storage/belt/utility/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_w_class = WEIGHT_CLASS_NORMAL
 	STR.max_combined_w_class = 21
 	STR.set_holdable(list(
 		/obj/item/multitool/tricorder,			//yogs tricorder: 'cause making it into the yogs belt dm makes it the only thing a belt can hold

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -38,8 +38,6 @@
 /obj/item/storage/belt/utility/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = 14
-	STR.max_w_class = WEIGHT_CLASS_NORMAL
 	STR.max_combined_w_class = 21
 	STR.set_holdable(list(
 		/obj/item/multitool/tricorder,			//yogs tricorder: 'cause making it into the yogs belt dm makes it the only thing a belt can hold
@@ -136,7 +134,6 @@
 /obj/item/storage/belt/medical/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = 14
 	STR.max_w_class = WEIGHT_CLASS_BULKY
 	STR.max_combined_w_class = 21
 	STR.set_holdable(list(


### PR DESCRIPTION
Reverts the PR that turned all storage belts into belts of holding.
It keeps the weight class change which was reasonable 
**This is not affecting the storage size, only the amount of maximum slots.**

**EDIT:**
-------
My PR is mainly fighting a shitty hotfix applied to all storage with special slots in the game.

The main arguments brought up so far are about the engineering belt, but there are like 12+ storage items affected by this.
Most of them were unintended because of the lazy hotfix
The correct way to increase the slots higher for a belt would be to go to the belt you want to increase, THEN changing the number instead of what the hotfix did of modifying the parent


:cl:  Hopek
tweak: Specialized belts are back to not automatically starting with 14 slots anymore. This is not affecting the storage size, only the amount of maximum slots.
/:cl:
