### PR TITLE
adds bone gel recipe for chemistry and alternative recipes for other stack healing items that require trekchems instead of botany

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -367,6 +367,7 @@
 		new /obj/item/stack/medical/poultice(location)
 
 /datum/chemical_reaction/bone_gel
+	id = "bone_gel"
 	required_reagents = list(/datum/reagent/consumable/milk = 10, /datum/reagent/carbon = 10) //good for bones and calcium
 	required_temp = 630
 	mob_react = FALSE

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -327,7 +327,7 @@
 /datum/chemical_reaction/medsuture/alt
 	name = "Trek Suture"
 	id = "med_suture_alt"
-	required_reagents = list(/datum/reagent/medicine/bicaridine = 10, /datum/reagent/medicine/c2/probital = 20, /datum/reagent/space_cleaner/sterilizine = 10)
+	required_reagents = list(/datum/reagent/medicine/bicaridine = 10, /datum/reagent/medicine/c2/probital = 20, /datum/reagent/medicine/spaceacillin  = 10)
 
 /datum/chemical_reaction/medsuture/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -327,7 +327,7 @@
 /datum/chemical_reaction/medsuture/alt
 	name = "Trek Suture"
 	id = "med_suture_alt"
-	required_reagents = list(/datum/reagent/bicaridine = 10, /datum/reagent/medicine/c2/probital = 20, /datum/reagent/space_cleaner/sterilizine = 10)
+	required_reagents = list(/datum/reagent/medicine/bicaridine = 10, /datum/reagent/medicine/c2/probital = 20, /datum/reagent/space_cleaner/sterilizine = 10)
 
 /datum/chemical_reaction/medsuture/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
@@ -372,7 +372,7 @@
 	mob_react = FALSE
 	mix_message = "The solution congeals into a blue gel."
 
-/datum/chemical_reaction/bone_gelon_reaction/(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/bone_gel/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
 	for(var/i in 1 to created_volume)
 		new /obj/item/stack/medical/bone_gel(location)

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -321,7 +321,13 @@
 /datum/chemical_reaction/medsuture
 	name = "Medicated Suture"
 	id = "med_suture"
+	mix_message = "The solution solidifies into a thin purple string."
 	required_reagents = list(/datum/reagent/cellulose = 10, /datum/reagent/toxin/formaldehyde = 20, /datum/reagent/medicine/polypyr = 15)
+
+/datum/chemical_reaction/medsuture/alt
+	name = "Trek Suture"
+	id = "med_suture_alt"
+	required_reagents = list(/datum/reagent/bicaridine = 10, /datum/reagent/medicine/c2/probital = 20, /datum/reagent/space_cleaner/sterilizine = 10)
 
 /datum/chemical_reaction/medsuture/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
@@ -331,7 +337,13 @@
 /datum/chemical_reaction/medmesh
 	name = "Advanced Mesh"
 	id = "adv_mesh"
+	mix_message = "The solution congeals into a small supply of easily portioned green gelatin."
 	required_reagents = list(/datum/reagent/cellulose = 20, /datum/reagent/consumable/aloejuice = 20, /datum/reagent/space_cleaner/sterilizine = 10)
+
+/datum/chemical_reaction/medmesh/alt
+	name = "Trek Mesh"
+	id = "adv_mesh_alt"
+	required_reagents = list(/datum/reagent/medicine/kelotane = 10, /datum/reagent/medicine/c2/lenturi = 20, /datum/reagent/space_cleaner/sterilizine = 10)
 
 /datum/chemical_reaction/medmesh/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
@@ -341,10 +353,11 @@
 /datum/chemical_reaction/poultice
 	name = "poultice"
 	id = "poultice"
+	mix_message = "The mixture produces an eerie green liquid."
 	required_reagents = list(/datum/reagent/toxin/amanitin = 10, /datum/reagent/cellulose = 20, /datum/reagent/consumable/aloejuice = 20)
 
 /datum/chemical_reaction/poultice/alt
-	name = "poultice"
+	name = "tribal poultice"
 	id = "poultice_alt"
 	required_reagents = list(/datum/reagent/consumable/entpoly = 15, /datum/reagent/cellulose = 20, /datum/reagent/consumable/tinlux = 12)
 
@@ -352,3 +365,14 @@
 	var/location = get_turf(holder.my_atom)
 	for(var/i in 1 to created_volume)
 		new /obj/item/stack/medical/poultice(location)
+
+/datum/chemical_reaction/bone_gel
+	required_reagents = list(/datum/reagent/consumable/milk = 10, /datum/reagent/carbon = 10) //good for bones and calcium
+	required_temp = 630
+	mob_react = FALSE
+	mix_message = "The solution congeals into a blue gel."
+
+/datum/chemical_reaction/bone_gelon_reaction/(datum/reagents/holder, created_volume)
+	var/location = get_turf(holder.my_atom)
+	for(var/i in 1 to created_volume)
+		new /obj/item/stack/medical/bone_gel(location)


### PR DESCRIPTION
# Document the changes in your pull request

adds some flavortext to stack healing chem mixtures also adds new recipes
bone gel: 10 milk and 10 carbon, heated 630 kelvin
sutures: 10 bicaridine 20 probital 10 spaceacillin
mesh: 10 kelotane 20 lenturi 10 sterilizine
this requires lemoline from cargo obviously to create the required trekchems so while it's easier to get than botany making anything EXCEPT weed it's not a cakewalk

the TG bone gel recipe requires grinding limbs that's boring and we DON'T have a calcium reagent for this so have fun getting milk for good bones instead
# Wiki Documentation

new recipes (old ones except bone gel which didn't have an old one are not removed)
bone gel: 10 milk and 10 carbon, heated 630 kelvin
sutures alt recipe: 10 bicaridine 20 probital 10 spaceacillin
mesh alt recipe: 10 kelotane 20 lenturi 10 sterilizine

# Changelog

:cl:  
rscadd: new recipe for medicated sutures (10 bicaridine 20 probital 10 spaceacillin)
rscadd: new recipe for advanced mesh (10 kelotane 20 lenturi 10 sterilizine)
rscadd: bone gel can now be crafted for 10 milk and 10 carbon heated to 630 kelvin
/:cl:
