### PR TITLE
Drones and clockwork shells now remove their listing if used up

### DIFF
--- a/code/modules/antagonists/clockcult/clock_items/construct_chassis.dm
+++ b/code/modules/antagonists/clockcult/clock_items/construct_chassis.dm
@@ -23,7 +23,9 @@
 	GLOB.poi_list -= src
 	var/list/spawners = GLOB.mob_spawners[name]
 	LAZYREMOVE(spawners, src)
-	. = ..()
+	if(!LAZYLEN(spawners))
+		GLOB.mob_spawners -= name
+	return ..()
 
 /obj/item/clockwork/construct_chassis/examine(mob/user)
 	clockwork_desc = "[clockwork_desc]<br>[construct_desc]"

--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -38,8 +38,11 @@
 
 /obj/item/drone_shell/Destroy()
 	GLOB.poi_list -= src
-	LAZYREMOVE(GLOB.mob_spawners[initial(name)], src)//Yogs -- Adds drone shells to Spawner Menu
-	. = ..()
+	var/list/spawners = GLOB.mob_spawners[name]
+	LAZYREMOVE(spawners, src)
+	if(!LAZYLEN(spawners))
+		GLOB.mob_spawners -= name
+	return ..()
 
 //ATTACK GHOST IGNORING PARENT RETURN VALUE
 /obj/item/drone_shell/attack_ghost(mob/user)


### PR DESCRIPTION
# Document the changes in your pull request
![image](https://user-images.githubusercontent.com/20369082/144754385-48d8b3ea-cbb4-4262-b5e5-164f21a85264.png)

Makes that not happen


# Changelog

:cl:  
tweak: Drones and clockwork shells now remove their listing if used up
/:cl:
