### PR TITLE
Disables all maps that are not box

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -20,21 +20,25 @@ endmap
 map omegastation
 	maxplayers 35
 	votable
+	disabled 
 endmap
 
 map yogsmeta
 	minplayers 25
 	votable
+	disabled 
 endmap
 
 map yogsdelta
 	minplayers 50
 	votable
+	disabled 
 endmap
 
 map kilostation
 	maxplayers 40
 	votable
+	disabled 
 endmap
 
 map icebox


### PR DESCRIPTION
# Github documenting your Pull Request

People don't like playing on not box, so now we wont

# Wiki Documentation

Remove all non box from in rotation maps

# Changelog

:cl:  
rscdel: Removed all non box maps from rotation
/:cl:
