### PR TITLE
Adds basic wires to AI Data Cores (Shock + disable for now)

### DIFF
--- a/code/datums/wires/ai_data_core.dm
+++ b/code/datums/wires/ai_data_core.dm
@@ -1,0 +1,37 @@
+/datum/wires/ai_data_core
+	holder_type = /obj/machinery/ai/data_core
+	proper_name = "AI Data Core"
+
+/datum/wires/ai_data_core/New(atom/holder)
+	wires = list(
+		WIRE_AI, WIRE_ZAP
+		//WIRE_HACK
+	)
+	add_duds(6)
+	..()
+
+/datum/wires/ai_data_core/interactable(mob/user)
+	var/obj/machinery/ai/data_core/C = holder
+	if(C.panel_open)
+		return TRUE
+
+/datum/wires/ai_data_core/get_status()
+	var/obj/machinery/ai/data_core/C = holder
+	var/list/status = list()
+	status += "The blue light is [C.ai_connection ? "blinking" : "off"]."
+	return status
+
+/datum/wires/ai_data_core/on_pulse(wire)
+	var/obj/machinery/ai/data_core/C = holder
+	switch(wire)
+		if(WIRE_AI)
+			C.ai_connection = FALSE
+			addtimer(CALLBACK(A, /obj/machinery/ai/data_core.proc/reset_wire, wire), 60)
+
+/datum/wires/ai_data_core/on_cut(wire, mend)
+	var/obj/machinery/ai/data_core/C = holder
+	switch(wire)
+		if(WIRE_ZAP)
+			C.shock(usr, 50)
+		if(WIRE_AI)
+			C.ai_connection = !mend

--- a/code/datums/wires/ai_data_core.dm
+++ b/code/datums/wires/ai_data_core.dm
@@ -26,7 +26,7 @@
 	switch(wire)
 		if(WIRE_AI)
 			C.ai_connection = FALSE
-			addtimer(CALLBACK(A, /obj/machinery/ai/data_core.proc/reset_wire, wire), 60)
+			addtimer(CALLBACK(C, /obj/machinery/ai/data_core.proc/reset_wire, wire), 10 SECONDS)
 
 /datum/wires/ai_data_core/on_cut(wire, mend)
 	var/obj/machinery/ai/data_core/C = holder

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -606,6 +606,7 @@
 #include "code\datums\weather\weather_types\radiation_storm.dm"
 #include "code\datums\weather\weather_types\snow_storm.dm"
 #include "code\datums\wires\_wires.dm"
+#include "code\datums\wires\ai_data_core.dm"
 #include "code\datums\wires\airalarm.dm"
 #include "code\datums\wires\airlock.dm"
 #include "code\datums\wires\airlock_cycle.dm"


### PR DESCRIPTION
# Document the changes in your pull request

Adds a wire that when pulsed disables AI entry into a core for 10 seconds. (Only new AIs, not current ones). Permanent if cut
Adds a shock wire too. 

TODO:
- [ ] Make it possible to send secret messages to the AI if the data core is hacked
- [ ] ???

Requires #13025 to be merged for icon update to work

# Wiki Documentation

# Changelog


:cl:  
rscadd: It is now possible to temporarily or permanently disable AI data cores via hacking them
/:cl:
