### PR TITLE
adds missing circuit to grounding rod so they can be deconstructed properly

### DIFF
--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -153,7 +153,7 @@
 	icon_state = "grounding_rod0"
 	anchored = FALSE
 	density = TRUE
-
+	circuit = /obj/item/circuitboard/machine/grounding_rod
 	can_buckle = TRUE
 	buckle_lying = FALSE
 	buckle_requires_restraints = TRUE


### PR DESCRIPTION
# Document the changes in your pull request
Fixes https://github.com/yogstation13/Yogstation/issues/12609

# Changelog

:cl:  
bugfix: adds circuit to grounding rod so it gets components, all grounding rods were missing the circuit.
/:cl:
