### PR TITLE
Makes clock cultists visible on the orbit window

### DIFF
--- a/code/modules/antagonists/clockcult/clockcult.dm
+++ b/code/modules/antagonists/clockcult/clockcult.dm
@@ -4,6 +4,7 @@
 	roundend_category = "clock cultists"
 	antagpanel_category = "Clockcult"
 	job_rank = ROLE_SERVANT_OF_RATVAR
+	show_to_ghosts = TRUE
 	antag_moodlet = /datum/mood_event/cult
 	var/datum/action/innate/hierophant/hierophant_network = new()
 	var/datum/team/clockcult/clock_team


### PR DESCRIPTION
# Document the changes in your pull request

Makes clockcultists visible on the orbit window, due to them having many messages visible to ghosts that give them away and are similar to nukies which are ghost visible . If it is preferred, I can change it to only after the recall.

# Wiki Documentation

None needed. 

# Changelog

:cl:  
tweak: clock cultists are now visible on the orbit window for ghosts
/:cl:
