### PR TITLE
Expands aux base construction to include a place for building shuttles

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -8406,13 +8406,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"axm" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/solar/port/fore)
 "axo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -20978,19 +20971,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"bmR" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/solar/port/fore)
 "bmS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -26271,6 +26251,16 @@
 /obj/effect/landmark/start/janitor,
 /turf/open/floor/plasteel,
 /area/janitor)
+"bFg" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "bFh" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -29522,6 +29512,19 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"cch" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "ccj" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -31428,22 +31431,6 @@
 /obj/structure/sign/warning/radiation/rad_area,
 /turf/closed/wall,
 /area/engine/engineering)
-"cus" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/solar/port/fore)
 "cuD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -32391,6 +32378,16 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"cLi" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "cLH" = (
 /obj/machinery/photocopier,
 /turf/open/floor/plasteel/grimy,
@@ -33313,6 +33310,13 @@
 /obj/machinery/chem_master,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"djM" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "dlq" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -33747,16 +33751,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
-"dyx" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/solar/port/fore)
 "dyz" = (
 /obj/machinery/portable_atmospherics/canister/bz,
 /obj/effect/turf_decal/bot,
@@ -34043,16 +34037,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"dHd" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/solar/port/fore)
 "dHx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -34262,13 +34246,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"dPr" = (
-/obj/machinery/door/airlock/external{
-	name = "Construction Zone";
-	req_one_access_txt = "32;47;48"
-	},
-/turf/open/floor/plating,
-/area/construction/mining/aux_base)
 "dPy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -34591,19 +34568,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"ebi" = (
+"ecu" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
 	},
 /turf/open/space/basic,
 /area/solar/port/fore)
@@ -34902,13 +34873,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"eqs" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/solar/port/fore)
 "erb" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -35002,14 +34966,6 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"evo" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/solar/port/fore)
 "evF" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = 32
@@ -35662,6 +35618,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"eNl" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "eNr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -36701,6 +36664,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"fvO" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/solar/port/fore)
 "fxr" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -36883,13 +36851,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"fDJ" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/solar/port/fore)
 "fDO" = (
 /obj/machinery/suit_storage_unit/standard_unit{
 	suit_type = /obj/item/clothing/suit/space/paramedic
@@ -36932,6 +36893,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
+"fGM" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "fHi" = (
 /obj/machinery/computer/security/telescreen{
 	name = "Test Chamber Monitor";
@@ -37037,13 +37006,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
-"fKP" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	name = "Fuel Port"
-	},
-/obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/plating,
-/area/construction/mining/aux_base)
 "fKR" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -38088,18 +38050,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"gxy" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Auxillary Base Construction";
-	req_one_access_txt = "32;47;48"
-	},
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "gxA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -38535,16 +38485,6 @@
 /obj/machinery/computer/operating,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"gKU" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/solar/port/fore)
 "gLg" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -38957,23 +38897,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"hcf" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/solar/port/fore)
 "hcE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39207,16 +39130,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"hnt" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/solar/port/fore)
 "hoc" = (
 /turf/closed/wall,
 /area/security/checkpoint/service)
@@ -40266,6 +40179,19 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"hVV" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "hWd" = (
 /obj/machinery/power/smes/engineering{
 	charge = 5e+006
@@ -40896,6 +40822,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"inQ" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/engineering{
+	name = "Auxillary Base Construction";
+	req_one_access_txt = "32;47;48"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "ioi" = (
 /obj/effect/landmark/start/artist,
 /turf/open/floor/plasteel/vaporwave,
@@ -41474,6 +41415,20 @@
 "iEt" = (
 /turf/open/floor/plasteel,
 /area/escapepodbay)
+"iFx" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/manifold/purple/visible{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "iFI" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -41911,6 +41866,13 @@
 	dir = 4
 	},
 /area/crew_quarters/theatre)
+"iSP" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "iTl" = (
 /obj/structure/chair,
 /turf/open/floor/plating,
@@ -42489,11 +42451,6 @@
 "jnE" = (
 /turf/closed/wall/r_wall,
 /area/medical/medbay/lobby)
-"jnJ" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/space/basic,
-/area/solar/port/fore)
 "joM" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
@@ -44135,13 +44092,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
-"kmq" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/solar/port/fore)
 "kmy" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -44295,16 +44245,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space/nearstation)
-"ksS" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/solar/port/fore)
 "kti" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood,
@@ -44658,14 +44598,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"kFD" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/space/basic,
-/area/solar/port/fore)
 "kFK" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -45102,19 +45034,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"kVq" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/solar/port/fore)
 "kVQ" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -45358,6 +45277,13 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"ldm" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "ldv" = (
 /obj/machinery/power/apc{
 	areastring = "/area/vacant_room/commissary";
@@ -46508,6 +46434,16 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/aft)
+"lPs" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "lPO" = (
 /obj/machinery/telecomms/bus/preset_three,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -47715,25 +47651,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"mIK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/poddoor{
-	id = "Secure Storage";
-	name = "secure storage"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/construction/mining/aux_base)
 "mJy" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
@@ -49367,6 +49284,25 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"nFd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	id = "Shuttle Construction Storage";
+	name = "shuttle construction storage"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/construction/mining/aux_base)
 "nFn" = (
 /obj/machinery/computer/shuttle/labor,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -50253,15 +50189,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/storage/tech)
-"ojL" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/space/basic,
-/area/solar/port/fore)
 "ojV" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -50415,6 +50342,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"oox" = (
+/obj/docking_port/stationary{
+	dwidth = 8;
+	height = 11;
+	id = "auxiliary_construction";
+	name = "SS13: Auxiliary Construction Dock";
+	width = 17
+	},
+/turf/open/space/basic,
+/area/space)
 "ooz" = (
 /obj/machinery/light_switch{
 	pixel_x = -23
@@ -50517,6 +50454,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/main)
+"orC" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
+	dir = 1;
+	name = "Shuttle Air Port"
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "orK" = (
 /obj/structure/urinal{
 	dir = 8;
@@ -53499,14 +53444,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"qjo" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/space/basic,
-/area/solar/port/fore)
 "qjv" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -53768,20 +53705,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"qrl" = (
-/obj/machinery/button/door{
-	desc = "A remote control-switch for secure storage.";
-	id = "Secure Storage";
-	name = "Engineering Secure Storage";
-	pixel_x = 24;
-	req_access_txt = "11"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "qrJ" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Two"
@@ -53919,6 +53842,11 @@
 "qtP" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/aft)
+"qup" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space/basic,
+/area/solar/port/fore)
 "quz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -54243,14 +54171,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"qHd" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/space/basic,
-/area/solar/port/fore)
 "qHe" = (
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
@@ -55083,6 +55003,17 @@
 	},
 /turf/open/space/basic,
 /area/ai_monitored/turret_protected/ai)
+"rfM" = (
+/obj/machinery/door/airlock/external{
+	name = "Construction Zone";
+	req_one_access_txt = "32;47;48"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/construction/mining/aux_base)
 "rfW" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
@@ -55388,16 +55319,6 @@
 /obj/item/soap/nanotrasen,
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
-"rsN" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/solar/port/fore)
 "rsV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -55508,6 +55429,13 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
+"rwS" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 6
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "rxj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -56118,6 +56046,13 @@
 	dir = 8
 	},
 /area/hallway/secondary/exit)
+"rTw" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "rTC" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -56527,19 +56462,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"sft" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/solar/port/fore)
 "sfB" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -56625,6 +56547,14 @@
 	},
 /turf/template_noop,
 /area/hydroponics)
+"shR" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 2;
+	name = "Fuel Port"
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "sia" = (
 /obj/effect/landmark/stationroom/maint/threexthree,
 /turf/template_noop,
@@ -57165,11 +57095,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"sBV" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/space/basic,
-/area/solar/port/fore)
 "sCf" = (
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
@@ -57439,19 +57364,6 @@
 /mob/living/carbon/monkey,
 /turf/open/floor/grass,
 /area/medical/genetics)
-"sMA" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/solar/port/fore)
 "sMG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -57478,16 +57390,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"sNl" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/solar/port/fore)
 "sNo" = (
 /obj/effect/landmark/start/cook,
 /turf/template_noop,
@@ -57606,14 +57508,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"sRs" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/solar/port/fore)
 "sSY" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell{
 	dir = 1
@@ -57815,6 +57709,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"sYk" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "sYn" = (
 /obj/structure/dresser,
 /obj/machinery/light/small{
@@ -58706,6 +58613,22 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
+"tCZ" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "tDz" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 1;
@@ -59009,6 +58932,14 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"tNk" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4;
+	name = "Fuel Port"
+	},
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/plating,
+/area/construction/mining/aux_base)
 "tNt" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/wintercoat,
@@ -59246,6 +59177,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"tUK" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/portables_connector/layer4{
+	dir = 1;
+	name = "Shuttle Waste Port"
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "tVa" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -59827,13 +59766,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"uoa" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/solar/port/fore)
 "uoF" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -60212,6 +60144,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"uBb" = (
+/obj/machinery/button/door{
+	desc = "A remote control-switch for shuttle construction storage.";
+	id = "Shuttle Construction Storage";
+	name = "Shuttle Construction Storage";
+	pixel_x = 24;
+	req_access_txt = "11"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "uBg" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -61879,6 +61825,19 @@
 /obj/item/multitool,
 /turf/open/floor/plasteel/white,
 /area/storage/tech)
+"vIb" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "vIg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62437,13 +62396,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"vZq" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	name = "Fuel Port"
-	},
-/turf/open/space/basic,
-/area/solar/port/fore)
 "vZz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -64731,17 +64683,6 @@
 /obj/item/toy/figure/miner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"xEJ" = (
-/obj/docking_port/stationary/public_mining_dock,
-/obj/docking_port/stationary{
-	dwidth = 8;
-	height = 11;
-	id = "whiteship_home";
-	name = "SS13: Auxiliary Construction Dock";
-	width = 17
-	},
-/turf/open/space/basic,
-/area/space)
 "xFh" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
@@ -65650,12 +65591,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"yhC" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/effect/spawner/structure/solars/solar_96,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/fore)
 "yif" = (
 /obj/machinery/camera{
 	c_tag = "Garden";
@@ -77461,7 +77396,7 @@ aaa
 apJ
 fRK
 ryp
-dPr
+rfM
 apN
 apN
 apN
@@ -78214,19 +78149,19 @@ aaa
 aaa
 aaa
 wiv
-jnJ
-dHd
-sMA
-dyx
-dyx
-dyx
-sMA
-dyx
-dyx
-dyx
-rsN
-kmq
-sRs
+oCs
+ldm
+cLi
+gYj
+gYj
+gYj
+cLi
+gYj
+gYj
+gYj
+iSP
+oCs
+fvO
 oCs
 eRz
 apJ
@@ -78471,7 +78406,7 @@ aaa
 aaa
 aaa
 wiv
-sBV
+oCs
 aaa
 aaa
 aaa
@@ -78483,12 +78418,12 @@ aaa
 aaa
 aaa
 aaa
-eqs
+oCs
 oCs
 apJ
 apJ
 emw
-gxy
+inQ
 apJ
 apN
 apN
@@ -78728,7 +78663,7 @@ aaa
 aaa
 aaa
 aaa
-sBV
+oCs
 aaa
 aaa
 aaa
@@ -78740,7 +78675,7 @@ aaa
 aaa
 aaa
 aaa
-eqs
+oCs
 oCs
 eec
 pzu
@@ -78985,7 +78920,7 @@ aaa
 aaa
 aaa
 gXs
-sBV
+oCs
 aaa
 aaa
 aaa
@@ -78997,7 +78932,7 @@ aaa
 aaa
 aaa
 aaa
-eqs
+oCs
 oCs
 arp
 lka
@@ -79242,7 +79177,7 @@ aaa
 aaa
 gXs
 gXs
-sBV
+oCs
 aaa
 aaa
 aaa
@@ -79254,7 +79189,7 @@ aaa
 aaa
 aaa
 aaa
-eqs
+oCs
 oCs
 arp
 jPO
@@ -79499,7 +79434,7 @@ aaa
 gXs
 gXs
 aaa
-sBV
+oCs
 aaa
 aaa
 aaa
@@ -79511,7 +79446,7 @@ aaa
 aaa
 aaa
 aaa
-eqs
+oCs
 oCs
 arp
 jPO
@@ -79756,7 +79691,7 @@ wiv
 wiv
 aaa
 aaa
-sBV
+oCs
 aaa
 aaa
 aaa
@@ -79768,7 +79703,7 @@ aaa
 aaa
 aaa
 aaa
-eqs
+oCs
 oCs
 arp
 jPO
@@ -80013,7 +79948,7 @@ aaS
 aaf
 aaf
 wiv
-kFD
+eNl
 aaa
 aaa
 aaa
@@ -80025,7 +79960,7 @@ aaa
 aaa
 aaa
 aaa
-eqs
+oCs
 oCs
 arp
 sZy
@@ -80270,7 +80205,7 @@ aaa
 aoV
 aaa
 wiv
-qHd
+sHq
 aaa
 aaa
 aaa
@@ -80527,7 +80462,7 @@ aaf
 vFJ
 abZ
 gYj
-ojL
+fGM
 aaa
 aaa
 aaa
@@ -80538,7 +80473,7 @@ aaa
 aaa
 aaa
 aaa
-xEJ
+oox
 hJL
 pPX
 hDJ
@@ -80784,7 +80719,7 @@ aaa
 aoV
 aaa
 wiv
-qHd
+sHq
 aaa
 aaa
 aaa
@@ -81041,7 +80976,7 @@ aba
 aaf
 aaf
 wiv
-qjo
+rTw
 aaa
 aaa
 aaa
@@ -81053,8 +80988,8 @@ aaa
 aaa
 aaa
 aaa
-hnt
-vZq
+rwS
+shR
 arp
 lTO
 tWf
@@ -81298,7 +81233,7 @@ gcm
 wiv
 aaa
 aaa
-sBV
+oCs
 aaa
 aaa
 aaa
@@ -81310,12 +81245,12 @@ aaa
 aaa
 aaa
 aaa
-bmR
-vZq
+ecu
+orC
 arp
 luG
 fdK
-qrl
+uBb
 apJ
 lFj
 lFj
@@ -81555,7 +81490,7 @@ aaa
 gXs
 gXs
 aaa
-sBV
+oCs
 aaa
 aaa
 aaa
@@ -81567,11 +81502,11 @@ aaa
 aaa
 aaa
 aaa
-cus
-vZq
+vIb
+tUK
 xmv
 xmv
-mIK
+nFd
 xmv
 xmv
 alU
@@ -81812,7 +81747,7 @@ aaa
 aaa
 gXs
 gXs
-sBV
+oCs
 aaa
 aaa
 aaa
@@ -81824,10 +81759,10 @@ aaa
 aaa
 aaa
 aaa
-ebi
+cch
 liu
 xmv
-fKP
+tNk
 tsO
 oBd
 xmv
@@ -82069,7 +82004,7 @@ aaa
 aaa
 aaa
 gXs
-sBV
+oCs
 aaa
 aaa
 aaa
@@ -82081,7 +82016,7 @@ aaa
 aaa
 aaa
 aaa
-hcf
+iFx
 uXH
 tFK
 mym
@@ -82326,7 +82261,7 @@ aaa
 aaa
 aaa
 aaa
-sBV
+oCs
 aaa
 aaa
 aaa
@@ -82338,7 +82273,7 @@ aaa
 aaa
 aaa
 aaa
-eqs
+hVV
 liu
 alR
 alR
@@ -82583,7 +82518,7 @@ aaa
 aaa
 aaa
 wiv
-sBV
+oCs
 aaa
 aaa
 aaa
@@ -82595,7 +82530,7 @@ aaa
 aaa
 aaa
 aaa
-sNl
+tCZ
 gYj
 pmW
 eAn
@@ -82840,19 +82775,19 @@ aaa
 aaa
 aaa
 quT
-uoa
-fDJ
-gKU
-ksS
-ksS
-ksS
-kVq
-ksS
-ksS
-ksS
-sft
-evo
-axm
+oCs
+oCs
+djM
+gYj
+gYj
+gYj
+bFg
+gYj
+gYj
+gYj
+lPs
+qup
+sYk
 wiv
 ali
 ali
@@ -83614,7 +83549,7 @@ gXs
 aaa
 naz
 adz
-yhC
+rdN
 aaa
 naz
 adz
@@ -83871,7 +83806,7 @@ aaf
 aaf
 naz
 adz
-yhC
+rdN
 aaa
 naz
 adz
@@ -84128,7 +84063,7 @@ aaS
 aaa
 naz
 adz
-yhC
+rdN
 aaf
 naz
 adz
@@ -84385,7 +84320,7 @@ aaS
 aaf
 naz
 adz
-yhC
+rdN
 aaa
 naz
 adz
@@ -84642,7 +84577,7 @@ aaS
 aaa
 naz
 adA
-yhC
+rdN
 aaa
 naz
 adA

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -7391,25 +7391,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"aub" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
-"auc" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "aud" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -7668,9 +7649,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"auQ" = (
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "auR" = (
 /obj/machinery/light{
 	dir = 8
@@ -7869,18 +7847,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"avp" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "aux_base_shutters";
-	name = "Auxillary Base Shutters"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "avq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -8440,6 +8406,13 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"axm" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "axo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10173,11 +10146,6 @@
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
 /area/engine/atmos_distro)
-"aCW" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "aCX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -13087,19 +13055,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
-"aLu" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Auxillary Base Construction";
-	req_one_access_txt = "32;47;48"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "aLv" = (
 /obj/machinery/firealarm{
 	pixel_y = 26
@@ -14590,18 +14545,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"aQj" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "aQl" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/blue{
@@ -30381,15 +30324,6 @@
 "ciZ" = (
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cjc" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/closed/wall,
-/area/construction/mining/aux_base)
 "cje" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30914,6 +30848,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"cmj" = (
+/obj/machinery/power/apc{
+	areastring = "/area/construction/mining/aux_base";
+	dir = 8;
+	name = "Auxillary Base Construction APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "cmn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -32806,6 +32753,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"cRT" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "cRZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -33076,16 +33033,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"cVG" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "cVZ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -33098,18 +33045,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"cWD" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "cWT" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/white,
@@ -33195,12 +33130,6 @@
 /obj/effect/turf_decal/tile/darkblue,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"cZy" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "dau" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -34269,6 +34198,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/janitor)
+"dNI" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Aux Base Construction Maintenance";
+	req_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "dOc" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -34320,6 +34262,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"dPr" = (
+/obj/machinery/door/airlock/external{
+	name = "Construction Zone";
+	req_one_access_txt = "32;47;48"
+	},
+/turf/open/floor/plating,
+/area/construction/mining/aux_base)
 "dPy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -34424,21 +34373,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/medical/virology)
-"dRU" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/closet/toolcloset,
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "dSv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34863,6 +34797,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"emw" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "aux_base_shutters";
+	name = "Auxillary Base Shutters"
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "emB" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -35112,16 +35063,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
-"evZ" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/computer/camera_advanced/base_construction{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "ewG" = (
 /turf/closed/wall,
 /area/maintenance/solars/starboard/fore)
@@ -35600,6 +35541,21 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/janitor)
+"eIh" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "eII" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -35855,6 +35811,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"eTn" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "eTs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/window/reinforced{
@@ -36468,6 +36432,17 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"fng" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "fnG" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/westleft{
@@ -36928,17 +36903,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"fEY" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "fFo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -37258,6 +37222,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"fRK" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "fRZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -37364,17 +37340,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
-"fXp" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "fXq" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/darkblue{
@@ -38100,6 +38065,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"gvb" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/closet/toolcloset,
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "gwn" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 1
@@ -38110,6 +38088,18 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"gxy" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Auxillary Base Construction";
+	req_one_access_txt = "32;47;48"
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "gxA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -38574,11 +38564,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"gLv" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/solar/port/fore)
 "gNi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38954,15 +38939,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"haa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "haw" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 4;
@@ -39386,14 +39362,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"htp" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/closet/toolcloset,
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "htC" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -39776,6 +39744,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"hDe" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "hDw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -39953,13 +39932,6 @@
 /obj/effect/landmark/start/geneticist,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
-"hJA" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/closed/wall,
-/area/construction/mining/aux_base)
 "hJL" = (
 /obj/machinery/door/airlock/external{
 	name = "Auxillary Base Construction Dock"
@@ -40365,6 +40337,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"hYf" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "hYP" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
@@ -40624,18 +40604,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"ifM" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "ifO" = (
 /obj/machinery/camera{
 	c_tag = "Engineering West";
@@ -41560,6 +41528,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"iGX" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/table,
+/obj/item/storage/box/lights/mixed,
+/obj/item/assault_pod/mining,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "iHb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41585,18 +41566,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"iIq" = (
-/obj/machinery/power/apc{
-	areastring = "/area/construction/mining/aux_base";
-	dir = 8;
-	name = "Auxillary Base Construction APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "iIB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -42520,6 +42489,11 @@
 "jnE" = (
 /turf/closed/wall/r_wall,
 /area/medical/medbay/lobby)
+"jnJ" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/space/basic,
+/area/solar/port/fore)
 "joM" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
@@ -43318,6 +43292,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
+"jME" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "jNo" = (
 /obj/machinery/lapvend,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -43352,32 +43335,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"jOG" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/rack,
-/obj/item/storage/bag/ore{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/t_scanner/adv_mining_scanner/lesser{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/t_scanner/adv_mining_scanner/lesser,
-/obj/item/t_scanner/adv_mining_scanner/lesser{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "jOV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -44185,6 +44142,25 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/fore)
+"kmy" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Auxillary Base Construction Office";
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "kmT" = (
 /obj/machinery/computer/med_data,
 /turf/open/floor/plasteel/grimy,
@@ -44460,6 +44436,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"kza" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "kzb" = (
 /obj/machinery/door/poddoor{
 	id = "turbinevent";
@@ -44551,6 +44536,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"kBR" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "kCd" = (
 /obj/machinery/requests_console{
 	department = "Tech storage";
@@ -45534,6 +45532,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"lka" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/folder/yellow{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "lkh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -45557,14 +45573,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port/aft)
-"lkX" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "lla" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 2
@@ -47918,6 +47926,16 @@
 /obj/machinery/telecomms/hub/preset,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
+"mQB" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "mRf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -48342,6 +48360,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"nbB" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/computer/camera_advanced/base_construction{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "nbD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -48435,6 +48463,36 @@
 	},
 /turf/open/floor/plating,
 /area/science/robotics/lab)
+"ncA" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/item/storage/bag/ore{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/t_scanner/adv_mining_scanner/lesser{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/item/t_scanner/adv_mining_scanner/lesser{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "ncR" = (
 /obj/machinery/power/apc{
 	areastring = "/area/storage/primary";
@@ -52284,6 +52342,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"pzu" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "pzw" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -53894,6 +53965,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
+"qvO" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Auxillary Base Construction";
+	dir = 8
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "qvR" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -54963,6 +55048,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"reP" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "rfa" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics";
@@ -55438,6 +55538,16 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood,
 /area/library)
+"ryp" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "ryP" = (
 /obj/structure/chair/stool,
 /obj/item/clothing/under/lawyer/blacksuit,
@@ -56752,6 +56862,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"sno" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "snD" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -57488,6 +57606,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"sRs" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "sSY" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell{
 	dir = 1
@@ -57702,6 +57828,16 @@
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
+"sZy" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "sZG" = (
 /obj/structure/chair/wood/wings,
 /turf/open/floor/plasteel/dark,
@@ -59366,6 +59502,17 @@
 /obj/machinery/processor/slime,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"ubN" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/closet/toolcloset,
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "ubY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -59680,6 +59827,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
+"uoa" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "uoF" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -60460,27 +60614,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"uQg" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp/green{
-	pixel_x = -5;
-	pixel_y = 1
-	},
-/obj/item/folder/yellow{
-	pixel_x = 5;
-	pixel_y = 2
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "uQw" = (
 /obj/item/storage/toolbox/mechanical,
 /obj/structure/rack,
@@ -60600,22 +60733,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"uSl" = (
-/obj/machinery/button/door{
-	id = "aux_base_shutters";
-	name = "Public Shutters Control";
-	pixel_x = 24;
-	req_one_access_txt = "32;47;48"
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "uSL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -62456,20 +62573,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
-"wcZ" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/storage/box/lights/mixed,
-/obj/item/assault_pod/mining,
-/obj/machinery/camera{
-	c_tag = "Auxillary Base Construction";
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "wdb" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -63717,6 +63820,27 @@
 /obj/effect/landmark/stationroom/maint/fivexthree,
 /turf/template_noop,
 /area/maintenance/port/aft)
+"wYO" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "aux_base_shutters";
+	name = "Public Shutters Control";
+	pixel_y = 24;
+	req_one_access_txt = "32;47;48"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "wYY" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
@@ -64705,6 +64829,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos_distro)
+"xIn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "xJn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -65553,6 +65688,18 @@
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"ykh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -76797,9 +76944,9 @@ rdN
 aaa
 aaf
 aaa
-aaa
-gXs
-gXs
+apJ
+apJ
+apJ
 apJ
 apN
 apN
@@ -77054,10 +77201,10 @@ rdN
 aaf
 aaf
 aaa
-aaa
-aaa
-gXs
 apJ
+gvb
+ubN
+asF
 apN
 apN
 apN
@@ -77311,10 +77458,10 @@ rdN
 aaa
 gXs
 aaa
-aaa
-aaa
-aaa
 apJ
+fRK
+ryp
+dPr
 apN
 apN
 apN
@@ -77568,10 +77715,10 @@ aaa
 aaa
 gXs
 aaa
-aaa
-aaa
-aaa
 apJ
+reP
+nbB
+asF
 apN
 apN
 apN
@@ -77823,12 +77970,12 @@ wiv
 sHq
 eRz
 wiv
+quT
 wiv
-wiv
-aaa
-aaa
-aaa
 apJ
+kmy
+iGX
+asF
 apN
 apN
 apN
@@ -78067,7 +78214,7 @@ aaa
 aaa
 aaa
 wiv
-oCs
+jnJ
 dHd
 sMA
 dyx
@@ -78079,13 +78226,13 @@ dyx
 dyx
 rsN
 kmq
-gLv
+sRs
 oCs
-quT
-aaa
-aaa
-aaa
+eRz
 apJ
+wYO
+mkx
+asF
 apN
 apN
 apN
@@ -78339,9 +78486,9 @@ aaa
 eqs
 oCs
 apJ
-cjc
 apJ
-hJA
+emw
+gxy
 apJ
 apN
 apN
@@ -78596,9 +78743,9 @@ aaa
 eqs
 oCs
 eec
-uQg
-aQj
-fEY
+pzu
+eIh
+cRT
 apJ
 apN
 apN
@@ -78853,9 +79000,9 @@ aaa
 eqs
 oCs
 arp
-jPO
-auQ
-mkx
+lka
+tWf
+eTn
 apJ
 apJ
 apJ
@@ -79111,7 +79258,7 @@ eqs
 oCs
 arp
 jPO
-auQ
+tWf
 uKz
 atI
 atI
@@ -79122,9 +79269,9 @@ atI
 atI
 atI
 atI
-auc
-avp
-cWD
+atI
+kBR
+xIn
 ayk
 awW
 aEa
@@ -79368,7 +79515,7 @@ eqs
 oCs
 arp
 jPO
-haa
+jME
 nwf
 aCX
 aCX
@@ -79379,9 +79526,9 @@ aCX
 aCX
 aCX
 aCX
-aub
-aLu
-fXp
+aCX
+kza
+dhy
 aym
 azB
 aSm
@@ -79624,21 +79771,21 @@ aaa
 eqs
 oCs
 arp
-cVG
+jPO
 tWf
 tTf
 xTX
 xTX
 xTX
-evZ
-wcZ
-dRU
-htp
-lkX
+mQB
+qvO
+hDe
 xTX
-uSl
-apJ
-ifM
+sno
+xTX
+xTX
+fng
+ykh
 eYV
 lyi
 arB
@@ -79881,7 +80028,7 @@ aaa
 eqs
 oCs
 arp
-lTO
+sZy
 tWf
 wyb
 apJ
@@ -79890,7 +80037,7 @@ apJ
 apJ
 apJ
 apJ
-apJ
+dNI
 apJ
 apJ
 apJ
@@ -80140,15 +80287,15 @@ arp
 arp
 lTO
 tWf
-jOG
+ncA
 apJ
 lFj
 lFj
 lFj
 xeC
 alU
-atJ
-iIq
+amC
+cmj
 dMJ
 hXJ
 bEJ
@@ -80404,8 +80551,8 @@ lFj
 lFj
 lFj
 alU
-aCW
-cZy
+amC
+hYf
 dMJ
 arS
 alU
@@ -80918,7 +81065,7 @@ lFj
 lFj
 lFj
 alU
-amC
+atJ
 arS
 alU
 alU
@@ -82693,7 +82840,7 @@ aaa
 aaa
 aaa
 quT
-oCs
+uoa
 fDJ
 gKU
 ksS
@@ -82705,7 +82852,7 @@ ksS
 ksS
 sft
 evo
-oCs
+axm
 wiv
 ali
 ali

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -14590,6 +14590,18 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"aQj" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "aQl" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/blue{
@@ -36018,6 +36030,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"eYk" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "eYm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced,
@@ -40447,6 +40464,12 @@
 /obj/machinery/telecomms/processor/preset_four,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
+"ibn" = (
+/obj/structure/rack,
+/obj/item/pipe_dispenser,
+/obj/item/shuttle_creator,
+/turf/open/floor/plating,
+/area/construction/mining/aux_base)
 "ibw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -47684,6 +47707,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"mIK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	id = "Secure Storage";
+	name = "secure storage"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/construction/mining/aux_base)
 "mJy" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
@@ -47876,16 +47918,6 @@
 /obj/machinery/telecomms/hub/preset,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
-"mQv" = (
-/obj/structure/rack,
-/obj/item/circuitboard/machine/spaceship_navigation_beacon{
-	pixel_x = 3;
-	pixel_y = 6
-	},
-/obj/item/pipe_dispenser,
-/obj/item/shuttle_creator,
-/turf/open/floor/plating,
-/area/construction/mining/aux_base)
 "mRf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -48576,6 +48608,17 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
+"nhp" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "nhP" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -50768,6 +50811,35 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"oBd" = (
+/obj/structure/rack,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera,
+/obj/item/circuitboard/computer/shuttle/flight_control{
+	pixel_x = -2;
+	pixel_y = 3
+	},
+/obj/item/circuitboard/machine/shuttle/engine{
+	pixel_x = 1
+	},
+/obj/item/circuitboard/machine/shuttle/heater{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/machinery/camera{
+	c_tag = "Auxillary Base Construction Storage";
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/construction/mining/aux_base)
 "oBE" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -51726,42 +51798,6 @@
 /obj/effect/spawner/lootdrop/aimodule_harmful,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"phu" = (
-/obj/structure/rack,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera,
-/obj/item/circuitboard/computer/shuttle/flight_control{
-	pixel_x = -2;
-	pixel_y = 3
-	},
-/obj/item/circuitboard/machine/shuttle/engine{
-	pixel_x = 1
-	},
-/obj/item/circuitboard/machine/shuttle/engine{
-	pixel_x = 1
-	},
-/obj/item/circuitboard/machine/shuttle/heater{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/circuitboard/machine/shuttle/heater{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/machinery/camera{
-	c_tag = "Auxillary Base Construction Storage";
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/construction/mining/aux_base)
 "phB" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -52786,6 +52822,37 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"pRl" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/item/pickaxe{
+	pixel_x = 5
+	},
+/obj/item/pickaxe{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/pickaxe{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/item/shovel{
+	pixel_x = -5
+	},
+/obj/item/shovel{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/item/shovel{
+	pixel_x = -1;
+	pixel_y = -4
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "pRt" = (
 /obj/machinery/cell_charger,
 /obj/structure/table,
@@ -53347,34 +53414,6 @@
 /obj/effect/spawner/structure/solars/solar_96,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/fore)
-"qhp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/poddoor{
-	id = "Secure Storage";
-	name = "secure storage"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/construction/mining/aux_base)
 "qhA" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -59970,36 +60009,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"uAv" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/rack,
-/obj/item/pickaxe{
-	pixel_x = 5
-	},
-/obj/item/pickaxe{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/pickaxe{
-	pixel_x = 2;
-	pixel_y = 1
-	},
-/obj/item/shovel{
-	pixel_x = -5
-	},
-/obj/item/shovel{
-	pixel_x = -3;
-	pixel_y = -2
-	},
-/obj/item/shovel{
-	pixel_x = -1;
-	pixel_y = -4
-	},
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "uAL" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -60697,6 +60706,22 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"uXH" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/binary/pump/layer2{
+	dir = 1;
+	name = "distro to shuttle"
+	},
+/obj/machinery/atmospherics/components/binary/pump/layer4{
+	name = "shuttle waste"
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "fuel to shuttle"
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "uXZ" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "QMLoad"
@@ -65583,18 +65608,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
-"ykQ" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/binary/pump/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/binary/pump/layer4,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/solar/port/fore)
 "ykZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -78584,7 +78597,7 @@ eqs
 oCs
 eec
 uQg
-atI
+aQj
 fEY
 apJ
 apN
@@ -80382,9 +80395,9 @@ xEJ
 hJL
 pPX
 hDJ
-lTO
-tWf
-uAv
+nhp
+eYk
+pRl
 apJ
 lFj
 lFj
@@ -81411,7 +81424,7 @@ cus
 vZq
 xmv
 xmv
-qhp
+mIK
 xmv
 xmv
 alU
@@ -81666,10 +81679,10 @@ aaa
 aaa
 ebi
 liu
-arp
+xmv
 fKP
 tsO
-phu
+oBd
 xmv
 alF
 anj
@@ -81922,11 +81935,11 @@ aaa
 aaa
 aaa
 hcf
-ykQ
+uXH
 tFK
 mym
 vsp
-mQv
+ibn
 xmv
 alF
 oOf

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -1035,11 +1035,6 @@
 /obj/item/bedsheet/red,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
-"acW" = (
-/obj/structure/cable,
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/solar/port/fore)
 "acX" = (
 /obj/item/assembly/igniter{
 	pixel_x = -5;
@@ -1239,24 +1234,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/solar/port/fore)
-"adw" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/solar/port/fore)
-"adx" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/solar/port/fore)
-"ady" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port/fore)
@@ -3671,13 +3648,6 @@
 "ajp" = (
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
-"ajq" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/solar/port/fore)
 "ajr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4846,24 +4816,8 @@
 "alP" = (
 /turf/closed/wall,
 /area/maintenance/starboard/fore)
-"alQ" = (
-/obj/machinery/power/solar_control{
-	id = "auxsolareast";
-	name = "Port Bow Solar Control"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
 "alR" = (
 /turf/closed/wall/r_wall,
-/area/maintenance/solars/port/fore)
-"alS" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = 32
-	},
-/turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "alT" = (
 /turf/closed/wall/r_wall,
@@ -5083,16 +5037,6 @@
 "amy" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
-"amz" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/terminal,
-/obj/machinery/light/small{
-	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
@@ -5436,27 +5380,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"anl" = (
-/obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
-"ano" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "anq" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/warden,
@@ -5581,10 +5504,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/foyer)
-"anH" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/maintenance/solars/port/fore)
 "anI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -6523,15 +6442,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"aqr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "aqs" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Escape Pod";
@@ -7079,40 +6989,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
-"asH" = (
-/obj/structure/closet/toolcloset,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
-"asI" = (
-/obj/structure/closet/toolcloset,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
-"asJ" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "asK" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -7204,18 +7080,6 @@
 "ata" = (
 /turf/open/floor/wood,
 /area/lawoffice)
-"atb" = (
-/obj/structure/table,
-/obj/item/stack/sheet/plasteel{
-	amount = 10
-	},
-/obj/item/stack/rods/fifty,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "atc" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/lawyer,
@@ -7667,27 +7531,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
-"aus" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/construction/mining/aux_base";
-	dir = 8;
-	name = "Auxillary Base Construction APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "auu" = (
 /obj/structure/chair{
 	dir = 8
@@ -8249,27 +8092,6 @@
 /obj/structure/sign/warning/pods,
 /turf/closed/wall,
 /area/hallway/secondary/entry)
-"avQ" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Auxillary Base Construction";
-	dir = 8
-	},
-/obj/machinery/computer/camera_advanced/base_construction{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "avS" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastleft{
@@ -8282,18 +8104,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
-"avY" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "avZ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/red,
@@ -8587,32 +8397,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"axc" = (
-/obj/structure/rack,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera,
-/obj/item/assault_pod/mining,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for the Auxillary Mining Base.";
-	dir = 8;
-	name = "Auxillary Base Monitor";
-	network = list("auxbase");
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "axd" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -10376,20 +10160,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"aCT" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "aCU" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -12440,25 +12210,6 @@
 /obj/item/clothing/ears/earmuffs,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"aIH" = (
-/obj/structure/table,
-/obj/item/storage/box/lights/mixed,
-/obj/item/pipe_dispenser,
-/obj/machinery/button/door{
-	id = "aux_base_shutters";
-	name = "Public Shutters Control";
-	pixel_x = 24;
-	req_one_access_txt = "32;47;48"
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "aIK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -15407,6 +15158,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/storage/tools)
+"aSD" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "aSG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -20771,6 +20530,10 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
+"blc" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/solar/port/fore)
 "bld" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Captain's Office Maintenance";
@@ -21260,6 +21023,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"bmR" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "bmS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -25050,6 +24826,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"bzh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "bzl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -26771,10 +26562,6 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/storage/tech)
-"bGx" = (
-/obj/structure/lattice,
-/turf/closed/wall,
-/area/maintenance/port/fore)
 "bGG" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -30582,6 +30369,15 @@
 "ciZ" = (
 /turf/open/floor/plating,
 /area/engine/engineering)
+"cjc" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/construction/mining/aux_base)
 "cje" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31673,6 +31469,22 @@
 /obj/structure/sign/warning/radiation/rad_area,
 /turf/closed/wall,
 /area/engine/engineering)
+"cus" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "cuD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -32465,6 +32277,15 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"cIm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "cIA" = (
 /obj/structure/chair{
 	dir = 8
@@ -33131,16 +32952,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"cTE" = (
-/obj/machinery/computer/shuttle/mining{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/construction/mining/aux_base)
 "cTK" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -33253,6 +33064,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"cVG" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "cVZ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -33362,6 +33183,12 @@
 /obj/effect/turf_decal/tile/darkblue,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"cZy" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "dau" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -33979,6 +33806,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
+"dyx" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "dyz" = (
 /obj/machinery/portable_atmospherics/canister/bz,
 /obj/effect/turf_decal/bot,
@@ -34265,6 +34102,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"dHd" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "dHx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -34389,6 +34236,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"dMJ" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "dNk" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/blue{
@@ -34561,6 +34412,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/medical/virology)
+"dRU" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/closet/toolcloset,
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "dSv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34707,18 +34573,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"dXk" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "dXw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34791,6 +34645,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"ebi" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "edp" = (
 /obj/structure/chair{
 	dir = 4
@@ -34816,6 +34686,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"eec" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/closed/wall,
+/area/construction/mining/aux_base)
 "eeI" = (
 /obj/structure/table/wood,
 /obj/item/canvas/twentythreeXnineteen{
@@ -34977,17 +34851,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"ema" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
 "emB" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -35076,6 +34939,13 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"eqs" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "erb" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -35169,6 +35039,14 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"evo" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "evF" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = 32
@@ -35222,6 +35100,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
+"evZ" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/computer/camera_advanced/base_construction{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "ewG" = (
 /turf/closed/wall,
 /area/maintenance/solars/starboard/fore)
@@ -35287,6 +35175,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"ext" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "exz" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -35367,6 +35260,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"eAn" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/advanced_airlock_controller{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/fore)
 "eAz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -36295,6 +36202,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"fdK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "feu" = (
 /obj/machinery/nuclearbomb/selfdestruct,
 /obj/effect/turf_decal/tile/neutral,
@@ -36740,15 +36660,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"ftu" = (
-/obj/item/coin/iron,
-/obj/machinery/computer/slot_machine{
-	balance = 15;
-	money = 500
-	},
-/obj/item/coin/gold,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "fuj" = (
 /obj/machinery/light{
 	dir = 1
@@ -36980,6 +36891,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"fDJ" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "fDO" = (
 /obj/machinery/suit_storage_unit/standard_unit{
 	suit_type = /obj/item/clothing/suit/space/paramedic
@@ -36993,6 +36911,17 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"fEY" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "fFo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -37127,6 +37056,13 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
+"fKP" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	name = "Fuel Port"
+	},
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/plating,
+/area/construction/mining/aux_base)
 "fKR" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -37566,6 +37502,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"gcm" = (
+/obj/structure/grille/broken,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "gcJ" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Robotics Access"
@@ -38458,6 +38399,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"gGd" = (
+/obj/structure/lattice,
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/maintenance/solars/port/fore)
 "gGe" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/structure/sign/warning/radiation/rad_area{
@@ -38582,6 +38528,16 @@
 /obj/machinery/computer/operating,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"gKU" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "gLg" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -38601,6 +38557,11 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"gLv" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/solar/port/fore)
 "gNi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38819,6 +38780,18 @@
 /obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"gVq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/fore)
 "gWe" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -38866,6 +38839,13 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
+"gYj" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "gYw" = (
 /obj/machinery/computer/libraryconsole,
 /obj/structure/table/wood,
@@ -38957,6 +38937,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"haa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "haw" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 4;
@@ -38975,6 +38964,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"hcf" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/manifold/purple/visible{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "hcE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39208,6 +39214,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"hnt" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "hoc" = (
 /turf/closed/wall,
 /area/security/checkpoint/service)
@@ -39353,6 +39369,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"htp" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/closet/toolcloset,
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "htC" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -39570,18 +39594,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"hzx" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "hzQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -39614,6 +39626,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"hAB" = (
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "hAK" = (
 /obj/machinery/door/airlock{
 	name = "Gift Shop";
@@ -39762,6 +39778,17 @@
 	},
 /turf/open/floor/plating,
 /area/clerk)
+"hDJ" = (
+/obj/machinery/door/airlock/external{
+	name = "Auxillary Base Construction Dock"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/construction/mining/aux_base)
 "hDX" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -39909,6 +39936,21 @@
 /obj/effect/landmark/start/geneticist,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"hJA" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/closed/wall,
+/area/construction/mining/aux_base)
+"hJL" = (
+/obj/machinery/door/airlock/external{
+	name = "Auxillary Base Construction Dock"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/construction/mining/aux_base)
 "hJN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -40294,9 +40336,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"hYC" = (
-/obj/effect/landmark/stationroom/maint/fivexthree,
-/turf/template_noop,
+"hXJ" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plating,
 /area/maintenance/port/fore)
 "hYP" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
@@ -40332,6 +40382,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"hZw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "hZA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -40960,6 +41022,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"irQ" = (
+/obj/structure/lattice,
+/obj/item/stack/cable_coil/random,
+/turf/open/space,
+/area/solar/port/fore)
 "isa" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -41495,6 +41562,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"iIq" = (
+/obj/machinery/power/apc{
+	areastring = "/area/construction/mining/aux_base";
+	dir = 8;
+	name = "Auxillary Base Construction APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "iIB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -41637,9 +41716,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
-"iMU" = (
-/turf/closed/wall,
-/area/maintenance/solars/port/fore)
 "iMW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -43026,6 +43102,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"jDL" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/space,
+/area/solar/port/fore)
 "jFA" = (
 /obj/structure/sign/departments/minsky/command/charge{
 	pixel_x = 32
@@ -43246,6 +43329,32 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"jOG" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/item/storage/bag/ore{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/t_scanner/adv_mining_scanner/lesser{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/item/t_scanner/adv_mining_scanner/lesser{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "jOV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -43262,6 +43371,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction)
+"jPO" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "jPU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -44034,6 +44155,13 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
+"kmq" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "kmT" = (
 /obj/machinery/computer/med_data,
 /turf/open/floor/plasteel/grimy,
@@ -44163,6 +44291,21 @@
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
+"ksi" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space/nearstation)
+"ksS" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "kti" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood,
@@ -44494,6 +44637,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"kFD" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "kFK" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -44551,6 +44702,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"kGQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/port/fore)
 "kHL" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -44919,6 +45081,19 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"kVq" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "kVQ" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -45302,6 +45477,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/tcoms)
+"liu" = (
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/solar/port/fore)
 "liH" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
@@ -45331,22 +45511,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"lje" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "lkh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -45370,6 +45534,14 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port/aft)
+"lkX" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "lla" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 2
@@ -45590,6 +45762,15 @@
 /obj/item/stock_parts/subspace/filter,
 /turf/open/floor/plasteel/white,
 /area/storage/tech)
+"lrb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "lrx" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -45657,6 +45838,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"luG" = (
+/obj/structure/sign/warning/securearea{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "lvg" = (
 /obj/structure/sign/poster/contraband/ambrosia_vulgaris{
 	pixel_y = 32
@@ -45828,18 +46019,6 @@
 	},
 /turf/template_noop,
 /area/crew_quarters/dorms)
-"lzr" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "lzJ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -46279,6 +46458,19 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/aft)
+"lOy" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/terminal,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/fore)
 "lOS" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plating{
@@ -46350,6 +46542,15 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"lTO" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "lUy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -46708,6 +46909,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/service)
+"mkx" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "mkz" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -47114,6 +47322,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"mym" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 9
+	},
+/obj/structure/closet/crate,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/sheet/plasteel{
+	amount = 10
+	},
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/plating,
+/area/construction/mining/aux_base)
 "myI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/grimy,
@@ -47652,6 +47876,16 @@
 /obj/machinery/telecomms/hub/preset,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
+"mQv" = (
+/obj/structure/rack,
+/obj/item/circuitboard/machine/spaceship_navigation_beacon{
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/obj/item/pipe_dispenser,
+/obj/item/shuttle_creator,
+/turf/open/floor/plating,
+/area/construction/mining/aux_base)
 "mRf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -47846,24 +48080,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"mWr" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "mWH" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -48748,6 +48964,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"nwf" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "nww" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -49927,6 +50152,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/storage/tech)
+"ojL" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "ojV" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -49949,14 +50183,6 @@
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"okC" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
 "okT" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/gun/syringe,
@@ -50606,6 +50832,10 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
+"oCs" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/solar/port/fore)
 "oCL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -51024,6 +51254,13 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"oOf" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
+	dir = 9
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "oOB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51138,18 +51375,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"oRm" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "oRq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -51501,6 +51726,42 @@
 /obj/effect/spawner/lootdrop/aimodule_harmful,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"phu" = (
+/obj/structure/rack,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera,
+/obj/item/circuitboard/computer/shuttle/flight_control{
+	pixel_x = -2;
+	pixel_y = 3
+	},
+/obj/item/circuitboard/machine/shuttle/engine{
+	pixel_x = 1
+	},
+/obj/item/circuitboard/machine/shuttle/engine{
+	pixel_x = 1
+	},
+/obj/item/circuitboard/machine/shuttle/heater{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/circuitboard/machine/shuttle/heater{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/machinery/camera{
+	c_tag = "Auxillary Base Construction Storage";
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/construction/mining/aux_base)
 "phB" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -51611,12 +51872,6 @@
 /obj/effect/variation/box/sec/brig_cell,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"pmC" = (
-/obj/docking_port/stationary/public_mining_dock{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/construction/mining/aux_base)
 "pmR" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -52496,6 +52751,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
+"pPX" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 1
+	},
+/obj/machinery/advanced_airlock_controller{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/construction/mining/aux_base)
 "pQy" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Escape Podbay"
@@ -52646,18 +52912,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"pTE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "pTL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -53093,6 +53347,34 @@
 /obj/effect/spawner/structure/solars/solar_96,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/fore)
+"qhp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor{
+	id = "Secure Storage";
+	name = "secure storage"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/construction/mining/aux_base)
 "qhA" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -53107,6 +53389,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"qjo" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "qjv" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -53320,6 +53610,14 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard/aft)
+"qpl" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/ore_box,
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "qpB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -53360,6 +53658,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"qrl" = (
+/obj/machinery/button/door{
+	desc = "A remote control-switch for secure storage.";
+	id = "Secure Storage";
+	name = "Engineering Secure Storage";
+	pixel_x = 24;
+	req_access_txt = "11"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "qrJ" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Two"
@@ -53807,6 +54119,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"qHd" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "qHe" = (
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
@@ -53890,6 +54210,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"qJU" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "qKd" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -54210,6 +54537,23 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"qUL" = (
+/obj/structure/lattice,
+/obj/machinery/door/airlock/engineering{
+	name = "Port Bow Solar Access";
+	req_access_txt = "10"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/fore)
 "qVe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -54905,6 +55249,16 @@
 /obj/item/soap/nanotrasen,
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
+"rsN" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "rsV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -55572,6 +55926,16 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/storage/tools)
+"rRo" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/fore)
 "rRB" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -55742,18 +56106,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/service)
-"rVA" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "rVP" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -56026,6 +56378,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"sft" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "sfB" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -56643,6 +57008,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"sBV" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/space/basic,
+/area/solar/port/fore)
 "sCf" = (
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
@@ -56651,6 +57021,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"sCv" = (
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 32
+	},
+/obj/machinery/power/solar_control{
+	dir = 8;
+	id = "auxsolareast";
+	name = "Port Bow Solar Control"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/fore)
 "sCB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56756,6 +57140,13 @@
 "sHo" = (
 /turf/open/floor/engine,
 /area/escapepodbay)
+"sHq" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "sHO" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -56891,6 +57282,19 @@
 /mob/living/carbon/monkey,
 /turf/open/floor/grass,
 /area/medical/genetics)
+"sMA" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "sMG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -56917,6 +57321,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"sNl" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "sNo" = (
 /obj/effect/landmark/start/cook,
 /turf/template_noop,
@@ -57083,6 +57497,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"sVa" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/fore)
 "sVj" = (
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
@@ -57300,6 +57726,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"tbr" = (
+/obj/structure/lattice,
+/turf/closed/wall/r_wall,
+/area/maintenance/solars/port/fore)
 "tbz" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -57842,6 +58272,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"tsO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/construction/mining/aux_base)
 "ttn" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -58165,6 +58604,13 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
+"tFK" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/construction/mining/aux_base)
 "tHl" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -58575,6 +59021,13 @@
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/carpet,
 /area/medical/psych)
+"tTf" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "tTv" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -58720,22 +59173,27 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/robotics/lab)
-"tXh" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Port Bow Solar Access";
-	req_access_txt = "10"
+"tWf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
+"tXk" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
+/area/maintenance/port/fore)
 "tYa" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -58865,13 +59323,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"ubI" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "ubM" = (
 /obj/machinery/processor/slime,
 /turf/open/floor/plasteel/dark,
@@ -59519,6 +59970,36 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"uAv" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/item/pickaxe{
+	pixel_x = 5
+	},
+/obj/item/pickaxe{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/pickaxe{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/item/shovel{
+	pixel_x = -5
+	},
+/obj/item/shovel{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/item/shovel{
+	pixel_x = -1;
+	pixel_y = -4
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "uAL" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -59619,6 +60100,21 @@
 /obj/structure/door_assembly/door_assembly_mhatch,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"uCs" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "uCN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59836,6 +60332,15 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/mechbay)
+"uKz" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "uKK" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -59946,6 +60451,27 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"uQg" = (
+/obj/structure/table,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/folder/yellow{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "uQw" = (
 /obj/item/storage/toolbox/mechanical,
 /obj/structure/rack,
@@ -60065,6 +60591,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"uSl" = (
+/obj/machinery/button/door{
+	id = "aux_base_shutters";
+	name = "Public Shutters Control";
+	pixel_x = 24;
+	req_one_access_txt = "32;47;48"
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "uSL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -60342,20 +60884,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"vcH" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/advanced_airlock_controller{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
 "vcV" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -60763,6 +61291,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"vsp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/construction/mining/aux_base)
 "vsP" = (
 /obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plating,
@@ -60819,6 +61356,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"vuB" = (
+/obj/machinery/computer/shuttle/mining,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for the Auxillary Mining Base.";
+	dir = 0;
+	name = "Auxillary Base Monitor";
+	network = list("auxbase");
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "vvi" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/chair,
@@ -61741,6 +62295,22 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"vZq" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	name = "Fuel Port"
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
+"vZz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "vZH" = (
 /obj/item/aicard{
 	pixel_x = 6;
@@ -61861,6 +62431,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
+"wcZ" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/storage/box/lights/mixed,
+/obj/item/assault_pod/mining,
+/obj/machinery/camera{
+	c_tag = "Auxillary Base Construction";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "wdb" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -62020,6 +62604,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"wiv" = (
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "wiA" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/loading_area{
@@ -62082,18 +62671,6 @@
 "wkN" = (
 /turf/closed/wall,
 /area/science/nanite)
-"wlH" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "wma" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
@@ -62349,11 +62926,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"wuz" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/port/fore)
 "wvo" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -62453,6 +63025,18 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
+"wyb" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Auxillary Base Construction Dock";
+	dir = 10
+	},
+/obj/structure/ore_box,
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "wyn" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/machinery/atmospherics/miner/n2o,
@@ -63450,6 +64034,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"xmv" = (
+/turf/closed/wall/r_wall,
+/area/construction/mining/aux_base)
 "xne" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -63995,6 +64582,17 @@
 /obj/item/toy/figure/miner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"xEJ" = (
+/obj/docking_port/stationary/public_mining_dock,
+/obj/docking_port/stationary{
+	dwidth = 8;
+	height = 11;
+	id = "whiteship_home";
+	name = "SS13: Auxiliary Construction Dock";
+	width = 17
+	},
+/turf/open/space/basic,
+/area/space)
 "xFh" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
@@ -64377,6 +64975,13 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"xTX" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
 "xTZ" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -64424,6 +65029,21 @@
 /obj/item/toy/figure/cmo,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"xUt" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "xUV" = (
 /obj/structure/window/reinforced,
 /obj/structure/cable{
@@ -64434,11 +65054,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
-"xVc" = (
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/port/fore)
 "xVA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -64591,6 +65206,15 @@
 	},
 /turf/open/space/basic,
 /area/ai_monitored/turret_protected/aisat_interior)
+"yct" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "ydd" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -64959,6 +65583,18 @@
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
+"ykQ" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/binary/pump/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump/layer4,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/solar/port/fore)
 "ykZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -72552,7 +73188,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cEB
 aaa
 aaa
 aaa
@@ -74587,7 +75223,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cEB
 aaa
 aaa
 aaa
@@ -75104,21 +75740,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaS
+aaS
+aaS
+aaS
+aaS
+aaS
+aaS
+aaS
+aaS
+aaS
+aaS
+aaS
+aba
+aaS
+aaS
 aaa
 aaa
 aaa
@@ -75361,22 +75997,22 @@ aaa
 aaa
 aaa
 aaa
+abY
 aaa
+aaf
 aaa
+aaf
 aaa
+aaf
+bWC
+irQ
 aaa
+aaf
 aaa
+aiS
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaS
+gXs
 aaa
 aaa
 aaa
@@ -75618,23 +76254,23 @@ aaa
 aaa
 aaa
 aaa
+abY
 aaa
+naz
+adv
+rdN
 aaa
+naz
+adv
+rdN
 aaa
+naz
+adv
+rdN
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaS
+gXs
+gXs
 aaa
 aaa
 apJ
@@ -75875,24 +76511,24 @@ aaa
 aaa
 aaa
 aaa
+abY
+blc
+naz
+adu
+rdN
 aaa
+naz
+adu
+rdN
 aaa
+naz
+adu
+rdN
+aaf
+aaf
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gXs
+gXs
 aaa
 apJ
 apN
@@ -76132,25 +76768,25 @@ aaa
 aaa
 aaa
 aaa
+abY
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+naz
+adu
+rdN
+aaf
+naz
+adu
+rdN
+aaf
+naz
+adu
+rdN
 aaa
 aaf
+aaa
+aaa
+gXs
+gXs
 apJ
 apN
 apN
@@ -76389,25 +77025,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaf
+blc
+naz
+adu
+rdN
+aaa
+naz
+adu
+rdN
+aaa
+naz
+adu
+rdN
+aaf
+aaf
+aaa
+aaa
+aaa
+gXs
 apJ
 apN
 apN
@@ -76646,25 +77282,25 @@ aaa
 aaa
 aaa
 aaa
+gXs
+aaa
+naz
+adu
+rdN
+aaa
+naz
+adu
+rdN
+aaa
+naz
+adu
+rdN
+aaa
+gXs
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
 apJ
 apN
 apN
@@ -76903,21 +77539,21 @@ aaa
 aaa
 aaa
 aaa
+gXs
+aaa
+aaa
+jDL
 aaa
 aaa
 aaa
+jDL
 aaa
 aaa
 aaa
+jDL
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -77160,22 +77796,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+wiv
+wiv
+gcm
+sHq
+wiv
+wiv
+wiv
+aSD
+wiv
+wiv
+wiv
+sHq
+eRz
+wiv
+wiv
+wiv
 aaa
 aaa
 aaa
@@ -77417,22 +78053,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+wiv
+oCs
+dHd
+sMA
+dyx
+dyx
+dyx
+sMA
+dyx
+dyx
+dyx
+rsN
+kmq
+gLv
+oCs
+quT
 aaa
 aaa
 aaa
@@ -77674,6 +78310,8 @@ aaa
 aaa
 aaa
 aaa
+wiv
+sBV
 aaa
 aaa
 aaa
@@ -77685,14 +78323,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
+eqs
+oCs
+apJ
+cjc
+apJ
+hJA
 apJ
 apN
 apN
@@ -77932,6 +78568,7 @@ aaa
 aaa
 aaa
 aaa
+sBV
 aaa
 aaa
 aaa
@@ -77943,19 +78580,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eqs
+oCs
+eec
+uQg
+atI
+fEY
 apJ
 apN
 apN
 apN
 apN
-pmC
+apN
 apN
 apN
 apN
@@ -78188,6 +78824,8 @@ aaa
 aaa
 aaa
 aaa
+gXs
+sBV
 aaa
 aaa
 aaa
@@ -78199,14 +78837,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eqs
+oCs
+arp
+jPO
+auQ
+mkx
 apJ
 apJ
 apJ
@@ -78444,6 +79080,9 @@ aaa
 aaa
 aaa
 aaa
+gXs
+gXs
+sBV
 aaa
 aaa
 aaa
@@ -78455,23 +79094,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-apJ
-asH
+eqs
+oCs
+arp
+jPO
+auQ
+uKz
 atI
 atI
 atI
-avY
+atI
+atI
+atI
+atI
+atI
 atI
 auc
 avp
@@ -78700,6 +79336,10 @@ aaa
 aaa
 aaa
 aaa
+gXs
+gXs
+aaa
+sBV
 aaa
 aaa
 aaa
@@ -78711,24 +79351,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eqs
+oCs
 arp
-asI
-auQ
-auQ
-auQ
-aqr
+jPO
+haa
+nwf
+aCX
+aCX
+aCX
+aCX
+aCX
+aCX
+aCX
+aCX
 aCX
 aub
 aLu
@@ -78956,6 +79592,11 @@ aaa
 aaa
 aaa
 aaa
+wiv
+wiv
+aaa
+aaa
+sBV
 aaa
 aaa
 aaa
@@ -78967,27 +79608,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-apJ
-asJ
-cTE
-avQ
-axc
-aCT
-atb
-aIH
+eqs
+oCs
+arp
+cVG
+tWf
+tTf
+xTX
+xTX
+xTX
+evZ
+wcZ
+dRU
+htp
+lkX
+xTX
+uSl
 apJ
 ifM
 eYV
@@ -79212,6 +79848,12 @@ aaa
 aaa
 aaa
 aaa
+aaS
+aaS
+aaf
+aaf
+wiv
+kFD
 aaa
 aaa
 aaa
@@ -79223,20 +79865,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eqs
+oCs
+arp
+lTO
+tWf
+wyb
+apJ
+apJ
 apJ
 apJ
 apJ
@@ -79469,6 +80105,12 @@ aaa
 aaa
 aaa
 aaa
+aaS
+aaa
+aoV
+aaa
+wiv
+qHd
 aaa
 aaa
 aaa
@@ -79480,28 +80122,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aaf
-aaf
-aaf
+arp
+arp
+arp
+lTO
+tWf
+jOG
+apJ
+lFj
+lFj
+lFj
+xeC
 alU
 atJ
-amC
-aus
+iIq
+dMJ
+hXJ
 bEJ
 axo
 xFW
@@ -79726,6 +80362,12 @@ aaa
 aaa
 aaa
 aaa
+aaS
+aaf
+vFJ
+abZ
+gYj
+ojL
 aaa
 aaa
 aaa
@@ -79736,28 +80378,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aae
-aaa
-aaa
-aaa
-aag
-alU
-alU
+xEJ
+hJL
+pPX
+hDJ
+lTO
+tWf
+uAv
+apJ
+lFj
+lFj
+lFj
+lFj
 alU
 aCW
-amC
+cZy
+dMJ
 arS
 alU
 alU
@@ -79983,6 +80619,12 @@ aaa
 aaa
 aaa
 aaa
+aaS
+aaa
+aoV
+aaa
+wiv
+qHd
 aaa
 aaa
 aaa
@@ -79994,26 +80636,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aag
-cXq
-qBb
-qFW
-rVA
+arp
+apJ
+apJ
+vuB
+tWf
+qpl
+apJ
+lFj
+lFj
+lFj
+lFj
+iBS
+amC
+uCs
 avq
 kjm
 avq
@@ -80240,6 +80876,12 @@ aaa
 aaa
 aaa
 aaa
+aaS
+aba
+aaf
+aaf
+wiv
+qjo
 aaa
 aaa
 aaa
@@ -80251,25 +80893,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+hnt
+vZq
+arp
+lTO
+tWf
+qJU
+apJ
+lFj
+lFj
+lFj
+lFj
 alU
-alU
-alU
-alU
-alU
+amC
 arS
 alU
 alU
@@ -80498,6 +81134,11 @@ aaa
 aaa
 aaa
 aaa
+gcm
+wiv
+aaa
+aaa
+sBV
 aaa
 aaa
 aaa
@@ -80509,24 +81150,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-alU
+bmR
+vZq
+arp
+luG
+fdK
+qrl
+apJ
 lFj
 lFj
-hYC
+lFj
+lFj
 alU
+amC
 arS
 alU
 lFj
@@ -80756,6 +81392,10 @@ aaa
 aaa
 aaa
 aaa
+gXs
+gXs
+aaa
+sBV
 aaa
 aaa
 aaa
@@ -80767,23 +81407,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
+cus
+vZq
+xmv
+xmv
+qhp
+xmv
+xmv
 alU
-lFj
-lFj
-lFj
 alU
+alU
+alU
+alU
+hAB
 arS
 alU
 lFj
@@ -81014,33 +81650,33 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaS
-aaS
-aaS
-aaS
-aaS
-aaS
-aaS
-aaS
-aaS
-aaS
-aaS
-aaS
-aba
-aaS
-aaS
-aaf
-aaf
-aaf
+gXs
+gXs
+sBV
 aaa
 aaa
 aaa
-alU
-lFj
-lFj
-lFj
-iBS
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+ebi
+liu
+arp
+fKP
+tsO
+phu
+xmv
+alF
+anj
+kar
+apO
+amC
+amC
 arS
 alU
 lFj
@@ -81272,32 +81908,32 @@ aaa
 aaa
 aaa
 aaa
-abY
-aaa
-aaf
-aaa
-aaf
-aaa
-aaf
-aaa
-acy
-aaa
-aaf
-aaa
-aiS
-aaa
-aaS
+gXs
+sBV
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-alU
-lFj
-lFj
-lFj
-alU
+aaa
+aaa
+aaa
+aaa
+aaa
+hcf
+ykQ
+tFK
+mym
+vsp
+mQv
+xmv
+alF
+oOf
+amC
+amC
+amC
+amC
 arS
 alU
 lFj
@@ -81529,33 +82165,33 @@ aaa
 aaa
 aaa
 aaa
-abY
 aaa
-naz
-adv
-rdN
-aaa
-naz
-adv
-rdN
-aaa
-naz
-adv
-rdN
-aaa
-aaS
-aaf
-aaf
-aaf
+sBV
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+eqs
+liu
+alR
+alR
+alR
+alR
+alR
+alR
+alR
 alU
-lFj
-lFj
-lFj
 alU
-arS
+alU
+tDS
+xUt
 alU
 lFj
 lFj
@@ -81783,36 +82419,36 @@ aaa
 aaa
 aaa
 aaa
-aae
 aaa
 aaa
-abY
-aaf
-naz
-adu
-rdN
 aaa
-naz
-adu
-rdN
-aaa
-naz
-adu
-rdN
-aaf
-aaf
+wiv
+sBV
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-alU
-alU
-alU
-alU
-alU
-mWr
+aaa
+aaa
+aaa
+aaa
+aaa
+sNl
+gYj
+pmW
+eAn
+mJV
+rRo
+sVa
+ang
+tbr
+aoj
+ayx
+apP
+amC
+arS
 alU
 alU
 alU
@@ -82043,33 +82679,33 @@ aaa
 aaa
 aaa
 aaa
-abY
-aaa
-naz
-adu
-rdN
-aaf
-naz
-adu
-rdN
-aaf
-naz
-adu
-rdN
-aaa
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aaa
-amw
-cSb
-oRm
-lje
+quT
+oCs
+fDJ
+gKU
+ksS
+ksS
+ksS
+kVq
+ksS
+ksS
+ksS
+sft
+evo
+oCs
+wiv
+ali
+ali
+ali
+amy
+gVq
+lYU
+qUL
+avq
+avq
+tXk
+hZw
+bzh
 avq
 avq
 avq
@@ -82300,32 +82936,32 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-naz
-adu
-rdN
-aaa
-naz
-adu
-rdN
-aaa
-naz
-adu
-rdN
-aaf
-aaf
-aaf
-aaf
-aaf
+wiv
+wiv
+wiv
+sHq
+quT
+wiv
+wiv
+sHq
+wiv
+wiv
+wiv
+sHq
+eRz
+quT
+wiv
 aaa
 aaa
-aaa
-aaf
-aaa
-amw
-atJ
-hzx
+ali
+sCv
+lOy
+anh
+gGd
+amC
+amC
+apP
+cIm
 alU
 alU
 alU
@@ -82554,26 +83190,27 @@ aaa
 aaa
 aaa
 aaa
-aaS
-aaS
-aaS
-aaf
 aaa
-naz
-adu
-rdN
 aaa
-naz
-adu
-rdN
 aaa
-naz
-adu
-rdN
+gXs
 aaa
-aaf
 aaa
-ali
+jDL
+aaa
+aaa
+aaa
+jDL
+aaa
+aaa
+aaa
+jDL
+aaa
+aaa
+gXs
+aaa
+aaa
+alR
 alR
 alR
 alR
@@ -82581,8 +83218,7 @@ alR
 alU
 alU
 alU
-tDS
-ano
+cIm
 alU
 lFj
 lFj
@@ -82811,35 +83447,35 @@ aaa
 aaa
 aaa
 aaa
-aaS
+aaa
+aaa
+aaa
+gXs
+aaa
+naz
+adz
+yhC
+aaa
+naz
+adz
+rdN
+aaa
+naz
+adz
+rdN
 aaa
 aaf
 aaa
 aaa
-aaa
-adw
-aaa
-aaa
-aaa
-adw
-aaa
-aaa
-aaa
-adw
-aaa
-aaa
-ali
-ali
-ali
-alQ
-amy
-ang
-alR
-aoj
+alU
+lFj
+lFj
+vAn
+alU
 ayx
-apP
 amC
-pTE
+amC
+cIm
 alU
 lFj
 lFj
@@ -83068,35 +83704,35 @@ aaa
 aaa
 aaa
 aaa
-aaS
+aaa
+aaa
+aaa
 aaf
-vFJ
-abZ
-abZ
-acW
-ady
-ady
-ady
-ady
-ady
-ady
-ady
-ady
-ady
-ady
-ajq
-pmW
-vcH
-mJV
-ema
-okC
-lYU
-tXh
-avq
-avq
-dXk
-wlH
-lzr
+aaf
+naz
+adz
+yhC
+aaa
+naz
+adz
+rdN
+aaa
+naz
+adz
+rdN
+aaf
+aaf
+aaa
+gXs
+alU
+lFj
+lFj
+lFj
+alU
+amC
+amC
+amC
+cIm
 alU
 lFj
 lFj
@@ -83325,35 +83961,35 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
 aaS
 aaa
+naz
+adz
+yhC
 aaf
+naz
+adz
+rdN
+aaf
+naz
+adz
+rdN
 aaa
-aaa
-aaa
-adx
-aaa
-aaa
-aaa
-adx
-aaa
-aaa
-aaa
-adx
-aaa
-aaa
-ali
-iMU
-ali
-alS
-amz
-anh
-anH
-xVc
+aaf
+gXs
+gXs
+alU
+lFj
+lFj
+lFj
+alU
+hrt
 amC
-ubI
 wAe
-wuz
+kGQ
 alU
 alU
 bQC
@@ -83582,11 +84218,11 @@ aaa
 aaa
 aaa
 aaa
-aaS
-aba
+aaa
+aaa
+aaa
 aaS
 aaf
-aaa
 naz
 adz
 yhC
@@ -83598,19 +84234,19 @@ aaa
 naz
 adz
 rdN
-aaa
 aaf
+abY
+gXs
 aaa
-ali
-alR
-alR
-alR
-alR
+alU
+alU
+nOU
+alU
+alU
 amC
-kvX
-apP
-amC
-amC
+vZz
+ext
+yct
 amC
 amC
 rAz
@@ -83842,30 +84478,30 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
+aaS
+aaa
 naz
-adz
+adA
 yhC
 aaa
 naz
-adz
+adA
 rdN
 aaa
 naz
-adz
+adA
 rdN
-aaf
-aaf
+aaa
+aaS
 aaa
 aaa
 alU
-alF
-anj
-kar
-apO
+aoU
 amC
-alU
+vZz
+ext
+ext
+yct
 amC
 alU
 alU
@@ -84096,32 +84732,32 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aae
 aaa
 aaa
 aaS
 aaa
-naz
-adz
-yhC
-aaf
-naz
-adz
-rdN
-aaf
-naz
-adz
-rdN
+acy
 aaa
 aaf
+aaa
 aaf
+aaa
 aaf
+aaa
+aaf
+aaa
+aaf
+aaa
+aaS
+aoV
+aoV
 alU
-alF
-anl
-amC
-amC
-aoU
+alU
+alU
+cIm
+alU
+alU
 alU
 amC
 alU
@@ -84357,29 +84993,29 @@ aaa
 aaa
 aaa
 aaS
-aaf
-naz
-adz
-yhC
+aaS
+aaS
+aaS
+aaS
+aba
+aaS
+aaS
+aaS
+aaS
+aaS
+aaS
+aaS
+aaS
+aaS
 aaa
-naz
-adz
-rdN
 aaa
-naz
-adz
-rdN
-aaf
-aaf
 aaa
 aaa
 alU
-alU
-xTf
-alU
-alU
-alU
-alU
+cIm
+amw
+aoV
+amw
 amC
 alU
 lFj
@@ -84613,27 +85249,27 @@ aaa
 aaa
 aaa
 aaa
-aaS
 aaa
-naz
-adA
-yhC
 aaa
-naz
-adA
-rdN
 aaa
-naz
-adA
-rdN
 aaa
-aaS
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 alU
-lFj
-lFj
-vAn
+cIm
 amw
 aoV
 amw
@@ -84870,30 +85506,30 @@ aaa
 aaa
 aaa
 aaa
-aaS
 aaa
-aaf
 aaa
-aaf
 aaa
-aaf
 aaa
-aaf
 aaa
-aaf
 aaa
-aaf
 aaa
-aaS
-aaf
-aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aoV
+aaa
+aaa
+aaa
 alU
-lFj
-lFj
-lFj
-alU
-bGx
-alU
+cIm
+amw
+aaa
+amw
 amC
 alU
 lFj
@@ -85127,30 +85763,30 @@ aaa
 aaa
 aaa
 aaa
-aaS
-aaS
-aaS
-aaS
-aaS
-aba
-aaS
-aaS
-aaS
-aaS
-aaS
-aaS
-aaS
-aaS
-aaS
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 alU
-lFj
-lFj
-lFj
-alU
-hrt
-amC
+lrb
+amw
+aaa
+amw
 amC
 wLh
 lFj
@@ -85400,14 +86036,14 @@ aaa
 aaa
 aaa
 aaa
+aoV
+aoV
+aoV
+alU
+lrb
 alU
 alU
 alU
-nOU
-alU
-alU
-alU
-nOU
 alU
 alU
 lFj
@@ -85657,11 +86293,11 @@ aaa
 aaa
 aaa
 aaa
+aag
 alU
-ftu
 alU
-amC
-amC
+alU
+lrb
 alU
 lFj
 lFj
@@ -85914,11 +86550,11 @@ aaa
 aaa
 aaa
 aaa
-alU
-alU
-alU
-alU
-amC
+ksi
+cXq
+qBb
+qFW
+yct
 iBS
 lFj
 lFj
@@ -86171,9 +86807,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+pEf
+alU
+alU
 amw
 amC
 alU

--- a/code/modules/mining/aux_base.dm
+++ b/code/modules/mining/aux_base.dm
@@ -214,7 +214,7 @@
 	if(is_mining_level(z)) //The console switches to controlling the mining shuttle once landed.
 		req_one_access = list()
 		shuttleId = "mining" //The base can only be dropped once, so this gives the console a new purpose.
-		possible_destinations = "mining_home;mining_away;landing_zone_dock;mining_public"
+		possible_destinations = "mining_home;mining_away;landing_zone_dock;mining_public;auxiliary_construction"
 
 /obj/machinery/computer/auxiliary_base/proc/set_landing_zone(turf/T, mob/user, no_restrictions)
 	var/obj/docking_port/mobile/auxiliary_base/base_dock = locate(/obj/docking_port/mobile/auxiliary_base) in SSshuttle.mobile

--- a/code/modules/shuttle/custom_shuttle.dm
+++ b/code/modules/shuttle/custom_shuttle.dm
@@ -11,7 +11,7 @@
 	light_color = LIGHT_COLOR_CYAN
 	req_access = list( )
 	var/shuttleId
-	var/possible_destinations = "whiteship_home"
+	var/possible_destinations = "whiteship_home;auxiliary_construction"
 	var/admin_controlled
 	var/no_destination_swap = 0
 	var/calculated_mass = 0
@@ -106,7 +106,7 @@
 
 /obj/machinery/computer/custom_shuttle/proc/linkShuttle(var/new_id)
 	shuttleId = new_id
-	possible_destinations = "whiteship_home;shuttle[new_id]_custom"
+	possible_destinations = "whiteship_home;auxiliary_construction;shuttle[new_id]_custom"
 
 /obj/machinery/computer/custom_shuttle/proc/calculateStats(var/useFuel = FALSE, var/dist = 0, var/ignore_cooldown = FALSE)
 	if(!ignore_cooldown && stat_calc_cooldown >= world.time)


### PR DESCRIPTION
# Document the changes in your pull request

Expands Aux Base Construction to include a place to build shuttles. It has also been merged with port bow solars, so I had to mess with maints a bit to get it to work. The mining shuttle also docks to the open area instead of inside the base construction area. The amount of wires needed to wire the solar panels is still 40, tough it is a bit of a walk. There is also some supplies for building shuttles in a storage room next to the solars room. I have not tested this, so some things may break because of the scale of the changes and my lack of experience.

## Images
### New Aux Base Construction
![image](https://user-images.githubusercontent.com/14363906/137433634-b3bbf2a1-d3f3-4eb7-8133-07b9c661172f.png)

![image](https://user-images.githubusercontent.com/14363906/137433968-7d5af9b1-074f-4fd1-bb14-b0aadd6a0c1f.png)

![image](https://user-images.githubusercontent.com/14363906/137434067-2c7c062f-4ebb-4b1e-96b6-81098302817d.png)

### Starting Boards
![image](https://user-images.githubusercontent.com/14363906/137433734-815a79e9-4d37-48bc-bf73-41f800b30a93.png)
![image](https://user-images.githubusercontent.com/14363906/137433879-7af672c2-7e6e-4b3f-9c09-4d7d5ef37244.png)

# Wiki Documentation

Many images will need to be changed, and if there is a page for aux base construction that will need to be updated too. 

# Changelog

:cl:  
tweak: expanded aux base construction to include a place for building shuttles
/:cl:
