### PR TITLE
Makes slings/darkspawn ghost visible when hatched/divulged

### DIFF
--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn.dm
@@ -350,6 +350,7 @@
 	to_chat(user, "<span class='velvet bold'>Your mind has expanded. The Psi Web is now available. Avoid the light. Keep to the shadows. Your time will come.</span>")
 	user.fully_heal()
 	user.set_species(/datum/species/darkspawn)
+	show_to_ghosts = TRUE
 	add_ability("psi_web", TRUE)
 	add_ability("sacrament", TRUE)
 	add_ability("devour_will", TRUE)

--- a/yogstation/code/modules/antagonists/shadowling/special_shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/special_shadowling_abilities.dm
@@ -90,6 +90,8 @@
 			H.undershirt = "Nude"
 			H.socks = "Nude"
 			H.faction |= "faithless"
+			for(var/datum/antagonist/shadowling/antag_datum in H.mind.antag_datums)
+				antag_datum.show_to_ghosts = TRUE
 			H.LoadComponent(/datum/component/walk/shadow)
 
 			H.equip_to_slot_or_del(new /obj/item/clothing/suit/space/shadowling(H), SLOT_WEAR_SUIT)


### PR DESCRIPTION
# Document the changes in your pull request

Makes slings/darkspawn ghost visible when hatched/divulged, so ghosts dont need to memorize names or can easily tell when one is dead.

# Wiki Documentation

None needed. 

# Changelog

:cl:   
tweak: slings/darkspawn are now ghost visible after hatching/divulging
/:cl:
