### PR TITLE
Disables Deltastation

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -29,7 +29,7 @@ endmap
 
 map yogsdelta
 	minplayers 50
-	votable
+	disabled
 endmap
 
 map kilostation


### PR DESCRIPTION
# Document the changes in your pull request
This is not a joke pr.
The data speaks for itself, over the last 6 months, delta has been played 16 times
![image](https://user-images.githubusercontent.com/48154165/144748012-b493df87-71fa-4b5b-a447-c8513bdfef1e.png)

I want it gone to not have a thing that needs to be maintained by devs but is played barely at all.
Let's take an example of the ai rework, the dev needs to redesign the entire core on all 4 active maps just to have his pr merged. It's annoying to have to do such a large amount of work just so people play it once in a month if not less.

The main intent here is to divert development focus into the one and true map everyone on yogs seems to love, box.
To raise non box map playability, we tried implementing rotation, changing weights around, other things, nothing really worked out in the end. So let's go the other way and start disabling nonbox maps.

# Wiki Documentation
Disables it from rotation and voting

# Changelog

:cl:  
tweak: disables deltastation
/:cl:
