### PR TITLE
putting a temporary spare in the spare id cabinet will burn out the cabinet when it self destructs

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -468,8 +468,22 @@ update_label("John Doe", "Clowny")
 		var/mob/living/M = loc
 		M.adjust_fire_stacks(1)
 		M.IgniteMob()
+	if(istype(loc,/obj/structure/fireaxecabinet/bridge/spare)) //if somebody is being naughty and putting the temporary spare in the cabinet
+		var/obj/structure/fireaxecabinet/bridge/spare/holder = loc
+		forceMove(holder.loc)
+		holder.spareid = null
+		if(holder.obj_integrity > holder.integrity_failure) //we dont want to heal it by accident
+			holder.take_damage(holder.obj_integrity - holder.integrity_failure, BURN) //we do a bit of trolling for being naughty
+		else
+			holder.update_icon() //update the icon anyway so it pops out
+		visible_message(span_danger("The heat of the temporary spare shatters the glass!"));
 	fire_act()
 	sleep(2 SECONDS)
+	if(istype(loc,/obj/structure/fireaxecabinet/bridge/spare)) //dude you put it back?
+		var/obj/structure/fireaxecabinet/bridge/spare/holder = loc
+		forceMove(holder.loc)
+		holder.spareid = null
+		holder.update_icon()
 	burn()
 
 /obj/item/card/id/centcom


### PR DESCRIPTION
# Document the changes in your pull request

shenanigans behest shenanigans

Fixes https://github.com/yogstation13/Yogstation/issues/13017 while also spicing it up so you are discouraged to be cheeky with the unintended behavior

Yes it's possible to just not allow the temporary spare to be put in it
Yes it's possible to just update the icon when the temporary spare self destructs

making it break the cabinet is funnier

# Wiki Documentation

Don't put the temporary spare in the spare id cabinet at 3 am caught on 4k

# Changelog

:cl:  
rscadd: temporary spare makes cabinet go boom when it burns
/:cl:
