### PR TITLE
Fixes Novaflower and death nettles never hitting their attack proc and also nerfs death nettles

### DIFF
--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -225,7 +225,9 @@
 	force = round((5 + seed.potency / 5), 1)
 
 /obj/item/grown/novaflower/attack(mob/living/carbon/M, mob/user)
-	if(!..())
+	if(..())
+		return
+	if(user.a_intent != INTENT_HARM)
 		return
 	if(isliving(M))
 		to_chat(M, span_danger("You are lit on fire from the intense heat of the [name]!"))

--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -103,7 +103,9 @@
 			to_chat(user, span_userdanger("You are stunned by the Deathnettle as you try picking it up!"))
 
 /obj/item/reagent_containers/food/snacks/grown/nettle/death/attack(mob/living/carbon/M, mob/user)
-	if(!..())
+	if(..())
+		return
+	if(user.a_intent != INTENT_HARM)
 		return
 	if(isliving(M))
 		to_chat(M, span_danger("You are stunned by the powerful acid of the Deathnettle!"))
@@ -111,6 +113,6 @@
 
 		M.adjust_blurriness(force/7)
 		if(prob(20))
-			M.Unconscious(force / 0.3)
-			M.Paralyze(force / 0.75)
+			M.Unconscious(force / 0.6)
+			M.Paralyze(force / 1.5)
 		M.drop_all_held_items()

--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -108,11 +108,7 @@
 	if(user.a_intent != INTENT_HARM)
 		return
 	if(isliving(M))
-		to_chat(M, span_danger("You are stunned by the powerful acid of the Deathnettle!"))
+		to_chat(M, span_danger("You are blinded by the powerful acid of [src]!"))
 		log_combat(user, M, "attacked", src)
 
 		M.adjust_blurriness(force/7)
-		if(prob(20))
-			M.Unconscious(force / 0.6)
-			M.Paralyze(force / 1.5)
-		M.drop_all_held_items()


### PR DESCRIPTION
# Document the changes in your pull request

Novaflowers and death nettles don't work properly: sometime between now and the past 6 years the attack proc has been changed so they do not properly trigger. The obj/proc/attack trigger returns false if it is successful and true if it is cancelled, so it will always return early and never do their special effects. It may have been broken the entire time yogs has existed, it's possible.

Only triggers their special effect (fire and paralyze/knockout for each) on harm intent. Still does their force damage in any other intent.

![image](https://user-images.githubusercontent.com/5091394/136779071-fe268c53-7268-4b22-9e10-0954d1df891a.png)

ok i nerfed the knockout/paralyze by making it half as strong

# Wiki Documentation

None probably

# Changelog


:cl:   
bugfix: made novaflowers and death nettles actually trigger attack effects
rscdel: deathnettles no longer have the capacity to stun people
/:cl:
