### PR TITLE
Gives digitigrade brig physician footwraps

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -244,9 +244,9 @@
 	if(DIGITIGRADE in H.dna.species.species_traits)
 		if(IS_COMMAND(H)) // command gets snowflake shoes too.
 			shoes = alt_shoes_c
-		else if(IS_SECURITY(H)) // Special shoes for sec, roll first to avoid defaulting
+		else if(IS_SECURITY(H) || find_job(H) == "Brig Physician") // Special shoes for sec and brig phys, roll first to avoid defaulting
 			shoes = alt_shoes_s
-		else if(find_job(H) == "Shaft Miner" || find_job(H) == "Mining Medic" || IS_ENGINEERING(H)) // Check to assign default digitigrade shoes
+		else if(find_job(H) == "Shaft Miner" || find_job(H) == "Mining Medic" || IS_ENGINEERING(H)) // Check to assign default digitigrade shoes to special cases
 			shoes = alt_shoes
 
 /datum/outfit/job/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)

--- a/yogstation/code/game/objects/items/storage/backpack.dm
+++ b/yogstation/code/game/objects/items/storage/backpack.dm
@@ -226,3 +226,4 @@
 	new /obj/item/clothing/suit/toggle/labcoat/physician(src)
 	new /obj/item/clothing/head/beret/med/phys(src)
 	new /obj/item/clothing/head/beret/corpsec/phys(src)
+	new /obj/item/clothing/shoes/xeno_wraps/jackboots(src)


### PR DESCRIPTION
# Github documenting your Pull Request

Gives digitigrade brig physician footwraps at round start and also puts some in their clothing bag. Personally I don't think they need them, but as they start with jackboots normally and mining medic gets normal footwraps even though they are not a part of a department that gets it, it would probably be best to do it for consistency. This is untested, but will probably work as I copied the code changes from the other PR I made.

# Wiki Documentation

Nothing will need to be changed, as I am lazy and still haven't finished the brig phys wiki page yet. 

# Changelog

:cl:  
tweak: gives digitigrade brig physician footwraps at round start and put footwraps in their clothing bag
/:cl:
