### PR TITLE
Revert "Removes Ashwalker's ability to speak common"

### DIFF
--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -275,9 +275,7 @@ Key procs
 							/datum/language/draconic = list(LANGUAGE_ATOM))
 
 /datum/language_holder/lizard/ash
-	understood_languages = list(/datum/language/draconic = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/draconic = list(LANGUAGE_ATOM))
-	blocked_languages = list(/datum/language/common = list(LANGUAGE_ATOM))
+	selected_language = /datum/language/draconic
 
 /datum/language_holder/monkey
 	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),


### PR DESCRIPTION
Reverts yogstation13/Yogstation#12112

I'm not sure why we would want the murder stab lizards to be able to communicate with people LESS unless we actually want them to murder stab kill people
does it make sense? we don't have ashwalker lore so that question is irrelevant
does it make it harder for ashwalkers to do stuff that isn't murder? yea

:cl:
rscadd: ashwalkers can speak common again
/:cl: