### PR TITLE
Ports "Removes move delay when damaged" #47702

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1217,7 +1217,6 @@
 	if(!(mobility_flags & MOBILITY_UI))
 		unset_machine()
 	density = !lying
-	var/changed = lying == lying_prev
 	if(lying)
 		if(!lying_prev)
 			fall(!canstand_involuntary)
@@ -1227,9 +1226,6 @@
 		if(layer == LYING_MOB_LAYER)
 			layer = initial(layer)
 	update_transform()
-	if(changed)
-		if(client)
-			client.move_delay = world.time + movement_delay()
 	lying_prev = lying
 
 /mob/living/proc/fall(forced)


### PR DESCRIPTION
# Document the changes in your pull request

Ports ["Removes move delay when damaged" #47702](https://github.com/tgstation/tgstation/pull/47702) by kriskog from TG. Removes some stuff that was broken, which fixes a few issues. Also, according to Mqiib, this might fix being shot while slow causing you to not move or something but I dont know if thats true. Untested, though as it is a small change it may work.

# Wiki Documentation

None needed. 

# Changelog

:cl:  Skoglol
bugfix: Lava no longer slows you down. 
bugfix: Getting hurt no longer adds a move delay.  
bugfix: Lava will no longer prevent you from ghosting out of your dead body.
/:cl:
