### PR TITLE
Removes syndicate surgery tech

### DIFF
--- a/code/modules/research/techweb/layout.dm
+++ b/code/modules/research/techweb/layout.dm
@@ -463,10 +463,6 @@
 	ui_x = -384
 	ui_y = -608
 
-/datum/techweb_node/syndicate_surgery
-	ui_x = -320
-	ui_y = -608
-
 /datum/techweb_node/mech_modules
 	ui_x = -640
 	ui_y = -32

--- a/yogstation/code/modules/research/techweb/all_nodes.dm
+++ b/yogstation/code/modules/research/techweb/all_nodes.dm
@@ -150,15 +150,6 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 2500
 
-	
-/datum/techweb_node/syndicate_surgery
-	id = "syndicate_surgery"
-	display_name = "Syndicate Surgery"
-	description = "The Syndicate did nothing wrong."
-	prereq_ids = list("exp_surgery", "syndicate_basic")
-	design_ids = list("surgery_brainwashing")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7000)
-	export_price = 7000
 
 /datum/techweb_node/nanite_harmonic
 	design_ids = list("fakedeath_nanites","aggressive_nanites","defib_nanites","regenerative_plus_nanites","brainheal_plus_nanites","purging_plus_nanites","nanite_heart")


### PR DESCRIPTION
# Document the changes in your pull request
![image](https://user-images.githubusercontent.com/14363906/142586141-f3281628-e7bc-4022-9892-e910763b036d.png)
_From [arcanist123 - report by Globypopz](https://forums.yogstation.net/threads/arcanist123-report-by-globypopz.24263/)_

So it was ruled that brainwashing someone as a non-antag is powergaming, no mater how good your intentions are. As such, there is no reason for non-antags to use this, so why should we tempt them into breaking the rules? Also removes syndicate surgery as it would unlock nothing. Untested, should work.

Edit: So the post was updated to say that it can be used in emergencies. Ill just leave this open for a bit in case staff decides they want it merged

# Wiki Documentation

Would need to update the techweb page to reflect this. 

# Changelog

:cl:   
rscdel: Removed syndicate surgery tech
/:cl:
