### PR TITLE
I somehow forgot to reduce the loot randomizer number after removing eye of god from the necro chest loot pool

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -13,7 +13,7 @@
 	desc = "It's watching you suspiciously."
 
 /obj/structure/closet/crate/necropolis/tendril/PopulateContents()
-	var/loot = rand(1,25)
+	var/loot = rand(1,24)
 	switch(loot)
 		if(1)
 			new /obj/item/shared_storage/red(src)


### PR DESCRIPTION
lmao
:cl:
bugfix: necro chest can't give no loot
/:cl:
