### PR TITLE
plating with tiles removed now remember what icon the tile came from too instead of just the icon_state

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -11,7 +11,8 @@
 	clawfootstep = FOOTSTEP_HARD_CLAW
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
 
-	var/icon_regular_floor = "floor" //used to remember what icon the tile should have by default
+	var/icon_state_regular_floor = "floor" //used to remember what icon state the tile should have by default
+	var/icon_regular_floor = 'icons/turf/floors.dmi' //used to remember what icon the tile should have by default
 	var/icon_plating = "plating"
 	thermal_conductivity = 0.040
 	heat_capacity = 10000
@@ -51,9 +52,11 @@
 					"ironsand6", "ironsand7", "ironsand8", "ironsand9", "ironsand10", "ironsand11",
 					"ironsand12", "ironsand13", "ironsand14", "ironsand15")
 	if(broken || burnt || (icon_state in icons_to_ignore_at_floor_init)) //so damaged/burned tiles or plating icons aren't saved as the default
-		icon_regular_floor = "floor"
+		icon_state_regular_floor = "floor"
+		icon_regular_floor = 'icons/turf/floors.dmi'
 	else
-		icon_regular_floor = icon_state
+		icon_state_regular_floor = icon_state
+		icon_regular_floor = icon
 	if(mapload && prob(33))
 		MakeDirty()
 	if(is_station_level(z))
@@ -152,9 +155,11 @@
 	if(!ispath(path, /turf/open/floor))
 		return ..()
 	var/old_icon = icon_regular_floor
+	var/old_icon_state = icon_state_regular_floor
 	var/old_dir = dir
 	var/turf/open/floor/W = ..()
 	W.icon_regular_floor = old_icon
+	W.icon_state_regular_floor = old_icon_state
 	W.setDir(old_dir)
 	W.update_icon()
 	return W

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -104,17 +104,17 @@
 /turf/open/floor/pod
 	name = "pod floor"
 	icon_state = "podfloor"
-	icon_regular_floor = "podfloor"
+	icon_state_regular_floor = "podfloor"
 	floor_tile = /obj/item/stack/tile/pod
 
 /turf/open/floor/pod/light
 	icon_state = "podfloor_light"
-	icon_regular_floor = "podfloor_light"
+	icon_state_regular_floor = "podfloor_light"
 	floor_tile = /obj/item/stack/tile/pod/light
 
 /turf/open/floor/pod/dark
 	icon_state = "podfloor_dark"
-	icon_regular_floor = "podfloor_dark"
+	icon_state_regular_floor = "podfloor_dark"
 	floor_tile = /obj/item/stack/tile/pod/dark
 
 

--- a/code/game/turfs/simulated/floor/plasteel_floor.dm
+++ b/code/game/turfs/simulated/floor/plasteel_floor.dm
@@ -17,7 +17,8 @@
 	if(!..())
 		return 0
 	if(!broken && !burnt)
-		icon_state = icon_regular_floor
+		icon = icon_regular_floor
+		icon_state = icon_state_regular_floor
 
 
 /turf/open/floor/plasteel/airless


### PR DESCRIPTION
# Document the changes in your pull request

Fixes https://github.com/yogstation13/Yogstation/issues/12592. No more null texture tiles when you remove the stairs, as the stairs were from a goon turf file. They do not keep their shadow decals but that's a ALL turfs. Think about if you want an extra variable in here for every turf. Might be a bandaid fix.

# Changelog
:cl:  
bugfix: no more null textures on goon stairs
/:cl:
