### PR TITLE
[admin] Adds simple message to the player when a ticket is taken

### DIFF
--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -201,7 +201,7 @@
 				// yogs start - Yog Tickets
 				admin_ticket_log(src, msg, FALSE)
 				if(recipient.current_ticket && !recipient.current_ticket.handling_admin)
-					recipient.current_ticket.Administer(src)
+					recipient.current_ticket.Administer()
 				// yogs end - Yog Tickets
 				if(recipient != src)	//reeee
 					admin_ticket_log(recipient, msg, FALSE) // yogs - Yog Tickets
@@ -225,7 +225,7 @@
 				if(!recipient.current_ticket)
 					new /datum/admin_help(msg, recipient, TRUE) // yogs - Yog Tickets
 				if(!recipient.current_ticket.handling_admin)
-					recipient.current_ticket.Administer(src) // yogs - Yog Tickets
+					recipient.current_ticket.Administer() // yogs - Yog Tickets
 
 				to_chat(recipient, "<font color='red' size='4'><b>-- Administrator private message --</b></font>", confidential=TRUE)
 				to_chat(recipient, span_adminsay("Admin PM from-<b>[key_name(src, recipient, 0)]</b>: [span_linkify("[msg]")]"), confidential=TRUE)

--- a/yogstation/code/modules/admin/verbs/adminhelp.dm
+++ b/yogstation/code/modules/admin/verbs/adminhelp.dm
@@ -588,7 +588,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	if(announce && initiator)
 		to_chat(initiator,
 			type = MESSAGE_TYPE_ADMINPM,
-			span_notice("[key_name(usr, TRUE, FALSE)] has taken your ticket and will respond shortly."),
+			html = span_notice("[key_name(usr, TRUE, FALSE)] has taken your ticket and will respond shortly."),
 			confidential = TRUE)
 
 //Admin activates the pop-ups

--- a/yogstation/code/modules/admin/verbs/adminhelp.dm
+++ b/yogstation/code/modules/admin/verbs/adminhelp.dm
@@ -569,7 +569,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	usr << browse(html, "window=ViewTicketLog[id]")
 
 // Admin claims a ticket
-/datum/admin_help/proc/Administer(key_name = key_name_admin(usr))
+/datum/admin_help/proc/Administer(announce = FALSE)
 	if(!usr.client)
 		return FALSE
 	handling_admin = usr.client
@@ -584,6 +584,12 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	var/msg = "[usr.ckey]/([usr]) has been assigned to [TicketHref("ticket #[id]")] as primary admin."
 	message_admins(msg)
 	log_admin_private(msg)
+
+	if(announce && initiator)
+		to_chat(initiator,
+			type = MESSAGE_TYPE_ADMINPM,
+			span_notice("[key_name(usr, TRUE, FALSE)] has taken your ticket and will respond shortly."),
+			confidential = TRUE)
 
 //Admin activates the pop-ups
 /datum/admin_help/proc/PopUps(key_name = key_name_admin(usr))
@@ -613,7 +619,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		if("reopen")
 			Reopen()
 		if("administer")
-			Administer()
+			Administer(TRUE)
 		if("wiki")
 			WikiIssue()
 		if("bug")

--- a/yogstation/code/modules/admin/verbs/ticketpanel.dm
+++ b/yogstation/code/modules/admin/verbs/ticketpanel.dm
@@ -184,7 +184,7 @@ GLOBAL_VAR_INIT(experimental_adminpanel, TRUE)
 			ticket.PopUps()
 			return
 		if("Administer")
-			ticket.Administer()
+			ticket.Administer(TRUE)
 			return
 		if("Wiki")
 			ticket.WikiIssue()


### PR DESCRIPTION
# Document the changes in your pull request

Clicking administer on a ticket will now send the player a message "name has taken your ticket and will respond shortly"
This is a feature on some other servers and I like it, so I'm stealing it. If the ticket is taken by the admin responding instead of the button, the message is not sent.

# Changelog

:cl:  
rscadd: Added simple notification for when a ticket is taken
/:cl:
