### PR TITLE
Makes strange reagent require rezadone rather than omnizine

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -162,7 +162,7 @@
 	name = "Strange Reagent"
 	id = /datum/reagent/medicine/strange_reagent
 	results = list(/datum/reagent/medicine/strange_reagent = 3)
-	required_reagents = list(/datum/reagent/medicine/omnizine = 1, /datum/reagent/water/holywater = 1, /datum/reagent/toxin/mutagen = 1)
+	required_reagents = list(/datum/reagent/medicine/rezadone = 1, /datum/reagent/water/holywater = 1, /datum/reagent/toxin/mutagen = 1)
 
 /datum/chemical_reaction/mannitol
 	name = "Mannitol"


### PR DESCRIPTION
# Github documenting your Pull Request
Alternative to, and closes #12118 
Alternative to, and closes #12121 
Not Jamie's idea
Uses rezadone which needs carpotoxin, making it much harder to get

# Wiki Documentation

Recipe for SR will need updated

# Changelog

:cl:  
tweak: makes strange reagent require rezadone
/:cl:
