### PR TITLE
Fixes preferences not saving

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -249,7 +249,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	buttons_locked		= sanitize_integer(buttons_locked, FALSE, TRUE, initial(buttons_locked))
 	windowflashing		= sanitize_integer(windowflashing, FALSE, TRUE, initial(windowflashing))
 	default_slot		= sanitize_integer(default_slot, 1, max_save_slots, initial(default_slot))
-	toggles				= sanitize_integer(toggles, 0, (1 << 23), initial(toggles)) // Yogs -- Fixes toggles not having >16 bits of flagspace
+	toggles				= sanitize_integer(toggles, 0, ~0, initial(toggles)) // Yogs -- Fixes toggles not having >16 bits of flagspace
 	clientfps			= sanitize_integer(clientfps, 0, 1000, 0)
 	parallax			= sanitize_integer(parallax, PARALLAX_INSANE, PARALLAX_DISABLE, null)
 	ambientocclusion	= sanitize_integer(ambientocclusion, FALSE, TRUE, initial(ambientocclusion))


### PR DESCRIPTION
# Document the changes in your pull request

After adding https://github.com/yogstation13/Yogstation/pull/12824 and https://github.com/yogstation13/Yogstation/pull/12647 we went over the assigned space for toggles. This ups it to ~0 which is the limit of precision integers

Fixes #12942 

# Wiki Documentation

# Changelog

:cl:  TheGamerdk & Alexkar598
bugfix: Your sound preferences should no longer be reverted if you have enabled alternative sounds and VOX
/:cl:
