### PR TITLE
Makes modular computer overlays glow in the dark

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -27,8 +27,10 @@
 	var/icon_state_unpowered = null							// Icon state when the computer is turned off.
 	var/icon_state_powered = null							// Icon state when the computer is turned on.
 	var/icon_state_menu = "menu"							// Icon state overlay when the computer is turned on, but no program is loaded that would override the screen.
+	var/icon_state_screensaver = "standby"					// Icon state overlay when the computer is turned off, but not out of power.
 	var/max_hardware_size = 0								// Maximal hardware w_class. Tablets/PDAs have 1, laptops 2, consoles 4.
 	var/steel_sheet_cost = 5								// Amount of steel sheets refunded when disassembling an empty frame of this computer.
+	var/overlay_skin = null									// What set of icons should be used for program overlays.
 
 	integrity_failure = 50
 	max_integrity = 100
@@ -196,20 +198,39 @@
 	. += get_modular_computer_parts_examine(user)
 
 /obj/item/modular_computer/update_icon()
-	cut_overlays()
+	SSvis_overlays.remove_vis_overlay(physical, physical.managed_vis_overlays)
+	var/program_overlay = ""
+	var/is_broken = obj_integrity <= integrity_failure
+	if(overlay_skin)
+		program_overlay = "[overlay_skin]-"
 	if(!enabled)
-		icon_state = icon_state_unpowered
+		if(use_power() && !isnull(icon_state_screensaver))
+			program_overlay += icon_state_screensaver
+		else
+			icon_state = icon_state_unpowered
 	else
 		icon_state = icon_state_powered
-		if(active_program)
-			add_overlay(active_program.program_icon_state ? active_program.program_icon_state : icon_state_menu)
+		if(is_broken)
+			program_overlay += "bsod"
 		else
-			add_overlay(icon_state_menu)
+			if(active_program)
+				program_overlay += active_program.program_icon_state ? "[active_program.program_icon_state]" : "[icon_state_menu]"
+			else
+				program_overlay += icon_state_menu
 
-	if(obj_integrity <= integrity_failure)
-		add_overlay("bsod")
-		add_overlay("broken")
+	SSvis_overlays.add_vis_overlay(physical, physical.icon, program_overlay, physical.layer, physical.plane, physical.dir)
+	SSvis_overlays.add_vis_overlay(physical, physical.icon, program_overlay, physical.layer, EMISSIVE_PLANE, physical.dir)
 
+	if(is_broken)
+		SSvis_overlays.add_vis_overlay(physical, physical.icon, "broken", physical.layer, physical.plane, physical.dir)
+
+/obj/item/modular_computer/equipped()
+	. = ..()
+	update_icon()
+
+/obj/item/modular_computer/dropped()
+	. = ..()
+	update_icon()
 
 // On-click handling. Turns on the computer if it's off and opens the GUI.
 /obj/item/modular_computer/interact(mob/user)

--- a/code/modules/modular_computers/computers/item/laptop.dm
+++ b/code/modules/modular_computers/computers/item/laptop.dm
@@ -37,7 +37,7 @@
 	if(screen_on)
 		..()
 	else
-		cut_overlays()
+		SSvis_overlays.remove_vis_overlay(physical, physical.managed_vis_overlays)
 		icon_state = icon_state_closed
 
 /obj/item/modular_computer/laptop/attack_self(mob/user)

--- a/code/modules/modular_computers/computers/item/processor.dm
+++ b/code/modules/modular_computers/computers/item/processor.dm
@@ -29,6 +29,9 @@
 	idle_threads = list()
 	machinery_computer = comp
 	machinery_computer.cpu = src
+	icon_state_menu = machinery_computer.screen_icon_state_menu
+	icon_state_screensaver = machinery_computer.screen_icon_screensaver
+	overlay_skin = machinery_computer.overlay_skin
 	hardware_flag = machinery_computer.hardware_flag
 	max_hardware_size = machinery_computer.max_hardware_size
 	steel_sheet_cost = machinery_computer.steel_sheet_cost
@@ -40,10 +43,6 @@
 
 /obj/item/modular_computer/processor/relay_qdel()
 	qdel(machinery_computer)
-
-/obj/item/modular_computer/processor/update_icon()
-	if(machinery_computer)
-		return machinery_computer.update_icon()
 
 // This thing is not meant to be used on it's own, get topic data from our machinery owner.
 //obj/item/modular_computer/processor/canUseTopic(atom/movable/M, be_close=FALSE, no_dextery=FALSE, no_tk=FALSE)

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -14,14 +14,15 @@
 	slot_flags = ITEM_SLOT_BELT
 	has_light = TRUE //LED flashlight!
 	comp_light_luminosity = 2.3 //Same as the PDA
-	var/has_variants = TRUE
+
+	var/list/variants = list("red","blue","brown","green","black")
 	var/finish_color = null
 
 /obj/item/modular_computer/tablet/update_icon()
 	..()
-	if (has_variants)
+	if (!isnull(variants))
 		if(!finish_color)
-			finish_color = pick("red","blue","brown","green","black")
+			finish_color = pick(variants)
 		icon_state = "[icon_state_base]-[finish_color]"
 		icon_state_unpowered = "[icon_state_base]-[finish_color]"
 		icon_state_powered = "[icon_state_base]-[finish_color]"
@@ -37,7 +38,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	slot_flags = ITEM_SLOT_ID | ITEM_SLOT_BELT
 	comp_light_luminosity = 6.3
-	has_variants = FALSE
+	variants = null
 
 /// Given to Nuke Ops members.
 /obj/item/modular_computer/tablet/nukeops

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -19,6 +19,7 @@
 	var/icon_state_powered = null						// Icon state when the computer is turned on.
 	var/screen_icon_state_menu = "menu"					// Icon state overlay when the computer is turned on, but no program is loaded that would override the screen.
 	var/screen_icon_screensaver = "standby"				// Icon state overlay when the computer is powered, but not 'switched on'.
+	var/overlay_skin = null		
 	var/max_hardware_size = 0							// Maximal hardware size. Currently, tablets have 1, laptops 2 and consoles 3. Limits what hardware types can be installed.
 	var/steel_sheet_cost = 10							// Amount of steel sheets refunded when disassembling an empty frame of this computer.
 	var/light_strength = 0								// Light luminosity when turned on
@@ -54,26 +55,7 @@
 	return (cpu.emag_act(user))
 
 /obj/machinery/modular_computer/update_icon()
-	cut_overlays()
-	icon_state = icon_state_powered
-
-	if(!cpu || !cpu.enabled)
-		if (!(stat & NOPOWER) && (cpu && cpu.use_power()))
-			add_overlay(screen_icon_screensaver)
-		else
-			icon_state = icon_state_unpowered
-		set_light(0)
-	else
-		set_light(light_strength)
-		if(cpu.active_program)
-			add_overlay(cpu.active_program.program_icon_state ? cpu.active_program.program_icon_state : screen_icon_state_menu)
-		else
-			add_overlay(screen_icon_state_menu)
-
-	if(cpu && cpu.obj_integrity <= cpu.integrity_failure)
-		add_overlay("bsod")
-		add_overlay("broken")
-
+	cpu.update_icon()
 
 /obj/machinery/modular_computer/AltClick(mob/user)
 	if(cpu)


### PR DESCRIPTION
# Document the changes in your pull request

Makes program overlays glow in the dark by using SSvis_overlay. Also unifies overlay code and adds a system for adding program overlay skins, though the latter is not used as I still need #12685 merged. I can atomize this down if needed. Is tested, does work.

![image](https://user-images.githubusercontent.com/14363906/145145927-21b19677-fd37-430c-8317-e465574f42b6.png)

# Wiki Documentation

No changes needed. 

# Changelog

:cl:  
tweak: modular computer program overlays now glow in the dark   
/:cl:
