### PR TITLE
Prevents abductors from using bluespace bodybags to bypass marking targets

### DIFF
--- a/code/modules/antagonists/abductor/machinery/pad.dm
+++ b/code/modules/antagonists/abductor/machinery/pad.dm
@@ -6,6 +6,13 @@
 	var/turf/teleport_target
 
 /obj/machinery/abductor/pad/proc/Warp(mob/living/target)
+	if(istype(target, /mob/living/carbon))
+		var/mob/living/carbon/C = target
+		var/list/inventory = C.get_all_gear()
+		for(var/atom/A in inventory)
+			if(istype(A, /obj/item/bodybag/bluespace))
+				to_chat(target, "<span class='warning'>[A] colapses in on it's self!</span>")
+				qdel(A)
 	if(!target.buckled)
 		target.forceMove(get_turf(src))
 


### PR DESCRIPTION
# Github documenting your Pull Request

Warping by using the abductor pad breaks bluespace bodybags and shows the message "The bluespace bodybag colapses in on it's self!" As it is currently, its way to easy to abduct everyone on the station due to the ability to use bluespace bodybags and skip the process of finding a good place to scan the abductee. I have done some testing, though I may have missed a few edge cases.

# Wiki Documentation

I dont think anything will need to be changed, as the abilty to warp with a bluespace bodybag is not mentioned . 

# Changelog

:cl:  
tweak: removed the ability for abductors from using bluespace bodybags to bypass marking targets.
/:cl:
