### PR TITLE
Removes the wound mod from the curator whip

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -551,8 +551,6 @@
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	slot_flags = ITEM_SLOT_BELT
 	force = 12
-	wound_bonus = 15
-	bare_wound_bonus = 10
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("flogged", "whipped", "lashed", "disciplined")
 	hitsound = 'sound/weapons/whip.ogg'


### PR DESCRIPTION
# Document the changes in your pull request

Removed the wound mod, as right now it can instantly dislocate uncovered bodyparts and Mqiib said that it probably shouldn't even have a wound mod.

# Wiki Documentation

Nothing needs to be changed. 

# Changelog

:cl:  
tweak: removed the wound mod from the curator whip 
/:cl:
