### PR TITLE
Should make the title on crew monitors to appear as alt titles

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -150,10 +150,12 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 
 				if (I)
 					name = I.registered_name
+					assignment_title = I.assignment
 					assignment = I.originalassignment
 					ijob = jobs[I.originalassignment]
 				else
 					name = "Unknown"
+					assignment_title = ""
 					assignment = ""
 					ijob = 80
 
@@ -184,7 +186,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 					pos_x = null
 					pos_y = null
 
-				results[++results.len] = list("name" = name, "assignment" = assignment, "ijob" = ijob, "life_status" = life_status, "oxydam" = oxydam, "toxdam" = toxdam, "burndam" = burndam, "brutedam" = brutedam, "area" = area, "pos_x" = pos_x, "pos_y" = pos_y, "can_track" = H.can_track(null))
+				results[++results.len] = list("name" = name, "assignment_title" = assignment_title, "assignment" = assignment, "ijob" = ijob, "life_status" = life_status, "oxydam" = oxydam, "toxdam" = toxdam, "burndam" = burndam, "brutedam" = brutedam, "area" = area, "pos_x" = pos_x, "pos_y" = pos_y, "can_track" = H.can_track(null))
 
 	data_by_z["[z]"] = sortTim(results,/proc/sensor_compare)
 	last_update["[z]"] = world.time

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -119,6 +119,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 	var/turf/pos
 	var/ijob
 	var/name
+	var/assignment_title
 	var/assignment
 	var/oxydam
 	var/toxdam

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -101,7 +101,7 @@ export const CrewConsole = (props, context) => {
                     <Table.Cell
                       bold={jobIsHead(sensor.ijob)}
                       color={jobToColor(sensor.ijob)}>
-                      {sensor.name} ({sensor.assignment})
+                      {sensor.name} ({sensor.assignment_title})
                     </Table.Cell>
                     <Table.Cell collapsing textAlign="center">
                       <ColorBox


### PR DESCRIPTION
# Document the changes in your pull request

Should make the title on crew monitors to appear as alt titles, but probably not. Untested, could possibly work (but knowing my luck with changing crew monitors it wont).

# Wiki Documentation

None needed. 

# Changelog

:cl:  
bugfix: titles on crew monitors now show custom names without breaking the formatting
/:cl:
