### PR TITLE
Fixed false walls not examining correctly

### DIFF
--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -143,8 +143,11 @@
 /obj/structure/falsewall/get_dumping_location(obj/item/storage/source,mob/user)
 	return null
 
+/obj/structure/falsewall/examine(mob/user)
+	. += ..()
+	. += span_notice("The outer plating is <b>welded</b> firmly in place.")
+
 /obj/structure/falsewall/examine_status(mob/user) //So you can't detect falsewalls by examine.
-	to_chat(user, span_notice("The outer plating is <b>welded</b> firmly in place."))
 	return null
 
 /*
@@ -159,8 +162,11 @@
 	walltype = /turf/closed/wall/r_wall
 	mineral = /obj/item/stack/sheet/plasteel
 
+/obj/structure/falsewall/reinforced/examine(mob/user)
+	. += ..()
+	. += span_notice("The outer <b>grille</b> is fully intact.")
+
 /obj/structure/falsewall/reinforced/examine_status(mob/user)
-	to_chat(user, span_notice("The outer <b>grille</b> is fully intact."))
 	return null
 
 /obj/structure/falsewall/reinforced/attackby(obj/item/tool, mob/user)

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -143,12 +143,8 @@
 /obj/structure/falsewall/get_dumping_location(obj/item/storage/source,mob/user)
 	return null
 
-/obj/structure/falsewall/examine(mob/user)
-	. += ..()
-	. += span_notice("The outer plating is <b>welded</b> firmly in place.")
-
 /obj/structure/falsewall/examine_status(mob/user) //So you can't detect falsewalls by examine.
-	return null
+	return span_notice("The outer plating is <b>welded</b> firmly in place.")
 
 /*
  * False R-Walls
@@ -162,12 +158,8 @@
 	walltype = /turf/closed/wall/r_wall
 	mineral = /obj/item/stack/sheet/plasteel
 
-/obj/structure/falsewall/reinforced/examine(mob/user)
-	. += ..()
-	. += span_notice("The outer <b>grille</b> is fully intact.")
-
 /obj/structure/falsewall/reinforced/examine_status(mob/user)
-	return null
+	return span_notice("The outer <b>grille</b> is fully intact.")
 
 /obj/structure/falsewall/reinforced/attackby(obj/item/tool, mob/user)
 	..()


### PR DESCRIPTION
# Document the changes in your pull request

The old way made the additional examine text appear before the actual examine text, not after

This fixes it

# Changelog

:cl:  
bugfix: Fixed false walls not examining correctly
/:cl:
