### PR TITLE
Fixes rechargers going invisible when using a screwdriver to open their panel

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -94,7 +94,7 @@
 		return 1
 
 	if(anchored && !charging)
-		if(default_deconstruction_screwdriver(user, "rechargeropen", "recharger0", G))
+		if(default_deconstruction_screwdriver(user, "rechargeropen", "recharger", G))
 			return
 
 		if(panel_open && G.tool_behaviour == TOOL_CROWBAR)


### PR DESCRIPTION

# Document the changes in your pull request

See title

# Wiki Documentation

# Changelog


:cl:  
bugfix: Recharger no longer go invisible if you screwdriver them to close their panel
/:cl:
