### PR TITLE
fixes a substantial amount of garbage related to borg buckling

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1180,14 +1180,16 @@
 	shell = TRUE
 
 /mob/living/silicon/robot/MouseDrop_T(mob/living/M, mob/living/user)
-	. = ..()
 	if(!(M in buckled_mobs) && isliving(M) && user && user.can_buckle)
-		buckle_mob(M)
+		buckle_mob(M, TRUE)
+	 . = ..()
 
 /mob/living/silicon/robot/buckle_mob(mob/living/M, force = FALSE, check_loc = TRUE)
 	if(!is_type_in_typecache(M, can_ride_typecache))
 		M.visible_message(span_warning("[M] really can't seem to mount [src]..."))
 		return
+	if(!force)
+		return //buckling is called twice if we don't do this which is a mess
 	var/datum/component/riding/riding_datum = LoadComponent(/datum/component/riding/cyborg)
 	if(has_buckled_mobs())
 		if(buckled_mobs.len >= max_buckled_mobs)
@@ -1203,10 +1205,11 @@
 			M.visible_message(span_boldwarning("Unfortunately, [M] just can't seem to hold onto [src]!"))
 			return
 	M.visible_message(span_warning("[M] begins to [M == usr ? "climb onto" : "be buckled to"] [src]..."))
-	if(!do_after(M, 0.75 SECONDS, target = src))
+	var/_target = usr == M ? src : M
+	if(!do_after(usr, 0.75 SECONDS, target = _target))
 		M.visible_message(span_boldwarning("[M] was prevented from buckling to [src]!"))
 		return
-		
+
 	if(iscarbon(M) && !M.incapacitated() && !riding_datum.equip_buckle_inhands(M, 1))
 		if(M.get_num_arms() <= 0)
 			M.visible_message(span_boldwarning("[M] can't climb onto [src] because [M.p_they()] don't have any usable arms!"))


### PR DESCRIPTION
# Document the changes in your pull request

turns out the fix for making the borg get the progress bar forr buckling was reverted due to an oversight or whatever not by me because I'm not that sadistic so instead I've made it actually show up for whoever initiated the buckling
ALSO borg buckling would be attempted TWICE so that gets fixed too

# Changelog

:cl:  
bugfix: borgs can see their progress bar when buckling again, also they can buckle incapacitated people
bugfix: failing to buckle to a borg will no longer result in you trying to buckle to the same borg a second time
/:cl:
