### PR TITLE
fixes spelling mistake in sec officer alt job title

### DIFF
--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -15,7 +15,7 @@
 
 	outfit = /datum/outfit/job/security
 
-	alt_titles = list("Threat Response Officer", "Civilan Protection Officer", "Security Cadet", "Corporate Marine")
+	alt_titles = list("Threat Response Officer", "Civilian Protection Officer", "Security Cadet", "Corporate Marine")
 
 	access = list(ACCESS_SECURITY, ACCESS_SEC_DOORS, ACCESS_BRIG, ACCESS_COURT, ACCESS_MAINT_TUNNELS, ACCESS_MECH_SECURITY, ACCESS_MORGUE, ACCESS_WEAPONS, ACCESS_FORENSICS_LOCKERS, ACCESS_MINERAL_STOREROOM)
 	minimal_access = list(ACCESS_SECURITY, ACCESS_SEC_DOORS, ACCESS_BRIG, ACCESS_COURT, ACCESS_WEAPONS, ACCESS_MECH_SECURITY, ACCESS_MINERAL_STOREROOM) // See /datum/job/officer/get_access()

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -117,7 +117,7 @@ GLOBAL_LIST_INIT(alt_security_positions, list(
 	"Security Commander", "Security Chief",
 	"Brig Watchman", "Brig Superintendent", "Security Staff Sergeant", "Security Dispatcher", "Prison Supervisor",
 	"Investigator", "Forensic Analyst", "Investigative Cadet", "Private Eye", "Inspector",
-	"Threat Response Officer", "Civilan Protection Officer", "Security Cadet", "Corporate Marine",
+	"Threat Response Officer", "Civilian Protection Officer", "Security Cadet", "Corporate Marine",
 	))
 
 GLOBAL_LIST_INIT(alt_nonhuman_positions, list(


### PR DESCRIPTION
# Document the changes in your pull request
https://github.com/yogstation13/Yogstation/issues/12754

civilan -> civilian 
# Changelog
:cl:  
bugfix: civilan -> civilian 
/:cl:
