### PR TITLE
prevents custom docking points from being placed on plating

### DIFF
--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -15,7 +15,7 @@
 	var/view_range = 0
 	var/x_offset = 0
 	var/y_offset = 0
-	var/list/whitelist_turfs = list(/turf/open/space, /turf/open/floor/plating, /turf/open/lava)
+	var/list/whitelist_turfs = list(/turf/open/space, /turf/open/floor/plating/asteroid, /turf/open/lava)
 	var/space_turfs_only = TRUE
 	var/see_hidden = FALSE
 	var/designate_time = 0


### PR DESCRIPTION
# Document the changes in your pull request

turns out plating is now a viable ship docking turf which means instead of needing to detonate a sizeable portion of the station to land a shuttle inside it you just would need to deconstruct all the walls and remove any floor tiles

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
tweak: custom shuttle landing points can now be placed on specifically asteroid/lavaland turfs not station maintenance
/:cl:
