### PR TITLE
Fixes and Tweaks Some Stuff With the Crew Monitor Again

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -27,6 +27,8 @@ GLOBAL_LIST_INIT(simple_animals, list(list(),list(),list(),list())) // One for e
 GLOBAL_LIST_EMPTY(spidermobs)				//all sentient spider mobs
 GLOBAL_LIST_EMPTY(bots_list)
 GLOBAL_LIST_EMPTY(aiEyes)
+GLOBAL_LIST_EMPTY(suit_sensors_list)			//all people with suit sensors on
+GLOBAL_LIST_EMPTY(nanite_sensors_list)			//app people with nanite monitoring program
 GLOBAL_LIST_EMPTY(new_player_list)			//all /mob/dead/new_player, in theory all should have clients and those that don't are in the process of spawning and get deleted when done.
 ///underages who have been reported to security for trying to buy things they shouldn't, so they can't spam
 GLOBAL_LIST_EMPTY(narcd_underages)

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -16,7 +16,7 @@
 /obj/machinery/computer/crew/syndie
 	icon_keyboard = "syndie_key"
 
-/obj/machinery/computer/crew/interact(mob/user)
+/obj/machinery/computer/crew/ui_interact(mob/user)
 	GLOB.crewmonitor.show(user,src)
 
 GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
@@ -67,6 +67,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 	jobs["Clerk"] = 71 //Yogs: Added IDs for this job, also need to skip 70 or it clerk would be considered a head job
 	jobs["Tourist"] = 72 //Yogs: Added IDs for this job
 	jobs["Artist"] = 73 //Yogs: Added IDs for this job
+	jobs["Assistant"] = 74 //Yogs: Assistants are with the other civilians
 	jobs["Admiral"] = 200
 	jobs["CentCom Commander"] = 210
 	jobs["Custodian"] = 211
@@ -76,7 +77,6 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 	jobs["Security Response Officer"] = 221
 	jobs["Engineer Response Officer"] = 222
 	jobs["Medical Response Officer"] = 223
-	jobs["Assistant"] = 999 //Unknowns/custom jobs should appear after civilians, and before assistants
 
 	src.jobs = jobs
 
@@ -128,18 +128,58 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 	var/pos_y
 	var/life_status
 
-	for(var/mob/living/carbon/human/H in GLOB.carbon_list)
+	for(var/i in GLOB.nanite_sensors_list)
+		var/mob/living/carbon/human/H = i
 		var/nanite_sensors = FALSE
 		if(H in SSnanites.nanite_monitored_mobs)
 			nanite_sensors = TRUE
 		// Check if their z-level is correct and if they are wearing a uniform.
 		// Accept H.z==0 as well in case the mob is inside an object.
-		if ((H.z == 0 || H.z == z) && (istype(H.w_uniform, /obj/item/clothing/under) || nanite_sensors))
+
+		if(((H.z == 0 || H.z == z || (is_station_level(H.z) && is_station_level(z))) && (nanite_sensors)))
+
+			pos = H.z == 0 || (nanite_sensors) ? get_turf(H) : null
+
+			// Special case: If the mob is inside an object confirm the z-level on turf level.
+			if (H.z == 0 && (!pos || pos.z != z))
+				continue
+
+			I = H.wear_id ? H.wear_id.GetID() : null
+
+			if (I)
+				name = I.registered_name
+				assignment = I.assignment
+				ijob = jobs[I.assignment]
+			else
+				name = "Unknown"
+				assignment = ""
+				ijob = 80
+
+			life_status = (!H.stat ? TRUE : FALSE)
+
+			oxydam = round(H.getOxyLoss(),1)
+			toxdam = round(H.getToxLoss(),1)
+			burndam = round(H.getFireLoss(),1)
+			brutedam = round(H.getBruteLoss(),1)
+
+			if (!pos)
+				pos = get_turf(H)
+			area = get_area_name(H, TRUE)
+			pos_x = pos.x
+			pos_y = pos.y
+
+			results[++results.len] = list("name" = name, "assignment" = assignment, "ijob" = ijob, "life_status" = life_status, "oxydam" = oxydam, "toxdam" = toxdam, "burndam" = burndam, "brutedam" = brutedam, "area" = area, "pos_x" = pos_x, "pos_y" = pos_y, "can_track" = H.can_track(null))
+
+	for(var/i in GLOB.suit_sensors_list)
+		var/mob/living/carbon/human/H = i
+		// Check if their z-level is correct and if they are wearing a uniform.
+		// Accept H.z==0 as well in case the mob is inside an object. Nanite sensors come before normal sensors.
+		if((H.z == 0 || H.z == z || (is_station_level(H.z) && is_station_level(z))) && (istype(H.w_uniform, /obj/item/clothing/under)) && !(H in GLOB.nanite_sensors_list))
 			U = H.w_uniform
 
 			// Are the suit sensors on?
-			if (nanite_sensors || ((U.has_sensor > 0) && U.sensor_mode))
-				pos = H.z == 0 || (nanite_sensors || U.sensor_mode == SENSOR_COORDS) ? get_turf(H) : null
+			if ((U.has_sensor > 0) && U.sensor_mode)
+				pos = H.z == 0 || (U.sensor_mode == SENSOR_COORDS) ? get_turf(H) : null
 
 				// Special case: If the mob is inside an object confirm the z-level on turf level.
 				if (H.z == 0 && (!pos || pos.z != z))
@@ -156,12 +196,12 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 					assignment = ""
 					ijob = 80
 
-				if (nanite_sensors || U.sensor_mode >= SENSOR_LIVING)
+				if (U.sensor_mode >= SENSOR_LIVING)
 					life_status = (!H.stat ? TRUE : FALSE)
 				else
 					life_status = null
 
-				if (nanite_sensors || U.sensor_mode >= SENSOR_VITALS)
+				if (U.sensor_mode >= SENSOR_VITALS)
 					oxydam = round(H.getOxyLoss(),1)
 					toxdam = round(H.getToxLoss(),1)
 					burndam = round(H.getFireLoss(),1)
@@ -172,7 +212,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 					burndam = null
 					brutedam = null
 
-				if (nanite_sensors || U.sensor_mode >= SENSOR_COORDS)
+				if (U.sensor_mode >= SENSOR_COORDS)
 					if (!pos)
 						pos = get_turf(H)
 					area = get_area_name(H, TRUE)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -214,7 +214,7 @@ BLIND     // can't see anything
 		to_chat(usr, "<span class='warning'>You have moved too far away!</span>")
 		return
 	sensor_mode = modes.Find(switchMode) - 1
-
+	set_sensor_glob()
 	if (src.loc == usr)
 		switch(sensor_mode)
 			if(0)
@@ -336,3 +336,17 @@ BLIND     // can't see anything
 		deconstruct(FALSE)
 	else
 		..()
+		
+/obj/item/clothing/proc/set_sensor_glob()
+	var/mob/living/carbon/human/H = src.loc
+
+	if (istype(H.w_uniform, /obj/item/clothing/under))
+		var/obj/item/clothing/under/U = H.w_uniform
+		if (U.has_sensor && U.sensor_mode && U.has_sensor != BROKEN_SENSORS)
+			GLOB.suit_sensors_list |= H
+
+		else 
+			GLOB.suit_sensors_list -= H
+
+	else 
+		GLOB.suit_sensors_list -= H	

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -101,6 +101,7 @@
 		attached_accessory.on_uniform_equip(src, user)
 		if(attached_accessory.above_suit)
 			H.update_inv_wear_suit()
+	set_sensor_glob()
 
 /obj/item/clothing/under/dropped(mob/user)
 	if(attached_accessory)
@@ -109,7 +110,7 @@
 			var/mob/living/carbon/human/H = user
 			if(attached_accessory.above_suit)
 				H.update_inv_wear_suit()
-
+	set_sensor_glob()
 	..()
 
 /obj/item/clothing/under/proc/attach_accessory(obj/item/I, mob/user, notifyAttach = 1)

--- a/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/code/modules/research/nanites/nanite_programs/utility.dm
@@ -82,11 +82,19 @@
 /datum/nanite_program/monitoring/enable_passive_effect()
 	. = ..()
 	SSnanites.nanite_monitored_mobs |= host_mob
+	if(ishuman(host_mob))
+		var/mob/living/carbon/human/H = host_mob
+		if(!(H in GLOB.nanite_sensors_list))
+			GLOB.nanite_sensors_list |= H
 	host_mob.hud_set_nanite_indicator()
 
 /datum/nanite_program/monitoring/disable_passive_effect()
 	. = ..()
 	SSnanites.nanite_monitored_mobs -= host_mob
+	if(ishuman(host_mob))
+		var/mob/living/carbon/human/H = host_mob
+		GLOB.nanite_sensors_list -= H
+
 	host_mob.hud_set_nanite_indicator()
 
 /datum/nanite_program/triggered/self_scan

--- a/tgui/packages/tgui/constants.js
+++ b/tgui/packages/tgui/constants.js
@@ -19,8 +19,8 @@ export const COLORS = {
     medbay: '#3498db',
     science: '#9b59b6',
     engineering: '#f1c40f',
-    cargo: '#f39c12',
-    civilian: '#535353', // Yogs: Added new civilian color
+    cargo: '#d4680d', // Yogs: Added new cargo color
+    civilian: '#b4b4b4', // Yogs: Added new civilian color
     centcom: '#00c100',
     other: '#c38312',
   },

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -71,7 +71,7 @@ export const CrewConsole = (props, context) => {
   return (
     <Window
       title="Crew Monitor"
-      width={1400}
+      width={1000}
       height={800}
       resizable>
       <Window.Content scrollable>
@@ -109,7 +109,7 @@ export const CrewConsole = (props, context) => {
                           ? healthToColor(
                             sensor.oxydam,
                             sensor.toxdam,
-                            sensor.brutedam,
+                            sensor.burndam,
                             sensor.brutedam) : (
                             sensor.life_status
                               ? HEALTH_COLOR_BY_LEVEL[0]


### PR DESCRIPTION
# Github documenting your Pull Request

So, this PR ports and adds some tweaks and fixes for the crew monitor. The fixes are all ports while the appearance changes are by me. Most of this has been tested, but there may be some stuff I missed.
## Ports
- [Allow ghosts to look at the crew monitor UI](https://github.com/BeeStation/BeeStation-Hornet/pull/4179) by [Cenrus](https://github.com/Cenrus): A small PR that allows ghosts to view crew monitors. A nice QoL fix.
- [fixes the crew console vitals square](https://github.com/tgstation/tgstation/pull/48087) by [nichlas0010](https://github.com/nichlas0010): This PR fixes something I was annoyed with for a while. As it is currently, the vital square does not take into account burn damage and doubles the brute damage in the calculation do to a typo.
- [Fixing crew monitor suit sensors](https://github.com/tgstation/tgstation/pull/51268) & [fixes my own stupid mistakes and crew monitor not showing any crew](https://github.com/tgstation/tgstation/pull/51337) by [MacBlaze1](https://github.com/MacBlaze1): These PRs potentially fix the issue with crew monitors showing many unknowns of the same person by refactoring some of the crew monitor code.

## Changes by Me
I also changed some stuff with the crew monitor to look better and fix a few issues I had with my [original PR](https://github.com/yogstation13/Yogstation/pull/11570)

- Moved assistants so they come after the other civilian jobs
- Changed the color for civilian jobs to be lighter (#b4b4b4) to help it better stand out from the background
- Changed the cargo color to a color that was more brown (#d4680d) to help it not blend in with engineering
- Shrank the window (1400x800 to 1000x800) to remove some of the unused space left by the removal of the map 

## What Does it Look Like Now?

![image](https://user-images.githubusercontent.com/14363906/129852306-c4a681df-ebdf-4634-81e5-b49c2678b691.png)

Here is an image showing many of the changes

# Wiki Documentation

As long as the UI for the crew monitor isn't show on the wiki (which I don't think it is) there should be no needed changes.

# Changelog

:cl:  MacBlaze1, Cenrus, nichlas0010, nmajask
bugfix: fixed ghosts not being able to view crew monitors
bugfix: fixed the crew monitor vital square not taking into account burn damage
bugfix: potentially fixed random duplicate unknowns of people appearing on the crew monitor
tweak: tweaked the appearance of the crew monitor UI
/:cl:
