### PR TITLE
stops revenants from loosing the singulo

### DIFF
--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -304,7 +304,7 @@
 		new /obj/effect/temp_visual/revenant(human.loc)
 		human.emp_act(EMP_HEAVY)
 	for(var/obj/thing in T)
-		if(istype(thing, /obj/machinery/power/apc) || istype(thing, /obj/machinery/power/smes)) //Doesn't work on SMES and APCs, to prevent kekkery
+		if(istype(thing, /obj/machinery/power/apc) || istype(thing, /obj/machinery/power/smes) || istype(thing, /obj/machinery/particle_accelerator/control_box)) //Doesn't work on SMES and APCs or the PA control box, to prevent kekkery
 			continue
 		if(prob(20))
 			if(prob(50))


### PR DESCRIPTION
when the emag effect is 😳 
:cl:  
bugfix: revenants can no longer cause a disgustingly massive amount of damage with the malfunction ability
/:cl:
