### PR TITLE
makes the medical webbing a reskinned medical belt since as is it's terrible

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -134,7 +134,6 @@
 	new /obj/item/radio/headset/headset_cargo(src)
 	new /obj/item/storage/firstaid/toxin(src)
 	new /obj/item/clothing/mask/gas/explorer(src)
-	new /obj/item/storage/belt/medical(src)
 	new /obj/item/pickaxe(src)
 	new /obj/item/twohanded/binoculars(src)
 	new /obj/item/clothing/ears/earmuffs(src)

--- a/code/modules/clothing/outfits/plasmaman.dm
+++ b/code/modules/clothing/outfits/plasmaman.dm
@@ -445,7 +445,7 @@
 		/obj/item/kitchen/knife/combat/survival = 1,\
 		/obj/item/gps/mining = 1,\
 		/obj/item/storage/box/plasmaman = 1)
-	belt = /obj/item/storage/belt/mining/medical
+	belt = /obj/item/storage/belt/medical/mining
 	ears = /obj/item/radio/headset/headset_medcargo
 	glasses = /obj/item/clothing/glasses/hud/health/meson
 	shoes = /obj/item/clothing/shoes/workboots/mining

--- a/yogstation/code/game/objects/items/storage/belt.dm
+++ b/yogstation/code/game/objects/items/storage/belt.dm
@@ -1,36 +1,5 @@
-/obj/item/storage/belt/mining/medical
+/obj/item/storage/belt/medical/mining
 	icon_state = "explorer2"
 	item_state = "explorer2"
 	name = "medical webbing"
 	desc = "A combat belt cherished by emergency medics in every corner of the galaxy."
-
-/obj/item/storage/belt/mining/medical/Initialize()
-	. = ..()
-	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_w_class = WEIGHT_CLASS_BULKY
-	STR.can_hold = typecacheof(list(
-		/obj/item/pickaxe,
-		/obj/item/bodybag,
-		/obj/item/healthanalyzer,
-		/obj/item/stack/medical,
-		/obj/item/extinguisher/mini,
-		/obj/item/clothing/mask/breath,
-		/obj/item/tank/internals/emergency_oxygen,
-		/obj/item/stack/medical/gauze,
-		/obj/item/lighter,
-		/obj/item/radio,
-		/obj/item/clothing/gloves/,
-		/obj/item/reagent_containers/hypospray,
-		/obj/item/reagent_containers/dropper,
-		/obj/item/reagent_containers/glass/beaker,
-		/obj/item/reagent_containers/glass/bottle,
-		/obj/item/reagent_containers/pill,
-		/obj/item/reagent_containers/syringe,
-		/obj/item/key/,
-		/obj/item/stack/sheet/animalhide,
-		/obj/item/stack/sheet/sinew,
-		/obj/item/stack/sheet/bone,
-		/obj/item/gps,
-		/obj/item/stack/ore/bluespace_crystal,
-		/obj/item/reagent_containers/food/drinks
-	))

--- a/yogstation/code/modules/jobs/job_types/mining_medic.dm
+++ b/yogstation/code/modules/jobs/job_types/mining_medic.dm
@@ -34,7 +34,7 @@
 	backpack_contents = list(/obj/item/roller = 1,\
 		/obj/item/kitchen/knife/combat/survival = 1,\
 		/obj/item/gps/mining = 1)
-	belt = /obj/item/storage/belt/mining/medical
+	belt = /obj/item/storage/belt/medical/mining
 	ears = /obj/item/radio/headset/headset_medcargo
 	glasses = /obj/item/clothing/glasses/hud/health/meson
 	shoes = /obj/item/clothing/shoes/workboots/mining


### PR DESCRIPTION
# Document the changes in your pull request

As much fun as it is carrying around a duffle bag to pretend the medical webbing isn't a straight downgrade to the medical belt I think it'd be better off being actually viable

# Wiki Documentation

medical webbing storage changed from a very small list to be identical to medical belts

# Changelog

:cl:  
tweak: medical webbing is now a reskinned medical belt
rscdel: removes the spare medical belt from the mining medic's locker because they'll start with what is effectively one anyways
/:cl:
