### PR TITLE
Prevents temporary spares from being used in the ID Card Modification program

### DIFF
--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -63,6 +63,9 @@
 	if(!id_card)
 		return
 
+	if(istype(id_card, /obj/item/card/id/captains_spare/temporary))
+		to_chat(user, span_warning("ERROR: [id_card] is not compatable with this program"))
+		return
 	region_access = list()
 	if(!target_dept && (ACCESS_CHANGE_IDS in id_card.access))
 		minor = FALSE


### PR DESCRIPTION
# Document the changes in your pull request

Prevents you from using temp spares in the card program, as it allows you to grant yourself a lot of access and seams to be an oversight. Is tested, does work

# Wiki Documentation

None needed. 

# Changelog

:cl:  
tweak: you can no longer use a temporary spare to give yourself access with the ID Card Modification program
/:cl:
