### PR TITLE
buffs lightning bolt spell

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -213,7 +213,6 @@
 /datum/spellbook_entry/lightningbolt
 	name = "Lightning Bolt"
 	spell_type = /obj/effect/proc_holder/spell/aimed/lightningbolt
-	cost = 3
 
 /datum/spellbook_entry/lightningbolt/Buy(mob/living/carbon/human/user,obj/item/spellbook/book) //return TRUE on success
 	. = ..()

--- a/code/modules/spells/spell_types/aimed.dm
+++ b/code/modules/spells/spell_types/aimed.dm
@@ -92,7 +92,7 @@
 	name = "Lightning Bolt"
 	desc = "Fire a lightning bolt at your foes! It will jump between targets, but can't knock them down."
 	school = "evocation"
-	charge_max = 200
+	charge_max = 150
 	clothes_req = TRUE
 	invocation = "UN'LTD P'WAH"
 	invocation_type = "shout"

--- a/code/modules/spells/spell_types/aimed.dm
+++ b/code/modules/spells/spell_types/aimed.dm
@@ -92,8 +92,8 @@
 	name = "Lightning Bolt"
 	desc = "Fire a lightning bolt at your foes! It will jump between targets, but can't knock them down."
 	school = "evocation"
-	charge_max = 150
-	clothes_req = TRUE
+	charge_max = 120
+	clothes_req = FALSE
 	invocation = "UN'LTD P'WAH"
 	invocation_type = "shout"
 	cooldown_min = 30


### PR DESCRIPTION
reduces cooldown by 5 seconds and cost by 1

previously cooldown was 20 seconds and cost was 3
the spell doesnt knock people down and only does like 20 burn damage, which is terrible. for one spellpoint less you can just instacrit someone with a fireball that has a 8 second cooldown

edit: cooldown is now 12 seconds and it is robeless

:cl:  
tweak: lightning bolt spell cooldown reduced by 8 and cost reduced by 1, also made robeless
/:cl:
