### PR TITLE
Revert "Disables using a default vote option for people who do not vote on map votes"

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -166,7 +166,7 @@ VOTE_PERIOD 600
 # NO_DEAD_VOTE
 
 ## players' votes default to "No vote" (otherwise,  default to "No change")
-DEFAULT_NO_VOTE
+# DEFAULT_NO_VOTE
 
 ## disable abandon mob
 NORESPAWN


### PR DESCRIPTION
Reverts yogstation13/Yogstation#12161

So what you're saying is that you'd rather want people to click the button to play Box every time a vote is made instead of clicking Box just once in the preference menu?

The only way this promotes non-box usage is by tricking people into thinking they'll vote for their preference.

If you really want to test out if people are just on box by default then revert everyone's map preference to "No Choice" and see if people put it back on Box or something else.
The default has been No Choice for some time but I don't doubt that some people (Especially older player) may have had it set to Box by default