### PR TITLE
makes sleeper stasis more intuitive

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -181,7 +181,7 @@
 	check_nap_violations()
 	var/mob/living/carbon/C = occupant
 	if(C)
-		if(stasis && C.stat == DEAD || C.health < 0)
+		if(stasis && (C.stat == DEAD || C.health < 0))
 			C.apply_status_effect(STATUS_EFFECT_STASIS, null, TRUE)
 		else
 			C.remove_status_effect(STATUS_EFFECT_STASIS)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -20,8 +20,6 @@
 
 	///efficiency, used to increase the effect of some healing methods
 	var/efficiency = 1
-	///maximum status stasis will activate at, occurs automatically
-	var/stasis_health = UNCONSCIOUS
 	///treatments currently available for use
 	var/list/available_treatments
 	///if the patient is able to use the sleeper's controls
@@ -183,7 +181,7 @@
 	check_nap_violations()
 	var/mob/living/carbon/C = occupant
 	if(C)
-		if(stasis && C.stat >= stasis_health)
+		if(stasis && C.stat == DEAD || C.health < 0)
 			C.apply_status_effect(STATUS_EFFECT_STASIS, null, TRUE)
 		else
 			C.remove_status_effect(STATUS_EFFECT_STASIS)


### PR DESCRIPTION
# Document the changes in your pull request

At the time I wanted to use stat alone but as it turns out there's no stat for being specifically in hardcrit and UNCONSCIOUS also shows up a myriad of other ways

Instead the sleeper will trigger stasis if either the occupant is dead or below 0 health

# Changelog

:cl:  
tweak: sleepers with the stasis upgrade will now put people into stasis under more specific circumstances
/:cl:
