### PR TITLE
Epinephrine purges lexorin

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -838,6 +838,8 @@
 	. = 1
 	if(prob(20))
 		M.AdjustAllImmobility(-20, FALSE)
+	if(holder.has_reagent(/datum/reagent/toxin/lexorin))
+		holder.remove_reagent(/datum/reagent/toxin/lexorin, 1)
 	..()
 
 /datum/reagent/medicine/epinephrine/overdose_process(mob/living/M)


### PR DESCRIPTION
As it stands, a single 15u lexorin syringe fired from a syringe gun gives the victim about 30 seconds to get help or else they're unconscious and well on their way to dead
Getting help can be difficult, as in most cases the lexorin syringe was fired by a living person who wants you to die and is also in the room with you
Lexorin, as a reminder, can be made in like 40u quantities within a minute from roundstart using a simple 1:1:1 = 3 recipe of base and easily acquired reagents

This would make it the same except if you think fast and use your epipen you can live, this time

Note that I have no idea how fast this actually purges lex, I think it's the same rate as charcoal, so pretty slow? But I do know that lexorin keeps working for a while even after completely leaving the system, so "too fast" or "fast enough" are both harder to achieve than they might look
Ideally this wouldn't make lexorin a bad poison, just make it so it isn't _miles ahead of everything else a chemist can make_ and effective as a deathmix entirely on its own. If the person is late in deploying epi they should suffer for it; if they're quick they should at least stay conscious.

Not tested but uses copypasta code soooo

# Wiki Documentation

Prevents oxygen damage from crit state. If the patient is in crit it heals 0.5 oxyloss, toxins, brute, and burn. 20% chance each tick to reduce stun times a bit. Gives a minor stamina regeneration buff. **Slowly purges lexorin.**
Worse than Atropine at saving critical patients, but better for mid combat use.
Overdose-Effect: 33% chance to deal 2.5 stamina and 1 toxin damage, and some suffocation.

# Changelog

:cl:  
tweak: Epinephrine purges lexorin
/:cl: