### PR TITLE
You can no longer start a map vote right after map rotation.

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -372,6 +372,7 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 	. = changemap(VM)
 	if (. && VM.map_name != config.map_name)
 		to_chat(world, span_boldannounce("Map rotation has chosen [VM.map_name] for next round!"))
+		CONFIG_SET(flag/allow_vote_map, FALSE)
 
 /datum/controller/subsystem/mapping/proc/changemap(var/datum/map_config/VM)
 	if(!VM.MakeNextMap())


### PR DESCRIPTION
:cl: Lucy
tweak: You can no longer start a map vote right after the map is automatically rotated.
/:cl:

This is mainly because every time the map rotation automatically goes to a non-Box map, some dingus will always make a map vote, and it'll go back to Box. It's not really a majority voting for box either - even with 50-60+ players, only like ~20 total will vote at all (and even if it was an actual majority, [tyranny of the majority](https://en.wikipedia.org/wiki/Tyranny_of_the_majority) is something that should be avoided). Sometimes you should *gasp* learn new things.