### PR TITLE
Highlander removes pacifist quirk

### DIFF
--- a/code/modules/antagonists/highlander/highlander.dm
+++ b/code/modules/antagonists/highlander/highlander.dm
@@ -54,6 +54,12 @@
 	H.equip_to_slot_or_del(new /obj/item/clothing/head/beret/highlander(H), SLOT_HEAD)
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/combat(H), SLOT_SHOES)
 	H.equip_to_slot_or_del(new /obj/item/pinpointer/nuke(H), SLOT_L_STORE)
+	//Yogs Start: Pacifists want to play too
+	for(var/V in H.roundstart_quirks)
+		var/datum/quirk/T = V
+		if(istype(T, /datum/quirk/nonviolent))
+			qdel(T) 
+	//Yogs End
 	for(var/obj/item/pinpointer/nuke/P in H)
 		P.attack_self(H)
 	var/obj/item/card/id/W = new(H)


### PR DESCRIPTION
# Github documenting your Pull Request

Becoming a highlander removes the pacifist quirk if you have it, allowing you to actually have fun. It does not get reapplied if highlander is removed and I have only done limited testing to make sure it works.

# Wiki Documentation

I don't think anything needs to be changed on the wiki. 

# Changelog

:cl:  
tweak: becoming a highlander removes the pacifist quirk if you have it  
/:cl:
