### PR TITLE
Disables Omegastation

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -19,7 +19,7 @@ endmap
 
 map omegastation
 	maxplayers 35
-	votable
+	disabled
 endmap
 
 map yogsmeta


### PR DESCRIPTION
# Document the changes in your pull request

Long overdue, should have been done when we added kilo, 
there are too many maps that we have to maintain right now and this will help reduce that amount.
Data speaks for itself, in the past 6 months omega has been played 9 (nine) times.
![image](https://user-images.githubusercontent.com/48154165/143069767-14cf55b5-7ece-4bfc-a6b2-70d4b91864af.png)


# Wiki Documentation

Disables Omegastation, doesnt remove it yet, just makes it not pickable

# Changelog

:cl:  
tweak: Disables Omegastation
/:cl:
