### PR TITLE
Renames microwave ovens to bluespace microwave ovens

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -1,7 +1,7 @@
 //Microwaving doesn't use recipes, instead it calls the microwave_act of the objects. For food, this creates something based on the food's cooked_type
 
 /obj/machinery/microwave
-	name = "microwave oven"
+	name = "bluespace microwave oven"
 	desc = "Cooks and boils stuff."
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "mw"


### PR DESCRIPTION
# Document the changes in your pull request

As microwaves can magically put food on plates, the only logical conclusion is that it uses bluespace magic to fabricate a plate. 

How does it do it? Why does it do it? I don't know. Its magic, I don't have to explain shit.
 
_Also Jamie said I could make a meme PR, so im not going to pass up this opportunity_

# How is This Good For The Game?

# Wiki Documentation

Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. 

# Did Jamie Come Up With This Idea for This PR?
No

# Changelog

:cl:  
bugfix: renamed microwave ovens to bluespace microwave ovens 
/:cl:
