### PR TITLE
Lets accessories that aren't on uniforms have their equip/unequip procs called when the clothing item is equipped or unequipped

### DIFF
--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -101,13 +101,13 @@
 		H.update_inv_w_uniform()
 //Yogs End
 	if(attached_accessory && slot != SLOT_HANDS)
-		attached_accessory.on_uniform_equip(src, user)
+		attached_accessory.on_clothing_equip(src, user)
 		if(attached_accessory.above_suit)
 			H.update_inv_wear_suit()
 
 /obj/item/clothing/under/dropped(mob/user)
 	if(attached_accessory)
-		attached_accessory.on_uniform_dropped(src, user)
+		attached_accessory.on_clothing_dropped(src, user)
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
 			if(attached_accessory.above_suit)

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -44,7 +44,7 @@
 	U.armor = U.armor.attachArmor(armor)
 
 	if(isliving(user))
-		on_uniform_equip(U, user)
+		on_clothing_equip(U, user)
 
 	return TRUE
 
@@ -55,7 +55,7 @@
 	U.armor = U.armor.detachArmor(armor)
 
 	if(isliving(user))
-		on_uniform_dropped(U, user)
+		on_clothing_dropped(U, user)
 
 	if(minimize_when_attached)
 		transform *= 2
@@ -67,10 +67,10 @@
 	U.attached_accessory = null
 	U.accessory_overlay = null
 
-/obj/item/clothing/accessory/proc/on_uniform_equip(obj/item/clothing/under/U, user)
+/obj/item/clothing/accessory/proc/on_clothing_equip(obj/item/clothing/U, user)
 	return
 
-/obj/item/clothing/accessory/proc/on_uniform_dropped(obj/item/clothing/under/U, user)
+/obj/item/clothing/accessory/proc/on_clothing_dropped(obj/item/clothing/U, user)
 	return
 
 /obj/item/clothing/accessory/AltClick(mob/user)
@@ -308,12 +308,12 @@
 		user.say("The testimony contradicts the evidence!", forced = "attorney's badge")
 	user.visible_message("[user] shows [user.p_their()] attorney's badge.", span_notice("You show your attorney's badge."))
 
-/obj/item/clothing/accessory/lawyers_badge/on_uniform_equip(obj/item/clothing/under/U, user)
+/obj/item/clothing/accessory/lawyers_badge/on_clothing_equip(obj/item/clothing/U, user)
 	var/mob/living/L = user
 	if(L)
 		L.bubble_icon = "lawyer"
 
-/obj/item/clothing/accessory/lawyers_badge/on_uniform_dropped(obj/item/clothing/under/U, user)
+/obj/item/clothing/accessory/lawyers_badge/on_clothing_dropped(obj/item/clothing/U, user)
 	var/mob/living/L = user
 	if(L)
 		L.bubble_icon = initial(L.bubble_icon)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/pandora.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/pandora.dm
@@ -182,12 +182,12 @@
 	armor = list("melee" = 5, "bullet" = 5, "laser" = 5, "energy" = 5, "bomb" = 20, "bio" = 20, "rad" = 5, "fire" = 0, "acid" = 25) //something something determination something
 	resistance_flags = FIRE_PROOF
 
-/obj/item/clothing/accessory/pandora_hope/on_uniform_equip(obj/item/clothing/under/U, user)
+/obj/item/clothing/accessory/pandora_hope/on_clothing_equip(obj/item/clothing/U, user)
 	var/mob/living/L = user
 	if(L && L.mind)
 		SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "hope_lavaland", /datum/mood_event/hope_lavaland)
 
-/obj/item/clothing/accessory/pandora_hope/on_uniform_dropped(obj/item/clothing/under/U, user)
+/obj/item/clothing/accessory/pandora_hope/on_clothing_dropped(obj/item/clothing/under/U, user)
 	var/mob/living/L = user
 	if(L && L.mind)
 		SEND_SIGNAL(L, COMSIG_CLEAR_MOOD_EVENT, "hope_lavaland")


### PR DESCRIPTION
# Document the changes in your pull request

Accessories have a proc that triggers when you equip or unequip the clothing item they're attached to, for some reason they're relegated to jumpsuits only so making it generically clothing it opens more opportunities for extension.

Currently only the lawyer badge and pandora pin thing make use of it.

Hopek said this would take 1-3 hours

# Changelog

:cl:  
tweak: clothing now has a more generic proc to handle on equip/unequip with accessories on them
/:cl:
