### PR TITLE
[s] Force update to a version without known hacks

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -335,10 +335,10 @@ AUTO_DEADMIN_THRESHOLD 4
 #CLIENT_WARN_VERSION 511
 #CLIENT_WARN_POPUP
 #CLIENT_WARN_MESSAGE Byond released 511 as the stable release. You can set the framerate your client runs at, which makes the game feel very different and cool. Shortly after its release we will end up using 511 client features and you will be forced to update.
-CLIENT_ERROR_VERSION 513
+CLIENT_ERROR_VERSION 514
 CLIENT_ERROR_MESSAGE Your version of byond is not supported. Please upgrade.
 ## The minimum build needed for joining the server, if using 512, a good minimum build would be 1421 as that disables the Middle Mouse Button exploit.
-CLIENT_ERROR_BUILD 1542
+CLIENT_ERROR_BUILD 1568
 
 ## TOPIC RATE LIMITING
 ## This allows you to limit how many topic calls (clicking on an interface window) the client can do in any given game second and/or game minute.


### PR DESCRIPTION
# Document the changes in your pull request
514.1566 has a know set of clientside hacks, they don't work on 514.1568. This is very much a bandaid fix (All it takes it the hacks to update) but people have used them on the server, so this will at least stop them for a bit.

# Changelog

:cl:  
tweak: minimum allowed version is now 514.1568
/:cl:
