### PR TITLE
Adds icons to some programs that don't have one

### DIFF
--- a/code/modules/modular_computers/file_system/programs/bounty_board.dm
+++ b/code/modules/modular_computers/file_system/programs/bounty_board.dm
@@ -8,6 +8,7 @@
 	network_destination = "bounty board interface"
 	size = 10
 	tgui_id = "NtosRequestKiosk"
+	program_icon = "comments-dollar"
 	///Reference to the currently logged in user.
 	var/datum/bank_account/current_user
 	///The station request datum being affected by UI actions.

--- a/code/modules/modular_computers/file_system/programs/energyharvestercontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/energyharvestercontrol.dm
@@ -10,7 +10,7 @@
 	network_destination = "energy harvester controller"
 	size = 1
 	tgui_id = "NtosEnergyHarvesterController"
-	program_icon = "plug"
+	program_icon = "charging-station"
 
 	var/status
 	var/obj/item/energy_harvester/moneysink

--- a/code/modules/modular_computers/file_system/programs/energyharvestercontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/energyharvestercontrol.dm
@@ -10,6 +10,7 @@
 	network_destination = "energy harvester controller"
 	size = 1
 	tgui_id = "NtosEnergyHarvesterController"
+	program_icon = "plug"
 
 	var/status
 	var/obj/item/energy_harvester/moneysink

--- a/code/modules/modular_computers/file_system/programs/portrait_printer.dm
+++ b/code/modules/modular_computers/file_system/programs/portrait_printer.dm
@@ -18,6 +18,7 @@
 	requires_ntnet = TRUE
 	size = 9
 	tgui_id = "NtosPortraitPrinter"
+	program_icon = "palette"
 
 /datum/computer_file/program/portrait_printer/ui_data(mob/user)
 	var/list/data = list()


### PR DESCRIPTION
# Document the changes in your pull request

Added icons to some programs that didn't have one, those being the bounty board, energy harvester controller, and portrait painter. Is tested, does work.

# Wiki Documentation

No changes needed. 

# Changelog

:cl:  
tweak: the bounty board, energy harvester controller, and portrait painter programs now have program icons  
/:cl:
