### PR TITLE
makes modify transform properly scale sprites

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -356,15 +356,15 @@
 /datum/mutation/human/gigantism/on_acquiring(mob/living/carbon/human/owner)
 	if(..())
 		return
-	owner.resize = 1.25
-	owner.update_transform()
+	owner.transform = owner.transform.Scale(1, 1.25)
+	passtable_on(owner, GENETIC_MUTATION)
 	owner.visible_message(span_danger("[owner] suddenly grows!"), span_notice("Everything around you seems to shrink.."))
 
 /datum/mutation/human/gigantism/on_losing(mob/living/carbon/human/owner)
 	if(..())
 		return
-	owner.resize = 0.8
-	owner.update_transform()
+	owner.transform = owner.transform.Scale(1, 0.8)
+	passtable_off(owner, GENETIC_MUTATION)
 	owner.visible_message(span_danger("[owner] suddenly shrinks!"), span_notice("Everything around you seems to grow.."))
 
 /datum/mutation/human/spastic

--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -18,7 +18,7 @@
 
 	if(resize != RESIZE_DEFAULT_SIZE)
 		changed++
-		ntransform.Scale(resize)
+		ntransform.Scale(resize, resize)
 		resize = RESIZE_DEFAULT_SIZE
 
 	if(changed)

--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -18,7 +18,10 @@
 
 	if(resize != RESIZE_DEFAULT_SIZE)
 		changed++
-		ntransform.Scale(resize, resize)
+		if(lying)
+			ntransform.Scale(1, resize)
+		else
+			ntransform.Scale(resize)
 		resize = RESIZE_DEFAULT_SIZE
 
 	if(changed)


### PR DESCRIPTION
# Document the changes in your pull request

turns out this has only been scaling the x axis the WHOLE TIME when it should be scaling BOTH x AND y axis
either that or I am about to unleash some horrible evil that has been kept locked away in the code for over a thousand millenea


# Changelog


:cl:  
bugfix: automatic scaling no longer forgets half of its job
/:cl:
