### PR TITLE
Adds Amaretto to the booze dispenser

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -537,7 +537,8 @@
 		/datum/reagent/consumable/ethanol/creme_de_coconut,
 		/datum/reagent/consumable/ethanol/triple_sec,
 		/datum/reagent/consumable/ethanol/sake,
-		/datum/reagent/consumable/ethanol/applejack
+		/datum/reagent/consumable/ethanol/applejack,
+		/datum/reagent/consumable/ethanol/amaretto
 	)
 	upgrade_reagents = null
 	emagged_reagents = list(


### PR DESCRIPTION
Title. Amaretto no longer exists only in bottle form in the booze-o-mat


:cl:  
rscadd: Amaretto is now in the booze dispenser
/:cl:
