### PR TITLE
Makes deadchat its own ban instead of OOC

### DIFF
--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -252,7 +252,7 @@
 			output += "</div></div>"
 		//departments/groups that don't have command staff would throw a javascript error since there's no corresponding reference for toggle_head()
 		var/list/headless_job_lists = list("Silicon" = GLOB.original_nonhuman_positions,
-										"Abstract" = list("Appearance", "Emote", "OOC", "Voice Announcements"))
+										"Abstract" = list("Appearance", "Emote", "OOC", "Voice Announcements", "DEAD"))
 		for(var/department in headless_job_lists)
 			output += "<div class='column'><label class='rolegroup [ckey(department)]'><input type='checkbox' name='[department]' class='hidden' [usr.client.prefs.tgui_fancy ? " onClick='toggle_checkboxes(this, \"_com\")'" : ""]>[department]</label><div class='content'>"
 			break_counter = 0

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -62,7 +62,7 @@
 		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")
 		return
 
-	var/jb = is_banned_from(ckey, "OOC")
+	var/jb = is_banned_from(ckey, "DEAD")
 	if(QDELETED(src))
 		return
 


### PR DESCRIPTION
# Github documenting your Pull Request

Makes deadchat its own ban instead of OOC

# Wiki Documentation

N/A

# Changelog

:cl:  
tweak: Makes deadchat its own ban instead of OOC
/:cl:
