### PR TITLE
allows the mining webbing to hold regen core stabilizers so it's not completely terrible

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -305,6 +305,7 @@
 		/obj/item/storage/pill_bottle,
 		/obj/item/stack/ore,
 		/obj/item/reagent_containers/food/drinks,
+		/obj/item/hivelordstabilizer,
 		/obj/item/organ/regenerative_core,
 		/obj/item/wormhole_jaunter,
 		/obj/item/storage/bag/plants,


### PR DESCRIPTION
# Document the changes in your pull request

I've wanted to do this ever since I tried to use the damn thing for the first time and realized it was actually bad and have put my ka on the belt slot ever since

I still won't use it because belt KA is good and if you say it's not you're wrong but it'll help with organizing your webbing if you want to put cores on it

# Wiki Documentation

exporerr webbing can now hold core stabilizers

# Changelog

:cl:  
tweak: explorer webbing can now hold core stabilizers
/:cl:
