### PR TITLE
Some items from the Protolathe now require Head/Armoury Access to use - (Lockboxes)

### DIFF
--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -41,6 +41,8 @@ other types of metals and chemistry for reagents).
 	var/icon_cache
 	/// Optional string that interfaces can use as part of search filters. See- item/borg/upgrade/ai and the Exosuit Fabs.
 	var/search_metadata
+	/// Spawns a lockbox with heads or Armoury Access.
+	var/locked = FALSE
 
 /datum/design/error_design
 	name = "ERROR"

--- a/code/modules/research/designs/AI_module_designs.dm
+++ b/code/modules/research/designs/AI_module_designs.dm
@@ -9,6 +9,7 @@
 	build_path = /obj/item/circuitboard/aicore
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	locked = TRUE
 
 /datum/design/board/safeguard_module
 	name = "Module Design (Safeguard)"

--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -23,6 +23,7 @@
 	category = list("Bluespace Designs")
 	dangerous_construction = TRUE
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	locked = TRUE
 
 /datum/design/bluespace_crystal
 	name = "Artificial Bluespace Crystal"

--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -29,6 +29,7 @@
 	build_path = /obj/item/circuitboard/computer/security
 	category = list("Computer Boards")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	locked = TRUE
 
 /datum/design/board/rdcamera
 	name = "Computer Design (Research Monitor)"
@@ -85,6 +86,7 @@
 	build_path = /obj/item/circuitboard/computer/communications
 	category = list("Computer Boards")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SECURITY				//Honestly should have a bridge techfab for this sometime.
+	locked = TRUE
 
 /datum/design/board/idcardconsole
 	name = "Computer Design (ID Console)"
@@ -93,6 +95,7 @@
 	build_path = /obj/item/circuitboard/computer/card
 	category = list("Computer Boards")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SECURITY				//Honestly should have a bridge techfab for this sometime.
+	locked = TRUE
 
 /datum/design/board/crewconsole
 	name = "Computer Design (Crew monitoring computer)"
@@ -101,6 +104,7 @@
 	build_path = /obj/item/circuitboard/computer/crew
 	category = list("Computer Boards")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY | DEPARTMENTAL_FLAG_MEDICAL
+	locked = TRUE
 
 /datum/design/board/secdata
 	name = "Computer Design (Security Records Console)"
@@ -109,6 +113,7 @@
 	build_path = /obj/item/circuitboard/computer/secure_data
 	category = list("Computer Boards")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	locked = TRUE
 
 /datum/design/board/atmosalerts
 	name = "Computer Design (Atmosphere Alert)"
@@ -133,6 +138,7 @@
 	build_path = /obj/item/circuitboard/computer/robotics
 	category = list("Computer Boards")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	locked = TRUE
 
 /datum/design/board/slot_machine
 	name = "Computer Design (Slot Machine)"
@@ -269,6 +275,7 @@
 	build_path = /obj/item/circuitboard/computer/apc_control
 	category = list("Computer Boards")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
+	locked = TRUE
 
 /datum/design/board/nanite_chamber_control
 	name = "Computer Design (Nanite Chamber Control)"
@@ -285,3 +292,4 @@
 	build_path = /obj/item/circuitboard/computer/nanite_cloud_controller
 	category = list("Computer Boards")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	locked = TRUE

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -129,6 +129,7 @@
 	build_path = /obj/item/circuitboard/computer/launchpad_console
 	category = list ("Teleportation Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	locked = TRUE
 
 /datum/design/board/teleconsole
 	name = "Computer Design (Teleporter Console)"
@@ -185,6 +186,7 @@
 	build_path = /obj/item/circuitboard/machine/smoke_machine
 	category = list ("Medical Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+	locked = TRUE
 
 /datum/design/board/reagentgrinder
 	name = "Machine Design (All-In-One Grinder)"
@@ -353,6 +355,7 @@
 	build_path = /obj/item/circuitboard/machine/gibber
 	category = list ("Misc. Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
+	locked = TRUE
 
 /datum/design/board/smartfridge
 	name = "Machine Design (Smartfridge Board)"

--- a/code/modules/research/designs/mecha_designs.dm
+++ b/code/modules/research/designs/mecha_designs.dm
@@ -41,6 +41,7 @@
 	build_path = /obj/item/circuitboard/mecha/gygax/main
 	category = list("Exosuit Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	locked = TRUE
 
 /datum/design/board/gygax_peri
 	name = "\"Gygax\" Peripherals Control module"
@@ -65,6 +66,7 @@
 	build_path = /obj/item/circuitboard/mecha/durand/main
 	category = list("Exosuit Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	locked = TRUE
 
 /datum/design/board/durand_peri
 	name = "\"Durand\" Peripherals Control module"
@@ -89,6 +91,7 @@
 	build_path = /obj/item/circuitboard/mecha/honker/main
 	category = list("Exosuit Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	locked = TRUE
 
 /datum/design/board/honker_peri
 	name = "\"H.O.N.K\" Peripherals Control module"
@@ -114,6 +117,7 @@
 	build_path = /obj/item/circuitboard/mecha/phazon/main
 	category = list("Exosuit Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	locked = TRUE
 
 /datum/design/board/phazon_peri
 	name = "\"Phazon\" Peripherals Control module"

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -220,6 +220,7 @@
 	materials = list(/datum/material/iron = 6000, /datum/material/glass = 1500, /datum/material/silver = 2000, /datum/material/gold = 1500, /datum/material/diamond = 200, /datum/material/titanium = 4000)
 	category = list("Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+	locked = TRUE
 
 /datum/design/mechanicalpinches
 	name = "Mechanical Pinches"
@@ -321,6 +322,7 @@
 	build_path = /obj/item/organ/cyberimp/eyes/hud/security
 	category = list("Implants", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+	locked = TRUE
 
 /datum/design/cyberimp_diagnostic_hud
 	name = "Diagnostic HUD Implant"
@@ -464,6 +466,7 @@
 	build_path = /obj/item/implantcase/chem
 	category = list("Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY | DEPARTMENTAL_FLAG_MEDICAL
+	locked = TRUE
 
 /datum/design/implant_tracking
 	name = "Tracking Implant Case"
@@ -474,6 +477,7 @@
 	build_path = /obj/item/implantcase/tracking
 	category = list("Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY | DEPARTMENTAL_FLAG_MEDICAL
+	locked = TRUE
 
 //Cybernetic organs
 
@@ -674,6 +678,7 @@
 	id = "surgery_brainwashing"
 	surgery = /datum/surgery/advanced/brainwashing
 	research_icon_state = "surgery_head"
+	locked = TRUE
 
 /datum/design/surgery/nerve_splicing
 	name = "Nerve Splicing"

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -173,6 +173,7 @@
 	build_path = /obj/item/gun/energy/e_gun/nuclear
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
+	locked = TRUE
 
 /datum/design/tele_shield
 	name = "Telescopic Riot Shield"
@@ -193,6 +194,7 @@
 	build_path = /obj/item/gun/energy/beam_rifle
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
+	locked = TRUE
 
 /datum/design/decloner
 	name = "Decloner"
@@ -204,6 +206,7 @@
 	build_path = /obj/item/gun/energy/decloner
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
+	locked = TRUE
 
 /datum/design/rapidsyringe
 	name = "Rapid Syringe Gun"
@@ -214,6 +217,7 @@
 	build_path = /obj/item/gun/syringe/rapidsyringe
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL		//uwu
+	locked = TRUE
 
 /datum/design/temp_gun
 	name = "Temperature Gun"
@@ -224,6 +228,7 @@
 	build_path = /obj/item/gun/energy/temperature
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	locked = TRUE
 
 /datum/design/flora_gun
 	name = "Floral Somatoray"
@@ -285,6 +290,7 @@
 	build_path = /obj/item/gun/energy/xray
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
+	locked = TRUE
 
 /datum/design/ioncarbine
 	name = "Ion Carbine"
@@ -295,6 +301,7 @@
 	build_path = /obj/item/gun/energy/ionrifle/carbine
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	locked = TRUE
 
 /datum/design/wormhole_projector
 	name = "Bluespace Wormhole Projector"
@@ -305,6 +312,7 @@
 	build_path = /obj/item/gun/energy/wormhole_projector
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	locked = TRUE
 
 //WT550 Mags
 
@@ -381,6 +389,7 @@
 	build_path = /obj/item/gun/energy/gravity_gun
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	locked = TRUE
 
 /datum/design/largecrossbow
 	name = "Energy Crossbow"
@@ -391,6 +400,7 @@
 	build_path = /obj/item/gun/energy/kinetic_accelerator/crossbow/large
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
+	locked = TRUE
 
 /datum/design/cryostatis_shotgun_dart
 	name = "Cryostatis Shotgun Dart"

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -81,7 +81,7 @@
 		reagents.trans_to(G, G.reagents.maximum_volume)
 	return ..()
 
-/obj/machinery/rnd/production/proc/do_print(path, amount, list/matlist, notify_admins)
+/obj/machinery/rnd/production/proc/do_print(path, amount, list/matlist, notify_admins, locked)
 	if(notify_admins)
 		investigate_log("[key_name(usr)] built [amount] of [path] at [src]([type]).", INVESTIGATE_RESEARCH)
 		message_admins("[ADMIN_LOOKUPFLW(usr)] has built [amount] of [path] at \a [src]([type]).")
@@ -89,6 +89,12 @@
 		var/obj/item/I = new path(get_turf(src))
 		if(efficient_with(I.type))
 			I.materials = matlist.Copy()
+		if(locked)
+			var/obj/item/storage/lockbox/L = new/obj/item/storage/lockbox(src.loc)
+			I.loc = L
+			L.name += " ([I.name])"
+			L.req_access = list()
+			L.req_one_access = list(ACCESS_ARMORY, ACCESS_HEADS)
 	SSblackbox.record_feedback("nested tally", "item_printed", amount, list("[type]", "[path]"))
 
 /obj/machinery/rnd/production/proc/check_mat(datum/design/being_built, var/mat)	// now returns how many times the item can be built with the material
@@ -156,7 +162,7 @@
 		flick(production_animation, src)
 	var/timecoeff = D.lathe_time_factor / efficiency_coeff
 	addtimer(CALLBACK(src, .proc/reset_busy), (30 * timecoeff * amount) ** 0.5)
-	addtimer(CALLBACK(src, .proc/do_print, D.build_path, amount, efficient_mats, D.dangerous_construction), (32 * timecoeff * amount) ** 0.8)
+	addtimer(CALLBACK(src, .proc/do_print, D.build_path, amount, efficient_mats, D.dangerous_construction, D.locked), (32 * timecoeff * amount) ** 0.8)
 	return TRUE
 
 /obj/machinery/rnd/production/proc/search(string)


### PR DESCRIPTION
# Document the changes in your pull request

Adds lockboxes to items from the protolathe/circuit imprinter that may be a security issue or waste resources. These lockboxes require heads or armoury ID to use.

The goal of this PR is to give back control to the heads of staff in the department they are assigned, Heads of staff dont really need to approve anything, people can just do what they want, build a durand? Sure. Waste all our resources on printing 30 portal guns? Sure.

With this PR it means Heads/Warden needs to approve anything printed and prevents people having free reign.

You can just shoot open/emp lockboxes or emag them if you really want to get into them. 
This mainly stops shit being given out like candy and also people invading science to get what they want.

# Wiki Documentation

Maybe anything about protolathes?

# Changelog

:cl:  
rscadd: Adds lockboxes to items from protolathe which could be classed as a security risk or high resource intensive.
/:cl:
