### PR TITLE
removes the check for ghosts being still in game for soul departed since we force ghosts to re-enter their body when reviving them and it made me look stupid once

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -114,7 +114,7 @@
 		if(hellbound)
 			. += span_warning("[t_His] soul seems to have been ripped out of [t_his] body.  Revival is impossible.")
 		. += ""
-		if(getorgan(/obj/item/organ/brain) && !key && !get_ghost(FALSE, TRUE))
+		if(getorgan(/obj/item/organ/brain) && !key && !get_ghost())
 			. += span_deadsay("[t_He] [t_is] limp and unresponsive; there are no signs of life and [t_his] soul has departed...")
 		else
 			. += span_deadsay("[t_He] [t_is] limp and unresponsive; there are no signs of life...")


### PR DESCRIPTION
# Document the changes in your pull request

soul departed is like catatonic it's for COMPLETELY IRRECOVERABLE corpses or some kind of shenaniganry not "i left the game for 2 seconds and am now being turned into a hamburger by the cook"


# Changelog

:cl:  
bugfix: yes this is a fucking bugfix: you will no longer have confusion between someone who has logged out of the game as a ghost and a body that has no player inhabitant at all, because one of these is recoverable and the other is extremely not recoverable and they SHOULDN'T LOOK THE EXACT SAME
/:cl:
