### PR TITLE
Revert "Makes event spawning based on alert level"

### DIFF
--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -29,9 +29,6 @@
 
 	var/triggering	//admin cancellation
 
-	var/max_alert = SEC_LEVEL_RED /// Highest alert level the event will trigger at
-	var/min_alert = SEC_LEVEL_GREEN /// Lowest alert level the event will trigger at
-
 	/// Whether or not dynamic should hijack this event
 	var/dynamic_should_hijack = FALSE
 
@@ -61,10 +58,6 @@
 	if(holidayID && (!SSevents.holidays || !SSevents.holidays[holidayID]))
 		return FALSE
 	if(ispath(typepath, /datum/round_event/ghost_role) && !(GLOB.ghost_role_flags & GHOSTROLE_MIDROUND_EVENT))
-		return FALSE
-	if(GLOB.security_level > max_alert)
-		return FALSE
-	if(GLOB.security_level < min_alert)
 		return FALSE
 
 	var/datum/game_mode/dynamic/dynamic = SSticker.mode

--- a/code/modules/events/aurora_caelus.dm
+++ b/code/modules/events/aurora_caelus.dm
@@ -4,7 +4,6 @@
 	max_occurrences = 1
 	weight = 1
 	earliest_start = 5 MINUTES
-	max_alert = SEC_LEVEL_DELTA
 
 /datum/round_event_control/aurora_caelus/canSpawnEvent(players, gamemode)
 	if(!CONFIG_GET(flag/starlight))


### PR DESCRIPTION
Reverts yogstation13/Yogstation#12071

This sets a precedent for event design that we do not want to encourage. If you for for some reason decide to actually need this functionality you can implement it in canSpawnEvent