### PR TITLE
Remove Heater from TEG Hot Loop (Reverting 12196)

### DIFF
--- a/_maps/RandomRuins/StationRuins/BoxStation/engine_teg.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/engine_teg.dmm
@@ -273,6 +273,13 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"en" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/orange/visible{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "er" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -462,18 +469,6 @@
 	},
 /turf/template_noop,
 /area/space/nearstation)
-"ms" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater,
-/obj/machinery/camera{
-	c_tag = "Engineering TEG Fore";
-	network = list("ss13","engine");
-	pixel_x = 23
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "mW" = (
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
 	dir = 1
@@ -548,21 +543,6 @@
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"oW" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 1
-	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "pq" = (
@@ -649,6 +629,17 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"sE" = (
+/obj/machinery/camera{
+	c_tag = "Engineering TEG Fore";
+	network = list("ss13","engine");
+	pixel_x = 23
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/engine,
@@ -1393,11 +1384,6 @@
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
-/area/engine/engineering)
-"Ow" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold4w/orange/visible,
-/turf/open/floor/engine,
 /area/engine/engineering)
 "OB" = (
 /obj/machinery/meter,
@@ -2346,9 +2332,9 @@ dG
 "}
 (20,1,1) = {"
 ad
-ms
-oW
-Ow
+sE
+bC
+en
 EE
 PV
 pP


### PR DESCRIPTION
# Document the changes in your pull request

Reverts PR 12196 -- removing the heater from the TEG hot loop because merged PR 11864 makes them functionally useless.

# Wiki Documentation

No real wiki change needed as my revision for the heater was never published.

# Changelog


:cl:  
rscdel: Removed TEG hot loop Heater, as PR 11864 merged makes them functionally useless.
/:cl:
