### PR TITLE
Re-adds drunkenness counting as a painkiller for surgery screwups

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -514,6 +514,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 	if(hallucination)
 		handle_hallucinations()
 
+	REMOVE_TRAIT_FROM(TRAIT_SURGERY_PREPARED, "drunk")
 	if(drunkenness)
 		drunkenness = max(drunkenness - (drunkenness * 0.04) - 0.01, 0)
 		if(drunkenness >= 6)
@@ -556,6 +557,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 			if(HAS_TRAIT(src, TRAIT_DRUNK_HEALING)) // effects stack with lower tiers
 				adjustBruteLoss(-0.3, FALSE)
 				adjustFireLoss(-0.15, FALSE)
+			ADD_TRAIT(TRAIT_SURGERY_PREPARED, "drunk")
 
 		if(drunkenness >= 51)
 			if(prob(3))

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -514,7 +514,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 	if(hallucination)
 		handle_hallucinations()
 
-	REMOVE_TRAIT_FROM(TRAIT_SURGERY_PREPARED, "drunk")
+	REMOVE_TRAIT(src, TRAIT_SURGERY_PREPARED, "drunk")
 	if(drunkenness)
 		drunkenness = max(drunkenness - (drunkenness * 0.04) - 0.01, 0)
 		if(drunkenness >= 6)
@@ -557,7 +557,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 			if(HAS_TRAIT(src, TRAIT_DRUNK_HEALING)) // effects stack with lower tiers
 				adjustBruteLoss(-0.3, FALSE)
 				adjustFireLoss(-0.15, FALSE)
-			ADD_TRAIT(TRAIT_SURGERY_PREPARED, "drunk")
+			ADD_TRAIT(src, TRAIT_SURGERY_PREPARED, "drunk")
 
 		if(drunkenness >= 51)
 			if(prob(3))


### PR DESCRIPTION
# Github documenting your Pull Request

this got killed off at some point probably because I couldn't be assed to properly fix it now I have though so it's fine :)
41 is the highest current effect range that won't cause vomiting or toxin damage so I think it's good

# Wiki Documentation

Drunkenness reaching 41 will remove the chance to screw up a surgery step and cause damage

# Changelog

:cl:  
tweak: Drunkenness reaching 41 will remove the chance to screw up a surgery step and cause damage
/:cl:
