### PR TITLE
Fixes some IDs not having original assignments

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -280,6 +280,7 @@ update_label("John Doe", "Clowny")
 	name = "Thirteen's ID Card (Reaper)"
 	access = list(ACCESS_MAINT_TUNNELS)
 	assignment = "Reaper"
+	originalassignment = "Reaper"
 	registered_name = "Thirteen"
 
 /obj/item/card/id/gold
@@ -346,6 +347,7 @@ update_label("John Doe", "Clowny")
 
 			registered_name = input_name
 			assignment = target_occupation
+			originalassignment = target_occupation
 			update_label()
 			forged = TRUE
 			to_chat(user, span_notice("You successfully forge the ID card."))
@@ -366,6 +368,7 @@ update_label("John Doe", "Clowny")
 		else if (popup_input == "Forge/Reset" && forged)
 			registered_name = initial(registered_name)
 			assignment = initial(assignment)
+			originalassignment = initial(originalassignment)
 			log_game("[key_name(user)] has reset \the [initial(name)] named \"[src]\" to default.")
 			update_label()
 			forged = FALSE
@@ -423,6 +426,7 @@ update_label("John Doe", "Clowny")
 	desc = "An ID straight from the Syndicate."
 	registered_name = "Syndicate"
 	assignment = "Syndicate Overlord"
+	originalassignment = "Syndicate Overlord"
 	access = list(ACCESS_SYNDICATE)
 
 /obj/item/card/id/captains_spare
@@ -434,6 +438,7 @@ update_label("John Doe", "Clowny")
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
 	registered_name = "Captain"
 	assignment = "Captain"
+	originalassignment = "Captain"
 	registered_age = null
 
 /obj/item/card/id/captains_spare/Initialize()
@@ -469,6 +474,7 @@ update_label("John Doe", "Clowny")
 	icon_state = "centcom"
 	registered_name = "Central Command"
 	assignment = "CentCom Official"
+	originalassignment = "CentCom Official"
 	registered_age = null
 
 /obj/item/card/id/centcom/silver
@@ -493,6 +499,7 @@ update_label("John Doe", "Clowny")
 	icon_state = "centcom"
 	registered_name = "Emergency Response Team Commander"
 	assignment = "Emergency Response Team Commander"
+	originalassignment = "Emergency Response Team Commander"
 	registered_age = null
 
 /obj/item/card/id/ert/debug/Initialize()
@@ -503,11 +510,13 @@ update_label("John Doe", "Clowny")
 	name = "\improper Amber Task Force ID"
 	desc = "An Amber Task Force ID card."
 	assignment = "Amber Task Force"
+	originalassignment = "Amber Task Force"
 
 /obj/item/card/id/ert/occupying
 	name = "\improper Occupying Force ID"
 	desc = "An Occupying Force ID card."
 	assignment = "Occupying Officer"
+	originalassignment = "Occupying Officer"
 
 /obj/item/card/id/ert/occupying/Initialize()
     access = list(ACCESS_SECURITY,ACCESS_BRIG,ACCESS_WEAPONS,ACCESS_SEC_DOORS,ACCESS_MAINT_TUNNELS)+get_ert_access("sec")
@@ -520,6 +529,7 @@ update_label("John Doe", "Clowny")
 /obj/item/card/id/ert/Security
 	registered_name = "Security Response Officer"
 	assignment = "Security Response Officer"
+	originalassignment = "Security Response Officer"
 
 /obj/item/card/id/ert/Security/Initialize()
 	access = get_all_accesses()+get_ert_access("sec")-ACCESS_CHANGE_IDS
@@ -528,6 +538,7 @@ update_label("John Doe", "Clowny")
 /obj/item/card/id/ert/Engineer
 	registered_name = "Engineer Response Officer"
 	assignment = "Engineer Response Officer"
+	originalassignment = "Engineer Response Officer"
 
 /obj/item/card/id/ert/Engineer/Initialize()
 	access = get_all_accesses()+get_ert_access("eng")-ACCESS_CHANGE_IDS
@@ -536,6 +547,7 @@ update_label("John Doe", "Clowny")
 /obj/item/card/id/ert/Medical
 	registered_name = "Medical Response Officer"
 	assignment = "Medical Response Officer"
+	originalassignment = "Medical Response Officer"
 
 /obj/item/card/id/ert/Medical/Initialize()
 	access = get_all_accesses()+get_ert_access("med")-ACCESS_CHANGE_IDS
@@ -544,6 +556,7 @@ update_label("John Doe", "Clowny")
 /obj/item/card/id/ert/chaplain
 	registered_name = "Religious Response Officer"
 	assignment = "Religious Response Officer"
+	originalassignment = "Religious Response Officer"
 
 /obj/item/card/id/ert/chaplain/Initialize()
 	access = get_all_accesses()+get_ert_access("sec")-ACCESS_CHANGE_IDS
@@ -552,6 +565,7 @@ update_label("John Doe", "Clowny")
 /obj/item/card/id/ert/Janitor
 	registered_name = "Janitorial Response Officer"
 	assignment = "Janitorial Response Officer"
+	originalassignment = "Janitorial Response Officer"
 
 /obj/item/card/id/ert/Janitor/Initialize()
 	access = get_all_accesses()
@@ -560,6 +574,7 @@ update_label("John Doe", "Clowny")
 /obj/item/card/id/ert/clown
 	registered_name = "Clown"
 	assignment = "Clown ERT"
+	originalassignment = "Clown ERT"
 
 /obj/item/card/id/ert/clown/Initialize()
 	access = get_all_accesses()
@@ -573,6 +588,7 @@ update_label("John Doe", "Clowny")
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
 	assignment = "Prisoner"
+	originalassignment = "Prisoner"
 	registered_name = "Scum"
 	var/goal = 0 //How far from freedom?
 	var/points = 0
@@ -637,18 +653,21 @@ update_label("John Doe", "Clowny")
 	name = "Charlie Station Security Officer's ID card"
 	desc = "A faded Charlie Station ID card. You can make out the rank \"Security Officer\"."
 	assignment = "Charlie Station Security Officer"
+	originalassignment = "Security Officer"
 	access = list(ACCESS_AWAY_GENERAL, ACCESS_AWAY_SEC)
 
 /obj/item/card/id/away/old/sci
 	name = "Charlie Station Scientist's ID card"
 	desc = "A faded Charlie Station ID card. You can make out the rank \"Scientist\"."
 	assignment = "Charlie Station Scientist"
+	originalassignment = "Scientist"
 	access = list(ACCESS_AWAY_GENERAL)
 
 /obj/item/card/id/away/old/eng
 	name = "Charlie Station Engineer's ID card"
 	desc = "A faded Charlie Station ID card. You can make out the rank \"Station Engineer\"."
 	assignment = "Charlie Station Engineer"
+	originalassignment = "Engineer"
 	access = list(ACCESS_AWAY_GENERAL, ACCESS_AWAY_ENGINE)
 
 /obj/item/card/id/away/old/apc

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -473,6 +473,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 			id.access = get_debug_access()
 			id.registered_name = H.real_name
 			id.assignment = "Captain"
+			id.originalassignment = "Captain"
 			id.update_label()
 
 			if(worn)

--- a/code/modules/antagonists/fugitive/fugitive_outfits.dm
+++ b/code/modules/antagonists/fugitive/fugitive_outfits.dm
@@ -110,5 +110,6 @@
 		return
 	var/obj/item/card/id/W = H.wear_id
 	W.assignment = "Police Officer"
+	W.originalassignment = "Police Officer"
 	W.registered_name = H.real_name
 	W.update_label()

--- a/code/modules/antagonists/highlander/highlander.dm
+++ b/code/modules/antagonists/highlander/highlander.dm
@@ -67,6 +67,7 @@
 	W.access = get_all_accesses()
 	W.access += get_all_centcom_access()
 	W.assignment = "Highlander"
+	W.originalassignment = "Highlander"
 	W.registered_name = H.real_name
 	ADD_TRAIT(W, TRAIT_NODROP, HIGHLANDER)
 	W.update_label(H.real_name)

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -233,6 +233,7 @@
 			W.access |= id_access_list
 		if(id_job)
 			W.assignment = id_job
+			W.originalassignment = id_job
 		W.registered_name = H.real_name
 		W.update_label()
 

--- a/code/modules/clothing/outfits/amber.dm
+++ b/code/modules/clothing/outfits/amber.dm
@@ -85,6 +85,7 @@
 	W.icon_state = "centcom"
 	W.registered_name = "Unknown"
 	W.assignment = "Amber Task Force"
+	W.originalassignment = "Amber Task Force"
 	W.update_label(W.registered_name, W.assignment)
 
 	H.ignores_capitalism = TRUE // Yogs -- Lets the Amber force buy a damned smoke for christ's sake

--- a/code/modules/clothing/outfits/occupying.dm
+++ b/code/modules/clothing/outfits/occupying.dm
@@ -94,6 +94,7 @@
 	W.icon_state = "centcom"
 	W.registered_name = "Unknown" // continuing the tradition of these ID's not being assigned to a particular person
 	W.assignment = "Peacekeeping Force"
+	W.originalassignment = "Peacekeeping Force"
 	W.update_label(W.registered_name, W.assignment)
 
 	H.ignores_capitalism = TRUE // Yogs -- Lets the Peacekeeping force buy a damned smoke for christ's sake

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -132,6 +132,7 @@
 	var/obj/item/card/id/W = H.wear_id
 	W.access = get_all_accesses()
 	W.assignment = "Tunnel Clown!"
+	W.originalassignment = "Clown"
 	W.registered_name = H.real_name
 	W.update_label(H.real_name)
 
@@ -196,6 +197,7 @@
 	var/obj/item/card/id/syndicate/W = H.wear_id
 	W.access = get_all_accesses()
 	W.assignment = "Reaper"
+	W.originalassignment = "Reaper"
 	W.registered_name = H.real_name
 	W.update_label(H.real_name)
 
@@ -224,6 +226,7 @@
 	W.access = get_all_accesses()
 	W.access += get_centcom_access("Special Ops Officer")
 	W.assignment = "Special Ops Officer"
+	W.originalassignment = "Special Ops Officer"
 	W.registered_name = H.real_name
 	W.update_label()
 
@@ -305,6 +308,7 @@
 	W.access = get_all_accesses()
 	W.access += get_centcom_access("Admiral")
 	W.assignment = "Admiral"
+	W.originalassignment = "Admiral"
 	W.registered_name = H.real_name
 	W.update_label()
 
@@ -326,6 +330,7 @@
 
 	var/obj/item/card/id/W = H.wear_id
 	W.assignment = "Assistant"
+	W.originalassignment = "Assistant"
 	W.registered_name = H.real_name
 	W.update_label()
 
@@ -379,6 +384,7 @@
 	W.access = get_all_accesses()//They get full station access.
 	W.access += get_centcom_access("Death Commando")//Let's add their alloted CentCom access.
 	W.assignment = "Death Commando"
+	W.originalassignment = "Death Commando"
 	W.registered_name = splittext(H.tag, "_")[2] // 412's ID Card (Death Commando); deathsquad are so edgy they are just numbers
 	W.update_label(W.registered_name, W.assignment)
 

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -268,6 +268,8 @@
 			C.assignment = J.title
 		if(H.mind?.assigned_role)
 			C.originalassignment = H.mind.assigned_role
+		else
+			C.originalassignment = J.title
 		if(H.age)
 			C.registered_age = H.age
 		C.update_label()

--- a/code/modules/jobs/job_types/centcom.dm
+++ b/code/modules/jobs/job_types/centcom.dm
@@ -39,6 +39,7 @@
 	W.access = get_centcom_access("CentCom Official")
 	W.access += ACCESS_WEAPONS
 	W.assignment = "CentCom Official"
+	W.originalassignment = "CentCom Official"
 	W.registered_name = H.real_name
 	W.update_label()
 
@@ -73,6 +74,7 @@
 	W.access = get_all_accesses()
 	W.access += get_centcom_access("CentCom Official")
 	W.assignment = "CentCom Captain"
+	W.originalassignment = "CentCom Captain"
 	W.registered_name = H.real_name
 	W.update_label()
 
@@ -106,6 +108,7 @@
 	W.access = get_all_accesses()
 	W.access += get_centcom_access("CentCom Official")
 	W.assignment = "CentCom Major"
+	W.originalassignment = "CentCom Major"
 	W.registered_name = H.real_name
 	W.update_label()
 
@@ -140,6 +143,7 @@
 	W.access = get_all_accesses()
 	W.access += get_centcom_access("CentCom Commander")
 	W.assignment = "CentCom Commodore"
+	W.originalassignment = "CentCom Commodore"
 	W.registered_name = H.real_name
 	W.update_label()
 
@@ -174,6 +178,7 @@
 	W.access = get_all_accesses()
 	W.access += get_centcom_access("CentCom Commander")
 	W.assignment = "CentCom Colonel"
+	W.originalassignment = "CentCom Colonel"
 	W.registered_name = H.real_name
 	W.update_label()
 
@@ -208,6 +213,7 @@
 	W.access = get_all_accesses()
 	W.access += get_centcom_access("CentCom Commander")
 	W.assignment = "CentCom Rear-Admiral"
+	W.originalassignment = "CentCom Rear-Admiral"
 	W.registered_name = H.real_name
 	W.update_label()
 
@@ -242,6 +248,7 @@
 	W.access = get_all_accesses()
 	W.access += get_centcom_access("CentCom Commander")
 	W.assignment = "CentCom Admiral"
+	W.originalassignment = "CentCom Admiral"
 	W.registered_name = H.real_name
 	W.update_label()
 
@@ -276,6 +283,7 @@
 	W.access = get_all_accesses()
 	W.access += get_centcom_access("CentCom Commander")
 	W.assignment = "CentCom Grand Admiral"
+	W.originalassignment = "CentCom Grand Admiral"
 	W.registered_name = H.real_name
 	W.update_label()
 

--- a/code/modules/paperwork/contract.dm
+++ b/code/modules/paperwork/contract.dm
@@ -291,12 +291,14 @@
 		id.icon_state = "gold"
 		id.access = get_all_accesses()+get_all_centcom_access()
 		id.assignment = "Captain"
+		id.originalassignment = "Captain"
 		id.update_label()
 	else
 		id = new /obj/item/card/id/gold(user.loc)
 		id.registered_name = user.real_name
 		id.access = get_all_accesses()+get_all_centcom_access()
 		id.assignment = "Captain"
+		id.originalassignment = "Captain"
 		id.update_label()
 		if(worn)
 			if(istype(worn, /obj/item/pda))

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -176,6 +176,7 @@
 		var/datum/job/J = pick(SSjob.occupations)
 		ID.registered_name = S.random_name(pick(MALE, FEMALE))
 		ID.assignment = J.title
+		ID.originalassignment = J.title
 
 		authorized += ID
 


### PR DESCRIPTION
# Document the changes in your pull request

I just searched all the files for places where assignment is set equal to something and made it also apply to the original assignment if it was applicable. Don't know for sure if this will fix a lot, but at the very least it should fix ERTs appearing in the wrong spot on crew monitor and (maybe) not having sec hud icons. Untested, should work.

# Wiki Documentation

None needed. 

# Changelog

:cl:  
bugfix: fixed some IDs appearing in the wrong spot on crew monitors
/:cl:
