### PR TITLE
Adds the "Toxic Tastes" positive quirk

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -180,7 +180,6 @@
 /datum/quirk/toxic_tastes/add()
 	var/mob/living/carbon/human/H = quirk_holder
 	var/datum/species/species = H.dna.species
-	var/liked = species.liked_food
 	var/toxic = species.toxic_food
 	species.liked_food |= toxic
 	species.toxic_food = null //removes toxic foods

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -169,6 +169,29 @@
 	H.equip_to_slot_or_del(new /obj/item/storage/box/fancy/candle_box(H), SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/storage/box/matches(H), SLOT_IN_BACKPACK)
 
+/datum/quirk/toxic_tastes
+	name = "Toxic Tastes"
+	desc = "You have a taste for normally dangerous foods."
+	value = 1
+	gain_text = span_notice("Your stomach feels robust.")
+	lose_text = span_notice("Your stomach feels normal again.")
+	medical_record_text = "Patient demonstrates abnormal ability to process certain toxins."
+
+/datum/quirk/toxic_tastes/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/datum/species/species = H.dna.species
+	var/liked = species.liked_food
+	var/toxic = species.toxic_food
+	species.liked_food |= toxic
+	species.toxic_food = null //removes toxic foods
+
+/datum/quirk/toxic_tastes/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(H)
+		var/datum/species/species = H.dna.species
+		species.toxic_food = initial(species.toxic_food)
+		species.liked_food = initial(species.liked_food)
+
 /datum/quirk/tagger
 	name = "Tagger"
 	desc = "You're an experienced artist. While drawing graffiti, you can get twice as many uses out of drawing supplies."


### PR DESCRIPTION
This PR aims to add the "Toxic Tastes" positive quirk. It's a 1 cost quirk that gives the ability to eat and enjoy normally toxic foods. This is an updated and cleaned version of the "Robust Diet" quirk I previously had submitted that no longer has odd

I have tested this quirk and it appears to work.

I'm submitting this PR both as a method of learning how the process of submitting PRs works on Yog, and as a potentially neat quirk for people who might be interested in it.

# Wiki Documentation

Add the "Toxic Tastes" quirk to the positive quirks section on the wiki

# Changelog

:cl:  
rscadd: Added the "Toxic Tastes" quirk. It is a 1 cost quirk that removes all species-specific toxic foods and adds them to the liked list.  
/:cl:
