### PR TITLE
Fixes "teal and green suitskirts do not have sprites on lizards"#12876

### DIFF
--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -43,6 +43,7 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
+	mutantrace_variation = NO_MUTANTRACE_VARIATION
 
 /obj/item/clothing/under/sl_suit
 	desc = "It's a very amish looking suit."
@@ -91,6 +92,7 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
+	mutantrace_variation = NO_MUTANTRACE_VARIATION
 
 /obj/item/clothing/under/rank/mailman
 	name = "mailman's jumpsuit"
@@ -243,6 +245,7 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
+	mutantrace_variation = NO_MUTANTRACE_VARIATION
 
 /obj/item/clothing/under/gimmick/rank/head_of_personnel/suit
 	name = "head of personnel's suit"
@@ -262,6 +265,7 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
+	mutantrace_variation = NO_MUTANTRACE_VARIATION
 
 /obj/item/clothing/under/suit_jacket
 	name = "black suit"


### PR DESCRIPTION
# Document the changes in your pull request

Should fix #12876. When i added the digi alts, I forgot to set some skirts to not try to use mutant race alts. Untested, should work.

# Wiki Documentation

None needed. 

# Changelog

:cl:  
bugfix: fixed some skirts having no icons when worn by someone with digitigrade legs
/:cl:
