### PR TITLE
Disables players from initiating a map-change vote

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -154,7 +154,7 @@ ID_CONSOLE_JOBSLOT_DELAY 30
 #ALLOW_VOTE_MODE
 
 ## allow players to initiate a map-change vote
-ALLOW_VOTE_MAP
+#ALLOW_VOTE_MAP
 
 ## min delay (deciseconds) between voting sessions (default 10 minutes)
 VOTE_DELAY 6000


### PR DESCRIPTION
As far as I can tell, map-change votes are exclusively used when the map is literally anything other than box, which is way over played as you can see by the data presented in #12726 (Which this PR also conflicts with)

This isn't a "meme PR" I genuinely think that the obsession with box is bad and initiating a map-change vote whenever the map isn't box is bad.

I'm aware that this PR will probably not do anything, but it's better than whining in Discord or the Forums about it.

:cl:  
tweak: Players can no longer initiate map votes.
/:cl:
