### PR TITLE
Gives Fission360 a program icon

### DIFF
--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -273,6 +273,7 @@
 	available_on_ntnet = FALSE
 	available_on_syndinet = TRUE
 	tgui_id = "NtosRadarSyndicate"
+	program_icon = "radiation"
 	arrowstyle = "ntosradarpointerS.png"
 	pointercolor = "red"
 


### PR DESCRIPTION
# Document the changes in your pull request

Forgot about this in my other PR. Gives Fission360 a radiation symbol as its icon so its not left out from the rest. Untested, should work.

# Wiki Documentation

No changes needed. 

# Changelog

:cl:  
tweak: Fission360 now has a program icon
/:cl:
