### PR TITLE
Fix get_remaining_days not working if there is no DB

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -636,8 +636,8 @@
 		return 0
 	if(!CONFIG_GET(flag/use_age_restriction_for_jobs))
 		return 0
-	if(!isnum(C.player_age))
-		return 0 //This is only a number if the db connection is established, otherwise it is text: "Requires database", meaning these restrictions cannot be enforced
+	if(C.player_age < 0)
+		return 0
 	if(!isnum(enemy_minimum_age))
 		return 0
 


### PR DESCRIPTION
# Document the changes in your pull request

player_age is -1 when there is no db, which is a number.

# Changelog

:cl:  
bugfix: fixed being unable to play any antag that requires playtime when the db is disabled
/:cl:
