### PR TITLE
Hopefully prevents people with no jobs enabled from being kicked to lobby after rolling antag

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -590,6 +590,10 @@
 	if(client.prefs.be_special.len > 0)
 		has_antags = TRUE
 	if(client.prefs.job_preferences.len == 0)
+		if(mind && mind.antag_datums.len > 0)
+			message_admins("[src.ckey] has no jobs enabled, but rolled antag. This shouldn't happen, notify coders.")
+			log_admin("[src.ckey] has rolled antag with no jobs enabled")
+			return TRUE
 		if(!ineligible_for_roles)
 			to_chat(src, "<span class='danger'>You have no jobs enabled, along with return to lobby if job is unavailable. This makes you ineligible for any round start role, please update your job preferences.</span>")
 		ineligible_for_roles = TRUE


### PR DESCRIPTION
# Github documenting your Pull Request

The antag rolling abuse code isn't called by all gamemodes, but it is called at roundstart, so it is possible for someone to get antag and then be booted to lobby if the gamemode is naughty. This will cause them to still get to play, then log a message so we can identify those gamemodes.

# Changelog

:cl:  
bugfix: fixed bug that caused people to roll antag and get kicked to lobby 
/:cl:
