### PR TITLE
Sheltered nerf

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -596,11 +596,11 @@
 
 /datum/quirk/sheltered
 	name = "Sheltered"
-	desc = "You never learned galactic common."
-	value = -3
+	desc = "You never learned to speak galactic common."
+	value = -1
 	mob_trait = TRAIT_SHELTERED
-	gain_text = span_danger("You do not understand galactic common.")
-	lose_text = span_notice("You start to put together what people are saying in galactic common.")
+	gain_text = span_danger("You do not speak galactic common.")
+	lose_text = span_notice("You start to put together how to speak galactic common.")
 	medical_record_text = "Patient looks perplexed when questioned in galactic common."
 
 


### PR DESCRIPTION
With the changes to Sheltered making it able to understand Common (#11994) , but unable to speak it, it requires updates to its descriptive text, and it also needs a corresponding drop in quirk point value. This is a stopgap should #12202 ultimately not go through.
Webedited, though it should be fine.

# Document the changes in your pull request

Sheltered text changes, quirk point value reduced to 1 from 3.

# Wiki Documentation

Sheltered should be noted as being able to understand Common, simply not speak it.

# Changelog

:cl:  
tweak: Sheltered's descriptive texts now properly reflect what it does.
tweak: Reduces the quirk balance of Sheltered from 3 to 1, as it is now only a Galactic Common Mute quirk.
/:cl:
