### PR TITLE
Adds an href token to the mob spawn VV link

### DIFF
--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -25,7 +25,7 @@
 		var/atom/A = holder.my_atom
 		var/turf/T = get_turf(A)
 		var/message = "A [reaction_name] reaction has occurred in [ADMIN_VERBOSEJMP(T)]"
-		message += " (<A HREF='?_src_=vars;Vars=[REF(A)]'>VV</A>)"
+		message += " (<A HREF='?_src_=vars;[HrefToken()];Vars=[REF(A)]'>VV</A>)"
 
 		var/mob/M = get(A, /mob)
 		if(M)


### PR DESCRIPTION
# Document the changes in your pull request

Not entirely sure why the VV link is here, but now it actually works

# Changelog

:cl:  
bugfix: fixed the VV link in the gold slime log not working
/:cl:
