### PR TITLE
Replaces silicons starting with Draconic with English

### DIFF
--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -306,10 +306,10 @@ Key procs
 /datum/language_holder/synthetic
 	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
 								/datum/language/machine = list(LANGUAGE_ATOM),
-								/datum/language/draconic = list(LANGUAGE_ATOM))
+								/datum/language/english = list(LANGUAGE_ATOM))
 	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
 							/datum/language/machine = list(LANGUAGE_ATOM),
-							/datum/language/draconic = list(LANGUAGE_ATOM))
+							/datum/language/english = list(LANGUAGE_ATOM))
 
 /datum/language_holder/plant
 	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),


### PR DESCRIPTION
# Document the changes in your pull request

Replaces silicons starting with Draconic with English. Untested, should work.

# Wiki Documentation

If its mentioned that borgs can speak Draconic, it should probably be replaced with English.

# Changelog

:cl:  
tweak: replaced silicons starting with Draconic with English
/:cl:
