### PR TITLE
Fixes Analgesia stamina regen only working with transmission 7+

### DIFF
--- a/yogstation/code/datums/diseases/advance/symptoms/confusion.dm
+++ b/yogstation/code/datums/diseases/advance/symptoms/confusion.dm
@@ -27,7 +27,7 @@
 		suppress_warning = TRUE
 	if(A.totalResistance() >= 8)
 		stun_reduce = -25
-	if(A.totalTransmittable() >= 7)
+	if(A.totalTransmittable() >= 6)
 		stamina_regen = TRUE
 		
 /datum/symptom/numb/Activate(datum/disease/advance/A)


### PR DESCRIPTION
# Document the changes in your pull request

Closes #12983 

# Changelog

:cl:  
bugfix: Analgesia transmission requirement is now accurate 
/:cl:
