### PR TITLE
Adds Medical and Engineering Award and Boxes

### DIFF
--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -131,6 +131,8 @@
 	new /obj/item/clothing/accessory/medal/silver/valor(src)
 	new /obj/item/clothing/accessory/medal/silver/valor(src)
 	new /obj/item/clothing/accessory/medal/silver/security(src)
+	new /obj/item/clothing/accessory/medal/silver/medical(src)
+	new /obj/item/clothing/accessory/medal/silver/engineering(src)
 	new /obj/item/clothing/accessory/medal/bronze_heart(src)
 	new /obj/item/clothing/accessory/medal/plasma/nobel_science(src)
 	new /obj/item/clothing/accessory/medal/plasma/nobel_science(src)
@@ -195,6 +197,24 @@
 	for(var/i in 1 to 3)
 		new /obj/item/clothing/accessory/medal/plasma/nobel_science(src)
 
+/obj/item/storage/lockbox/medal/med
+	name = "medical medal box"
+	desc = "A locked box used to store medals to be given to members of the medical department."
+	req_access = list(ACCESS_CMO)
+
+/obj/item/storage/lockbox/medal/med/PopulateContents()
+	for(var/i in 1 to 3)
+		new obj/item/clothing/accessory/medal/silver/medical(src)
+
+obj/item/storage/lockbox/medal/eng
+	name = "engineering medal box"
+	desc = "A locked box used to store medals to be given to members of the engineering department."
+	req_access = list(ACCESS_CE)
+
+/obj/item/storage/lockbox/medal/eng/PopulateContents()
+	for(var/i in 1 to 3)
+		new obj/item/clothing/accessory/medal/silver/engineering(src)
+
 //Yogs: Vial Holder
 /obj/item/storage/lockbox/vialbox
 	name = "vial box"
@@ -242,7 +262,7 @@
 /obj/item/storage/lockbox/vialbox/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_w_class = WEIGHT_CLASS_TINY 
+	STR.max_w_class = WEIGHT_CLASS_TINY
 	STR.max_combined_w_class = 6
 	STR.max_items = 6
 	STR.locked = TRUE

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -110,7 +110,7 @@
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_w_class = WEIGHT_CLASS_SMALL
-	STR.max_items = 10
+	STR.max_items = 15
 	STR.max_combined_w_class = 20
 	STR.set_holdable(list(/obj/item/clothing/accessory/medal))
 

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -204,16 +204,16 @@
 
 /obj/item/storage/lockbox/medal/med/PopulateContents()
 	for(var/i in 1 to 3)
-		new obj/item/clothing/accessory/medal/silver/medical(src)
+		new /obj/item/clothing/accessory/medal/silver/medical(src)
 
-obj/item/storage/lockbox/medal/eng
+/obj/item/storage/lockbox/medal/eng
 	name = "engineering medal box"
 	desc = "A locked box used to store medals to be given to members of the engineering department."
 	req_access = list(ACCESS_CE)
 
 /obj/item/storage/lockbox/medal/eng/PopulateContents()
 	for(var/i in 1 to 3)
-		new obj/item/clothing/accessory/medal/silver/engineering(src)
+		new /obj/item/clothing/accessory/medal/silver/engineering(src)
 
 //Yogs: Vial Holder
 /obj/item/storage/lockbox/vialbox

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -26,6 +26,7 @@
 	new /obj/item/clipboard/yog/paperwork/ce(src)
 	new /obj/item/poster/firstsingularity(src)
 	new /obj/item/storage/backpack/duffelbag/clothing/ce(src)
+	new /obj/item/storage/lockbox/medal/eng(src)
 
 /obj/structure/closet/secure_closet/engineering_electrical
 	name = "electrical supplies locker"

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -70,6 +70,7 @@
 	new /obj/item/storage/photo_album/CMO(src)
 	new /obj/item/clipboard/yog/paperwork/cmo(src)
 	new /obj/item/storage/backpack/duffelbag/clothing/med/chief(src)
+	new /obj/item/storage/lockbox/medal/med(src)
 
 
 /obj/structure/closet/secure_closet/paramedic

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -239,7 +239,7 @@
 
 /obj/item/clothing/accessory/medal/plasma/nobel_science
 	name = "nobel sciences award"
-	desc = "A plasma medal which represents significant contributions to the field of science or engineering."
+	desc = "A plasma medal which represents significant contributions to the field of science or robotics."
 
 ////////////
 //Armbands//

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -197,6 +197,14 @@
 	name = "head of personnel award for outstanding achievement in the field of excellence"
 	desc = "Nanotrasen's dictionary defines excellence as \"the quality or condition of being excellent\". This is awarded to those rare crewmembers who fit that definition."
 
+/obj/item/clothing/accessory/medal/silver/medical
+	name = "award for medical excellence"
+	desc = "An award for an exceptional application of medical service. Can be awarded to any crewmember who provides an outstanding benefit to the station through their medical knowledge."
+
+/obj/item/clothing/accessory/medal/silver/engineering
+	name = "medal of engineering integrity"
+	desc = "A medal made of silver portaying the bearer as a crewmember who demonstrates notable engineering prowess. The merits of those who earn this award can range from atmospheric wizardry to simply rebuilding half the station after a toxins explosion."
+
 /obj/item/clothing/accessory/medal/gold
 	name = "gold medal"
 	desc = "A prestigious golden medal."
@@ -232,8 +240,6 @@
 /obj/item/clothing/accessory/medal/plasma/nobel_science
 	name = "nobel sciences award"
 	desc = "A plasma medal which represents significant contributions to the field of science or engineering."
-
-
 
 ////////////
 //Armbands//
@@ -377,4 +383,4 @@
 	light_range = 1.4 //Same as cosmic bedsheet
 	light_color = "#9E1F1F" //dim red
 	w_class = WEIGHT_CLASS_TINY
-	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF // Good luck destroying a singularity 
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF // Good luck destroying a singularity

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -203,7 +203,7 @@
 
 /obj/item/clothing/accessory/medal/silver/engineering
 	name = "medal of engineering integrity"
-	desc = "A medal made of silver portaying the bearer as a crewmember who demonstrates notable engineering prowess. The merits of those who earn this award can range from atmospheric wizardry to simply rebuilding half the station after a toxins explosion."
+	desc = "A medal made of silver portraying the bearer as a crewmember who demonstrates notable engineering prowess. The merits of those who earn this award can range from atmospheric wizardry to simply rebuilding half the station after a toxins explosion."
 
 /obj/item/clothing/accessory/medal/gold
 	name = "gold medal"


### PR DESCRIPTION
# Document the changes in your pull request

Adds medals and a medal box for the Medical and Engineering departments, accessible by CMO and CE respectively (and Captain). Also adds one of each new medal to the Captain's medal box.

# Changelog

:cl:  
rscadd: Added Medical and Engineering Awards (one each)
rscadd: Added a medal box in CMO and CE locker for respective awards
rscadd: Added 1 of each new award to Captain's award box
tweak: Adjusted Award Box from 10 to 15 to allow the Captain to put an award back if they take out the wrong one.
/:cl:
