### PR TITLE
Adds a Rarity value to all seeds of mutated plants

### DIFF
--- a/code/modules/hydroponics/grown/ambrosia.dm
+++ b/code/modules/hydroponics/grown/ambrosia.dm
@@ -43,7 +43,7 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/ambrosia/deus
 	mutatelist = list(/obj/item/seeds/ambrosia/gaia)
 	reagents_add = list(/datum/reagent/medicine/omnizine = 0.15, /datum/reagent/medicine/synaptizine = 0.15, /datum/reagent/drug/space_drugs = 0.1, /datum/reagent/consumable/nutriment = 0.05)
-	rarity = 40
+	rarity = 30
 
 /obj/item/reagent_containers/food/snacks/grown/ambrosia/deus
 	seed = /obj/item/seeds/ambrosia/deus
@@ -63,7 +63,7 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia
 	mutatelist = list(/obj/item/seeds/ambrosia/deus)
 	reagents_add = list(/datum/reagent/medicine/earthsblood = 0.05, /datum/reagent/consumable/nutriment = 0.06)
-	rarity = 30 //These are some pretty good plants right here
+	rarity = 40 //These are some pretty good plants right here
 	genes = list()
 	weed_rate = 4
 	weed_chance = 100

--- a/code/modules/hydroponics/grown/cereals.dm
+++ b/code/modules/hydroponics/grown/cereals.dm
@@ -35,6 +35,7 @@
 	plantname = "Oat Stalks"
 	product = /obj/item/reagent_containers/food/snacks/grown/oat
 	mutatelist = list()
+	rarity = 10
 
 /obj/item/reagent_containers/food/snacks/grown/oat
 	seed = /obj/item/seeds/wheat/oat
@@ -82,6 +83,7 @@
 	plantname = "Meatwheat"
 	product = /obj/item/reagent_containers/food/snacks/grown/meatwheat
 	mutatelist = list()
+	rarity = 20 //it's literally growing meat, this is a bit of a standout
 
 /obj/item/reagent_containers/food/snacks/grown/meatwheat
 	name = "meatwheat"

--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -103,6 +103,7 @@
 	endurance = 45
 	yield = 4
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.05)
+	rarity = 20
 
 /obj/item/reagent_containers/food/snacks/grown/firelemon
 	seed = /obj/item/seeds/firelemon
@@ -175,6 +176,7 @@
 	icon_dead = "lime-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.05)
+	rarity = 30 
 
 /obj/item/reagent_containers/food/snacks/grown/citrus/orange_3d
 	seed = /obj/item/seeds/orange_3d

--- a/code/modules/hydroponics/grown/cocoa_vanilla.dm
+++ b/code/modules/hydroponics/grown/cocoa_vanilla.dm
@@ -40,6 +40,7 @@
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list()
 	reagents_add = list(/datum/reagent/consumable/vanilla = 0.25, /datum/reagent/consumable/nutriment = 0.1)
+	rarity = 10
 
 /obj/item/reagent_containers/food/snacks/grown/vanillapod
 	seed = /obj/item/seeds/cocoapod/vanillapod

--- a/code/modules/hydroponics/grown/cotton.dm
+++ b/code/modules/hydroponics/grown/cotton.dm
@@ -63,6 +63,7 @@
 	growthstages = 3
 	growing_icon = 'icons/obj/hydroponics/growing.dmi'
 	icon_dead = "cotton-dead"
+	rarity = 20
 
 /obj/item/grown/cotton/durathread
 	seed = /obj/item/seeds/cotton/durathread

--- a/code/modules/hydroponics/grown/eggplant.dm
+++ b/code/modules/hydroponics/grown/eggplant.dm
@@ -37,6 +37,7 @@
 	production = 12
 	mutatelist = list()
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.1)
+	rarity = 10
 
 /obj/item/reagent_containers/food/snacks/grown/shell/eggy
 	seed = /obj/item/seeds/eggplant/eggy

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -37,6 +37,7 @@
 	plantname = "Lily Plants"
 	product = /obj/item/reagent_containers/food/snacks/grown/poppy/lily
 	mutatelist = list(/obj/item/seeds/bee_balm, /obj/item/seeds/poppy/lily/trumpet)
+	rarity = 10
 
 /obj/item/reagent_containers/food/snacks/grown/poppy/lily
 	seed = /obj/item/seeds/poppy/lily
@@ -87,6 +88,7 @@
 	plantname = "Geranium Plants"
 	product = /obj/item/reagent_containers/food/snacks/grown/poppy/geranium
 	mutatelist = list()
+	rarity = 10
 
 /obj/item/reagent_containers/food/snacks/grown/poppy/geranium
 	seed = /obj/item/seeds/poppy/geranium
@@ -266,6 +268,7 @@
 	icon_dead = "bee_balm-dead"
 	mutatelist = list(/obj/item/seeds/poppy/geranium, /obj/item/seeds/bee_balm/honey) //Lower odds of becoming honey
 	reagents_add = list(/datum/reagent/medicine/spaceacillin = 0.1, /datum/reagent/space_cleaner/sterilizine = 0.05)
+	rarity = 20
 
 /obj/item/reagent_containers/food/snacks/grown/bee_balm
 	seed = /obj/item/seeds/bee_balm

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -39,6 +39,7 @@
 	growing_icon = 'icons/obj/hydroponics/growing_flowers.dmi'
 	genes = list()
 	mutatelist = list()
+	rarity = 20 //atmospheric anomaly plant gets a little bit better rarity
 
 /obj/item/seeds/starthistle/corpse_flower/pre_attack(obj/machinery/hydroponics/I)
 	if(istype(I, /obj/machinery/hydroponics))
@@ -80,6 +81,7 @@
 	genes = list(/datum/plant_gene/trait/plant_type/weed_hardy)
 	mutatelist = list()
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.05, /datum/reagent/medicine/silibinin = 0.1)
+	rarity = 10
 
 /obj/item/reagent_containers/food/snacks/grown/galaxythistle
 	seed = /obj/item/seeds/galaxythistle

--- a/code/modules/hydroponics/grown/onion.dm
+++ b/code/modules/hydroponics/grown/onion.dm
@@ -37,6 +37,7 @@
 	weed_chance = 1
 	product = /obj/item/reagent_containers/food/snacks/grown/onion/red
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.1, /datum/reagent/consumable/tearjuice = 0.05)
+	rarity = 10
 
 /obj/item/reagent_containers/food/snacks/grown/onion/red
 	seed = /obj/item/seeds/onion/red

--- a/code/modules/hydroponics/grown/potato.dm
+++ b/code/modules/hydroponics/grown/potato.dm
@@ -58,6 +58,7 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/potato/sweet
 	mutatelist = list()
 	reagents_add = list(/datum/reagent/consumable/sugar = 0.1, /datum/reagent/consumable/nutriment = 0.1)
+	rarity = 10
 
 /obj/item/reagent_containers/food/snacks/grown/potato/sweet
 	seed = /obj/item/seeds/potato/sweet

--- a/code/modules/hydroponics/grown/root.dm
+++ b/code/modules/hydroponics/grown/root.dm
@@ -46,6 +46,7 @@
 	icon_dead = "carrot-dead"
 	mutatelist = list()
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.05)
+	rarity = 10
 
 /obj/item/reagent_containers/food/snacks/grown/parsnip
 	seed = /obj/item/seeds/carrot/parsnip
@@ -99,6 +100,7 @@
 	icon_dead = "whitebeet-dead"
 	genes = list(/datum/plant_gene/trait/maxchem)
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.05)
+	rarity = 20 //noteworthy for being the usual source of densified chems trait
 
 /obj/item/reagent_containers/food/snacks/grown/redbeet
 	seed = /obj/item/seeds/redbeet


### PR DESCRIPTION
After Theos pointed out that the seed exports were bugged and fixed it, he noted that mutated plants could be sold through cargo for some easy pocket change, but mutant seeds without a rarity modifier would have slashed values since the default is 0. I tried to keep the rarities conservative and only the standout plants in botany get higher values, so this won't lead to massive profits, just the ability to generate a bit more money the first time you export a unique mutant seed. You know, if two departments work together.

# Wiki Documentation

I don't think there's anything on the botany guide or cargo guide that relates to the rarities or being tied to cargo worth. If this change and Theo's go through, it might be worth adding a section about it.

# Changelog

:cl:  
tweak: gives rarity values to seeds from mutated plants that didn't have one previously.
tweak: Ambrosia Gaia and Deus got their rarity values flipped because Deus shouldn't be considered more rare than Gaia
/:cl:
