### PR TITLE
Makes the SMES display its capacity instead of precent and clarifies its charge

### DIFF
--- a/code/modules/goals/department_goals/engineering.dm
+++ b/code/modules/goals/department_goals/engineering.dm
@@ -4,8 +4,8 @@
 // Store like 70e6 joules
 // Which is like, 14 roundstart SMES' worth (so requires upgrades)
 /datum/department_goal/eng/SMES
-	name = "Store 70MJ"
-	desc = "Store 70MJ of energy in the station's SMES'"
+	name = "Store 1.4GJ"
+	desc = "Store 1.4GJ of energy in the station's SMES"
 	reward = "50000"
 
 /datum/department_goal/eng/SMES/check_complete()
@@ -14,7 +14,7 @@
 		if(!is_station_level(s.z))
 			continue
 		charge += s.charge
-	return charge >= 70e6
+	return charge >= 1.4e9
 
 
 // Fire up a supermatter

--- a/code/modules/goals/department_goals/engineering.dm
+++ b/code/modules/goals/department_goals/engineering.dm
@@ -1,8 +1,9 @@
 /datum/department_goal/eng
 	account = ACCOUNT_ENG
 
-// Store like 70e6 joules
-// Which is like, 14 roundstart SMES' worth (so requires upgrades)
+// Store 1.4e9J
+// Which is around 21 roundstart SMES' worth (so requires upgrades)
+// Or 6 fully upgraded SMES'
 /datum/department_goal/eng/SMES
 	name = "Store 1.4GJ"
 	desc = "Store 1.4GJ of energy in the station's SMES"

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -1,8 +1,6 @@
 // the SMES
 // stores power
 
-#define SMESRATE 0.05			// rate of internal charge to external power
-
 //Cache defines
 #define SMES_CLEVEL_1		1
 #define SMES_CLEVEL_2		2
@@ -22,19 +20,29 @@
 	use_power = NO_POWER_USE
 	circuit = /obj/item/circuitboard/machine/smes
 
-	var/capacity = 5e6 // maximum charge
-	var/charge = 0 // actual charge
-
-	var/input_attempt = TRUE // TRUE = attempting to charge, FALSE = not attempting to charge
-	var/inputting = TRUE // TRUE = actually inputting, FALSE = not inputting
-	var/input_level = 50000 // amount of power the SMES attempts to charge by
-	var/input_level_max = 200000 // cap on input_level
-	var/input_available = 0 // amount of charge available from input last tick
-
-	var/output_attempt = TRUE // TRUE = attempting to output, FALSE = not attempting to output
-	var/outputting = TRUE // TRUE = actually outputting, FALSE = not outputting
-	var/output_level = 50000 // amount of power the SMES attempts to output
-	var/output_level_max = 200000 // cap on output_level
+	/// Maximum charge of the SMES
+	var/capacity = 5e6
+	/// Current charge of the SMES
+	var/charge = 0
+	/// TRUE = attempting to charge, FALSE = not attempting to charge
+	var/input_attempt = TRUE
+	/// TRUE = actually inputting, FALSE = not inputting
+	var/inputting = TRUE
+	/// Desired Power Input Level
+	var/input_level = 50000
+	/// Maximum Power Input
+	var/input_level_max = 200000
+	/// Last power input
+	var/input_available = 0
+	/// TRUE = attempting to output, FALSE = not attempting to output
+	var/output_attempt = TRUE
+	/// TRUE = actually outputting, FALSE = not outputting
+	var/outputting = TRUE
+	/// Desired Power Output Level
+	var/output_level = 50000
+	/// Maximum Power Output
+	var/output_level_max = 200000
+	/// Last power output
 	var/output_used = 0 // amount of power actually outputted. may be less than output_level if the powernet returns excess power
 
 	var/obj/machinery/power/terminal/terminal = null
@@ -71,9 +79,9 @@
 	for(var/obj/item/stock_parts/cell/PC in component_parts)
 		MC += PC.maxcharge
 		C += PC.charge
-	capacity = MC / (15000) * 1e6
+	capacity = MC / (15000) * 2e7
 	if(!initial(charge) && !charge)
-		charge = C / 15000 * 1e6
+		charge = C / 15000 * 2e7
 
 /obj/machinery/power/smes/attackby(obj/item/I, mob/user, params)
 	//opening using screwdriver
@@ -245,9 +253,9 @@
 		if(inputting)
 			if(input_available > 0)		// if there's power available, try to charge
 
-				var/load = min(min((capacity-charge)/SMESRATE, input_level), input_available)		// charge at set rate, limited to spare capacity
+				var/load = min(min((capacity-charge), input_level), input_available)		// charge at set rate, limited to spare capacity
 
-				charge += load * SMESRATE	// increase the charge
+				charge += load	// increase the charge
 
 				terminal.add_load(load) // add the load to the terminal side network
 
@@ -263,10 +271,10 @@
 	//outputting
 	if(output_attempt)
 		if(outputting)
-			output_used = min( charge/SMESRATE, output_level)		//limit output to that stored
+			output_used = min( charge, output_level)		//limit output to that stored
 
 			if (add_avail(output_used))				// add output to powernet if it exists (smes side)
-				charge -= output_used*SMESRATE		// reduce the storage (may be recovered in /restore() if excessive)
+				charge -= output_used		// reduce the storage (may be recovered in /restore() if excessive)
 			else
 				outputting = FALSE
 
@@ -301,13 +309,13 @@
 
 	excess = min(output_used, excess)				// clamp it to how much was actually output by this SMES last ptick
 
-	excess = min((capacity-charge)/SMESRATE, excess)	// for safety, also limit recharge by space capacity of SMES (shouldn't happen)
+	excess = min((capacity-charge), excess)	// for safety, also limit recharge by space capacity of SMES (shouldn't happen)
 
 	// now recharge this amount
 
 	var/clev = chargedisplay()
 
-	charge += excess * SMESRATE			// restore unused power
+	charge += excess			// restore unused power
 	powernet.netexcess -= excess		// remove the excess from the powernet, so later SMESes don't try to use it
 
 	output_used -= excess
@@ -439,7 +447,6 @@
 	log_smes(user)
 	update_icon()
 
-#undef SMESRATE
 
 #undef SMES_CLEVEL_1
 #undef SMES_CLEVEL_2

--- a/tgui/packages/tgui/format.js
+++ b/tgui/packages/tgui/format.js
@@ -68,6 +68,10 @@ export const formatPower = (value, minBase1000 = 0) => {
   return formatSiUnit(value, minBase1000, 'W');
 };
 
+export const formatJoule = (value, minBase1000 = 0) => {
+  return formatSiUnit(value, minBase1000, 'J');
+};
+
 export const formatMoney = (value, precision = 0) => {
   if (!Number.isFinite(value)) {
     return value;

--- a/tgui/packages/tgui/interfaces/Smes.js
+++ b/tgui/packages/tgui/interfaces/Smes.js
@@ -49,7 +49,7 @@ export const Smes = (props, context) => {
             <Box>
               {formatJoule(charge) + " / " + formatJoule(capacity) + " (" + capacityPercent + "%)"}
             </Box>
-        </ProgressBar>
+          </ProgressBar>
         </Section>
         <Section title="Input">
           <LabeledList>

--- a/tgui/packages/tgui/interfaces/Smes.js
+++ b/tgui/packages/tgui/interfaces/Smes.js
@@ -1,6 +1,6 @@
 import { useBackend } from '../backend';
 import { Box, Button, Flex, LabeledList, ProgressBar, Section, Slider } from '../components';
-import { formatPower } from '../format';
+import { formatPower, formatJoule } from '../format';
 import { Window } from '../layouts';
 
 // Common power multiplier
@@ -41,6 +41,7 @@ export const Smes = (props, context) => {
         <Section title="Stored Energy">
           <ProgressBar
             value={capacityPercent * 0.01}
+            children={formatJoule(charge) + " / " + formatJoule(capacity)}
             ranges={{
               good: [0.5, Infinity],
               average: [0.15, 0.5],

--- a/tgui/packages/tgui/interfaces/Smes.js
+++ b/tgui/packages/tgui/interfaces/Smes.js
@@ -41,12 +41,15 @@ export const Smes = (props, context) => {
         <Section title="Stored Energy">
           <ProgressBar
             value={capacityPercent * 0.01}
-            children={formatJoule(charge) + " / " + formatJoule(capacity)}
             ranges={{
               good: [0.5, Infinity],
               average: [0.15, 0.5],
               bad: [-Infinity, 0.15],
-            }} />
+            }}>
+            <Box>
+              {formatJoule(charge) + " / " + formatJoule(capacity) + " (" + capacityPercent + "%)"}
+            </Box>
+        </ProgressBar>
         </Section>
         <Section title="Input">
           <LabeledList>


### PR DESCRIPTION
# Document the changes in your pull request
Provides a UI update, autodocs, and removal of some weird scale factor


Fun fact: the SMES was actually doing this all on a 0.05x scale for some reason removed that and adjusted the values accordingly

Modified the UI a little (stock smes) to report capacity instead of precentage
![image](https://user-images.githubusercontent.com/20369082/146649188-e9a33f53-366e-49b4-8999-da78c5b55a3d.png)


# Wiki Documentation

SMES will no longer confuse people with its weird scaling
SMES also reports capacity instead of precentage

# Changelog

:cl:  
tweak: SMES reports its charge/capacity instead of a percentage
/:cl:
