### PR TITLE
Makes event spawning based on alert level

### DIFF
--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -29,6 +29,8 @@
 
 	var/triggering	//admin cancellation
 
+	var/max_alert = SEC_LEVEL_RED /// Highest alert level the event will trigger at
+
 	/// Whether or not dynamic should hijack this event
 	var/dynamic_should_hijack = FALSE
 
@@ -58,6 +60,8 @@
 	if(holidayID && (!SSevents.holidays || !SSevents.holidays[holidayID]))
 		return FALSE
 	if(ispath(typepath, /datum/round_event/ghost_role) && !(GLOB.ghost_role_flags & GHOSTROLE_MIDROUND_EVENT))
+		return FALSE
+	if(GLOB.security_level > max_alert)
 		return FALSE
 
 	var/datum/game_mode/dynamic/dynamic = SSticker.mode

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -30,6 +30,7 @@
 	var/triggering	//admin cancellation
 
 	var/max_alert = SEC_LEVEL_RED /// Highest alert level the event will trigger at
+	var/min_alert = SEC_LEVEL_GREEN /// Lowest alert level the event will trigger at
 
 	/// Whether or not dynamic should hijack this event
 	var/dynamic_should_hijack = FALSE
@@ -62,6 +63,8 @@
 	if(ispath(typepath, /datum/round_event/ghost_role) && !(GLOB.ghost_role_flags & GHOSTROLE_MIDROUND_EVENT))
 		return FALSE
 	if(GLOB.security_level > max_alert)
+		return FALSE
+	if(GLOB.security_level < min_alert)
 		return FALSE
 
 	var/datum/game_mode/dynamic/dynamic = SSticker.mode

--- a/code/modules/events/aurora_caelus.dm
+++ b/code/modules/events/aurora_caelus.dm
@@ -4,6 +4,7 @@
 	max_occurrences = 1
 	weight = 1
 	earliest_start = 5 MINUTES
+	max_alert = SEC_LEVEL_DELTA
 
 /datum/round_event_control/aurora_caelus/canSpawnEvent(players, gamemode)
 	if(!CONFIG_GET(flag/starlight))


### PR DESCRIPTION
# Github documenting your Pull Request

Each event can now specify the minimum and maximum security level it can activate on. Default is green through red alert, only override right now is allowing the aurora to activate on any alert level.

# Changelog

:cl:  
tweak: tweaked events to only spawn on some alert levels
/:cl:
