### PR TITLE
Makes SM monitor program require engine access

### DIFF
--- a/code/modules/modular_computers/file_system/programs/sm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/sm_monitor.dm
@@ -5,7 +5,7 @@
 	program_icon_state = "smmon_0"
 	extended_desc = "This program connects to specially calibrated supermatter sensors to provide information on the status of supermatter-based engines."
 	requires_ntnet = TRUE
-	transfer_access = ACCESS_CONSTRUCTION
+	transfer_access = ACCESS_ENGINE
 	network_destination = "supermatter monitoring system"
 	size = 5
 	tgui_id = "NtosSupermatterMonitor"


### PR DESCRIPTION
# Document the changes in your pull request

Basically, allows many more people to download it like atmos techs and sig techs.

# Wiki Documentation

None needed. 

# Changelog

:cl:   
tweak: sm monitor program now requires engine access
/:cl:
