### PR TITLE
Microwaving tin foil hats now creates explodes (Technically not an explosion but a flash)

### DIFF
--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -330,6 +330,9 @@
 	. = ..()
 	if(!warped)
 		warp_up()
+	visible_message(M, span_danger("[M] starts to fizzle!"))
+	sleep(0.25 SECONDS)
+	explosion(get_turf(M), 0, 0, 0, 5)
 
 /obj/item/clothing/head/franks_hat
 	name = "Frank's Hat"


### PR DESCRIPTION
# Document the changes in your pull request

I'm sure this won't go wrong

# Wiki Documentation

Title

# Changelog


:cl:  
tweak: In addition to warping your tin foil hat, microwaving it now also creates a minor blast
/:cl: