### PR TITLE
Grav gen event checks the grav gen power state before turning on the generator

### DIFF
--- a/yogstation/code/modules/events/weightless.dm
+++ b/yogstation/code/modules/events/weightless.dm
@@ -23,8 +23,8 @@
 /datum/round_event/weightless/end()
 	for(var/obj/machinery/gravity_generator/main/station/A in GLOB.machines)
 		if(A)
-			A.set_state(1)
 			if(control && A.on)
-				control.weight *= 2		
+				control.weight *= 2	
+			A.set_state(1)	
 	if(announceWhen >= 0)
 		priority_announce("Artificial gravity arrays are now functioning within normal parameters. Please report any irregularities to your respective head of staff.")


### PR DESCRIPTION
# Github documenting your Pull Request

Supposed to check if the grav gen was rebooted, but after the event reboots it, big dumb
Now checks before the event reboots it

# Changelog

:cl:  
bugfix: gravgen event now checks the grav gen state before rebooting the grav gen
/:cl:
