### PR TITLE
"black overlay, unconscious = black screen" but for those with the heavy sleeper quirk

### DIFF
--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -106,6 +106,11 @@
 	layer = BLIND_LAYER
 
 /obj/screen/fullscreen/blind
+	icon_state = "blindimageoverlay"
+	layer = BLIND_LAYER
+	plane = FULLSCREEN_PLANE
+
+/obj/screen/fullscreen/black
 	icon_state = "blackimageoverlay"
 	layer = BLIND_LAYER
 	plane = FULLSCREEN_PLANE

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -218,7 +218,7 @@
 
 /datum/quirk/heavy_sleeper
 	name = "Heavy Sleeper"
-	desc = "You sleep like a rock! Whenever you're put to sleep or knocked unconscious, you take a little bit longer to wake up."
+	desc = "You sleep like a rock! Whenever you're put to sleep or knocked unconscious, you take a little bit longer to wake up and cant see anything."
 	value = -2
 	mob_trait = TRAIT_HEAVY_SLEEPER
 	gain_text = "<span class='danger'>You feel sleepy.</span>"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -219,7 +219,7 @@
 /datum/quirk/heavy_sleeper
 	name = "Heavy Sleeper"
 	desc = "You sleep like a rock! Whenever you're put to sleep or knocked unconscious, you take a little bit longer to wake up."
-	value = -1
+	value = -2
 	mob_trait = TRAIT_HEAVY_SLEEPER
 	gain_text = "<span class='danger'>You feel sleepy.</span>"
 	lose_text = "<span class='notice'>You feel awake again.</span>"

--- a/code/modules/mob/status_procs.dm
+++ b/code/modules/mob/status_procs.dm
@@ -29,7 +29,10 @@
 		if(!old_eye_blind)
 			if(stat == CONSCIOUS || stat == SOFT_CRIT)
 				throw_alert("blind", /obj/screen/alert/blind)
-			overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
+			if(stat != CONSCIOUS && HAS_TRAIT(src, TRAIT_HEAVY_SLEEPER))
+				overlay_fullscreen("blind", /obj/screen/fullscreen/black)
+			else
+				overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
 
 /**
   * Adjust a mobs blindness by an amount
@@ -43,7 +46,10 @@
 		if(!old_eye_blind)
 			if(stat == CONSCIOUS || stat == SOFT_CRIT)
 				throw_alert("blind", /obj/screen/alert/blind)
-			overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
+			if(stat != CONSCIOUS && HAS_TRAIT(src, TRAIT_HEAVY_SLEEPER))
+				overlay_fullscreen("blind", /obj/screen/fullscreen/black)
+			else
+				overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
 	else if(eye_blind)
 		var/blind_minimum = 0
 		if((stat != CONSCIOUS && stat != SOFT_CRIT))
@@ -66,7 +72,10 @@
 		if(client && !old_eye_blind)
 			if(stat == CONSCIOUS || stat == SOFT_CRIT)
 				throw_alert("blind", /obj/screen/alert/blind)
-			overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
+			if(stat != CONSCIOUS && HAS_TRAIT(src, TRAIT_HEAVY_SLEEPER))
+				overlay_fullscreen("blind", /obj/screen/fullscreen/black)
+			else
+				overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
 	else if(eye_blind)
 		var/blind_minimum = 0
 		if(stat != CONSCIOUS && stat != SOFT_CRIT)


### PR DESCRIPTION
# Github documenting your Pull Request

Reworks "[black overlay, unconscious = black screen](https://github.com/yogstation13/Yogstation/pull/10982)" by [ynot01](https://github.com/ynot01) so that it only effects those with the heavy sleeper quirk. I have only done a little bit of testing to make sure the main point of this PR works, so there may be a few issues I missed. If you want a better description of what this does, look at the [original PR](https://github.com/yogstation13/Yogstation/pull/10982).

# Wiki Documentation

If there is any mention of what Heavy Sleeper does, it will probably need to be edited to state this new feature.

# Changelog

:cl:  ynot01, nmajask
tweak: You can no longer see the real world when you're sleeping if you have the heavy sleeper quirk
/:cl:
