### PR TITLE
Ninja's max drain speed is 8x faster

### DIFF
--- a/code/modules/ninja/suit/gloves.dm
+++ b/code/modules/ninja/suit/gloves.dm
@@ -35,7 +35,7 @@
 	var/draining = 0
 	var/candrain = 0
 	var/mindrain = 200
-	var/maxdrain = 400
+	var/maxdrain = 3200
 
 
 /obj/item/clothing/gloves/space_ninja/Touch(atom/A,proximity)


### PR DESCRIPTION
I assume that's what this change does anyway
If you've played ninja, especially with an upgraded cell, you understand
it's meant as QoL

If not: charging a bluespace suit cell from a fully-upgraded fully-charged SMES takes about two entire _minutes_ of just standing around and sparking like the moron you are, maybe talking to the two ghosts who have the patience to orbit you in the meantime

I don't think this is significant as a buff because
a) you can just use a cell charger (up to 2000 per tick to this change's 3200, but why wouldn't their tech be better)
b) it just means the ninja has less downtime which if anything means they die faster lmao

# Changelog

:cl:  
tweak: Ninjas can drain power up to 8 times faster
/:cl: