### PR TITLE
Give admins a prefix color like mentors do

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -100,7 +100,7 @@ GLOBAL_VAR_INIT(mentor_ooc_colour, YOGS_MENTOR_OOC_COLOUR) // yogs - mentor ooc 
 	var/oocmsg_toadmins = FALSE; // The message sent to admins.
 	if(holder) // If the speaker is an admin or something
 		if(check_rights_for(src, R_ADMIN)) // If they're supposed to have their own admin OOC colour
-			oocmsg += "<span class='adminooc'>[(CONFIG_GET(flag/allow_admin_ooccolor) && prefs.ooccolor) ? "<font color=[prefs.ooccolor]>" :"" ]<span class='prefix'>[find_admin_rank(src)]" // The header for an Admin's OOC.
+			oocmsg += "<span class='adminooc'><span class='prefix'>[find_admin_rank(src)][(CONFIG_GET(flag/allow_admin_ooccolor) && prefs.ooccolor) ? "<font color=[prefs.ooccolor]>" :"" ]" // The header for an Admin's OOC.
 		else // Else if they're an AdminObserver
 			oocmsg += "<span class='adminobserverooc'><span class='prefix'>[find_admin_rank(src)]" // The header for an AO's OOC.
 		//Check yogstation\code\module\client\verbs\ooc for the find_admin_rank definition.


### PR DESCRIPTION
# Document the changes in your pull request

I like that mentor OOC stands out even with the custom color, no clue why admin OOC is all your pref color without the brackets, helps me at least pick them out by associating colors.

this color can be changed in code with the .adminooc color set in interface/stylesheet.dm, it's currently #700038 (a dark red). Feel free to suggest a color or someone far smarter than me make it so it colors it by the rank you are.

if this was intended then close my PR

# Changelog

:cl:  
tweak: moved span so OOC message is colored by your prefs after it already has your rank said
/:cl:
