### PR TITLE
Disables using a default vote option for people who do not vote on map votes

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -166,7 +166,7 @@ VOTE_PERIOD 600
 # NO_DEAD_VOTE
 
 ## players' votes default to "No vote" (otherwise,  default to "No change")
-# DEFAULT_NO_VOTE
+DEFAULT_NO_VOTE
 
 ## disable abandon mob
 NORESPAWN


### PR DESCRIPTION
# Github documenting your Pull Request

Currently when voting on maps, if you do not vote on a map vote, your preference is used. This change requires players to actually vote for the map they want.

# Changelog

:cl:  
rscdel: Removed default vote on map votes
/:cl:
