### PR TITLE
Adds a docking port to the space bar

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacebar.dmm
@@ -234,22 +234,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/ruin/space/has_grav/powered/spacebar)
-"iP" = (
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/spacebar)
-"iZ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/spacebar)
 "jd" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -261,6 +245,15 @@
 	name = "Storage";
 	req_access_txt = "25"
 	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/powered/spacebar)
+"je" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
 "jk" = (
@@ -300,6 +293,19 @@
 /obj/effect/turf_decal/tile/bar,
 /obj/machinery/vending/coffee,
 /obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/powered/spacebar)
+"ke" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/powered/spacebar)
+"ld" = (
+/obj/effect/turf_decal/tile/slightlydarkerblue,
+/obj/effect/turf_decal/tile/slightlydarkerblue{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -548,6 +554,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
+"uJ" = (
+/obj/effect/turf_decal/tile/slightlydarkerblue,
+/obj/effect/turf_decal/tile/slightlydarkerblue{
+	dir = 1
+	},
+/obj/machinery/computer/arcade{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/powered/spacebar)
 "vh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -578,6 +594,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/ruin/space/has_grav/powered/spacebar)
+"wo" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/powered/spacebar)
 "wz" = (
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/spacebar)
@@ -596,6 +618,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
+"xY" = (
+/obj/effect/turf_decal/tile/slightlydarkerblue,
+/obj/effect/turf_decal/tile/slightlydarkerblue{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/book/random{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/powered/spacebar)
 "yg" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1;
@@ -607,10 +640,6 @@
 "yK" = (
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall,
-/area/ruin/space/has_grav/powered/spacebar)
-"yN" = (
-/obj/machinery/light,
-/turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/spacebar)
 "zE" = (
 /turf/open/floor/carpet,
@@ -632,6 +661,10 @@
 	dir = 8
 	},
 /obj/machinery/teleport/station,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/powered/spacebar)
+"AV" = (
+/obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/spacebar)
 "AZ" = (
@@ -820,6 +853,28 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/ruin/space/has_grav/powered/spacebar)
+"Id" = (
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 11;
+	height = 22;
+	id = "spacebar";
+	name = "Space Bar";
+	width = 35
+	},
+/turf/template_noop,
+/area/template_noop)
+"Ik" = (
+/obj/effect/turf_decal/tile/slightlydarkerblue,
+/obj/effect/turf_decal/tile/slightlydarkerblue{
+	dir = 1
+	},
+/obj/structure/chair,
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/powered/spacebar)
 "IA" = (
 /obj/structure/closet/secure_closet/freezer/meat{
 	req_access = null;
@@ -915,6 +970,14 @@
 	use_power = 0
 	},
 /turf/open/floor/plasteel,
+/area/ruin/space/has_grav/powered/spacebar)
+"MF" = (
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/spacebar)
 "Na" = (
 /obj/effect/turf_decal/tile/bar{
@@ -1045,6 +1108,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
+"RT" = (
+/obj/effect/turf_decal/tile/slightlydarkerblue,
+/obj/effect/turf_decal/tile/slightlydarkerblue{
+	dir = 1
+	},
+/obj/structure/chair,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/powered/spacebar)
 "RY" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1;
@@ -1090,6 +1161,16 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
+/area/ruin/space/has_grav/powered/spacebar)
+"UV" = (
+/obj/effect/turf_decal/tile/slightlydarkerblue,
+/obj/effect/turf_decal/tile/slightlydarkerblue{
+	dir = 1
+	},
+/obj/machinery/modular_computer/console/preset/civilian{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
 "Vj" = (
 /obj/machinery/light/small,
@@ -1161,6 +1242,16 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
+"XW" = (
+/obj/effect/turf_decal/tile/slightlydarkerblue,
+/obj/effect/turf_decal/tile/slightlydarkerblue{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/powered/spacebar)
 "YH" = (
 /turf/template_noop,
 /area/template_noop)
@@ -1210,7 +1301,7 @@ YH
 YH
 YH
 YH
-YH
+Id
 YH
 YH
 YH
@@ -1234,17 +1325,17 @@ YH
 YH
 YH
 YH
+sM
+sM
+sM
+sM
+ZN
+ZN
+ZN
 YH
-YH
-YH
-YH
-YH
-YH
-YH
-YH
-YH
-YH
-YH
+FB
+PR
+FB
 YH
 YH
 YH
@@ -1266,18 +1357,18 @@ YH
 YH
 YH
 YH
-YH
-YH
-YH
-YH
-YH
+sM
+sM
+sM
+sM
+sM
+sM
+sM
 ZN
-xi
-xi
-YH
-YH
-YH
-YH
+ZN
+FB
+sX
+FB
 YH
 YH
 YH
@@ -1299,19 +1390,19 @@ YH
 YH
 YH
 YH
-YH
-YH
-YH
-YH
-ZN
-ZN
+sM
 FB
-iP
-iP
-iP
-iP
-iP
-iP
+FB
+FB
+FB
+FB
+FB
+KO
+KO
+FB
+as
+FB
+KO
 FB
 xi
 xi
@@ -1332,19 +1423,19 @@ YH
 YH
 YH
 YH
-YH
-YH
-YH
-YH
-sM
-sM
+ZN
+MF
+wz
+wz
+wo
+wz
 FB
-wz
-wz
-wz
-wz
-wz
-wz
+RT
+ld
+ld
+ld
+uJ
+uJ
 FB
 FB
 FB
@@ -1364,20 +1455,20 @@ YH
 (6,1,1) = {"
 YH
 YH
-YH
-YH
-YH
-YH
-sM
-sM
-sM
+ZN
+ZN
+MF
+wz
+wz
+ZJ
+CP
 FB
-wz
-wz
-wz
-wz
-wz
-wz
+Ik
+ld
+ld
+ld
+ld
+ld
 Jq
 jy
 OV
@@ -1397,20 +1488,20 @@ YH
 (7,1,1) = {"
 YH
 YH
-YH
-YH
-YH
-YH
-sM
-sM
-sM
+ZN
+ZN
+MF
+wz
+wz
+mL
+og
 FB
-iZ
-ZJ
-CP
-ZJ
-CP
-yN
+xY
+ld
+ld
+ld
+ld
+XW
 FB
 FB
 FB
@@ -1430,20 +1521,20 @@ YH
 (8,1,1) = {"
 YH
 YH
-YH
-YH
-YH
-sM
-sM
-sM
-sM
-FB
+ZN
+ZN
+MF
 wz
-mL
-og
-mL
-og
 wz
+wz
+wz
+AV
+ld
+ld
+ld
+ld
+ld
+UV
 FB
 Hf
 FB
@@ -1463,20 +1554,20 @@ YH
 (9,1,1) = {"
 YH
 YH
-YH
-YH
-YH
-sM
-sM
-sM
-sM
+ZN
+ZN
+MF
+wz
+wz
+ZJ
+CP
+FB
 FB
 KO
 KO
+je
 KO
-KO
-KO
-KO
+FB
 FB
 TU
 FB
@@ -1495,14 +1586,14 @@ YH
 "}
 (10,1,1) = {"
 YH
-YH
-YH
-YH
-sM
-sM
-sM
-sM
-sM
+ZN
+ZN
+ZN
+MF
+wz
+wz
+mL
+og
 FB
 nK
 yg
@@ -1528,14 +1619,14 @@ YH
 "}
 (11,1,1) = {"
 YH
-YH
-YH
-YH
-sM
-sM
-sM
-sM
-sM
+ZN
+ZN
+ZN
+MF
+wz
+wz
+ke
+wz
 FB
 jY
 yg
@@ -1561,12 +1652,12 @@ YH
 "}
 (12,1,1) = {"
 YH
-YH
-YH
+ZN
 sM
 sM
-sM
-sM
+FB
+FB
+FB
 FB
 FB
 FB
@@ -1594,11 +1685,11 @@ YH
 "}
 (13,1,1) = {"
 YH
-YH
-YH
 ZN
 ZN
-ZN
+sM
+sM
+sM
 sM
 FB
 aH
@@ -1628,7 +1719,7 @@ YH
 (14,1,1) = {"
 YH
 YH
-YH
+ZN
 ZN
 ZN
 ZN
@@ -1661,7 +1752,7 @@ YH
 (15,1,1) = {"
 YH
 YH
-YH
+ZN
 ZN
 ZN
 ZN
@@ -1694,7 +1785,7 @@ YH
 (16,1,1) = {"
 YH
 YH
-YH
+ZN
 ZN
 ZN
 ZN

--- a/_maps/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacebar.dmm
@@ -247,15 +247,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
-"je" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/machinery/door/airlock/glass,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/powered/spacebar)
 "jk" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1;
@@ -1052,6 +1043,21 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/spacebar)
+"OT" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/machinery/door/airlock/glass,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/powered/spacebar)
 "OV" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -1565,7 +1571,7 @@ FB
 FB
 KO
 KO
-je
+OT
 KO
 FB
 FB

--- a/code/modules/shuttle/custom_shuttle.dm
+++ b/code/modules/shuttle/custom_shuttle.dm
@@ -11,7 +11,7 @@
 	light_color = LIGHT_COLOR_CYAN
 	req_access = list( )
 	var/shuttleId
-	var/possible_destinations = "whiteship_home;auxiliary_construction"
+	var/possible_destinations = "whiteship_home;auxiliary_construction;spacebar"
 	var/admin_controlled
 	var/no_destination_swap = 0
 	var/calculated_mass = 0
@@ -106,7 +106,7 @@
 
 /obj/machinery/computer/custom_shuttle/proc/linkShuttle(var/new_id)
 	shuttleId = new_id
-	possible_destinations = "whiteship_home;auxiliary_construction;shuttle[new_id]_custom"
+	possible_destinations = "whiteship_home;auxiliary_construction;spacebar;shuttle[new_id]_custom"
 
 /obj/machinery/computer/custom_shuttle/proc/calculateStats(var/useFuel = FALSE, var/dist = 0, var/ignore_cooldown = FALSE)
 	if(!ignore_cooldown && stat_calc_cooldown >= world.time)

--- a/code/modules/shuttle/syndicate.dm
+++ b/code/modules/shuttle/syndicate.dm
@@ -9,7 +9,7 @@
 	light_color = LIGHT_COLOR_RED
 	req_access = list(ACCESS_SYNDICATE)
 	shuttleId = "syndicate"
-	possible_destinations = "syndicate_away;syndicate_z5;syndicate_ne;syndicate_nw;syndicate_n;syndicate_se;syndicate_sw;syndicate_s;syndicate_custom"
+	possible_destinations = "syndicate_away;syndicate_z5;syndicate_ne;syndicate_nw;syndicate_n;syndicate_se;syndicate_sw;syndicate_s;spacebar;syndicate_custom"
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	flags_1 = NODECONSTRUCT_1
 

--- a/code/modules/shuttle/white_ship.dm
+++ b/code/modules/shuttle/white_ship.dm
@@ -3,7 +3,7 @@
 	desc = "Used to control the White Ship."
 	circuit = /obj/item/circuitboard/computer/white_ship
 	shuttleId = "whiteship"
-	possible_destinations = "whiteship_away;whiteship_home;whiteship_z4;whiteship_lavaland;whiteship_custom"
+	possible_destinations = "whiteship_away;whiteship_home;whiteship_z4;whiteship_lavaland;spacebar;whiteship_custom"
 
 /obj/machinery/computer/shuttle/white_ship/pod
 	name = "Salvage Pod Console"


### PR DESCRIPTION
# Document the changes in your pull request

Adds a docking port with a little lobby to the space bar, and moves the hanger for space pods above it. Also includes a computer for contacting your ride back to the station and because I can't make a PR that doesn't include modular computers.

![image](https://user-images.githubusercontent.com/14363906/144196058-67d4d440-3dc3-4e63-a2a7-950070b151ec.png)

# Wiki Documentation

Image for the space bar will need to be updated. 

# Changelog

:cl:   
tweak: added a shuttle docking port to the space bar  
/:cl:
