### PR TITLE
buffs the reviver implant

### DIFF
--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -56,7 +56,7 @@
 
 /obj/item/organ/cyberimp/chest/reviver/on_life()
 	if(reviving)
-		if(owner.stat == UNCONSCIOUS || owner.stat == LIGHT_CRIT)
+		if(owner.stat == UNCONSCIOUS || owner.stat == SOFT_CRIT)
 			addtimer(CALLBACK(src, .proc/heal), 2 SECONDS)
 		else
 			cooldown = revive_cost + world.time

--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -104,7 +104,7 @@
 		if(H.stat != DEAD && prob(50 / severity) && H.can_heartattack())
 			H.set_heartattack(TRUE)
 			to_chat(H, span_userdanger("You feel a horrible agony in your chest!"))
-			addtimer(CALLBACK(src, .proc/undo_heart_attack), 30 SECONDS / severity)
+			addtimer(CALLBACK(src, .proc/undo_heart_attack), 10 SECONDS / severity)
 
 /obj/item/organ/cyberimp/chest/reviver/proc/undo_heart_attack()
 	var/mob/living/carbon/human/H = owner

--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -56,8 +56,8 @@
 
 /obj/item/organ/cyberimp/chest/reviver/on_life()
 	if(reviving)
-		if(owner.stat == UNCONSCIOUS)
-			addtimer(CALLBACK(src, .proc/heal), 30)
+		if(owner.stat == UNCONSCIOUS || owner.stat == LIGHT_CRIT)
+			addtimer(CALLBACK(src, .proc/heal), 2 SECONDS)
 		else
 			cooldown = revive_cost + world.time
 			reviving = FALSE
@@ -78,16 +78,16 @@
 /obj/item/organ/cyberimp/chest/reviver/proc/heal()
 	if(owner.getOxyLoss())
 		owner.adjustOxyLoss(-5)
-		revive_cost += 5
+		revive_cost += 0.5 SECONDS
 	if(owner.getBruteLoss())
 		owner.adjustBruteLoss(-2)
-		revive_cost += 40
+		revive_cost += 4 SECONDS
 	if(owner.getFireLoss())
 		owner.adjustFireLoss(-2)
-		revive_cost += 40
+		revive_cost += 4 SECONDS
 	if(owner.getToxLoss())
 		owner.adjustToxLoss(-1)
-		revive_cost += 40
+		revive_cost += 4 SECONDS
 
 /obj/item/organ/cyberimp/chest/reviver/emp_act(severity)
 	. = ..()
@@ -95,16 +95,16 @@
 		return
 
 	if(reviving)
-		revive_cost += 200
+		revive_cost += 20 SECONDS
 	else
-		cooldown += 200
+		cooldown += 20 SECONDS
 
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 		if(H.stat != DEAD && prob(50 / severity) && H.can_heartattack())
 			H.set_heartattack(TRUE)
 			to_chat(H, span_userdanger("You feel a horrible agony in your chest!"))
-			addtimer(CALLBACK(src, .proc/undo_heart_attack), 600 / severity)
+			addtimer(CALLBACK(src, .proc/undo_heart_attack), 30 SECONDS / severity)
 
 /obj/item/organ/cyberimp/chest/reviver/proc/undo_heart_attack()
 	var/mob/living/carbon/human/H = owner


### PR DESCRIPTION
# Document the changes in your pull request

Reviver implant has gotten several numbers buffs for being kind of trash for an implant that chainstuns you for a minute if you get EMPed

heal delay lowered from 3 seconds to 2 seconds
reviver implant now works in softcrit so it can actually take you out of crit if you are dying
heart attack timer reduced from 1 minute to 10 seconds

all numbers have been changed to define numbers for easier reading


# Changelog

:cl:  
tweak: reviver implant is now faster, works in soft crit if you aren't sleeping, and has had its heart attack emp effect reduced from a minute to 10 seconds
/:cl:
