### PR TITLE
Fixes Servants of Ratvar's IDs not having an original assignment

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -294,6 +294,7 @@ Credit where due:
 	var/obj/item/card/id/W = new(H)
 	var/obj/item/pda/PDA = H.wear_id
 	W.assignment = "Assistant"
+	W.originalassignment = "Assistant"
 	W.access += ACCESS_MAINT_TUNNELS
 	W.registered_name = H.real_name
 	W.update_label()


### PR DESCRIPTION
# Document the changes in your pull request

Alt titles breaking things again. Untested, should work. Closes #12693.

# Wiki Documentation

None needed. 

# Changelog

:cl:  
bugfix: Fixed Servants of Ratvar's IDs not having an original assignment, causing them to appear at the top of the crew monitor
/:cl:
