### PR TITLE
Forgot to add descriptions when I added the access to freeminers

### DIFF
--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -353,6 +353,14 @@
 			return "Clerk"
 		if(ACCESS_BRIG_PHYS)
 			return "Brig Physician"
+		if(ACCESS_MECH_FREEMINER)
+			return "Freeminer Mech"
+		if(ACCESS_FREEMINER)
+			return "Freeminer"
+		if(ACCESS_FREEMINER_ENGINEER)
+			return "Freeminer Engineer"
+		if(ACCESS_FREEMINER_CAPTAIN)
+			return "Freeminer Captain"
 		// yogs end
 
 /// Get descriptions for centcom accesses


### PR DESCRIPTION
# Github documenting your Pull Request

Forgot to add descriptions, so here they are, now adding the access to mechs works

:cl:  
rscadd: Added descriptions to free miner access, allowing them to actually be used
/:cl:
