### PR TITLE
doubles the effective healing speed of cryoxadone

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -134,7 +134,7 @@
 	taste_description = "sludge"
 
 /datum/reagent/medicine/cryoxadone/on_mob_life(mob/living/carbon/M)
-	var/power = -0.00003 * (M.bodytemperature ** 2) + 3
+	var/power = -0.00006 * (M.bodytemperature ** 2) + 6
 	if(M.bodytemperature < T0C)
 		M.adjustOxyLoss(-3 * power, 0)
 		M.adjustBruteLoss(-power, 0)


### PR DESCRIPTION
# Github documenting your Pull Request

nobody uses cryo anyways lmao

# Wiki Documentation

cryox healing effective maximum 3 -> 6

# Changelog

:cl:  
tweak: cryoxadone healing increased from a maximum of 3 to a maximum of 6
/:cl:
