### PR TITLE
makes ash knife trasmmutation use ap ile of ash instead of a match

### DIFF
--- a/code/modules/antagonists/eldritch_cult/transmutations/ash_transmutations.dm
+++ b/code/modules/antagonists/eldritch_cult/transmutations/ash_transmutations.dm
@@ -1,6 +1,6 @@
 /datum/eldritch_transmutation/ash_knife
 	name = "Ashen Blade"
-	required_atoms = list(/obj/item/kitchen/knife,/obj/item/match)
+	required_atoms = list(/obj/item/kitchen/knife,/obj/effect/decal/cleanable/ash)
 	result_atoms = list(/obj/item/melee/sickly_blade/ash)
 	required_shit_list = "A pile of ash and a knife."
 


### PR DESCRIPTION
roughly as renewable and easy to make as the other two path knife requirements vs a match which you need to buy at specifically a match selling vendor
also I already have it saying that's what you need in transmutation clippy so
:cl:  
tweak: ash heretics use ash for their knife transmutation instead of matches
/:cl:
