### PR TITLE
Fixed airlock painter

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1462,6 +1462,8 @@
 	icon = initial(airlock.icon)
 	overlays_file = initial(airlock.overlays_file)
 	assemblytype = initial(airlock.assemblytype)
+	anim_parts = initial(airlock.anim_parts)
+	rebuild_parts()
 	update_icon()
 
 /obj/machinery/door/airlock/CanAStarPass(obj/item/card/id/ID)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -95,8 +95,6 @@
 	var/abandoned = FALSE
 	/// Material of inner filling; if its an airlock with glass, this should be set to "glass"
 	var/airlock_material
-	/// Can this airlock be repainted, FALSE if it has weird transforms(hatches)
-	var/can_repaint = TRUE
 
 	var/obj/item/electronics/airlock/electronics
 	var/previous_airlock = /obj/structure/door_assembly //what airlock assembly mineral plating was applied to
@@ -1437,9 +1435,6 @@
 
 
 /obj/machinery/door/airlock/proc/change_paintjob(obj/item/airlock_painter/painter, mob/user)
-	if(!can_repaint)
-		to_chat(user, span_warning("The airlock painter does not support this airlock."))
-		return
 
 	if((!in_range(src, user) && loc != user) || !painter.can_use(user)) // user should be adjacent to the airlock, and the painter should have a toner cartridge that isn't empty
 		return

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -378,7 +378,6 @@
 	overlays_file = 'icons/obj/doors/airlocks/hatch/overlays.dmi'
 	note_overlay_file = 'icons/obj/doors/airlocks/hatch/overlays.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_hatch
-	can_repaint = FALSE
 	//anim_parts = "ul=-9,9;ur=9,9;dl=-9,-9;dr=9,-9"
 	anim_parts = "ul=-15,0,0,5,-90;ur=0,15,0,5,-90;dl=0,-15,0,5,-90;dr=15,0,0,5,-90"
 	note_attachment = "ul"
@@ -394,7 +393,6 @@
 	anim_parts = "ul=-15,0,0,5,-90;ur=0,15,0,5,-90;dl=0,-15,0,5,-90;dr=15,0,0,5,-90"
 	note_attachment = "ul"
 	panel_attachment = "dr"
-	can_repaint = FALSE
 
 //////////////////////////////////
 /*
@@ -460,7 +458,6 @@
 	var/openingoverlaytype = /obj/effect/temp_visual/cult/door
 	var/friendly = FALSE
 	var/stealthy = FALSE
-	can_repaint = FALSE
 
 /obj/machinery/door/airlock/cult/Initialize()
 	. = ..()
@@ -567,7 +564,6 @@
 	damage_deflection = 30
 	normal_integrity = 240
 	var/construction_state = GEAR_SECURE //Pinion airlocks have custom deconstruction
-	can_repaint = FALSE
 
 /obj/machinery/door/airlock/clockwork/Initialize()
 	. = ..()
@@ -686,7 +682,6 @@
 	assemblytype = null
 	glass = TRUE
 	bound_width = 64 // 2x1
-	can_repaint = FALSE
 
 /obj/machinery/door/airlock/glass_large/narsie_act()
 	return


### PR DESCRIPTION
# Document the changes in your pull request

Airlock painters no longer break when painting between specific types of airlock.
Fixes #12786 
Fixes #12539 
Fixes #12135 


# Changelog

:cl:  
bugfix: fixed airlocks sometimes being invisible when painted
/:cl:
