### PR TITLE
Force roll a number of security personnel based on roundstart pop

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -97,6 +97,8 @@
 	integer = FALSE
 	min_val = 1
 
+/datum/config_entry/number/min_security_scaling_coeff	//how much does the amount of players get divided by to determine forced security positions
+
 /datum/config_entry/number/abductor_scaling_coeff	//how many players per abductor team
 	config_entry_value = 15
 	integer = FALSE

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -206,7 +206,7 @@ SUBSYSTEM_DEF(job)
 //This is basically to ensure that there's atleast a few heads in the round
 /datum/controller/subsystem/job/proc/FillHeadPosition()
 	for(var/level in level_order)
-		for(var/command_position in GLOB.command_positions)
+		for(var/command_position in GLOB.original_command_positions)
 			var/datum/job/job = GetJob(command_position)
 			if(!job)
 				continue
@@ -215,7 +215,7 @@ SUBSYSTEM_DEF(job)
 			var/list/candidates = FindOccupationCandidates(job, level)
 			if(!candidates.len)
 				continue
-			var/mob/dead/new_player/candidate = PickCommander(candidates) // Yogs -- makes command jobs weighted towards players of greater experience
+			var/mob/dead/new_player/candidate = PickCommander(candidates,command_position) // Yogs -- makes command jobs weighted towards players of greater experience
 			if(AssignRole(candidate, command_position))
 				return 1
 	return 0
@@ -224,7 +224,7 @@ SUBSYSTEM_DEF(job)
 //This proc is called at the start of the level loop of DivideOccupations() and will cause head jobs to be checked before any other jobs of the same level
 //This is also to ensure we get as many heads as possible
 /datum/controller/subsystem/job/proc/CheckHeadPositions(level)
-	for(var/command_position in GLOB.command_positions)
+	for(var/command_position in GLOB.original_command_positions)
 		var/datum/job/job = GetJob(command_position)
 		if(!job)
 			continue
@@ -256,6 +256,30 @@ SUBSYSTEM_DEF(job)
 		return TRUE
 	return FALSE
 
+/// Rolls a number of security based on the roundstart population
+/datum/controller/subsystem/job/proc/FillSecurityPositions()
+	var/coeff = CONFIG_GET(number/min_security_scaling_coeff)
+	if(!coeff)
+		return
+	var/target_count = initial_players_to_assign / coeff
+	var/current_count = 0
+
+	for(var/level in level_order)
+		for(var/security_position in GLOB.original_security_positions)
+			var/datum/job/job = GetJob(security_position)
+			if(!job)
+				continue
+			if((job.current_positions >= job.total_positions) && job.total_positions != -1)
+				continue
+			var/list/candidates = FindOccupationCandidates(job, level)
+			if(!candidates.len)
+				continue
+			var/mob/dead/new_player/candidate = pick(candidates) // Yogs -- makes command jobs weighted towards players of greater experience
+			if(AssignRole(candidate, security_position))
+				current_count++
+				if(current_count >= target_count)
+					return TRUE
+	return FALSE
 
 /** Proc DivideOccupations
  *  fills var "assigned_role" for all ready players.
@@ -319,6 +343,11 @@ SUBSYSTEM_DEF(job)
 	JobDebug("DO, Running AI Check")
 	FillAIPosition()
 	JobDebug("DO, AI Check end")
+
+	//Check for Security
+	JobDebug("DO, Running Security Check")
+	FillSecurityPositions()
+	JobDebug("DO, Security Check end")
 
 	//Other jobs are now checked
 	JobDebug("DO, Running Standard Check")

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -252,6 +252,11 @@ CHANGELING_SCALING_COEFF 8
 ## Set to 0 to disable scaling and use default numbers instead.
 SECURITY_SCALING_COEFF 7
 
+## Scales the number of forced security posistions based on population, this should probably be higher than the one above
+## Used as (Forced Security = Population / Coeff)
+## Set to 0 to disable forced security rolling
+MIN_SECURITY_SCALING_COEFF 10
+
 ## The number of objectives traitors get.
 ## Not including escaping/hijacking.
 TRAITOR_OBJECTIVES_AMOUNT 2


### PR DESCRIPTION
# Document the changes in your pull request

Rolls a number of security (HoS, Warden, Det, and Secoff all count for this) with a priority slightly below the single head / AI roll already in place. Currently rolls 1 per 10 people, adjustable via config.

Also fixed PickCommander in FillHeadPosition not being used properly, and increase the speed at which FillHeadPosition and CheckHeadPositions run.

# Changelog

:cl:  
rscadd: Added a population based number of forced sec personnel
bugfix: fixed some head rolling not using playtime weights
bugfix: fixed head rolling using alt titles, slowing it down
/:cl:
