### PR TITLE
Fixes code so non-ventcrawling simple mobs + borgs can't disposal themselves, but can disposal other people

### DIFF
--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -111,7 +111,7 @@
 		stuff_mob_in(target, user)
 
 /obj/machinery/disposal/proc/stuff_mob_in(mob/living/target, mob/living/user)
-	if(!iscarbon(user) && !user.ventcrawler) //only carbon and ventcrawlers can climb into disposal by themselves.
+	if(!iscarbon(user) && !user.ventcrawler && user == target) //only carbon and ventcrawlers can climb into disposal by themselves.
 		if (iscyborg(user))
 			var/mob/living/silicon/robot/borg = user
 			if (!borg.module || !borg.module.canDispose)


### PR DESCRIPTION
# Document the changes in your pull request

Makes the code work as intended

Closes #12359 (This PR actually fixes the problem with that code instead of removing code that's always been working)

# Wiki Documentation

# Changelog

:cl:  
bugfix: Allows simple mobs and silicons to disposal stuff again
/:cl:
