### PR TITLE
Increases the singularity's maximum rad pulse to 9000 from 5000

### DIFF
--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -145,7 +145,7 @@
 /obj/singularity/process()
 	if(current_size >= STAGE_TWO)
 		move()
-		radiation_pulse(src, min(5000, (energy*4.5)+1000), RAD_DISTANCE_COEFFICIENT*0.5)
+		radiation_pulse(src, min(9000, (energy*4.5)+1000), RAD_DISTANCE_COEFFICIENT*0.5)
 		if(prob(event_chance))//Chance for it to run a special event TODO:Come up with one or two more that fit
 			event()
 	eat()


### PR DESCRIPTION
t the changes in your pull request

singularity's radiation now increases through the majority of stage 3 and 4 rather than capping at high stage 3
this is probably going to be terrible for the environment but will give cringineers a reason to get a stage 4 contained sinuglo (it is possible just very hard)

# Changelog

:cl:  
tweak: singulo now produces far more rads at higher energy levels, increasing power output and probably making it more of a hazard
/:cl:
