### PR TITLE
reduces shitcode in SMESes

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -416,9 +416,7 @@
 	outputting = output_attempt
 	output_level = rand(0, output_level_max)
 	input_level = rand(0, input_level_max)
-	charge -= 1e6/severity
-	if (charge < 0)
-		charge = 0
+	charge = max(charge - 1e6/severity, 0)
 	update_icon()
 	log_smes()
 
@@ -427,7 +425,7 @@
 
 /obj/machinery/power/smes/magical
 	name = "magical power storage unit"
-	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit. Magically produces power."
+	desc = "A high-capacity superconducting magical energy storage (SMES) unit. Magically produces power."
 
 /obj/machinery/power/smes/magical/process()
 	capacity = INFINITY


### PR DESCRIPTION
# Github documenting your Pull Request

why use 3 lines when I can use 1

:cl:  
tweak: SMES emp takes up less lines of code (no gameplay interaction)
bugfix: the magical SMES's name now uses proper terminology
/:cl:
