### PR TITLE
includes seen_mobs list in photocopied pictures to fix the bug where I don't greentext

### DIFF
--- a/code/modules/photography/_pictures.dm
+++ b/code/modules/photography/_pictures.dm
@@ -175,4 +175,6 @@
 		if(picture_image)
 			P.picture_image.Crop(cropx, cropy, psize_x - cropx, psize_y - cropy)
 		P.regenerate_small_icon()
+	if(mobs_seen)
+		P.mobs_seen = mobs_seen
 	return P

--- a/code/modules/photography/_pictures.dm
+++ b/code/modules/photography/_pictures.dm
@@ -175,6 +175,5 @@
 		if(picture_image)
 			P.picture_image.Crop(cropx, cropy, psize_x - cropx, psize_y - cropy)
 		P.regenerate_small_icon()
-	if(mobs_seen)
-		P.mobs_seen = mobs_seen
+	P.mobs_seen = mobs_seen
 	return P


### PR DESCRIPTION
# Document the changes in your pull request

Fixes https://github.com/yogstation13/Yogstation/issues/12684

![nHMQkGZfTG](https://user-images.githubusercontent.com/5091394/142180947-9f4b423d-90cc-4696-bfa3-00cf6718e41f.png)
![dreamseeker_OJFfDW8ck2](https://user-images.githubusercontent.com/5091394/142180954-a4cfa6d5-3e41-49ed-825a-f320d4be6235.png)



description is copied correctly but not what it actually checks for at the end, seen_mobs. Photocopies include the blueprints so why not seen_mobs too?

give me the ided label

# Changelog
:cl:  
bugfix: transfers mobs_seen to photocopy
/:cl:
