### PR TITLE
Adds mushroom wood

### DIFF
--- a/code/game/objects/items/manuals.dm
+++ b/code/game/objects/items/manuals.dm
@@ -231,7 +231,7 @@
 				All are not dangerous when consumed in moderation, save for mushroom caps.
 				All may be fermented and brewed into substances that induce a woozy and feel-good high.
 				Cacti fruit is rich in juices that will nurtur and heal your body.
-				Polypore shavings are tough and can be used for crafts such as bowls and contain a higher than average resin content.
+				Polypore shavings are tough and can be used for crafts such as bowls and wood substitute, and contain a higher than average resin content.
 				Porcini leaves contain a similar content to cacti fruit along with a substance that increases brain focus.
 				Inocybe caps contain deadly toxins in their raw state, but with ash and heat can be neutralized to instead detox the body.
 				Embershroom stems contain a bioluminescient substance that manages to even light up the body when consumed.

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -257,6 +257,9 @@ GLOBAL_LIST_INIT(wood_recipes, list ( \
 /obj/item/stack/sheet/mineral/wood/fifty
 	amount = 50
 
+/obj/item/stack/sheet/mineral/wood/mushroom
+	desc = "Wood made of packed together mushroom shavings that have dried and changed color. Just tough enough to pass as wood."
+
 /*
  * Bamboo
  */

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -267,6 +267,12 @@
 	reagents_add = list(/datum/reagent/consumable/tinlux = 0.04, /datum/reagent/consumable/nutriment = 0.02, /datum/reagent/drug/space_drugs = 0.02, /datum/reagent/consumable/ashresin = 0.02)
 
 //CRAFTING
+/datum/crafting_recipe/mushroomwood
+	name = "Wood Substitute"
+	result = /obj/item/stack/sheet/mineral/wood/mushroom
+	reqs = list(/obj/item/reagent_containers/food/snacks/grown/ash_flora/shavings = 2)
+	time = 2 SECONDS
+	category = CAT_PRIMAL
 
 /datum/crafting_recipe/mushroom_bowl
 	name = "Mushroom Bowl"


### PR DESCRIPTION
Adds mushroom wood. Its just normal wood that can be made with polypore mushroom shavings, 2 shavings per plank. Incredibly inefficient and slow to make a sizable amount of wood this way, but allows you to make mortars and pestles on lavaland without being ashwalkers/lifebringers.

also tweaks the TOME OF HERBAL KNOWLEDGE to include knowledge of this grand new discovery.

# Changelog

:cl:  
rscadd: You can make woodplanks out of polypore mushroom shavings now.
tweak: adds info about mushroom wood to tome of herbal knowledge
/:cl:
