### PR TITLE
stops the syndie hat from embedding when it throws itself back to its user

### DIFF
--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -124,10 +124,10 @@
 		attack_verb = list("poked", "tipped")
 		hitsound = 'sound/weapons/genhit.ogg'
 
-/obj/item/clothing/head/det_hat/evil/throw_impact(atom/hit_atom,)
-	if(iscarbon(src.loc))
+/obj/item/clothing/head/det_hat/evil/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
+	if(iscarbon(loc) || !iscarbon(thrownby))
 		return ..()
-	throw_at(thrownby, throw_range+3, throw_speed, null)
+	throw_at(thrownby, throw_range+3, 3, null)
 	..()
 
 /obj/item/clothing/head/det_hat/evil/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, force, quickstart = TRUE)


### PR DESCRIPTION
# Github documenting your Pull Request

fun fact items being thrown at a speed of 4 or higher can embed

# Changelog

:cl:  
bugfix: the syndicate  fedora no longer attempts to embed itself in the person who threw it if it doesn't embed in the person it hits 
/:cl:
