### PR TITLE
removes specifically the heart attack effect from being fat

### DIFF
--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -84,11 +84,6 @@
 			beat = BEAT_NONE
 	if(HAS_TRAIT(owner, TRAIT_FAT) && owner.stat != DEAD) //yogs: being fat causes heart damage
 		owner.adjustOrganLoss(ORGAN_SLOT_HEART, maxHealth * STANDARD_ORGAN_DECAY, 85) //eat happy, eat healthy
-		if(damage >= 80 && beating)
-			if(prob(1))
-				if(owner.stat == CONSCIOUS)
-					owner.visible_message(span_userdanger("[owner] clutches at [owner.p_their()] chest as if [owner.p_their()] heart is stopping!"))
-				owner.set_heartattack(TRUE) //yogs end
 	if(organ_flags & ORGAN_FAILING)	//heart broke, stopped beating, death imminent
 		if(owner.stat == CONSCIOUS)
 			owner.visible_message(span_userdanger("[owner] clutches at [owner.p_their()] chest as if [owner.p_their()] heart is stopping!"))


### PR DESCRIPTION
# Document the changes in your pull request

technically this is funny but it actually kills people way more often than it should just because it's a MASSIVE pain to deal with obesity without the help of a chemist or bartender or actual doctor who knows what they are doing (rare), coupled with how easy it is to accidentally overeat (especially if you don't know it's lethal) and get stuck with several minutes of fatness a feature that randomly kills you for going overweight is kind of stupid

I'm keeping the heart damage though that's thematic and still a good downside since you lose a large amount of time post death where you can be defibbed without a bypass or replacement heart

# Changelog
:cl:  
rscdel: being fat no longer causes heart attacks on its own, it will still cause massive damage to the heart over time
/:cl:
