### PR TITLE
Some idiot approved the stamp PR while the stamp was being defined twice

### DIFF
--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -138,10 +138,3 @@
 	item = /obj/item/storage/briefcase/syndie_mantis
 	cost = 18
 	surplus = 0
-
-/datum/uplink_item/badass/syndistamp
-	name = "Syndicate Stamp"
-	desc = "Even evil needs to do paperwork."
-	item = /obj/item/stamp/syndiround
-	cost = 1
-	illegal_tech = FALSE


### PR DESCRIPTION
# Document the changes in your pull request

Fixes small code issue

# Changelog

:cl:  
bugfix: fixed duplicate uplink definition for the syndicate stamp
/:cl:
