### PR TITLE
removes the extra arm item from nukeops

### DIFF
--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -71,11 +71,6 @@
 	surplus = 0
 	exclude_modes = list(/datum/game_mode/nuclear)
 
-/datum/uplink_item/device_tools/arm/nuke
-	cost = 15
-	exclude_modes = list()
-	include_modes = list(/datum/game_mode/nuclear)
-
 /datum/uplink_item/device_tools/arm/spawn_item(spawn_item, mob/user)
 	var/limbs = user.held_items.len
 	user.change_number_of_hands(limbs+1)


### PR DESCRIPTION
# Document the changes in your pull request

several items are balanced around requiring two hands to use, preventing the use of a shield (i.e. the SAW, resident meta pick weapon for its high damage and low ttk)
this item specifically gives spare arms for shields, negating the entire point of "this requires both hands to use"

# Wiki Documentation

extra arm not purchaseable on ops

# Changelog

:cl:  
rscdel: you can no longer buy extra arms as a nukeop
/:cl:
