### PR TITLE
Revert 12196, removing the heater from the TEG Hot Loop

### DIFF
--- a/_maps/RandomRuins/StationRuins/BoxStation/engine_teg.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/engine_teg.dmm
@@ -462,14 +462,9 @@
 	},
 /turf/template_noop,
 /area/space/nearstation)
-"ms" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater,
-/obj/machinery/camera{
-	c_tag = "Engineering TEG Fore";
-	network = list("ss13","engine");
-	pixel_x = 23
-	},
-/obj/effect/turf_decal/stripes/line{
+"mp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/orange/visible{
 	dir = 1
 	},
 /turf/open/floor/engine,
@@ -548,21 +543,6 @@
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"oW" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 1
-	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "pq" = (
@@ -1394,11 +1374,6 @@
 	dir = 4
 	},
 /area/engine/engineering)
-"Ow" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold4w/orange/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "OB" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -1687,6 +1662,17 @@
 	},
 /obj/structure/sign/poster/official/safety_eye_protection{
 	pixel_y = -32
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"Wn" = (
+/obj/machinery/camera{
+	c_tag = "Engineering TEG Fore";
+	network = list("ss13","engine");
+	pixel_x = 23
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -2346,9 +2332,9 @@ dG
 "}
 (20,1,1) = {"
 ad
-ms
-oW
-Ow
+Wn
+bC
+mp
 EE
 PV
 pP


### PR DESCRIPTION
# Document the changes in your pull request

Reverts PR 12196 -- removing the heater from the TEG hot loop because merged PR 11864 makes them functionally useless.

# Wiki Documentation

No real wiki change needed as my revision for the heater was never published.

# Changelog


:cl:  
rscdel: Removed TEG hot loop Heater, as PR 11864 merged makes them functionally useless.
Experimental: Why yes I did just copy paste this from the PR I literally just closes. Now with BRANCHES!
/:cl:
