### PR TITLE
reduce armor polish cost from 6 to 2

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1286,7 +1286,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			Reinforced with nanite technology, you are able to stay looking good while bashing heads in. \
 			Beware, you can only polish suits and headgear!"
 	item = /obj/item/armorpolish
-	cost = 6
+	cost = 2
 
 
 


### PR DESCRIPTION
# Document the changes in your pull request

giving a random piece of clothes extremely basic armor is not on par with other 6 tc items like implants or the emag, it's roughly on par with the chamkit which gives a piece of chameleon armor that sucks compared to generic armor but has other stuff like an armored jumpsuit

also I think this is closer to the initial amount when i spitballed the idea for an armor buff to outerwear but I can't find anything to back that up in under 5 minutes

# Wiki Documentation

armor polish cost 6 > 2

# Changelog


:cl:  
tweak: armor polish is now 2 tc down from 6
/:cl:
