### PR TITLE
Makes burglar alarms send a message in sec radio when triggered

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -432,6 +432,14 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 			//Cancel silicon alert after 1 minute
 			addtimer(CALLBACK(SILICON, /mob/living/silicon.proc/cancelAlarm,"Burglar",src,trigger), 600)
 
+	var/obj/item/radio/radio = new /obj/item/radio(trigger)
+	radio.set_frequency(FREQ_SECURITY)
+	radio.use_command = TRUE
+	radio.independent = TRUE
+	radio.name = "burglar alarm"
+	radio.talk_into(radio, "Warning: Burglar alarm triggered in [src]!! Break in of [trigger]!!")
+	qdel(radio)
+
 /**
   * Trigger the fire alarm visual affects in an area
   *


### PR DESCRIPTION
# Github documenting your Pull Request

Now if the AI is not paying attention, sec officers are alerted.

# Changelog

:cl:  
tweak: tweaked burglar alarm to announce a break in on radio
/:cl:
