### PR TITLE
Removes normal footwraps from non-engi and non-miner jobs

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -241,13 +241,13 @@
 
 	if (isplasmaman(H) && !(visualsOnly)) //this is a plasmaman fix to stop having two boxes
 		box = null
-
-	if((DIGITIGRADE in H.dna.species.species_traits) && (IS_COMMAND(H))) // command gets snowflake shoes too.
-		shoes = alt_shoes_c
-	else if((DIGITIGRADE in H.dna.species.species_traits) && (IS_SECURITY(H))) // Special shoes for sec, roll first to avoid defaulting
-		shoes = alt_shoes_s
-	else if(DIGITIGRADE in H.dna.species.species_traits) // Check to assign default digitigrade shoes
-		shoes = alt_shoes
+	if(DIGITIGRADE in H.dna.species.species_traits)
+		if(IS_COMMAND(H)) // command gets snowflake shoes too.
+			shoes = alt_shoes_c
+		else if(IS_SECURITY(H)) // Special shoes for sec, roll first to avoid defaulting
+			shoes = alt_shoes_s
+		else if(find_job(H) == "Shaft Miner" || find_job(H) == "Mining Medic" || IS_ENGINEERING(H)) // Check to assign default digitigrade shoes
+			shoes = alt_shoes
 
 /datum/outfit/job/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(visualsOnly)


### PR DESCRIPTION
# Github documenting your Pull Request

Removes normal footwraps from non-engi department and non-miner jobs. The main reason for this was to make normal footwraps act as replacements for work boots instead of normal shoes.

## Why?

Because giving them to everyone makes digitigrade legs less interesting by essentially removing an interesting flaw they have. The only time you see the lack of ability to wear normal shoes is with specialized shoes, which is rare. Also, they can be crafted for two leather, so just bug botany if you really need them.

# Wiki Documentation

Will obviously need to change any place where the effected jobs were mentioned to have them. 

# Changelog

:cl:   
tweak: removed normal footwraps from non-engi department and non-miner jobs 
/:cl:
