### PR TITLE
[PORT] Adds SEAFOOD foodtype

### DIFF
--- a/code/__DEFINES/food.dm
+++ b/code/__DEFINES/food.dm
@@ -16,6 +16,7 @@
 #define GRILLED		(1<<15)
 #define EGG			(1<<16) // for eggpeople, to nerf egg-cannibalism
 #define CHOCOLATE	(1<<17) //cat
+#define SEAFOOD		(1<<18)
 
 #define DRINK_NICE	1
 #define DRINK_GOOD	2

--- a/code/modules/food_and_drinks/food/snacks_burgers.dm
+++ b/code/modules/food_and_drinks/food/snacks_burgers.dm
@@ -67,7 +67,7 @@
 	icon_state = "fishburger"
 	bonus_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/nutriment/vitamin = 3)
 	tastes = list("bun" = 4, "fish" = 4)
-	foodtype = GRAIN | MEAT
+	foodtype = GRAIN | SEAFOOD
 
 /obj/item/reagent_containers/food/snacks/burger/tofu
 	name = "tofu burger"

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -65,7 +65,7 @@
 	filling_color = "#CD853F"
 	list_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/capsaicin = 1)
 	tastes = list("fish" = 4, "batter" = 1, "hot peppers" = 1)
-	foodtype = MEAT
+	foodtype = SEAFOOD
 
 /obj/item/reagent_containers/food/snacks/carpmeat
 	name = "carp fillet"
@@ -75,7 +75,7 @@
 	bitesize = 6
 	filling_color = "#FA8072"
 	tastes = list("fish" = 1)
-	foodtype = MEAT
+	foodtype = SEAFOOD
 
 /obj/item/reagent_containers/food/snacks/carpmeat/Initialize()
 	. = ..()
@@ -94,7 +94,7 @@
 	bitesize = 1
 	filling_color = "#CD853F"
 	tastes = list("fish" = 1, "breadcrumbs" = 1)
-	foodtype = MEAT
+	foodtype = SEAFOOD
 
 /obj/item/reagent_containers/food/snacks/fishandchips
 	name = "fish and chips"
@@ -104,7 +104,7 @@
 	list_reagents = list(/datum/reagent/consumable/nutriment = 6)
 	filling_color = "#FA8072"
 	tastes = list("fish" = 1, "chips" = 1)
-	foodtype = MEAT | VEGETABLES | FRIED
+	foodtype = SEAFOOD | VEGETABLES | FRIED
 
 /obj/item/reagent_containers/food/snacks/fishfry
 	name = "fish fry"
@@ -113,7 +113,7 @@
 	list_reagents = list (/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/vitamin = 3)
 	filling_color = "#ee7676"
 	tastes = list("fish" = 1, "pan seared vegtables" = 1)
-	foodtype = MEAT | VEGETABLES | FRIED
+	foodtype = SEAFOOD | VEGETABLES | FRIED
 
 /obj/item/reagent_containers/food/snacks/sashimi
 	name = "carp sashimi"
@@ -123,7 +123,7 @@
 	list_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/capsaicin = 5)
 	filling_color = "#FA8072"
 	tastes = list("fish" = 1, "hot peppers" = 1)
-	foodtype = MEAT | TOXIC
+	foodtype = SEAFOOD | TOXIC
 
 ////////////////////////////////////////////MEATS AND ALIKE////////////////////////////////////////////
 

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -6,6 +6,7 @@
 
 	mutant_bodyparts = list("ears", "tail_human")
 	default_features = list("mcolor" = "FFF", "tail_human" = "Cat", "ears" = "Cat", "wings" = "None")
+	liked_food = SEAFOOD
 	toxic_food = TOXIC | CHOCOLATE
 	mutantears = /obj/item/organ/ears/cat
 	mutanttail = /obj/item/organ/tail/cat

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -21,7 +21,7 @@
 	skinned_type = /obj/item/stack/sheet/animalhide/lizard
 	exotic_bloodtype = "L"
 	disliked_food = GRAIN | DAIRY
-	liked_food = GROSS | MEAT | GRILLED
+	liked_food = GROSS | MEAT | GRILLED | SEAFOOD
 	inert_mutation = FIREBREATH
 	deathsound = 'sound/voice/lizard/deathsound.ogg'
 	screamsound = 'yogstation/sound/voice/lizardperson/lizard_scream.ogg' //yogs - lizard scream

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -14,7 +14,7 @@
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/moth
 	liked_food = VEGETABLES | DAIRY | CLOTH
 	disliked_food = FRUIT | GROSS
-	toxic_food = MEAT | RAW
+	toxic_food = MEAT | RAW | SEAFOOD
 	mutanteyes = /obj/item/organ/eyes/moth
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/mothmen

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -13,7 +13,7 @@
 	heatmod = 1.5
 	payday_modifier = 0.7 //Neutrally viewed by NT
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/plant
-	disliked_food = MEAT | DAIRY
+	disliked_food = MEAT | DAIRY | SEAFOOD
 	liked_food = VEGETABLES | FRUIT | GRAIN
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 


### PR DESCRIPTION
# Document the changes in your pull request

Partial port of https://github.com/tgstation/tgstation/pull/61506. 

Adds SEAFOOD foodtype. We don't have a lot of fish available as food, and you will rarely come across it. 
Changed Items: Fish Burger, Cuban Carp, Carp Meat, Fish Sticks, Fish and Chips, Fish Fry, Sashimi.

Doesn't bring shrimp chips with it. Doesn't bring Carpotoxin immunity for felinids from it. TG has a bunch more fish items that aren't brought over (yet?)

Felinids (OH NO A FELINID BUFF) like it, along with lizards.
Toxic to moths.
Podpeople dislike it.

I am porting this for future plans. 👀

# Wiki Documentation
These things have to be changed on the wiki
# Changelog

:cl:  
rscadd: new food type, seafood
tweak: races like them differently
tweak: all fish related food items were changed from meat to seafood
/:cl:
