### PR TITLE
makes generic bleedstacks stack

### DIFF
--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -902,7 +902,7 @@
 
 	var/bleed_rate = 0
 	if(generic_bleedstacks > 0)
-		bleed_rate++
+		bleed_rate += generic_bleedstacks
 
 	//We want an accurate reading of .len
 	listclearnulls(embedded_objects)


### PR DESCRIPTION
# Document the changes in your pull request

generic bleedstacks are now not completely harmless and cause bleeding based on the number of stacks instead of just 1

:cl:  
tweak: gneeric bleedstacks are now more lethal
/:cl:
