### PR TITLE
Makes the medical belt be able to hold 14 items again

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -137,6 +137,7 @@
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_w_class = WEIGHT_CLASS_BULKY
 	STR.max_combined_w_class = 21
+	STR.max_items = 14
 	STR.set_holdable(list(
 		/obj/item/healthanalyzer,
 		/obj/item/dnainjector,


### PR DESCRIPTION
So much crying to get this done quickly, but I need my Saturday beauty sleep.

Author's note:
If this PR gets a merge conflict like for example, if #12101 gets merged first, there is a 50% chance I'll fix it; otherwise, someone else can make the 1 line change.

:cl:  Hopek
tweak: Medical belts can now hold 14 items again without affecting every other belt in the game.
/:cl:
