### PR TITLE
Fixes swarmers not being visible on the orbit window

### DIFF
--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -12,6 +12,7 @@
 	name = "Swarmer"
 	job_rank = ROLE_ALIEN
 	show_in_antagpanel = FALSE
+	show_to_ghosts = TRUE
 	prevent_roundtype_conversion = FALSE
 	var/datum/team/swarmer/swarmer_team
 


### PR DESCRIPTION
# Document the changes in your pull request

Makes swarmers ghost visable, seams simple and more of an oversight than an intended thing.

# Wiki Documentation

None needed. 

# Changelog

:cl:  
tweak: swarmers are now visible on the orbit window for ghosts
/:cl:
