### PR TITLE
FIxes random polysmorph names having a closing square bracket

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -5,7 +5,7 @@
 		return "[pick(GLOB.lizard_names_female)]-[pick(GLOB.lizard_names_female)]"
 
 /proc/polysmorph_name()
-	return "[pick(GLOB.polysmorph_names)]]"
+	return "[pick(GLOB.polysmorph_names)]"
 
 /proc/ethereal_name()
 	var/tempname = "[pick(GLOB.ethereal_names)] [random_capital_letter()]"


### PR DESCRIPTION
# Github documenting your Pull Request

Someone did dumb code, Jamie helped a little

# Changelog

:cl:  
bugfix: random polysmorph names no longer end in a closing bracket
/:cl:
