### PR TITLE
Gives CE sunglasses roundstart

### DIFF
--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -38,6 +38,7 @@
 
 	id = /obj/item/card/id/silver
 	belt = /obj/item/storage/belt/utility/chief/full
+	glasses = /obj/item/clothing/glasses/sunglasses
 	l_pocket = /obj/item/pda/heads/ce
 	ears = /obj/item/radio/headset/heads/ce
 	uniform = /obj/item/clothing/under/rank/chief_engineer


### PR DESCRIPTION
# Document the changes in your pull request
The CE now has sunglasses at roundstart so they're not a free kill for any antag anymore

This PR is objectively good because literally every head has flash protection except for the CE, they shouldn't be an easy target for any antag to flash and convert/kill them, if every other head gets flash protection the CE should aswell

This PR is an ided

# Wiki Documentation

Maybe something on the CE page

# Changelog

:cl:  
tweak: CE has sunglasses roundstart now
/:cl:
