### PR TITLE
Replaces water in squirt cider with sugar to prevent tomato soup turning into alcohol

### DIFF
--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -632,7 +632,7 @@
 	name = "Squirt Cider"
 	id = /datum/reagent/consumable/ethanol/squirt_cider
 	results = list(/datum/reagent/consumable/ethanol/squirt_cider = 1)
-	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/consumable/tomatojuice = 1, /datum/reagent/consumable/nutriment = 1)
+	required_reagents = list(/datum/reagent/consumable/sugar = 1, /datum/reagent/consumable/tomatojuice = 1, /datum/reagent/consumable/nutriment = 1)
 	mix_message = "The mix swirls and turns a bright red that reminds you of an apple's skin."
 
 /datum/chemical_reaction/fringe_weaver


### PR DESCRIPTION
# Document the changes in your pull request

Replaces water in squirt cider with sugar to prevent tomato soup turning into alcohol
Fixes #12439 

# Wiki Documentation

Squirt cider takes sugar instead of water now

:cl:  
tweak: Squirt cider takes sugar instead of water nowsoundadd: added a new sound thingy  
bugfix: tomato soup no longer turns into alcohol
/:cl:
