### PR TITLE
puts brainwashing surgery back where it belongs (in alien surgery)

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -125,7 +125,7 @@
 	display_name = "Alien Surgery"
 	description = "Abductors did nothing wrong."
 	prereq_ids = list("exp_surgery", "alientech")
-	design_ids = list("surgery_zombie","surgery_heal_combo_upgrade_femto")
+	design_ids = list("surgery_zombie","surgery_heal_combo_upgrade_femto", "surgery_brainwashing")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7000)
 	export_price = 5000
 


### PR DESCRIPTION
# Document the changes in your pull request

if someone ACTUALLY gets this they get to do the gimmick
also this is way harder to get on purpose so you can't rush it to give antags boring "don't do your objectives you are effectively a borg now lol" directives

# Changelog

:cl:  
tweak: brainwashing surgery is available under alien surgery where it used to be
/:cl:
