### PR TITLE
Prevents cogscarabs from heralding Ratvar

### DIFF
--- a/code/modules/antagonists/clockcult/clock_structures/heralds_beacon.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/heralds_beacon.dm
@@ -68,7 +68,7 @@
 	if(!available)
 		to_chat(user, span_danger("You can no longer vote with [src]."))
 		return
-	if(istype(M, /mob/living/simple_animal/drone/cogscarab))
+	if(istype(user, /mob/living/simple_animal/drone/cogscarab))
 		to_chat(user, span_danger("You are unable to activate [src]."))
 		return
 

--- a/code/modules/antagonists/clockcult/clock_structures/heralds_beacon.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/heralds_beacon.dm
@@ -68,7 +68,7 @@
 	if(!available)
 		to_chat(user, span_danger("You can no longer vote with [src]."))
 		return
-	if(issilicon(user))
+	if(istype(M, /mob/living/simple_animal/drone/cogscarab))
 		to_chat(user, span_danger("You are unable to activate [src]."))
 		return
 

--- a/code/modules/antagonists/clockcult/clock_structures/heralds_beacon.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/heralds_beacon.dm
@@ -68,6 +68,10 @@
 	if(!available)
 		to_chat(user, span_danger("You can no longer vote with [src]."))
 		return
+	if(issilicon(user))
+		to_chat(user, span_danger("You are unable to activate [src]."))
+		return
+
 	var/voting = !(user.key in voters)
 	if(alert(user, "[voting ? "Cast a" : "Undo your"] vote to activate the beacon?", "Herald's Beacon", "Change Vote", "Cancel") == "Cancel")
 		return


### PR DESCRIPTION
# Document the changes in your pull request

Disallows cog-scarabs from declaring war to prevents them from overriding the decisions of the human clockies.

Fixes #12713 

# Changelog

:cl:  
rscdel: Removed the ability for cogscarabs to herald Ratvar
/:cl:
