### PR TITLE
Add TEG Heater

### DIFF
--- a/_maps/RandomRuins/StationRuins/BoxStation/engine_teg.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/engine_teg.dmm
@@ -187,6 +187,12 @@
 	},
 /turf/template_noop,
 /area/space/nearstation)
+"cI" = (
+/obj/machinery/atmospherics/pipe/manifold/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "cL" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -513,6 +519,16 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/template_noop,
 /area/space/nearstation)
+"oD" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "oK" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/airalarm{
@@ -981,13 +997,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"AD" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "Bf" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -1070,12 +1079,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"EE" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -2300,7 +2303,7 @@ Zn
 MF
 DR
 US
-AD
+oD
 Ji
 te
 hN
@@ -2328,7 +2331,7 @@ ad
 Ar
 bC
 Bh
-EE
+cI
 PV
 pP
 Ic

--- a/_maps/RandomRuins/StationRuins/BoxStation/engine_teg.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/engine_teg.dmm
@@ -187,12 +187,6 @@
 	},
 /turf/template_noop,
 /area/space/nearstation)
-"cI" = (
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cL" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -337,12 +331,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"is" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "iD" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -452,12 +440,6 @@
 	},
 /turf/template_noop,
 /area/space/nearstation)
-"mW" = (
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "nh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
@@ -519,16 +501,6 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/template_noop,
 /area/space/nearstation)
-"oD" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "oK" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/airalarm{
@@ -714,6 +686,19 @@
 /area/space/nearstation)
 "tJ" = (
 /obj/machinery/atmospherics/pipe/manifold/dark/visible,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"tV" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "ue" = (
@@ -997,6 +982,13 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"AD" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "Bf" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -1079,6 +1071,12 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"EE" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -1415,6 +1413,10 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"Qa" = (
+/obj/machinery/atmospherics/pipe/manifold4w/orange/visible,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "Qg" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -1606,6 +1608,13 @@
 	pixel_y = -32
 	},
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"UK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/heater,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "UM" = (
@@ -2272,9 +2281,9 @@ dG
 "}
 (18,1,1) = {"
 ac
-is
-bC
-mW
+UK
+tV
+Qa
 kD
 kB
 kp
@@ -2303,7 +2312,7 @@ Zn
 MF
 DR
 US
-oD
+AD
 Ji
 te
 hN
@@ -2331,7 +2340,7 @@ ad
 Ar
 bC
 Bh
-cI
+EE
 PV
 pP
 Ic


### PR DESCRIPTION
This adds a heater to the TEG hot loop. This makes it easier for new/inexperienced engineers, or non-engineers if the station doesn't have any, to set up the engine in a stable way to provide sufficient power to the station.

I have tested this. It's not changing much so there wasn't much to test.

# Wiki Documentation

The wiki will need a rewrite for the *basic* TEG setup. I have most of it written already, I just would need to tweak it to fit what I ended up mapping.
This would replace the current "basic" setup, which involves a plasma burn. That should be kept, just perhaps as an advanced course.
The TEG image would need to be changed.

# Changelog

:cl:  
rscadd: Added heater to TEG hot loop.
/:cl:
