### PR TITLE
Shunt is useful again

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1086,7 +1086,8 @@
 		occupier.parent = malf.parent
 	else
 		occupier.parent = malf
-	malf.shunted = 1
+	malf.shunted = TRUE
+	QDEL_NULL(occupier.builtInCamera)
 	occupier.eyeobj.name = "[occupier.name] (AI Eye)"
 	if(malf.parent)
 		qdel(malf)


### PR DESCRIPTION
Having a *camera* on shunted AIs makes it nearly _useless_ to shunt, as someone can just check the camera console and hunt you down immediately.

# Changelog

:cl:  
tweak: Malf AIs who shunt no longer appear on camera consoles. Sorry, you gotta actually look for it now!
/:cl:
