### PR TITLE
Shower tweaks, showers on boiling do not burn people with resistheat, and showers will stabilize the body temp of their occupents when set to normal heat

### DIFF
--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -128,9 +128,15 @@
 	else if(current_temperature == SHOWER_BOILING)
 		if(iscarbon(L))
 			C.adjust_bodytemperature(35, 0, 500)
-		L.adjustFireLoss(5)
+		if(!HAS_TRAIT(L, TRAIT_RESISTHEAT))
+			L.adjustFireLoss(5)
 		to_chat(L, span_danger("[src] is searing!"))
-
+	else
+		if(iscarbon(L))
+			if(C.bodytemperature < 288) // 15C
+				C.adjust_bodytemperature(10)
+			if(C.bodytemperature > 298) // 25C
+				C.adjust_bodytemperature(-10)
 
 /obj/effect/mist
 	name = "mist"


### PR DESCRIPTION
# Document the changes in your pull request

If the shower is set to boiling, it won't damage people with heat adaptation (and other people with TRAIT_RESISTHEAT)
If the shower is at default temp, it will adjust the body temp of anyone whose temperature outside the 15-25C range back into it

# Wiki Documentation

TRAIT_RESISTHEAT protects from shower burns
If body temp is outside the 15-25C range, it is adjusted by 10C toward 20C. (Freezing does -80C per tick, and boiling does 25 per tick for comparison)

# Changelog

:cl:  
tweak: showers on default temp stabilize temperature of occupants
tweak: showers on boiling do not harm people with heat adaptation
/:cl:
