### PR TITLE
"Toxins" that don't do toxin damage won't cause liver damage

### DIFF
--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -30,6 +30,8 @@
 			if(filterToxins && !HAS_TRAIT(owner, TRAIT_TOXINLOVER))
 				//handle liver toxin filtration
 				for(var/datum/reagent/toxin/T in C.reagents.reagent_list)
+					if (!T.toxpwr)
+						continue
 					var/thisamount = C.reagents.get_reagent_amount(T.type)
 					if (thisamount && thisamount <= toxTolerance)
 						C.reagents.remove_reagent(T.type, 1)


### PR DESCRIPTION
`toxpwr = 0` should not cause liver damage

:cl:  Lucy
tweak: Reagents that are considered "toxins" but don't deal any toxin damage will no longer damage your liver.
/:cl:
