### PR TITLE
cauterizing a surgery now causes it to fully stop bleeding

### DIFF
--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -96,7 +96,7 @@
 			close_tool_type = /obj/item/screwdriver
 		if(istype(close_tool, close_tool_type) || iscyborg(user))
 			if(S.operated_bodypart)
-				S.operated_bodypart.generic_bleedstacks -= 5
+				S.operated_bodypart.generic_bleedstacks -= 10
 			M.surgeries -= S
 			user.visible_message("[user] closes [M]'s [parse_zone(selected_zone)] with [close_tool] and removes [I].", \
 				span_notice("You close [M]'s [parse_zone(selected_zone)] with [close_tool] and remove [I]."))

--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -99,7 +99,7 @@
 		var/mob/living/carbon/human/H = target
 		var/obj/item/bodypart/BP = H.get_bodypart(target_zone)
 		if(BP)
-			BP.generic_bleedstacks -= 3
+			BP.generic_bleedstacks -= 10
 	return ..()
 
 /datum/surgery_step/close/nofail


### PR DESCRIPTION
# Document the changes in your pull request

for some reason the cauterize and clamp bleeders steps don't really fully stop the bleeding when completed idk why

# Changelog

:cl:  
tweak: surgeries that are cauterized will now not bleed
/:cl:
