### PR TITLE
Adds an alert & sound to brainwashing

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -268,6 +268,11 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	desc = "You're on fire. Click to stop, drop and roll to put the fire out or move to a vacuum area."
 	icon_state = "fire"
 
+/obj/screen/alert/brainwashed
+	name = "Brainwashed"
+	desc = "You've been brainwashed! Check your notes to see your objective."
+	icon_state = "hypnosis"
+
 /obj/screen/alert/fire/Click()
 	var/mob/living/L = usr
 	if(!istype(L) || !L.can_resist())

--- a/code/modules/antagonists/brainwashing/brainwashing.dm
+++ b/code/modules/antagonists/brainwashing/brainwashing.dm
@@ -34,6 +34,9 @@
 /datum/antagonist/brainwashed/greet()
 	to_chat(owner, span_warning("Your mind reels as it begins focusing on a single purpose..."))
 	to_chat(owner, "<big><span class='warning'><b>Follow the Directives, at any cost!</b></span></big>")
+	owner.current.throw_alert("brainwash_notif", /obj/screen/alert/brainwashed)
+	SEND_SOUND(owner.current, sound('sound/ambience/ambimystery.ogg'))
+	SEND_SOUND(owner.current, sound('sound/effects/glassbr1.ogg'))
 	var/i = 1
 	for(var/X in objectives)
 		var/datum/objective/O = X
@@ -43,6 +46,7 @@
 /datum/antagonist/brainwashed/farewell()
 	to_chat(owner, span_warning("Your mind suddenly clears..."))
 	to_chat(owner, "<big><span class='warning'><b>You feel the weight of the Directives disappear! You no longer have to obey them.</b></span></big>")
+	owner.current.clear_alert("brainwash_notif")
 	owner.announce_objectives()
 
 /datum/antagonist/brainwashed/admin_add(datum/mind/new_owner,mob/admin)


### PR DESCRIPTION
# Document the changes in your pull request

https://forums.yogstation.net/threads/make-brainwashing-play-a-sound-and-or-display-a-hud-element.23921/

Turn on audio

https://user-images.githubusercontent.com/28408322/134219930-5fb200e8-7113-457c-b040-a762dc507e5e.mp4

Adds brainwash alert when you get brainwashed and removes self on removal of brainwash
Makes glass breaking & ominous sound when you get brainwashed

# Changelog

:cl:  
tweak: Made brainwashing a more obvious to those affected
/:cl:
