### PR TITLE
Bugfixes with permissions editing

### DIFF
--- a/code/modules/admin/permissionedit.dm
+++ b/code/modules/admin/permissionedit.dm
@@ -138,6 +138,8 @@
 	if(IsAdminAdvancedProcCall())
 		to_chat(usr, "<span class='admin prefix'>Admin Edit blocked: Advanced ProcCall detected.</span>", confidential=TRUE)
 		return
+	if(!mfa_query())
+		return
 	var/datum/asset/permissions_assets = get_asset_datum(/datum/asset/simple/namespaced/common)
 	permissions_assets.send(src)
 	var/admin_key = href_list["key"]
@@ -324,6 +326,8 @@
 	if(new_rank == "*New Rank*")
 		new_rank = trim(input("Please input a new rank", "New custom rank") as text|null)
 	if(!new_rank)
+		if(!D)
+			remove_admin(admin_ckey, admin_key, use_db, null)
 		return
 	R = rank_names[new_rank]
 	if(!R) //rank with that name doesn't exist yet - make it

--- a/code/modules/admin/permissionedit.dm
+++ b/code/modules/admin/permissionedit.dm
@@ -138,7 +138,7 @@
 	if(IsAdminAdvancedProcCall())
 		to_chat(usr, "<span class='admin prefix'>Admin Edit blocked: Advanced ProcCall detected.</span>", confidential=TRUE)
 		return
-	if(!mfa_query())
+	if(!owner.mfa_query())
 		return
 	var/datum/asset/permissions_assets = get_asset_datum(/datum/asset/simple/namespaced/common)
 	permissions_assets.send(src)


### PR DESCRIPTION
# Document the changes in your pull request
Added 2FA to editing someone's rank, to prevent using the player panel to bypass the check on the permissions panel. Also fixed bug where pressing 'Cancel' on adding a new min would leave them in a limbo state.

# Wiki Documentation

# Changelog

:cl:  
bugfix: fixed some bugs in the perms panel
/:cl:
