### PR TITLE
Adds TOTP MFA for admins.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ where the admin rank must be properly capitalised.
 This codebase also depends on a native library called rust-g. A precompiled
 Windows DLL is included in this repository, but Linux users will need to build
 and install it themselves. Directions can be found at the [rust-g
-repo](https://github.com/tgstation/rust-g).
+repo](https://github.com/tgstation/rust-g). The `hash` feature is required.
 
 Finally, to start the server, run Dream Daemon and enter the path to your
 compiled yogstation.dmb file. Make sure to set the port to the one you

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -2,11 +2,25 @@ Any time you make a change to the schema files, remember to increment the databa
 
 The latest database version is 5.6; The query to update the schema revision table is:
 
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 6);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 7);
 or
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 6);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 7);
 
 In any query remember to add a prefix to the table names if you use one.
+
+version 5.7 23 September 2021, by adamsogm
+
+Adds table for storing mfa logins
+
+DROP TABLE IF EXISTS `mfa_logins`
+CREATE TABLE IF NOT EXISTS `mfa_logins` (
+	`ckey` varchar(32) NOT NULL,
+	`ip` int(10) unsigned NOT NULL,
+	`cid` varchar(32) NOT NULL,
+	PRIMARY KEY (`ckey`,`ip`,`cid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+----------------------------------------------------
 
 version 5.6 14 August 2021, by alexkar598
 

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -21,6 +21,7 @@ CREATE TABLE IF NOT EXISTS `mfa_logins` (
 	`ckey` varchar(32) NOT NULL,
 	`ip` int(10) unsigned NOT NULL,
 	`cid` varchar(32) NOT NULL,
+	`datetime` timestamp NOT NULL DEFAULT current_timestamp(),
 	PRIMARY KEY (`ckey`,`ip`,`cid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -12,7 +12,7 @@ version 5.7 23 September 2021, by adamsogm
 
 Adds table for storing mfa login cache and a column for storing TOTP seeds and one for mfa backup code
 
-ALTER TABLE ss13_player
+ALTER TABLE player
 ADD COLUMN totp_seed varchar(20),
 ADD COLUMN mfa_backup varchar(128);
 

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -10,9 +10,13 @@ In any query remember to add a prefix to the table names if you use one.
 
 version 5.7 23 September 2021, by adamsogm
 
-Adds table for storing mfa logins
+Adds table for storing mfa login cache and a column for storing TOTP seeds and one for mfa backup code
 
-DROP TABLE IF EXISTS `mfa_logins`
+ALTER TABLE ss13_player
+ADD COLUMN totp_seed varchar(20),
+ADD COLUMN mfa_backup varchar(128);
+
+DROP TABLE IF EXISTS `mfa_logins`;
 CREATE TABLE IF NOT EXISTS `mfa_logins` (
 	`ckey` varchar(32) NOT NULL,
 	`ip` int(10) unsigned NOT NULL,

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -342,6 +342,8 @@ CREATE TABLE IF NOT EXISTS `player` (
   `credits` bigint(20) unsigned NOT NULL DEFAULT 0,
   `antag_weight` mediumint(8) unsigned NOT NULL DEFAULT 100,
   `job_whitelisted` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  `totp_seed` varchar(20),
+  `mfa_backup` varchar(128),
   PRIMARY KEY (`ckey`),
   KEY `idx_player_cid_ckey` (`computerid`,`ckey`),
   KEY `idx_player_ip_ckey` (`ip`,`ckey`)

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -313,6 +313,7 @@ CREATE TABLE IF NOT EXISTS `mfa_logins` (
 	`ckey` varchar(32) NOT NULL,
 	`ip` int(10) unsigned NOT NULL,
 	`cid` varchar(32) NOT NULL,
+	`datetime` timestamp NOT NULL DEFAULT current_timestamp(),
 	PRIMARY KEY (`ckey`,`ip`,`cid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -308,7 +308,7 @@ CREATE TABLE IF NOT EXISTS `messages` (
   KEY `idx_msg_type_ckey_time_odr` (`type`,`targetckey`,`timestamp`,`deleted`)
 ) ENGINE=InnoDB AUTO_INCREMENT=75629 DEFAULT CHARSET=utf8;
 
-DROP TABLE IF EXISTS `mfa_logins`
+DROP TABLE IF EXISTS `mfa_logins`;
 CREATE TABLE IF NOT EXISTS `mfa_logins` (
 	`ckey` varchar(32) NOT NULL,
 	`ip` int(10) unsigned NOT NULL,

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -308,6 +308,13 @@ CREATE TABLE IF NOT EXISTS `messages` (
   KEY `idx_msg_type_ckey_time_odr` (`type`,`targetckey`,`timestamp`,`deleted`)
 ) ENGINE=InnoDB AUTO_INCREMENT=75629 DEFAULT CHARSET=utf8;
 
+DROP TABLE IF EXISTS `mfa_logins`
+CREATE TABLE IF NOT EXISTS `mfa_logins` (
+	`ckey` varchar(32) NOT NULL,
+	`ip` int(10) unsigned NOT NULL,
+	`cid` varchar(32) NOT NULL,
+	PRIMARY KEY (`ckey`,`ip`,`cid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 DROP TABLE IF EXISTS `misc`;
 CREATE TABLE IF NOT EXISTS `misc` (

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -308,7 +308,7 @@ CREATE TABLE IF NOT EXISTS `SS13_messages` (
   KEY `idx_msg_type_ckey_time_odr` (`type`,`targetckey`,`timestamp`,`deleted`)
 ) ENGINE=InnoDB AUTO_INCREMENT=75629 DEFAULT CHARSET=utf8;
 
-DROP TABLE IF EXISTS `SS13_mfa_logins`
+DROP TABLE IF EXISTS `SS13_mfa_logins`;
 CREATE TABLE IF NOT EXISTS `SS13_mfa_logins` (
 	`ckey` varchar(32) NOT NULL,
 	`ip` int(10) unsigned NOT NULL,

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -313,6 +313,7 @@ CREATE TABLE IF NOT EXISTS `SS13_mfa_logins` (
 	`ckey` varchar(32) NOT NULL,
 	`ip` int(10) unsigned NOT NULL,
 	`cid` varchar(32) NOT NULL,
+	`datetime` timestamp NOT NULL DEFAULT current_timestamp(),
 	PRIMARY KEY (`ckey`,`ip`,`cid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -342,6 +342,8 @@ CREATE TABLE IF NOT EXISTS `SS13_player` (
   `credits` bigint(20) unsigned NOT NULL DEFAULT 0,
   `antag_weight` mediumint(8) unsigned NOT NULL DEFAULT 100,
   `job_whitelisted` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  `totp_seed` varchar(20),
+  `mfa_backup` varchar(128),
   PRIMARY KEY (`ckey`),
   KEY `idx_player_cid_ckey` (`computerid`,`ckey`),
   KEY `idx_player_ip_ckey` (`ip`,`ckey`)

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -308,6 +308,13 @@ CREATE TABLE IF NOT EXISTS `SS13_messages` (
   KEY `idx_msg_type_ckey_time_odr` (`type`,`targetckey`,`timestamp`,`deleted`)
 ) ENGINE=InnoDB AUTO_INCREMENT=75629 DEFAULT CHARSET=utf8;
 
+DROP TABLE IF EXISTS `SS13_mfa_logins`
+CREATE TABLE IF NOT EXISTS `SS13_mfa_logins` (
+	`ckey` varchar(32) NOT NULL,
+	`ip` int(10) unsigned NOT NULL,
+	`cid` varchar(32) NOT NULL,
+	PRIMARY KEY (`ckey`,`ip`,`cid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 DROP TABLE IF EXISTS `SS13_misc`;
 CREATE TABLE IF NOT EXISTS `SS13_misc` (

--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -78,5 +78,18 @@
 #define rustg_http_request_async(method, url, body, headers) call(RUST_G, "http_request_async")(method, url, body, headers)
 #define rustg_http_check_request(req_id) call(RUST_G, "http_check_request")(req_id)
 
+#define rustg_hash_string(algorithm, text) call(RUST_G, "hash_string")(algorithm, text)
+#define rustg_hash_file(algorithm, fname) call(RUST_G, "hash_file")(algorithm, fname)
 #define rustg_hash_generate_totp(seed) call(RUST_G, "generate_totp")(seed)
-#define rustg_hash_string(algorithm, input) call(RUST_G, "hash_string")(algorithm, input)
+#define rustg_hash_generate_totp_tolerance(seed, tolerance) call(RUST_G, "generate_totp_tolerance")(seed, "[tolerance]")
+
+#define RUSTG_HASH_MD5 "md5"
+#define RUSTG_HASH_SHA1 "sha1"
+#define RUSTG_HASH_SHA256 "sha256"
+#define RUSTG_HASH_SHA512 "sha512"
+#define RUSTG_HASH_XXH64 "xxh64"
+#define RUSTG_HASH_BASE64 "base64"
+
+#ifdef RUSTG_OVERRIDE_BUILTINS
+	#define md5(thing) (isfile(thing) ? rustg_hash_file(RUSTG_HASH_MD5, "[thing]") : rustg_hash_string(RUSTG_HASH_MD5, thing))
+#endif

--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -77,3 +77,6 @@
 #define rustg_http_request_blocking(method, url, body, headers) call(RUST_G, "http_request_blocking")(method, url, body, headers)
 #define rustg_http_request_async(method, url, body, headers) call(RUST_G, "http_request_async")(method, url, body, headers)
 #define rustg_http_check_request(req_id) call(RUST_G, "http_check_request")(req_id)
+
+#define rustg_hash_generate_totp(seed) call(RUST_G, "generate_totp")(seed)
+#define rustg_hash_string(algorithm, input) call(RUST_G, "hash_string")(algorithm, input)

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -21,7 +21,7 @@
   * make sure you add an update to the schema_version stable in the db changelog
   */
 
-#define DB_MINOR_VERSION 6
+#define DB_MINOR_VERSION 7
 
 //! ## Timing subsystem
 /**

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -652,7 +652,10 @@
 			A = GLOB.deadmins[i]
 			if (!A)
 				continue
-		file_data["admins"]["[i]"] = A.rank.name
+		file_data["admins"]["[i]"] = list()
+		file_data["admins"]["[i]"]["rank"] = A.rank.name
+		file_data["admins"]["[i]"]["ip_cache"] = A.ip_cache
+		file_data["admins"]["[i]"]["cid_cache"] = A.cid_cache
 	fdel(json_file)
 	WRITE_FILE(json_file, json_encode(file_data))
 

--- a/code/controllers/configuration/entries/dbconfig.dm
+++ b/code/controllers/configuration/entries/dbconfig.dm
@@ -1,6 +1,9 @@
 /datum/config_entry/flag/sql_enabled	// for sql switching
 	protection = CONFIG_ENTRY_LOCKED
 
+/datum/config_entry/flag/mfa_enabled
+	protection = CONFIG_ENTRY_LOCKED
+
 /datum/config_entry/string/address
 	config_entry_value = "localhost"
 	protection = CONFIG_ENTRY_LOCKED | CONFIG_ENTRY_HIDDEN

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -272,7 +272,9 @@ GLOBAL_PROTECT(protected_ranks)
 					skip = TRUE
 			if(skip)
 				continue
-			new /datum/admins(trim(rank_names[backup_file_json["admins"]["[J]"]]), ckey("[J]"))
+			var/datum/admins/A = new /datum/admins(trim(rank_names[backup_file_json["admins"]["[J]"]["rank"]]), ckey("[J]"))
+			A.ip_cache = backup_file_json["admins"]["[J]"]["ip_cache"]
+			A.cid_cache = backup_file_json["admins"]["[J]"]["cid_cache"]
 	#ifdef TESTING
 	var/msg = "Admins Built:\n"
 	for(var/ckey in GLOB.admin_datums)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -21,7 +21,8 @@ GLOBAL_PROTECT(admin_verbs_default)
 	/client/proc/stop_sounds,
 	/client/proc/fix_air, // yogs - fix air verb
 	/client/proc/fix_air_z,
-	/client/proc/debugstatpanel
+	/client/proc/debugstatpanel,
+	/client/proc/clear_mfa,
 	)
 GLOBAL_LIST_INIT(admin_verbs_admin, world.AVerbsAdmin())
 GLOBAL_PROTECT(admin_verbs_admin)
@@ -694,7 +695,15 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	message_admins("[src] deadmined themself.")
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Deadmin")
 
+/client/proc/clear_mfa()
+	set name = "Forget 2FA logins"
+	set category = "Admin"
+	set desc= "Forgets all saved 2FA logins"
 
+	if(!holder)
+		return
+	
+	holder.mfa_reset()
 
 /client/proc/readmin()
 	set name = "Readmin"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -703,7 +703,8 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	if(!holder)
 		return
 	
-	holder.mfa_reset()
+	if(alert("Are you sure? This will forget all the previously saved 2FA logins", "Confirmation", "Yes", "No") == "Yes")
+		mfa_reset(ckey, TRUE)
 
 /client/proc/readmin()
 	set name = "Readmin"

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -98,7 +98,7 @@ GLOBAL_PROTECT(href_token)
 		disassociate()
 		add_verb(C, /client/proc/readmin)
 
-/datum/admins/proc/associate(client/C)
+/datum/admins/proc/associate(client/C, allow_query = TRUE)
 	if(IsAdminAdvancedProcCall())
 		var/msg = " has tried to elevate permissions!"
 		message_admins("[key_name_admin(usr)][msg]")
@@ -112,7 +112,7 @@ GLOBAL_PROTECT(href_token)
 			log_admin("[key_name(C)][msg]")
 			return FALSE
 
-		if(!handle_mfa(C))
+		if(!handle_mfa(C, allow_query))
 			return FALSE
 
 		if (deadmined)

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -98,7 +98,7 @@ GLOBAL_PROTECT(href_token)
 		disassociate()
 		add_verb(C, /client/proc/readmin)
 
-/datum/admins/proc/associate(client/C, allow_query = TRUE)
+/datum/admins/proc/associate(client/C, allow_mfa_query = TRUE)
 	if(IsAdminAdvancedProcCall())
 		var/msg = " has tried to elevate permissions!"
 		message_admins("[key_name_admin(usr)][msg]")
@@ -112,7 +112,9 @@ GLOBAL_PROTECT(href_token)
 			log_admin("[key_name(C)][msg]")
 			return FALSE
 
-		if(!handle_mfa(C, allow_query))
+		if(!C.mfa_check(allow_mfa_query))
+			if(!deadmined)
+				deactivate()
 			return FALSE
 
 		if (deadmined)

--- a/code/modules/admin/mfa.dm
+++ b/code/modules/admin/mfa.dm
@@ -1,0 +1,221 @@
+/datum/admins/proc/handle_mfa(client/C)
+	if(IsAdminAdvancedProcCall())
+		var/msg = " has tried to elevate permissions!"
+		message_admins("[key_name_admin(usr)][msg]")
+		log_admin("[key_name(usr)][msg]")
+		return
+
+	if(CONFIG_GET(flag/mfa_enabled))
+		if(check_mfa_cache(C))
+			return TRUE
+		else // Need to run MFA
+			INVOKE_ASYNC(src, .proc/query_mfa, C) // Don't want to hang while the user inputs their TOTP code
+
+			if(!deadmined)
+				deactivate()
+
+			return FALSE
+
+	return TRUE
+
+/datum/admins/proc/check_mfa_cache(client/C)
+	if(IsAdminAdvancedProcCall())
+		var/msg = " has tried to elevate permissions!"
+		message_admins("[key_name_admin(usr)][msg]")
+		log_admin("[key_name(usr)][msg]")
+		return FALSE
+
+	if(!C)
+		return FALSE
+
+	if(cid_cache == C.computer_id && ip_cache == C.address)
+		return TRUE
+
+	var/datum/DBQuery/query_mfa_check = SSdbcore.NewQuery(
+		"SELECT COUNT(1) FROM [format_table_name("mfa_logins")] WHERE ckey = :ckey AND ip = INET_ATON(:address) AND cid = :cid",
+		list("ckey" = target, "address" = C.address, "cid" = C.computer_id)
+	)
+
+	var/success = (query_mfa_check.warn_execute() && query_mfa_check.NextRow() && text2num(query_mfa_check.item[1]) > 0) // Check if they have connected before from this IP/CID
+	qdel(query_mfa_check)
+	return success
+
+/datum/admins/proc/query_mfa(client/C)
+	if(IsAdminAdvancedProcCall())
+		var/msg = " has tried to elevate permissions!"
+		message_admins("[key_name_admin(usr)][msg]")
+		log_admin("[key_name(usr)][msg]")
+		return
+	
+	if(!C)
+		return
+
+	var/datum/DBQuery/query_totp_seed = SSdbcore.NewQuery(
+		"SELECT totp_seed FROM [format_table_name("player")] WHERE ckey = :ckey",
+		list("ckey" = target)
+	)
+
+	if(!query_totp_seed.warn_execute())
+		qdel(query_totp_seed)
+		message_admins("SQL Error getting TOTP seed for [target]")
+		return
+
+	if(!query_totp_seed.NextRow())
+		qdel(query_totp_seed)
+		message_admins("Cannot find DB entry for [target] who is attempting to use MFA, this shouldn't be possible.")
+		return
+
+	var/seed = query_totp_seed.item[1]
+	qdel(query_totp_seed)
+
+	if(!seed)
+		enroll_mfa(C)
+		return
+
+	var/code = input(C, "Please enter your authentication code", "MFA Check") as null|num
+
+	if(code)
+		var/generated_code = rustg_hash_generate_totp(seed)
+		if(num2text(code) == generated_code)
+			login_mfa(C)
+			return
+
+	var/response = alert(C, "How would you like to proceed?", "Authentication Error", "Retry TOTP", "Backup Code", "Cancel")
+
+	if(response == "Cancel")
+		return
+
+	if(response == "Retry TOTP")
+		query_mfa()
+		return
+	else if(response == "Backup Code")
+		query_mfa_backup()
+	else
+		CRASH("INVALID RESPONSE TO QUERY")
+
+/datum/admins/proc/enroll_mfa(client/C)
+	var/list/base32lookup = list(
+		"A" = 0,
+		"B" = 1,
+		"C" = 2,
+		"D" = 3,
+		"E" = 4,
+		"F" = 5,
+		"G" = 6,
+		"H" = 7,
+		"I" = 8,
+		"J" = 9,
+		"K" = 10,
+		"L" = 11,
+		"M" = 12,
+		"N" = 13,
+		"O" = 14,
+		"P" = 15,
+		"Q" = 16,
+		"R" = 17,
+		"S" = 18,
+		"T" = 19,
+		"U" = 20,
+		"V" = 21,
+		"W" = 22,
+		"X" = 23,
+		"Y" = 24,
+		"Z" = 25, // 0 and 1 skipped due to similarty to O and I, RFC 4648
+		"2" = 26,
+		"3" = 27,
+		"4" = 28,
+		"5" = 29,
+		"6" = 30,
+		"7" = 31
+	)
+
+	var/code_b32 = ""
+	for(var/i = 0; i<16; i++) // Generate 16 character base 32 number
+		code_b32 += pick(base32lookup)
+	
+	var/code_b2 = ""
+	for(var/char in splittext(code_b32, ""))
+		code_b2 += num2text(base32lookup[char], 5, 2)
+
+	var/code_b16 = ""
+	for(var/byte in splittext(code_b2,regex(@"([01]{4})")))
+		if(byte == "")
+			continue
+		code_b16 = num2text(text2num(code_b2, 2), 0, 16)
+
+	to_chat(C, span_userdanger("Your 2FA code is [code_b32]!"), confidential = TRUE)
+
+	while(TRUE)
+		var/code = input(C, "Please verify your authentication code", "MFA Check") as null|num
+
+		if(code)
+			var/generated_code = rustg_hash_generate_totp(code_b16)
+			if(num2text(code) == generated_code)
+				break
+		else
+			return
+	
+	var/alphabet = splittext("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789", "")
+
+	var/raw_backup = ""
+	for(var/i = 0; i < 16; i++) // Generate 16 character base 32 number
+		raw_backup += pick(alphabet)
+	
+	var/backup_hash = rustg_hash_string("sha512", raw_backup)
+	to_chat(C, span_userdanger("Your 2FA backup code is [raw_backup]. This can be used to recover your account in the event you lose your 2FA device."), confidential=TRUE)
+
+	var/datum/DBQuery/query_set_totp_seed = SSdbcore.NewQuery(
+		"UPDATE [format_table_name("player")] SET totp_seed = :totp_seed, mfa_backup = :mfa_backup WHERE ckey = :ckey",
+		list("totp_seed" = code_b16, "mfa_backup" = backup_hash, "ckey" = target)
+	)
+
+	if(!query_set_totp_seed.warn_execute())
+		qdel(query_set_totp_seed)
+		return
+	qdel(query_set_totp_seed)
+	login_mfa(C)
+
+/datum/admins/proc/query_mfa_backup(client/C)
+	var/mfa_backup = input(C, "Please enter your authentication code", "MFA Check") as null|text
+	
+	if(!mfa_backup)
+		return
+
+	var/datum/DBQuery/query_mfa_backup = SSdbcore.NewQuery(
+		"SELECT COUNT(1) FROM [format_table_name("player")] WHERE ckey = :ckey AND mfa_backup = :code",
+		list("ckey" = target, "code" = rustg_hash_string("sha512", mfa_backup))
+	)
+
+	if(!query_mfa_backup.warn_execute() || !query_mfa_backup.NextRow())
+		qdel(query_mfa_backup)
+		message_admins("Unable to fetch backup codes for [target]!")
+
+	var/authed = query_mfa_backup.item[1] > 0
+	qdel(query_mfa_backup)
+	if(authed)
+		login_mfa(C)
+	else
+		to_chat(C, span_warning("Failed to validate backup code"))
+	
+
+/datum/admins/proc/login_mfa(client/C)
+	if(IsAdminAdvancedProcCall())
+		var/msg = " has tried to elevate permissions!"
+		message_admins("[key_name_admin(usr)][msg]")
+		log_admin("[key_name(usr)][msg]")
+		return
+
+	var/datum/DBQuery/mfa_addverify = SSdbcore.NewQuery(
+		"INSERT INTO [format_table_name("mfa_logins")] (ckey, ip, cid) VALUE (:ckey, INET_ATON(:address), :cid)",
+		list("ckey" = target, "address" = C.address, "cid" = C.computer_id)
+	)
+
+	if(!mfa_addverify.Execute())
+		qdel(mfa_addverify)
+		message_admins("Failed to add login info for [target], they will be unable to login")
+		return
+
+	qdel(mfa_addverify)
+
+	var/datum/admins/admin = GLOB.deadmins[target] || GLOB.admin_datums[target]
+	admin.activate()

--- a/code/modules/admin/mfa.dm
+++ b/code/modules/admin/mfa.dm
@@ -86,7 +86,11 @@
 	var/code = input(C, "Please enter your authentication code", "MFA Check") as null|num
 
 	if(code)
-		var/generated_codes = json_decode(rustg_hash_generate_totp_tolerance(seed, 1))
+		var/json_codes = rustg_hash_generate_totp_tolerance(seed, 1)
+		if(findtext(json_codes, "ERROR") != 0) // Something went wrong, exit
+			message_admins("Error with TOTP: [json_codes]")
+			return FALSE
+		var/generated_codes = json_decode(json_codes)
 		if(num2text(code) in generated_codes)
 			return TRUE
 
@@ -183,6 +187,9 @@
 		var/code = input(C, "Please verify your authentication code", "MFA Check") as null|num
 		if(code)
 			var/json_codes = rustg_hash_generate_totp_tolerance(code_b16, "1")
+			if(findtext(json_codes, "ERROR") != 0) // Something went wrong, exit
+				message_admins("Error with TOTP: [json_codes]")
+				return FALSE
 			var/generated_codes = json_decode(json_codes)
 			if(num2text(code) in generated_codes)
 				break

--- a/code/modules/admin/mfa.dm
+++ b/code/modules/admin/mfa.dm
@@ -35,7 +35,7 @@
 		return TRUE
 
 	var/datum/DBQuery/query_mfa_check = SSdbcore.NewQuery(
-		"SELECT COUNT(1) FROM [format_table_name("mfa_logins")] WHERE ckey = :ckey AND ip = INET_ATON(:address) AND cid = :cid",
+		"SELECT COUNT(1) FROM [format_table_name("mfa_logins")] WHERE ckey = :ckey AND ip = INET_ATON(:address) AND cid = :cid AND datetime > current_timestamp() - INTERVAL 30 DAY;",
 		list("ckey" = target, "address" = C.address, "cid" = C.computer_id)
 	)
 

--- a/code/modules/admin/mfa.dm
+++ b/code/modules/admin/mfa.dm
@@ -247,9 +247,6 @@
 		log_admin("[key_name(usr)][msg]")
 		return FALSE
 
-	message_admins("MFA for [src] has been reset by [usr]!")
-	log_admin("MFA Reset for [src] by [usr]!")
-
 	var/datum/DBQuery/query_clear_mfa = SSdbcore.NewQuery(
 		"DELETE FROM [format_table_name("mfa_logins")] WHERE ckey = :ckey",
 		list("ckey" = target)

--- a/code/modules/admin/permissionedit.dm
+++ b/code/modules/admin/permissionedit.dm
@@ -2,7 +2,7 @@
 	set category = "Server"
 	set name = "Permissions Panel"
 	set desc = "Edit admin permissions"
-	if(!check_rights(R_PERMISSIONS) || !holder.query_mfa(src)) // Require MFA to access the permissions panel
+	if(!check_rights(R_PERMISSIONS) || !mfa_query()) // Require MFA to access the permissions panel
 		return
 	usr.client.holder.edit_admin_permissions()
 
@@ -208,11 +208,11 @@
 				return
 			if(alert("If you have been requested to reset the MFA credentials for someone, please confirm that you have verified their identity. Resetting MFA for an unverified person can result in a break of server security.", "Confirmation", "I Understand", "Cancel") != "I Understand")
 				return
-			if(!query_mfa(target))
+			if(!owner.mfa_query())
 				return
 			message_admins("MFA for [src] has been reset by [usr]!")
 			log_admin("MFA Reset for [src] by [usr]!")
-			D.mfa_reset()
+			mfa_reset(admin_ckey)
 	edit_admin_permissions()
 
 /datum/admins/proc/add_admin(admin_ckey, admin_key, use_db)

--- a/code/modules/admin/permissionedit.dm
+++ b/code/modules/admin/permissionedit.dm
@@ -210,6 +210,8 @@
 				return
 			if(!query_mfa(target))
 				return
+			message_admins("MFA for [src] has been reset by [usr]!")
+			log_admin("MFA Reset for [src] by [usr]!")
 			D.mfa_reset()
 	edit_admin_permissions()
 

--- a/code/modules/admin/permissionedit.dm
+++ b/code/modules/admin/permissionedit.dm
@@ -208,8 +208,6 @@
 				return
 			if(alert("If you have been requested to reset the MFA credentials for someone, please confirm that you have verified their identity. Resetting MFA for an unverified person can result in a break of server security.", "Confirmation", "I Understand", "Cancel") != "I Understand")
 				return
-			if(!owner.mfa_query())
-				return
 			message_admins("MFA for [src] has been reset by [usr]!")
 			log_admin("MFA Reset for [src] by [usr]!")
 			mfa_reset(admin_ckey)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -298,8 +298,8 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	//Admin Authorisation
 	holder = GLOB.admin_datums[ckey]
 	if(holder)
-		GLOB.admins |= src
-		holder.owner = src
+		if(!holder.associate(src))
+			holder = null
 		connecting_admin = TRUE
 	else if(GLOB.deadmins[ckey])
 		add_verb(src, /client/proc/readmin)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -298,7 +298,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	//Admin Authorisation
 	holder = GLOB.admin_datums[ckey]
 	if(holder)
-		if(!holder.associate(src))
+		if(!holder.associate(src, FALSE)) // Prevent asking for MFA at this point, it likely won't work
 			holder = null
 		connecting_admin = TRUE
 	else if(GLOB.deadmins[ckey])

--- a/config/private_default.txt
+++ b/config/private_default.txt
@@ -72,6 +72,9 @@ TICK_LIMIT_MC_INIT 500
 ## Should SQL be enabled? Uncomment to enable
 #SQL_ENABLED
 
+## Should discord based MFA be enabled for admins? Uncomment to enable
+#MFA_ENABLED
+
 ## Prefix to be added to the name of every table, older databases will require this be set to erro_
 ## Note, this does not change the table names in the database, you will have to do that yourself.
 ##IE:

--- a/config/private_default.txt
+++ b/config/private_default.txt
@@ -70,10 +70,10 @@ ENABLE_LOCALHOST_RANK
 TICK_LIMIT_MC_INIT 500
 
 ## Should SQL be enabled? Uncomment to enable
-#SQL_ENABLED
+SQL_ENABLED
 
 ## Should discord based MFA be enabled for admins? Uncomment to enable
-#MFA_ENABLED
+MFA_ENABLED
 
 ## Prefix to be added to the name of every table, older databases will require this be set to erro_
 ## Note, this does not change the table names in the database, you will have to do that yourself.

--- a/config/private_default.txt
+++ b/config/private_default.txt
@@ -70,10 +70,10 @@ ENABLE_LOCALHOST_RANK
 TICK_LIMIT_MC_INIT 500
 
 ## Should SQL be enabled? Uncomment to enable
-SQL_ENABLED
+#SQL_ENABLED
 
 ## Should discord based MFA be enabled for admins? Uncomment to enable
-MFA_ENABLED
+#MFA_ENABLED
 
 ## Prefix to be added to the name of every table, older databases will require this be set to erro_
 ## Note, this does not change the table names in the database, you will have to do that yourself.

--- a/config/private_server.txt
+++ b/config/private_server.txt
@@ -79,6 +79,9 @@ TICK_LIMIT_MC_INIT 98
 ## Should SQL be enabled? Uncomment to enable
 SQL_ENABLED
 
+## Should discord based MFA be enabled for admins? Uncomment to enable
+MFA_ENABLED
+
 ## Prefix to be added to the name of every table, older databases will require this be set to erro_
 ## Note, this does not change the table names in the database, you will have to do that yourself.
 ##IE:

--- a/config/secret.txt
+++ b/config/secret.txt
@@ -4,7 +4,7 @@
 $include private_default.txt
 
 ## Communication key for receiving data through world/Topic(), you don't want to give this out
-COMMS_KEY default_passwd
+#COMMS_KEY default_pwd
 
 ## Hub address for tracking stats
 ## example: Hubmakerckey.Hubname
@@ -27,8 +27,8 @@ COMMS_KEY default_passwd
 # IPINTEL_EMAIL ch@nge.me
 
 ##Used to send round data to a webhook. Can now use HTTPS thanks to rust_g
-WEBHOOK_ADDRESS http://127.0.0.1:8080/api/byond
-WEBHOOK_KEY test
+#WEBHOOK_ADDRESS https://example.com
+#WEBHOOK_KEY webkey
 
 ## The XF API key for forum verification
 #XENFORO_KEY xenforokey

--- a/config/secret.txt
+++ b/config/secret.txt
@@ -4,7 +4,7 @@
 $include private_default.txt
 
 ## Communication key for receiving data through world/Topic(), you don't want to give this out
-#COMMS_KEY default_pwd
+COMMS_KEY default_passwd
 
 ## Hub address for tracking stats
 ## example: Hubmakerckey.Hubname
@@ -27,8 +27,8 @@ $include private_default.txt
 # IPINTEL_EMAIL ch@nge.me
 
 ##Used to send round data to a webhook. Can now use HTTPS thanks to rust_g
-#WEBHOOK_ADDRESS https://example.com
-#WEBHOOK_KEY webkey
+WEBHOOK_ADDRESS http://127.0.0.1:8080/api/byond
+WEBHOOK_KEY test
 
 ## The XF API key for forum verification
 #XENFORO_KEY xenforokey

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -1272,6 +1272,7 @@
 #include "code\modules\admin\holder2.dm"
 #include "code\modules\admin\ipintel.dm"
 #include "code\modules\admin\IsBanned.dm"
+#include "code\modules\admin\mfa.dm"
 #include "code\modules\admin\outfits.dm"
 #include "code\modules\admin\permissionedit.dm"
 #include "code\modules\admin\player_panel.dm"

--- a/yogstation/code/datums/world_topic.dm
+++ b/yogstation/code/datums/world_topic.dm
@@ -122,5 +122,7 @@ GLOBAL_VAR_INIT(mentornoot, FALSE)
 		message_admins("Failed to add login info for [ckey], they will be unable to login")
 		return
 
+	qdel(mfa_addverify)
+
 	var/datum/admins/admin = GLOB.deadmins[ckey] || GLOB.admin_datums[ckey]
 	admin.activate()

--- a/yogstation/code/datums/world_topic.dm
+++ b/yogstation/code/datums/world_topic.dm
@@ -103,3 +103,24 @@ GLOBAL_VAR_INIT(mentornoot, FALSE)
 		return "[ckey] has been unlinked!"
 	else
 		return "Account not unlinked! Please contact a coder."
+
+/datum/world_topic/mfa_verify
+	keyword = "mfa_verify"
+	require_comms_key = TRUE
+
+/datum/world_topic/mfa_verify/Run(list/input)
+	var/ckey = input["ckey"]
+	var/ip = input["ip"]
+	var/cid = input["cid"]
+	
+	var/datum/DBQuery/mfa_addverify = SSdbcore.NewQuery(
+		"INSERT INTO [format_table_name("mfa_logins")] (ckey, ip, cid) VALUE (:ckey, INET_ATON(:address), :cid)",
+		list("ckey" = ckey, "address" = ip, "cid" = cid)
+	)
+
+	if(!mfa_addverify.Execute())
+		message_admins("Failed to add login info for [ckey], they will be unable to login")
+		return
+
+	var/datum/admins/admin = GLOB.deadmins[ckey] || GLOB.admin_datums[ckey]
+	admin.activate()

--- a/yogstation/code/datums/world_topic.dm
+++ b/yogstation/code/datums/world_topic.dm
@@ -103,26 +103,3 @@ GLOBAL_VAR_INIT(mentornoot, FALSE)
 		return "[ckey] has been unlinked!"
 	else
 		return "Account not unlinked! Please contact a coder."
-
-/datum/world_topic/mfa_verify
-	keyword = "mfa_verify"
-	require_comms_key = TRUE
-
-/datum/world_topic/mfa_verify/Run(list/input)
-	var/ckey = input["ckey"]
-	var/ip = input["ip"]
-	var/cid = input["cid"]
-	
-	var/datum/DBQuery/mfa_addverify = SSdbcore.NewQuery(
-		"INSERT INTO [format_table_name("mfa_logins")] (ckey, ip, cid) VALUE (:ckey, INET_ATON(:address), :cid)",
-		list("ckey" = ckey, "address" = ip, "cid" = cid)
-	)
-
-	if(!mfa_addverify.Execute())
-		message_admins("Failed to add login info for [ckey], they will be unable to login")
-		return
-
-	qdel(mfa_addverify)
-
-	var/datum/admins/admin = GLOB.deadmins[ckey] || GLOB.admin_datums[ckey]
-	admin.activate()

--- a/yogstation/code/modules/admin/holder2.dm
+++ b/yogstation/code/modules/admin/holder2.dm
@@ -1,6 +1,6 @@
 /datum/admins/associate(client/C)
 	. = ..()
-	if(istype(C))
+	if(istype(C) && .)
 		C.mentor_datum_set(TRUE)
 
 /datum/admins/disassociate()

--- a/yogstation/code/modules/admin/holder2.dm
+++ b/yogstation/code/modules/admin/holder2.dm
@@ -1,5 +1,5 @@
 /datum/admins/associate(client/C)
-	..()
+	. = ..()
 	if(istype(C))
 		C.mentor_datum_set(TRUE)
 

--- a/yogstation/code/modules/webhook/webhook.dm
+++ b/yogstation/code/modules/webhook/webhook.dm
@@ -46,8 +46,3 @@
 	var/query = list("ckey" = url_encode(ckey), "ckey2" = url_encode(ckey2), "action" = url_encode(action))
 	webhook_send("mchange", query)
 
-
-///////////// MFA /////////////
-/proc/webhook_request_mfa(var/ckey, var/ip, var/cid)
-	var/query = list("ckey" = ckey, "ip" = ip, "cid" = cid)
-	webhook_send("mfarequest", query)

--- a/yogstation/code/modules/webhook/webhook.dm
+++ b/yogstation/code/modules/webhook/webhook.dm
@@ -45,3 +45,9 @@
 /proc/webhook_send_mchange(var/ckey, var/ckey2, var/action)
 	var/query = list("ckey" = url_encode(ckey), "ckey2" = url_encode(ckey2), "action" = url_encode(action))
 	webhook_send("mchange", query)
+
+
+///////////// MFA /////////////
+/proc/webhook_request_mfa(var/ckey, var/ip, var/cid)
+	var/query = list("ckey" = ckey, "ip" = ip, "cid" = cid)
+	webhook_send("mfarequest", query)


### PR DESCRIPTION
# Document the changes in your pull request

This prevents a client from associating with their admin datum until they authenticate with 2FA. The user must provide a one time password from an app like Google Authenticator (Other apps will work, this is just a popular one), at which point they will be authenticated and readminned. The server will save a successful CID/IP pair for up to 30 days if the user so desires, so they don't have to re-enter the 2FA login every round. 
In the event of a database failure, the last successful connection will be used.
If a user is not enrolled in 2FA when they try to readmin, they will be presented with a QR code, the raw TOTP seed, and a backup code. Most apps will be able to scan the QR code to get all the necessary information to generate 2FA codes, and the backup can be used in the event the 2FA device is lost. The server will ask for a code before saving these, to verify that the user has setup 2FA properly.
The permissions panel now requires a 2FA code to access, and can reset 2FA logins for any admin.
<details><summary>Images</summary>

Setup window
![image](https://user-images.githubusercontent.com/4607006/136124159-fd50254d-5fe4-4613-8416-71c67946618e.png)
Google Authenticator after scanning the code
![image](https://user-images.githubusercontent.com/4607006/136124034-34065035-b09a-4ffb-8571-f85d879f2819.png)
Entering the code
![image](https://user-images.githubusercontent.com/4607006/136123941-8ae6d8fa-969f-4892-8f26-70e7fdace23f.png)
Save confirmation
![image](https://user-images.githubusercontent.com/4607006/136123957-504774bb-cd2c-4d86-8177-c5261bbc51bf.png)
</details>

Requires rust_g update with the hash feature enabled.