### PR TITLE
Makes station threats trigger gamma alert

### DIFF
--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -187,6 +187,7 @@
 		bloodstone_areas.Add(A.map_name)
 	priority_announce("Figments of an eldritch god are being pulled through the veil anomaly in [bloodstone_areas[1]], [bloodstone_areas[2]], [bloodstone_areas[3]], and [bloodstone_areas[4]]! Destroy any occult structures located in those areas!","Central Command Higher Dimensional Affairs")
 	addtimer(CALLBACK(src, .proc/increase_bloodstone_power), 30 SECONDS)
+	set_security_level(SEC_LEVEL_GAMMA)
 
 /datum/game_mode/proc/increase_bloodstone_power()
 	if(!bloodstone_list.len) //check if we somehow ran out of bloodstones

--- a/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -94,7 +94,7 @@
 	@!$, [text2ratvar("PURGE ALL UNTRUTHS")] <&. the anomalies and destroy their source to prevent further damage to corporate property. This is \
 	not a drill.[grace_period ? " Estimated time of appearance: [grace_period] seconds. Use this time to prepare for an attack on [station_name()]." : ""]", \
 	"Central Command Higher Dimensional Affairs", 'sound/magic/clockwork/ark_activation.ogg')
-	set_security_level("delta")
+	set_security_level(SEC_LEVEL_GAMMA)
 	for(var/V in SSticker.mode.servants_of_ratvar)
 		var/datum/mind/M = V
 		if(!M || !M.current)
@@ -331,6 +331,7 @@
 			glow.icon_state = "clockwork_gateway_closing"
 		if(GATEWAY_RATVAR_ARRIVAL to INFINITY)
 			if(!purpose_fulfilled)
+				set_security_level(SEC_LEVEL_DELTA)
 				countdown.stop()
 				resistance_flags |= INDESTRUCTIBLE
 				purpose_fulfilled = TRUE

--- a/code/modules/antagonists/clockcult/clock_structures/heralds_beacon.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/heralds_beacon.dm
@@ -93,6 +93,7 @@
 /obj/structure/destructible/clockwork/heralds_beacon/proc/herald_the_justiciar()
 	priority_announce("A powerful group of fanatical zealots following the cause of Ratvar have brazenly sacrificed stealth for power, and dare anyone \
 	to try and stop them.", title = "The Justiciar Comes", sound = 'sound/magic/clockwork/ark_activation.ogg')
+	set_security_level(SEC_LEVEL_GAMMA)
 	GLOB.ratvar_approaches = TRUE
 	available = FALSE
 	STOP_PROCESSING(SSprocessing, src)

--- a/code/modules/antagonists/eldritch_cult/transmutations/ash_transmutations.dm
+++ b/code/modules/antagonists/eldritch_cult/transmutations/ash_transmutations.dm
@@ -64,6 +64,7 @@
 
 /datum/eldritch_transmutation/final/ash_final/on_finished_recipe(mob/living/user, list/atoms, loc)
 	priority_announce("$^@&#*$^@(#&$(@&#^$&#^@# Fear The Blaze, for Ashbringer [user.real_name] has come! $^@&#*$^@(#&$(@&#^$&#^@#","#$^@&#*$^@(#&$(@&#^$&#^@#", ANNOUNCER_SPANOMALIES)
+	set_security_level(SEC_LEVEL_GAMMA)
 	user.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/fire_cascade/big)
 	user.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/fire_sworn)
 	var/mob/living/carbon/human/H = user

--- a/code/modules/antagonists/eldritch_cult/transmutations/flesh_transmutations.dm
+++ b/code/modules/antagonists/eldritch_cult/transmutations/flesh_transmutations.dm
@@ -109,6 +109,7 @@
 			ghoul2.max_amt *= 3
 			var/mob/dead/observer/ghost_candidate = pick(candidates)
 			priority_announce("$^@&#*$^@(#&$(@&#^$&#^@# Fear the dark, for Vassal of Arms has ascended! The Terror of the Night has come! $^@&#*$^@(#&$(@&#^$&#^@#","#$^@&#*$^@(#&$(@&#^$&#^@#", ANNOUNCER_SPANOMALIES)
+			set_security_level(SEC_LEVEL_GAMMA)
 			log_game("[key_name_admin(ghost_candidate)] has taken control of ([key_name_admin(summoned)]).")
 			summoned.ghostize(FALSE)
 			summoned.key = ghost_candidate.key
@@ -126,6 +127,7 @@
 					user.mind.spell_list.Remove(S)
 					qdel(S)
 			priority_announce("$^@&#*$^@(#&$(@&#^$&#^@# Fear the dark, for King of Arms has ascended! Our Lord of the Night has come! $^@&#*$^@(#&$(@&#^$&#^@#","#$^@&#*$^@(#&$(@&#^$&#^@#", ANNOUNCER_SPANOMALIES)
+			set_security_level(SEC_LEVEL_GAMMA)
 			log_game("[user.real_name] ascended as [summoned.real_name]")
 			var/mob/living/carbon/carbon_user = user
 			var/datum/antagonist/heretic/ascension = carbon_user.mind.has_antag_datum(/datum/antagonist/heretic)

--- a/code/modules/antagonists/eldritch_cult/transmutations/rust_transmutations.dm
+++ b/code/modules/antagonists/eldritch_cult/transmutations/rust_transmutations.dm
@@ -28,6 +28,7 @@
 	H.physiology.stamina_mod = 0
 	H.physiology.stun_mod = 0
 	priority_announce("$^@&#*$^@(#&$(@&#^$&#^@# Fear the decay, for Rustbringer [user.real_name] has come! $^@&#*$^@(#&$(@&#^$&#^@#","#$^@&#*$^@(#&$(@&#^$&#^@#", ANNOUNCER_SPANOMALIES)
+	set_security_level(SEC_LEVEL_GAMMA)
 	new /datum/rust_spread(loc)
 	var/datum/antagonist/heretic/ascension = H.mind.has_antag_datum(/datum/antagonist/heretic)
 	ascension.ascended = TRUE

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -51,6 +51,7 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 		return
 
 	priority_announce(war_declaration, title = "Declaration of War", sound = 'sound/machines/alarm.ogg', has_important_message = TRUE)
+	set_security_level(SEC_LEVEL_GAMMA)
 
 	to_chat(user, "You've attracted the attention of powerful forces within the syndicate. A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission.")
 

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -89,7 +89,7 @@
 					continue
 				if(!GLOB.emergency_access)
 					make_maint_all_access()
-				else if(GLOB.security_level != SEC_LEVEL_DELTA)
+				else if(GLOB.security_level < SEC_LEVEL_RED)
 					set_security_level(SEC_LEVEL_RED)
 
 

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn.dm
@@ -362,7 +362,7 @@
 	user.mind.transfer_to(progenitor)
 	progenitor.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/progenitor_curse(null))
 	if(!SSticker.mode.sacrament_done)
-		set_security_level(SECURITY_LEVEL_GAMMA)
+		set_security_level(SEC_LEVEL_GAMMA)
 		addtimer(CALLBACK(src, .proc/sacrament_shuttle_call), 50)
 	for(var/V in abilities)
 		remove_ability(abilities[V], TRUE)

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn.dm
@@ -362,6 +362,7 @@
 	user.mind.transfer_to(progenitor)
 	progenitor.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/progenitor_curse(null))
 	if(!SSticker.mode.sacrament_done)
+		set_security_level(SECURITY_LEVEL_GAMMA)
 		addtimer(CALLBACK(src, .proc/sacrament_shuttle_call), 50)
 	for(var/V in abilities)
 		remove_ability(abilities[V], TRUE)

--- a/yogstation/code/modules/antagonists/shadowling/special_shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/special_shadowling_abilities.dm
@@ -183,7 +183,7 @@
 			H.invisibility = 60 //This is pretty bad, but is also necessary for the shuttle call to function properly
 			H.forceMove(A)
 			if(!SSticker.mode.shadowling_ascended)
-				set_security_level(SEC_LEVEL_DELTA)
+				set_security_level(SEC_LEVEL_GAMMA)
 				SSshuttle.emergencyCallTime = 1800
 				SSshuttle.emergency.request(null, 0.3)
 				SSshuttle.emergencyNoRecall = TRUE


### PR DESCRIPTION
# Github documenting your Pull Request

Adds a couple of triggers for gamma alert, because it is so underused.

Nukies war ops
Clockies war ops
Clockies forced mass recall (not a manual eminence one, used to go delta, now that is delayed until ratvar is summoned)
Blood cult blood stones
Heretic ascension
Sling ascension
Darkspawn sacrament

Also tweaked greytide to account for the fact it might be gamma now

# Wiki Documentation

Documenting the new sources of gamma

# Changelog

:cl:  
rscadd: Bloodcult triggers gamma alert when bloodstones are triggered.
rscadd: Nuclear operatives and clock cult war ops now trigger gamma alert
rscadd: Clock cult forced mass recall now triggers gamma alert
rscadd: Ascending heretics, shadowlings, and darkspawn now trigger gamma alert.
tweak: Greytide won't red alert on gamma now
/:cl:
