### PR TITLE
Traitor AIs now have access to malf modules

### DIFF
--- a/code/modules/antagonists/malf/malf.dm
+++ b/code/modules/antagonists/malf/malf.dm
@@ -1,5 +1,4 @@
 /datum/antagonist/traitor/malf //inheriting traitor antag datum since traitor AIs use it.
-	malf = TRUE
 	roundend_category = "malfunctioning AIs"
 	name = "Malf"
 

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -59,10 +59,9 @@
 	if(traitor_kind == TRAITOR_AI && owner.current && isAI(owner.current))
 		var/mob/living/silicon/ai/A = owner.current
 		A.set_zeroth_law("")
-		if(malf)
-			remove_verb(A, /mob/living/silicon/ai/proc/choose_modules)
-			A.malf_picker.remove_malf_verbs(A)
-			qdel(A.malf_picker)
+		remove_verb(A, /mob/living/silicon/ai/proc/choose_modules)
+		A.malf_picker.remove_malf_verbs(A)
+		qdel(A.malf_picker)
 	owner.remove_employee(company)
 	UnregisterSignal(owner.current, COMSIG_MOVABLE_HEAR)
 	SSticker.mode.traitors -= owner

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -13,7 +13,6 @@
 	var/should_give_codewords = TRUE
 	var/should_equip = TRUE
 	var/traitor_kind = TRAITOR_HUMAN //Set on initial assignment
-	var/malf = FALSE //whether or not the AI is malf (in case it's a traitor)
 	var/datum/contractor_hub/contractor_hub
 	can_hijack = HIJACK_HIJACKER
 
@@ -302,8 +301,7 @@
 	killer.set_zeroth_law(law, law_borg)
 	killer.set_syndie_radio()
 	to_chat(killer, "Your radio has been upgraded! Use :t to speak on an encrypted channel with Syndicate Agents!")
-	if(malf)
-		killer.add_malf_picker()
+	killer.add_malf_picker()
 
 /datum/antagonist/traitor/proc/equip(var/silent = FALSE)
 	if(traitor_kind == TRAITOR_HUMAN)

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -163,7 +163,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/AI_Module))
 	unlock_text = span_notice("You slowly, carefully, establish a connection with the on-station self-destruct. You can now activate it at any time.")
 
 /datum/AI_Module/destructive/nuke_station/can_use(mob/living/silicon/ai/AI)
-	return !AI.mind.has_antag_datum(/datum/antagonist/hijacked_ai)
+	return AI.mind.has_antag_datum(/datum/antagonist/traitor/malf)
 
 /datum/action/innate/ai/nuke_station
 	name = "Doomsday Device"
@@ -552,7 +552,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/AI_Module))
 	unlock_sound = 'sound/machines/ping.ogg'
 
 /datum/AI_Module/utility/place_cyborg_transformer/can_use(mob/living/silicon/ai/AI)
-	return !AI.mind.has_antag_datum(/datum/antagonist/hijacked_ai)
+	return AI.mind.has_antag_datum(/datum/antagonist/traitor/malf)
 
 /datum/action/innate/ai/place_transformer
 	name = "Place Robotics Factory"


### PR DESCRIPTION
If an AI's working for the syndicate, it's obviously malfunctioning in some way, right?

This give traitor AI access to malf modules, _except_ for Doomsday Device or Robotic Factory. Those two are still full malf-only.

# Changelog

:cl: Lucy
tweak: Turns out, AIs working for the syndicate are, in fact, malfunctioning, and behave like a malfunctioning AI!
/:cl:
