### PR TITLE
[admin] Operation Intrude: Alert status thematic changes.

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -56,8 +56,8 @@
 #define SEC_LEVEL_GREEN		0
 #define SEC_LEVEL_BLUE		1
 #define SEC_LEVEL_RED		2
-#define SEC_LEVEL_GAMMA		3
-#define SEC_LEVEL_EPSILON	4
+#define SEC_LEVEL_BLACK		3
+#define SEC_LEVEL_OMEGA		4
 #define SEC_LEVEL_DELTA		5
 
 //some arbitrary defines to be used by self-pruning global lists. (see master_controller)

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -181,28 +181,28 @@
 /datum/config_entry/flag/arrivals_shuttle_require_safe_latejoin	//Require the arrivals shuttle to be operational in order for latejoiners to join
 
 /datum/config_entry/string/alert_green
-	config_entry_value = "All threats to the station have passed. Security may not have weapons visible, privacy laws are once again fully enforced."
+	config_entry_value = "All threats to the station have passed. Security staff may now stand down, privacy laws are once again fully enforced."
 
 /datum/config_entry/string/alert_blue_upto
-	config_entry_value = "The station has received reliable information about possible hostile activity on the station. Security staff may have weapons visible, random searches are permitted."
+	config_entry_value = "Caution! The station has received reliable information of possible hostile activity on the station. Security staff are to be alert, random searches are permitted."
 
 /datum/config_entry/string/alert_blue_downto
-	config_entry_value = "The immediate threat has passed. Security may no longer have weapons drawn at all times, but may continue to have them visible. Random searches are still allowed."
+	config_entry_value = "The immediate threat has passed. Security staff may return to their normal positions, but must remain alert. Random searches are still permitted."
 
 /datum/config_entry/string/alert_red_upto
-	config_entry_value = "There is an immediate serious threat to the station. Security may have weapons unholstered at all times. Random searches are allowed and advised."
+	config_entry_value = "Alert! There is an immediate threat onboard the station! Security staff may pacify the enemy with lethal force. Random searches are advised."
 
 /datum/config_entry/string/alert_red_downto
-	config_entry_value = "The station's destruction has been averted. There is still however an immediate serious threat to the station. Security may have weapons unholstered at all times, random searches are allowed and advised."
+	config_entry_value = "The station's destruction has been averted. However, hostile activity is still present. Security staff may pacify the enemy with letal force. Random searches are allowed and advised."
 
-/datum/config_entry/string/alert_gamma
-	config_entry_value = "Central Command has ordered the Gamma security level on the station. Security is to have weapons equipped at all times, and all civilians are to immediately seek their nearest head for transportation to a secure location. Violating orders is punishable by death."
+/datum/config_entry/string/alert_black
+	config_entry_value = "High alert! There is a serious risk to the station's integrity! Security staff must eliminate all hostile elements by any means. Insubordination is punishable by death."
 
-/datum/config_entry/string/alert_epsilon
-	config_entry_value = "Central Command has ordered the Epsilon security level on the station. Consider all contracts terminated."
+/datum/config_entry/string/alert_omega
+	config_entry_value = "All crew this is CC! Your station has been issued code Omega! All contracts are hereby terminated!"
 
 /datum/config_entry/string/alert_delta
-	config_entry_value = "Destruction of the station is imminent. All crew are instructed to obey all instructions given by heads of staff. Any violations of these orders can be punished by death. This is not a drill."
+	config_entry_value = "Destruction of the station is imminent! All crew are instructed evacuate immediately! Any violations of space law are punishable by death! This is not a drill!"
 
 /datum/config_entry/flag/revival_pod_plants
 

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -241,7 +241,7 @@ SUBSYSTEM_DEF(shuttle)
 	var/emergency_reason = "\nNature of emergency:\n\n[call_reason]"
 	var/security_num = seclevel2num(get_security_level())
 	switch(security_num)
-		if(SEC_LEVEL_RED,SEC_LEVEL_GAMMA,SEC_LEVEL_EPSILON,SEC_LEVEL_DELTA)
+		if(SEC_LEVEL_RED,SEC_LEVEL_BLACK,SEC_LEVEL_OMEGA,SEC_LEVEL_DELTA)
 			emergency.request(null, signal_origin, html_decode(emergency_reason), 1) //There is a serious threat we gotta move no time to give them five minutes.
 		else
 			emergency.request(null, signal_origin, html_decode(emergency_reason), 0)

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -187,7 +187,7 @@
 		bloodstone_areas.Add(A.map_name)
 	priority_announce("Figments of an eldritch god are being pulled through the veil anomaly in [bloodstone_areas[1]], [bloodstone_areas[2]], [bloodstone_areas[3]], and [bloodstone_areas[4]]! Destroy any occult structures located in those areas!","Central Command Higher Dimensional Affairs")
 	addtimer(CALLBACK(src, .proc/increase_bloodstone_power), 30 SECONDS)
-	set_security_level(SEC_LEVEL_GAMMA)
+	set_security_level(SEC_LEVEL_BLACK)
 
 /datum/game_mode/proc/increase_bloodstone_power()
 	if(!bloodstone_list.len) //check if we somehow ran out of bloodstones

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -864,7 +864,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!check_rights(R_ADMIN))
 		return
 
-	var/level = input("Select security level to change to","Set Security Level") as null|anything in list("green","blue","red","gamma","epsilon","delta")
+	var/level = input("Select security level to change to","Set Security Level") as null|anything in list("green","blue","red","black","omega","delta")
 	if(level)
 		set_security_level(level)
 
@@ -1103,12 +1103,12 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		if(ADMIN_PUNISHMENT_BRAINDAMAGE)
 			target.adjustOrganLoss(ORGAN_SLOT_BRAIN, 199, 199)
 		if(ADMIN_PUNISHMENT_MCNUGGET)
-			if(iscarbon(target)) 
+			if(iscarbon(target))
 				var/mob/living/carbon/CM = target
 				for(var/obj/item/bodypart/bodypart in CM.bodyparts)
 					if(bodypart.body_part != HEAD && bodypart.body_part != CHEST)
 						if(bodypart.dismemberable)
-							bodypart.dismember() 
+							bodypart.dismember()
 		if(ADMIN_PUNISHMENT_GIB)
 			target.gib(FALSE)
 		if(ADMIN_PUNISHMENT_BSA)
@@ -1293,12 +1293,12 @@ Traitors and the like can also be revived with the previous role mostly intact.
 			A.copy_to(H)
 			H.dna.update_dna_identity()
 			H.equipOutfit(/datum/outfit/centcom/official/nopda)
-			
+
 			var/datum/mind/Mind = new /datum/mind(M.key) // Reusing the mob's original mind actually breaks objectives for any antag who had this person as their target.
 			// For that reason, we're making a new one. This mimics the behavior of, say, lone operatives, and I believe other ghostroles.
 			Mind.active = 1
 			Mind.transfer_to(H)
-			
+
 			var/msg = "[key_name_admin(H)] has spawned in at centcom [ADMIN_VERBOSEJMP(H)]."
 			message_admins(msg)
 			log_admin(msg)
@@ -1314,8 +1314,8 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		qdel(a)
 	message_admins("[key_name_admin(usr)] has cleared all radiation.")
 	log_admin("[key_name_admin(usr)] has cleared all radiation.")
-	
-	
+
+
 /mob/living/proc/whistle()
 	INVOKE_ASYNC(src, .proc/whistletrigger, "whistle")
 

--- a/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -94,7 +94,7 @@
 	@!$, [text2ratvar("PURGE ALL UNTRUTHS")] <&. the anomalies and destroy their source to prevent further damage to corporate property. This is \
 	not a drill.[grace_period ? " Estimated time of appearance: [grace_period] seconds. Use this time to prepare for an attack on [station_name()]." : ""]", \
 	"Central Command Higher Dimensional Affairs", 'sound/magic/clockwork/ark_activation.ogg')
-	set_security_level(SEC_LEVEL_GAMMA)
+	set_security_level(SEC_LEVEL_BLACK)
 	for(var/V in SSticker.mode.servants_of_ratvar)
 		var/datum/mind/M = V
 		if(!M || !M.current)

--- a/code/modules/antagonists/clockcult/clock_structures/heralds_beacon.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/heralds_beacon.dm
@@ -93,7 +93,7 @@
 /obj/structure/destructible/clockwork/heralds_beacon/proc/herald_the_justiciar()
 	priority_announce("A powerful group of fanatical zealots following the cause of Ratvar have brazenly sacrificed stealth for power, and dare anyone \
 	to try and stop them.", title = "The Justiciar Comes", sound = 'sound/magic/clockwork/ark_activation.ogg')
-	set_security_level(SEC_LEVEL_GAMMA)
+	set_security_level(SEC_LEVEL_BLACK)
 	GLOB.ratvar_approaches = TRUE
 	available = FALSE
 	STOP_PROCESSING(SSprocessing, src)

--- a/code/modules/antagonists/eldritch_cult/transmutations/ash_transmutations.dm
+++ b/code/modules/antagonists/eldritch_cult/transmutations/ash_transmutations.dm
@@ -64,7 +64,7 @@
 
 /datum/eldritch_transmutation/final/ash_final/on_finished_recipe(mob/living/user, list/atoms, loc)
 	priority_announce("$^@&#*$^@(#&$(@&#^$&#^@# Fear The Blaze, for Ashbringer [user.real_name] has come! $^@&#*$^@(#&$(@&#^$&#^@#","#$^@&#*$^@(#&$(@&#^$&#^@#", ANNOUNCER_SPANOMALIES)
-	set_security_level(SEC_LEVEL_GAMMA)
+	set_security_level(SEC_LEVEL_BLACK)
 	user.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/fire_cascade/big)
 	user.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/fire_sworn)
 	var/mob/living/carbon/human/H = user

--- a/code/modules/antagonists/eldritch_cult/transmutations/flesh_transmutations.dm
+++ b/code/modules/antagonists/eldritch_cult/transmutations/flesh_transmutations.dm
@@ -109,7 +109,7 @@
 			ghoul2.max_amt *= 3
 			var/mob/dead/observer/ghost_candidate = pick(candidates)
 			priority_announce("$^@&#*$^@(#&$(@&#^$&#^@# Fear the dark, for Vassal of Arms has ascended! The Terror of the Night has come! $^@&#*$^@(#&$(@&#^$&#^@#","#$^@&#*$^@(#&$(@&#^$&#^@#", ANNOUNCER_SPANOMALIES)
-			set_security_level(SEC_LEVEL_GAMMA)
+			set_security_level(SEC_LEVEL_BLACK)
 			log_game("[key_name_admin(ghost_candidate)] has taken control of ([key_name_admin(summoned)]).")
 			summoned.ghostize(FALSE)
 			summoned.key = ghost_candidate.key
@@ -127,7 +127,7 @@
 					user.mind.spell_list.Remove(S)
 					qdel(S)
 			priority_announce("$^@&#*$^@(#&$(@&#^$&#^@# Fear the dark, for King of Arms has ascended! Our Lord of the Night has come! $^@&#*$^@(#&$(@&#^$&#^@#","#$^@&#*$^@(#&$(@&#^$&#^@#", ANNOUNCER_SPANOMALIES)
-			set_security_level(SEC_LEVEL_GAMMA)
+			set_security_level(SEC_LEVEL_BLACK)
 			log_game("[user.real_name] ascended as [summoned.real_name]")
 			var/mob/living/carbon/carbon_user = user
 			var/datum/antagonist/heretic/ascension = carbon_user.mind.has_antag_datum(/datum/antagonist/heretic)

--- a/code/modules/antagonists/eldritch_cult/transmutations/rust_transmutations.dm
+++ b/code/modules/antagonists/eldritch_cult/transmutations/rust_transmutations.dm
@@ -28,7 +28,7 @@
 	H.physiology.stamina_mod = 0
 	H.physiology.stun_mod = 0
 	priority_announce("$^@&#*$^@(#&$(@&#^$&#^@# Fear the decay, for Rustbringer [user.real_name] has come! $^@&#*$^@(#&$(@&#^$&#^@#","#$^@&#*$^@(#&$(@&#^$&#^@#", ANNOUNCER_SPANOMALIES)
-	set_security_level(SEC_LEVEL_GAMMA)
+	set_security_level(SEC_LEVEL_BLACK)
 	new /datum/rust_spread(loc)
 	var/datum/antagonist/heretic/ascension = H.mind.has_antag_datum(/datum/antagonist/heretic)
 	ascension.ascended = TRUE

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -51,7 +51,7 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 		return
 
 	priority_announce(war_declaration, title = "Declaration of War", sound = 'sound/machines/alarm.ogg', has_important_message = TRUE)
-	set_security_level(SEC_LEVEL_GAMMA)
+	set_security_level(SEC_LEVEL_BLACK)
 
 	to_chat(user, "You've attracted the attention of powerful forces within the syndicate. A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission.")
 

--- a/code/modules/security_levels/security_levels.dm
+++ b/code/modules/security_levels/security_levels.dm
@@ -2,8 +2,8 @@ GLOBAL_VAR_INIT(security_level, SEC_LEVEL_GREEN)
 //SEC_LEVEL_GREEN = code green
 //SEC_LEVEL_BLUE = code blue
 //SEC_LEVEL_RED = code red
-//SEC_LEVEL_GAMMA = code gamma
-//SEC_LEVEL_EPSILON = code epsilon
+//SEC_LEVEL_BLACK = code black
+//SEC_LEVEL_OMEGA = code omega
 //SEC_LEVEL_DELTA = code delta
 
 //config.alert_desc_blue_downto
@@ -16,10 +16,10 @@ GLOBAL_VAR_INIT(security_level, SEC_LEVEL_GREEN)
 			level = SEC_LEVEL_BLUE
 		if("red")
 			level = SEC_LEVEL_RED
-		if("gamma")
-			level = SEC_LEVEL_GAMMA
-		if("epsilon")
-			level = SEC_LEVEL_EPSILON
+		if("black")
+			level = SEC_LEVEL_BLACK
+		if("omega")
+			level = SEC_LEVEL_OMEGA
 		if("delta")
 			level = SEC_LEVEL_DELTA
 
@@ -33,7 +33,7 @@ GLOBAL_VAR_INIT(security_level, SEC_LEVEL_GREEN)
 					modTimer = 4
 				else
 					modTimer = 2
-				
+
 			if(SEC_LEVEL_BLUE)
 				if(GLOB.security_level < SEC_LEVEL_BLUE)
 					minor_announce(CONFIG_GET(string/alert_blue_upto), "Attention! Security level elevated to blue:", TRUE)
@@ -51,11 +51,11 @@ GLOBAL_VAR_INIT(security_level, SEC_LEVEL_GREEN)
 						modTimer = 0.5
 				else
 					minor_announce(CONFIG_GET(string/alert_red_downto), "Attention! Code red!")
-					if(GLOB.security_level == SEC_LEVEL_GAMMA)
+					if(GLOB.security_level == SEC_LEVEL_BLACK)
 						modTimer = 2
-          
-			if(SEC_LEVEL_GAMMA)
-				minor_announce(CONFIG_GET(string/alert_gamma), "Attention! Gamma security level activated!", TRUE)
+
+			if(SEC_LEVEL_BLACK)
+				minor_announce(CONFIG_GET(string/alert_black), "Attention! Code black!", TRUE)
 				SEND_SOUND(world, 'sound/misc/gamma_alert.ogg')
 				if(GLOB.security_level == SEC_LEVEL_GREEN)
 					modTimer = 0.25
@@ -63,12 +63,12 @@ GLOBAL_VAR_INIT(security_level, SEC_LEVEL_GREEN)
 					modTimer = 0.50
 				else if(GLOB.security_level == SEC_LEVEL_RED)
 					modTimer = 0.75
-						
-			if(SEC_LEVEL_EPSILON)
-				minor_announce(CONFIG_GET(string/alert_epsilon), "Attention! Epsilon security level reached!", TRUE)
+
+			if(SEC_LEVEL_OMEGA)
+				minor_announce(CONFIG_GET(string/alert_omega), "Attention! Code omega issued!", TRUE)
 				SEND_SOUND(world, 'sound/misc/epsilon_alert.ogg')
-				to_chat(world, "<span class='notice'>You get a bad feeling as you hear the Epsilon alert siren.</span>")
-				if(GLOB.security_level < SEC_LEVEL_EPSILON)
+				to_chat(world, "<span class='notice'>You get a bad feeling as you hear the omega alert siren.</span>")
+				if(GLOB.security_level < SEC_LEVEL_OMEGA)
 					modTimer = 1
 
 			if(SEC_LEVEL_DELTA)
@@ -108,10 +108,10 @@ GLOBAL_VAR_INIT(security_level, SEC_LEVEL_GREEN)
 			return "blue"
 		if(SEC_LEVEL_RED)
 			return "red"
-		if(SEC_LEVEL_GAMMA)
-			return "gamma"
-		if(SEC_LEVEL_EPSILON)
-			return "epsilon"
+		if(SEC_LEVEL_BLACK)
+			return "black"
+		if(SEC_LEVEL_OMEGA)
+			return "omega"
 		if(SEC_LEVEL_DELTA)
 			return "delta"
 
@@ -123,10 +123,10 @@ GLOBAL_VAR_INIT(security_level, SEC_LEVEL_GREEN)
 			return "blue"
 		if(SEC_LEVEL_RED)
 			return "red"
-		if(SEC_LEVEL_GAMMA)
-			return "gamma"
-		if(SEC_LEVEL_EPSILON)
-			return "epsilon"
+		if(SEC_LEVEL_BLACK)
+			return "black"
+		if(SEC_LEVEL_OMEGA)
+			return "omega"
 		if(SEC_LEVEL_DELTA)
 			return "delta"
 
@@ -138,9 +138,9 @@ GLOBAL_VAR_INIT(security_level, SEC_LEVEL_GREEN)
 			return SEC_LEVEL_BLUE
 		if("red")
 			return SEC_LEVEL_RED
-		if("gamma")
-			return SEC_LEVEL_GAMMA
-		if("epsilon")
-			return SEC_LEVEL_EPSILON
+		if("black")
+			return SEC_LEVEL_BLACK
+		if("omega")
+			return SEC_LEVEL_OMEGA
 		if("delta")
 			return SEC_LEVEL_DELTA

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn.dm
@@ -362,7 +362,7 @@
 	user.mind.transfer_to(progenitor)
 	progenitor.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/progenitor_curse(null))
 	if(!SSticker.mode.sacrament_done)
-		set_security_level(SEC_LEVEL_GAMMA)
+		set_security_level(SEC_LEVEL_BLACK)
 		addtimer(CALLBACK(src, .proc/sacrament_shuttle_call), 50)
 	for(var/V in abilities)
 		remove_ability(abilities[V], TRUE)

--- a/yogstation/code/modules/antagonists/shadowling/special_shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/special_shadowling_abilities.dm
@@ -183,7 +183,7 @@
 			H.invisibility = 60 //This is pretty bad, but is also necessary for the shuttle call to function properly
 			H.forceMove(A)
 			if(!SSticker.mode.shadowling_ascended)
-				set_security_level(SEC_LEVEL_GAMMA)
+				set_security_level(SEC_LEVEL_BLACK)
 				SSshuttle.emergencyCallTime = 1800
 				SSshuttle.emergency.request(null, 0.3)
 				SSshuttle.emergencyNoRecall = TRUE


### PR DESCRIPTION
# Github documenting your Pull Request

After learning of the existence of the 'new' epsilon and gamma alerts I found them rather inconsistent and lacking. People described gamma as a massive threat but I felt it was just an odd copy of red alert. Upon further inspection I decided to tweak practically all the alerts to be less vague and a little more interesting. 

The two first prominent changes are that to gamma and epsilon. I will try to briefly describe my reasoning.

## **Gamma, now Code Black** 
**before:**
`Central Command has ordered the Gamma security level on the station. Security is to have weapons equipped at all times, and all civilians are to immediately seek their nearest head for transportation to a secure location. Violating orders is punishable by death.`

The sudden change from Red to phonetic alphabet, Gamma, felt a little odd to me seeing as gamma is still an alert pertaining to the status of the station. Its wording is also cringey for lack of a better word, IE. "nearest head for transportation"; "civilians".

**after:**
`High alert! There is a serious risk to the station's integrity! Security staff must eliminate all hostile elements by any means. Insubordination is punishable by death.`

I believe with the proper wording i've made the distinction between red and gamma better: Red within this PR is now a confirmed threat onboard the station, while gamma is a threat to the station itself. More concise language as well.

As for the name change, Black was given to keep it in line with the colour standard, while also retaining the seriousness of the alert.

## **Epsilon, now Code Omega**
**before:**
`Central Command has ordered the Epsilon security level on the station. Consider all contracts terminated.`

**after:**
`All crew this is CC! Your station has been issued code Omega! All contracts are hereby terminated`

Language has been changed to make it seem like a direct order by Central, akin to Order 66. Change from Epsilon to Omega was because Omega is a theme of finality, while Epsilon seems random.

## **Green, Blue, Red**

### Green:
`All threats to the station have passed. Security may not have weapons visible, privacy laws are once again fully enforced.`
to
`All threats to the station have passed. Security staff may now stand down, privacy laws are once again fully enforced.`

### Blue:

`The station has received reliable information about possible hostile activity on the station. Security staff may have weapons visible, random searches are permitted.`
to
`Caution! The station has received reliable information of possible hostile activity on the station. Security staff are to be alert, random searches are permitted.`

### Red:
`There is an immediate serious threat to the station. Security may have weapons unholstered at all times. Random searches are allowed and advised.`
to
`Alert! There is an immediate threat onboard the station! Security staff may pacify the enemy with lethal force. Random searches are advised.`

A blanket change was to statements of security unholstering, equipping weapons etc. These were pretty vague and not adhered to as far as I recall. Its pretty much a universal constant that you don't hold out your laser gun in central hallway at all times. Instead, if possibly controversially, The alerts now tell security they may use lethal force. Beforehand, Red stating to have weapon unholstered seems like an implication to use such weapons but now we're not beating around the bush. TL;DR What the alerts say has more substance.

Another theme you may have noticed is the introductions to the alert, "Caution, Alert, High Alert", which gives some flavour to them too.

## **Delta**
`Destruction of the station is imminent. All crew are instructed to obey all instructions given by heads of staff. Any violations of these orders can be punished by death. This is not a drill.`
to
`Destruction of the station is imminent! All crew are instructed evacuate immediately! Any violations of space law are punishable by death! This is not a drill!`

Okay so I may have escalated the severity of this alert, but at the point of delta its over anyway. Also tells the crew to actually evacuate instead of it being a given.

-

This PR is a little long-winded and probably could have been structured better but if you are unsure of any changes please do inquire or give feedback. 

If you downvote without giving some sort of explanation I will literally come for you.

# Wiki Documentation

Documentation for Epsilon and Gamma are on the wiki I think so that will definitely need altering,

# Changelog

:cl:  Identification
tweak: Gamma has been changed to Code Black
tweak: Epsilon has been changed to Code Omega
tweak: Alterations to the language used in Code green, code blue, and code red. As well as Code delta.
tweak: Language used in Gamma and Epsilon has also been altered. Gamma specifically to be more distinct from alert level red.
/:cl:
