### PR TITLE
changes minimum nanite timer to 5 from 10

### DIFF
--- a/code/modules/research/nanites/nanite_programmer.dm
+++ b/code/modules/research/nanites/nanite_programmer.dm
@@ -129,7 +129,7 @@
 			if(!isnull(timer))
 				playsound(src, "terminal_type", 25, 0)
 				if(!timer == 0)
-					timer = clamp(round(timer, 1),10,3600)
+					timer = clamp(round(timer, 1),5,3600)
 				program.timer = timer
 			. = TRUE
 		if("set_timer_type")


### PR DESCRIPTION
some nanites use 10 nanites a second and if on for the minimum time would drain 100 nanites for something you usually only need a few seconds of
:cl:  
tweak: tweaked minimum nanite timer
/:cl:
