### PR TITLE
Remoevs the L6's burst fire since its effective long range dps is higher than the sniper

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -226,7 +226,6 @@
 	weapon_weight = WEAPON_HEAVY
 	var/cover_open = FALSE
 	can_suppress = FALSE
-	burst_size = 3
 	fire_delay = 1
 	spread = 7
 	pin = /obj/item/firing_pin/implant/pindicate


### PR DESCRIPTION
# Document the changes in your pull request

meta pick gun needs to be slightly less meta, it still deals enough damage to instantly slow people with all rounds it just can't instakill people regardless of their health and armor. Considering this means it outpreforms both the shotgun (dealing 120 damage if all 3 shots hit up from a buckshot ~70) and the sniper (which stuns on hit but has an ass long cooldown between shots) it needs something to not be the objectively best gun for warops

# Wiki Documentation

L6 has no 3 round burst mode

# Changelog

:cl:  
rscdel: removes the 3 round burst mode from the L6
/:cl:
