### PR TITLE
Makes most belts bulky

### DIFF
--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -67590,17 +67590,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"cZo" = (
-/obj/structure/easel,
-/obj/structure/rack,
-/obj/item/storage/belt{
-	desc = "Can hold quite a lot of stuff.";
-	name = "multi-belt"
-	},
-/obj/item/clothing/gloves/color/fyellow,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "cZr" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -78315,6 +78304,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"pEE" = (
+/obj/structure/easel,
+/obj/structure/rack,
+/obj/item/storage/belt/multi,
+/obj/item/clothing/gloves/color/fyellow,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "pGf" = (
 /obj/machinery/light{
 	dir = 1
@@ -125202,7 +125199,7 @@ iWR
 mCZ
 uGU
 bfq
-cZo
+pEE
 dnS
 dnS
 eXf

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -6,6 +6,7 @@
 	item_state = "utility"
 	lefthand_file = 'icons/mob/inhands/equipment/belt_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/belt_righthand.dmi'
+	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BELT
 	attack_verb = list("whipped", "lashed", "disciplined")
 	max_integrity = 300
@@ -208,6 +209,7 @@
 	desc = "Can hold security gear like handcuffs and flashes."
 	icon_state = "securitybelt"
 	item_state = "security"//Could likely use a better one.
+	w_class = WEIGHT_CLASS_NORMAL
 	content_overlays = TRUE
 
 /obj/item/storage/belt/security/ComponentInitialize()
@@ -248,6 +250,7 @@
 	desc = "Unique and versatile chest rig, can hold security gear."
 	icon_state = "securitywebbing"
 	item_state = "securitywebbing"
+	w_class = WEIGHT_CLASS_BULKY
 	content_overlays = FALSE
 	custom_premium_price = 800
 
@@ -261,7 +264,6 @@
 	desc = "A versatile chest rig, cherished by miners and hunters alike."
 	icon_state = "explorer1"
 	item_state = "explorer1"
-	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/storage/belt/mining/ComponentInitialize()
 	. = ..()
@@ -676,7 +678,6 @@
 	desc = "An ornate sheath designed to hold an officer's blade."
 	icon_state = "sheath"
 	item_state = "sheath"
-	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/storage/belt/sabre/ComponentInitialize()
 	. = ..()
@@ -718,3 +719,8 @@
 /obj/item/storage/belt/sabre/PopulateContents()
 	new /obj/item/melee/sabre(src)
 	update_icon()
+
+/obj/item/storage/belt/multi
+	name = "multi-belt"
+	desc = "Can hold quite a lot of stuff."
+	w_class = WEIGHT_CLASS_NORMAL


### PR DESCRIPTION
# Document the changes in your pull request

Makes most belts bulky instead of normal, with the only exceptions being the sec belt and the multi-belt (both of which are because mqiib told me not to). The important difference that this make is that you cant put belts in normal backpacks. Also adds a path for the multi-belt so it isn't just a weird var-edited thing on meta. Untested, should work.

## Why?

With current belts, being able to put them in backpacks is very important due to the massive amounts of items they can hold. This often leads to people having almost every single tool they will ever need in their backpack and, due to them not being worn, you cant tell if someone even has it on them so you need to search their backpack to see if they have a full set of tools on them. Allowing belts to be put in backpacks also makes the question if you should have a tool on you less of a question of if you have enough space and more of a question if you have the belt that you can put it on, as you can put a medical belt, toolbelt, and sec belt in a satchel and still have room for two boxes.

# Wiki Documentation

If it is mentioned that belts are normal sized items or can be put in a backpack, that should probably be changed. 

# Changelog

:cl:    
tweak: changed most belts from being normal sized items to bulky sized items
/:cl:
