### PR TITLE
Fixes bug where putting the kitty ears in your bag gives you a fake message that you unequipped them

### DIFF
--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -141,11 +141,12 @@
 	..()
 
 /obj/item/clothing/head/kitty/dropped(mob/user)
+	..()
 	var/datum/language_holder/LH = user.get_language_holder()
 	if(LH.has_language(/datum/language/felinid) || LH.can_speak_language(/datum/language/felinid)) //sanity
 		to_chat(user, "You rid yourself of degeneracy.")
 		LH.remove_language(/datum/language/felinid,TRUE,TRUE,LANGUAGE_CATEARS)
-	..()
+	
 
 /obj/item/clothing/head/kitty/update_icon(mob/living/carbon/human/user)
 	if(ishuman(user))


### PR DESCRIPTION
# Document the changes in your pull request

read title

# Wiki Documentation

I don't think so
# Changelog

:cl:  
tweak: move parent call to the start qq
/:cl:
