### PR TITLE
Gives sigtech a tablet round start

### DIFF
--- a/yogstation/code/modules/jobs/job_types/signal_technician.dm
+++ b/yogstation/code/modules/jobs/job_types/signal_technician.dm
@@ -38,6 +38,7 @@
 	suit = /obj/item/clothing/suit/hooded/wintercoat/engineering/tcomms
 	gloves = /obj/item/clothing/gloves/color/black
 	shoes = /obj/item/clothing/shoes/workboots
+	backpack_contents = list(/obj/item/modular_computer/tablet/preset/advanced=1)
 
 	backpack = /obj/item/storage/backpack/industrial
 	satchel = /obj/item/storage/backpack/satchel/eng


### PR DESCRIPTION
# Document the changes in your pull request

Kinda strange that everyone in the engineering department gets a computer except the computer guy. Untested, but it should work.

# Wiki Documentation

Should probably mention this on the wiki page. 

# Changelog

:cl:  
tweak: sigtech now has a tablet round start
/:cl:
