### PR TITLE
Fixes cyborgs abilities to unbuckle at a distance

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -11,13 +11,13 @@
 	. = ..()
 	if(.)
 		return
-	if(can_buckle && has_buckled_mobs())
+	if(Adjacent(user) && can_buckle && has_buckled_mobs())
 		if(buckled_mobs.len > 1)
 			var/unbuckled = input(user, "Who do you wish to unbuckle?","Unbuckle Who?") as null|mob in buckled_mobs
-			if(user_unbuckle_mob(unbuckled,user))
+			if(user_unbuckle_mob(unbuckled, user))
 				return 1
 		else
-			if(user_unbuckle_mob(buckled_mobs[1],user))
+			if(user_unbuckle_mob(buckled_mobs[1], user))
 				return 1
 
 /atom/movable/attack_hand(mob/living/user)

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -1,10 +1,3 @@
-/mob/living/silicon/robot/attack_robot(mob/user) // allowing for clicking people off like a chair
-	. = ..()
-	if(user == src && buckled_mobs?.len && user.a_intent == INTENT_HELP)
-		for(var/i in buckled_mobs)
-			var/mob/buckmob = i
-			unbuckle_mob(buckmob)
-
 /mob/living/silicon/robot/attackby(obj/item/I, mob/living/user)
 	if(I.slot_flags & ITEM_SLOT_HEAD && hat_offset != INFINITY && user.a_intent == INTENT_HELP && !is_type_in_typecache(I, blacklisted_hats))
 		to_chat(user, span_notice("You begin to place [I] on [src]'s head..."))


### PR DESCRIPTION
# Document the changes in your pull request
Fixes issue of borg's being able to unbuckle at a distance. 
This is because attack_robot has no check for adjacency.

PR #9689 enabled borgs to unbuckle, but failed to check adjacency.
Also removed redundant code.

Similar to PR of tgstation/tgstation#49808

Fixes issue #12617.

# Wiki Documentation
Nothing to document.

# Changelog
:cl:  
bugfix: cyborg are no longer able to unbuckle at a distance  
/:cl:
