### PR TITLE
reduces stuttering from vampire screeches to be about 1 minute

### DIFF
--- a/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -369,7 +369,7 @@
 				to_chat(C, span_warning("<font size='3'><b>You hear a ear piercing shriek and your senses dull!</font></b>"))
 				C.Knockdown(40)
 				C.adjustEarDamage(0, 30)
-				C.stuttering = 250
+				C.stuttering = 30
 				C.Paralyze(40)
 				C.Jitter(150)
 	for(var/obj/structure/window/W in view(4))


### PR DESCRIPTION
500 seconds is stupid
fixes #12719

:cl:  
tweak: vampire screech will now only cause you to stutter for about a minute because it used to be for around like 5
/:cl:
