### PR TITLE
Should reduce cryo jank

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -172,6 +172,9 @@
 /obj/machinery/atmospherics/components/unary/cryo_cell/process()
 	..()
 
+	if(state_open)
+		reagent_transfer = 0
+		return
 	if(!on)
 		return
 	if(!is_operational())


### PR DESCRIPTION
# Document the changes in your pull request

Reduces the confusion around cryo by resetting its internal timer between injections if the tube is opened
This timer can get really long with higher tier bins since its meant to reduce the chems expended allowing for a more efficient and safer cryo chem mix but it doesn't reset on the patient being removed so it can lead to some confusion when a cryotube just doesn't inject people for a solid minute
To remedy this, whenever a cryotube is left open i.e. after having a patient removed, it will have the reagent injection timer reset to 0, causing the reagents to be applied to the next patient about as soon as the tube is turned on

# Changelog

:cl:  
bugfix: cryo is like 200% more reliable, chemicals will be injected as soon as they are allowed to be whenever a person is loaded into a cryotube and it is turned on, rather than having an effectively random delay that gets extremely long
/:cl:
