### PR TITLE
Ninja Stim Shots

### DIFF
--- a/code/datums/actions/ninja.dm
+++ b/code/datums/actions/ninja.dm
@@ -14,6 +14,13 @@
 	button_icon_state = "repulse"
 	icon_icon = 'icons/mob/actions/actions_spells.dmi'
 
+/datum/action/item_action/ninjastim
+	check_flags = NONE
+	name = "Stim Shot"
+	desc = "Inject a chemical cocktail that heals slash wounds and helps to stabilize blood loss."
+	button_icon_state = "fleshmend"
+	icon_icon = 'icons/mob/actions/actions_changeling.dmi'
+
 /datum/action/item_action/ninjapulse
 	name = "EM Burst (25E)"
 	desc = "Disable any nearby technology with an electro-magnetic pulse."

--- a/code/modules/ninja/__ninjaDefines.dm
+++ b/code/modules/ninja/__ninjaDefines.dm
@@ -11,6 +11,7 @@ Contents:
 #define N_STEALTH_CANCEL	1
 #define N_SMOKE_BOMB		2
 #define N_ADRENALINE		3
+#define N_STIM		4
 
 //ninjaDrainAct() defines for non numerical returns
 //While not strictly needed, it's nicer than them just returning "twat"

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_cost_check.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_cost_check.dm
@@ -22,4 +22,8 @@
 			if(!a_boost)
 				to_chat(H, "<span class='danger'>You do not have any more adrenaline boosters.</span>")
 				return 1
+		if(N_STIM)
+			if(!s_shots)
+				to_chat(H, "<span class='danger'>You do not have any more stim shots.</span>")
+				return 1
 	return (s_coold)//Returns the value of the variable which counts down to zero.

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_stimshot.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_stimshot.dm
@@ -1,0 +1,12 @@
+//Injects the user with a small amount of coagulant, perf, and saline glucose solution.
+//Heals a very slight amount of damage while removing any slash wounds and slightly helping with bloodloss.
+/obj/item/clothing/suit/space/space_ninja/proc/ninjastim()
+
+	if(!ninjacost(0,N_STIM))
+		var/mob/living/carbon/human/H = affecting
+		H.reagents.add_reagent(/datum/reagent/medicine/coagulant, 5)
+		H.reagents.add_reagent(/datum/reagent/medicine/salglu_solution, 10)
+		H.reagents.add_reagent(/datum/reagent/medicine/perfluorodecalin, 5)
+		s_shots--
+		to_chat(H, "<span class='notice'>There are <B>[s_shots]</B> stim shots remaining.</span>")
+		s_coold = 1

--- a/code/modules/ninja/suit/suit.dm
+++ b/code/modules/ninja/suit/suit.dm
@@ -22,7 +22,7 @@ Contents:
 	armor = list("melee" = 50, "bullet" = 40, "laser" = 30,"energy" = 15, "bomb" = 30, "bio" = 30, "rad" = 30, "fire" = 100, "acid" = 100)
 	strip_delay = 12
 
-	actions_types = list(/datum/action/item_action/initialize_ninja_suit, /datum/action/item_action/ninjasmoke, /datum/action/item_action/ninjaboost, /datum/action/item_action/ninjapulse, /datum/action/item_action/ninjastar, /datum/action/item_action/ninjanet, /datum/action/item_action/ninja_sword_recall, /datum/action/item_action/ninja_stealth, /datum/action/item_action/toggle_glove)
+	actions_types = list(/datum/action/item_action/initialize_ninja_suit, /datum/action/item_action/ninjasmoke, /datum/action/item_action/ninjastim,  /datum/action/item_action/ninjaboost, /datum/action/item_action/ninjapulse, /datum/action/item_action/ninjastar, /datum/action/item_action/ninjanet, /datum/action/item_action/ninja_sword_recall, /datum/action/item_action/ninja_stealth, /datum/action/item_action/toggle_glove)
 
 		//Important parts of the suit.
 	var/mob/living/carbon/human/affecting = null
@@ -46,6 +46,7 @@ Contents:
 	var/a_transfer = 20//How much radium is used per adrenaline boost.
 	var/a_maxamount = 7//Maximum number of adrenaline boosts.
 	var/s_maxamount = 20//Maximum number of smoke bombs.
+	var/st_maxamount = 4//Maximum number of stimshots.
 	var/do_gib = TRUE // yogs
 
 		//Support function variables.
@@ -55,6 +56,7 @@ Contents:
 		//Ability function variables.
 	var/s_bombs = 10//Number of smoke bombs.
 	var/a_boost = 3//Number of adrenaline boosters.
+	var/s_shots = 2//Number of stim shots.
 
 
 /obj/item/clothing/suit/space/space_ninja/get_cell()
@@ -92,6 +94,7 @@ Contents:
 	s_delay = rand(10,100)
 	s_bombs = rand(5,20)
 	a_boost = rand(1,7)
+	s_shots = rand(2,4)
 
 
 //This proc prevents the suit from being taken off.
@@ -155,6 +158,7 @@ Contents:
 			. += "All systems operational. Current energy capacity: <B>[DisplayEnergy(cell.charge)]</B>.\n"+\
 			"The CLOAK-tech device is <B>[stealth?"active":"inactive"]</B>.\n"+\
 			"There are <B>[s_bombs]</B> smoke bomb\s remaining.\n"+\
+			"There are <B>[s_shots]</B> stim shot\s remaining.\n"+\
 			"There are <B>[a_boost]</B> adrenaline booster\s remaining."
 
 /obj/item/clothing/suit/space/space_ninja/ui_action_click(mob/user, action)
@@ -166,6 +170,9 @@ Contents:
 		return FALSE
 	if(istype(action, /datum/action/item_action/ninjasmoke))
 		ninjasmoke()
+		return TRUE
+	if(istype(action, /datum/action/item_action/ninjastim))
+		ninjastim()
 		return TRUE
 	if(istype(action, /datum/action/item_action/ninjaboost))
 		ninjaboost()

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2545,6 +2545,7 @@
 #include "code\modules\ninja\suit\n_suit_verbs\ninja_smoke.dm"
 #include "code\modules\ninja\suit\n_suit_verbs\ninja_stars.dm"
 #include "code\modules\ninja\suit\n_suit_verbs\ninja_stealth.dm"
+#include "code\modules\ninja\suit\n_suit_verbs\ninja_stimshot.dm"
 #include "code\modules\ninja\suit\n_suit_verbs\ninja_sword_recall.dm"
 #include "code\modules\NTNet\netdata.dm"
 #include "code\modules\NTNet\network.dm"


### PR DESCRIPTION
Adds stim shots for ninjas. They get 2-4 of these and they inject 5 units of sangurite or whatever, also known as coagulant, and 5 units of perf and 10 units of saline glucose solution. The stimshot heals slash wounds rather quickly, and also helps to deal with bloodloss. However, the stimshot is just about useless for healing other damage so it is not a replacement for taking off your suit to use meds to fix up everything else. Also it wont help with fractures, burns, and i dont know about pierce wounds.

Good for game cause dying from a weeping avulsion you got from accidently clicking yourself once with a katana and not being able to even survive long enough to take off your suit, let alone treat it, is very unfun.

# Changelog

:cl:  
rscadd: Adds ninja stim shots for, what a surprise, ninjas. (They help with slash wounds and blood loss)
/:cl:
