### PR TITLE
Adds to the list of antags that mindshield nanites don't work on

### DIFF
--- a/code/modules/research/nanites/nanite_programs/buffing.dm
+++ b/code/modules/research/nanites/nanite_programs/buffing.dm
@@ -101,9 +101,23 @@
 
 /datum/nanite_program/mindshield/enable_passive_effect()
 	. = ..()
-	if(!host_mob.mind.has_antag_datum(/datum/antagonist/rev, TRUE) && !is_hivemember(host_mob) && !host_mob.is_wokevessel()) //won't work if on a rev, to avoid having implanted revs. same applies for hivemind members.
-		ADD_TRAIT(host_mob, TRAIT_MINDSHIELD, "nanites")
-		host_mob.sec_hud_set_implants()
+	//won't work if on a rev, to avoid having implanted revs. same applies for hivemind members.
+	if(host_mob.mind.has_antag_datum(/datum/antagonist/rev, TRUE))
+		return
+	if(is_hivemember(host_mob))
+		return
+	if(host_mob.is_wokevessel())
+		return
+	if(host_mob.mind.has_antag_datum(/datum/antagonist/brainwashed))
+		return
+	if(host_mob.mind.has_antag_datum(/datum/antagonist/gang, TRUE))
+		return
+	if(is_shadow_or_thrall(host_mob))
+		return
+	if(host_mob.mind.has_antag_datum(/datum/antagonist/veil) || host_mob.mind.has_antag_datum(/datum/antagonist/darkspawn))
+		return
+	ADD_TRAIT(host_mob, TRAIT_MINDSHIELD, "nanites")
+	host_mob.sec_hud_set_implants()
 
 /datum/nanite_program/mindshield/disable_passive_effect()
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request

Its currently possible for a large number of antags to get mindshield from nanites. This shouldn't be possible.

Yes, I did get my ass beat by a thrall with a mindshield.

# Changelog

:cl:  
bugfix: fixed some antags getting mind-shielded from nanites
/:cl:
