### PR TITLE
Excludes the hacked AI law upload module from infiltrators

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1470,6 +1470,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/aiModule/syndicate
 	cost = 4
 	manufacturer = /datum/corporation/traitor/cybersun
+	exclude_modes = list(/datum/game_mode/infiltration)
 
 /datum/uplink_item/device_tools/hypnotic_flash
 	name = "Hypnotic Flash"


### PR DESCRIPTION
This is meant to discourage infiltrators from screwing with the AI. It *never* ends well, and honestly goes against the whole stealth thing.

:cl: Lucy
tweak: Infiltrators can no longer buy the hacked AI law upload board. Stop screwing with the AI ffs!
/:cl: