### PR TITLE
Fixes ling points not being fully refunded if you had extra points from absorbing another ling

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -128,7 +128,9 @@
 		mimicing = ""
 
 		for(var/datum/action/changeling/p in purchasedpowers)
-			additionalpoints += p.dna_cost
+			if p.dna_cost > 0
+				additionalpoints += p.dna_cost
+			
 			purchasedpowers -= p
 			p.Remove(owner.current)
 			

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -121,17 +121,16 @@
 
 /datum/antagonist/changeling/proc/remove_changeling_powers()
 	if(ishuman(owner.current) || ismonkey(owner.current))
-		var/additionalpoints = (initial(geneticpoints) * -1) + geneticpoints // negative of initial + any points you had left over
+		var/additionalpoints = geneticpoints
 
 		for(var/datum/action/changeling/p in purchasedpowers)
-			additionalpoints += p.dna_cost // Refunds all of your points into the additional points. If you had no absorbed points, this would add up to 0
+			additionalpoints += p.dna_cost
 
 		changeling_speak = 0
 		chosen_sting = null
-		geneticpoints = initial(geneticpoints)
 		mimicing = ""
 
-		geneticpoints += additionalpoints // Gives the extra points you had
+		geneticpoints = additionalpoints
 
 		for(var/datum/action/changeling/p in purchasedpowers)
 			purchasedpowers -= p

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -126,7 +126,10 @@
 		for(var/datum/action/changeling/p in purchasedpowers)
 			additionalpoints += p.dna_cost // Refunds all of your points into the additional points. If you had no absorbed points, this would add up to 0
 
-		reset_properties()
+		changeling_speak = 0
+		chosen_sting = null
+		geneticpoints = initial(geneticpoints)
+		mimicing = ""
 
 		geneticpoints += additionalpoints // Gives the extra points you had
 

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -123,18 +123,16 @@
 	if(ishuman(owner.current) || ismonkey(owner.current))
 		var/additionalpoints = geneticpoints
 
-		for(var/datum/action/changeling/p in purchasedpowers)
-			additionalpoints += p.dna_cost
-
 		changeling_speak = 0
 		chosen_sting = null
 		mimicing = ""
 
-		geneticpoints = additionalpoints
-
 		for(var/datum/action/changeling/p in purchasedpowers)
+			additionalpoints += p.dna_cost
 			purchasedpowers -= p
 			p.Remove(owner.current)
+			
+		geneticpoints = additionalpoints
 
 	//MOVE THIS
 	if(owner.current.hud_used && owner.current.hud_used.lingstingdisplay)

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -128,7 +128,7 @@
 		mimicing = ""
 
 		for(var/datum/action/changeling/p in purchasedpowers)
-			if p.dna_cost > 0
+			if(p.dna_cost > 0)
 				additionalpoints += p.dna_cost
 			
 			purchasedpowers -= p

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -121,7 +121,15 @@
 
 /datum/antagonist/changeling/proc/remove_changeling_powers()
 	if(ishuman(owner.current) || ismonkey(owner.current))
+		var/additionalpoints = (initial(geneticpoints) * -1) + geneticpoints // negative of initial + any points you had left over
+
+		for(var/datum/action/changeling/p in purchasedpowers)
+			additionalpoints += p.dna_cost // Refunds all of your points into the additional points. If you had no absorbed points, this would add up to 0
+
 		reset_properties()
+
+		geneticpoints += additionalpoints // Gives the extra points you had
+
 		for(var/datum/action/changeling/p in purchasedpowers)
 			purchasedpowers -= p
 			p.Remove(owner.current)


### PR DESCRIPTION
# Document the changes in your pull request

Takes your leftover points + refunds your abilities so you should have regular amount

No longer sets unnecessary things like max chem storage so those also are not reset

# Changelog

:cl:  
bugfix: Fixed ling points not being fully refunded if you had extra points from absorbing another ling
/:cl:
