### PR TITLE
Tweaks the debug outfit

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -391,3 +391,20 @@
 	STR.max_w_class = WEIGHT_CLASS_SMALL
 	STR.insert_preposition = "in"
 	STR.set_holdable(list(/obj/item/stack/ore/bluespace_crystal, /obj/item/assembly, /obj/item/stock_parts, /obj/item/reagent_containers/glass/beaker, /obj/item/stack/cable_coil, /obj/item/circuitboard, /obj/item/electronics, /obj/item/organ, /obj/item/bodypart))
+
+
+/obj/item/storage/bag/construction/admin/full/ComponentInitialize()
+	. = ..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_combined_w_class = 1000
+	STR.max_items = 100
+	
+/obj/item/storage/bag/construction/admin/full/PopulateContents()
+	new /obj/item/stack/cable_coil(src,MAXCOIL,"red")
+	for(var/i in 1 to 10)
+		new /obj/item/stock_parts/capacitor/quadratic(src)
+		new /obj/item/stock_parts/scanning_module/triphasic(src)
+		new /obj/item/stock_parts/manipulator/femto(src)
+		new /obj/item/stock_parts/micro_laser/quadultra(src)
+		new /obj/item/stock_parts/matter_bin/bluespace(src)
+		new /obj/item/stock_parts/cell/infinite(src)

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -71,7 +71,8 @@
 		/obj/item/grenade/chem_grenade/metalfoam,
 		/obj/item/storage/bag/construction,
 		/obj/item/handdrill,
-		/obj/item/jawsoflife
+		/obj/item/jawsoflife,
+		/obj/item/shuttle_creator //Yogs: Added this here cause I felt it fits
 		))
 
 /obj/item/storage/belt/utility/chief
@@ -89,6 +90,18 @@
 	new /obj/item/extinguisher/mini(src)
 	new /obj/item/holosign_creator/multi/CE(src)
 	//much roomier now that we've managed to remove two tools
+
+/obj/item/storage/belt/utility/chief/admin/full/PopulateContents()
+	new /obj/item/construction/rcd/combat/admin(src)
+	new /obj/item/pipe_dispenser(src)
+	new /obj/item/shuttle_creator/admin(src)
+	new /obj/item/handdrill(src)
+	new /obj/item/jawsoflife(src)
+	new /obj/item/weldingtool/experimental(src)//This can be changed if this is too much
+	new /obj/item/multitool/tricorder(src)	//yogs: changes the multitool to the tricorder and removes the analyzer
+	new /obj/item/storage/bag/construction/admin/full(src)
+	new /obj/item/extinguisher/mini(src)
+	new /obj/item/holosign_creator/multi/CE(src)
 
 /obj/item/storage/belt/utility/full/PopulateContents()
 	new /obj/item/screwdriver(src)

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1157,6 +1157,7 @@
 /obj/item/storage/box/materials/PopulateContents()
 	var/static/items_inside = list(
 		/obj/item/stack/sheet/metal/fifty = 2,
+		/obj/item/stack/sheet/glass/fifty = 2,
 		/obj/item/stack/rods/fifty = 2,
 		/obj/item/stack/sheet/plasteel/fifty = 2,
 		/obj/item/stack/sheet/plastic/fifty = 2,
@@ -1174,3 +1175,10 @@
 		/obj/item/stack/sheet/mineral/silver/fifty = 1,
 		/obj/item/stack/sheet/mineral/bananium/fifty = 1)
 	generate_items_inside(items_inside,src)
+
+/obj/item/storage/box/materials/ComponentInitialize()
+	. = ..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_combined_w_class = 200
+	STR.max_items = 30
+	STR.max_w_class = WEIGHT_CLASS_GIGANTIC

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -403,7 +403,7 @@
 	shoes = /obj/item/clothing/shoes/magboots/advance
 	suit_store = /obj/item/tank/internals/oxygen
 	mask = /obj/item/clothing/mask/gas/syndicate
-	belt = /obj/item/storage/belt/utility/chief/full
+	belt = /obj/item/storage/belt/utility/chief/admin/full
 	gloves = /obj/item/clothing/gloves/combat
 	id = /obj/item/card/id/ert/debug
 	glasses = /obj/item/clothing/glasses/meson/night
@@ -411,16 +411,15 @@
 	back = /obj/item/storage/backpack/holding
 	backpack_contents = list(
 		/obj/item/flashlight/emp/debug=1,\
-		/obj/item/construction/rcd/combat=1,\
 		/obj/item/gun/magic/wand/resurrection/debug=1,\
 		/obj/item/melee/transforming/energy/axe=1,\
 		/obj/item/storage/part_replacer/bluespace/tier4=1,\
 		/obj/item/construction/rld=1,\
-		/obj/item/pipe_dispenser=1,\
 		/obj/item/uplink/debug=1,\
 		/obj/item/disk/surgery/debug=1,\
 		/obj/item/disk/tech_disk/debug=1,\
 		/obj/item/guardiancreator/debug=1,\
 		/obj/item/card/emag/bluespace=1,\
 		/obj/item/dnainjector/hulkmut=1,\
-		/obj/item/storage/box/materials=1)
+		/obj/item/storage/box/materials=1,\
+		/obj/item/modular_computer/tablet/preset/syndicate=1)

--- a/code/modules/modular_computers/computers/item/tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/tablet_presets.dm
@@ -28,6 +28,18 @@
 	install_component(new /obj/item/computer_hardware/network_card)
 	install_component(new /obj/item/computer_hardware/printer/mini)
 
+// A tablet made by the Syndacate for use by their comms agents, has a Syndicate hard drive, is emagged, and is red because Syndicate
+/obj/item/modular_computer/tablet/preset/syndicate/Initialize()
+	. = ..()
+	finish_color = "red"
+	install_component(new /obj/item/computer_hardware/processor_unit/small)
+	install_component(new /obj/item/computer_hardware/battery(src, /obj/item/stock_parts/cell/computer))
+	install_component(new /obj/item/computer_hardware/hard_drive/small/syndicate)
+	install_component(new /obj/item/computer_hardware/network_card/advanced)
+	install_component(new /obj/item/computer_hardware/printer/mini)
+	obj_flags |= EMAGGED
+	update_icon()
+
 /// Given by the syndicate as part of the contract uplink bundle - loads in the Contractor Uplink.
 /obj/item/modular_computer/tablet/syndicate_contract_uplink/preset/uplink/Initialize()
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request

Made many tweaks to the debug outfit, making it have better stuff and easier to use. 

## What Is Changed?
- Added RSDs to the list of what toolbelts can hold (if you want this removed or atomized just asked, I just included it in here as its required for one of the later changes and felt minor enough to include)
- Added an admin CE belt that contains an admin RCD, RPD, ARSD, and an admin construction bag
- Added an admin construction bag that is just a construction bag that contains wires, a bunch of stock parts, and some infinite cells and can hold more stuff
- Added two stacks of glass to material box and allowed the box to actually hold everything inside of it
- Added a syndicate tablet that has good parts and starts emagged and added it to the bag of holding
- Removed the RCD and RPD from the bag of holding

# Wiki Documentation

Nothing will need to be changed. 

# Changelog

:cl:   
tweak: tweaked the debug outfit  
tweak: added RSDs to the list of what toolbelts can hold  
/:cl:
