### PR TITLE
Small sling glare changes

### DIFF
--- a/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
@@ -9,7 +9,7 @@
 	else if(is_shadow(usr)) to_chat(usr, span_warning("Your telepathic ability is suppressed. Hatch or use Rapid Re-Hatch first."))
 	return 0
 
-/obj/effect/proc_holder/spell/targeted/sling //Stuns and mutes a human target for 10 seconds
+/obj/effect/proc_holder/spell/targeted/sling
 	ranged_mousepointer = 'icons/effects/cult_target.dmi'
 	var/mob/living/user
 	var/mob/living/target
@@ -52,7 +52,7 @@
 
 /obj/effect/proc_holder/spell/targeted/sling/glare //Stuns and mutes a human target for 10 seconds
 	name = "Glare"
-	desc = "Disrupts the target's motor and speech abilities."
+	desc = "Disrupts the target's motor and speech abilities. Much more effective within two meters."
 	panel = "Shadowling Abilities"
 	charge_max = 300
 	human_req = TRUE
@@ -83,7 +83,8 @@
 	else //Distant glare
 		var/loss = 100 - (distance * 10)
 		target.adjustStaminaLoss(loss)
-		target.stuttering = loss
+		if(!issilicon(target))
+			target.stuttering = loss
 		to_chat(target, span_userdanger("A purple light flashes across your vision, and exhaustion floods your body..."))
 		target.visible_message(span_danger("[target] looks very tired..."))
 	charge_counter = 0

--- a/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
@@ -83,8 +83,10 @@
 	else //Distant glare
 		var/loss = 100 - (distance * 10)
 		target.adjustStaminaLoss(loss)
-		if(!issilicon(target))
+		if(iscarbon(target))
 			target.stuttering = loss
+		else if(issilicon(target))
+			target.stuttering = distance
 		to_chat(target, span_userdanger("A purple light flashes across your vision, and exhaustion floods your body..."))
 		target.visible_message(span_danger("[target] looks very tired..."))
 	charge_counter = 0


### PR DESCRIPTION
Borgs no longer infinitely stutter when glared at
Description hints at the range you should be using it from
There is no longer a comment about how glare works on something that is not glare

:cl:  
bugfix: Borgs should no longer infinitely stutter when glared at by slings
tweak: Glare's description hints that it should be used within two tiles of the target
/:cl: