### PR TITLE
Removes Ashwalker's ability to speak common

### DIFF
--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -275,7 +275,9 @@ Key procs
 							/datum/language/draconic = list(LANGUAGE_ATOM))
 
 /datum/language_holder/lizard/ash
-	selected_language = /datum/language/draconic
+	understood_languages = list(/datum/language/draconic = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/draconic = list(LANGUAGE_ATOM))
+	blocked_languages = list(/datum/language/common = list(LANGUAGE_ATOM))
 
 /datum/language_holder/monkey
 	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),


### PR DESCRIPTION
# Github documenting your Pull Request

Removes Ashwalker's ability to speak common. Could allow for some interesting situations, like needing a curator or lizard to come down to mining to translate.

# Wiki Documentation

If its mentioned that Ashwalkers can speak common, that will need to be changed. 

# Changelog

:cl:   
tweak: Removed Ashwalker's ability to speak common
/:cl:
