### PR TITLE
doubles the amount of cryoxadone time required to auto-heal a wound since I also doubled the cryoxadone healing speed

### DIFF
--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -319,7 +319,7 @@
 /// Called from cryoxadone and pyroxadone when they're proc'ing. Wounds will slowly be fixed separately from other methods when these are in effect. crappy name but eh
 /datum/wound/proc/on_xadone(power)
 	cryo_progress += power
-	if(cryo_progress > 33 * severity)
+	if(cryo_progress > 66 * severity)
 		qdel(src)
 
 /// When synthflesh is applied to the victim, we call this. No sense in setting up an entire chem reaction system for wounds when we only care for a few chems. Probably will change in the future


### PR DESCRIPTION
# Document the changes in your pull request

Turns out this is a thing that exists and it takes half the time it's meant to because I buffed cryox lmao

# Changelog

:cl:  
tweak: cryoxadone no longer heals wounds twice as fast as it's meant to
/:cl:
