### PR TITLE
Removes catgirls

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -3,6 +3,7 @@
 	name = "Felinid Human"
 	id = "felinid"
 	limbs_id = "human"
+    gender = "male"
 
 	mutant_bodyparts = list("ears", "tail_human")
 	default_features = list("mcolor" = "FFF", "tail_human" = "Cat", "ears" = "Cat", "wings" = "None")

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -3,7 +3,7 @@
 	name = "Felinid Human"
 	id = "felinid"
 	limbs_id = "human"
-    gender = "male"
+	gender = "male"
 
 	mutant_bodyparts = list("ears", "tail_human")
 	default_features = list("mcolor" = "FFF", "tail_human" = "Cat", "ears" = "Cat", "wings" = "None")


### PR DESCRIPTION
Weird request but okay 

![KgRka5uqEf](https://user-images.githubusercontent.com/24533979/142055949-9ffa238d-48e6-42b9-9dfd-bb0084bd553a.png)

Wiki changes:
Catgirls don't exist in the ss13 universe anymore.

:cl:  Hopek
sounddel: Removed catgirls
/:cl:
