### PR TITLE
Makes reflector boxes rotate by shuttle rotation

### DIFF
--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -43,8 +43,8 @@
 			else
 				. += span_notice("Use screwdriver to unlock the rotation.")
 
-/obj/structure/reflector/proc/setAngle(new_angle)
-	if(can_rotate)
+/obj/structure/reflector/proc/setAngle(new_angle, override_rotate = FALSE)
+	if(can_rotate || override_rotate)
 		rotation_angle = new_angle
 		if(deflector_overlay)
 			cut_overlay(deflector_overlay)

--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -69,6 +69,10 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 		if(dpdir & D)
 			new_dpdir = new_dpdir | angle2dir(rotation+dir2angle(D))
 	dpdir = new_dpdir
+	
+/obj/structure/reflector/shuttleRotate(rotation, params)
+	. = ..()
+	setAngle(rotation_angle + rotation, TRUE)
 
 /obj/structure/table/wood/bar/shuttleRotate(rotation, params)
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request
When placed on a shuttle, reflectors now rotate instead of staying on a fixed degree. This rotation happens even if the reflector is locked (screwed in).

I have tested the change and it doesn't seem break anything.

# Changelog

:cl:  
bugfix: reflectors now rotate properly when welded on top of a shuttle
/:cl:
