### PR TITLE
You can no longer map vote right after map rotation: Part 2 Electric Boogaloo

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -372,6 +372,7 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 	. = changemap(VM)
 	if (. && VM.map_name != config.map_name)
 		to_chat(world, span_boldannounce("Map rotation has chosen [VM.map_name] for next round!"))
+		CONFIG_SET(flag/allow_vote_map, FALSE)
 
 /datum/controller/subsystem/mapping/proc/changemap(var/datum/map_config/VM)
 	if(!VM.MakeNextMap())


### PR DESCRIPTION
:cl: Lucy
tweak: You can no longer start a map vote right after the map is automatically rotated.
/:cl:

This is mainly because every time the map rotation automatically goes to a non-Box map, some dingus will always make a map vote, and it'll go back to Box. It's not really a majority voting for box either - even with 50-60+ players, only like ~20 total will vote at all (and even if it was an actual majority, [tyranny of the majority](https://en.wikipedia.org/wiki/Tyranny_of_the_majority) is something that should be avoided). Sometimes you should *gasp* learn new things.

---

Here's a debunk for Jamie's reason for closing:

> I'm not forcing players to play on a map which many many people don't like or don't wish to play on.

Oh wow, like 13 people out of _59_ don't want to play Box. Most votes end up like this. Such "many many" 🙄 

![image](https://user-images.githubusercontent.com/65794972/146092832-3c59cd41-114a-4269-8291-edee0a2af40d.png)

21% want Box, 16% want Meta, **63% seemingly do not care either way.**

> Also lots of people will just not play next round tanking player count

I'd like to see evidence for this, my experiences do not reflect this at all.

> I would rather a more populated round then an empty ship on a different map for "variety"

Do you really think simply changing the map to Meta will result in an "empty ship"? Have you even played on the server in a while?

Apologies if this seems hostile, I'm just mildly pissed off after an awful round and some idiot starting a map vote the instant the map rotated.

