### PR TITLE
[Vote 848, 849] Disable time lockout for cryo, change to lockout on gamma alert

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -143,10 +143,14 @@ SUBSYSTEM_DEF(ticker)
 	return ..()
 
 /datum/controller/subsystem/ticker/fire()
-	if(world.time > 30 MINUTES && !GLOB.cryopods_enabled)
+	if(seclevel2num(get_security_level()) < SEC_LEVEL_GAMMA && !GLOB.cryopods_enabled)
 		GLOB.cryopods_enabled = TRUE
 		for(var/obj/machinery/cryopod/pod as anything in GLOB.cryopods)
 			pod.PowerOn()
+	else if(seclevel2num(get_security_level()) >= SEC_LEVEL_GAMMA && GLOB.cryopods_enabled)
+		GLOB.cryopods_enabled = FALSE
+		for(var/obj/machinery/cryopod/pod as anything in GLOB.cryopods)
+			pod.PowerOff()
 
 	switch(current_state)
 		if(GAME_STATE_STARTUP)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -195,6 +195,10 @@ GLOBAL_VAR_INIT(cryopods_enabled, FALSE)
 	if(!occupant)
 		open_machine()
 
+/obj/machinery/cryopod/proc/PowerOff()
+	if(!occupant)
+		icon_state = "cryopod-off"
+
 /obj/machinery/cryopod/proc/find_control_computer(urgent = 0)
 	for(var/M in GLOB.cryopod_computers)
 		var/obj/machinery/computer/cryopod/C = M
@@ -362,7 +366,7 @@ GLOBAL_VAR_INIT(cryopods_enabled, FALSE)
 		return
 
 	if(!GLOB.cryopods_enabled)
-		to_chat(user, span_boldnotice("[src] is currently disabled. It will be enabled in [round(((30 MINUTES) - world.time) / (1 MINUTES))] minutes"))
+		to_chat(user, span_boldnotice("NanoTrasen does not allow abandoning your crew during a crisis. Cryo systems disabled until the current crisis is resolved."))
 		return
 
 	if(occupant)


### PR DESCRIPTION
# Document the changes in your pull request

Removes the 30 minute lockout, locks out cryo pods on gamma alert and higher

# Changelog

:cl:  
tweak: tweaked the cryo lockout from first 30 minutes to gamma alert or higher
/:cl:
