### PR TITLE
Reduces potential infiltrator metagaming (plus a bugfix!)

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -135,7 +135,14 @@
 				continue
 			var/obj/item/tank/T = o
 			found_amount += T.air_contents.get_moles(/datum/gas/plasma)
-
+	if (istype(objective.team, /datum/team/infiltrator))
+		for (var/area/A in world)
+			if (is_type_in_typecache(A, GLOB.infiltrator_objective_areas))
+				for (var/obj/item/tank/T in A.GetAllContents()) //Check for items
+					found_amount += T.air_contents.get_moles(/datum/gas/plasma)
+					CHECK_TICK
+			CHECK_TICK
+		CHECK_TICK
 	return found_amount >= target_amount
 
 

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -379,6 +379,10 @@ update_label("John Doe", "Clowny")
 			return
 	return ..()
 
+/obj/item/card/id/syndicate/on_chameleon_change()
+	. = ..()
+	update_label()
+
 // Returns true if new account was set.
 /obj/item/card/id/proc/set_new_account(mob/living/user)
 	. = FALSE

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -235,6 +235,7 @@
 		qdel(helmet)
 		//YOGS END
 	target.icon = initial(picked_item.icon)
+	target.on_chameleon_change()
 
 /datum/action/item_action/chameleon/change/Trigger()
 	if(!IsAvailable())
@@ -673,6 +674,10 @@
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
+/obj/item/pda/chameleon/on_chameleon_change()
+	. = ..()
+	update_label()
+
 /obj/item/stamp/chameleon
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
@@ -691,3 +696,6 @@
 /obj/item/stamp/chameleon/broken/Initialize()
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
+
+/obj/item/proc/on_chameleon_change()
+	return

--- a/yogstation/code/modules/antagonists/infiltrator/items/hardsuit.dm
+++ b/yogstation/code/modules/antagonists/infiltrator/items/hardsuit.dm
@@ -1,9 +1,10 @@
 /obj/item/clothing/head/helmet/space/hardsuit/infiltration
-	name = "chameleon hardsuit helmet"
+	name = "engineering hardsuit helmet"
 	icon_state = "hardsuit0-engineering"
 	item_state = "eng_helm"
 	item_color = "engineering"
 	armor = list("melee" = 35, "bullet" = 15, "laser" = 30,"energy" = 10, "bomb" = 10, "bio" = 100, "rad" = 50, "fire" = 75, "acid" = 75)
+	syndicate = TRUE
 
 /obj/item/clothing/head/helmet/space/hardsuit/infiltration/Initialize()
 	. = ..()
@@ -12,7 +13,7 @@
 		I.head_piece = src
 
 /obj/item/clothing/suit/space/hardsuit/infiltration
-	name = "chameleon hardsuit"
+	name = "engineering hardsuit"
 	icon_state = "hardsuit-engineering"
 	item_state = "eng_hardsuit"
 	w_class = WEIGHT_CLASS_NORMAL
@@ -20,8 +21,14 @@
 	allowed = list(/obj/item/gun, /obj/item/ammo_box,/obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/melee/transforming/energy/sword/saber, /obj/item/restraints/handcuffs, /obj/item/tank/internals)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/infiltration
 	jetpack = /obj/item/tank/jetpack/suit
+	syndicate = TRUE
 	var/datum/action/item_action/chameleon/change/chameleon_action
 	var/obj/item/clothing/head/helmet/space/hardsuit/infiltration/head_piece
+
+/obj/item/clothing/suit/space/hardsuit/infiltration/examine(mob/user)
+	. = ..()
+	if (is_syndicate(user))
+		. += span_notice("There appears to be a hidden panel on it, showing various customization options.")
 
 /obj/item/clothing/suit/space/hardsuit/infiltration/Initialize()
 	. = ..()

--- a/yogstation/code/modules/antagonists/infiltrator/outfit.dm
+++ b/yogstation/code/modules/antagonists/infiltrator/outfit.dm
@@ -1,15 +1,15 @@
 /datum/outfit/infiltrator
 	name = "Syndicate Infiltrator"
 
-	uniform = /obj/item/clothing/under/chameleon
-	shoes = /obj/item/clothing/shoes/chameleon/noslip
-	gloves = /obj/item/clothing/gloves/chameleon
-	back = /obj/item/storage/backpack/chameleon
-	ears = /obj/item/radio/headset/chameleon
+	uniform = /obj/item/clothing/under/chameleon/syndicate
+	shoes = /obj/item/clothing/shoes/chameleon/noslip/syndicate
+	gloves = /obj/item/clothing/gloves/chameleon/syndicate
+	back = /obj/item/storage/backpack/chameleon/syndicate
+	ears = /obj/item/radio/headset/chameleon/syndicate
 	id = /obj/item/card/id/syndicate
-	mask = /obj/item/clothing/mask/chameleon
-	belt = /obj/item/pda/chameleon
-	backpack_contents = list(/obj/item/storage/box/syndie=1,\
+	mask = /obj/item/clothing/mask/chameleon/syndicate
+	belt = /obj/item/pda/chameleon/syndicate
+	backpack_contents = list(/obj/item/storage/box/engineer=1,\
 		/obj/item/kitchen/knife/combat/survival=1,\
 		/obj/item/gun/ballistic/automatic/pistol=1)
 


### PR DESCRIPTION
This makes several different core elements of infiltrators much harder to metagame. Now, some metagaming stuff still needs to be enforced admin-side, but this should remove several different mechanics that could allow for metagaming - such as examining them and seeing "chameleon hardsuit" (which defeats the purpose of a chameleon hardsuit), stripping an infiltrator to check their clothes, looking for a generic ID/PDA name, or checking their backpack for a syndie mask in the box.

:cl:  
tweak: All infiltrator chameleon items are now syndicate chameleon items, meaning only they will get the action buttons for them.
tweak: All chameleon hardsuits now default to being called "engineering hardsuit", and their chameleon functionality is also syndicate-only
tweak: Infiltrators now have an engineer box and not a syndicate box in their backpack, because why do they need a very un-stealthy syndicate mask?
fix: Chameleon IDs and PDAs will no longer go back to a "generic" name when their appearance is changed
fix: The "steal 28 moles of plasma" objective will now be complete for infiltrators if it's in the base
/:cl:
