### PR TITLE
Adds the "Robust Diet" quirk

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -141,6 +141,33 @@
 	H.equip_to_slot(camera, SLOT_NECK)
 	H.regenerate_icons()
 
+/datum/quirk/robust_diet
+	name = "Robust Diet"
+	desc = "You reguarly eat things that would make your peers unwell."
+	value = 1
+	gain_text = span_notice("Your stomach feels robust.")
+	lose_text = span_notice("Your stomach feels normal again.")
+	medical_record_text = "Patient demonstrates abnormally robust digestive abilities."
+
+/datum/quirk/robust_diet/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/datum/species/species = H.dna.species
+	var/liked = species.liked_food
+	var/toxic = species.toxic_food
+	species.toxic_food = null //removes toxic foods
+	if(/datum/species/moth) //mothcheck
+		species.liked_food |= MEAT //Meat is tasty.
+	if(/datum/species/human/felinid) //catcheck
+		species.liked_food |= CHOCOLATE //Chocolate is tasty.
+
+
+/datum/quirk/robust_diet/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(H)
+		var/datum/species/species = H.dna.species
+		species.toxic_food = initial(species.toxic_food)
+		species.liked_food = initial(species.liked_food)
+
 /datum/quirk/selfaware
 	name = "Self-Aware"
 	desc = "You know your body well, and can accurately assess the extent of your wounds."


### PR DESCRIPTION
This PR adds the Robust Diet quirk. The Robust Diet quirk is a 1 cost quirk that allows the player to eat normally species-specific toxic foods without ill effects, such as moths and meat alongside cats and chocolate. Furthermore, in those two specific cases, they are added to the list of liked foods, because they're pretty tasty.

I have tested this in a lobby and there don't seem to be any immediate issues.

I think it could be a neat quirk for people that wanted it, whether for playing naturally hardy characters or those that are veritable trash bags.

# Wiki Documentation

The addition of the Robust Diet quirk to the wiki

# Changelog


:cl:  
rscadd: Added the Robust Diet quirk.  








/:cl:
