### PR TITLE
Fixes AI eyeobj recovery not working

### DIFF
--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -161,7 +161,7 @@
 	cameraFollow = null
 	unset_machine()
 
-	if(isturf(loc) && (QDELETED(eyeobj) || !eyeobj.loc))
+	if(isvalidAIloc(loc) && (QDELETED(eyeobj) || !eyeobj.loc))
 		to_chat(src, "ERROR: Eyeobj not found. Creating new eye...")
 		create_eye()
 


### PR DESCRIPTION
# Document the changes in your pull request
If for any random reason your eyeobj is removed, which can just happen randomly, hitting view core will once again fix it, just like it used to.

# Wiki Documentation

# Changelog
Edge case, no changelog needed
