### PR TITLE
Fixes crew monitors not handling alt titles correctly 

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -150,8 +150,8 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 
 				if (I)
 					name = I.registered_name
-					assignment = I.assignment
-					ijob = jobs[I.assignment]
+					assignment = I.originalassignment
+					ijob = jobs[I.originalassignment]
 				else
 					name = "Unknown"
 					assignment = ""


### PR DESCRIPTION
# Github documenting your Pull Request

So, turns out that my [""Fixes" "Fixes and Tweaks Some Stuff With the Crew Monitor Again" #12074" #12093](https://github.com/yogstation13/Yogstation/pull/12093) PR broke the alt titles  on the crew monitor. How it was intended to work was that instead of showing alt titles, it shows the job. This has been tested a bit, but I may have missed a few issues.

# Wiki Documentation

No changes to the wiki are needed. 

# Changelog

:cl:  
bugfix: fixed crew monitors not handling alt titles correctly 
/:cl:
