### PR TITLE
fixes seed exports

### DIFF
--- a/code/modules/cargo/exports/seeds.dm
+++ b/code/modules/cargo/exports/seeds.dm
@@ -2,7 +2,7 @@ GLOBAL_LIST_EMPTY(discoveredPlants)
 
 /datum/export/seed
 	cost = 50 // Gets multiplied by potency
-	k_elasticity = 1	//price inelastic/quantity elastic, only need to export a few samples
+	k_elasticity = 0	//price inelastic/quantity elastic, only need to export a few samples
 	unit_name = "new plant species sample"
 	export_types = list(/obj/item/seeds)
 	var/needs_discovery = FALSE // Only for undiscovered species
@@ -15,9 +15,9 @@ GLOBAL_LIST_EMPTY(discoveredPlants)
 		return 0
 	return ..() * S.rarity // That's right, no bonus for potency. Send a crappy sample first to "show improvement" later.
 
-/datum/export/seed/sell_object(obj/O)
+/datum/export/seed/sell_object(obj/O, datum/export_report/report, dry_run, apply_elastic)
 	. = ..()
-	if(.)
+	if(. && !dry_run)
 		var/obj/item/seeds/S = O
 		GLOB.discoveredPlants[S.type] = S.potency
 


### PR DESCRIPTION
# Document the changes in your pull request

>elasticity is 1
>this actually makes the seeds worth half their effective price
>they still reduce the price of other seeds substantially
>lmao

# Changelog

:cl:  
bugfix: scanning seeds with an export scanner no longer reduces their price substantially
bugfix: seed samples being sold at cargo now don't conflict with eachother's prices because wtf (this is a botany buff)
/:cl:
