### PR TITLE
Crew Console now has a setting to either show original job title or alternate title

### DIFF
--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -1,4 +1,4 @@
-import { useBackend } from '../backend';
+import { useBackend, useLocalState  } from '../backend';
 import { Box, Button, ColorBox, Section, Table, Flex } from '../components';
 import { COLORS } from '../constants';
 import { Window } from '../layouts';
@@ -65,6 +65,10 @@ const HealthStat = props => {
 };
 
 export const CrewConsole = (props, context) => {
+  const [
+    originalTitles,
+    setoriginalTitles,
+  ] = useLocalState(context, 'originalTitles', false);
   const { act, data } = useBackend(context);
   const sensors = data.sensors || [];
 
@@ -77,7 +81,10 @@ export const CrewConsole = (props, context) => {
       <Window.Content scrollable>
         <Flex>
           <Flex.Item>
-            <Section minHeight={90}>
+            <Section minHeight={90} buttons={{<Button.Checkbox checked={originalTitles} onClick={() => setoriginalTitles(!originalTitles)}>
+                Use Original Job Titles
+               </Button.Checkbox>
+              }}>
               <Table>
                 <Table.Row>
                   <Table.Cell bold>
@@ -101,7 +108,7 @@ export const CrewConsole = (props, context) => {
                     <Table.Cell
                       bold={jobIsHead(sensor.ijob)}
                       color={jobToColor(sensor.ijob)}>
-                      {sensor.name} ({sensor.assignment_title})
+                      {sensor.name} ({!originalTitles ? sensor.assignment_title : sensor.assignment})
                     </Table.Cell>
                     <Table.Cell collapsing textAlign="center">
                       <ColorBox

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -82,7 +82,7 @@ export const CrewConsole = (props, context) => {
         <Flex>
           <Flex.Item>
             <Section minHeight={90} 
-                buttons={(<Button.Checkbox checked={originalTitles} 
+              buttons={(<Button.Checkbox checked={originalTitles} 
               onClick={() => setoriginalTitles(!originalTitles)}>
               Use Original Job Titles
               </Button.Checkbox>

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -82,10 +82,11 @@ export const CrewConsole = (props, context) => {
         <Flex>
           <Flex.Item>
             <Section minHeight={90} 
-              buttons={(<Button.Checkbox checked={originalTitles} onClick={() => setoriginalTitles(!originalTitles)}>
+                buttons={(<Button.Checkbox checked={originalTitles} 
+              onClick={() => setoriginalTitles(!originalTitles)}>
               Use Original Job Titles
-             </Button.Checkbox>
-            )}>
+              </Button.Checkbox>
+              )}>
               <Table>
                 <Table.Row>
                   <Table.Cell bold>

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -81,10 +81,10 @@ export const CrewConsole = (props, context) => {
       <Window.Content scrollable>
         <Flex>
           <Flex.Item>
-            <Section minHeight={90} buttons={{<Button.Checkbox checked={originalTitles} onClick={() => setoriginalTitles(!originalTitles)}>
+            <Section minHeight={90} buttons={(<Button.Checkbox checked={originalTitles} onClick={() => setoriginalTitles(!originalTitles)}>
                 Use Original Job Titles
                </Button.Checkbox>
-              }}>
+              )}>
               <Table>
                 <Table.Row>
                   <Table.Cell bold>

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -1,4 +1,4 @@
-import { useBackend, useLocalState  } from '../backend';
+import { useBackend, useLocalState } from '../backend';
 import { Box, Button, ColorBox, Section, Table, Flex } from '../components';
 import { COLORS } from '../constants';
 import { Window } from '../layouts';
@@ -81,10 +81,11 @@ export const CrewConsole = (props, context) => {
       <Window.Content scrollable>
         <Flex>
           <Flex.Item>
-            <Section minHeight={90} buttons={(<Button.Checkbox checked={originalTitles} onClick={() => setoriginalTitles(!originalTitles)}>
-                Use Original Job Titles
-               </Button.Checkbox>
-              )}>
+            <Section minHeight={90} 
+              buttons={(<Button.Checkbox checked={originalTitles} onClick={() => setoriginalTitles(!originalTitles)}>
+              Use Original Job Titles
+             </Button.Checkbox>
+            )}>
               <Table>
                 <Table.Row>
                   <Table.Cell bold>
@@ -108,7 +109,8 @@ export const CrewConsole = (props, context) => {
                     <Table.Cell
                       bold={jobIsHead(sensor.ijob)}
                       color={jobToColor(sensor.ijob)}>
-                      {sensor.name} ({!originalTitles ? sensor.assignment_title : sensor.assignment})
+                      {sensor.name} 
+                      ({!originalTitles ? sensor.assignment_title : sensor.assignment})
                     </Table.Cell>
                     <Table.Cell collapsing textAlign="center">
                       <ColorBox

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -82,10 +82,11 @@ export const CrewConsole = (props, context) => {
         <Flex>
           <Flex.Item>
             <Section minHeight={90} 
-              buttons={(<Button.Checkbox checked={originalTitles} 
-              onClick={() => setoriginalTitles(!originalTitles)}>
-              Use Original Job Titles
-              </Button.Checkbox>
+              buttons={(
+                <Button.Checkbox checked={originalTitles} 
+                  onClick={() => setoriginalTitles(!originalTitles)}>
+                  Use Original Job Titles
+                </Button.Checkbox>
               )}>
               <Table>
                 <Table.Row>


### PR DESCRIPTION
# Document the changes in your pull request

Untested

# Wiki Documentation


# Changelog


:cl:  
tweak: Crew Monitoring Console now has a setting to either show original job title or alternate title
/:cl:
