### PR TITLE
Makes the recharger gradient more obvious when its fully charged

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -165,10 +165,10 @@
 		var/mutable_appearance/scan = mutable_appearance(icon, "[initial(icon_state)]filled")
 		var/obj/item/stock_parts/cell/C = charging.get_cell()
 		if(C)
-			scan.color = gradient(list("#ff0000", "#00ff00"), round(C.charge/C.maxcharge, 0.01))
+			scan.color = gradient(list(0, "#ff0000", 0.99, "#00ff00", 1, "#cece00"), round(C.charge/C.maxcharge, 0.01))
 		if(istype(charging, /obj/item/ammo_box/magazine/recharge))
 			var/obj/item/ammo_box/magazine/recharge/R = charging
-			scan.color = gradient(list("#ff0000", "#00ff00"), round(R.stored_ammo.len/R.max_ammo, 0.01))
+			scan.color = gradient(list(0, "#ff0000", 0.99, "#00ff00", 1, "#cece00"), round(R.stored_ammo.len/R.max_ammo, 0.01))
 		add_overlay(scan)
 
 /obj/machinery/recharger/wallrecharger


### PR DESCRIPTION
# Document the changes in your pull request

![image](https://user-images.githubusercontent.com/20369082/142404212-11ba38f3-7bf3-4b06-8e03-b01a40624918.png)


Makes the charger turn yellow at 100%

# Wiki Documentation

It now turns yellow

# Changelog

:cl:  
tweak: Charger gradient now gives a clearer charged indicator
/:cl:
