### PR TITLE
Adds engineer atmos holosign to engineering cyborgs.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -330,6 +330,7 @@
 		/obj/item/multitool/cyborg,
 		/obj/item/t_scanner,
 		/obj/item/analyzer,
+		/obj/item/holosign_creator/atmos,
 		/obj/item/geiger_counter/cyborg,
 		/obj/item/assembly/signaler/cyborg,
 		/obj/item/areaeditor/blueprints/cyborg,


### PR DESCRIPTION
Intent of your Pull Request

Add the engineer atmos holosign to engineering borgs

Why is this change good for the game?

It makes perfect sense to add the holosign to the borg, the same reason why the engineering borg has a Geiger counter or analyzer.

:cl:  
rscadd: Added the engineer atmos holosign to engineering borgs. 

/:cl:
