### PR TITLE
Webedit quickfix for long ban reasons causing bans to break

### DIFF
--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -359,7 +359,7 @@
 	reason = href_list["reason"]
 	if(!reason)
 		error_state += "No reason was provided."
-	if(reason.len > 600)
+	if(length(reason) > 600)
 		error_state += "Reason cannot be more than 600 characters."
 	if(href_list["editid"])
 		edit_id = href_list["editid"]

--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -174,7 +174,7 @@
 		<div class='column'>
 			Reason
 			<br>
-			<textarea class='reason' name='reason'>[reason]</textarea>
+			<textarea class='reason' name='reason' maxlength='600'>[reason]</textarea>
 		</div>
 	</div>
 	"}
@@ -359,6 +359,8 @@
 	reason = href_list["reason"]
 	if(!reason)
 		error_state += "No reason was provided."
+	if(reason.len > 600)
+		error_state += "Reason cannot be more than 600 characters."
 	if(href_list["editid"])
 		edit_id = href_list["editid"]
 		if(href_list["mirroredit"])
@@ -393,10 +395,12 @@
 				roles_to_ban += "Server"
 			if("role")
 				href_list.Remove("Command", "Security", "Engineering", "Medical", "Science", "Supply", "Silicon", "Abstract", "Civilian", "Ghost and Other Roles", "Antagonist Positions") //remove the role banner hidden input values
-				if(href_list[href_list.len] == "roleban_delimiter")
+				var/delimiter_pos = href_list.Find("roleban_delimiter")
+				if(href_list.len == delimiter_pos)
 					error_state += "Role ban was selected but no roles to ban were selected."
+				else if(delimiter_pos == 0)
+					error_state += "roleban_delimiter not found in href. Report this to coders."
 				else
-					var/delimiter_pos = href_list.Find("roleban_delimiter")
 					href_list.Cut(1, delimiter_pos+1)//remove every list element before and including roleban_delimiter so we have a list of only the roles to ban
 					for(var/key in href_list) //flatten into a list of only unique keys
 						roles_to_ban |= key


### PR DESCRIPTION
# Document the changes in your pull request

With the current code, an admin, or council member, might end up writing a ban message that is over 1263 characters long. This breaks things, and it reaches the max href length, causing important tags to get dropped. This code both adds a length max on ban reasons, both in the banning panel and the href parser, and adds a check to make sure the roleban_delimiter href tag is present, because removing it causes all href tags to get treated as roles to be banned. 