### PR TITLE
prevents borgs from self destructing while stunned

### DIFF
--- a/yogstation/code/modules/mob/living/silicon/robot/robot.dm
+++ b/yogstation/code/modules/mob/living/silicon/robot/robot.dm
@@ -74,7 +74,7 @@
 	set name = "Self Destruct"
 
 	if(usr.stat == DEAD || usr.incapacitated())
-		return //won't work if dead
+		return //won't work if dead or incapacitated
 
 	if(alert("WARNING: Are you sure you wish to self-destruct? This action cannot be undone!",,"Yes","No") != "Yes")
 		return

--- a/yogstation/code/modules/mob/living/silicon/robot/robot.dm
+++ b/yogstation/code/modules/mob/living/silicon/robot/robot.dm
@@ -73,15 +73,15 @@
 	set category = "Robot Commands"
 	set name = "Self Destruct"
 
-	if(usr.stat == DEAD)
+	if(usr.stat == DEAD || usr.incapacitated())
 		return //won't work if dead
 
 	if(alert("WARNING: Are you sure you wish to self-destruct? This action cannot be undone!",,"Yes","No") != "Yes")
 		return
 
-	if(usr.stat == DEAD)
-		to_chat(usr, span_danger("You are already dead."))
-		return //won't work if dead
+	if(usr.stat == DEAD || usr.incapacitated())
+		to_chat(usr, span_danger("You can't do that right now!"))
+		return //won't work if dead or incapacitated
 
 	var/turf/T = get_turf(usr)
 	message_admins(span_notice("[ADMIN_LOOKUPFLW(usr)] detonated themselves at [ADMIN_VERBOSEJMP(T)]!"))


### PR DESCRIPTION
# Document the changes in your pull request

![image](https://user-images.githubusercontent.com/24857008/140650658-bef2f8af-d025-4012-8bef-45f4c8a37492.png)
oh boy time to convert this borg I've stunned I sure hope nothing wacky or uncharacteristic happe-

![image](https://user-images.githubusercontent.com/24857008/140650679-472401b4-9935-47db-b826-6270a6f51778.png)



I had an argument with biome like a couple days ago about this and decided to not do anything but then I got redtexted because a borg self destructing got me killed due to the knockdown and have decided against not doing it because whatever argument can be come up with to give borgs which are already powerful in combat a way to cause more damage even if they lose is stupid and wrong

tldr self destructing when already stunned has no real downside since you're going to be dead/converted whether you do it or not and gives you one last chance to fuck over whoever has stunned you. Liberal use of the self destruct feature can prevent:
traitors from emagging you
clock cultists from converting you
anyone else from killing you if they don't have a gun to keep a safe distance with

# Changelog

:cl:  
rscdel: borgs can no longer self destruct while stunned
/:cl:
