### PR TITLE
Fixed typo in burn healing surgery

### DIFF
--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -197,7 +197,7 @@
 	var/estimated_remaining_steps = target.getFireLoss() / burn_healed
 	var/progress_text
 	if(locate(/obj/item/healthanalyzer) in user.held_items)
-		progress_text = ". Remaining brute: <font color='#ff9933'>[target.getFireLoss()]</font>"
+		progress_text = ". Remaining burn: <font color='#ff9933'>[target.getFireLoss()]</font>"
 	else
 		switch(estimated_remaining_steps)
 			if(-INFINITY to 1)


### PR DESCRIPTION
# Document the changes in your pull request

You should not get a readout saying remaining brute when its telling you remaining burn

# Changelog

:cl:  
spellcheck: fixed message when doing burn healing surgery with a med scanner
/:cl:
