### PR TITLE
Update dental_implant.dm

### DIFF
--- a/code/modules/surgery/dental_implant.dm
+++ b/code/modules/surgery/dental_implant.dm
@@ -2,6 +2,8 @@
 	name = "Dental implant"
 	steps = list(/datum/surgery_step/drill, /datum/surgery_step/insert_pill)
 	possible_locs = list(BODY_ZONE_PRECISE_MOUTH)
+	lying_required = FALSE
+	self_operable = TRUE
 
 /datum/surgery_step/insert_pill
 	name = "insert pill"


### PR DESCRIPTION
# Document the changes in your pull request

Allows the "Dental Implant" surgery to be performed on oneself.

Changes have been tested.

It makes logical sense for this operation to be something you can perform on yourself as well as seems convenient and fun; ergo a decent thing to merge!



# Wiki Documentation

Add a comment on the wiki that the Dental Implant surgery can be performed on itself (possibly change any reference to prosthetic manipulation being the only surgery that can be done to self)




:cl:  
tweak: Allows Dental Implant to be performed on yourself
/:cl:
