### PR TITLE
Adds logging to bar load in case it fails

### DIFF
--- a/yogstation/code/modules/jobs/job_types/_job.dm
+++ b/yogstation/code/modules/jobs/job_types/_job.dm
@@ -114,6 +114,10 @@
 	
 	var/datum/map_template/template = SSmapping.station_room_templates[choice]
 
+	if(!template)
+		log_game("BAR FAILED TO LOAD!!! [C.ckey]/([M.name]) attempted to load [choice]. Loading Bar Arcade as backup.")
+		template = SSmapping.station_room_templates["Bar Arcade"]
+
 	for(var/obj/effect/landmark/stationroom/box/bar/B in GLOB.landmarks_list)
 		template.load(B.loc, centered = FALSE)
 		qdel(B)

--- a/yogstation/code/modules/jobs/job_types/_job.dm
+++ b/yogstation/code/modules/jobs/job_types/_job.dm
@@ -116,6 +116,7 @@
 
 	if(!template)
 		log_game("BAR FAILED TO LOAD!!! [C.ckey]/([M.name]) attempted to load [choice]. Loading Bar Arcade as backup.")
+		message_admins("BAR FAILED TO LOAD!!! [C.ckey]/([M.name]) attempted to load [choice]. Loading Bar Arcade as backup.")
 		template = SSmapping.station_room_templates["Bar Arcade"]
 
 	for(var/obj/effect/landmark/stationroom/box/bar/B in GLOB.landmarks_list)


### PR DESCRIPTION
# Github documenting your Pull Request

it randomly failed today and i dont know why so heres logging

```
if(!template)
	log_game("BAR FAILED TO LOAD!!! [C.ckey]/([M.name]) attempted to load [choice]. Loading Bar Arcade as backup.")
	message_admins("BAR FAILED TO LOAD!!! [C.ckey]/([M.name]) attempted to load [choice]. Loading Bar Arcade as backup.")
	template = SSmapping.station_room_templates["Bar Arcade"]
```