### PR TITLE
probably makes people not get pod dropped in the botany backroom

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -778,7 +778,7 @@ SUBSYSTEM_DEF(job)
 
 ///Lands specified mob at a random spot in the hallways
 /datum/controller/subsystem/job/proc/DropLandAtRandomHallwayPoint(mob/living/living_mob)
-	var/turf/spawn_turf = get_safe_random_station_turf(typesof(/area/hallway))
+	var/turf/spawn_turf = get_safe_random_station_turf(typesof(/area/hallway) - typesof(/area/hallway/secondary))
 	if(!spawn_turf)
 		return FALSE
 	var/obj/structure/closet/supplypod/centcompod/toLaunch = new()


### PR DESCRIPTION
ermoves all secondary hallway areas from random drop since they tend to be in maint
:cl:  
bugfix: no more getting dropped in a near inescapable room lmao
/:cl:
