### PR TITLE
Timeskip rework

### DIFF
--- a/yogstation/code/modules/guardian/abilities/major/time.dm
+++ b/yogstation/code/modules/guardian/abilities/major/time.dm
@@ -1,3 +1,5 @@
+#define TIMESKIP_SOLID_OBJECT_MULTIPLIER	3
+
 /datum/guardian_ability/major/time
 	name = "Time Erasure"
 	desc = "The guardian can erase a short period of time."
@@ -9,6 +11,12 @@
 	. = ..()
 	var/obj/effect/proc_holder/spell/self/erase_time/S = spell
 	S.length = master_stats.potential * 2 * 10
+
+/datum/guardian_ability/major/time/Manifest()
+	if (guardian.erased_time && istype(guardian.loc, /obj/effect/dummy/phased_mob/king_crimson))
+		var/obj/effect/dummy/phased_mob/king_crimson/jaunt = guardian.loc
+		jaunt.forceMove(guardian.summoner.current.loc)
+		return TRUE
 
 /obj/effect/proc_holder/spell/self/erase_time
 	name = "Erase Time"
@@ -24,58 +32,131 @@
 		revert_cast()
 		return
 	var/list/immune = list(user)
-	var/list/fakes = list()
 	if(isguardian(user))
 		var/mob/living/simple_animal/hostile/guardian/G = user
 		if(G.summoner?.current)
 			immune |= G.summoner.current
-			for(var/mob/living/simple_animal/hostile/guardian/GG in G.summoner.current.hasparasites())
-				immune |= GG
+			for(var/other in G.summoner.current.hasparasites())
+				immune |= other
 	for(var/mob/living/L in immune)
-		SEND_SOUND(L, sound('yogstation/sound/effects/kingcrimson_start.ogg'))
-		var/image/I = image(icon = 'icons/effects/blood.dmi', icon_state = null, loc = L)
-		I.override = TRUE
-		if(isturf(L.loc))
-			var/mob/living/simple_animal/hostile/illusion/doppelganger/E = new(L.loc)
-			E.setDir(L.dir)
-			E.Copy_Parent(L, INFINITY, 100)
-			E.target = null
-			fakes += E
-		L.status_flags |= GODMODE
-		L.opacity = FALSE
-		L.mouse_opacity = FALSE
-		L.density = FALSE
-		L.alpha = 128
-		if(L.pulledby)
-			L.pulledby.stop_pulling()
-		if(isguardian(L))
-			var/mob/living/simple_animal/hostile/guardian/G = L
-			G.erased_time = TRUE
-		ADD_TRAIT(L, TRAIT_PACIFISM, GUARDIAN_TRAIT)
-		ADD_TRAIT(L, TRAIT_NO_STUN_WEAPONS, GUARDIAN_TRAIT)
-		ADD_TRAIT(L, TRAIT_NOINTERACT, GUARDIAN_TRAIT) // no touching anything ever
-		L.remove_alt_appearance("king_crimson")
-		L.add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/king_crimson, "king_crimson", I, NONE, immune)
-	sleep(length)
-	if(LAZYLEN(fakes))
-		var/mob/living/simple_animal/hostile/illusion/doppelganger/DP = pick(fakes)
-		playsound(DP.loc, 'yogstation/sound/effects/kingcrimson_end.ogg', 100)
-	for(var/mob/living/simple_animal/hostile/illusion/doppelganger/DG in fakes)
-		DG.death()
-	for(var/mob/living/L in immune)
-		SEND_SOUND(L, sound('yogstation/sound/effects/kingcrimson_end.ogg'))
-		if(isguardian(L))
-			var/mob/living/simple_animal/hostile/guardian/G = L
-			G.erased_time = FALSE
-		L.status_flags &= ~GODMODE
-		L.opacity = initial(L.opacity)
-		L.mouse_opacity = initial(L.mouse_opacity)
-		L.density = initial(L.density)
-		L.alpha = initial(L.alpha)
-		L.remove_alt_appearance("king_crimson")
-		REMOVE_TRAIT(L, TRAIT_PACIFISM, GUARDIAN_TRAIT)
-		REMOVE_TRAIT(L, TRAIT_NO_STUN_WEAPONS, GUARDIAN_TRAIT)
-		REMOVE_TRAIT(L, TRAIT_NOINTERACT, GUARDIAN_TRAIT)
+		disappear(L, length, immune)
+	charge_counter = 0
+	addtimer(CALLBACK(src, .proc/start_recharge), length)
+
+/obj/effect/proc_holder/spell/self/erase_time/proc/disappear(mob/living/target, length, list/immune)
+	SEND_SOUND(target, sound('yogstation/sound/effects/kingcrimson_start.ogg'))
+	target.SetAllImmobility(0)
+	target.setStaminaLoss(0, 0)
+	target.status_flags |= GODMODE
+	var/mob/living/old_pulledby = target.pulledby
+	if(old_pulledby)
+		target.pulledby.stop_pulling()
+	var/mob/living/simple_animal/hostile/illusion/fake
+	if(isturf(target.loc))
+		fake = new(target.loc)
+		fake.setDir(target.dir)
+		fake.Copy_Parent(target, INFINITY, 100)
+		fake.target = null
+		if (old_pulledby)
+			old_pulledby.start_pulling(fake, supress_message = TRUE)
+	if(isguardian(target))
+		var/mob/living/simple_animal/hostile/guardian/G = target
+		G.erased_time = TRUE
+	ADD_TRAIT(target, TRAIT_PACIFISM, GUARDIAN_TRAIT)
+	ADD_TRAIT(target, TRAIT_NO_STUN_WEAPONS, GUARDIAN_TRAIT)
+	ADD_TRAIT(target, TRAIT_NOINTERACT, GUARDIAN_TRAIT) // no touching anything ever
+	var/obj/effect/dummy/phased_mob/king_crimson/jaunt = new(target.loc, target)
+	target.forceMove(jaunt)
+	var/image/invisible = image(icon = 'icons/effects/effects.dmi', icon_state = "nothing", loc = jaunt)
+	invisible.override = TRUE
+	jaunt.add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/king_crimson, "king_crimson", invisible, NONE, immune)
+	addtimer(CALLBACK(src, .proc/reappear, target, fake, jaunt), length)
+
+/obj/effect/proc_holder/spell/self/erase_time/proc/reappear(mob/living/target, mob/living/fake, obj/effect/dummy/phased_mob/king_crimson/jaunt)
+	if (fake)
+		fake.death()
+	SEND_SOUND(target, sound('yogstation/sound/effects/kingcrimson_end.ogg'))
+	target.status_flags &= ~GODMODE
+	REMOVE_TRAIT(target, TRAIT_PACIFISM, GUARDIAN_TRAIT)
+	REMOVE_TRAIT(target, TRAIT_NO_STUN_WEAPONS, GUARDIAN_TRAIT)
+	REMOVE_TRAIT(target, TRAIT_NOINTERACT, GUARDIAN_TRAIT)
+	if (target.loc == jaunt)
+		target.forceMove(jaunt.loc)
+	qdel(jaunt)
+
+/obj/effect/dummy/phased_mob/king_crimson
+	name = "disturbed time"
+	opacity = FALSE
+	mouse_opacity = FALSE
+	density = FALSE
+	anchored = TRUE
+	var/next_animate = 0
+	var/next_move = 0
+
+/obj/effect/dummy/phased_mob/king_crimson/Initialize(mapload, mob/living/jaunter)
+	. = ..(mapload)
+	appearance = jaunter.appearance
+	alpha = 128
+	dir = jaunter.dir
+	var/X,Y,i,rsq
+	for(i=1, i<=7, ++i)
+		do
+			X = 60*rand() - 30
+			Y = 60*rand() - 30
+			rsq = X*X + Y*Y
+		while(rsq<100 || rsq>900)
+		filters += filter(type="wave", x=X, y=Y, size=rand()*2.5+0.5, offset=rand())
+	START_PROCESSING(SSobj, src)
+	animate(src, alpha = 127, time = 3 SECONDS, easing = LINEAR_EASING)
+
+/obj/effect/dummy/phased_mob/king_crimson/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	return ..()
+
+/obj/effect/dummy/phased_mob/king_crimson/process()
+	if(next_animate > world.time)
+		return
+	var/i,f
+	for(i=1, i<=7, ++i)
+		f = filters[i]
+		var/next = rand()*20+10
+		animate(f, offset=f:offset, time=0, loop=3, flags=ANIMATION_PARALLEL)
+		animate(offset=f:offset-1, time=next)
+		next_animate = world.time + next
+
+/obj/effect/dummy/phased_mob/king_crimson/ex_act()
+	return
+
+/obj/effect/dummy/phased_mob/king_crimson/emp_act()
+	return
+
+/obj/effect/dummy/phased_mob/king_crimson/bullet_act()
+	return BULLET_ACT_FORCE_PIERCE
+
+/obj/effect/dummy/phased_mob/king_crimson/relaymove(mob/user, direction)
+	if (world.time >= next_move)
+		setDir(direction)
+		var/turf/destination = get_step(src, direction)
+		if (istype(destination, /turf/closed/indestructible))
+			return
+		forceMove(destination)
+		var/delay = user.movement_delay()
+		if (istype(loc, /turf/closed/wall) || locate(/obj/structure/window) in loc)
+			delay *= TIMESKIP_SOLID_OBJECT_MULTIPLIER
+		else
+			var/obj/machinery/door/door = locate() in loc
+			if (door?.density)
+				delay *= TIMESKIP_SOLID_OBJECT_MULTIPLIER
+		next_move = world.time + delay
+
+/mob/living/simple_animal/hostile/illusion/doppelganger
+	melee_damage_lower = 0
+	melee_damage_upper = 0
+	speed = -1
+	obj_damage = 0
+	vision_range = 0
+	environment_smash = ENVIRONMENT_SMASH_NONE
+	deathmessage = null
 
 /datum/atom_hud/alternate_appearance/basic/king_crimson
 	var/list/seers
@@ -92,11 +173,3 @@
 	if(isobserver(M) || (M in seers))
 		return FALSE // they see the actual sprite
 	return TRUE
-
-/mob/living/simple_animal/hostile/illusion/doppelganger
-	melee_damage_lower = 0
-	melee_damage_upper = 0
-	speed = -1
-	obj_damage = 0
-	vision_range = 0
-	environment_smash = ENVIRONMENT_SMASH_NONE


### PR DESCRIPTION
This reworks the timeskip holopara ability, making it much more useful and worth 4 points.

 - It is now like a very limited jaunt. You'll still move at normal movement speed, and trying to go through walls/windows/doors will have **3x delay**. Yes, this is faithful to JoJo, as King Crimson seems to also erase _space_ when erasing time.
 	- Do note, the functionality is **exactly the same**, with the added ability to very slowly move through solid objects.
 - The real user/holopara won't appear on HUDs anymore.

:cl: Lucy
tweak: Reworked the Time Erasure holopara ability. It is now a limited jaunt - you will still move at regular speed, and moving through walls, windows, or closed doors is extra slow.
bugfix: Timeskip users will no longer appear on HUDs when erasing time.
/:cl:

If the limited jaunt thing is a bit too OP, I can increase the delay, make it unable to go through r-walls, or just make it not go through solid objects entirely.