### PR TITLE
Fix bar shutters not having bartender access

### DIFF
--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_casino.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_casino.dmm
@@ -842,19 +842,6 @@
 /obj/effect/spawner/xmastree,
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
-"qD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "Bar Shutters Control";
-	pixel_x = -26;
-	pixel_y = 24;
-	req_access_txt = "28"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "tZ" = (
 /obj/machinery/griddle,
 /turf/open/floor/plasteel/ameridiner,
@@ -1026,6 +1013,19 @@
 	},
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/kitchen)
+"TC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Shutters Control";
+	pixel_x = -26;
+	pixel_y = 24;
+	req_access_txt = "25"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "Uk" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/item/toy/figure/chef,
@@ -1279,7 +1279,7 @@ ax
 aK
 aW
 be
-qD
+TC
 cm
 cm
 bZ


### PR DESCRIPTION
# Document the changes in your pull request

Fixes #12724 

# Changelog

:cl:  
bugfix: fixed bartender shutters having the wrong access on the casino bar 
/:cl:
