### PR TITLE
Removes section box in spawner menu if there are no spawners

### DIFF
--- a/tgui/packages/tgui/interfaces/SpawnersMenu.js
+++ b/tgui/packages/tgui/interfaces/SpawnersMenu.js
@@ -13,47 +13,50 @@ export const SpawnersMenu = (props, context) => {
       height={600}
       resizable>
       <Window.Content scrollable>
-        <Section>
-          {spawners.map(spawner => (
-            <Section
-              key={spawner.name}
-              title={spawner.name + ' (' + spawner.amount_left + ' left)'}
-              level={2}
-              buttons={(
-                <Fragment>
-                  <Button
-                    content="Jump"
-                    onClick={() => act('jump', {
-                      name: spawner.name,
-                    })} />
-                  <Button
-                    content="Spawn"
-                    onClick={() => act('spawn', {
-                      name: spawner.name,
-                    })} />
-                </Fragment>
-              )}>
-              <Box
-                bold
-                mb={1}
-                fontSize="20px">
-                {spawner.short_desc}
-              </Box>
-              <Box>
-                {spawner.flavor_text}
-              </Box>
-              {!!spawner.important_info && (
+        {!!spawners.length && (
+          <Section>
+            {spawners.map(spawner => (
+              <Section
+                key={spawner.name}
+                title={spawner.name + ' (' + spawner.amount_left + ' left)'}
+                level={2}
+                buttons={(
+                  <Fragment>
+                    <Button
+                      content="Jump"
+                      onClick={() => act('jump', {
+                        name: spawner.name,
+                      })} />
+                    <Button
+                      content="Spawn"
+                      onClick={() => act('spawn', {
+                        name: spawner.name,
+                      })} />
+                  </Fragment>
+                )}>
                 <Box
-                  mt={1}
                   bold
-                  color="bad"
-                  fontSize="26px">
-                  {spawner.important_info}
+                  mb={1}
+                  fontSize="20px">
+                  {spawner.short_desc}
                 </Box>
-              )}
-            </Section>
-          ))}
-        </Section>
+                <Box>
+                  {spawner.flavor_text}
+                </Box>
+                {!!spawner.important_info && (
+                  <Box
+                    mt={1}
+                    bold
+                    color="bad"
+                    fontSize="26px">
+                    {spawner.important_info}
+                  </Box>
+                )}
+              </Section>
+            ))}
+          </Section>
+          )
+        }
       </Window.Content>
     </Window>
   );

--- a/tgui/packages/tgui/interfaces/SpawnersMenu.js
+++ b/tgui/packages/tgui/interfaces/SpawnersMenu.js
@@ -13,48 +13,49 @@ export const SpawnersMenu = (props, context) => {
       height={600}
       resizable>
       <Window.Content scrollable>
-        {!!spawners.length && (
-          <Section>
-            {spawners.map(spawner => (
-              <Section
-                key={spawner.name}
-                title={spawner.name + ' (' + spawner.amount_left + ' left)'}
-                level={2}
-                buttons={(
-                  <Fragment>
-                    <Button
-                      content="Jump"
-                      onClick={() => act('jump', {
-                        name: spawner.name,
-                      })} />
-                    <Button
-                      content="Spawn"
-                      onClick={() => act('spawn', {
-                        name: spawner.name,
-                      })} />
-                  </Fragment>
-                )}>
-                <Box
-                  bold
-                  mb={1}
-                  fontSize="20px">
-                  {spawner.short_desc}
-                </Box>
-                <Box>
-                  {spawner.flavor_text}
-                </Box>
-                {!!spawner.important_info && (
+        {
+          !!spawners.length && (
+            <Section>
+              {spawners.map(spawner => (
+                <Section
+                  key={spawner.name}
+                  title={spawner.name + ' (' + spawner.amount_left + ' left)'}
+                  level={2}
+                  buttons={(
+                    <Fragment>
+                      <Button
+                        content="Jump"
+                        onClick={() => act('jump', {
+                          name: spawner.name,
+                        })} />
+                      <Button
+                        content="Spawn"
+                        onClick={() => act('spawn', {
+                          name: spawner.name,
+                        })} />
+                    </Fragment>
+                  )}>
                   <Box
-                    mt={1}
                     bold
-                    color="bad"
-                    fontSize="26px">
-                    {spawner.important_info}
+                    mb={1}
+                    fontSize="20px">
+                    {spawner.short_desc}
                   </Box>
-                )}
-              </Section>
-            ))}
-          </Section>
+                  <Box>
+                    {spawner.flavor_text}
+                  </Box>
+                  {!!spawner.important_info && (
+                    <Box
+                      mt={1}
+                      bold
+                      color="bad"
+                      fontSize="26px">
+                      {spawner.important_info}
+                    </Box>
+                  )}
+                </Section>
+              ))}
+            </Section>
           )
         }
       </Window.Content>


### PR DESCRIPTION
# Document the changes in your pull request
OLD:
![image](https://user-images.githubusercontent.com/20369082/144765469-28b900ad-923d-44c7-99d2-0aee538d0704.png)


NEW:
![image](https://user-images.githubusercontent.com/20369082/144765331-09dfdcdf-71d7-4e35-aa4f-a808c9e473bf.png)

Removes an ugly box


# Changelog

:cl:  
tweak: Spawner menu now looks marginally better if there are no spawners
/:cl:
