### PR TITLE
Locks flamethrowers behind makeshift weapons

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -281,6 +281,7 @@
 	time = 1 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
+	always_availible = FALSE
 
 /datum/crafting_recipe/pulseslug
 	name = "Pulse Slug Shell"

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -439,6 +439,6 @@
 /obj/item/book/granter/crafting_recipe/weapons
 	name = "makeshift weapons 101"
 	desc = "A book filled with directions on how to make various weaponry."
-	crafting_recipe_types = list(/datum/crafting_recipe/baseball_bat, /datum/crafting_recipe/lance, /datum/crafting_recipe/knifeboxing)
+	crafting_recipe_types = list(/datum/crafting_recipe/baseball_bat, /datum/crafting_recipe/lance, /datum/crafting_recipe/knifeboxing, /datum/crafting_recipe/flamethrower)
 	icon_state = "bookCrafting"
 	oneuse = TRUE


### PR DESCRIPTION
# Document the changes in your pull request

Fully locks flamethrowers behind Makeshift weapons 101.
Thats it.

Flamethrowers have very little use outside of lone wolf fighting against large crowds, and are shit if you have any teammates without full fire immunity.

In general flamethrowers will only be correctly used by people who would have access to them with the traitor gear.

# Wiki Documentation

Add flamethrower to the list of items under Makeshift weapons book, in https://wiki.yogstation.net/wiki/Syndicate_Items

# Changelog
:cl:  
tweak: Flamethrowers are now locked behind Makeshift Weapons 101
/:cl:
