### PR TITLE
hypno now shows blood cost hgehehe

### DIFF
--- a/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -176,7 +176,7 @@
 
 
 /obj/effect/proc_holder/spell/pointed/hypno
-	name = "Hypnotize"
+	name = "Hypnotize (20)"
 	desc = "Knock out your target."
 	charge_max = 300
 	blood_used = 20


### PR DESCRIPTION
# Document the changes in your pull request

some idiot (theos probably) set it to cost 20 blood but didnt have it say (20) now it does

# Changelog

:cl:  
bugfix: Vampire's Hypnotize is now labeled with its blood cost
/:cl:
