### PR TITLE
Pandemic machines can no longer give infinitely long names to diseases

### DIFF
--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -195,7 +195,10 @@
 				var/new_name = html_encode(params["name"])
 				if(!new_name || ..())
 					return
-				A.AssignName(new_name)
+				if(length(new_name) < MAX_NAME_LEN)
+					A.AssignName(new_name)
+				else
+					to_chat(usr, span_warning("That name is too long!"))
 				. = TRUE
 		if("create_culture_bottle")
 			if (wait)


### PR DESCRIPTION
# Document the changes in your pull request



# Wiki Documentation


# Changelog


:cl:  
bugfix: Pandemic machines can no longer give infinitely long names to diseases
/:cl:
