### PR TITLE
gibbing simplemobs drops their guaranteed butcher stuff as well as their normal butcher stuff

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -277,10 +277,14 @@
 		adjustHealth(unsuitable_atmos_damage)
 
 /mob/living/simple_animal/gib()
+	var/atom/Tsec = drop_location()
 	if(butcher_results)
-		var/atom/Tsec = drop_location()
 		for(var/path in butcher_results)
 			for(var/i in 1 to butcher_results[path])
+				new path(Tsec)
+	if(guaranteed_butcher_results)
+		for(var/path in guaranteed_butcher_results)
+			for(var/i in 1 to guaranteed_butcher_results[path])
 				new path(Tsec)
 	..()
 


### PR DESCRIPTION
# If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md


# Document the changes in your pull request

t

# Wiki Documentation

if it's mentioned goliaths don't drop hide unless butchered by hand that's no longer applicable

# Changelog

:cl:  
bugfix: goliaths drop hide when gibbed without butchering
/:cl:
