### PR TITLE
New space ruin: crashed UFO

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/crashedufo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedufo.dmm
@@ -1,0 +1,366 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"c" = (
+/obj/machinery/abductor/gland_dispenser,
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/unpowered)
+"d" = (
+/obj/item/stack/sheet/mineral/abductor,
+/turf/template_noop,
+/area/template_noop)
+"e" = (
+/obj/structure/table_frame/abductor,
+/obj/item/stack/sheet/mineral/abductor,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/unpowered)
+"g" = (
+/obj/structure/table/abductor,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/unpowered)
+"j" = (
+/obj/structure/showcase/horrific_experiment,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/unpowered)
+"k" = (
+/turf/closed/wall/mineral/abductor,
+/area/ruin/unpowered)
+"n" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/unpowered)
+"o" = (
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/unpowered)
+"p" = (
+/obj/item/circuitboard/machine/chem_dispenser/abductor,
+/turf/closed/mineral,
+/area/ruin/unpowered)
+"s" = (
+/obj/structure/table_frame/abductor,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/unpowered)
+"t" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/unpowered)
+"x" = (
+/obj/effect/decal/cleanable/blood/gibs/core,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/unpowered)
+"B" = (
+/obj/effect/decal/cleanable/blood/gibs{
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/blood/gibs/limb{
+	pixel_x = -8;
+	pixel_y = -1
+	},
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/unpowered)
+"C" = (
+/turf/closed/mineral,
+/area/ruin/unpowered)
+"D" = (
+/turf/template_noop,
+/area/template_noop)
+"I" = (
+/obj/effect/mob_spawn/human/abductor,
+/obj/machinery/abductor/pad{
+	team_number = 100
+	},
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/unpowered)
+"K" = (
+/obj/item/stack/rods,
+/turf/template_noop,
+/area/template_noop)
+"P" = (
+/obj/structure/closet/abductor,
+/obj/item/screwdriver/abductor,
+/obj/item/crowbar/abductor,
+/obj/item/wirecutters/abductor,
+/obj/item/wrench/abductor,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/unpowered)
+"U" = (
+/obj/structure/table/abductor,
+/obj/item/paper/guides/antag/abductor,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/unpowered)
+
+(1,1,1) = {"
+D
+D
+D
+D
+D
+D
+D
+D
+D
+D
+C
+C
+D
+D
+D
+D
+D
+"}
+(2,1,1) = {"
+D
+D
+D
+D
+D
+D
+C
+D
+D
+D
+D
+K
+D
+D
+D
+D
+D
+"}
+(3,1,1) = {"
+D
+D
+D
+D
+C
+C
+C
+C
+C
+D
+D
+D
+d
+D
+D
+D
+D
+"}
+(4,1,1) = {"
+D
+D
+D
+C
+C
+C
+C
+k
+k
+k
+k
+D
+D
+D
+C
+D
+D
+"}
+(5,1,1) = {"
+D
+D
+C
+C
+C
+C
+C
+e
+U
+g
+k
+k
+D
+D
+C
+C
+D
+"}
+(6,1,1) = {"
+D
+D
+C
+C
+C
+k
+C
+C
+t
+o
+c
+k
+K
+D
+D
+D
+D
+"}
+(7,1,1) = {"
+D
+D
+D
+C
+C
+k
+C
+C
+s
+o
+B
+C
+C
+D
+D
+D
+D
+"}
+(8,1,1) = {"
+D
+D
+D
+K
+C
+k
+I
+x
+n
+C
+p
+C
+D
+D
+D
+D
+D
+"}
+(9,1,1) = {"
+d
+D
+D
+D
+D
+k
+k
+P
+e
+j
+C
+C
+C
+D
+D
+D
+D
+"}
+(10,1,1) = {"
+D
+K
+D
+D
+D
+D
+k
+k
+k
+C
+C
+C
+D
+D
+D
+D
+D
+"}
+(11,1,1) = {"
+D
+D
+D
+C
+D
+D
+D
+C
+C
+C
+C
+D
+D
+D
+D
+D
+D
+"}
+(12,1,1) = {"
+d
+D
+C
+C
+D
+D
+D
+D
+D
+D
+D
+D
+D
+D
+D
+D
+D
+"}
+(13,1,1) = {"
+D
+D
+C
+D
+D
+d
+D
+D
+D
+D
+D
+D
+D
+D
+D
+D
+D
+"}

--- a/_maps/RandomRuins/SpaceRuins/crashedufo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedufo.dmm
@@ -1,11 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "c" = (
-/obj/machinery/abductor/gland_dispenser,
-/obj/effect/decal/cleanable/blood/gibs,
-/obj/effect/decal/cleanable/blood/gibs/limb,
-/turf/open/floor/plating/abductor{
-	initial_gas_mix = "TEMP=2.7"
-	},
+/turf/open/floor/plating/asteroid/airless,
 /area/ruin/unpowered)
 "d" = (
 /obj/item/stack/sheet/mineral/abductor,
@@ -33,13 +28,6 @@
 "k" = (
 /turf/closed/wall/mineral/abductor,
 /area/ruin/unpowered)
-"n" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/plating/abductor{
-	initial_gas_mix = "TEMP=2.7"
-	},
-/area/ruin/unpowered)
 "o" = (
 /turf/open/floor/plating/abductor{
 	initial_gas_mix = "TEMP=2.7"
@@ -61,6 +49,10 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/ruin/unpowered)
+"v" = (
+/obj/item/stack/rods,
+/turf/open/floor/plating/asteroid/airless,
+/area/template_noop)
 "x" = (
 /obj/effect/decal/cleanable/blood/gibs/core,
 /turf/open/floor/plating/abductor{
@@ -99,6 +91,12 @@
 /obj/item/stack/rods,
 /turf/template_noop,
 /area/template_noop)
+"M" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/unpowered)
 "P" = (
 /obj/structure/closet/abductor,
 /obj/item/screwdriver/abductor,
@@ -109,6 +107,15 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/ruin/unpowered)
+"R" = (
+/obj/machinery/abductor/gland_dispenser,
+/turf/open/floor/plating/abductor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/unpowered)
+"T" = (
+/turf/open/floor/plating/asteroid/airless,
+/area/template_noop)
 "U" = (
 /obj/structure/table/abductor,
 /obj/item/paper/guides/antag/abductor,
@@ -142,7 +149,7 @@ D
 D
 D
 D
-D
+T
 C
 D
 D
@@ -165,8 +172,8 @@ C
 C
 C
 C
-D
-D
+T
+T
 D
 d
 D
@@ -223,11 +230,11 @@ C
 C
 t
 o
-c
+R
 k
-K
+v
 D
-D
+T
 D
 D
 "}
@@ -259,7 +266,7 @@ C
 k
 I
 x
-n
+M
 C
 p
 C
@@ -274,7 +281,7 @@ d
 D
 D
 D
-D
+T
 k
 k
 P
@@ -293,14 +300,14 @@ D
 K
 D
 D
-D
-D
+T
+T
 k
 k
 k
 C
 C
-C
+c
 D
 D
 D
@@ -312,9 +319,9 @@ D
 D
 D
 C
-D
-D
-D
+T
+T
+T
 C
 C
 C
@@ -333,8 +340,8 @@ C
 C
 D
 D
-D
-D
+T
+T
 D
 D
 D

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -202,6 +202,13 @@
 	name = "Crashed Ship"
 	description = "Among civilian vessels the most common cause of tragedy is lack of food. \
 	This ship was outfitted with a multitude of food-generating features, then summarily ran into an asteroid shortly after takeoff."
+	
+/datum/map_template/ruin/space/crashedufo
+	id = "crashedufo"
+	suffix = "crashedufo.dmm"
+	name = "Crashed UFO"
+	description = "Turns out even high-tech ships of abductors happen to crash into stray asteroids. \
+	Who knows what secrets might be unearthed from the wreckage?"
 
 /datum/map_template/ruin/space/listeningstation
 	id = "listeningstation"

--- a/config/spaceruinblacklist.txt
+++ b/config/spaceruinblacklist.txt
@@ -16,6 +16,7 @@
 #_maps/RandomRuins/SpaceRuins/cloning_facility.dmm
 #_maps/RandomRuins/SpaceRuins/crashedclownship.dmm
 #_maps/RandomRuins/SpaceRuins/crashedship.dmm
+#_maps/RandomRuins/SpaceRuins/crashedufo.dmm
 #_maps/RandomRuins/SpaceRuins/deepstorage.dmm
 #_maps/RandomRuins/SpaceRuins/derelict1.dmm
 #_maps/RandomRuins/SpaceRuins/derelict2.dmm


### PR DESCRIPTION
# Document the changes in your pull request
<details> 
  <summary>Adds a neat little space ruin that is essentially an abductor ship crashing into the middle of a small asteroid (click to view) </summary>
   
![obraz](https://user-images.githubusercontent.com/71487903/143677648-7d15ea59-aa4f-424f-9e34-739260dfaa8e.png)

</details>
It contains a dead abductor, some of the abductor tools, no surgery tools, an abductor chemical dispenser circuit board and a gland dispenser.

Thanks to this ruin station can get access to abductor tech and abductor grade tools, similarly how the lavaland ruin gives access to abductor tech and their surgery tools.

# Wiki Documentation
I suppose it should be added to the space ruins page, i guess.

# Changelog
:cl:  
rscadd: Added a new space ruin: UFO crashed into asteroid
/:cl:
