### PR TITLE
Microwaving a bluespace crystal now teleports the microwave

### DIFF
--- a/code/game/objects/items/stacks/bscrystal.dm
+++ b/code/game/objects/items/stacks/bscrystal.dm
@@ -47,7 +47,7 @@
 		use(1)
 
 /obj/item/stack/ore/bluespace_crystal/microwave_act(obj/machinery/microwave/M)
-	M.visible_message("[M] starts sputtering in and out of reality!")
+	M.visible_message(span_danger("[M] starts sputtering in and out of reality!"))
 	sleep(0.25 SECONDS)
 	blink_mob(M)
 

--- a/code/game/objects/items/stacks/bscrystal.dm
+++ b/code/game/objects/items/stacks/bscrystal.dm
@@ -46,6 +46,12 @@
 			blink_mob(hit_atom)
 		use(1)
 
+/obj/item/stack/ore/bluespace_crystal/microwave_act(obj/machinery/microwave/M)
+	M.visible_message("[M] starts sputtering in and out of reality!")
+	sleep(0.25 SECONDS)
+	blink_mob(M)
+	
+
 //Artificial bluespace crystal, doesn't give you much research.
 /obj/item/stack/ore/bluespace_crystal/artificial
 	name = "artificial bluespace crystal"

--- a/code/game/objects/items/stacks/bscrystal.dm
+++ b/code/game/objects/items/stacks/bscrystal.dm
@@ -50,7 +50,6 @@
 	M.visible_message("[M] starts sputtering in and out of reality!")
 	sleep(0.25 SECONDS)
 	blink_mob(M)
-	
 
 //Artificial bluespace crystal, doesn't give you much research.
 /obj/item/stack/ore/bluespace_crystal/artificial


### PR DESCRIPTION
# Document the changes in your pull request

Remove this text and explain what the purpose of your PR is.

They're bluespace microwaves are they not?

# Wiki Documentation

See title

# Changelog

:cl:  
rscadd: Microwaving a bluespace crystal will now teleport the microwave after a short delay
/:cl:
