### PR TITLE
Fixes modular console components

### DIFF
--- a/code/modules/modular_computers/computers/item/processor.dm
+++ b/code/modules/modular_computers/computers/item/processor.dm
@@ -8,6 +8,7 @@
 	icon_state_unpowered = null
 	icon_state_menu = null
 	hardware_flag = 0
+	max_bays = 5
 
 	var/obj/machinery/modular_computer/machinery_computer = null
 

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -25,9 +25,6 @@
 	var/base_active_power_usage = 100					// Power usage when the computer is open (screen is active) and can be interacted with. Remember hardware can use power too.
 	var/base_idle_power_usage = 10						// Power usage when the computer is idle and screen is off (currently only applies to laptops)
 
-	var/list/expansion_bays								/// Lazy List of extra hardware slots that can be used modularly.
-	var/max_bays = 0									/// Number of total expansion bays this computer has available.
-
 	var/obj/item/modular_computer/processor/cpu = null				// CPU that handles most logic while this type only handles power and other specific things.
 
 /obj/machinery/modular_computer/Initialize()

--- a/code/modules/modular_computers/computers/machinery/modular_console.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_console.dm
@@ -12,7 +12,6 @@
 	base_idle_power_usage = 100
 	base_active_power_usage = 500
 	max_hardware_size = WEIGHT_CLASS_BULKY
-	max_bays = 5
 	steel_sheet_cost = 10
 	light_strength = 2
 	max_integrity = 300


### PR DESCRIPTION
# Document the changes in your pull request

So turns out mod PCs didnt have any slots for extra components, this fixes it.

# Wiki Documentation

None needed. 

# Changelog

:cl:  
bugfix: fixed modular consoles not being able to hold some componets
/:cl:
