### PR TITLE
Changes heretic progression to allow for more experimentation

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -84,12 +84,23 @@
 #define CONTRACT_UPLINK_PAGE_CONTRACTS "CONTRACTS"
 #define CONTRACT_UPLINK_PAGE_HUB "HUB"
 
+///Heretics
 ///It is faster as a macro than a proc
 #define IS_HERETIC(mob) (mob.mind?.has_antag_datum(/datum/antagonist/heretic))
 #define IS_HERETIC_MONSTER(mob) (mob.mind?.has_antag_datum(/datum/antagonist/heretic_monster))
+#define IS_EXCLUSIVE_KNOWLEDGE(knowledge) (knowledge.tier % 2)
 
 #define PATH_SIDE "Side"
 
 #define PATH_ASH "Ash"
 #define PATH_RUST "Rust"
 #define PATH_FLESH "Flesh"
+
+#define TIER_NONE 0
+#define TIER_PATH 1
+#define TIER_1 2
+#define TIER_MARK 3
+#define TIER_2 4
+#define TIER_BLADE 5
+#define TIER_3 6
+#define TIER_ASCEND 7

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -223,9 +223,11 @@
 	if(!initialized_knowledge.tier == TIER_NONE && knowledge_tier != TIER_ASCEND)
 		if(IS_EXCLUSIVE_KNOWLEDGE(initialized_knowledge))
 			knowledge_tier++
+			to_chat(owner, "<span class='cultbold'>Your new knowledge brings you a breakthrough! you are now able to research a new group of subjects.</span>")
 		else if(initialized_knowledge.tier == knowledge_tier && ++tier_counter == 3)
 			knowledge_tier++
 			tier_counter = 0
+			to_chat(owner, "<span class='cultbold'>Your studies are bearing fruit, you are on the edge of a breakthrough...</span>")
 	return TRUE
 
 /datum/antagonist/heretic/proc/get_researchable_knowledge()

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -11,6 +11,18 @@
 	var/total_sacrifices = 0
 	var/ascended = FALSE
 	var/charge = 1
+///current tier of knowledge this heretic is on, each level unlocks new knowledge bits
+	var/knowledge_tier = TIER_PATH //oh boy this is going to be fun
+///tracks the number of knowledges to next tier, currently 3
+	var/tier_counter = 0
+///list of knowledges available, by path. every odd tier is an exclusive upgrade, and every even one is a set of upgrades of which 3 need to be picked to move on.
+	var/list/knowledges = list(	TIER_PATH = list(/datum/eldritch_knowledge/base_ash, /datum/eldritch_knowledge/base_flesh, /datum/eldritch_knowledge/base_rust),
+	 							TIER_1 = list(/datum/eldritch_knowledge/ashen_shift, /datum/eldritch_knowledge/ashen_eyes, /datum/eldritch_knowledge/flesh_ghoul, /datum/eldritch_knowledge/rust_regen, /datum/eldritch_knowledge/armor, /datum/eldritch_knowledge/essence),
+	 							TIER_MARK = list(/datum/eldritch_knowledge/ash_mark, /datum/eldritch_knowledge/flesh_mark, /datum/eldritch_knowledge/rust_mark),
+	 							TIER_2 = list(/datum/eldritch_knowledge/blindness, /datum/eldritch_knowledge/corrosion, /datum/eldritch_knowledge/paralysis, /datum/eldritch_knowledge/raw_prophet, /datum/eldritch_knowledge/blood_siphon, /datum/eldritch_knowledge/area_conversion),
+	 							TIER_BLADE = list(/datum/eldritch_knowledge/ash_blade_upgrade, /datum/eldritch_knowledge/flesh_blade_upgrade, /datum/eldritch_knowledge/rust_blade_upgrade),
+	 							TIER_3 = list(/datum/eldritch_knowledge/flame_birth, /datum/eldritch_knowledge/cleave, /datum/eldritch_knowledge/stalker, /datum/eldritch_knowledge/ashy, /datum/eldritch_knowledge/rusty, /datum/eldritch_knowledge/entropic_plume),
+	 							TIER_ASCEND = list(/datum/eldritch_knowledge/ash_final, /datum/eldritch_knowledge/flesh_final, /datum/eldritch_knowledge/rust_final))
 
 /datum/antagonist/heretic/admin_add(datum/mind/new_owner,mob/admin)
 	give_equipment = FALSE
@@ -208,6 +220,12 @@
 	researched_knowledge[initialized_knowledge.type] = initialized_knowledge
 	initialized_knowledge.on_gain(owner.current)
 	charge -= initialized_knowledge.cost
+	if(!initialized_knowledge.tier == TIER_NONE && knowledge_tier != TIER_ASCEND)
+		if(IS_EXCLUSIVE_KNOWLEDGE(initialized_knowledge))
+			knowledge_tier++
+		else if(initialized_knowledge.tier == knowledge_tier && ++tier_counter == 3)
+			knowledge_tier++
+			tier_counter = 0
 	return TRUE
 
 /datum/antagonist/heretic/proc/get_researchable_knowledge()
@@ -215,9 +233,11 @@
 	var/list/banned_knowledge = list()
 	for(var/X in researched_knowledge)
 		var/datum/eldritch_knowledge/EK = researched_knowledge[X]
-		researchable_knowledge |= EK.next_knowledge
 		banned_knowledge |= EK.banned_knowledge
 		banned_knowledge |= EK.type
+	for(var/i in TIER_PATH to knowledge_tier)
+		for(var/knowledge in knowledges[i])
+			researchable_knowledge += knowledge
 	researchable_knowledge -= banned_knowledge
 	return researchable_knowledge
 

--- a/code/modules/antagonists/eldritch_cult/eldritch_book.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_book.dm
@@ -91,6 +91,7 @@
 		lore["type"] = EK.type
 		lore["name"] = EK.name
 		lore["cost"] = EK.cost
+		lore["progression"] = EK.tier == cultie.knowledge_tier
 		lore["disabled"] = EK.cost <= cultie.charge ? FALSE : TRUE
 		lore["path"] = EK.route
 		lore["state"] = "Research"

--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -15,8 +15,8 @@
 	var/gain_text = ""
 	///Cost of knowledge in souls
 	var/cost = 0
-	///Next knowledge in the research tree
-	var/list/next_knowledge = list()
+	///tier of the spell, 3 of any tier is required to purchase the next ugprade knowledge, and upgrades unlock the next tier. TIER_NONE will not advance anything.
+	var/tier = TIER_NONE
 	///What knowledge is incompatible with this. This will simply make it impossible to research knowledges that are in banned_knowledge once this gets researched.
 	var/list/banned_knowledge = list()
 	///What path is this on defaults to "Side"
@@ -86,7 +86,6 @@
 	name = "Break of Dawn"
 	desc = "Starts your journey in the mansus. Allows you to select a target transmuting a living heart on a transmutation rune, create new living hearts by transmuting a heart, poppy, and pool of blood, and create new codex cicatrixes by transmuting human skin, a bible, a poppy and a pen."
 	gain_text = "Gates of mansus open up to your mind."
-	next_knowledge = list(/datum/eldritch_knowledge/base_rust,/datum/eldritch_knowledge/base_ash,/datum/eldritch_knowledge/base_flesh)
 	cost = 0
 	spells_to_add = list(/obj/effect/proc_holder/spell/targeted/touch/mansus_grasp)
 	unlocked_transmutations = list(/datum/eldritch_transmutation/basic, /datum/eldritch_transmutation/living_heart, /datum/eldritch_transmutation/codex_cicatrix, /datum/eldritch_transmutation/recall)

--- a/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
@@ -1,31 +1,14 @@
 /datum/eldritch_knowledge/base_ash
 	name = "Nightwatcher's Secret"
-	desc = "Opens up the path of ash to you. Allows you to transmute a match with a knife or its derivatives into an ashen blade."
+	desc = "Opens up the path of ash to you. Allows you to transmute a match with a knife or its derivatives into an ashen blade. Additionally empowers your mansus grasp to throw away enemies."
 	gain_text = "The City Guard knows their watch. If you ask them past dusk they may tell you tales of the Ashy Lantern."
 	banned_knowledge = list(/datum/eldritch_knowledge/base_rust,/datum/eldritch_knowledge/base_flesh,/datum/eldritch_knowledge/rust_final,/datum/eldritch_knowledge/flesh_final)
-	next_knowledge = list(/datum/eldritch_knowledge/ashen_grasp)
 	unlocked_transmutations = list(/datum/eldritch_transmutation/ash_knife)
 	cost = 1
 	route = PATH_ASH
+	tier = TIER_PATH
 
-/datum/eldritch_knowledge/ashen_shift
-	name = "Ashen Shift"
-	gain_text = "Ash is so simple, yet so numerous. Is it possible to master it all?"
-	desc = "Short range jaunt that can help you escape from bad situations."
-	cost = 1
-	spells_to_add = list(/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift/ash)
-	next_knowledge = list(/datum/eldritch_knowledge/ash_mark,/datum/eldritch_knowledge/essence,/datum/eldritch_knowledge/ashen_eyes)
-	route = PATH_ASH
-
-/datum/eldritch_knowledge/ashen_grasp
-	name = "Grasp of Ash"
-	gain_text = "Gates have opened, minds have flooded, only I remain."
-	desc = "Empowers your mansus grasp to throw away enemies."
-	cost = 1
-	next_knowledge = list(/datum/eldritch_knowledge/ashen_shift)
-	route = PATH_ASH
-
-/datum/eldritch_knowledge/ashen_grasp/on_mansus_grasp(atom/target, mob/user, proximity_flag, click_parameters)
+/datum/eldritch_knowledge/base_ash/on_mansus_grasp(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
 	if(!iscarbon(target))
 		return
@@ -46,13 +29,22 @@
 		C.throw_at(throw_target, rand(4,8), 14, user)
 	return
 
+/datum/eldritch_knowledge/ashen_shift
+	name = "Ashen Shift"
+	gain_text = "Ash is so simple, yet so numerous. Is it possible to master it all?"
+	desc = "Short range jaunt that can help you escape from bad situations."
+	cost = 1
+	spells_to_add = list(/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift/ash)
+	route = PATH_ASH
+	tier = TIER_1
+
 /datum/eldritch_knowledge/ashen_eyes
 	name = "Ashen Eyes"
 	gain_text = "These piercing eyes may guide me through the mundane."
 	desc = "Allows you to craft an eldritch amulet by transmutating eyes with a glass shard. When worn, the amulet will give you thermal vision."
 	unlocked_transmutations = list(/datum/eldritch_transmutation/ashen_eyes)
 	cost = 1
-	next_knowledge = list(/datum/eldritch_knowledge/ashen_shift,/datum/eldritch_knowledge/flesh_ghoul)
+	tier = TIER_1
 
 
 /datum/eldritch_knowledge/ash_mark
@@ -60,9 +52,9 @@
 	gain_text = "Spread the famine."
 	desc = "Your sickly blade now applies ash mark on hit. Use your mansus grasp to detonate the mark. The Mark of Ash causes stamina damage, and fire loss, and spreads to a nearby carbon. Damage decreases with how many times the mark has spread."
 	cost = 2
-	next_knowledge = list(/datum/eldritch_knowledge/blindness)
 	banned_knowledge = list(/datum/eldritch_knowledge/rust_mark,/datum/eldritch_knowledge/flesh_mark)
 	route = PATH_ASH
+	tier = TIER_MARK
 
 /datum/eldritch_knowledge/ash_mark/on_eldritch_blade(target,user,proximity_flag,click_parameters)
 	. = ..()
@@ -76,26 +68,33 @@
 	desc = "Curse someone with 2 minutes of complete blindness by transmuting a pair of eyes, a screwdriver and a pool of blood, with an object that the victim has touched with their bare hands."
 	cost = 1
 	unlocked_transmutations = list(/datum/eldritch_transmutation/curse/blindness)
-	next_knowledge = list(/datum/eldritch_knowledge/corrosion,/datum/eldritch_knowledge/ash_blade_upgrade,/datum/eldritch_knowledge/paralysis)
 	route = PATH_ASH
+	tier = TIER_2
 
-/datum/eldritch_knowledge/flame_birth
-	name = "Flame Birth"
-	gain_text = "The Nightwatcher was a man of principles, and yet he arose from the chaos he vowed to protect from."
-	desc = "A healing spell that saps the life from those combusted nearby."
+/datum/eldritch_knowledge/corrosion
+	name = "Curse of Corrosion"
+	gain_text = "Cursed land, Cursed man, Cursed mind."
+	desc = "Curse someone for 2 minutes of vomiting and major organ damage by transmuting a wirecutter, a spill of blood, a heart, left arm and a right arm, and an item that the victim touched  with their bare hands."
 	cost = 1
-	spells_to_add = list(/obj/effect/proc_holder/spell/targeted/fiery_rebirth)
-	next_knowledge = list(/datum/eldritch_knowledge/cleave,/datum/eldritch_knowledge/ashy,/datum/eldritch_knowledge/ash_final)
-	route = PATH_ASH
+	unlocked_transmutations = list(/datum/eldritch_transmutation/curse/corrosion)
+	tier = TIER_2
+
+/datum/eldritch_knowledge/paralysis
+	name = "Curse of Paralysis"
+	gain_text = "Corrupt their flesh, make them suffer."
+	desc = "Curse someone for 5 minutes of inability to walk. Using a knife, pool of blood, left leg, right leg, a hatchet and an item that the victim touched with their bare hands. "
+	cost = 1
+	unlocked_transmutations = list(/datum/eldritch_transmutation/curse/paralysis)
+	tier = TIER_2
 
 /datum/eldritch_knowledge/ash_blade_upgrade
 	name = "Fiery Blade"
 	gain_text = "May the sun burn the heretics."
 	desc = "Your blade of choice will now add firestacks."
 	cost = 2
-	next_knowledge = list(/datum/eldritch_knowledge/flame_birth)
 	banned_knowledge = list(/datum/eldritch_knowledge/rust_blade_upgrade,/datum/eldritch_knowledge/flesh_blade_upgrade)
 	route = PATH_ASH
+	tier = TIER_BLADE
 
 /datum/eldritch_knowledge/ash_blade_upgrade/on_eldritch_blade(target,user,proximity_flag,click_parameters)
 	. = ..()
@@ -104,21 +103,14 @@
 		C.adjust_fire_stacks(1)
 		C.IgniteMob()
 
-/datum/eldritch_knowledge/corrosion
-	name = "Curse of Corrosion"
-	gain_text = "Cursed land, Cursed man, Cursed mind."
-	desc = "Curse someone for 2 minutes of vomiting and major organ damage by transmuting a wirecutter, a spill of blood, a heart, left arm and a right arm, and an item that the victim touched  with their bare hands."
+/datum/eldritch_knowledge/flame_birth
+	name = "Flame Birth"
+	gain_text = "The Nightwatcher was a man of principles, and yet he arose from the chaos he vowed to protect from."
+	desc = "A healing spell that saps the life from those combusted nearby."
 	cost = 1
-	unlocked_transmutations = list(/datum/eldritch_transmutation/curse/corrosion)
-	next_knowledge = list(/datum/eldritch_knowledge/blindness,/datum/eldritch_knowledge/area_conversion)
-
-/datum/eldritch_knowledge/paralysis
-	name = "Curse of Paralysis"
-	gain_text = "Corrupt their flesh, make them suffer."
-	desc = "Curse someone for 5 minutes of inability to walk. Using a knife, pool of blood, left leg, right leg, a hatchet and an item that the victim touched with their bare hands. "
-	cost = 1
-	unlocked_transmutations = list(/datum/eldritch_transmutation/curse/paralysis)
-	next_knowledge = list(/datum/eldritch_knowledge/blindness,/datum/eldritch_knowledge/raw_prophet)
+	spells_to_add = list(/obj/effect/proc_holder/spell/targeted/fiery_rebirth)
+	route = PATH_ASH
+	tier = TIER_3
 
 /datum/eldritch_knowledge/cleave
 	name = "Blood Cleave"
@@ -126,7 +118,7 @@
 	desc = "Gives AOE spell that causes heavy bleeding and blood loss."
 	cost = 1
 	spells_to_add = list(/obj/effect/proc_holder/spell/pointed/cleave)
-	next_knowledge = list(/datum/eldritch_knowledge/entropic_plume,/datum/eldritch_knowledge/flame_birth)
+	tier = TIER_3
 
 /datum/eldritch_knowledge/ash_final
 	name = "Ashlord's Rite"
@@ -135,3 +127,4 @@
 	cost = 3
 	unlocked_transmutations = list(/datum/eldritch_transmutation/final/ash_final)
 	route = PATH_ASH
+	tier = TIER_ASCEND

--- a/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
@@ -2,7 +2,7 @@
 	name = "Nightwatcher's Secret"
 	desc = "Opens up the path of ash to you. Allows you to transmute a match with a knife or its derivatives into an ashen blade. Additionally empowers your mansus grasp to throw away enemies."
 	gain_text = "The City Guard knows their watch. If you ask them past dusk they may tell you tales of the Ashy Lantern."
-	banned_knowledge = list(/datum/eldritch_knowledge/base_rust,/datum/eldritch_knowledge/base_flesh,/datum/eldritch_knowledge/rust_final,/datum/eldritch_knowledge/flesh_final)
+	banned_knowledge = list(/datum/eldritch_knowledge/base_rust,/datum/eldritch_knowledge/base_flesh,/datum/eldritch_knowledge/rust_mark,/datum/eldritch_knowledge/flesh_mark,/datum/eldritch_knowledge/rust_blade_upgrade,/datum/eldritch_knowledge/flesh_blade_upgrade,/datum/eldritch_knowledge/rust_final,/datum/eldritch_knowledge/flesh_final)
 	unlocked_transmutations = list(/datum/eldritch_transmutation/ash_knife)
 	cost = 1
 	route = PATH_ASH

--- a/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
@@ -1,33 +1,16 @@
 /datum/eldritch_knowledge/base_flesh
 	name = "Principle of Hunger"
-	desc = "Opens up the path of flesh to you. Allows you to transmute a pool of blood with a knife into a Flesh Blade"
+	desc = "Opens up the path of flesh to you. Allows you to transmute a pool of blood with a knife into a Flesh Blade. Additionally, your mansus grasp now raises dead players into subservient ghouls, this does not work on husks or mindshielded people and husks the person it's used on."
 	gain_text = "Hundreds of us starved, but I.. I found the strength in my greed."
 	banned_knowledge = list(/datum/eldritch_knowledge/base_ash,/datum/eldritch_knowledge/base_rust,/datum/eldritch_knowledge/ash_final,/datum/eldritch_knowledge/rust_final)
-	next_knowledge = list(/datum/eldritch_knowledge/flesh_grasp)
 	cost = 1
 	unlocked_transmutations = list(/datum/eldritch_transmutation/flesh_blade)
 	route = PATH_FLESH
-
-/datum/eldritch_knowledge/flesh_ghoul
-	name = "Imperfect Ritual"
-	desc = "Allows you to resurrect the dead as voiceless dead by sacrificing them on the transmutation rune with a poppy. Voiceless dead are mute and have 50 HP. You can only have 2 at a time."
-	gain_text = "I found notes.. notes of a ritual, it was unfinished and yet I still did it."
-	cost = 1
-	next_knowledge = list(/datum/eldritch_knowledge/flesh_mark,/datum/eldritch_knowledge/armor,/datum/eldritch_knowledge/ashen_eyes)
-	unlocked_transmutations = list(/datum/eldritch_transmutation/voiceless_dead)
-	route = PATH_FLESH
-
-/datum/eldritch_knowledge/flesh_grasp
-	name = "Grasp of Flesh"
-	gain_text = "My newfound desire, it drove me to do great things! To revoke the grasp of death! The Priest said."
-	desc = "Empowers your mansus grasp to be able to create a single ghoul out of a dead person. Ghouls have only 25 HP and become husked."
-	cost = 1
-	next_knowledge = list(/datum/eldritch_knowledge/flesh_ghoul)
+	tier = TIER_PATH
 	var/ghoul_amt = 1
 	var/list/spooky_scaries
-	route = PATH_FLESH
 
-/datum/eldritch_knowledge/flesh_grasp/on_mansus_grasp(atom/target, mob/user, proximity_flag, click_parameters)
+/datum/eldritch_knowledge/base_flesh/on_mansus_grasp(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
 	if(!ishuman(target) || target == user)
 		return
@@ -77,20 +60,29 @@
 	return
 
 
-/datum/eldritch_knowledge/flesh_grasp/proc/remove_ghoul(datum/source)
+/datum/eldritch_knowledge/base_flesh/proc/remove_ghoul(datum/source)
 	var/mob/living/carbon/human/humie = source
 	spooky_scaries -= humie
 	humie.mind.remove_antag_datum(/datum/antagonist/heretic_monster)
 	UnregisterSignal(source, COMSIG_MOB_DEATH)
+
+/datum/eldritch_knowledge/flesh_ghoul
+	name = "Imperfect Ritual"
+	desc = "Allows you to resurrect the dead as voiceless dead by sacrificing them on the transmutation rune with a poppy. Voiceless dead are mute and have 50 HP. You can only have 2 at a time."
+	gain_text = "I found notes.. notes of a ritual, it was unfinished and yet I still did it."
+	cost = 1
+	unlocked_transmutations = list(/datum/eldritch_transmutation/voiceless_dead)
+	route = PATH_FLESH
+	tier = TIER_1
 
 /datum/eldritch_knowledge/flesh_mark
 	name = "Mark of flesh"
 	gain_text = "I saw them, the Marked ones. The screams.. the silence."
 	desc = "Your sickly blade now applies mark of flesh status effect. To activate the mark, use your mansus grasp on the marked. Mark of flesh when procced causeds additional bleeding."
 	cost = 2
-	next_knowledge = list(/datum/eldritch_knowledge/raw_prophet)
 	banned_knowledge = list(/datum/eldritch_knowledge/rust_mark,/datum/eldritch_knowledge/ash_mark)
 	route = PATH_FLESH
+	tier = TIER_MARK
 
 /datum/eldritch_knowledge/flesh_mark/on_eldritch_blade(target,user,proximity_flag,click_parameters)
 	. = ..()
@@ -98,54 +90,14 @@
 		var/mob/living/living_target = target
 		living_target.apply_status_effect(/datum/status_effect/eldritch/flesh)
 
-/datum/eldritch_knowledge/flesh_blade_upgrade
-	name = "Bleeding Steel"
-	gain_text = "It rained blood, that's when I understood The Gravekeeper's advice."
-	desc = "Your blade will now cause additional bleeding."
-	cost = 2
-	next_knowledge = list(/datum/eldritch_knowledge/stalker)
-	banned_knowledge = list(/datum/eldritch_knowledge/ash_blade_upgrade,/datum/eldritch_knowledge/rust_blade_upgrade)
-	route = PATH_FLESH
-
-/datum/eldritch_knowledge/flesh_blade_upgrade/on_eldritch_blade(target,user,proximity_flag,click_parameters)
-	. = ..()
-	if(ishuman(target))
-		var/mob/living/carbon/human/H = target
-		H.bleed_rate += 3
-
 /datum/eldritch_knowledge/raw_prophet
 	name = "Raw Ritual"
 	gain_text = "I saw the mirror-sheen in their dead eyes. It could be put to use."
 	desc = "You can now summon a Raw Prophet by transmuting eyes, a left arm and a right arm. Raw prophets have a massive sight range, X-ray, and can sustain a telepathic network, but are very fragile and weak."
 	cost = 1
-	next_knowledge = list(/datum/eldritch_knowledge/flesh_blade_upgrade,/datum/eldritch_knowledge/blood_siphon,/datum/eldritch_knowledge/paralysis)
 	unlocked_transmutations = list(/datum/eldritch_transmutation/summon/raw_prophet)
 	route = PATH_FLESH
-
-/datum/eldritch_knowledge/stalker
-	name = "Lonely Ritual"
-	gain_text = " The Uncanny Man walks lonely in the Valley, I called for his aid."
-	desc = "You can now summon a Stalker by transmuting a knife, a candle, a pen and a piece of paper. Stalkers can shapeshift into harmeless animals and have access to an EMP."
-	cost = 1
-	next_knowledge = list(/datum/eldritch_knowledge/ashy,/datum/eldritch_knowledge/rusty,/datum/eldritch_knowledge/flesh_final)
-	unlocked_transmutations = list(/datum/eldritch_transmutation/summon/stalker)
-	route = PATH_FLESH
-
-/datum/eldritch_knowledge/ashy
-	name = "Ashen Ritual"
-	gain_text = "I combined the principle of Hunger with a desire for Destruction. The Eyeful Lords took notice."
-	desc = "You can now summon an Ash Man by transmutating a pile of ash, a head and a book. Ash Men have powerful offensive abilities and access to the Ash Passage spell."
-	cost = 1
-	next_knowledge = list(/datum/eldritch_knowledge/stalker,/datum/eldritch_knowledge/flame_birth)
-	unlocked_transmutations = list(/datum/eldritch_transmutation/summon/ashy)
-
-/datum/eldritch_knowledge/rusty
-	name = "Rusted Ritual"
-	gain_text = "I combined the principle of Hunger with a desire of Corruption. The Rusted Hills call my name."
-	desc = "You can now summon a Rust Walker transmutating vomit pool and a book. Rust Walkers are capable of spreading rust and have a decent but short ranged projectile attack."
-	cost = 1
-	next_knowledge = list(/datum/eldritch_knowledge/stalker,/datum/eldritch_knowledge/entropic_plume)
-	unlocked_transmutations = list(/datum/eldritch_transmutation/summon/rusty)
+	tier = TIER_2
 
 /datum/eldritch_knowledge/blood_siphon
 	name = "Blood Siphon"
@@ -153,7 +105,47 @@
 	desc = "You gain a spell that drains enemies health and restores yours."
 	cost = 1
 	spells_to_add = list(/obj/effect/proc_holder/spell/targeted/touch/blood_siphon)
-	next_knowledge = list(/datum/eldritch_knowledge/raw_prophet,/datum/eldritch_knowledge/area_conversion)
+	tier = TIER_2
+
+/datum/eldritch_knowledge/flesh_blade_upgrade
+	name = "Bleeding Steel"
+	gain_text = "It rained blood, that's when I understood The Gravekeeper's advice."
+	desc = "Your blade will now cause additional bleeding."
+	cost = 2
+	banned_knowledge = list(/datum/eldritch_knowledge/ash_blade_upgrade,/datum/eldritch_knowledge/rust_blade_upgrade)
+	route = PATH_FLESH
+	tier = TIER_BLADE
+
+/datum/eldritch_knowledge/flesh_blade_upgrade/on_eldritch_blade(target,user,proximity_flag,click_parameters)
+	. = ..()
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		H.bleed_rate += 3
+
+/datum/eldritch_knowledge/stalker
+	name = "Lonely Ritual"
+	gain_text = " The Uncanny Man walks lonely in the Valley, I called for his aid."
+	desc = "You can now summon a Stalker by transmuting a knife, a candle, a pen and a piece of paper. Stalkers can shapeshift into harmeless animals and have access to an EMP."
+	cost = 1
+	unlocked_transmutations = list(/datum/eldritch_transmutation/summon/stalker)
+	route = PATH_FLESH
+	tier = TIER_3
+
+/datum/eldritch_knowledge/ashy
+	name = "Ashen Ritual"
+	gain_text = "I combined the principle of Hunger with a desire for Destruction. The Eyeful Lords took notice."
+	desc = "You can now summon an Ash Man by transmutating a pile of ash, a head and a book. Ash Men have powerful offensive abilities and access to the Ash Passage spell."
+	cost = 1
+	unlocked_transmutations = list(/datum/eldritch_transmutation/summon/ashy)
+	tier = TIER_3
+
+/datum/eldritch_knowledge/rusty
+	name = "Rusted Ritual"
+	gain_text = "I combined the principle of Hunger with a desire of Corruption. The Rusted Hills call my name."
+	desc = "You can now summon a Rust Walker transmutating vomit pool and a book. Rust Walkers are capable of spreading rust and have a decent but short ranged projectile attack."
+	cost = 1
+	unlocked_transmutations = list(/datum/eldritch_transmutation/summon/rusty)
+	tier = TIER_3
 
 /datum/eldritch_knowledge/flesh_final
 	name = "Priest's Final Hymn"
@@ -162,3 +154,4 @@
 	cost = 3
 	route = PATH_FLESH
 	unlocked_transmutations = list(/datum/eldritch_transmutation/final/flesh_final)
+	tier = TIER_ASCEND

--- a/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
@@ -2,7 +2,7 @@
 	name = "Principle of Hunger"
 	desc = "Opens up the path of flesh to you. Allows you to transmute a pool of blood with a knife into a Flesh Blade. Additionally, your mansus grasp now raises dead players into subservient ghouls, this does not work on husks or mindshielded people and husks the person it's used on."
 	gain_text = "Hundreds of us starved, but I.. I found the strength in my greed."
-	banned_knowledge = list(/datum/eldritch_knowledge/base_ash,/datum/eldritch_knowledge/base_rust,/datum/eldritch_knowledge/ash_final,/datum/eldritch_knowledge/rust_final)
+	banned_knowledge = list(/datum/eldritch_knowledge/base_ash,/datum/eldritch_knowledge/base_rust,/datum/eldritch_knowledge/ash_mark,/datum/eldritch_knowledge/rust_mark,/datum/eldritch_knowledge/ash_blade_upgrade,/datum/eldritch_knowledge/rust_blade_upgrade,/datum/eldritch_knowledge/ash_final,/datum/eldritch_knowledge/rust_final)
 	cost = 1
 	unlocked_transmutations = list(/datum/eldritch_transmutation/flesh_blade)
 	route = PATH_FLESH

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -2,7 +2,7 @@
 	name = "Blacksmith's Tale"
 	desc = "Opens up the path of rust to you. Allows you to transmute a knife with any trash item into a Rusty Blade. Additionally, your mansus grasp now deal 500 damage to inorganic matter. Rusts any surface it's used on, and destroys any surface that is already rusty."
 	gain_text = "Let me tell you a story, The Blacksmith said as he gazed into his rusty blade."
-	banned_knowledge = list(/datum/eldritch_knowledge/base_ash,/datum/eldritch_knowledge/base_flesh,/datum/eldritch_knowledge/ash_final,/datum/eldritch_knowledge/flesh_final)
+	banned_knowledge = list(/datum/eldritch_knowledge/base_ash,/datum/eldritch_knowledge/base_flesh,/datum/eldritch_knowledge/ash_mark,/datum/eldritch_knowledge/flesh_mark,/datum/eldritch_knowledge/ash_blade_upgrade,/datum/eldritch_knowledge/flesh_blade_upgrade,/datum/eldritch_knowledge/ash_final,/datum/eldritch_knowledge/flesh_final)
 	cost = 1
 	unlocked_transmutations = list(/datum/eldritch_transmutation/rust_blade)
 	route = PATH_RUST

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -1,24 +1,14 @@
 /datum/eldritch_knowledge/base_rust
 	name = "Blacksmith's Tale"
-	desc = "Opens up the path of rust to you. Allows you to transmute a knife with any trash item into a Rusty Blade."
+	desc = "Opens up the path of rust to you. Allows you to transmute a knife with any trash item into a Rusty Blade. Additionally, your mansus grasp now deal 500 damage to inorganic matter. Rusts any surface it's used on, and destroys any surface that is already rusty."
 	gain_text = "Let me tell you a story, The Blacksmith said as he gazed into his rusty blade."
 	banned_knowledge = list(/datum/eldritch_knowledge/base_ash,/datum/eldritch_knowledge/base_flesh,/datum/eldritch_knowledge/ash_final,/datum/eldritch_knowledge/flesh_final)
-	next_knowledge = list(/datum/eldritch_knowledge/rust_fist)
 	cost = 1
 	unlocked_transmutations = list(/datum/eldritch_transmutation/rust_blade)
 	route = PATH_RUST
+	tier = TIER_PATH
 
-/datum/eldritch_knowledge/rust_fist
-	name = "Grasp of rust"
-	desc = "Empowers your mansus grasp to deal 500 damage to non-living matter and rust any turf it touches. Destroys already rusted turfs."
-	gain_text = "Rust grows on the ceiling of the mansus."
-	cost = 1
-	next_knowledge = list(/datum/eldritch_knowledge/rust_regen)
-	var/rust_force = 500
-	var/static/list/blacklisted_turfs = typecacheof(list(/turf/closed,/turf/open/space,/turf/open/lava,/turf/open/chasm,/turf/open/floor/plating/rust))
-	route = PATH_RUST
-
-/datum/eldritch_knowledge/rust_fist/on_mansus_grasp(atom/target, mob/user, proximity_flag, click_parameters)
+/datum/eldritch_knowledge/base_rust/on_mansus_grasp(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
@@ -29,22 +19,13 @@
 	target.rust_heretic_act()
 	return TRUE
 
-/datum/eldritch_knowledge/area_conversion
-	name = "Agressive Spread"
-	desc = "Spreads rust to nearby turfs. Destroys already rusted walls."
-	gain_text = "All men wise know not to touch the bound king."
-	cost = 1
-	spells_to_add = list(/obj/effect/proc_holder/spell/aoe_turf/rust_conversion)
-	next_knowledge = list(/datum/eldritch_knowledge/rust_blade_upgrade,/datum/eldritch_knowledge/corrosion,/datum/eldritch_knowledge/blood_siphon)
-	route = PATH_RUST
-
 /datum/eldritch_knowledge/rust_regen
 	name = "Leeching Walk"
 	desc = "Passively heals you when you are on rusted tiles."
 	gain_text = "His strength was unparallel, it was unnatural. The Blacksmith was smiling."
 	cost = 1
-	next_knowledge = list(/datum/eldritch_knowledge/rust_mark,/datum/eldritch_knowledge/armor,/datum/eldritch_knowledge/essence)
 	route = PATH_RUST
+	tier = TIER_1
 
 /datum/eldritch_knowledge/rust_regen/on_life(mob/user)
 	. = ..()
@@ -58,14 +39,30 @@
 	living_user.adjustOxyLoss(-0.5, FALSE)
 	living_user.adjustStaminaLoss(-2)
 
+/datum/eldritch_knowledge/armor
+	name = "Armorer's ritual"
+	desc = "You can now create a powerful set of armor by transmuting a table and gas mask."
+	gain_text = "For I am the heir to the throne of their doom."
+	cost = 1
+	unlocked_transmutations = list(/datum/eldritch_transmutation/armor)
+	tier = TIER_1
+
+/datum/eldritch_knowledge/essence
+	name = "Priest's ritual"
+	desc = "You can now transmute a tank of water into a bottle of eldritch water."
+	gain_text = "I learned an old recipe, tought by an Owl in my dreams."
+	cost = 1
+	unlocked_transmutations = list(/datum/eldritch_transmutation/water)
+	tier = TIER_1
+
 /datum/eldritch_knowledge/rust_mark
 	name = "Mark of Rust"
 	desc = "Your eldritch blade now applies a rust mark. The Rust Mark has a chance to deal between 0 to 200 damage to 75% of enemies items. To Detonate the Mark use your mansus grasp on it."
 	gain_text = "Lords of the depths help those in dire need at a cost."
 	cost = 2
-	next_knowledge = list(/datum/eldritch_knowledge/area_conversion)
 	banned_knowledge = list(/datum/eldritch_knowledge/ash_mark,/datum/eldritch_knowledge/flesh_mark)
 	route = PATH_RUST
+	tier = TIER_MARK
 
 /datum/eldritch_knowledge/rust_mark/on_eldritch_blade(target,user,proximity_flag,click_parameters)
 	. = ..()
@@ -73,14 +70,23 @@
 		var/mob/living/living_target = target
 		living_target.apply_status_effect(/datum/status_effect/eldritch/rust)
 
+/datum/eldritch_knowledge/area_conversion
+	name = "Agressive Spread"
+	desc = "Spreads rust to nearby turfs. Destroys already rusted walls."
+	gain_text = "All men wise know not to touch the bound king."
+	cost = 1
+	spells_to_add = list(/obj/effect/proc_holder/spell/aoe_turf/rust_conversion)
+	route = PATH_RUST
+	tier = TIER_2
+
 /datum/eldritch_knowledge/rust_blade_upgrade
 	name = "Toxic blade"
 	gain_text = "Let your blade guide you through the flesh."
 	desc = "Your blade of choice will now add toxin to enemies bloodstream."
 	cost = 2
-	next_knowledge = list(/datum/eldritch_knowledge/entropic_plume)
 	banned_knowledge = list(/datum/eldritch_knowledge/ash_blade_upgrade,/datum/eldritch_knowledge/flesh_blade_upgrade)
 	route = PATH_RUST
+	tier = TIER_BLADE
 
 /datum/eldritch_knowledge/rust_blade_upgrade/on_eldritch_blade(target,user,proximity_flag,click_parameters)
 	. = ..()
@@ -94,24 +100,8 @@
 	gain_text = "Messengers of hope fear I, the Rustbringer!"
 	cost = 1
 	spells_to_add = list(/obj/effect/proc_holder/spell/cone/staggered/entropic_plume)
-	next_knowledge = list(/datum/eldritch_knowledge/rust_final,/datum/eldritch_knowledge/cleave,/datum/eldritch_knowledge/rusty)
 	route = PATH_RUST
-
-/datum/eldritch_knowledge/armor
-	name = "Armorer's ritual"
-	desc = "You can now create a powerful set of armor by transmuting a table and gas mask."
-	gain_text = "For I am the heir to the throne of their doom."
-	cost = 1
-	next_knowledge = list(/datum/eldritch_knowledge/rust_regen,/datum/eldritch_knowledge/flesh_ghoul)
-	unlocked_transmutations = list(/datum/eldritch_transmutation/armor)
-
-/datum/eldritch_knowledge/essence
-	name = "Priest's ritual"
-	desc = "You can now transmute a tank of water into a bottle of eldritch water."
-	gain_text = "I learned an old recipe, tought by an Owl in my dreams."
-	cost = 1
-	next_knowledge = list(/datum/eldritch_knowledge/rust_regen,/datum/eldritch_knowledge/ashen_shift)
-	unlocked_transmutations = list(/datum/eldritch_transmutation/water)
+	tier = TIER_3
 
 /datum/eldritch_knowledge/rust_final
 	name = "Rustbringer's Oath"
@@ -120,3 +110,4 @@
 	cost = 3
 	unlocked_transmutations = list(/datum/eldritch_transmutation/final/rust_final)
 	route = PATH_RUST
+	tier = TIER_ASCEND

--- a/code/modules/antagonists/eldritch_cult/transmutations/flesh_transmutations.dm
+++ b/code/modules/antagonists/eldritch_cult/transmutations/flesh_transmutations.dm
@@ -103,7 +103,7 @@
 			H.physiology.brute_mod *= 0.5
 			H.physiology.burn_mod *= 0.5
 			var/datum/antagonist/heretic/heretic = user.mind.has_antag_datum(/datum/antagonist/heretic)
-			var/datum/eldritch_knowledge/flesh_grasp/ghoul1 = heretic.get_knowledge(/datum/eldritch_knowledge/flesh_grasp)
+			var/datum/eldritch_knowledge/base_flesh/ghoul1 = heretic.get_knowledge(/datum/eldritch_knowledge/base_flesh)
 			ghoul1.ghoul_amt *= 3
 			var/datum/eldritch_transmutation/voiceless_dead/ghoul2 = heretic.get_transmutation(/datum/eldritch_transmutation/voiceless_dead)
 			ghoul2.max_amt *= 3

--- a/tgui/packages/tgui/interfaces/ForbiddenLore.js
+++ b/tgui/packages/tgui/interfaces/ForbiddenLore.js
@@ -34,6 +34,7 @@ export const ForbiddenLore = (props, context) => {
                   <Button
                     content={knowledge.state}
                     disabled={knowledge.disabled}
+                    color = {knowledge.progression ? 'green' : 'blue'}
                     onClick={() => act('research', {
                       name: knowledge.name,
                       cost: knowledge.cost,

--- a/tgui/packages/tgui/interfaces/ForbiddenLore.js
+++ b/tgui/packages/tgui/interfaces/ForbiddenLore.js
@@ -34,7 +34,7 @@ export const ForbiddenLore = (props, context) => {
                   <Button
                     content={knowledge.state}
                     disabled={knowledge.disabled}
-                    color = {knowledge.progression ? 'green' : 'blue'}
+                    color={knowledge.progression ? 'green' : 'blue'}
                     onClick={() => act('research', {
                       name: knowledge.name,
                       cost: knowledge.cost,


### PR DESCRIPTION
# Github documenting your Pull Request

Heretic abilities are now seperated into tiers, functioning much the same as they do currently; you can only select abilities from a "tier" you have unlocked, and purchasing abilities vertically according to the wiki chart will unlock more tiers.
However, instead of requiring abilities to be unlocked by purchasing adjacent abilities, the whole set of abilities in a row are unlocked once they are made available i.e. you can purchase path of rust then immediately purchase imperfect ritual, allowing for less of a restricted playstyle.
HOWEVER, you now ALSO are required to purchase at least 3 abilities from a tier before unlocking the mark blade or ascension tiers.

Also, the grasp upgrade for each path has been removed, and its effects placed in the path's initial selection. This means you no longer have to find an influence to actually have any antag powers.

The codex's TGUI has been updated to show what abilities will go towards the next tier (shown in green) and which ones will not (shown in blue)

# Wiki Documentation

Heretics need to purchase 3 abilities from a side-classing set of abilities to unlock the exclusive blade mark and ascension knowledges, rather than needing to purchase an adjacent ability, and sideclassing no longer requires an adjacent ability to unlock

Additionally, the grasp and base path unlocks have been merged into one knowledge, conveniently squishing their descriptions and effects.

# Changelog

:cl:  
tweak: heretics are now required to purchase 3 abilities from each set before purchasing the next set of abilities
tweak: heretics now have a nice green/blue indicator for which abilities will allow them to progress
tweak: heretics no longer need to purchase their mansus grasp upgrade seperate from their path selection, reducing the cost of progression by 1 point
/:cl:
