### PR TITLE
Boots the AI back to their core when being turned into a traitor, as being in a shell breaks things

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -104,6 +104,8 @@ GLOBAL_LIST_INIT(turfs_without_ground, typecacheof(list(
 
 #define isAI(A) (istype(A, /mob/living/silicon/ai))
 
+#define isAIShell(A) (istype(A, /mob/living/silicon/robot/shell))
+
 #define ispAI(A) (istype(A, /mob/living/silicon/pai))
 
 //Simple animals

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -18,6 +18,10 @@
 	can_hijack = HIJACK_HIJACKER
 
 /datum/antagonist/traitor/on_gain()
+	if(owner.current && isAIShell(owner.current))
+		var/mob/living/silicon/robot/shell/shell = owner.current
+		shell.undeploy()
+
 	if(owner.current && isAI(owner.current))
 		traitor_kind = TRAITOR_AI
 

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -18,9 +18,10 @@
 	can_hijack = HIJACK_HIJACKER
 
 /datum/antagonist/traitor/on_gain()
-	if(owner.current && isAIShell(owner.current))
-		var/mob/living/silicon/robot/shell/shell = owner.current
-		shell.undeploy()
+	if(owner.current && iscyborg(owner.current))
+		var/mob/living/silicon/robot/robot = owner.current
+		if(robot.shell)
+			robot.undeploy()
 
 	if(owner.current && isAI(owner.current))
 		traitor_kind = TRAITOR_AI


### PR DESCRIPTION
# Document the changes in your pull request

While in a shell a traitor AI doesn't get their law 0 properly, so they now get bonked back into their core when they become traitor

# Changelog

:cl:  
bugfix: fixed traitor AIs in shells breaking
/:cl:
