### PR TITLE
Fixes AI's not being able to control mechs with AI control beacons

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -497,7 +497,7 @@
 		if(!GLOB.cameranet.checkCameraVis(M))
 			to_chat(src, span_warning("Exosuit is no longer near active cameras."))
 			return
-		if(!isturf(loc))
+		if(!isvalidAIloc(loc))
 			to_chat(src, span_warning("You aren't in your core!"))
 			return
 		if(M)


### PR DESCRIPTION
# Document the changes in your pull request
See title

# Wiki Documentation


# Changelog


:cl:  
bugfix: AIs can once again control mechs provided there's an AI control beacon inserted
/:cl:
