### PR TITLE
Fixes mods being told they need +VAREDIT for check antags

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -393,7 +393,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	if(check_rights(R_ADMIN))
 	// yogs start
 		log_admin("[key_name(usr)] checked antagonists.")	//for tsar~
-		if((!isobserver(usr) && SSticker.HasRoundStarted()) || !check_rights(R_VAREDIT))
+		if((!isobserver(usr) && SSticker.HasRoundStarted()) || !check_rights(R_VAREDIT, FALSE))
 			message_admins("[key_name_admin(usr)] checked antagonists.")
 		holder.check_antagonists()
 


### PR DESCRIPTION
# Document the changes in your pull request

Not having +VAREDIT gets a message admins when checking antags, but it also causes a message to the person without the perms that they need it to perform the action. This is not true, added the flag to suppress the message.

# Changelog

:cl:  
bugfix: fixed permissions error when running check antags as a mod
/:cl:
