### PR TITLE
4 new traits + some trait rebalancing (big) (epic) (clickbait)

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -250,6 +250,9 @@
 #define TRAIT_FRIENDLY			"friendly"
 #define TRAIT_ALLERGIC			"allergic"
 #define TRAIT_KLEPTOMANIAC		"kleptomaniac"
+#define TRAIT_EAT_LESS			"eat_less"
+#define TRAIT_CRAFTY			"crafty"
+#define TRAIT_ANOREXIC			"anorexic"
 
 // common trait sources
 #define TRAIT_GENERIC "generic"

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -157,6 +157,8 @@
 /datum/component/personal_crafting/proc/construct_item(mob/user, datum/crafting_recipe/R)
 	var/list/contents = get_surroundings(user)
 	var/send_feedback = 1
+	if(HAS_TRAIT(user, TRAIT_CRAFTY))
+		R.time *= 0.75
 	if(check_contents(R, contents))
 		if(check_tools(user, R, contents))
 			if(do_after(user, R.time, target = user))

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -4,7 +4,7 @@
 /datum/quirk/no_taste
 	name = "Ageusia"
 	desc = "You can't taste anything! Toxic food will still poison you."
-	value = 1
+	value = 2
 	mob_trait = TRAIT_AGEUSIA
 	gain_text = span_notice("You can't taste anything!")
 	lose_text = span_notice("You can taste again!")
@@ -13,7 +13,7 @@
 /datum/quirk/alcohol_tolerance
 	name = "Alcohol Tolerance"
 	desc = "You become drunk more slowly and suffer fewer drawbacks from alcohol."
-	value = 1
+	value = 2
 	mob_trait = TRAIT_ALCOHOL_TOLERANCE
 	gain_text = span_notice("You feel like you could drink a whole keg!")
 	lose_text = span_danger("You don't feel as resistant to alcohol anymore. Somehow.")
@@ -22,7 +22,7 @@
 /datum/quirk/apathetic
 	name = "Apathetic"
 	desc = "You just don't care as much as other people. That's nice to have in a place like this, I guess."
-	value = 1
+	value = 2
 	mood_quirk = TRUE
 	medical_record_text = "Patient was administered the Apathy Evaluation Scale but did not bother to complete it."
 
@@ -40,7 +40,7 @@
 /datum/quirk/drunkhealing
 	name = "Drunken Resilience"
 	desc = "Nothing like a good drink to make you feel on top of the world. Whenever you're drunk, you slowly recover from injuries."
-	value = 2
+	value = 4
 	mob_trait = TRAIT_DRUNK_HEALING
 	gain_text = span_notice("You feel like a drink would do you good.")
 	lose_text = span_danger("You no longer feel like drinking would ease your pain.")
@@ -49,7 +49,7 @@
 /datum/quirk/empath
 	name = "Empath"
 	desc = "Whether it's a sixth sense or careful study of body language, it only takes you a quick glance at someone to understand how they feel."
-	value = 2
+	value = 4
 	mob_trait = TRAIT_EMPATH
 	gain_text = span_notice("You feel in tune with those around you.")
 	lose_text = span_danger("You feel isolated from others.")
@@ -58,7 +58,7 @@
 /datum/quirk/freerunning
 	name = "Freerunning"
 	desc = "You're great at quick moves! You can climb tables more quickly."
-	value = 2
+	value = 4
 	mob_trait = TRAIT_FREERUNNING
 	gain_text = span_notice("You feel lithe on your feet!")
 	lose_text = span_danger("You feel clumsy again.")
@@ -77,7 +77,7 @@
 /datum/quirk/jolly
 	name = "Jolly"
 	desc = "You sometimes just feel happy, for no reason at all."
-	value = 1
+	value = 2
 	mob_trait = TRAIT_JOLLY
 	mood_quirk = TRUE
 	medical_record_text = "Patient demonstrates constant euthymia irregular for environment. It's a bit much, to be honest."
@@ -85,7 +85,7 @@
 /datum/quirk/light_step
 	name = "Light Step"
 	desc = "You walk with a gentle step; stepping on sharp objects is quieter, less painful and you won't leave footprints behind you."
-	value = 1
+	value = 2
 	mob_trait = TRAIT_LIGHT_STEP
 	gain_text = span_notice("You walk with a little more litheness.")
 	lose_text = span_danger("You start tromping around like a barbarian.")
@@ -112,7 +112,7 @@
 /datum/quirk/night_vision
 	name = "Night Vision"
 	desc = "You can see slightly more clearly in full darkness than most people."
-	value = 1
+	value = 2
 	mob_trait = TRAIT_NIGHT_VISION
 	gain_text = span_notice("The shadows seem a little less dark.")
 	lose_text = span_danger("Everything seems a little darker.")
@@ -144,14 +144,14 @@
 /datum/quirk/selfaware
 	name = "Self-Aware"
 	desc = "You know your body well, and can accurately assess the extent of your wounds."
-	value = 2
+	value = 4
 	mob_trait = TRAIT_SELF_AWARE
 	medical_record_text = "Patient demonstrates an uncanny knack for self-diagnosis."
 
 /datum/quirk/skittish
 	name = "Skittish"
 	desc = "You can conceal yourself in danger. Ctrl-shift-click a closed locker to jump into it, as long as you have access."
-	value = 2
+	value = 4
 	mob_trait = TRAIT_SKITTISH
 	medical_record_text = "Patient demonstrates a high aversion to danger and has described hiding in containers out of fear."
 
@@ -172,7 +172,7 @@
 /datum/quirk/toxic_tastes
 	name = "Toxic Tastes"
 	desc = "You have a taste for normally dangerous foods."
-	value = 1
+	value = 2
 	gain_text = span_notice("Your stomach feels robust.")
 	lose_text = span_notice("Your stomach feels normal again.")
 	medical_record_text = "Patient demonstrates abnormal ability to process certain toxins."
@@ -215,3 +215,50 @@
 	gain_text = span_notice("You feel HONGRY.")
 	lose_text = span_danger("You no longer feel HONGRY.")
 	medical_record_text = "Patient demonstrates a disturbing capacity for eating."
+
+/datum/quirk/efficient_metabolism //about 25% slower hunger
+	name = "Efficient Metabolism"
+	desc = "Your metabolism is unusually efficient, allowing you to better process your food and go longer periods without eating."
+	value = 1
+	mob_trait = TRAIT_EAT_LESS
+	gain_text = span_notice("You don't feel very hungry.")
+	lose_text = span_danger("You feel a bit peckish.")
+	medical_record_text = "Patient has unusually efficient stomach metabolism and requires less sustenance to survive."
+
+/datum/quirk/crafty //about 25% faster crafting
+	name = "Crafty"
+	desc = "You're very good at making stuff, and can craft faster than others."
+	value = 2
+	mob_trait = TRAIT_CRAFTY
+	gain_text = span_notice("You feel like crafting some stuff.")
+	lose_text = span_danger("You lose the itch to craft.")
+	medical_record_text = "Patient is unusually speedy when creating crafts."
+
+/datum/quirk/cyberorgan //random upgraded cybernetic organ
+	name = "Cybernetic Organ"
+	desc = "Due to a past incident you lost function of one of your organs, but now have a fancy upgraded cybernetic organ!"
+	value = 6
+	var/slot_string = "organ"
+	medical_record_text = "During physical examination, patient was found to have an upgraded cybernetic organ."
+
+/datum/quirk/cyberorgan/on_spawn()
+	var/organ_slot = pick(ORGAN_SLOT_LUNGS, ORGAN_SLOT_HEART, ORGAN_SLOT_LIVER)
+	var/mob/living/carbon/human/H = quirk_holder
+	var/obj/item/organ/old_part = H.getorganslot(organ_slot)
+	var/obj/item/organ/prosthetic
+	switch(organ_slot)
+		if(ORGAN_SLOT_LUNGS)
+			prosthetic = new/obj/item/organ/lungs/cybernetic/upgraded(quirk_holder)
+			slot_string = "lungs"
+		if(ORGAN_SLOT_HEART)
+			prosthetic = new/obj/item/organ/heart/cybernetic/upgraded(quirk_holder)
+			slot_string = "heart"
+		if(ORGAN_SLOT_LIVER)
+			prosthetic = new/obj/item/organ/liver/cybernetic/upgraded(quirk_holder)
+			slot_string = "liver"
+	prosthetic.Insert(H)
+	qdel(old_part)
+	H.regenerate_icons()
+
+/datum/quirk/cyberorgan/post_add()
+	to_chat(quirk_holder, "<span class='boldannounce'>Your [slot_string] has been replaced with an upgraded cybernetic variant.</span>")

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -49,7 +49,7 @@
 /datum/quirk/empath
 	name = "Empath"
 	desc = "Whether it's a sixth sense or careful study of body language, it only takes you a quick glance at someone to understand how they feel."
-	value = 4
+	value = 1
 	mob_trait = TRAIT_EMPATH
 	gain_text = span_notice("You feel in tune with those around you.")
 	lose_text = span_danger("You feel isolated from others.")

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -3,7 +3,7 @@
 /datum/quirk/badback
 	name = "Bad Back"
 	desc = "Thanks to your poor posture, backpacks and other bags never sit right on your back. More evenly weighted objects are fine, though."
-	value = -2
+	value = -4
 	mood_quirk = TRUE
 	gain_text = span_danger("Your back REALLY hurts!")
 	lose_text = span_notice("Your back feels better.")
@@ -19,7 +19,7 @@
 /datum/quirk/blooddeficiency
 	name = "Blood Deficiency"
 	desc = "Your body can't produce enough blood to sustain itself."
-	value = -2
+	value = -4
 	gain_text = span_danger("You feel your vigor slowly fading away.")
 	lose_text = span_notice("You feel vigorous again.")
 	medical_record_text = "Patient requires regular treatment for blood loss due to low production of blood."
@@ -35,7 +35,7 @@
 /datum/quirk/blindness
 	name = "Blind"
 	desc = "You are completely blind, nothing can counteract this."
-	value = -4
+	value = -9
 	gain_text = span_danger("You can't see anything.")
 	lose_text = span_notice("You miraculously gain back your vision.")
 	medical_record_text = "Patient has permanent blindness."
@@ -53,7 +53,7 @@
 /datum/quirk/brainproblems
 	name = "Brain Tumor"
 	desc = "You have a little friend in your brain that is slowly destroying it. Better bring some mannitol!"
-	value = -3
+	value = -6
 	gain_text = span_danger("You feel smooth.")
 	lose_text = span_notice("You feel wrinkled again.")
 	medical_record_text = "Patient has a tumor in their brain that is slowly driving them to brain death."
@@ -78,7 +78,7 @@
 /datum/quirk/deafness
 	name = "Deaf"
 	desc = "You are incurably deaf."
-	value = -2
+	value = -6
 	mob_trait = TRAIT_DEAF
 	gain_text = span_danger("You can't hear anything.")
 	lose_text = span_notice("You're able to hear again!")
@@ -88,7 +88,7 @@
 	name = "Depression"
 	desc = "You sometimes just hate life."
 	mob_trait = TRAIT_DEPRESSION
-	value = -1
+	value = -2
 	gain_text = span_danger("You start feeling depressed.")
 	lose_text = span_notice("You no longer feel depressed.") //if only it were that easy!
 	medical_record_text = "Patient has a mild mood disorder, causing them to experience episodes of depression."
@@ -97,7 +97,7 @@
 /datum/quirk/family_heirloom
 	name = "Family Heirloom"
 	desc = "You are the current owner of an heirloom, passed down for generations. You have to keep it safe!"
-	value = -1
+	value = -2
 	mood_quirk = TRUE
 	var/obj/item/heirloom
 	var/where
@@ -219,7 +219,7 @@
 /datum/quirk/heavy_sleeper
 	name = "Heavy Sleeper"
 	desc = "You sleep like a rock! Whenever you're put to sleep or knocked unconscious, you take a little bit longer to wake up and cant see anything."
-	value = -2
+	value = -4
 	mob_trait = TRAIT_HEAVY_SLEEPER
 	gain_text = span_danger("You feel sleepy.")
 	lose_text = span_notice("You feel awake again.")
@@ -228,7 +228,7 @@
 /datum/quirk/hypersensitive
 	name = "Hypersensitive"
 	desc = "For better or worse, everything seems to affect your mood more than it should."
-	value = -1
+	value = -2
 	gain_text = span_danger("You seem to make a big deal out of everything.")
 	lose_text = span_notice("You don't seem to make a big deal out of everything anymore.")
 	mood_quirk = TRUE //yogs
@@ -248,7 +248,7 @@
 /datum/quirk/light_drinker
 	name = "Light Drinker"
 	desc = "You just can't handle your drinks and get drunk very quickly."
-	value = -1
+	value = -2
 	mob_trait = TRAIT_LIGHT_DRINKER
 	gain_text = span_notice("Just the thought of drinking alcohol makes your head spin.")
 	lose_text = span_danger("You're no longer severely affected by alcohol.")
@@ -257,7 +257,7 @@
 /datum/quirk/nearsighted //t. errorage
 	name = "Nearsighted"
 	desc = "You are nearsighted without prescription glasses, but spawn with a pair."
-	value = -1
+	value = -2
 	gain_text = span_danger("Things far away from you start looking blurry.")
 	lose_text = span_notice("You start seeing faraway things normally again.")
 	medical_record_text = "Patient requires prescription glasses in order to counteract nearsightedness."
@@ -275,7 +275,7 @@
 /datum/quirk/nyctophobia
 	name = "Nyctophobia"
 	desc = "As far as you can remember, you've always been afraid of the dark. While in the dark without a light source, you instinctually act careful, and constantly feel a sense of dread."
-	value = -1
+	value = -2
 	medical_record_text = "Patient demonstrates a fear of the dark. (Seriously?)"
 
 /datum/quirk/nyctophobia/on_process()
@@ -297,7 +297,7 @@
 /datum/quirk/nonviolent
 	name = "Pacifist"
 	desc = "The thought of violence makes you sick. So much so, in fact, that you can't hurt anyone."
-	value = -2
+	value = -4
 	mob_trait = TRAIT_PACIFISM
 	gain_text = span_danger("You feel repulsed by the thought of violence!")
 	lose_text = span_notice("You think you can defend yourself again.")
@@ -307,7 +307,7 @@
 /datum/quirk/paraplegic
 	name = "Paraplegic"
 	desc = "Your legs do not function. Nothing will ever fix this. But hey, free wheelchair!"
-	value = -3
+	value = -7
 	human_only = TRUE
 	gain_text = null // Handled by trauma.
 	lose_text = null
@@ -342,21 +342,21 @@
 /datum/quirk/poor_aim
 	name = "Poor Aim"
 	desc = "You're terrible with guns and can't line up a straight shot to save your life. Dual-wielding is right out."
-	value = -1
+	value = -2
 	mob_trait = TRAIT_POOR_AIM
 	medical_record_text = "Patient possesses a strong tremor in both hands."
 
 /datum/quirk/prosopagnosia
 	name = "Prosopagnosia"
 	desc = "You have a mental disorder that prevents you from being able to recognize faces at all."
-	value = -1
+	value = -2
 	mob_trait = TRAIT_PROSOPAGNOSIA
 	medical_record_text = "Patient suffers from prosopagnosia and cannot recognize faces."
 
 /datum/quirk/prosthetic_limb
 	name = "Prosthetic Limb"
 	desc = "An accident caused you to lose one of your limbs. Because of this, you now have a random prosthetic!"
-	value = -1
+	value = -2
 	var/slot_string = "limb"
 	var/specific = null
 	medical_record_text = "During physical examination, patient was found to have a prosthetic limb."
@@ -438,7 +438,7 @@
 /datum/quirk/social_anxiety
 	name = "Social Anxiety"
 	desc = "Talking to people is very difficult for you, and you often stutter or even lock up."
-	value = -1
+	value = -2
 	gain_text = span_danger("You start worrying about what you're saying.")
 	lose_text = span_notice("You feel easier about talking again.") //if only it were that easy!
 	medical_record_text = "Patient is usually anxious in social encounters and prefers to avoid them."
@@ -465,7 +465,7 @@
 /datum/quirk/junkie
 	name = "Junkie"
 	desc = "You can't get enough of hard drugs."
-	value = -2
+	value = -4
 	gain_text = span_danger("You suddenly feel the craving for drugs.")
 	lose_text = span_notice("You feel like you should kick your drug habit.")
 	medical_record_text = "Patient has a history of hard drugs."
@@ -550,7 +550,7 @@
 /datum/quirk/junkie/smoker
 	name = "Smoker"
 	desc = "Sometimes you just really want a smoke. Probably not great for your lungs."
-	value = -1
+	value = -2
 	mood_quirk = TRUE
 	gain_text = span_danger("You could really go for a smoke right about now.")
 	lose_text = span_notice("You feel like you should quit smoking.")
@@ -587,7 +587,7 @@
 /datum/quirk/unstable
 	name = "Unstable"
 	desc = "Due to past troubles, you are unable to recover your sanity if you lose it. Be very careful managing your mood!"
-	value = -2
+	value = -4
 	mood_quirk = TRUE
 	mob_trait = TRAIT_UNSTABLE
 	gain_text = span_danger("There's a lot on your mind right now.")
@@ -597,7 +597,7 @@
 /datum/quirk/sheltered
 	name = "Sheltered"
 	desc = "You never learned to speak galactic common."
-	value = -1
+	value = -2
 	mob_trait = TRAIT_SHELTERED
 	gain_text = span_danger("You do not speak galactic common.")
 	lose_text = span_notice("You start to put together how to speak galactic common.")
@@ -613,7 +613,7 @@
 /datum/quirk/allergic
 	name = "Allergic Reaction"
 	desc = "You have had an allergic reaction to medicine in the past. Better stay away from it!"
-	value = -1
+	value = -2
 	mob_trait = TRAIT_ALLERGIC
 	gain_text = span_danger("You remember your allergic reaction to a common medicine.")
 	lose_text = span_notice("You no longer are allergic to medicine.")
@@ -650,10 +650,10 @@
 /datum/quirk/kleptomaniac
 	name = "Kleptomaniac"
 	desc = "You have an uncontrollable urge to pick up things you see. Even things that don't belong to you."
-	value = -1
+	value = -2
 	mob_trait = TRAIT_KLEPTOMANIAC
 	gain_text = span_danger("You have an unmistakeable urge to grab nearby objects.")
-	lose_text = span_notice("You no feel the urge to steal.")
+	lose_text = span_notice("You no longer feel the urge to steal.")
 	medical_record_text = "Patient has an uncontrollable urge to steal."
 
 /datum/quirk/kleptomaniac/on_process()
@@ -673,7 +673,7 @@
 /datum/quirk/ineloquent
 	name = "Ineloquent"
 	desc = "Thinking big words makes brain go hurt."
-	value = -1
+	value = -2
 	human_only = TRUE
 	gain_text = "You feel your vocabularly slipping away."
 	lose_text = "You regrasp the full extent of your linguistic prowess."
@@ -683,3 +683,12 @@
 	var/datum/brain_trauma/mild/expressive_aphasia/T = new()
 	var/mob/living/carbon/human/H = quirk_holder
 	H.gain_trauma(T, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/hemophilia //basically permanent heparin
+	name = "Hemophiliac"
+	desc = "You can't naturally clot bleeding wounds and bleed much more from them than most people, making even small cuts possibly life threatening."
+	value = -6
+	mob_trait = TRAIT_BLOODY_MESS
+	gain_text = span_danger("You feel like your blood is thin.")
+	lose_text = span_notice("You feel like your blood is of normal thickness once more.")
+	medical_record_text = "Patient appears unable to naturally form blood clots."

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1173,6 +1173,8 @@ GLOBAL_LIST_EMPTY(mentor_races)
 		var/datum/component/mood/mood = H.GetComponent(/datum/component/mood)
 		if(mood && mood.sanity > SANITY_DISTURBED)
 			hunger_rate *= max(0.5, 1 - 0.002 * mood.sanity) //0.85 to 0.75
+		if(HAS_TRAIT(H, TRAIT_EAT_LESS))
+			hunger_rate *= 0.75 //hunger rate reduced by about 25%
 		// Whether we cap off our satiety or move it towards 0
 		if(H.satiety > MAX_SATIETY)
 			H.satiety = MAX_SATIETY


### PR DESCRIPTION
Basically, all traits have their point values doubled because the old amount of points was rather restricting, since you pretty much only had a range of 4 point values, but now its more reasonable to go up to a range of 8. Basically this means that traits that used to give 1 point give 2, and perks that costed 1 point cost 2, and so on. This ultimately means that asides from the following traits the costs remain the exact same overall. Voracious, tagger, empath, photographer, musician, spiritual, and friendly all have only 1 point instead of 2 points though because they're not very powergamey. Meanwhile, paraplegic and blind give you an extra point (7 for paraplegic and 9 for blind) because they're near completely debilitating.

New traits

NEGATIVE: Hemophiliac - gives 6 points, basically permanent heparin. Bleeding wounds bleed much more and do not clot on their own, which makes even small cut wounds fatal if you don't get first aid soon.

POSITIVE: Efficient metabolism - Costs 1 point. You hunger 25% slower. Nice if you don't like taking the time to eat.

POSITIVE: Crafty - Costs 2 points. You craft 25% faster. Nice if your job includes a lot of crafting, like if you're a chef.

POSITIVE: Cyber Organ - Costs 6 points. You start with either an upgraded cybernetic heart, liver, or lungs. Preternis players might like this to further their total machine body goals from the get-go.

# Changelog

:cl:  
rscadd: Adds 4 new traits: Hemophiliac, Efficient Metabolism, Crafty, and Cyber Organ.
tweak: trait points are doubled across the board to allow for more middleground. Voracious, tagger, photographer, musician, spiritual, empath, and friendly cost less while Blind and Paraplegic give an extra point.
/:cl:
