### PR TITLE
removes 1.5 second delay from borg buckling

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1202,11 +1202,6 @@
 		if(!module.allow_riding)
 			M.visible_message("<span class='boldwarning'>Unfortunately, [M] just can't seem to hold onto [src]!</span>")
 			return
-	M.visible_message("<span class='warning'>[M] begins to [M == usr ? "climb onto" : "be buckled to"] [src]...</span>")
-	if(!do_after(M, 1.5 SECONDS, target = src))
-		M.visible_message("<span class='boldwarning'>[M] was prevented from buckling to [src]!</span>")
-		return
-
 	if(iscarbon(M) && !M.incapacitated() && !riding_datum.equip_buckle_inhands(M, 1))
 		if(M.get_num_arms() <= 0)
 			M.visible_message("<span class='boldwarning'>[M] can't climb onto [src] because [M.p_they()] don't have any usable arms!</span>")


### PR DESCRIPTION
# Github documenting your Pull Request

Theos' original PR was to prevent buckling for nefarious purposes, but it seems to have kneecapped any borg trying to help out literally... anywhere. 
Saving someone in maints? Nah they get to keep em
Saving a person from xenos? Nah they get to keep em
Preventing cult from grabbing a guy? Nah they get to keep em
Trying to get someone on the stasis bed as a medical borg? Nah, the chemist (why) grabs them from you because "WHY WONT YOU BUCKLE THEM"
Trying to evacuate people from an open plasma canister? Nah the plasma owns them now.

This means that from anyone with a welding mask or greater, as a normal borg you will 100% lose every encounter you're in by having a dragging war. If any bad person has a flash, you are instantly dead because you have to sit for 1.5 seconds strapping crit/dead people to you to be able to rescue them

I believe part of this is a a kneejerk reaction to something that Theos encountered in game and then he hastily rage-coded in the game, partly stemming from that he didn't even test his original PR and found the numerous bugs/oversights in it.

- Can't even grab people that are crit/dead, they fail the buckle check
- Can't grab flashed people (literally your only tool to use on others)
- Borg doesn't get the progress bar so they dont know how long they have
- will spam your text chat if you try to grab someone that's down/flashed

The buckling and *spin was already nipped by the cooldown, so I don't understand any reason why this would actually need to happen, as it actively hampers helpful borgs to stop one or two instances of bad borgs in the first place.

:cl:  
rscdel: Removed 1.5 second delay when buckling
/:cl:
