### PR TITLE
Adds Extended Shock Touch

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -46,6 +46,7 @@
 #define MINDREAD	/datum/mutation/human/mindreader
 #define INSULATED	/datum/mutation/human/insulated
 #define SHOCKTOUCH	/datum/mutation/human/shock
+#define SHOCKTOUCHFAR		/datum/mutation/human/shock/far
 #define OLFACTION	/datum/mutation/human/olfaction
 #define ACIDFLESH	/datum/mutation/human/acidflesh
 #define BADBLINK	/datum/mutation/human/badblink

--- a/code/datums/mutations/_combined.dm
+++ b/code/datums/mutations/_combined.dm
@@ -25,6 +25,10 @@
 	required = "/datum/mutation/human/insulated; /datum/mutation/human/radioactive"
 	result = SHOCKTOUCH
 
+/datum/generecipe/shockfar
+	required = "/datum/mutation/human/shock; /datum/mutation/human/telekinesis"
+	result = SHOCKTOUCHFAR
+
 /datum/generecipe/antiglow
 	required = "/datum/mutation/human/glow; /datum/mutation/human/void"
 	result = ANTIGLOWY

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -32,7 +32,7 @@
 	var/far = FALSE
 
 /obj/item/melee/touch_attack/shock/afterattack(atom/target, mob/living/carbon/user, proximity)
-	if(!proximity && !far)
+	if((!proximity && !far) || !can_see(target) || get_dist(target, user) > 5)
 		return
 	if(iscarbon(target))
 		var/mob/living/carbon/C = target

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -33,7 +33,7 @@
 
 /obj/item/melee/touch_attack/shock/afterattack(atom/target, mob/living/carbon/user, proximity)
 	if((!proximity && !far) || !can_see(target) || get_dist(target, user) > 5)
-		user.visible_message("<span class='notice'>[user]'s hand does something funny.</span>")
+		user.visible_message("<span class='notice'>[user]'s hand reaches out but nothing happens.</span>")
 		return
 	if(iscarbon(target))
 		var/mob/living/carbon/C = target

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -29,9 +29,10 @@
 	on_use_sound = 'sound/weapons/zapbang.ogg'
 	icon_state = "zapper"
 	item_state = "zapper"
+	var/far = FALSE
 
 /obj/item/melee/touch_attack/shock/afterattack(atom/target, mob/living/carbon/user, proximity)
-	if(!proximity)
+	if(!proximity && !far)
 		return
 	if(iscarbon(target))
 		var/mob/living/carbon/C = target

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -33,6 +33,7 @@
 
 /obj/item/melee/touch_attack/shock/afterattack(atom/target, mob/living/carbon/user, proximity)
 	if((!proximity && !far) || !can_see(target) || get_dist(target, user) > 5)
+		user.visible_message("<span class='notice'>[user]'s hand does something funny.</span>")
 		return
 	if(iscarbon(target))
 		var/mob/living/carbon/C = target

--- a/code/datums/mutations/touchfar.dm
+++ b/code/datums/mutations/touchfar.dm
@@ -1,0 +1,13 @@
+/datum/mutation/human/shock/far
+	name = "Extended Shock Touch"
+	desc = "The affected can channel excess electricity through their hands without shocking themselves, allowing them to shock others at range."
+	instability = 40
+	text_gain_indication = "<span class='notice'>You feel unlimited power flow through your hands.</span>"
+	power = /obj/effect/proc_holder/spell/targeted/touch/shock/far
+
+/obj/effect/proc_holder/spell/targeted/touch/shock/far
+	name = "Extended Shock Touch"
+	hand_path = /obj/item/melee/touch_attack/shock/far
+
+/obj/item/melee/touch_attack/shock/far
+	far = TRUE

--- a/code/datums/mutations/touchfar.dm
+++ b/code/datums/mutations/touchfar.dm
@@ -1,7 +1,7 @@
 /datum/mutation/human/shock/far
 	name = "Extended Shock Touch"
 	desc = "The affected can channel excess electricity through their hands without shocking themselves, allowing them to shock others at range."
-	instability = 40
+	instability = 30
 	text_gain_indication = "<span class='notice'>You feel unlimited power flow through your hands.</span>"
 	power = /obj/effect/proc_holder/spell/targeted/touch/shock/far
 

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -574,6 +574,7 @@
 #include "code\datums\mutations\speech.dm"
 #include "code\datums\mutations\telekinesis.dm"
 #include "code\datums\mutations\touch.dm"
+#include "code\datums\mutations\touchfar.dm"
 #include "code\datums\ruins\icemoon.dm"
 #include "code\datums\ruins\lavaland.dm"
 #include "code\datums\ruins\space.dm"


### PR DESCRIPTION
# Document the changes in your pull request

Demonstrates how superior I am to boodaliboo

![](https://thumbs.gfycat.com/TintedChubbyIndochinahogdeer-max-1mb.gif)

Adds Extended Shock Touch, which is Shock Touch without the proximity check

It is created only by combining Shock Touch with Telekinesis & has 30 instability (Shock Touch has 20 for reference)

max distance is 5 tiles away in any cardinal or ordinal direction

# Wiki Documentation

30 instability
Extended Shock Touch - Shock Touch + Telekinesis
max distance is 5 tiles away in any cardinal or ordinal direction

# Changelog

:cl:  
rscadd: Added Extended Shock Touch, which allows you to zap people from afar
/:cl:
