### PR TITLE
Adds bilingual quirk

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -37,6 +37,19 @@
 		if(mood)
 			mood.mood_modifier += 0.2
 
+/datum/quirk/bilingual
+	name = "Bilingual"
+	desc = "You learned the langauge of your people"
+	value = 1
+	gain_text = span_notice("You begin to understand the native language of your people")
+	lose_text = span_notice("Your knowledge of the native language of your people slips away")
+
+/datum/quirk/bilingual/on_spawn()
+	. = ..()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/lang = H.dna.species.species_bilingual_language || /datum/language/japanese
+	H.grant_language(lang, TRUE, TRUE)
+
 /datum/quirk/drunkhealing
 	name = "Drunken Resilience"
 	desc = "Nothing like a good drink to make you feel on top of the world. Whenever you're drunk, you slowly recover from injuries."

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -607,8 +607,8 @@
 /datum/quirk/sheltered/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	H.remove_language(/datum/language/common, FALSE, TRUE)
-	if(!H.get_selected_language())
-		H.grant_language(/datum/language/japanese)
+	var/lang = H.dna.species.species_bilingual_language || /datum/language/japanese
+	H.grant_language(lang, TRUE, TRUE)
 
 /datum/quirk/allergic
 	name = "Allergic Reaction"

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -48,8 +48,10 @@ GLOBAL_LIST_EMPTY(mentor_races)
 	var/nojumpsuit = FALSE
 	/// affects the speech message
 	var/say_mod = "says"
-	///Used if you want to give your species thier own language
+	/// Used if you want to always give your species thier own language
 	var/species_language_holder = /datum/language_holder
+	/// Used for the bilingual quirk
+	var/species_bilingual_language
 	/// Default mutant bodyparts for this species. Don't forget to set one for every mutant bodypart you allow this species to have.
 	var/list/default_features = list()
 	/// Visible CURRENT bodyparts that are unique to a species. DO NOT USE THIS AS A LIST OF ALL POSSIBLE BODYPARTS AS IT WILL FUCK SHIT UP! Changes to this list for non-species specific bodyparts (ie cat ears and tails) should be assigned at organ level if possible. Layer hiding is handled by handle_mutant_bodyparts() below.

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -17,7 +17,7 @@
 	species_traits = list(DYNCOLORS, AGENDER, NO_UNDERWEAR, HAS_FLESH, HAS_BONE) // i mean i guess they have blood so they can have wounds too
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	inherent_traits = list(TRAIT_NOHUNGER)
-	species_language_holder = /datum/language_holder/ethereal
+	species_bilingual_language = /datum/language/etherean
 	sexes = FALSE //no fetish content allowed
 	toxic_food = NONE
 	inert_mutation = SHOCKTOUCH

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -10,7 +10,7 @@
 	mutantears = /obj/item/organ/ears/cat
 	mutanttail = /obj/item/organ/tail/cat
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
-	species_language_holder = /datum/language_holder/felinid
+	species_bilingual_language = /datum/language/felinid
 
 /datum/species/human/felinid/qualifies_for_rank(rank, list/features)
 	return TRUE

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -16,7 +16,7 @@
 	heatmod = 0.5 // = 1/4x heat damage
 	burnmod = 0.5 // = 1/2x generic burn damage
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
-	species_language_holder = /datum/language_holder/jelly
+	species_bilingual_language = /datum/language/slime
 
 /datum/species/jelly/on_species_loss(mob/living/carbon/C)
 	if(regenerate_limbs)

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -26,7 +26,7 @@
 	deathsound = 'sound/voice/lizard/deathsound.ogg'
 	screamsound = 'yogstation/sound/voice/lizardperson/lizard_scream.ogg' //yogs - lizard scream
 	wings_icon = "Dragon"
-	species_language_holder = /datum/language_holder/lizard
+	species_bilingual_language = /datum/language/draconic
 
 /datum/species/lizard/random_name(gender,unique,lastname)
 	if(unique)

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -17,7 +17,7 @@
 	toxic_food = MEAT | RAW
 	mutanteyes = /obj/item/organ/eyes/moth
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
-	species_language_holder = /datum/language_holder/mothmen
+	species_bilingual_language = /datum/language/mothian
 
 /datum/species/moth/regenerate_organs(mob/living/carbon/C,datum/species/old_species,replace_current=TRUE)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -22,7 +22,7 @@
 	disliked_food = FRUIT
 	liked_food = VEGETABLES | GRILLED
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC
-	species_language_holder = /datum/language_holder/plasmaman
+	species_bilingual_language = /datum/language/bonespeak
 
 /datum/species/plasmaman/spec_life(mob/living/carbon/human/H)
 	var/datum/gas_mixture/environment = H.loc.return_air()

--- a/code/modules/mob/living/carbon/human/species_types/polysmorphs.dm
+++ b/code/modules/mob/living/carbon/human/species_types/polysmorphs.dm
@@ -7,7 +7,7 @@
 	liked_food = GROSS | MEAT
 	disliked_food = GRAIN | DAIRY | VEGETABLES | FRUIT
 	say_mod = "hisses"
-	species_language_holder = /datum/language_holder/polysmorph
+	species_bilingual_language = /datum/language/polysmorph
 	coldmod = 0.75
 	heatmod = 1.5
 	acidmod = 0.2 //Their blood is literally acid

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
@@ -18,7 +18,7 @@
 	disliked_food = MEAT | DAIRY
 	liked_food = VEGETABLES | FRUIT | GRAIN
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
-	species_language_holder = /datum/language_holder/pod
+	species_bilingual_language = /datum/language/sylvan
 
 	var/no_light_heal = FALSE
 	var/light_heal_multiplier = 1

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -32,7 +32,7 @@ adjust_charge - take a positive or negative value to adjust the charge level
 	var/draining = FALSE
 	screamsound = 'goon/sound/robot_scream.ogg'
 	wings_icon = "Robotic"
-	species_language_holder = /datum/language_holder/preternis
+	species_bilingual_language = /datum/language/machine
 
 /datum/species/preternis/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request

Xenos no longer get their species specific language by default, they get it by taking the bilingual quirk. Its only one point, incompatible with sheltered.

# Wiki Documentation

Bilingual is a new quirk for 1 point, gives race specific language (or Japanese). Galactic common still removes ability to speak common.

# Changelog

:cl:  
rscadd: Added bilingual quirk, to allow xenos to speak their race specific language
rscdel: Removed xenos getting race specific languages by default
/:cl:
