### PR TITLE
Constructing a lattice now correctly says how many rods you need

### DIFF
--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -112,12 +112,12 @@
 			to_chat(user, span_warning("There is already a catwalk here!"))
 			return
 		if(L)
-			if(R.use(2))
+			if(R.use(1))
 				to_chat(user, span_notice("You construct a catwalk."))
 				playsound(src, 'sound/weapons/genhit.ogg', 50, 1)
 				new/obj/structure/lattice/catwalk(src)
 			else
-				to_chat(user, span_warning("You need two rods to build a catwalk!"))
+				to_chat(user, span_warning("You need one rod to build a catwalk!"))
 			return
 		if(R.use(1))
 			to_chat(user, span_notice("You construct a lattice."))

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -112,7 +112,7 @@
 			to_chat(user, span_warning("There is already a catwalk here!"))
 			return
 		if(L)
-			if(R.use(1))
+			if(R.use(2))
 				to_chat(user, span_notice("You construct a catwalk."))
 				playsound(src, 'sound/weapons/genhit.ogg', 50, 1)
 				new/obj/structure/lattice/catwalk(src)


### PR DESCRIPTION
# Document the changes in your pull request

`to_chat(user, span_warning("You need two rods to build a catwalk!"))`

Fixes that

# Changelog

:cl:  
tweak: Catwalks now say they need one rod
/:cl:
