### PR TITLE
Adds lesser sentience potion as an uplink item (traitor)

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -738,6 +738,10 @@
 	SM.access_card = new /obj/item/card/id/syndicate(SM)
 	ADD_TRAIT(SM.access_card, TRAIT_NODROP, ABSTRACT_ITEM_TRAIT)
 
+/obj/item/slimepotion/slime/sentience/traitor
+	name = "lesser syndicate intelligence potion"
+	desc = "A miraculous chemical mix that grants human like intelligence to living beings. The Syndicate have gone to great lengths to secure this, don't waste it!"
+
 /obj/item/slimepotion/transference
 	name = "consciousness transference potion"
 	desc = "A strange slime-based chemical that, when used, allows the user to transfer their consciousness to a lesser being."

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1622,6 +1622,15 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 	restricted = TRUE
 
+/datum/uplink_item/device_tools/potion/traitor
+	name = "Lesser Syndicate Sentience Potion"
+	item = /obj/item/slimepotion/slime/sentience/traitor
+	desc = "With recent advancements in Syndicate technology thanks to stolen slime cores, the Syndicate have created their own sentience potions. \
+			Using it will make any animal sentient, and bound to serve you, but as slime cores are still a hot commodity in the black market, they aint cheap."
+	cost = 12
+	include_modes = list() //clear the list
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops, /datum/game_mode/infiltration) // yogs: infiltration
+
 /datum/uplink_item/device_tools/suspiciousphone
 	name = "Protocol CRAB-17 Phone"
 	desc = "The Protocol CRAB-17 Phone, a phone borrowed from an unknown third party, it can be used to crash the space market, funneling the losses of the crew to your bank account.\

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1627,8 +1627,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/slimepotion/slime/sentience/traitor
 	desc = "The Syndicate have recently synthesized artificial sentience potions thanks to stolen slime cores. \
 			Using it will make any animal sentient, and bound to serve you in your dastardly deeds."
-	cost = 7
-	limited_stock = 1 //only buy one, prevents certain mushroom shenanigans
+	cost = 2
+	limited_stock = 2 //only buy two, prevents certain mushroom shenanigans
 	include_modes = list() //clear the list
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops, /datum/game_mode/infiltration) // yogs: infiltration
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1625,8 +1625,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/device_tools/potion/traitor
 	name = "Lesser Syndicate Sentience Potion"
 	item = /obj/item/slimepotion/slime/sentience/traitor
-	desc = "With recent advancements in Syndicate technology thanks to stolen slime cores, the Syndicate have created their own sentience potions. \
-			Using it will make any animal sentient, and bound to serve you, but as slime cores are still a hot commodity in the black market, they aint cheap."
+	desc = "The Syndicate have recently synthesized artificial sentience potions thanks to stolen slime cores. \
+			Using it will make any animal sentient, and bound to serve you in your dastardly deeds."
 	cost = 7
 	limited_stock = 1 //only buy one, prevents certain mushroom shenanigans
 	include_modes = list() //clear the list

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1627,7 +1627,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/slimepotion/slime/sentience/traitor
 	desc = "With recent advancements in Syndicate technology thanks to stolen slime cores, the Syndicate have created their own sentience potions. \
 			Using it will make any animal sentient, and bound to serve you, but as slime cores are still a hot commodity in the black market, they aint cheap."
-	cost = 12
+	cost = 7
+	limited_stock = 1 //only buy one, prevents certain mushroom shenanigans
 	include_modes = list() //clear the list
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops, /datum/game_mode/infiltration) // yogs: infiltration
 


### PR DESCRIPTION
# Document the changes in your pull request

Funny things happen with sentient antagonist creatures

adds a lesser sentience potion to the uplink for normal traitors. ~12~ ~7~ 2 TC, no implant, no access card. ~It's so high so people play with the gimmick of "sentient creature will help with objectives" instead of a tc tax~ buy two, have them instantly die.

# Wiki Documentation

new uplink item

# Changelog

:cl:  
rscadd: lesser syndicate sentience potion added
/:cl:
