### PR TITLE
Adds rare speech verbs that sometimes take the place of "Says"

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -1,5 +1,7 @@
+#define RARE_VERB_CHANCE 10
+
 /mob/living/carbon/human/say_mod(input, message_mode)
-	if(prob(10) && dna.species.rare_say_mod.len)
+	if(prob(RARE_VERB_CHANCE) && dna.species.rare_say_mod.len)
 		verb_say = pick(dna.species.rare_say_mod)
 	else
 		verb_say = dna.species.say_mod

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -1,5 +1,9 @@
 /mob/living/carbon/human/say_mod(input, message_mode)
-	verb_say = dna.species.say_mod
+	if(prob(10) && dna.species.rare_say_mod.len)
+		verb_say = pick(dna.species.rare_say_mod)
+	else
+		verb_say = dna.species.say_mod
+	
 	if(slurring)
 		return "slurs"
 	else

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -1,8 +1,8 @@
-#define RARE_VERB_CHANCE 10
-
 /mob/living/carbon/human/say_mod(input, message_mode)
-	if(prob(RARE_VERB_CHANCE) && dna.species.rare_say_mod.len)
-		verb_say = pick(dna.species.rare_say_mod)
+	var/rare_verb = pick(dna.species.rare_say_mod)
+	
+	if(rare_verb && prob(dna.species.rare_say_mod[rare_verb]))
+		verb_say = rare_verb
 	else
 		verb_say = dna.species.say_mod
 	

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -52,6 +52,8 @@ GLOBAL_LIST_EMPTY(mentor_races)
 	var/nojumpsuit = FALSE
 	/// affects the speech message
 	var/say_mod = "says"
+	/// 1/10 chance when speaking to pick an easter egg speaking verb, like for felinids "meows" instead of "says"
+	var/list/rare_say_mod = list()
 	///Used if you want to give your species thier own language
 	var/species_language_holder = /datum/language_holder
 	/// Default mutant bodyparts for this species. Don't forget to set one for every mutant bodypart you allow this species to have.

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -6,7 +6,7 @@
 
 	mutant_bodyparts = list("ears", "tail_human")
 	default_features = list("mcolor" = "FFF", "tail_human" = "Cat", "ears" = "Cat", "wings" = "None")
-	rare_say_mod = list("meows")
+	rare_say_mod = list("meows"= 10)
 	liked_food = SEAFOOD | DAIRY
 	toxic_food = TOXIC | CHOCOLATE
 	mutantears = /obj/item/organ/ears/cat

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -6,6 +6,7 @@
 
 	mutant_bodyparts = list("ears", "tail_human")
 	default_features = list("mcolor" = "FFF", "tail_human" = "Cat", "ears" = "Cat", "wings" = "None")
+	rare_say_mod = list("meows")
 	liked_food = SEAFOOD | DAIRY
 	toxic_food = TOXIC | CHOCOLATE
 	mutantears = /obj/item/organ/ears/cat

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
@@ -6,6 +6,7 @@
 	id = "pod" // We keep this at pod for compatibility reasons
 	default_color = "59CE00"
 	species_traits = list(MUTCOLORS,EYECOLOR,HAS_FLESH,HAS_BONE)
+	rare_say_mod = list("rustles")
 	attack_verb = "slash"
 	attack_sound = 'sound/weapons/slice.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
@@ -6,7 +6,7 @@
 	id = "pod" // We keep this at pod for compatibility reasons
 	default_color = "59CE00"
 	species_traits = list(MUTCOLORS,EYECOLOR,HAS_FLESH,HAS_BONE)
-	rare_say_mod = list("rustles")
+	rare_say_mod = list("rustles" = 10)
 	attack_verb = "slash"
 	attack_sound = 'sound/weapons/slice.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'


### PR DESCRIPTION
Truz like the idea of felinids rarely meowing instead of speaking and Marmio hated the idea so i was inspired to make it work. All species now have a rare_say_mod variable that's an empty list that can be populated with speech verbs that will be chosen instead of the default with 10% frequency.

1/10 chance for cat people to meow or plant people to rustle.
![image](https://user-images.githubusercontent.com/46236974/147864682-06ffd64f-09c3-46a8-88df-861fb074751d.png)
![image](https://user-images.githubusercontent.com/46236974/147864690-8aaf8644-4a09-4a53-86c6-4ecaedee071a.png)
![image](https://user-images.githubusercontent.com/46236974/147864693-48cd77eb-ce69-4d9d-bf90-c3663a2605ec.png)

Feel free to make one for your species of choice if this gets in

# Why is this good for the game?
I dunno i just think some extra conversational flavor is nice. Just less of the same text

# Wiki Documentation

Cats sometimes meow
Plants sometimes rustle

# Changelog

:cl:  
rscadd: Adds support for rare speech verbs to species 
rscadd: Felinids and Phytosians sometimes use easter egg speech verbs instead of "Says"
/:cl:
