### PR TITLE
Move Sterilizine From Vending Machine To Surgery Duffels

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -369,6 +369,7 @@
 	new /obj/item/circular_saw(src)
 	new /obj/item/surgicaldrill(src)
 	new /obj/item/cautery(src)
+	new /obj/item/reagent_containers/medspray/sterilizine(src)
 	new /obj/item/bonesetter(src)
 	new /obj/item/surgical_drapes(src)
 	new /obj/item/clothing/mask/surgical(src)
@@ -393,6 +394,7 @@
 	new /obj/item/surgicaldrill(src)
 	new /obj/item/cautery(src)
 	new /obj/item/surgical_drapes(src)
+	new /obj/item/reagent_containers/medspray/sterilizine(src)
 	new /obj/item/clothing/mask/surgical(src)
 
 /obj/item/storage/backpack/duffelbag/engineering

--- a/code/modules/vending/medical.dm
+++ b/code/modules/vending/medical.dm
@@ -22,7 +22,6 @@
 					/obj/item/reagent_containers/syringe/antiviral = 6,
 					/obj/item/reagent_containers/medspray/styptic = 2,
 					/obj/item/reagent_containers/medspray/silver_sulf = 2,
-					/obj/item/reagent_containers/medspray/sterilizine = 1,
 					/obj/item/sensor_device = 2,
 					/obj/item/pinpointer/crew = 2,
 					/obj/item/healthanalyzer/wound = 4,

--- a/code/modules/vending/medical_wall.dm
+++ b/code/modules/vending/medical_wall.dm
@@ -10,7 +10,6 @@
 					/obj/item/reagent_containers/pill/charcoal = 2,
 					/obj/item/reagent_containers/medspray/styptic = 2,
 					/obj/item/reagent_containers/medspray/silver_sulf = 2,
-					/obj/item/reagent_containers/medspray/sterilizine = 1,
 					/obj/item/healthanalyzer/wound = 2,
 					/obj/item/stack/medical/bone_gel = 2)
 	contraband = list(/obj/item/reagent_containers/pill/tox = 2,


### PR DESCRIPTION
# Document the changes in your pull request
Sterilizine is primarily used for surgery. It can be used as Space Cleaner but also why would you do that Space Cleaner is so easy to make? It *can* also be used to help burn wounds from getting infected but this PR doesn't really interfere with its availibility in fact it makes it easier since it doesn't need an ID or credits to pull out anymore.

All this really does is save a step between a doctor going "oh wait I need a boost for this surgery" and walking away to the vendor to get it. This is primarily for brain surgery. If you're doing ghetto surgery elsewhere I doubt you have the original surgery duffel with you anyway.

There were 2 bottles, 1 in each vendor. I took one and put it into the surgery duffel. I took the other and put it into the Brig Medbay's surgery duffel. This PR does add a third bottle in the Mining Medic's surgery duffel since it is the same one code-wise as in Medbay surgery, but I don't see that as a huge deal and if you're going all the way to lavaland for a bottle of the stuff I feel like the extra effort to get it more than counteracts a third bottle existing.

Honestly I feel like this is just a QoL change. Saves a step for non-100% surgeries (the step being walking away from your patient if you forgot to get it before surgery.

# Changelog

:cl:  
rscadd: Added 1 Sterilizine spray bottle to Medbay and Brig Medbay surgery duffel bags.
rscdel: Removed the bottles of Sterilizine from the 2 Vending Machines in medbay (the wall one and the stock room one).
tweak: This gives Mining Medic a bottle of the stuff now too in their own bag because it's the "same" one as the Medbay one.
/:cl:
