### PR TITLE
Reduces the required strange reagent to revive from 10 to 2 because rezadone is already enough of a pain in the ass as is

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1,7 +1,7 @@
 #define PERF_BASE_DAMAGE		0.5
 #define REAGENT_REVIVE_MINIMUM_HEALTH (HEALTH_THRESHOLD_CRIT + 20)
 /// Required strange reagent for revival.
-#define REQUIRED_STRANGE_REAGENT_FOR_REVIVAL 10 ///Adam Sucks
+#define REQUIRED_STRANGE_REAGENT_FOR_REVIVAL 2 ///Adam Sucks
 
 /////////////////////////////////////////////////////////////////////////////////////////
 					// MEDICINE REAGENTS

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1,7 +1,7 @@
 #define PERF_BASE_DAMAGE		0.5
 #define REAGENT_REVIVE_MINIMUM_HEALTH (HEALTH_THRESHOLD_CRIT + 20)
 /// Required strange reagent for revival.
-#define REQUIRED_STRANGE_REAGENT_FOR_REVIVAL 2 ///Adam Sucks
+#define REQUIRED_STRANGE_REAGENT_FOR_REVIVAL 2
 
 /////////////////////////////////////////////////////////////////////////////////////////
 					// MEDICINE REAGENTS


### PR DESCRIPTION
# Github documenting your Pull Request

each carp fillet gives 2 units of carpotoxin, if someone is actually hunting space carp they'll get 4 per, and if cargo gives a damn and buys meat crates they have a decent but still rather low chance to get 2-6 units
If something is locked THIS far behind teamwork, and causes damage, the least it can be is attainable in a usable amount.
Effectively, with it requiring rezadone to mix currently, strange reagent with this change will give 6 revives per carp flesh, up from 1. If that's too much it can be changed to 4 units to only allow 3 revivals per carp flesh.

# Wiki Documentation

strange reagent requires 2 units to work down from 10

# Changelog


:cl:  
tweak: strange reagent requires 2 units to work down from 10
/:cl:
