### PR TITLE
No more Mr. nice NT ninja

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -699,7 +699,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	var/area/centcom/holding/A = GLOB.areas_by_type[/area/centcom/holding]
 	for(var/mob/living/carbon/human/M in A)//Humans.
 		if(!istype(src,/datum/objective/capture/living) && M.stat == DEAD)
-				captured_amount+=0.5
+			captured_amount+= 0.5
 		else
 			captured_amount+= 1 //dont care if they are dead or alive in living capture because you shouldn't be able to capture them if they dead
 	for(var/mob/living/carbon/monkey/M in A)//Monkeys are almost worthless, you failure.

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -734,6 +734,10 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 /datum/objective/capture/living
 	name = "capture living"
 
+/datum/objective/capture/living/update_explanation_text()
+	. = ..()
+	explanation_text = "Capture [target_amount] living lifeform\s with an energy net. Only alive specimens count."
+
 /datum/objective/protect_object
 	name = "protect object"
 	var/obj/protect_target

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -698,11 +698,8 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	var/captured_amount = 0
 	var/area/centcom/holding/A = GLOB.areas_by_type[/area/centcom/holding]
 	for(var/mob/living/carbon/human/M in A)//Humans.
-		if(!istype(src,/datum/objective/capture/living))
-			if(M.stat == DEAD)//Dead folks are worth less (or not at all if you need to capture living)
+		if(!istype(src,/datum/objective/capture/living) && M.stat == DEAD)
 				captured_amount+=0.5
-			else
-				captured_amount+=1
 		else
 			captured_amount+= 1 //dont care if they are dead or alive in living capture because you shouldn't be able to capture them if they dead
 	for(var/mob/living/carbon/monkey/M in A)//Monkeys are almost worthless, you failure.

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -698,10 +698,13 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	var/captured_amount = 0
 	var/area/centcom/holding/A = GLOB.areas_by_type[/area/centcom/holding]
 	for(var/mob/living/carbon/human/M in A)//Humans.
-		if(M.stat == DEAD)//Dead folks are worth less.
-			captured_amount+=0.5
-			continue
-		captured_amount+=1
+		if(!istype(src,/datum/objective/capture/living))
+			if(M.stat == DEAD)//Dead folks are worth less (or not at all if you need to capture living)
+				captured_amount+=0.5
+			else
+				captured_amount+=1
+		else
+			captured_amount+= 1 //dont care if they are dead or alive in living capture because you shouldn't be able to capture them if they dead
 	for(var/mob/living/carbon/monkey/M in A)//Monkeys are almost worthless, you failure.
 		captured_amount+=0.1
 	for(var/mob/living/carbon/alien/larva/M in A)//Larva are important for research.
@@ -727,6 +730,9 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	if(count)
 		target_amount = count
 	update_explanation_text()
+
+/datum/objective/capture/living
+	name = "capture living"
 
 /datum/objective/protect_object
 	name = "protect object"

--- a/code/modules/antagonists/ninja/ninja.dm
+++ b/code/modules/antagonists/ninja/ninja.dm
@@ -124,6 +124,10 @@ GLOBAL_LIST_EMPTY(ninja_capture)
 	to_chat(owner.current, "I am an elite mercenary assassin of the mighty Spider Clan. A <font color='red'><B>SPACE NINJA</B></font>!")
 	to_chat(owner.current, "Surprise is my weapon. Shadows are my armor. Without them, I am nothing. (//initialize your suit by right clicking on it, to use abilities like stealth)!")
 	to_chat(owner.current, "Officially, [helping_station?"Nanotrasen":"The Syndicate"] are my employer.")
+	to_chat(owner.current, "<b>If you are new to playing the Space Ninja, please review the <a href='https://wiki.yogstation.net/wiki/Space_Ninja'>Space Ninja</a> wiki entry for explanations and abilities.</b>") //Yogs
+	if(helping_station) {
+		to_chat(owner.current, "<b>As a Nanotrasen ninja, you are beholden to <a href='https://forums.yogstation.net/help/rules/#rule-3_1_1'>rule 3.1.1</a>: Do not murderbone.</b>")
+	}
 	owner.announce_objectives()
 	return
 

--- a/code/modules/antagonists/ninja/ninja.dm
+++ b/code/modules/antagonists/ninja/ninja.dm
@@ -98,7 +98,12 @@ GLOBAL_LIST_EMPTY(ninja_capture)
 					O.explanation_text = "Steal the brain of [M.current.real_name]."
 					objectives += O
 				else										//capture
-					var/datum/objective/capture/O = new /datum/objective/capture()
+					var/datum/objective/capture/O
+					if(helping_station) {
+						O = new /datum/objective/capture()
+					} else {
+						O = new /datum/objective/capture/living()
+					}
 					O.owner = owner
 					O.gen_amount_goal()
 					objectives += O

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_net.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_net.dm
@@ -7,6 +7,17 @@
 	if(QDELETED(C)||!(C in oview(H)))
 		return 0
 
+	for(var/datum/antagonist/A in H.mind.antag_datums)
+		if(istype(A,/datum/antagonist/ninja)) {
+			var/datum/antagonist/ninja/ninja_datum = A;
+			if(ninja_datum.helping_station) {
+				if(C.stat == DEAD) {
+					to_chat(H, span_warning("[C.p_they(TRUE)] will bring no honor to your Clan!"))
+					return
+				}
+			}
+		}
+
 	if(!C.client)//Monkeys without a client can still step_to() and bypass the net. Also, netting inactive people is lame.
 		to_chat(H, span_warning("[C.p_they(TRUE)] will bring no honor to your Clan!"))
 		return


### PR DESCRIPTION
# Document the changes in your pull request

 - NT ninja gets living targets capture instead of normal capture
    This functionally does not change the way they're calculated at the end, since NT ninjas:
 - NT ninja cannot energy net dead people - gives you more incentive to not murderbone. You can still die in the capture area (which would be a dick move) but since you died after capture it still counts as 1 for an NT ninja
 - Ninja is sent a link to the wiki if they have no clue how to play akin to blood cult
 - NT Ninja gets a link to the murderbone rule that they CANT MURDERBONE

# Wiki Documentation

Ninja probably gotta be updated

# Changelog

:cl:  
rscadd: Added new objective: Living Capture
rscadd: NT ninja cant net dead people
rscadd: put guide to ninja in ninja greet text
rscadd: put specific calling to murderbone rule in NT ninja greet text

/:cl:
