### PR TITLE
Makes strange reagent require carpotoxin rather than omnizine

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -162,7 +162,7 @@
 	name = "Strange Reagent"
 	id = /datum/reagent/medicine/strange_reagent
 	results = list(/datum/reagent/medicine/strange_reagent = 3)
-	required_reagents = list(/datum/reagent/medicine/omnizine = 1, /datum/reagent/water/holywater = 1, /datum/reagent/toxin/mutagen = 1)
+	required_reagents = list(/datum/reagent/toxin/carpotoxin = 1, /datum/reagent/water/holywater = 1, /datum/reagent/toxin/mutagen = 1)
 
 /datum/chemical_reaction/mannitol
 	name = "Mannitol"


### PR DESCRIPTION
# Github documenting your Pull Request
Alternative to, and closes #12119 
Alternative to, and closes #12118 
Uses carpotoxin to require more than with rezadone
Not Jamie's idea

# Wiki Documentation

Update SR recipe

# Changelog

:cl:  
tweak: strange reagent requires carpotoxin
/:cl:
