### PR TITLE
Removes the janitor's tablet

### DIFF
--- a/code/modules/jobs/job_types/janitor.dm
+++ b/code/modules/jobs/job_types/janitor.dm
@@ -38,4 +38,3 @@
 	belt = /obj/item/pda/janitor
 	ears = /obj/item/radio/headset/headset_srv
 	uniform = /obj/item/clothing/under/rank/janitor
-	backpack_contents = list(/obj/item/modular_computer/tablet/preset/advanced=1)


### PR DESCRIPTION
# Document the changes in your pull request

Dont know if this is the best change, but it is kind of odd that they start with one.

# Wiki Documentation

If it is mentioned, it should be removed. 

# Changelog

:cl:  
tweak: janitors now don't have a tablet round start
/:cl:
