### PR TITLE
Adds a program to view labor camp cameras

### DIFF
--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -184,11 +184,32 @@
 			camlist["[cam.c_tag]"] = cam
 	return camlist
 
+//////////////////
+//Mining Cameras//
+//////////////////
+
+///A program that allows you to view the cameras on the Mining Base
 /datum/computer_file/program/secureye/mining
 	filename = "overwatch"
 	filedesc = "OverWatch"
 	extended_desc = "This program allows access to the mining base camera network."
 	transfer_access = ACCESS_MINING
 	size = 5
+	program_icon = "globe"
 
 	network = list("mine", "auxbase")
+
+//////////////////////
+//Labor Camp Cameras//
+//////////////////////
+
+///A program that allows you to view the cameras on the Labor Camp
+/datum/computer_file/program/secureye/laborcamp
+	filename = "overseer"
+	filedesc = "OverSeer"
+	extended_desc = "This program allows access to the labor camp camera network."
+	transfer_access = ACCESS_ARMORY
+	size = 5
+	program_icon = "dungeon"
+
+	network = list("labor")


### PR DESCRIPTION
# Document the changes in your pull request

Adds a program that is a subtype of secureye that can view labor camp cams called OverSeer. Also gives a new icon for overwatch to make it different from secureye.

# Wiki Documentation

No changes needed. 

# Changelog

:cl:  
rscadd: Added OverSeer, a program to view labor camp cameras
/:cl:
