### PR TITLE
Fixes shocking touch mutation

### DIFF
--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -32,7 +32,7 @@
 	var/far = FALSE
 
 /obj/item/melee/touch_attack/shock/afterattack(atom/target, mob/living/carbon/user, proximity)
-	if((!proximity && !far) || !can_see(target) || get_dist(target, user) > 5)
+	if(!(proximity || far) || !can_see(user, target, 5) || get_dist(target, user) > 5)
 		user.visible_message("<span class='notice'>[user]'s hand reaches out but nothing happens.</span>")
 		return
 	if(iscarbon(target))


### PR DESCRIPTION
# Document the changes in your pull request
Fixes shocking touch mutation. This borked with PR #12334.

Added two missing parameters to can_see() proc

Reduced (!proximity && !far) to !(proximity || far)
![Proof](https://user-images.githubusercontent.com/73314266/142586311-4ccd6432-5416-4478-8c86-6f9706e1fa92.PNG)


This fixes issue #12678 and #12540

# Wiki Documentation
Nothing to document.

# Changelog
:cl:  
bugfix: Fixes shocking touch
/:cl:
