### PR TITLE
Removes greentext and adds custom objective

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1287,3 +1287,9 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	var/area/target_area = get_area(target)
 
 	return (istype(user_area, dropoff) && istype(target_area, dropoff))
+
+/datum/objective/usercustom
+	name = "custom"
+
+/datum/objective/usercustom/check_completion()
+	return TRUE

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -141,7 +141,7 @@
 		if(prob(50) && length(GLOB.admins) > 0)
 			var/FunAdmin = FALSE
 			for(var/client/A in GLOB.admins)
-				if(check_rights_for(X,R_FUN))
+				if(check_rights_for(A,R_FUN))
 					FunAdmin = TRUE
 					break
 			

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -151,7 +151,7 @@
 			if(C && C.holder && C.holder.fakekey)
 				R = "(<a href='?priv_msg=[C.findStealthKey()]'>REPLY</a>)"
 			else
-				R = "(<a href='?priv_msg=[ckey]'>REPLY</a>)"
+				R = "(<a href='?priv_msg=[C.ckey]'>REPLY</a>)"
 			
 			if(custom_request != "Nothing." && custom_request != "")
 				for(var/client/X in GLOB.admins)

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -138,6 +138,27 @@
 					minorObjective = null
 			if(minorObjective)
 				add_objective(minorObjective)
+		if(prob(50) && length(GLOB.admins) > 0)
+			//Give them a custom objective
+			var/datum/objective/usercustom/custom_objective = new
+			add_objective(custom_objective)
+			var/custom_request = input(owner, "Enter your custom objective:", "Custom Objective Request", "Nothing.")
+			var/client/C = owner.current.client
+			if(!C)
+				return
+
+			var/R = ""
+			if(C && C.holder && C.holder.fakekey)
+				R = "(<a href='?priv_msg=[C.findStealthKey()]'>REPLY</a>)"
+			else
+				R = "(<a href='?priv_msg=[ckey]'>REPLY</a>)"
+			
+			if(custom_request != "Nothing." && custom_request != "")
+				for(var/client/X in GLOB.admins)
+					if(check_rights_for(X,R_FUN))
+						SEND_SOUND(X, sound('sound/effects/adminhelp.ogg'))
+						to_chat(GLOB.admins, "<b>CUSTOM OBJECTIVE: <font color='#e04414'>[ADMIN_LOOKUPFLW(owner)] [R]</b> is requesting the custom objective: [custom_request]</font>")
+
 		if(!(locate(/datum/objective/escape) in objectives))
 			var/datum/objective/escape/escape_objective = new
 			escape_objective.owner = owner
@@ -365,32 +386,22 @@
 		var/count = 1
 		for(var/datum/objective/objective in objectives)
 			if(objective.check_completion())
-				objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text] [span_greentext("Success!")]"
+				objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text]"
 			else
-				objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text] [span_redtext("Fail.")]"
+				objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text]"
 				traitorwin = FALSE
 			count++
 
 	if(uplink_true)
 		var/uplink_text = "(used [TC_uses] TC) [purchases]"
 		if(TC_uses==0 && traitorwin)
-			var/static/icon/badass = icon('icons/badass.dmi', "badass")
-			uplink_text += "<BIG>[icon2html(badass, world)]</BIG>"
 			SSachievements.unlock_achievement(/datum/achievement/badass, owner.current.client)
 		result += uplink_text
 
 	result += objectives_text
 
-	var/special_role_text = lowertext(name)
-
 	if (contractor_hub)
 		result += contractor_round_end()
-
-	if(traitorwin)
-		result += span_greentext("The [special_role_text] was successful!")
-	else
-		result += span_redtext("The [special_role_text] has failed!")
-		SEND_SOUND(owner.current, 'sound/ambience/ambifailure.ogg')
 
 	return result.Join("<br>")
 

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -143,6 +143,7 @@
 			for(var/client/A in GLOB.admins)
 				if(check_rights_for(X,R_FUN))
 					FunAdmin = TRUE
+					break
 			
 			if(!FunAdmin)
 				return

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -139,6 +139,14 @@
 			if(minorObjective)
 				add_objective(minorObjective)
 		if(prob(50) && length(GLOB.admins) > 0)
+			var/FunAdmin = FALSE
+			for(var/client/A in GLOB.admins)
+				if(check_rights_for(X,R_FUN))
+					FunAdmin = TRUE
+			
+			if(!FunAdmin)
+				return
+
 			//Give them a custom objective
 			var/datum/objective/usercustom/custom_objective = new
 			add_objective(custom_objective)


### PR DESCRIPTION
# Document the changes in your pull request

The complaint about this last time was that there was no code changes to supplement it so I added custom objective and we're trying this again

Discourages the 'win' and gloating mindset
Discourages the validhunt/murderbone to 'win' and 'must redtext the traitor' mindsets
Encourages the addition of more creative and liberal objectives without worrying about how possible it is to track within code

Custom objective brings up a prompt
You input what you want and it tells the admins
From there the admins can decide if they want to approve it or not or discuss with you further about it.

# Changelog

:cl:  
rscadd: Added custom objectives
rscdel: Removed greentext
/:cl: