### PR TITLE
Reverts 12776 and reverts the reversion of 12775 (mindslaves now resist mindshields instead of removing mindslave)

### DIFF
--- a/code/game/objects/items/implants/implant_mindshield.dm
+++ b/code/game/objects/items/implants/implant_mindshield.dm
@@ -39,7 +39,7 @@
 				target.visible_message(span_warning("[target] seems to resist the implant!"), span_warning("You feel something interfering with your mental conditioning, but you resist it!"))
 			removed(target, TRUE)
 			return FALSE
-		if(target.mind.has_antag_datum(/datum/antagonist/gang/boss) || is_shadow_or_thrall(target))
+		if(target.mind.has_antag_datum(/datum/antagonist/gang/boss) || is_shadow_or_thrall(target) || target.mind.has_antag_datum(/datum/antagonist/mindslave))
 			if(!silent)
 				target.visible_message(span_warning("[target] seems to resist the implant!"), span_warning("You feel something interfering with your mental conditioning, but you resist it!"))
 			removed(target, TRUE)
@@ -71,8 +71,6 @@
 			target.mind.remove_antag_datum(/datum/antagonist/gang)
 		if(target.mind.has_antag_datum(/datum/antagonist/veil))
 			target.mind.remove_antag_datum(/datum/antagonist/veil)
-		if(target.mind.has_antag_datum(/datum/antagonist/mindslave))
-			target.mind.remove_antag_datum(/datum/antagonist/mindslave)
 		if(!silent)
 			if(target.mind in SSticker.mode.cult)
 				to_chat(target, span_warning("You feel something interfering with your mental conditioning, but you resist it!"))


### PR DESCRIPTION
# Document the changes in your pull request

I wanted https://github.com/yogstation13/Yogstation/pull/12775 to go through and https://github.com/yogstation13/Yogstation/pull/12776 was made to functionally be a "worse future" version of 12775 if it wasn't agreeable. Jamie accidentally merged both and then fixed it but left the more reasonable one as the one that was reverted.

this makes sense IC because they will still have the implant in them, so it makes sense that implants would resist implants instead of turning off one for ??? (also you can remove the mindslave implant from someone and use it again with it's current form)

# Wiki Documentation
something about how this changes

# Changelog
:cl:  
tweak: mindslaved people reject mindshields instead of removing mindslave status
/:cl:
