### PR TITLE
Alternative station announcers now almost never appear.

### DIFF
--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -51,7 +51,7 @@
 /datum/station_trait/announcement_medbot
 	name = "Announcement \"System\""
 	trait_type = STATION_TRAIT_NEUTRAL
-	weight = 0.01
+	weight = 0.2
 	show_in_report = TRUE
 	report_message = "Our announcement system is under scheduled maintenance at the moment. Thankfully, we have a backup."
 	blacklist = list(/datum/station_trait/announcement_intern)

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -39,7 +39,7 @@
 /datum/station_trait/announcement_intern
 	name = "Announcement Intern"
 	trait_type = STATION_TRAIT_NEUTRAL
-	weight = 0.01
+	weight = 0.2
 	show_in_report = TRUE
 	report_message = "Please be nice to him."
 	blacklist = list(/datum/station_trait/announcement_medbot)

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -39,7 +39,7 @@
 /datum/station_trait/announcement_intern
 	name = "Announcement Intern"
 	trait_type = STATION_TRAIT_NEUTRAL
-	weight = 1
+	weight = 0
 	show_in_report = TRUE
 	report_message = "Please be nice to him."
 	blacklist = list(/datum/station_trait/announcement_medbot)
@@ -51,7 +51,7 @@
 /datum/station_trait/announcement_medbot
 	name = "Announcement \"System\""
 	trait_type = STATION_TRAIT_NEUTRAL
-	weight = 1
+	weight = 0
 	show_in_report = TRUE
 	report_message = "Our announcement system is under scheduled maintenance at the moment. Thankfully, we have a backup."
 	blacklist = list(/datum/station_trait/announcement_intern)

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -39,7 +39,7 @@
 /datum/station_trait/announcement_intern
 	name = "Announcement Intern"
 	trait_type = STATION_TRAIT_NEUTRAL
-	weight = 0
+	weight = 0.01
 	show_in_report = TRUE
 	report_message = "Please be nice to him."
 	blacklist = list(/datum/station_trait/announcement_medbot)

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -51,7 +51,7 @@
 /datum/station_trait/announcement_medbot
 	name = "Announcement \"System\""
 	trait_type = STATION_TRAIT_NEUTRAL
-	weight = 0
+	weight = 0.01
 	show_in_report = TRUE
 	report_message = "Our announcement system is under scheduled maintenance at the moment. Thankfully, we have a backup."
 	blacklist = list(/datum/station_trait/announcement_intern)


### PR DESCRIPTION
This changes the weights of the alternative station announcers from 1 to 0, making them (almost) never appear.

# Changelog

Changes the weights for alternative station announcers from 1 to 0.

:cl:  Xoxeyos
tweak: Alternative station announcers now (almost) never appear. 
/:cl:
