### PR TITLE
Adds an ashwalker fertilizer mix and redescribes gutlunch milk and cheese to be more fitting for a bug

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_cheese.dm
+++ b/code/modules/food_and_drinks/food/snacks_cheese.dm
@@ -308,16 +308,18 @@
 //bug cheese
 /obj/item/reagent_containers/food/snacks/store/cheesewheel/bug
 	name = "bug cheese ball"
-	desc = "A big ball of nasty looking bug cheese."
+	desc = "A big ball of gutlunch "honey", with a similar consistency to cheese."
 	icon_state = "bug_ball"
+	foodtype = SUGAR | MEAT //honey made by a carnivorous scavenging bug
 	slice_path = /obj/item/reagent_containers/food/snacks/cheesewedge/bug
 	list_reagents = list(/datum/reagent/consumable/nutriment = 10, /datum/reagent/consumable/nutriment/vitamin = 5)
-	tastes = list("bug" = 1,"cheese" = 1)
+	tastes = list("a rather large serving of sugar" = 1, "meat" = 1)
 
 /obj/item/reagent_containers/food/snacks/cheesewedge/bug
 	name = "bug cheese piece"
-	desc = "A piece of bug cheese."
+	desc = "A piece of gutlunch "honey"."
 	icon_state = "bug_piece"
 	filling_color = "#ddedd5"
+	foodtype = SUGAR | MEAT
 	list_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/nutriment/vitamin = 1)
-	tastes = list("bug" = 1,"cheese" = 1)
+	tastes = list("a rather large serving of sugar" = 1, "meat" = 1)

--- a/code/modules/food_and_drinks/food/snacks_cheese.dm
+++ b/code/modules/food_and_drinks/food/snacks_cheese.dm
@@ -317,7 +317,7 @@
 
 /obj/item/reagent_containers/food/snacks/cheesewedge/bug
 	name = "bug cheese piece"
-	desc = "A piece of gutlunch "honey"."
+	desc = "A piece of gutlunch \"honey\"."
 	icon_state = "bug_piece"
 	filling_color = "#ddedd5"
 	foodtype = SUGAR | MEAT

--- a/code/modules/food_and_drinks/food/snacks_cheese.dm
+++ b/code/modules/food_and_drinks/food/snacks_cheese.dm
@@ -308,7 +308,7 @@
 //bug cheese
 /obj/item/reagent_containers/food/snacks/store/cheesewheel/bug
 	name = "bug cheese ball"
-	desc = "A big ball of gutlunch "honey", with a similar consistency to cheese."
+	desc = "A big ball of gutlunch \"honey\", with a similar consistency to cheese."
 	icon_state = "bug_ball"
 	foodtype = SUGAR | MEAT //honey made by a carnivorous scavenging bug
 	slice_path = /obj/item/reagent_containers/food/snacks/cheesewedge/bug

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -495,6 +495,10 @@
 		mutmod = 0
 		adjustNutri(round(S.get_reagent_amount(/datum/reagent/plantnutriment/robustharvestnutriment) *1 ))
 
+	if(S.has_reagent(/datum/reagent/plantnutriment/tribalnutriment, 1))
+		mutmod = 0
+		adjustNutri(round(S.get_reagent_amount(/datum/reagent/plantnutriment/tribalnutriment) *1 ))
+
 	// Ambrosia Gaia produces earthsblood.
 	if(S.has_reagent(/datum/reagent/medicine/earthsblood))
 		self_sufficiency_progress += S.get_reagent_amount(/datum/reagent/medicine/earthsblood)

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -314,14 +314,14 @@
 	..()
 
 /datum/reagent/consumable/cream/bug
-	name = "Bug Cream"
-	description = "The very fatty, still liquid part of bug milk. It looks pretty gross."
+	name = "Gutlunch Honey"
+	description = "A sweet, creamy substance produced by gutlunches, functioning as a sort of strange honey."
 	color = "#800000"
 	nutriment_factor = 2
-	taste_description = "creamy bug milk"
+	taste_description = "excessively sugary cream"
 	glass_icon_state  = "chocolateglass"
 	glass_name = "glass of bug cream"
-	glass_desc = "Ewwwww!"
+	glass_desc = "This came from a WHAT?!"
 
 /datum/reagent/consumable/coffee
 	name = "Coffee"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1467,7 +1467,12 @@
 	color = "#9D9D00" // RBG: 157, 157, 0
 	tox_prob = 15
 
-
+/datum/reagent/plantnutriment/tribalnutriment
+	name = "Mushroom Paste Fertilizer"
+	description = "A fertilizer made from mushrooms and gutlunch honey found on lavaland that preventes plants from mutating."
+	color = "#800000"
+	tox_prob = 15
+	taste_description = "actual hell"
 
 
 

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -643,6 +643,14 @@
 /datum/chemical_reaction/cellulose_carbonization
 	name = "Cellulose_Carbonization"
 	id = /datum/reagent/carbon
+	mix_message = "The fibers char, producing a soft black powder."
 	results = list(/datum/reagent/carbon = 1)
 	required_reagents = list(/datum/reagent/cellulose = 1)
 	required_temp = 512
+
+/datum/chemical_reaction/tribalnutriment
+	name = "Mushroom Paste Congealation"
+	id = "mushroom_paste"
+	mix_message = "The mixture congeals into a foul smelling paste."
+	results = list(/datum/reagent/plantnutriment/tribalnutriment = 6)
+	required_reagents = list(/datum/reagent/consumable/cream/bug = 2, /datum/reagent/consumable/vitfro = 2, /datum/reagent/consumable/entpoly = 2)


### PR DESCRIPTION
# Document the changes in your pull request

HAVE YOU EVER wanted to produce GOOD CROPS as a DIRTY, TRIBAL, ASH LIZARD but have FAILED because BOTANY RNG MUTATIONS decided you were NOT ALLOWED TO HARVEST YOUR BAMBOO?

HAVE YOU EVER WONDERED WHY bug cheese IS CRAFTABLE BY LIZARDS, BUT LIZARDS HATE CHEESE?

TODAY IS YOUR LUCKY DAY

ashwalkers can now make a SPECIAL fertilizer that will prevent plant mutations (as well as functioning as a decent fertilizer) from 2 units of gutlunch cream, 2 units of vitrium froth, and 2 units of entropic polywhatever! You no longer will need to pray to the botany RNG gods for the harvest to not just be bountiful but EXIST AT ALL!

Gutlunch milk has been rebranded as gutlunch "honey" (with quotations because it is not real honey), an excessively sweet substance that can be turned into a cheese with the food groups of SUGAR and MEAT making it EDIBLE FOR ASHWALKERS (probably)! Now you will ACTUALLY maybe MAKE BUG CHEESE it's still not as good as cacti yet (yet)

# Wiki Documentation

new chemical mushroom paste fertilizer made from2 units of gutlunch cream, 2 units of vitrium froth, and 2 units of entpoly which prevents random plant mutations

bug cheese is now given the food groups of sugar and meat instead of dairy as it is made from not milk

# Changelog

:cl:  
rscadd: new fertilizer for ashwalkers made from gutlunch cream, vitrium froth, and entpoly which prevents plant mutations (like robust harvest but without the 30%  bonus yield)
tweak: bug cheese and gutlunch cream are rebranded as bug products being "honey" (but not real honey)
tweak: burning "cellulose fibers (wood) in a beaker will now not show flavortext for bubbling and instead show something more akin to woodchips burning
/:cl:
