### PR TITLE
Makes crew monitors actually checks to see if someone is dead to label them as dead

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -163,7 +163,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 					ijob = 80
 
 				if (nanite_sensors || U.sensor_mode >= SENSOR_LIVING)
-					life_status = (!H.stat ? TRUE : FALSE)
+					life_status = H.stat < DEAD
 				else
 					life_status = null
 


### PR DESCRIPTION
# Document the changes in your pull request

Should fix #12863. Should do as the title says, fixes crew monitors saying people in soft crit and unconscious as dead. Untested, should work

# Wiki Documentation

No changes needed. 

# Changelog

:cl:  
bugfix: fixed crew monitors labeling people in soft crit and unconscious as dead
/:cl:
