### PR TITLE
People without science access can no longer use R&D consoles to research [#2 electric boogaloo]

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -880,7 +880,10 @@ Nothing else in the console has ID requirements.
 		say("Resynced with nearby devices.")
 	if(ls["back_screen"])
 		back = text2num(ls["back_screen"])
-	if(ls["build"]) //Causes the Protolathe to build something.
+	if(ls["build"]) //Causes the Protolathe to build something
+		if(!allowed(usr))
+			to_chat(usr, "<span class='boldwarning'>Unauthorized Access<span>")
+			return
 		if(QDELETED(linked_lathe))
 			say("No Protolathe Linked!")
 			return
@@ -889,6 +892,9 @@ Nothing else in the console has ID requirements.
 		else
 			linked_lathe.user_try_print_id(ls["build"], ls["amount"])
 	if(ls["imprint"])
+		if(!allowed(usr))
+			to_chat(usr, "<span class='boldwarning'>Unauthorized Access<span>")
+			return
 		if(QDELETED(linked_imprinter))
 			say("No Circuit Imprinter Linked!")
 			return
@@ -974,6 +980,9 @@ Nothing else in the console has ID requirements.
 	if(ls["disk_slot"])
 		disk_slot_selected = text2num(ls["disk_slot"])
 	if(ls["research_node"])
+		if(!allowed(usr))
+			to_chat(usr, "<span class='boldwarning'>Unauthorized Access<span>")
+			return
 		if(!research_control)
 			return				//honestly should call them out for href exploiting :^)
 		if(!SSresearch.science_tech.available_nodes[ls["research_node"]])

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -881,9 +881,6 @@ Nothing else in the console has ID requirements.
 	if(ls["back_screen"])
 		back = text2num(ls["back_screen"])
 	if(ls["build"]) //Causes the Protolathe to build something
-		if(!allowed(usr))
-			to_chat(usr, "<span class='boldwarning'>Unauthorized Access<span>")
-			return
 		if(QDELETED(linked_lathe))
 			say("No Protolathe Linked!")
 			return
@@ -892,9 +889,6 @@ Nothing else in the console has ID requirements.
 		else
 			linked_lathe.user_try_print_id(ls["build"], ls["amount"])
 	if(ls["imprint"])
-		if(!allowed(usr))
-			to_chat(usr, "<span class='boldwarning'>Unauthorized Access<span>")
-			return
 		if(QDELETED(linked_imprinter))
 			say("No Circuit Imprinter Linked!")
 			return
@@ -1149,8 +1143,6 @@ Nothing else in the console has ID requirements.
 
 /obj/machinery/computer/rdconsole/robotics
 	name = "Robotics R&D Console"
-	req_access = null
-	req_access_txt = "29"
 
 /obj/machinery/computer/rdconsole/robotics/Initialize()
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request

It’s powergaming

Note: doesn’t prevent anyone in the current science department from researching.

# Wiki Documentation

Self evident

# Changelog

:cl:  
tweak: Researching is now locked behind science access
/:cl:
