### PR TITLE
[admin]s now properly trigger mhelp chat notif

### DIFF
--- a/yogstation/code/modules/mentor/mentorpm.dm
+++ b/yogstation/code/modules/mentor/mentorpm.dm
@@ -53,12 +53,12 @@
 
 	//get message text, limit it's length.and clean/escape html
 	if(!msg)
-		if(mentor_datum || holder)
+		if(is_mentor())
 			to_chat((GLOB.admins - GLOB.deadmins) | GLOB.mentors, "<b><span class='purple mentor'>[key_name_mentor(src)] has started answering [key_name_mentor(C)]'s mentorhelp.</span></b>", confidential=TRUE)
 		msg = input(src,"Message:", "Private message") as text|null
 
 		if(!msg)
-			if(mentor_datum || holder)
+			if(is_mentor())
 				to_chat((GLOB.admins - GLOB.deadmins) | GLOB.mentors, "<b><span class='purple mentor'>[key_name_mentor(src)] has decided not to answer [key_name_mentor(C)]'s mentorhelp.</span></b>", confidential=TRUE)
 			return
 

--- a/yogstation/code/modules/mentor/mentorpm.dm
+++ b/yogstation/code/modules/mentor/mentorpm.dm
@@ -53,12 +53,12 @@
 
 	//get message text, limit it's length.and clean/escape html
 	if(!msg)
-		if(mentor_datum)
+		if(mentor_datum || holder)
 			to_chat((GLOB.admins - GLOB.deadmins) | GLOB.mentors, "<b><span class='purple mentor'>[key_name_mentor(src)] has started answering [key_name_mentor(C)]'s mentorhelp.</span></b>", confidential=TRUE)
 		msg = input(src,"Message:", "Private message") as text|null
 
 		if(!msg)
-			if(mentor_datum)
+			if(mentor_datum || holder)
 				to_chat((GLOB.admins - GLOB.deadmins) | GLOB.mentors, "<b><span class='purple mentor'>[key_name_mentor(src)] has decided not to answer [key_name_mentor(C)]'s mentorhelp.</span></b>", confidential=TRUE)
 			return
 


### PR DESCRIPTION
# Github documenting your Pull Request

"[ckey] started answering [ckey]'s mentorhelp"
this thing ^

admins sometimes have mentor datums sometimes they dont
is_mentor better

# Changelog

:cl:  
bugfix: fixed admins not showing up when answering mentorhelps
/:cl:
