### PR TITLE
strange reagent properly causees damage 3: slimepeople and speedmerges

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -872,7 +872,7 @@
 			M.adjustBruteLoss(-100)
 			M.adjustFireLoss(-100)
 			M.adjustOxyLoss(-200, 0)
-			M.adjustToxLoss(-200, 0)
+			M.adjustToxLoss(-200, 0, TRUE)
 			M.adjustCloneLoss(max(REAGENT_REVIVE_MINIMUM_HEALTH - M.getCloneLoss(), 0))
 			M.updatehealth()
 			if(M.revive())


### PR DESCRIPTION
sets forced to true so it doesn't instakill toxinlovers for fucks SAKE

:cl:  
tweak: strange reagent won't kill slimepeople
/:cl:
