### PR TITLE
Adds a fallback if the bar selection is null, along with plenty of admin messages

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -564,7 +564,7 @@ SUBSYSTEM_DEF(job)
 
 	if(isnull(template))
 		message_admins("WARNING: BAR RECOVERY FAILED! THERE WILL BE NO BAR FOR THIS ROUND!")
-		log_game("WARNING: BAR TEMPLATE [backup_bar] FAILED TO LOAD! ATTEMPTING TO LOAD BACKUP")
+		log_game("WARNING: BAR RECOVERY FAILED! THERE WILL BE NO BAR FOR THIS ROUND!")
 		return
 
 	for(var/obj/effect/landmark/stationroom/box/bar/B in GLOB.landmarks_list)

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -554,14 +554,17 @@ SUBSYSTEM_DEF(job)
 
 	if(isnull(template))
 		message_admins("WARNING: BAR TEMPLATE [choice] FAILED TO LOAD! ATTEMPTING TO LOAD BACKUP")
+		log_game("WARNING: BAR TEMPLATE [choice] FAILED TO LOAD! ATTEMPTING TO LOAD BACKUP")
 		for(var/backup_bar in GLOB.potential_box_bars)
 			template = SSmapping.station_room_templates[backup_bar]
 			if(!isnull(template))
 				break
 			message_admins("WARNING: BAR TEMPLATE [backup_bar] FAILED TO LOAD! ATTEMPTING TO LOAD BACKUP")
+			log_game("WARNING: BAR TEMPLATE [backup_bar] FAILED TO LOAD! ATTEMPTING TO LOAD BACKUP")
 
 	if(isnull(template))
 		message_admins("WARNING: BAR RECOVERY FAILED! THERE WILL BE NO BAR FOR THIS ROUND!")
+		log_game("WARNING: BAR TEMPLATE [backup_bar] FAILED TO LOAD! ATTEMPTING TO LOAD BACKUP")
 		return
 
 	for(var/obj/effect/landmark/stationroom/box/bar/B in GLOB.landmarks_list)

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -552,6 +552,19 @@ SUBSYSTEM_DEF(job)
 	
 	var/datum/map_template/template = SSmapping.station_room_templates[choice]
 
+	if(isnull(template))
+		message_admins("WARNING: BAR TEMPLATE [choice] FAILED TO LOAD! ATTEMPTING TO LOAD BACKUP")
+		for(var/backup_bar in GLOB.potential_box_bars)
+			template = SSmapping.station_room_templates[backup_bar]
+			if(isnull(template))
+				message_admins("WARNING: BAR TEMPLATE [backup_bar] FAILED TO LOAD! ATTEMPTING TO LOAD BACKUP")
+			else
+				break
+
+	if(isnull(template))
+		message_admins("WARNING: BAR RECOVERY FAILED! THERE WILL BE NO BAR FOR THIS ROUND!")
+		return
+
 	for(var/obj/effect/landmark/stationroom/box/bar/B in GLOB.landmarks_list)
 		template.load(B.loc, centered = FALSE)
 		qdel(B)

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -556,7 +556,9 @@ SUBSYSTEM_DEF(job)
 		message_admins("WARNING: BAR TEMPLATE [choice] FAILED TO LOAD! ATTEMPTING TO LOAD BACKUP")
 		for(var/backup_bar in GLOB.potential_box_bars)
 			template = SSmapping.station_room_templates[backup_bar]
-			if(isnull(template))
+			if(!isnull(template))
+				break
+			message_admins("WARNING: BAR TEMPLATE [backup_bar] FAILED TO LOAD! ATTEMPTING TO LOAD BACKUP")
 				message_admins("WARNING: BAR TEMPLATE [backup_bar] FAILED TO LOAD! ATTEMPTING TO LOAD BACKUP")
 			else
 				break

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -559,9 +559,6 @@ SUBSYSTEM_DEF(job)
 			if(!isnull(template))
 				break
 			message_admins("WARNING: BAR TEMPLATE [backup_bar] FAILED TO LOAD! ATTEMPTING TO LOAD BACKUP")
-				message_admins("WARNING: BAR TEMPLATE [backup_bar] FAILED TO LOAD! ATTEMPTING TO LOAD BACKUP")
-			else
-				break
 
 	if(isnull(template))
 		message_admins("WARNING: BAR RECOVERY FAILED! THERE WILL BE NO BAR FOR THIS ROUND!")


### PR DESCRIPTION
# Document the changes in your pull request

Apparently, the bar can still sometimes not spawn for reasons. Hopefully this will allow the bar to spawn, while also informing the admins that an error has occurred.

# Changelog

:cl:  
rscadd: Added redundant bar selector, and logging for when it is used
/:cl:
