### PR TITLE
halves the amount of bleeding scalpel steps cause because it's apparently quite a lot

### DIFF
--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -5,7 +5,7 @@
 	implements = list(TOOL_SCALPEL = 100, /obj/item/melee/transforming/energy/sword = 75, /obj/item/kitchen/knife = 65,
 		/obj/item/shard = 45, /obj/item = 30) // 30% success with any sharp item.
 	time = 16
-	var/bleeding = 10 //how much bleeding you get from this being done
+	var/bleeding = 5 //how much bleeding you get from this being done
 
 /datum/surgery_step/incise/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, span_notice("You begin to make an incision in [target]'s [parse_zone(target_zone)]..."),


### PR DESCRIPTION
# Document the changes in your pull request

this kills the crab

:cl:  
tweak: bleeding from surgeries will now probably kill people slightly less
/:cl:
