### PR TITLE
Gives QM new alternative name of "Head of Cargo"

### DIFF
--- a/code/modules/jobs/job_types/quartermaster.dm
+++ b/code/modules/jobs/job_types/quartermaster.dm
@@ -11,7 +11,7 @@
 
 	outfit = /datum/outfit/job/quartermaster
 
-	alt_titles = list("Stock Controller", "Cargo Coordinator", "Shipping Overseer")
+	alt_titles = list("Stock Controller", "Cargo Coordinator", "Shipping Overseer", "Head of Cargo")
 
 	access = list(ACCESS_MAINT_TUNNELS, ACCESS_MAILSORTING, ACCESS_CARGO, ACCESS_QM, ACCESS_MINING, ACCESS_MECH_MINING, ACCESS_MINING_STATION, ACCESS_MINERAL_STOREROOM, ACCESS_VAULT)
 	minimal_access = list(ACCESS_MAINT_TUNNELS, ACCESS_MAILSORTING, ACCESS_CARGO, ACCESS_QM, ACCESS_MINING, ACCESS_MECH_MINING, ACCESS_MINING_STATION, ACCESS_MINERAL_STOREROOM, ACCESS_VAULT)

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -93,7 +93,7 @@ GLOBAL_LIST_INIT(alt_science_positions, list(
 
 GLOBAL_LIST_INIT(alt_supply_positions, list(
 	"Chief of Staff", "Head of Internal Affairs",
-	"Stock Controller", "Cargo Coordinator", "Shipping Overseer",
+	"Stock Controller", "Cargo Coordinator", "Shipping Overseer", "Head of Cargo",
 	"Deliveryperson", "Mail Service", "Exports Handler", "Cargo Trainee", "Crate Pusher",
 	"Lavaland Scout", "Prospector", "Junior Miner", "Major Miner"))
 


### PR DESCRIPTION
# Document the changes in your pull request

Quartermaster is like a sub-head. So I give them the name **Head of Cargo**

# Wiki Documentation

None needed

# Changelog

:cl:  
tweak: Adds new alt name for QM
/:cl:
