### PR TITLE
Alert ghosts on bloodstone spawn, minor optimization of stone spawning

### DIFF
--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -178,13 +178,14 @@
 			altogether."
 
 /datum/game_mode/proc/begin_bloodstone_phase()
+	var/list/bloodstone_areas = list()
 	for(var/i = 0, i < 4, i++) //four bloodstones
 		var/spawnpoint = get_turf(pick(GLOB.generic_event_spawns))
-		new /obj/structure/destructible/cult/bloodstone(spawnpoint)
-	var/list/bloodstone_areas = list()
-	for(var/obj/structure/destructible/cult/bloodstone/B in bloodstone_list)
-		var/area/A = get_area(B)
+		var/stone = new /obj/structure/destructible/cult/bloodstone(spawnpoint)
+		notify_ghosts("Bloodcult has an object of interest: [stone]!", source=stone, action=NOTIFY_ORBIT, header="Praise the Geometer!")
+		var/area/A = get_area(stone)
 		bloodstone_areas.Add(A.map_name)
+
 	priority_announce("Figments of an eldritch god are being pulled through the veil anomaly in [bloodstone_areas[1]], [bloodstone_areas[2]], [bloodstone_areas[3]], and [bloodstone_areas[4]]! Destroy any occult structures located in those areas!","Central Command Higher Dimensional Affairs")
 	addtimer(CALLBACK(src, .proc/increase_bloodstone_power), 30 SECONDS)
 	set_security_level(SEC_LEVEL_GAMMA)


### PR DESCRIPTION
# Document the changes in your pull request
Gives ghosts an orbit button to orbit bloodstones when they spawn.

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
rscadd: Added orbit button to bloodstones
/:cl:
