### PR TITLE
Fix parallax animation

### DIFF
--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -167,7 +167,8 @@
 
 		L.transform = newtransform
 
-		animate(L, transform = matrix(), time = T, loop = -1, flags = ANIMATION_END_NOW)
+		animate(L, transform = L.transform, time = 0, loop = -1, flags = ANIMATION_END_NOW)
+		animate(transform = matrix(), time = T)
 
 /datum/hud/proc/update_parallax()
 	var/client/C = mymob.client


### PR DESCRIPTION
so it turns out lummox changed the behavior of loops, such that the starting point of loops has to be the same as the end so if you want a discontinuous jump you *have* to have an "initial state" time=0 frame in the animation