### PR TITLE
Fixes a duplicate locker in arrivals at 50,150

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -36372,14 +36372,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"fwo" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/structure/closet/firecloset/full,
-/obj/structure/closet/firecloset/full,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "fxr" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -61826,6 +61818,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"vAD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "vAP" = (
 /obj/machinery/telecomms/receiver/preset_left{
 	name = "subspace receiver A"
@@ -63617,38 +63616,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
-"wHY" = (
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"wHA" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/item/hand_labeler,
-/obj/item/book/manual/wiki/medicine,
-/obj/machinery/requests_console{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC";
-	pixel_y = -32
-	},
-/obj/item/toy/figure/md{
-	layer = 2.79;
-	pixel_x = -9;
-	pixel_y = 16
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
 "wIv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -78721,7 +78688,7 @@ aaa
 aaa
 aaa
 aSm
-fwo
+vAD
 tqk
 nlx
 aRY


### PR DESCRIPTION
# Document the changes in your pull request

Removes a duplicate firefighting locker from arrivals




# Wiki Documentation

n/a


# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
rscdel: removed a duplicate fire cabinet from arrivals(50,150) under the emergency shuttle
/:cl:
