### PR TITLE
supermatter scalpel no longer off itself on successfully attempting to harvest a shard

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -819,6 +819,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 					to_chat(user, span_notice("A tiny piece of \the [W] falls off, rendering it useless!"))
 			else
 				to_chat(user, span_notice("You fail to extract a sliver from \The [src]. \the [W] isn't sharp enough anymore!"))
+			return
 	if(istype(W, /obj/item/supermatter_corruptor))
 		if(corruptor_attached)
 			to_chat(user, "A corruptor is already attached!")


### PR DESCRIPTION
# Document the changes in your pull request

there's no return here apparently

# Changelog


:cl:  
bugfix: the supermatter cutting scalpel no longer gets deleted for cutting the supermatter when trying to cut the supermatter
/:cl:
