### PR TITLE
Makes strange reagent require tricordrazine rather than omnizine.

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -162,7 +162,7 @@
 	name = "Strange Reagent"
 	id = /datum/reagent/medicine/strange_reagent
 	results = list(/datum/reagent/medicine/strange_reagent = 3)
-	required_reagents = list(/datum/reagent/medicine/omnizine = 1, /datum/reagent/water/holywater = 1, /datum/reagent/toxin/mutagen = 1)
+	required_reagents = list(/datum/reagent/medicine/tricordrazine = 1, /datum/reagent/water/holywater = 1, /datum/reagent/toxin/mutagen = 1)
 
 /datum/chemical_reaction/mannitol
 	name = "Mannitol"


### PR DESCRIPTION
# Github documenting your Pull Request

Makes strange reagent harder to obtain, especially at round-start by making it require tricordrazine instead of omnizine.

Alternative to, and closes #12121 
Alternative to, and closes #12119 



# Wiki Documentation

Update the recipe of strange reagent, same ratio, just tricord instead. 

# Changelog

:cl:  
tweak: tweaked strange reagent to require tricordrazine
/:cl:
