### PR TITLE
Fixes issues with the mining medic's and brig physician's caps

### DIFF
--- a/yogstation/code/modules/clothing/head/jobs.dm
+++ b/yogstation/code/modules/clothing/head/jobs.dm
@@ -8,12 +8,12 @@
 //Mining Medic
 /obj/item/clothing/head/soft/emt/mining
 	name = "Mining Medic's cap"
-	desc = "It's a baseball hat with a dark turquoise color and a reflective cross on the top. Has MM embrossed into it."
+	desc = "It's a baseball hat with a dark turquoise color and a reflective cross on the top. Has MM embossed into it."
 
 //Brig Physician
 /obj/item/clothing/head/soft/emt/phys
 	name = "Brig Physician's cap"
-	desc = "It's a baseball hat with a dark brown color and a reflective cross on the top. Has BP embrossed into it."
+	desc = "It's a baseball hat with a dark brown color and a reflective cross on the top. Has BP embossed into it."
 	icon = 'yogstation/icons/obj/clothing/hats.dmi'
 	alternate_worn_icon = 'yogstation/icons/mob/head.dmi'
 	icon_state = "emtsecsoft"

--- a/yogstation/code/modules/clothing/head/jobs.dm
+++ b/yogstation/code/modules/clothing/head/jobs.dm
@@ -8,14 +8,12 @@
 //Mining Medic
 /obj/item/clothing/head/soft/emt/mining
 	name = "Mining Medic's cap"
-	desc = "It's a baseball hat with a dark turquoise color and a reflective cross on the top."
-	icon = 'yogstation/icons/obj/clothing/hats.dmi'
-	alternate_worn_icon = 'yogstation/icons/mob/head.dmi'
+	desc = "It's a baseball hat with a dark turquoise color and a reflective cross on the top. Has MM embrossed into it."
 
 //Brig Physician
 /obj/item/clothing/head/soft/emt/phys
 	name = "Brig Physician's cap"
-	desc = "It's a baseball hat with a dark brown color and a reflective cross on the top. On the back are "
+	desc = "It's a baseball hat with a dark brown color and a reflective cross on the top. Has BP embrossed into it."
 	icon = 'yogstation/icons/obj/clothing/hats.dmi'
 	alternate_worn_icon = 'yogstation/icons/mob/head.dmi'
 	icon_state = "emtsecsoft"

--- a/yogstation/code/modules/clothing/suits/labcoat.dm
+++ b/yogstation/code/modules/clothing/suits/labcoat.dm
@@ -1,14 +1,14 @@
 //Mining Medic
 /obj/item/clothing/suit/toggle/labcoat/emt/explorer
 	name = "mining medics jacket"
-	desc = "A protective jacket for medical emergencies on off-world planets. Has MM embrossed into it."
+	desc = "A protective jacket for medical emergencies on off-world planets. Has MM embossed into it."
 	armor = list(melee = 10, bullet = 10, laser = 0,energy = 0, bomb = 0, bio = 50, rad = 0, fire = 50, acid = 50)
 	allowed = list(/obj/item/analyzer,/obj/item/stack/medical,/obj/item/dnainjector,/obj/item/reagent_containers/dropper,/obj/item/reagent_containers/syringe,/obj/item/reagent_containers/hypospray,/obj/item/healthanalyzer,/obj/item/flashlight/pen,/obj/item/reagent_containers/glass/bottle,/obj/item/reagent_containers/glass/beaker,/obj/item/reagent_containers/pill,/obj/item/storage/pill_bottle,/obj/item/paper,/obj/item/melee/classic_baton/telescopic,/obj/item/soap,/obj/item/sensor_device,/obj/item/tank/internals)
 
 //Brig Physician
 /obj/item/clothing/suit/toggle/labcoat/emt/physician
 	name = "brig physicians jacket"
-	desc = "A protective jacket for medical emergencies on off-world planets. Has BP embrossed into it."
+	desc = "A protective jacket for medical emergencies on off-world planets. Has BP embossed into it."
 	alternate_worn_icon = 'yogstation/icons/mob/suit.dmi'
 	icon = 'yogstation/icons/obj/clothing/suits.dmi'
 	icon_state = "labcoat_emtsec"
@@ -16,7 +16,7 @@
 
 /obj/item/clothing/suit/toggle/labcoat/physician
 	name = "brig physician's labcoat"
-	desc = "A white labcoat with red medical crosses. Has BP embrossed into it."
+	desc = "A white labcoat with red medical crosses. Has BP embossed into it."
 	alternate_worn_icon = 'yogstation/icons/mob/suit.dmi'
 	icon = 'yogstation/icons/obj/clothing/suits.dmi'
 	icon_state = "labcoat_sec"


### PR DESCRIPTION
# Github documenting your Pull Request

So, I added a cap to the mining medic with the brig physician PR, for consistency and cause it looks cool. You may not have noticed it, as it is completely invisible cause I forgot to change some vars. This fixes that as well as some typos the description of both caps.

# Wiki Documentation

Probably nothing. 

# Changelog

:cl:  
bugfix: fixed the mining medic cap not using an icon  
spellcheck: fixed the description for the mining medic and brig phys caps
/:cl:
