### PR TITLE
Fixes two bugs with grilling/griddles

### DIFF
--- a/code/datums/components/grillable.dm
+++ b/code/datums/components/grillable.dm
@@ -41,6 +41,7 @@
 
 ///Ran when an object starts grilling on something
 /datum/component/grillable/proc/StartGrilling(atom/grill_source)
+	currently_grilling = TRUE
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, .proc/OnMoved,TRUE)
 	AddGrilledItemOverlay(parent)
 

--- a/code/modules/food_and_drinks/kitchen_machinery/griddle.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/griddle.dm
@@ -28,8 +28,6 @@
 	variant = rand(1,3)
 
 /obj/machinery/griddle/attackby(obj/item/I, mob/user, params)
-	. = ..()
-
 	if(default_deconstruction_crowbar(I))
 		return
 
@@ -51,6 +49,8 @@
 		to_chat(user, "<span class='notice'>You place [I] on [src].</span>")
 		AddToGrill(I, user)
 		update_icon()
+	else
+		return ..()
 
 /obj/machinery/griddle/attack_hand(mob/user)
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request

- grillable components never actually told themselves they were grilling, so every time it would cook the object it would add another steam overlay, making them functionally opaque.

- placing things on a griddle would play the animation of an item moving to it, which was unintended. Fixed now.

# Changelog

:cl:  
bugfix: grilling items dont spam steam overlays
bugfix: placing things on the griddle doesn't have the item move animation
/:cl:
