### PR TITLE
Sets security level to gamma when cult ascends

### DIFF
--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -293,6 +293,7 @@
 				to_chat(B.current, "<span class='cultlarge'>Your cult is ascendent and the red harvest approaches - you cannot hide your true nature for much longer!!")
 				addtimer(CALLBACK(src, .proc/ascend, B.current), 200)
 		cult_ascendent = TRUE
+		set_security_level(SEC_LEVEL_GAMMA)
 
 
 /datum/team/cult/proc/rise(cultist)


### PR DESCRIPTION
# Github documenting your Pull Request

Lets the crew know that they should start fighting the cult because 40% of the station is now cult

# Changelog

:cl:  
tweak: Security level is now set to gamma when cult have halos
/:cl:
