### PR TITLE
Felinid buff: Dairy is now a liked food group

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -6,7 +6,7 @@
 
 	mutant_bodyparts = list("ears", "tail_human")
 	default_features = list("mcolor" = "FFF", "tail_human" = "Cat", "ears" = "Cat", "wings" = "None")
-	liked_food = SEAFOOD
+	liked_food = SEAFOOD | DAIRY
 	toxic_food = TOXIC | CHOCOLATE
 	mutantears = /obj/item/organ/ears/cat
 	mutanttail = /obj/item/organ/tail/cat


### PR DESCRIPTION
Why are Moths the only race that specifically LIKE milk?? 
Cats like milk and I want to make it canon

((Don't say I never tried to do anything for any race that isn't Pods))

# Wiki Documentation

Cats like milk

# Changelog

:cl:  
rscadd: Dairy is now a liked food group for felinids
/:cl:
