### PR TITLE
adds griddles to ruins that need them

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -820,6 +820,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
+"eE" = (
+/obj/structure/table/wood,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/kitchen/knife{
+	pixel_x = 6
+	},
+/turf/open/floor/wood,
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "eG" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/decal/cleanable/dirt,
@@ -3829,19 +3841,6 @@
 /obj/structure/chair/stool/bar,
 /turf/open/floor/plasteel/dark,
 /area/ruin/unpowered/syndicate_lava_base/bar)
-"lz" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/rag{
-	pixel_x = -4;
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/food/drinks/beer{
-	pixel_x = 5;
-	pixel_y = -2
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
 "lA" = (
 /turf/open/floor/wood,
 /area/ruin/unpowered/syndicate_lava_base/bar)
@@ -5613,6 +5612,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
+"CN" = (
+/obj/structure/table/wood,
+/obj/item/toy/cards/deck/syndicate{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/storage/pill_bottle/dice{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/machinery/reagentgrinder/kitchen,
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "CV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -5642,6 +5656,10 @@
 /obj/effect/spawner/structure/window/plastitanium,
 /turf/open/floor/plating,
 /area/ruin/unpowered/syndicate_lava_base/bar)
+"Er" = (
+/obj/machinery/griddle,
+/turf/open/floor/wood,
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "Ev" = (
 /obj/structure/filingcabinet/medical,
 /turf/open/floor/plasteel/dark,
@@ -5661,20 +5679,6 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/bar)
-"EG" = (
-/obj/structure/table/wood,
-/obj/item/toy/cards/deck/syndicate{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/storage/pill_bottle/dice{
-	pixel_x = 7;
-	pixel_y = 3
-	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken4"
-	},
 /area/ruin/unpowered/syndicate_lava_base/bar)
 "EY" = (
 /obj/machinery/telecomms/relay/preset/ruskie{
@@ -5762,6 +5766,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered/syndicate_lava_base/medbay)
+"FD" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/rag{
+	pixel_x = -4;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/wood,
+/area/ruin/unpowered/syndicate_lava_base/bar)
 "Gv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -6218,15 +6236,6 @@
 	dir = 6
 	},
 /area/ruin/unpowered/syndicate_lava_base/medbay)
-"Ob" = (
-/obj/structure/table/wood,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
 "Oh" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "lavalandsyndi_telecomms"
@@ -6350,15 +6359,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
-"Qv" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife{
-	pixel_x = 6
-	},
-/obj/machinery/reagentgrinder/kitchen,
-/turf/open/floor/wood,
 /area/ruin/unpowered/syndicate_lava_base/bar)
 "QJ" = (
 /obj/machinery/door/airlock/hatch{
@@ -7768,8 +7768,8 @@ jN
 jZ
 kJ
 yP
-lz
-Ob
+FD
+eE
 YQ
 jy
 jy
@@ -7817,7 +7817,7 @@ jN
 jZ
 ko
 kK
-EG
+CN
 lA
 lX
 mw
@@ -7918,7 +7918,7 @@ nJ
 kq
 oK
 lk
-Qv
+Er
 lZ
 mx
 jy

--- a/_maps/RandomRuins/LavaRuins/miningbase.dmm
+++ b/_maps/RandomRuins/LavaRuins/miningbase.dmm
@@ -314,6 +314,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"cu" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/item/storage/box/donkpockets,
+/obj/item/kitchen/knife,
+/turf/open/floor/plasteel/cafeteria,
+/area/mine/break_room)
 "cz" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Mining Station Construction Area"
@@ -986,6 +993,18 @@
 	},
 /turf/open/floor/plating,
 /area/mine/maintenance)
+"iP" = (
+/obj/structure/table,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -32
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/storage/box/drinkingglasses,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/plasteel/cafeteria,
+/area/mine/break_room)
 "iQ" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -1989,6 +2008,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/mine/maintenance)
+"Aa" = (
+/obj/machinery/griddle,
+/turf/open/floor/plasteel/cafeteria,
+/area/mine/break_room)
 "Ad" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
@@ -2013,13 +2036,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel/freezer,
 /area/mine/living_quarters)
-"Av" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/obj/item/kitchen/knife,
-/obj/item/storage/box/donkpockets,
-/turf/open/floor/plasteel/cafeteria,
-/area/mine/break_room)
 "Ax" = (
 /obj/structure/sign/poster/random{
 	pixel_y = -32
@@ -2060,11 +2076,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"AL" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/plasteel/cafeteria,
-/area/mine/break_room)
 "AP" = (
 /obj/structure/closet/secure_closet/miner{
 	anchored = 1
@@ -2448,17 +2459,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"EQ" = (
-/obj/structure/table,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -32
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/plasteel/cafeteria,
-/area/mine/break_room)
 "ET" = (
 /obj/machinery/mineral/mint{
 	input_dir = 4
@@ -4823,7 +4823,7 @@ zW
 jp
 zW
 zW
-EQ
+iP
 pl
 NP
 By
@@ -4907,7 +4907,7 @@ qr
 At
 Jx
 zW
-Av
+Aa
 Oe
 YL
 DS
@@ -4949,7 +4949,7 @@ gm
 AG
 qe
 zW
-AL
+cu
 Oe
 YV
 aZ

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -3489,22 +3489,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/ancientstation/rnd)
-"hT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/plasteel/cafeteria,
-/area/ruin/space/has_grav/ancientstation/kitchen)
-"hU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/enzyme{
-	layer = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/cafeteria,
-/area/ruin/space/has_grav/ancientstation/kitchen)
 "hV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -8300,6 +8284,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
+"DH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/griddle,
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/space/has_grav/ancientstation/kitchen)
 "DJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch{
@@ -8612,6 +8603,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
+"Rf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/kitchen/rollingpin,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	layer = 5
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/space/has_grav/ancientstation/kitchen)
 "RP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -10763,7 +10763,7 @@ ey
 oO
 gY
 Su
-hT
+Rf
 Cr
 ly
 ht
@@ -10812,7 +10812,7 @@ nV
 oP
 mA
 nf
-hU
+DH
 vu
 ly
 iL

--- a/_maps/shuttles/whiteship_miner.dmm
+++ b/_maps/shuttles/whiteship_miner.dmm
@@ -575,12 +575,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/abandoned)
-"cp" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/gibs/old,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
 "cq" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -681,6 +675,13 @@
 /obj/item/healthanalyzer,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/abandoned)
+"eH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/abandoned)
 "eT" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/ore_box,
@@ -755,39 +756,6 @@
 /obj/machinery/computer/mech_bay_power_console,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/abandoned)
-"jA" = (
-/obj/structure/table,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/paper/crumpled{
-	info = "WHO THE FUCK ORDERED SO MUCH SALT?<br><br>-K";
-	pixel_x = 4;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -10;
-	pixel_y = 12
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -5;
-	pixel_y = 12
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -10;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -10;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -10;
-	pixel_y = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
 "kL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/suit_storage_unit/mining/eva,
@@ -836,21 +804,6 @@
 /obj/item/clothing/gloves/color/black,
 /obj/item/clothing/glasses/meson,
 /obj/item/pickaxe,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"mR" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/box/fancy/egg_box{
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 4
-	},
-/obj/item/storage/box/monkeycubes{
-	pixel_y = 4
-	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/abandoned)
 "ov" = (
@@ -1044,6 +997,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned)
+"CQ" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/condiment/enzyme{
+	layer = 5
+	},
+/obj/item/reagent_containers/dropper,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = 12
+	},
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/abandoned)
 "Di" = (
 /obj/effect/decal/cleanable/xenoblood,
 /turf/open/floor/mineral/titanium,
@@ -1134,6 +1103,11 @@
 /obj/effect/decal/cleanable/xenoblood/xgibs/limb,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
+"Nw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/griddle,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/abandoned)
 "Oj" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal{
@@ -1184,19 +1158,20 @@
 /obj/item/wrench,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/abandoned)
-"Xh" = (
+"VW" = (
 /obj/structure/table,
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 5
-	},
-/obj/item/reagent_containers/food/condiment/enzyme{
-	layer = 5
-	},
-/obj/item/reagent_containers/dropper,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = 12
+/obj/item/storage/box/fancy/egg_box{
+	pixel_y = 5
 	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_y = 4
+	},
+/obj/item/kitchen/knife,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/abandoned)
 "Xq" = (
@@ -1424,7 +1399,7 @@ aL
 bk
 aI
 mu
-mR
+VW
 ae
 "}
 (12,1,1) = {"
@@ -1439,9 +1414,9 @@ bI
 bk
 bk
 bk
-cp
+Nw
 cz
-Xh
+CQ
 ae
 "}
 (13,1,1) = {"
@@ -1457,7 +1432,7 @@ JR
 JR
 bk
 cq
-jA
+eH
 ry
 bk
 "}


### PR DESCRIPTION
# Document the changes in your pull request

Adds griddle to charlie station, white ship, and lavaland syndicate station. I don't want to give every available place a griddle as they don't really need one (charlie station = xeno meat, syndicate base has meat, etc)

# Wiki Documentation

map

# Changelog


:cl:  
rscadd: Adds griddle to charlie station, white ship, and lavaland syndicate station  
/:cl:
