### PR TITLE
Adds Access to Warden for infirmary but Prevents access to sleeper.

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -85055,6 +85055,14 @@
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
+"dJT" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Infirmary";
+	red_alert_access = 1;
+	req_one_access_txt = "5;3"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "dKP" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -87941,6 +87949,20 @@
 	dir = 8
 	},
 /area/hallway/primary/port)
+"gNv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Infirmary";
+	red_alert_access = 1;
+	req_one_access_txt = "5;3"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/dark,
+/area/security/warden)
 "gNy" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -89693,14 +89715,6 @@
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/ai_monitored/turret_protected/ai)
-"iFa" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Infirmary";
-	red_alert_access = 1;
-	req_access_txt = "5"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "iFr" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -97246,20 +97260,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
-"qrw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Infirmary";
-	red_alert_access = 1;
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/dark,
-/area/security/warden)
 "qsW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -123536,12 +123536,12 @@ aef
 aef
 bXp
 adz
-qrw
+gNv
 cdp
 xOK
 cnB
 crz
-iFa
+dJT
 aLi
 bxS
 bPI

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -48874,7 +48874,7 @@
 	icon_state = "right";
 	name = "Brig Infirmary";
 	red_alert_access = 1;
-	req_one_access_txt = "5, 3"
+	req_one_access_txt = "5;3"
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -65762,7 +65762,7 @@
 	name = "Brig Infirmary";
 	red_alert_access = 1;
 	req_access_txt = "0";
-	req_one_access_txt = "5, 3"
+	req_one_access_txt = "5;3"
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -3086,22 +3086,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
-"ahW" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/sleeper{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "ahZ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -48883,6 +48867,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"nvM" = (
+/obj/machinery/door/window/westleft{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	name = "Brig Infirmary";
+	red_alert_access = 1;
+	req_one_access_txt = "5, 3"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "nvN" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -57185,6 +57190,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"sBY" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/sleeper{
+	dir = 4;
+	req_access_txt = "5"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "sCf" = (
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
@@ -64201,19 +64223,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"xit" = (
-/obj/machinery/door/window/westleft{
-	dir = 4;
-	name = "Brig Infirmary";
-	red_alert_access = 1;
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "xjm" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -64342,27 +64351,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"xng" = (
-/obj/machinery/door/window/westleft{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	name = "Brig Infirmary";
-	red_alert_access = 1;
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "xnF" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -65768,6 +65756,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"ygh" = (
+/obj/machinery/door/window/westleft{
+	dir = 4;
+	name = "Brig Infirmary";
+	red_alert_access = 1;
+	req_access_txt = "0";
+	req_one_access_txt = "5, 3"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "ygi" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -94287,7 +94289,7 @@ afH
 agj
 gCK
 ahu
-ahW
+sBY
 aiD
 aaC
 ajg
@@ -95057,8 +95059,8 @@ aiB
 acd
 agj
 ahm
-xit
-xng
+ygh
+nvM
 ctf
 agj
 ajA

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -69264,27 +69264,6 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"dNs" = (
-/obj/machinery/door/window/westleft{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	name = "Infirmary";
-	red_alert_access = 1;
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "dPt" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
 /obj/effect/mapping_helpers/teleport_anchor,
@@ -78181,6 +78160,27 @@
 /obj/machinery/modular_computer/console/preset/mining,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"qkK" = (
+/obj/machinery/door/window/westleft{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	name = "Infirmary";
+	red_alert_access = 1;
+	req_one_access_txt = "5;3"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "qle" = (
 /obj/machinery/bookbinder,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -82434,25 +82434,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"vMZ" = (
-/obj/machinery/door/window/westleft{
-	dir = 4;
-	name = "Infirmary";
-	red_alert_access = 1;
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "vNW" = (
 /turf/closed/wall,
 /area/science/misc_lab/range)
@@ -83505,6 +83486,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"xjV" = (
+/obj/machinery/door/window/westleft{
+	dir = 4;
+	name = "Infirmary";
+	red_alert_access = 1;
+	req_one_access_txt = "5;3"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "xmr" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/tinted/fulltile,
@@ -108574,8 +108574,8 @@ ahx
 ait
 ahx
 woV
-vMZ
-dNs
+xjV
+qkK
 hnY
 ahx
 aqZ

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -226,6 +226,7 @@
 	data["open"] = state_open
 	data["active_treatment"] = active_treatment
 	data["can_sedate"] = can_sedate()
+	data["no_access"] = !allowed(user)
 
 	data["treatments"] = list()
 	for(var/T in available_treatments)
@@ -281,12 +282,12 @@
 			. = TRUE
 		if("set")
 			var/treatment = params["treatment"]
-			if(!is_operational() || !mob_occupant || isnull(treatment))
+			if(!is_operational() || !mob_occupant || isnull(treatment) || !allowed(usr))
 				return
 			active_treatment = treatment
 			. = TRUE
 		if("sedate")
-			if(can_sedate())
+			if(can_sedate() || !allowed(usr))
 				mob_occupant.reagents.add_reagent(/datum/reagent/medicine/morphine, 10)
 				if(usr)
 					log_combat(usr,occupant, "injected morphine into", addition = "via [src]")

--- a/tgui/packages/tgui/interfaces/Sleeper.js
+++ b/tgui/packages/tgui/interfaces/Sleeper.js
@@ -12,7 +12,7 @@ export const Sleeper = (props, context) => {
     occupied,
     active_treatment,
     can_sedate,
-    no_access
+    no_access,
   } = data;
 
   const treatments = data.treatments || [];

--- a/tgui/packages/tgui/interfaces/Sleeper.js
+++ b/tgui/packages/tgui/interfaces/Sleeper.js
@@ -12,6 +12,7 @@ export const Sleeper = (props, context) => {
     occupied,
     active_treatment,
     can_sedate,
+    no_access
   } = data;
 
   const treatments = data.treatments || [];
@@ -95,7 +96,7 @@ export const Sleeper = (props, context) => {
               <Button
                 icon={'flask'}
                 content={'Sedate'}
-                disabled={!can_sedate}
+                disabled={!can_sedate || no_access}
                 onClick={() => act('sedate')} />
             )} >
             {occupant.reagents.map(reagent => (
@@ -125,7 +126,7 @@ export const Sleeper = (props, context) => {
               key={treatment}
               icon="first-aid"
               content={treatment}
-              disabled={!occupied}
+              disabled={!occupied || no_access}
               color={active_treatment===treatment ? 'green' : null}
               /* key={chem.name}
               icon="flask"


### PR DESCRIPTION
# Document the changes in your pull request

People have disagreements whether warden should be allowed into infirmary.

There are two arguments, one for access for security purposes and one for medical purposes.

Due to the fact the whole point of medical physician is designed to be in the brig doing medical duties they should obviously be the first point of call.

The second argument about security of the brig is agreeable, so this should be the best of both worlds, giving the warden what he had before but hopefully meaning brig physician can still be relevant without warden overstepping.

# Changelog

:cl:  
tweak: Changed access to brig physician room and denied to sleeper in room.
/:cl:
