### PR TITLE
Prevents nonmedical personnel from using sleepers

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -11,7 +11,10 @@
 	icon_state = "sleeper"
 	density = FALSE
 	state_open = TRUE
+
 	circuit = /obj/item/circuitboard/machine/sleeper
+
+	var/req_job = TRUE
 
 	var/efficiency = 1
 	var/min_health = -25
@@ -161,10 +164,11 @@
 /obj/machinery/sleeper/nap_violation(mob/violator)
 	open_machine()
 
-/obj/machinery/sleeper/ui_data()
+/obj/machinery/sleeper/ui_data(mob/user)
 	var/list/data = list()
 	data["occupied"] = occupant ? 1 : 0
 	data["open"] = state_open
+	data["canuse"] = IS_MEDICAL(user) || issilicon(user) || !req_job
 
 	data["chems"] = list()
 	for(var/chem in available_chems)
@@ -261,6 +265,7 @@
 /obj/machinery/sleeper/syndie
 	icon_state = "sleeper_s"
 	controls_inside = TRUE
+	req_job = FALSE
 
 /obj/machinery/sleeper/syndie/fullupgrade/Initialize()
 	. = ..()
@@ -278,6 +283,7 @@
 	icon_state = "sleeper_clockwork"
 	enter_message = "<span class='bold inathneq_small'>You hear the gentle hum and click of machinery, and are lulled into a sense of peace.</span>"
 	possible_chems = list(list(/datum/reagent/medicine/epinephrine, /datum/reagent/medicine/salbutamol, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oculine, /datum/reagent/medicine/inacusiate, /datum/reagent/medicine/mannitol))
+	req_job = FALSE
 
 /obj/machinery/sleeper/clockwork/process()
 	if(occupant && isliving(occupant))

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -168,7 +168,7 @@
 	var/list/data = list()
 	data["occupied"] = occupant ? 1 : 0
 	data["open"] = state_open
-	data["canuse"] = IS_MEDICAL(user) || issilicon(user) || !req_job
+	data["canuse"] = IS_MEDICAL(user) || issilicon(user) || !req_job || !CONFIG_GET(flag/jobs_have_minimal_access)
 
 	data["chems"] = list()
 	for(var/chem in available_chems)
@@ -221,7 +221,9 @@
 			. = TRUE
 		if("inject")
 			var/chem = text2path(params["chem"])
-			if(!is_operational() || !mob_occupant || isnull(chem))
+			if(!(IS_MEDICAL(user) || issilicon(user) || !req_job || !CONFIG_GET(flag/jobs_have_minimal_access)))
+				return
+			if(!is_operational() || !mob_occupant || isnull(chem) || !canuse)
 				return
 			if(mob_occupant.health < min_health && chem != /datum/reagent/medicine/epinephrine)
 				return

--- a/tgui/packages/tgui/interfaces/Sleeper.js
+++ b/tgui/packages/tgui/interfaces/Sleeper.js
@@ -10,6 +10,7 @@ export const Sleeper = (props, context) => {
     open,
     occupant = {},
     occupied,
+    canuse,
   } = data;
 
   const chems = data.chems || [];
@@ -114,7 +115,7 @@ export const Sleeper = (props, context) => {
               key={chem.name}
               icon="flask"
               content={chem.name}
-              disabled={!(occupied && chem.allowed)}
+              disabled={!(occupied && chem.allowed && canuse)}
               width="350px"
               onClick={() => act('inject', {
                 chem: chem.id,


### PR DESCRIPTION
# Github documenting your Pull Request

People who aren't doctors like to powergame and use the sleepers, now they can't. 
This does not apply to syndicate or clockie sleepers.

# Wiki Documentation

Should probably mention only doctors can use them

# Changelog

:cl:  
tweak: Locked sleeper use to doctors only
/:cl:
