### PR TITLE
Fixed comment on admins.txt mentioning character stripping that no longer occurs

### DIFF
--- a/config/admins.txt
+++ b/config/admins.txt
@@ -2,10 +2,8 @@
 # Basically, ckey goes first. Rank goes after the "="                                         #
 # Case is not important for ckey.                                                             #
 # Case IS important for the rank.                                                             #
-# All punctuation (spaces etc) EXCEPT '-', '_' and '@' will be stripped from rank names.      #
 # Ranks can be anything defined in admin_ranks.txt                                            #
 # NOTE: if the rank-name cannot be found in admin_ranks.txt, they will not be adminned! ~Carn #
-# NOTE: syntax was changed to allow hyphenation of ranknames, since spaces are stripped.      #
 # If SQL-based admin loading is enabled, admins listed here will always be loaded first		  #
 # and will override any duplicate entries in the database.									  #
 ###############################################################################################


### PR DESCRIPTION
# Document the changes in your pull request

I removed the stripping of spaces, so the comments should no longer say spaces are stripped

# Changelog

:cl:  
rscdel: Removed incorrect comments from admins.txt file
/:cl:
