### PR TITLE
Some idiot approved the Mantis Blade PR while the mantis blade kit was being defined twice

### DIFF
--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -132,9 +132,3 @@
 	cost = 40
 	cant_discount = TRUE
 
-/datum/uplink_item/implants/mantis_kit
-	name = "G.O.R.L.E.X.  Mantis Blades Kit"
-	desc = "Comes with 2 G.O.R.L.E.X.  Mantis blades. All packaged with autosurgeons."
-	item = /obj/item/storage/briefcase/syndie_mantis
-	cost = 18
-	surplus = 0


### PR DESCRIPTION
# Document the changes in your pull request
Fixed small code issue

# Changelog

:cl:  
bugfix: fixed duplicate uplink definition for mantis blade kit
/:cl:
