### PR TITLE
Make energy bars more filling to the ethereals 

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_vend.dm
+++ b/code/modules/food_and_drinks/food/snacks_vend.dm
@@ -98,7 +98,7 @@
 	icon_state = "energybar"
 	desc = "An energy bar with a lot of punch, you probably shouldn't eat this if you're not an Ethereal."
 	trash = /obj/item/trash/energybar
-	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/liquidelectricity = 3)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/liquidelectricity = 4)
 	filling_color = "#97ee63"
 	tastes = list("pure electricity" = 3, "fitness" = 2)
 	foodtype = TOXIC


### PR DESCRIPTION

# Document the changes in your pull request

gives 1 more liquid electricity to the energy bars so they are more filling to ethereals, current can fill between 30 to 45 charge, this one could give from 40 to 60 charge.

# Wiki Documentation

none

# Changelog

:cl:    
tweak: energy bars have 1 more liquid electricity
/:cl:
