### PR TITLE
[s] Patch a server crashing exploit (#61057)

### DIFF
--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -28,6 +28,8 @@
 //INDEXES
 #define COOLDOWN_BORG_SELF_REPAIR	"borg_self_repair"
 
+// item cooldowns
+#define COOLDOWN_SIGNALLER_SEND "cooldown_signaller_send"
 
 //TIMER COOLDOWN MACROS
 

--- a/code/game/communications.dm
+++ b/code/game/communications.dm
@@ -164,6 +164,7 @@ GLOBAL_LIST_INIT(reverseradiochannels, list(
 				if(start_point.z != end_point.z || (range > 0 && get_dist(start_point, end_point) > range))
 					continue
 			device.receive_signal(signal)
+			CHECK_TICK
 
 /datum/radio_frequency/proc/add_listener(obj/device, filter as text|null)
 	if (!filter)

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -76,6 +76,10 @@
 
 	switch(action)
 		if("signal")
+			if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_SIGNALLER_SEND))
+				to_chat(usr, span_warning("[src] is still recharging..."))
+				return
+			TIMER_COOLDOWN_START(src, COOLDOWN_SIGNALLER_SEND, 1 SECONDS)
 			INVOKE_ASYNC(src, .proc/signal)
 			. = TRUE
 		if("freq")

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -77,7 +77,7 @@
 	switch(action)
 		if("signal")
 			if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_SIGNALLER_SEND))
-				to_chat(usr, span_warning("[src] is still recharging..."))
+				to_chat(usr, "<span class='warning'>[src] is still recharging...</span>")
 				return
 			TIMER_COOLDOWN_START(src, COOLDOWN_SIGNALLER_SEND, 1 SECONDS)
 			INVOKE_ASYNC(src, .proc/signal)


### PR DESCRIPTION
# Github documenting your Pull Request

if you create a bunch of signallers then spam the send signal button you can grind the server to a halt at low numbers and crash it at high numbers of signallers

This is an imperfect fix as a proper fix would refactor signal datums to use a subsystem but I dont feel like rewriting all of signal code thank you very much

Ports tgstation/tgstation#61057

# Changelog

:cl:  TiviPlus
bugfix: fixed exploit with signallers
/:cl:
