### PR TITLE
Clean up Ghost role descriptions

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -14,7 +14,7 @@
 	short_desc = "You are a sentient ecosystem, an example of the mastery over life that your creators possessed."
 	flavour_text = "Your masters, benevolent as they were, created uncounted \
 	seed vaults and spread them across the universe to every planet they could chart. You are in one such seed vault. Your goal is to cultivate and spread life wherever it will go while waiting \
-	for contact from your creators. Estimated time of last contact: Deployment, 5x10^3 millennia ago.</b>"
+	for contact from your creators. Estimated time of last contact: Deployment, 5x10^3 millennia ago."
 	assignedrole = "Lifebringer"
 
 /obj/effect/mob_spawn/human/seed_vault/special(mob/living/new_spawn)
@@ -47,7 +47,7 @@
 	density = FALSE
 	short_desc = "You are an ash walker. Your tribe worships the Necropolis."
 	flavour_text = "The wastes are sacred ground, its monsters a blessed bounty. \
-	You have seen lights in the distance... they foreshadow the arrival of outsiders that seek to tear apart the Necropolis and its domain. Fresh sacrifices for your nest.</b>"
+	You have seen lights in the distance... they foreshadow the arrival of outsiders that seek to tear apart the Necropolis and its domain. Fresh sacrifices for your nest."
 	assignedrole = "Ash Walker"
 	var/datum/team/ashwalkers/team
 
@@ -240,7 +240,7 @@
 			outfit.suit = /obj/item/clothing/suit/toggle/labcoat
 			outfit.back = /obj/item/storage/backpack/medic
 		if(4)
-			flavour_text += "you were always joked about by your friends for \"not playing with a full deck\", as they so <i>kindly</i> put it. It seems that they were right when you, on a tour \
+			flavour_text += "you were always joked about by your friends for \"not playing with a full deck\", as they so kindly put it. It seems that they were right when you, on a tour \
 			at one of Nanotrasen's state-of-the-art research facilities, were in one of the escape pods alone and saw the red button. It was big and shiny, and it caught your eye. You pressed \
 			it, and after a terrifying and fast ride for days, you landed here. You've had time to wisen up since then, and you think that your old friends wouldn't be laughing now."
 

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -262,9 +262,9 @@
 	name = "broken rejuvenation pod"
 	desc = "A small sleeper typically used to instantly restore minor wounds. This one seems broken, and its occupant is comatose."
 	mob_name = "a translocated vet"
-	flavour_text = "<span class='big bold'>What...?</span><b> Where are you? Where are the others? This is still the animal hospital - you should know, you've been an intern here for weeks - but \
+	flavour_text = "What...? Where are you? Where are the others? This is still the animal hospital - you should know, you've been an intern here for weeks - but \
 	everyone's gone. One of the cats scratched you just a few minutes ago. That's why you were in the pod - to heal the scratch. The scabs are still fresh; you see them right now. So where is \
-	everyone? Where did they go? What happened to the hospital? And is that <i>smoke</i> you smell? You need to find someone else. Maybe they can tell you what happened.</b>"
+	everyone? Where did they go? What happened to the hospital? And is that smoke you smell? You need to find someone else. Maybe they can tell you what happened."
 	assignedrole = "Translocated Vet"
 
 /obj/effect/mob_spawn/human/doctor/alive/lavaland/Destroy()

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -412,7 +412,8 @@
 
 /obj/effect/mob_spawn/human/bartender/alive/space
 	name = "space bartender sleeper"
-	flavour_text = "<span class='big bold'>You are a space bartender!</span> You got this place from your old man, a bar in the middle of nowhere. Or at least, until NanoTrasen decided to move in. Time to mix drinks and change lives. <b>Do not leave your post under any circumstances!</b>"
+	flavour_text = "You got this place from your old man, a bar in the middle of nowhere. Or at least, until NanoTrasen decided to move in. Time to mix drinks and change lives."
+	important_info = "Do not leave your post under any circumstances!"
 	outfit = /datum/outfit/spacebartender/space
 
 /obj/effect/mob_spawn/human/bartender/alive/space/special(mob/living/L)

--- a/yogstation/code/modules/ruins/lavaland_ruin_code.dm
+++ b/yogstation/code/modules/ruins/lavaland_ruin_code.dm
@@ -12,7 +12,8 @@
 	mask = /obj/item/clothing/mask/bandana/green
 	r_pocket = /obj/item/tank/internals/emergency_oxygen/double
 	r_hand = /obj/item/instrument/guitar
-	flavour_text = "You are a travelling Bard! Your only purpose in life is to travel the galaxy, playing songs and telling epic tales of adventure, you have seen many things and you only wish to share your knowledge with all those who you pass. You are a very passive person and dislike the idea of killing another sentient person, if you cannot stop conflict through peace then you would rather remain neutral. Despite your peaceful demeanor, you are not immune to brainwashing or conversion techniques, if converted or brainwashed you are to follow the will of your masters."
+	flavour_text = "You are a travelling Bard! Your only purpose in life is to travel the galaxy, playing songs and telling epic tales of adventure, you have seen many things and you only wish to share your knowledge with all those who you pass. You are a very passive person and dislike the idea of killing another sentient person, if you cannot stop conflict through peace then you would rather remain neutral."
+	important_info = "Despite your peaceful demeanor, you are not immune to brainwashing or conversion techniques, if converted or brainwashed you are to follow the will of your masters."
 	short_desc = "You are a travelling Bard!"
 	id_job = "Travelling Bard"
 	id = /obj/item/card/id
@@ -31,8 +32,9 @@
 	back = /obj/item/storage/backpack/medic
 	belt = /obj/item/storage/belt/medical
 	glasses = /obj/item/clothing/glasses/hud/health
-	flavour_text = "<font size=3><b>Y</b></font><b>ou were working on a medical outpost on Orion when a bluespace translocation was reported in the vicinity, it seems to have moved the outpost to some strange ashen wasteland, regardless of the situation the medical supplies are low and medical scanners report you aren't the first here, time to put your expertise to use and see if there's anyone out there who needs help</b>"
 	short_desc = "You are an Orion medical doctor."
+	flavour_text = "You were working on a medical outpost on Orion when a bluespace translocation was reported in the vicinity, it seems to have moved the outpost to some strange ashen wasteland, regardless of the situation the medical supplies are low and medical scanners report you aren't the first here."
+	important_info = "Time to put your expertise to use and see if there's anyone out there who needs help."
 	id_job = "Medical Doctor"
 	id = /obj/item/card/id
 	roundstart = FALSE
@@ -67,7 +69,7 @@
 /obj/effect/mob_spawn/human/gasstation_clerk
 	name = "Gas Station Clerk"
 	short_desc = "You are a gas station clerk."
-	flavour_text = "<span class='big bold'>You are a Gas Station Clerk.</span> The gas station you worked most of your life in was moved to some hellhole in the middle of nowhere for some reason, you are to try to make the best of the situation and make as much money as possible from any locals or passerbys you may encounter. Feel free to explore around the planet and find things to sell to potential customers but do not leave the planet unless the gas station is somehow completely destroyed, If someone is trying to break in or is trying to steal your products you have the right to use any means necessary to stop them including murder."
+	flavour_text = "The gas station you worked most of your life in was moved to some hellhole in the middle of nowhere for some reason, you are to try to make the best of the situation and make as much money as possible from any locals or passerbys you may encounter. Feel free to explore around the planet and find things to sell to potential customers but do not leave the planet unless the gas station is somehow completely destroyed, If someone is trying to break in or is trying to steal your products you have the right to use any means necessary to stop them including murder."
 	roundstart = FALSE
 	death = FALSE
 	icon = 'icons/obj/machines/sleeper.dmi'


### PR DESCRIPTION
# Document the changes in your pull request

A lot of Ghost roles have broken html in them such as useless \<b> and\</b>s or repeat titles in a class span that doesn't work. I'm kind of assuming this is a remnant of switching to TGUI or being ported at some point. 
Speculation aside, this just aims to clean up the text and also move some information like "You're free to leave your spawn to find people" or "Stay in your ruin" to the critical information sections in bolded red.

Please let me know if you see any broken tags I missed or if the critical information for some roles is unnecessary/extra.

# Wiki Documentation

Nothing. take a day off I guess

# Changelog

:cl:  
tweak: Moved some important ghost role text to the critical information section of the descriptions
spellcheck: Removed Ghost role syntax that wasn't doing anything  
/:cl:
