### PR TITLE
Lobster suit added to autodrobe

### DIFF
--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -48,6 +48,8 @@
 					/obj/item/clothing/under/griffin = 1,
 					/obj/item/clothing/shoes/griffin = 1,
 					/obj/item/clothing/head/griffin = 1,
+					/obj/item/clothing/head/lobsterhat = 1,
+					/obj/item/clothing/under/lobster = 1,
 					/obj/item/clothing/suit/apron = 1,
 					/obj/item/clothing/under/waiter = 1,
 					/obj/item/clothing/suit/jacket/miljacket = 1,


### PR DESCRIPTION
adds the lobsters suit to the autodrobe


# Document the changes in your pull request

again, lobstersuit in autodrobe, for like the fifth time but i think i didnt fuck it up this time
# Wiki Documentation

add the lobster suit to the list of buyable items if it exist
# Changelog

lobster -> autodrobre

:cl:  
tweak: tweaked a few things  
/:cl:
