### PR TITLE
adds a cap on throwspeed from monstermos to carbons so you probably won't bust your bones open nearly as often

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -238,6 +238,8 @@
 			if(throw_target && (get_dir(src, throw_target) & direction))
 				throw_turf = get_turf(throw_target)
 			var/throw_speed = clamp(round(move_force / 2000), 1, 10)
+			if(iscarbon(src))
+				throw_speed = min(throw_speed, 4)
 			throw_at(throw_turf, move_force / 2000, throw_speed)
 		else
 			step(src, direction)


### PR DESCRIPTION
# Document the changes in your pull request

considering monstermos can spam throws this is necessary

# Changelog

:cl:  
tweak: carbons can now only be thrown twice as fast as normal by air
/:cl:
