### PR TITLE
fixes add reagent select ID for REAL

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -1012,7 +1012,7 @@
 								var/datum/reagent/selected = reagent_options[ID]
 								if(selected?.name == chosen_id) //apparently I have to do this because the other method wasn't WORKING
 									valid_id = TRUE
-									chosen_id = selected
+									chosen_id = ID
 							if(!valid_id)
 								to_chat(usr, span_warning("A reagent with that ID doesn't exist!"))
 					if("Choose ID")


### PR DESCRIPTION
turns out I forgot a very important ibt last time somehow even though it wroked when i tested it and it was trying to create the reagent given the reagent as a variable not the path
:cl:  
bugfix: admin reagent adding with select ID now actually works instead of pretending to
/:cl:
