### PR TITLE
More interesting singularity movement

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1579,3 +1579,11 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	return call(source, proctype)(arglist(arguments))
 
 #define TURF_FROM_COORDS_LIST(List) (locate(List[1], List[2], List[3]))
+
+/proc/get_box(corner_x, corner_y, z, size_x, size_y)
+	. = list()
+	for	(var/x in corner_x to corner_x + size_x)
+		for (var/y in corner_y to corner_y + size_y)
+			var/turf/T = locate(x, y, z)
+			if (T && istype(T))
+				. |= T

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1579,11 +1579,3 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	return call(source, proctype)(arglist(arguments))
 
 #define TURF_FROM_COORDS_LIST(List) (locate(List[1], List[2], List[3]))
-
-/proc/get_box(corner_x, corner_y, z, size_x, size_y)
-	. = list()
-	for	(var/x in corner_x to corner_x + size_x)
-		for (var/y in corner_y to corner_y + size_y)
-			var/turf/T = locate(x, y, z)
-			if (T && istype(T))
-				. |= T

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -15,6 +15,7 @@
 	light_range = 15
 	light_color = rgb(255, 0, 0)
 	gender = FEMALE
+	does_targeting = FALSE
 	var/clashing = FALSE //If Nar-Sie is fighting Ratvar
 
 /obj/singularity/narsie/large

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -377,18 +377,15 @@
 			for (var/turf/T in box)
 				if (!isspaceturf(T))
 					interest += 2
-				var/list/objs = list()
+				var/objs = 0
 				for (var/A in T.contents)
 					if (istype(A, /atom/movable))
-						objs += A
-				interest += CEILING(length(objs) / 7.5, 0.5)
+						objs += 1
+				interest += CEILING(objs / 7.5, 0.5)
 			sections[section_loc] = interest
-	to_chat(world, "singularity sees [LAZYLEN(sections)] sections.")
 	var/turf/section = pickweight(sections)
 	if (section && istype(section))
-		to_chat(world, "singularity picked target at [section.x],[section.y],[section.z] (interest value of [sections[section]])")
 		random_target = section
-		
 
 /obj/singularity/proc/check_turfs_in(direction = 0, step = 0)
 	if(!direction)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -30,6 +30,7 @@
 	var/last_warning
 	var/consumedSupermatter = 0 //If the singularity has eaten a supermatter shard and can go to stage six
 	var/maxStage = 0 //The largest stage this singularity has been
+	var/does_targeting = TRUE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 	obj_flags = CAN_BE_HIT | DANGEROUS_POSSESSION
 
@@ -351,7 +352,7 @@
 	if (random_target && (random_target.z != z || get_dist(src, random_target) <= 2))
 		random_target = null
 
-	if (!random_target && prob(50))
+	if (does_targeting && !random_target && prob(50))
 		pick_random_target()
 
 /obj/singularity/proc/check_cardinals_range(steps, retry_with_move = FALSE)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -371,9 +371,10 @@
 	for (var/section_x = -SINGULARITY_QUADRANT_DISTANCE - SINGULARITY_QUADRANT_SIZE; section_x <= SINGULARITY_QUADRANT_DISTANCE - SINGULARITY_QUADRANT_SIZE; section_x += SINGULARITY_QUADRANT_SIZE)
 		for (var/section_y = -SINGULARITY_QUADRANT_DISTANCE - SINGULARITY_QUADRANT_SIZE; section_y <= SINGULARITY_QUADRANT_DISTANCE - SINGULARITY_QUADRANT_SIZE; section_y += SINGULARITY_QUADRANT_SIZE)
 			var/turf/section_loc = locate(x + section_x, y + section_y, z)
-			if (!section_loc || !istype(section_loc))
+			var/turf/bottom_corner = locate(x + section_x + SINGULARITY_QUADRANT_SIZE - 1, y + section_y + SINGULARITY_QUADRANT_SIZE - 1, z)
+			if (!section_loc || !istype(section_loc) || !bottom_corner || !istype(bottom_corner))
 				continue
-			var/list/box = get_box(x + section_x, y + section_y, z, SINGULARITY_QUADRANT_SIZE, SINGULARITY_QUADRANT_SIZE)
+			var/list/box = block(section_loc, bottom_corner)
 			var/interest = 0
 			for (var/turf/T in box)
 				if (!isspaceturf(T))

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -1,5 +1,7 @@
 #define SINGULARITY_QUADRANT_SIZE 3
 #define SINGULARITY_QUADRANT_DISTANCE 15
+#define SINGULARITY_INTEREST_OBJECT 7.5
+#define SINGULARITY_INTEREST_NONSPACE 2
 
 /obj/singularity
 	name = "gravitational singularity"
@@ -368,8 +370,8 @@
 
 /obj/singularity/proc/pick_random_target()
 	var/list/sections = list()
-	for (var/section_x = -SINGULARITY_QUADRANT_DISTANCE - SINGULARITY_QUADRANT_SIZE; section_x <= SINGULARITY_QUADRANT_DISTANCE - SINGULARITY_QUADRANT_SIZE; section_x += SINGULARITY_QUADRANT_SIZE)
-		for (var/section_y = -SINGULARITY_QUADRANT_DISTANCE - SINGULARITY_QUADRANT_SIZE; section_y <= SINGULARITY_QUADRANT_DISTANCE - SINGULARITY_QUADRANT_SIZE; section_y += SINGULARITY_QUADRANT_SIZE)
+	for (var/section_x = -SINGULARITY_QUADRANT_DISTANCE - SINGULARITY_QUADRANT_SIZE; section_x < SINGULARITY_QUADRANT_DISTANCE + SINGULARITY_QUADRANT_SIZE; section_x += SINGULARITY_QUADRANT_SIZE)
+		for (var/section_y = -SINGULARITY_QUADRANT_DISTANCE - SINGULARITY_QUADRANT_SIZE; section_y < SINGULARITY_QUADRANT_DISTANCE + SINGULARITY_QUADRANT_SIZE; section_y += SINGULARITY_QUADRANT_SIZE)
 			var/turf/section_loc = locate(x + section_x, y + section_y, z)
 			var/turf/bottom_corner = locate(x + section_x + SINGULARITY_QUADRANT_SIZE - 1, y + section_y + SINGULARITY_QUADRANT_SIZE - 1, z)
 			if (!section_loc || !istype(section_loc) || !bottom_corner || !istype(bottom_corner))
@@ -378,12 +380,12 @@
 			var/interest = 0
 			for (var/turf/T in box)
 				if (!isspaceturf(T))
-					interest += 2
+					interest += SINGULARITY_INTEREST_NONSPACE
 				var/objs = 0
 				for (var/A in T.contents)
 					if (istype(A, /atom/movable))
 						objs += 1
-				interest += CEILING(objs / 7.5, 0.5)
+				interest += CEILING(objs / SINGULARITY_INTEREST_OBJECT, 0.5)
 			sections[section_loc] = interest
 	var/turf/section = pickweight(sections)
 	if (section && istype(section))


### PR DESCRIPTION
The singularity's movement has been changed. It can now pick a "random target" based on an interest value. It goes through 3x3 sections in a 15 tile radius from the singularity, assigning an interest value based on the amount of non-space tiles and objects that are in the tile. It will then pick where to move based on a weighted pick - it can still pick an uninteresting target to move to, but it's much more likely to go towards somewhere with 50 bajillion objects on a tile.

The singularity can still move randomly, though. It will also continue to prioritize active singularity beacons above this new system.

:cl: Lucy
tweak: The singularity is less likely to fuck off into space now.
/:cl:
