### PR TITLE
slightly buffs wizard spellblade and nerfs mining spellblade [alternative to #12994]

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1039,7 +1039,7 @@
 		if(2)
 			new /obj/item/blood_contract(src)
 		if(3)
-			new /obj/item/gun/magic/staff/spellblade(src)
+			new /obj/item/gun/magic/staff/spellblade/weak(src)
 		if(4)
 			new /obj/item/organ/stomach/cursed(src)
 

--- a/code/modules/projectiles/ammunition/special/magic.dm
+++ b/code/modules/projectiles/ammunition/special/magic.dm
@@ -42,6 +42,9 @@
 /obj/item/ammo_casing/magic/spellblade
 	projectile_type = /obj/item/projectile/magic/spellblade
 
+/obj/item/ammo_casing/magic/spellblade/weak
+	projectile_type = /obj/item/projectile/magic/spellblade/weak
+
 /obj/item/ammo_casing/magic/arcane_barrage
 	projectile_type = /obj/item/projectile/magic/arcane_barrage
 

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -99,6 +99,11 @@
 	sharpness = SHARP_EDGED
 	max_charges = 4
 
+/obj/item/gun/magic/staff/spellblade/weak
+	name = "ashy spellblade"
+	desc = "A deadly combination of laziness and bloodlust, this blade allows the user to dismember their enemies without all the hard work of actually swinging the sword. This one seems to be covered in ash."
+	ammo_type = /obj/item/ammo_casing/magic/spellblade/weak
+
 /obj/item/gun/magic/staff/spellblade/Initialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 15, 125, 0, hitsound)

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -389,7 +389,7 @@
 
 /obj/item/projectile/magic/spellblade/weak
 	damage = 15
-	dismemberment = 35
+	dismemberment = 20
 
 /obj/item/projectile/magic/arcane_barrage
 	name = "arcane bolt"

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -381,11 +381,15 @@
 /obj/item/projectile/magic/spellblade
 	name = "blade energy"
 	icon_state = "lavastaff"
-	damage = 15
+	damage = 20
 	damage_type = BURN
 	flag = "magic"
 	dismemberment = 50
 	nodamage = FALSE
+
+/obj/item/projectile/magic/spellblade/weak
+	damage = 15
+	dismemberment = 35
 
 /obj/item/projectile/magic/arcane_barrage
 	name = "arcane bolt"


### PR DESCRIPTION
spellblade's projectile has damage increased to 20 instead of 15. Weak spellblade keeps the normal 15 damage projectiles and has it's dismemberment ability lowered from 50(%?) to 20.

I had made this before #12994 but hadn't published it yet
but nows a good time as ever to make it as an alternative

keeping in the slight spellblade buff because its pretty good but not good enough to contend with something like mjolnir.

# Changelog

:cl:  
tweak: spellblade's projectile has damage increased to 20 instead of 15. Lavaland/bubblegum spellblade keeps the normal 15 damage projectiles and has it's dismemberment ability lowered from 50(%?) to 20.
/:cl:
