### PR TITLE
adds a fail message for SR being below the required dosage

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -848,6 +848,7 @@
 /datum/reagent/medicine/strange_reagent/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	var/datum/reagent/S = M.reagents.get_reagent(/datum/reagent/medicine/strange_reagent)
 	if((S?.volume + reac_volume) < REQUIRED_STRANGE_REAGENT_FOR_REVIVAL)
+		M.visible_message("<span class='warning'>[M]'s body shivers slightly, maybe the dose wasn't enough...</span>")
 		return ..()
 	if(M.stat == DEAD)
 		if(M.suiciding || M.hellbound) //they are never coming back


### PR DESCRIPTION
# Github documenting your Pull Request

makes it more obvious why it's not working

# Changelog
:cl:  
tweak: strange reagent now has a failure message when the dosage is below the required amount to revive
/:cl:
