### PR TITLE
Gives alternative name for CE, meet "The Arsonist"!

### DIFF
--- a/code/modules/jobs/chief_engineer.dm
+++ b/code/modules/jobs/chief_engineer.dm
@@ -1,0 +1,68 @@
+/datum/job/chief_engineer
+	title = "Chief Engineer"
+	flag = CHIEF
+	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
+	department_head = list("Captain")
+	department_flag = ENGSEC
+	head_announce = list("Engineering")
+	faction = "Station"
+	total_positions = 1
+	spawn_positions = 1
+	supervisors = "the captain"
+	selection_color = "#ffeeaa"
+	req_admin_notify = 1
+	minimal_player_age = 7
+	exp_requirements = 180
+	exp_type = EXP_TYPE_CREW
+	exp_type_department = EXP_TYPE_ENGINEERING
+	alt_titles = list("Engineering Director", "Head of Engineering", "Chief Arsonist")
+
+	outfit = /datum/outfit/job/ce
+
+	access = list(ACCESS_ENGINE, ACCESS_ENGINE_EQUIP, ACCESS_TECH_STORAGE, ACCESS_MAINT_TUNNELS,
+			            ACCESS_EXTERNAL_AIRLOCKS, ACCESS_ATMOSPHERICS, ACCESS_EVA,
+			            ACCESS_HEADS, ACCESS_CONSTRUCTION, ACCESS_SEC_DOORS, ACCESS_MINISAT, ACCESS_MECH_ENGINE,
+			            ACCESS_CE, ACCESS_RC_ANNOUNCE, ACCESS_KEYCARD_AUTH, ACCESS_TCOMSAT, ACCESS_MINERAL_STOREROOM)
+	minimal_access = list(ACCESS_ENGINE, ACCESS_ENGINE_EQUIP, ACCESS_TECH_STORAGE, ACCESS_MAINT_TUNNELS,
+			            ACCESS_EXTERNAL_AIRLOCKS, ACCESS_ATMOSPHERICS, ACCESS_EVA,
+			            ACCESS_HEADS, ACCESS_CONSTRUCTION, ACCESS_SEC_DOORS, ACCESS_MINISAT, ACCESS_MECH_ENGINE,
+			            ACCESS_CE, ACCESS_RC_ANNOUNCE, ACCESS_KEYCARD_AUTH, ACCESS_TCOMSAT, ACCESS_MINERAL_STOREROOM)
+	paycheck = PAYCHECK_COMMAND
+	paycheck_department = ACCOUNT_ENG
+
+	display_order = JOB_DISPLAY_ORDER_CHIEF_ENGINEER
+
+/datum/outfit/job/ce
+	name = "Chief Engineer"
+	jobtype = /datum/job/chief_engineer
+
+	id = /obj/item/card/id/silver
+	belt = /obj/item/storage/belt/utility/chief/full
+	l_pocket = /obj/item/pda/heads/ce
+	ears = /obj/item/radio/headset/heads/ce
+	uniform = /obj/item/clothing/under/rank/chief_engineer
+	shoes = /obj/item/clothing/shoes/sneakers/brown
+	alt_shoes = /obj/item/clothing/shoes/xeno_wraps/command // Provides Command shoes to digitigrade species
+	head = /obj/item/clothing/head/hardhat/white
+	gloves = /obj/item/clothing/gloves/color/black/ce
+	backpack_contents = list(/obj/item/melee/classic_baton/telescopic=1, /obj/item/modular_computer/tablet/phone/preset/advanced/command=1) //yogs - removes eng budget
+	glasses = /obj/item/clothing/glasses/meson/sunglasses
+
+	backpack = /obj/item/storage/backpack/industrial
+	satchel = /obj/item/storage/backpack/satchel/eng
+	duffelbag = /obj/item/storage/backpack/duffelbag/engineering
+	box = /obj/item/storage/box/engineer
+	pda_slot = SLOT_L_STORE
+	chameleon_extras = /obj/item/stamp/ce
+
+/datum/outfit/job/ce/rig
+	name = "Chief Engineer (Hardsuit)"
+
+	mask = /obj/item/clothing/mask/breath
+	suit = /obj/item/clothing/suit/space/hardsuit/engine/elite
+	shoes = /obj/item/clothing/shoes/magboots/advance
+	suit_store = /obj/item/tank/internals/oxygen
+	glasses = /obj/item/clothing/glasses/meson/sunglasses
+	gloves = /obj/item/clothing/gloves/color/yellow
+	head = null
+	internals_slot = SLOT_S_STORE

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -64,12 +64,12 @@ GLOBAL_LIST_INIT(alt_command_positions, list(
 	"Station Commander", "Facility Director",
 	"Chief of Staff", "Head of Internal Affairs", "First Officer",
 	"Security Commander", "Security Chief",
-	"Head of Engineering", "Engineering Director",
+	"Head of Engineering", "Engineering Director", "Chief Arsonist",
 	"Chief Science Officer", "Head of Research",
 	"Medical Director", "Head of Medical"))
 
 GLOBAL_LIST_INIT(alt_engineering_positions, list(
-	"Head of Engineering", "Engineering Director",
+	"Head of Engineering", "Engineering Director", "Chief Arsonist,",
 	"Engine Technician", "Solar Engineer", "Project Engineer", "Junior Engineer", "Construction Specialist",
 	"Life-support Technician", "Fire Suppression Specialist", "Atmospherics Trainee", "Environmental Maintainer",
 	"NTSL Programmer", "Comms Tech", "Station IT Support"


### PR DESCRIPTION
# Document the changes in your pull request

Adds alternative name for Chief Engineer. Gives the new name, "The Arsonist." Fully tested.
(Ignore the +298 and -230. I only changed like 3 lines of code... probaabllyyy..)
# Wiki Documentation

No changes Required
# Changelog

:cl:  
tweak: Gave CE new alternative name.
/:cl:
