### PR TITLE
Fix Remote Signaling Device UI

### DIFF
--- a/tgui/packages/tgui/interfaces/Signaler.js
+++ b/tgui/packages/tgui/interfaces/Signaler.js
@@ -16,7 +16,7 @@ export const Signaler = (props, context) => {
   return (
     <Window
       width={280}
-      height={132}>
+      height={150}>
       <Window.Content>
         <Section>
           <Grid>
@@ -82,7 +82,7 @@ export const Signaler = (props, context) => {
             <Grid.Column>
               <Button
                 icon="sync"
-                width={25.75}
+                width={13.1}
                 color={color}
                 content={color}
                 onClick={() => act('color')} />

--- a/tgui/packages/tgui/styles/colors.scss
+++ b/tgui/packages/tgui/styles/colors.scss
@@ -16,10 +16,12 @@ $yellow: #fbd608 !default;
 $olive: #b5cc18 !default;
 $green: #20b142 !default;
 $teal: #00b5ad !default;
+$cyan: #00ffff !default;
 $blue: #2185d0 !default;
 $violet: #6435c9 !default;
 $purple: #a333c8 !default;
 $pink: #e03997 !default;
+$magenta: #ff0fff !default;
 $brown: #a5673f !default;
 $grey: #767676 !default;
 
@@ -62,6 +64,8 @@ $_gen_map: (
   'average': $average,
   'bad': $bad,
   'label': $label,
+  'cyan': $cyan,
+  'magenta': $magenta
 );
 
 // Foreground color names for which to generate a color map


### PR DESCRIPTION
Fixes the Remote Signaling Device's UI. It was cut off. The colour map also didn't contain cyan or magenta, so while the button was green for green signals, cyan/magenta had resulted in just a black button.

Before:
![dreamseeker_BW3cMRrtkv](https://user-images.githubusercontent.com/1077971/145427911-4407085a-c5c5-4473-99db-185b469ce3a1.png)

After:
![image](https://user-images.githubusercontent.com/1077971/145430726-24ba3ce7-59a4-49f2-80fa-b63c653cc8c9.png)

Tested by tgui dev server / ingame

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
fix: Fixed Remote signaling device UI being cut off
fix: Fixed Remote signaling device UI button not having cyan/magenta colours, resulting in black button when those were selected
/:cl:
