### PR TITLE
Revert "Fix jealous assassinate"

### DIFF
--- a/code/modules/antagonists/creep/creep.dm
+++ b/code/modules/antagonists/creep/creep.dm
@@ -161,8 +161,7 @@
 
 /datum/objective/assassinate/jealous/update_explanation_text()
 	..()
-	old = target
-	target = find_coworker(old)
+	old = find_coworker(target)
 	if(target && target.current && old)
 		explanation_text = "Murder [target.name], [old]'s coworker."
 	else


### PR DESCRIPTION
Reverts yogstation13/Yogstation#12031
this actually breaks the problem it was trying to solve which didn't exist??????
like the code is fucking stupid but tldr it sets target in the proc then returns the mind it was given so while it used to look like a complete fucking mess it'd work now it sets old, then sets target to the RIGHT target in the proc, then sets the target back to the returned mind used in the proc