### PR TITLE
Ports "Makes alarm manager update even while off and fire alarms clear" #4561

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -38,3 +38,4 @@ GLOBAL_LIST_EMPTY(ai_status_displays)
 
 GLOBAL_LIST_EMPTY(mob_spawners) 		    // All mob_spawn objects
 GLOBAL_LIST_EMPTY(alert_consoles)			// Station alert consoles, /obj/machinery/computer/station_alert
+GLOBAL_LIST_INIT(alarms, list("Fire" = list(), "Atmosphere" = list(), "Power" = list())) //all engineering alerts for station alert consoles and alarm manager

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -4,7 +4,6 @@
 	icon_screen = "alert:0"
 	icon_keyboard = "atmos_key"
 	circuit = /obj/item/circuitboard/computer/stationalert
-	var/alarms = list("Fire" = list(), "Atmosphere" = list(), "Power" = list())
 
 	light_color = LIGHT_COLOR_CYAN
 
@@ -26,9 +25,9 @@
 	var/list/data = list()
 
 	data["alarms"] = list()
-	for(var/class in alarms)
+	for(var/class in GLOB.alarms)
 		data["alarms"][class] = list()
-		for(var/area in alarms[class])
+		for(var/area in GLOB.alarms[class])
 			data["alarms"][class] += area
 
 	return data
@@ -39,7 +38,7 @@
 	if(stat & (BROKEN))
 		return
 
-	var/list/L = alarms[class]
+	var/list/L = GLOB.alarms[class]
 	for(var/I in L)
 		if (I == A.name)
 			var/list/alarm = L[I]
@@ -62,7 +61,7 @@
 /obj/machinery/computer/station_alert/proc/cancelAlarm(class, area/A, obj/origin)
 	if(stat & (BROKEN))
 		return
-	var/list/L = alarms[class]
+	var/list/L = GLOB.alarms[class]
 	var/cleared = 0
 	for (var/I in L)
 		if (I == A.name)
@@ -80,8 +79,8 @@
 	if(stat & (NOPOWER|BROKEN))
 		return
 	var/active_alarms = FALSE
-	for(var/cat in alarms)
-		var/list/L = alarms[cat]
+	for(var/cat in GLOB.alarms)
+		var/list/L = GLOB.alarms[cat]
 		if(L.len)
 			active_alarms = TRUE
 	if(active_alarms)

--- a/code/modules/modular_computers/file_system/programs/alarm.dm
+++ b/code/modules/modular_computers/file_system/programs/alarm.dm
@@ -10,7 +10,6 @@
 	tgui_id = "NtosStationAlertConsole"
 
 	var/has_alert = 0
-	var/alarms = list("Fire" = list(), "Atmosphere" = list(), "Power" = list())
 
 /datum/computer_file/program/alarm_monitor/process_tick()
 	..()
@@ -30,9 +29,9 @@
 	var/list/data = get_header_data()
 
 	data["alarms"] = list()
-	for(var/class in alarms)
+	for(var/class in GLOB.alarms)
 		data["alarms"][class] = list()
-		for(var/area in alarms[class])
+		for(var/area in GLOB.alarms[class])
 			data["alarms"][class] += area
 
 	return data
@@ -44,7 +43,7 @@
 	else if(!is_mining_level(source.z) || istype(A, /area/ruin))
 		return
 
-	var/list/L = alarms[class]
+	var/list/L = GLOB.alarms[class]
 	for(var/I in L)
 		if (I == A.name)
 			var/list/alarm = L[I]
@@ -85,8 +84,8 @@
 
 /datum/computer_file/program/alarm_monitor/proc/update_alarm_display()
 	has_alert = FALSE
-	for(var/cat in alarms)
-		var/list/L = alarms[cat]
+	for(var/cat in GLOB.alarms)
+		var/list/L = GLOB.alarms[cat]
 		if(L.len)
 			has_alert = TRUE
 

--- a/code/modules/modular_computers/file_system/programs/alarm.dm
+++ b/code/modules/modular_computers/file_system/programs/alarm.dm
@@ -67,7 +67,7 @@
 
 
 /datum/computer_file/program/alarm_monitor/proc/cancelAlarm(class, area/A, obj/origin)
-	var/list/L = alarms[class]
+	var/list/L = GLOB.alarms[class]
 	var/cleared = 0
 	for (var/I in L)
 		if (I == A.name)


### PR DESCRIPTION
# Document the changes in your pull request

Ported ["Makes alarm manager update even while off and fire alarms clear" #4561](https://github.com/BeeStation/BeeStation-Hornet/pull/4561) by lordScrubling from BeeStation. Should make alarms on the alarm manager and alarm monitor app update more consistently  by making them use a glob instead of internal lists. Due to our codebase not running on dream daemon, I have no clue if this will actually work

# Wiki Documentation

None needed. 

# Changelog

:cl:  lordScrubling
bugfix: alarm manager now shows alarm changes from when it was off
bugfix: fire alarms clear when you pull them up now
/:cl:
