### PR TITLE
Should fix head modular consoles missing some programs

### DIFF
--- a/code/modules/modular_computers/computers/machinery/console_presets.dm
+++ b/code/modules/modular_computers/computers/machinery/console_presets.dm
@@ -122,6 +122,7 @@
 	desc = "A stationary computer. This one comes preloaded with bureaucratic programs."
 
 /obj/machinery/modular_computer/console/preset/command/hop/install_programs()
+	. = ..()
 	var/obj/item/computer_hardware/hard_drive/hard_drive = cpu.all_components[MC_HDD]
 	hard_drive.store_file(new/datum/computer_file/program/job_management())
 	hard_drive.store_file(new/datum/computer_file/program/crew_manifest())
@@ -134,6 +135,7 @@
 	desc = "A stationary computer. This one comes preloaded with security programs."
 
 /obj/machinery/modular_computer/console/preset/command/hos/install_programs()
+	. = ..()
 	var/obj/item/computer_hardware/hard_drive/hard_drive = cpu.all_components[MC_HDD]
 	hard_drive.store_file(new/datum/computer_file/program/secureye())
 
@@ -143,6 +145,7 @@
 	desc = "A stationary computer. This one comes preloaded with engineering programs."
 
 /obj/machinery/modular_computer/console/preset/command/ce/install_programs()
+	. = ..()
 	var/obj/item/computer_hardware/hard_drive/hard_drive = cpu.all_components[MC_HDD]
 	hard_drive.store_file(new/datum/computer_file/program/power_monitor())
 	hard_drive.store_file(new/datum/computer_file/program/alarm_monitor())
@@ -156,6 +159,7 @@
 	_has_ai = TRUE
 
 /obj/machinery/modular_computer/console/preset/command/rd/install_programs()
+	. = ..()
 	var/obj/item/computer_hardware/hard_drive/hard_drive = cpu.all_components[MC_HDD]
 	hard_drive.store_file(new/datum/computer_file/program/ntnetmonitor())
 	hard_drive.store_file(new/datum/computer_file/program/aidiag())
@@ -168,6 +172,7 @@
 
 /*
 /obj/machinery/modular_computer/console/preset/command/cmo/install_programs()
+	. = ..()
 	var/obj/item/computer_hardware/hard_drive/hard_drive = cpu.all_components[MC_HDD]
 */
 

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -25,6 +25,9 @@
 	var/base_active_power_usage = 100					// Power usage when the computer is open (screen is active) and can be interacted with. Remember hardware can use power too.
 	var/base_idle_power_usage = 10						// Power usage when the computer is idle and screen is off (currently only applies to laptops)
 
+	var/list/expansion_bays								/// Lazy List of extra hardware slots that can be used modularly.
+	var/max_bays = 0									/// Number of total expansion bays this computer has available.
+
 	var/obj/item/modular_computer/processor/cpu = null				// CPU that handles most logic while this type only handles power and other specific things.
 
 /obj/machinery/modular_computer/Initialize()

--- a/code/modules/modular_computers/computers/machinery/modular_console.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_console.dm
@@ -11,7 +11,8 @@
 	density = TRUE
 	base_idle_power_usage = 100
 	base_active_power_usage = 500
-	max_hardware_size = 4
+	max_hardware_size = WEIGHT_CLASS_BULKY
+	max_bays = 5
 	steel_sheet_cost = 10
 	light_strength = 2
 	max_integrity = 300


### PR DESCRIPTION
# Document the changes in your pull request

Turns out I did a bad thing and forgot to add ..() to the procs and it overrid stuff, meaning bad stuff. Should fix it, though this is untested.

# Wiki Documentation

None needed. 

# Changelog

:cl:  
bugfix: fixed head modular consoles from missing some programs 
/:cl:
