### PR TITLE
removes all maps except box from rotation because the playerbase is always right

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -24,17 +24,17 @@ endmap
 
 map yogsmeta
 	minplayers 25
-	votable
+	disabled
 endmap
 
 map yogsdelta
 	minplayers 50
-	votable
+	disabled
 endmap
 
 map kilostation
 	maxplayers 40
-	votable
+	disabled
 endmap
 
 map icebox


### PR DESCRIPTION
# Document the changes in your pull request

Now you will never have to play shitty maps like anything except box ever again
I will take my unanimous 50 upvotes now please

# Changelog

:cl:  
rscdel: every map except box is now out of rotation, aka nothing has changed
/:cl:
