### PR TITLE
Adds tooltips to the sleeper UI

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -169,7 +169,7 @@
 	data["chems"] = list()
 	for(var/chem in available_chems)
 		var/datum/reagent/R = GLOB.chemical_reagents_list[chem]
-		data["chems"] += list(list("name" = R.name, "id" = R.type, "allowed" = chem_allowed(chem)))
+		data["chems"] += list(list("name" = R.name, "id" = R.type, "allowed" = chem_allowed(chem), "desc" = R.description))
 
 	data["occupant"] = list()
 	var/mob/living/mob_occupant = occupant

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -161,8 +161,9 @@
 /obj/machinery/sleeper/nap_violation(mob/violator)
 	open_machine()
 
-/obj/machinery/sleeper/ui_data()
+/obj/machinery/sleeper/ui_data(mob/user)
 	var/list/data = list()
+	data["knowledge"] = IS_MEDICAL(user)
 	data["occupied"] = occupant ? 1 : 0
 	data["open"] = state_open
 

--- a/tgui/packages/tgui/interfaces/Sleeper.js
+++ b/tgui/packages/tgui/interfaces/Sleeper.js
@@ -34,7 +34,7 @@ export const Sleeper = (props, context) => {
   ];
 
   return (
-    <Window width={310} height={465}>
+    <Window width={400} height={520}>
       <Window.Content scrollable>
         <Section
           title={occupant.name ? occupant.name : 'No Occupant'}
@@ -113,6 +113,8 @@ export const Sleeper = (props, context) => {
             <Button
               key={chem.name}
               icon="flask"
+              tooltip={chem.desc}
+              tooltipPosition='top'
               content={chem.name}
               disabled={!(occupied && chem.allowed)}
               width="350px"

--- a/tgui/packages/tgui/interfaces/Sleeper.js
+++ b/tgui/packages/tgui/interfaces/Sleeper.js
@@ -113,8 +113,8 @@ export const Sleeper = (props, context) => {
             <Button
               key={chem.name}
               icon="flask"
-              tooltip={chem.desc}
-              tooltipPosition="top"
+              tooltip={data.knowledge ? chem.desc : 'You don\'t know what this chemical does!'}
+              tooltipPosition='top'
               content={chem.name}
               disabled={!(occupied && chem.allowed)}
               width="350px"

--- a/tgui/packages/tgui/interfaces/Sleeper.js
+++ b/tgui/packages/tgui/interfaces/Sleeper.js
@@ -114,7 +114,7 @@ export const Sleeper = (props, context) => {
               key={chem.name}
               icon="flask"
               tooltip={chem.desc}
-              tooltipPosition='top'
+              tooltipPosition="top"
               content={chem.name}
               disabled={!(occupied && chem.allowed)}
               width="350px"

--- a/tgui/packages/tgui/interfaces/Sleeper.js
+++ b/tgui/packages/tgui/interfaces/Sleeper.js
@@ -113,8 +113,8 @@ export const Sleeper = (props, context) => {
             <Button
               key={chem.name}
               icon="flask"
-              tooltip={data.knowledge ? chem.desc : 'You don\'t know what this chemical does!'}
-              tooltipPosition='top'
+              tooltip={data.knowledge ? chem.desc : "You don\'t know what this chemical does!"}
+              tooltipPosition="top"
               content={chem.name}
               disabled={!(occupied && chem.allowed)}
               width="350px"


### PR DESCRIPTION
# Github documenting your Pull Request

Adds tooltips to the buttons on the sleeper UI, which use the description found in the chemical dataum. Should help new players use the sleeper without having the wiki open. I've done some testing, but I may have missed a few issues.

![SleeperTT](https://user-images.githubusercontent.com/14363906/131415621-8742c884-d6b0-4409-9ee9-582d46fe9531.PNG)

This tooltip is only shown to those in the medical department when they spawn, those who are not are shown this instead:

![image](https://user-images.githubusercontent.com/14363906/131426936-4f63c4e8-817f-4aa1-b9a4-e70a64483ddf.png)

# Wiki Documentation

I dont think anything will need to be changed, though it may be a good idea to mention this in a tip or something. 

# Changelog

:cl:  
tweak: added tooltips to the sleeper tgui
/:cl:
