### PR TITLE
placing apc frames checks the area where the user is standing, not where the apc is being placed.

### DIFF
--- a/code/game/objects/items/apc_frame.dm
+++ b/code/game/objects/items/apc_frame.dm
@@ -92,6 +92,8 @@
 	if(!..())
 		return
 	var/turf/T = get_turf(user.loc) //get the turf the user is standing on, not where it's being placed.
+	if(!user || !user.loc)
+		T = get_turf(on_wall) //default back to the turf if the user or their loc is null
 	var/area/A = get_area(T)
 	if(A.get_apc())
 		to_chat(user, span_warning("This area already has an APC!"))

--- a/code/game/objects/items/apc_frame.dm
+++ b/code/game/objects/items/apc_frame.dm
@@ -91,10 +91,9 @@
 /obj/item/wallframe/apc/try_build(turf/on_wall, mob/user)
 	if(!..())
 		return
-	var/turf/T = get_turf(user.loc) //get the turf the user is standing on, not where it's being placed.
-	if(!user || !user.loc)
-		T = get_turf(on_wall) //default back to the turf if the user or their loc is null
-	var/area/A = get_area(T)
+	var/area/A = get_area(user) //get the turf the user is standing on, not where it's being placed.
+	if(!A)
+		A = get_area(on_wall) //default back to the turf if the user or their loc is null
 	if(A.get_apc())
 		to_chat(user, span_warning("This area already has an APC!"))
 		return //only one APC per area

--- a/code/game/objects/items/apc_frame.dm
+++ b/code/game/objects/items/apc_frame.dm
@@ -91,6 +91,7 @@
 /obj/item/wallframe/apc/try_build(turf/on_wall, mob/user)
 	if(!..())
 		return
+	var/turf/T = get_turf(on_wall) //we still need T for checks later in this proc
 	var/area/A = get_area(user) //get the turf the user is standing on, not where it's being placed.
 	if(!A)
 		A = get_area(on_wall) //default back to the turf if the user or their loc is null

--- a/code/game/objects/items/apc_frame.dm
+++ b/code/game/objects/items/apc_frame.dm
@@ -88,7 +88,7 @@
 	inverse = 1
 
 
-/obj/item/wallframe/apc/try_build(turf/on_wall, user)
+/obj/item/wallframe/apc/try_build(turf/on_wall, mob/user)
 	if(!..())
 		return
 	var/turf/T = get_turf(user.loc) //get the turf the user is standing on, not where it's being placed.

--- a/code/game/objects/items/apc_frame.dm
+++ b/code/game/objects/items/apc_frame.dm
@@ -40,7 +40,7 @@
 		if(inverse)
 			ndir = turn(ndir, 180)
 
-		var/obj/O = new result_path(get_turf(user), ndir, TRUE)
+		var/obj/O = new result_path(get_turf(user), ndir, TRUE, user)
 		if(pixel_shift)
 			switch(ndir)
 				if(NORTH)

--- a/code/game/objects/items/apc_frame.dm
+++ b/code/game/objects/items/apc_frame.dm
@@ -91,7 +91,7 @@
 /obj/item/wallframe/apc/try_build(turf/on_wall, user)
 	if(!..())
 		return
-	var/turf/T = get_turf(on_wall) //the user is not where it needs to be.
+	var/turf/T = get_turf(user.loc) //get the turf the user is standing on, not where it's being placed.
 	var/area/A = get_area(T)
 	if(A.get_apc())
 		to_chat(user, span_warning("This area already has an APC!"))

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -156,7 +156,7 @@
 	if(terminal)
 		terminal.connect_to_network()
 
-/obj/machinery/power/apc/New(turf/loc, var/ndir, var/building=0)
+/obj/machinery/power/apc/New(turf/loc, var/ndir, var/building=0, mob/user)
 	//if (!req_access)
 		//req_access = list(ACCESS_ENGINE_EQUIP) // Yogs -- Commented out to allow for use of req_one_access. Also this is just generally bad and the guy who wrote this doesn't get OOP
 	if (!armor)
@@ -193,7 +193,10 @@
 				log_mapping("APC: ([src]) at [AREACOORD(src)] with dir ([tdir] | [uppertext(dir2text(tdir))]) has pixel_x value ([pixel_x] - should be -25.)")
 			pixel_x = -25
 	if (building)
-		area = get_area(src)
+		if(user)
+			area = get_area(user)
+		else
+			area = get_area(src)
 		opened = APC_COVER_OPENED
 		operating = FALSE
 		name = "[area.name] APC"


### PR DESCRIPTION
# Document the changes in your pull request

apc placement is fucky with areas, since individual room areas are padded over hallway areas, it's pretty much impossible to remake hallway APCs (the ones most bombed) if they get destroyed because placing it on a hallway wall will think it's whatever area is on the other side of the wall. This fixes it by checking the area where the user is standing, not the wall at which it's placed (which is where APC's technically are anyway)

# Wiki Documentation

none

# Changelog

:cl:  
bugfix: APC frames now check where the user is standing instead of the wall at which you're placing it, giving more consistent placement in hallways.
/:cl:
