### PR TITLE
Gives Ash Walkers Night Vision

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -49,6 +49,7 @@
 	species_traits = list(MUTCOLORS,EYECOLOR,LIPS,DIGITIGRADE,HAS_FLESH,HAS_BONE)
 	inherent_traits = list(TRAIT_NOGUNS) //yogs start - ashwalkers have special lungs and actually breathe
 	mutantlungs = /obj/item/organ/lungs/ashwalker
+	mutanteyes = /obj/item/organ/eyes/night_vision/ash_walker
 	breathid = "n2" // yogs end
 	species_language_holder = /datum/language_holder/lizard/ash
 

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -119,6 +119,11 @@
 	name = "fung-eye"
 	desc = "While on the outside they look inert and dead, the eyes of mushroom people are actually very advanced."
 
+/obj/item/organ/eyes/night_vision/ash_walker
+	name = "lizard eyes"
+	desc = "Centuries of evolutions gave those scale wearing specimens night vision to aid their unending hunt"
+	sight_flags = TRAIT_NIGHT_VISION
+
 ///Robotic
 
 /obj/item/organ/eyes/robotic


### PR DESCRIPTION
# Document the changes in your pull request

# By Spooder just helping him

Gives ash walkers night vision
presumably because lavaland can get dark?

# Wiki Documentation

Ashwalkers can see in the dark

# Changelog

:cl:  
tweak: Gives ashwalkers night vision
/:cl:
