### PR TITLE
medbelts cant carry viro or chem bags, and have 3 less weight slots

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -152,7 +152,7 @@
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_w_class = WEIGHT_CLASS_BULKY
 	STR.max_items = 12
-	STR.max_combined_w_class = 21
+	STR.max_combined_w_class = 18
 	STR.set_holdable(list(
 		/obj/item/healthanalyzer,
 		/obj/item/dnainjector,
@@ -191,8 +191,6 @@
 		/obj/item/clothing/glasses,
 		/obj/item/wrench/medical,
 		/obj/item/clothing/mask/muzzle,
-		/obj/item/storage/bag/chemistry,
-		/obj/item/storage/bag/bio,
 		/obj/item/reagent_containers/blood,
 		/obj/item/tank/internals/emergency_oxygen,
 		/obj/item/gun/syringe/syndicate,


### PR DESCRIPTION
As the title says

3 less weight slots does not mean the belt has 3 less slots. Previously the medbelt could hold UP TO 12 items, but had a limit of 21 weight slots, so it could hold like 7 normal sized items or up to 12 tiny sized items. Now it has 18 so it can hold up to 6 normal sized items or still 12 tiny sized items, or a mix match, etc.

good for game because power gamers do not need to hold this much crap

# Changelog

:cl:  
tweak: medbelts cant carry viro or chem bags, and have 3 less weight slots
/:cl:
