### PR TITLE
[admin] Fix for being unable to refresh MFA logins due to duplicate primary keys

### DIFF
--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -2,11 +2,19 @@ Any time you make a change to the schema files, remember to increment the databa
 
 The latest database version is 5.6; The query to update the schema revision table is:
 
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 8);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 9);
 or
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 8);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 9);
 
 In any query remember to add a prefix to the table names if you use one.
+
+version 5.9 23 November 2021, by adamsogm
+
+Adds the datetime column to the primary key for the MFA table
+
+ALTER TABLE ss13_mfa_logins
+    DROP PRIMARY KEY,
+    ADD PRIMARY KEY (`ckey`,`ip`,`cid`, `datetime`);
 
 version 5.8 25 October 2021, by adamsogm
 

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -324,7 +324,7 @@ CREATE TABLE IF NOT EXISTS `mfa_logins` (
 	`ip` int(10) unsigned NOT NULL,
 	`cid` varchar(32) NOT NULL,
 	`datetime` timestamp NOT NULL DEFAULT current_timestamp(),
-	PRIMARY KEY (`ckey`,`ip`,`cid`)
+	PRIMARY KEY (`ckey`,`ip`,`cid`, `datetime`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 DROP TABLE IF EXISTS `misc`;

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -325,7 +325,7 @@ CREATE TABLE IF NOT EXISTS `SS13_mfa_logins` (
 	`ip` int(10) unsigned NOT NULL,
 	`cid` varchar(32) NOT NULL,
 	`datetime` timestamp NOT NULL DEFAULT current_timestamp(),
-	PRIMARY KEY (`ckey`,`ip`,`cid`)
+	PRIMARY KEY (`ckey`,`ip`,`cid`,`datetime`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 DROP TABLE IF EXISTS `SS13_misc`;

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -21,7 +21,7 @@
   * make sure you add an update to the schema_version stable in the db changelog
   */
 
-#define DB_MINOR_VERSION 7
+#define DB_MINOR_VERSION 9
 
 //! ## Timing subsystem
 /**


### PR DESCRIPTION
# Document the changes in your pull request

Fixes the SQL error caused by refreshing your login from the same IP/CID as before due to duplicate primary keys

# Changelog

:cl:  
bugfix: fixed being unable to refresh mfa logins
/:cl:
