### PR TITLE
fixes light pink pylons giving no warning for lightgeistification (ruined poor phillip's round very sad)

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -750,6 +750,10 @@ Difficulty: Very Hard
 /mob/living/simple_animal/hostile/lightgeist/healing/slime
 	name = "crystalline lightgeist"
 
+/mob/living/simple_animal/hostile/lightgeist/healing/slime/Initialize()
+	. = ..()
+		ADD_TRAIT(L, TRAIT_MUTE, TRAIT_EMOTEMUTE)
+		
 /obj/machinery/anomalous_crystal/refresher //Deletes and recreates a copy of the item, "refreshing" it.
 	observer_desc = "This crystal \"refreshes\" items that it affects, rendering them as new."
 	activation_method = ACTIVATE_TOUCH

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -751,7 +751,6 @@ Difficulty: Very Hard
 	name = "crystalline lightgeist"
 
 /mob/living/simple_animal/hostile/lightgeist/healing/slime/Initialize()
-	. = ..()
 		ADD_TRAIT(L, TRAIT_MUTE, TRAIT_EMOTEMUTE)
 		
 /obj/machinery/anomalous_crystal/refresher //Deletes and recreates a copy of the item, "refreshing" it.

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -751,7 +751,9 @@ Difficulty: Very Hard
 	name = "crystalline lightgeist"
 
 /mob/living/simple_animal/hostile/lightgeist/healing/slime/Initialize()
-		ADD_TRAIT(TRAIT_MUTE, TRAIT_EMOTEMUTE)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_MUTE, INNATE_TRAIT)
+	ADD_TRAIT(src, TRAIT_EMOTEMUTE, INNATE_TRAIT)
 		
 /obj/machinery/anomalous_crystal/refresher //Deletes and recreates a copy of the item, "refreshing" it.
 	observer_desc = "This crystal \"refreshes\" items that it affects, rendering them as new."

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -751,7 +751,7 @@ Difficulty: Very Hard
 	name = "crystalline lightgeist"
 
 /mob/living/simple_animal/hostile/lightgeist/healing/slime/Initialize()
-		ADD_TRAIT(L, TRAIT_MUTE, TRAIT_EMOTEMUTE)
+		ADD_TRAIT(TRAIT_MUTE, TRAIT_EMOTEMUTE)
 		
 /obj/machinery/anomalous_crystal/refresher //Deletes and recreates a copy of the item, "refreshing" it.
 	observer_desc = "This crystal \"refreshes\" items that it affects, rendering them as new."

--- a/code/modules/research/xenobiology/crossbreeding/_structures.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_structures.dm
@@ -560,13 +560,12 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 
 /obj/structure/slime_crystal/lightpink/attack_ghost(mob/user)
 	. = ..()
-	if(.)
-		return
-	if(ready_to_deploy)
-		var/be_helper = alert("Become a Lightgeist? (Warning, You can no longer be cloned!)",,"Yes","No")
-		if(be_helper == "Yes" && !QDELETED(src) && isobserver(user))
-			var/mob/living/simple_animal/hostile/lightgeist/healing/W = new /mob/living/simple_animal/hostile/lightgeist/healing(get_turf(loc))
-			W.key = user.key
+	var/be_helper = alert("Become a Lightgeist? (Warning, You can no longer be cloned!)",,"Yes","No")
+	if(be_helper == "Yes" && !QDELETED(src) && isobserver(user))
+		var/mob/living/simple_animal/hostile/lightgeist/healing/W = new /mob/living/simple_animal/hostile/lightgeist/healing/slime/L(get_turf(loc))
+		W.key = user.key
+		ADD_TRAIT(L,TRAIT_MUTE,type)
+		ADD_TRAIT(L,TRAIT_EMOTEMUTE,type)
 
 /obj/structure/slime_crystal/lightpink/on_mob_leave(mob/living/affected_mob)
 	if(istype(affected_mob,/mob/living/simple_animal/hostile/lightgeist/healing/slime))

--- a/code/modules/research/xenobiology/crossbreeding/_structures.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_structures.dm
@@ -564,8 +564,8 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 	if(be_helper == "Yes" && !QDELETED(src) && isobserver(user))
 		var/mob/living/simple_animal/hostile/lightgeist/healing/W = new /mob/living/simple_animal/hostile/lightgeist/healing/slime(get_turf(loc))
 		W.key = user.key
-		ADD_TRAIT(TRAIT_MUTE,type)
-		ADD_TRAIT(TRAIT_EMOTEMUTE,type)
+		ADD_TRAIT(TRAIT_MUTE)
+		ADD_TRAIT(TRAIT_EMOTEMUTE)
 
 /obj/structure/slime_crystal/lightpink/on_mob_leave(mob/living/affected_mob)
 	if(istype(affected_mob,/mob/living/simple_animal/hostile/lightgeist/healing/slime))

--- a/code/modules/research/xenobiology/crossbreeding/_structures.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_structures.dm
@@ -564,8 +564,6 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 	if(be_helper == "Yes" && !QDELETED(src) && isobserver(user))
 		var/mob/living/simple_animal/hostile/lightgeist/healing/W = new /mob/living/simple_animal/hostile/lightgeist/healing/slime(get_turf(loc))
 		W.key = user.key
-		ADD_TRAIT(TRAIT_MUTE)
-		ADD_TRAIT(TRAIT_EMOTEMUTE)
 
 /obj/structure/slime_crystal/lightpink/on_mob_leave(mob/living/affected_mob)
 	if(istype(affected_mob,/mob/living/simple_animal/hostile/lightgeist/healing/slime))

--- a/code/modules/research/xenobiology/crossbreeding/_structures.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_structures.dm
@@ -560,11 +560,13 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 
 /obj/structure/slime_crystal/lightpink/attack_ghost(mob/user)
 	. = ..()
-	var/mob/living/simple_animal/hostile/lightgeist/healing/slime/L = new(get_turf(src))
-	L.ckey = user.ckey
-	affected_mobs[L] = 0
-	ADD_TRAIT(L,TRAIT_MUTE,type)
-	ADD_TRAIT(L,TRAIT_EMOTEMUTE,type)
+	if(.)
+		return
+	if(ready_to_deploy)
+		var/be_helper = alert("Become a Lightgeist? (Warning, You can no longer be cloned!)",,"Yes","No")
+		if(be_helper == "Yes" && !QDELETED(src) && isobserver(user))
+			var/mob/living/simple_animal/hostile/lightgeist/healing/W = new /mob/living/simple_animal/hostile/lightgeist/healing(get_turf(loc))
+			W.key = user.key
 
 /obj/structure/slime_crystal/lightpink/on_mob_leave(mob/living/affected_mob)
 	if(istype(affected_mob,/mob/living/simple_animal/hostile/lightgeist/healing/slime))

--- a/code/modules/research/xenobiology/crossbreeding/_structures.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_structures.dm
@@ -562,10 +562,10 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 	. = ..()
 	var/be_helper = alert("Become a Lightgeist? (Warning, You can no longer be cloned!)",,"Yes","No")
 	if(be_helper == "Yes" && !QDELETED(src) && isobserver(user))
-		var/mob/living/simple_animal/hostile/lightgeist/healing/W = new /mob/living/simple_animal/hostile/lightgeist/healing/slime/L(get_turf(loc))
+		var/mob/living/simple_animal/hostile/lightgeist/healing/W = new /mob/living/simple_animal/hostile/lightgeist/healing/slime(get_turf(loc))
 		W.key = user.key
-		ADD_TRAIT(L,TRAIT_MUTE,type)
-		ADD_TRAIT(L,TRAIT_EMOTEMUTE,type)
+		ADD_TRAIT(TRAIT_MUTE,type)
+		ADD_TRAIT(TRAIT_EMOTEMUTE,type)
 
 /obj/structure/slime_crystal/lightpink/on_mob_leave(mob/living/affected_mob)
 	if(istype(affected_mob,/mob/living/simple_animal/hostile/lightgeist/healing/slime))


### PR DESCRIPTION
no clue why the colossus code wasnt just copied in the first place but oh well
fixes #12905 
:cl:  
bugfix: light pink pylons now ask before turning you into a lightgeist
/:cl:
