### PR TITLE
Replaces Engineers and Atmo Techs tablets with phones

### DIFF
--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -46,7 +46,7 @@
 	duffelbag = /obj/item/storage/backpack/duffelbag/engineering
 	box = /obj/item/storage/box/engineer
 	pda_slot = SLOT_L_STORE
-	backpack_contents = list(/obj/item/modular_computer/tablet/preset/advanced=1)
+	backpack_contents = list(/obj/item/modular_computer/tablet/phone/preset/advanced=1)
 
 /datum/outfit/job/atmos/rig
 	name = "Atmospheric Technician (Hardsuit)"

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -104,7 +104,7 @@ GLOBAL_LIST_INIT(available_depts_eng, list(ENG_DEPT_MEDICAL, ENG_DEPT_SCIENCE, E
 	duffelbag = /obj/item/storage/backpack/duffelbag/engineering
 	box = /obj/item/storage/box/engineer
 	pda_slot = SLOT_L_STORE
-	backpack_contents = list(/obj/item/modular_computer/tablet/preset/advanced=1)
+	backpack_contents = list(/obj/item/modular_computer/tablet/phone/preset/advanced=1)
 
 /datum/outfit/job/engineer/gloved
 	name = "Station Engineer (Gloves)"


### PR DESCRIPTION
# Document the changes in your pull request

Gave engis and atmo techs phones instead of tablets. Not replacing the CE's tablet cause they still need it for the ID modification program. Untested, should work.

from the phone PR
![image](https://user-images.githubusercontent.com/14363906/137573711-86ad7f8c-99c2-4fe6-8564-d2e3357e2981.png)

# Wiki Documentation

The job page will need to be updated to include the new items. 

# Changelog

:cl:  
tweak: replace engineers and atmo techs tablets with phones
/:cl:
