### PR TITLE
removes dullahans and replaces them with halloween roundstart flies 

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -648,8 +648,6 @@
 						BP.dismember()
 					else
 						gib()
-				else
-					set_species(/datum/species/dullahan)
 			if(4)
 				visible_message(span_warning("[src]'s skin melts off!"), span_boldwarning("Your skin melts off!"))
 				spawn_gibs()

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -109,7 +109,7 @@
 		if(istype(AM, /obj/item))
 			var/obj/item/bodypart/head/as_head = AM
 			var/obj/item/mmi/as_mmi = AM
-			if(istype(AM, /obj/item/organ/brain) || (istype(as_head) && as_head.brain) || (istype(as_mmi) && as_mmi.brain) || istype(AM, /obj/item/dullahan_relay))
+			if(istype(AM, /obj/item/organ/brain) || (istype(as_head) && as_head.brain) || (istype(as_mmi) && as_mmi.brain))
 				living_detected = TRUE
 			nom += AM
 		else if(isliving(AM) && !istype(AM, /mob/living/simple_animal/hostile/megafauna))

--- a/code/modules/mob/living/carbon/human/species_types/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dullahan.dm
@@ -19,7 +19,7 @@
 
 /datum/species/dullahan/check_roundstart_eligible()
 	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
-		return TRUE
+		return FALSE
 	return FALSE
 
 /datum/species/dullahan/on_species_gain(mob/living/carbon/human/H, datum/species/old_species)

--- a/code/modules/mob/living/carbon/human/species_types/flypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/flypeople.dm
@@ -34,3 +34,8 @@
 	if(istype(weapon, /obj/item/melee/flyswatter))
 		return 29 //Flyswatters deal 30x damage to flypeople.
 	return 0
+	
+/datum/species/fly/check_roundstart_eligible()
+	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
+		return TRUE
+	return ..()

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2280,7 +2280,6 @@
 #include "code\modules\mob\living\carbon\human\species_types\abductors.dm"
 #include "code\modules\mob\living\carbon\human\species_types\android.dm"
 #include "code\modules\mob\living\carbon\human\species_types\corporate.dm"
-#include "code\modules\mob\living\carbon\human\species_types\dullahan.dm"
 #include "code\modules\mob\living\carbon\human\species_types\eggpeople.dm"
 #include "code\modules\mob\living\carbon\human\species_types\ethereal.dm"
 #include "code\modules\mob\living\carbon\human\species_types\felinid.dm"


### PR DESCRIPTION
This buggy mess of a race is such a pain and frankly it's just bloat with how little it's ever used in the game. I really tried approaching the topic of fixing them myself, but honestly, as much as I like them... it isn't worth it imo. I'd be down for eventual re-implementation but right now all it does is clog up our bug reports with hundreds of complaints about how miserably broken it is. For now I decided to fill the slot of another halloween race with flypeople since I like them and they aren't mechanically too crazy or weird balance wise 🪰 bzz bzz buzz
:cl:  
rscdel: removed dullahans  
tweak: flypeople now a roundstart halloween race  
/:cl:
