### PR TITLE
Ports split personality commune from tg

### DIFF
--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -19,7 +19,13 @@
 
 /datum/brain_trauma/severe/split_personality/proc/make_backseats()
 	stranger_backseat = new(owner, src)
+	var/obj/effect/proc_holder/spell/targeted/personality_commune/stranger_spell = new(src)
+	stranger_backseat.AddSpell(stranger_spell)
+
 	owner_backseat = new(owner, src)
+	var/obj/effect/proc_holder/spell/targeted/personality_commune/owner_spell = new(src)
+	owner_backseat.AddSpell(owner_spell)
+
 
 /datum/brain_trauma/severe/split_personality/proc/get_ghost()
 	set waitfor = FALSE

--- a/code/modules/spells/spell_types/personality_commune.dm
+++ b/code/modules/spells/spell_types/personality_commune.dm
@@ -1,0 +1,32 @@
+/obj/effect/proc_holder/spell/targeted/personality_commune
+	name = "Personality Commune"
+	desc = "Sends thoughts to your alternate consciousness."
+	charge_max = 0
+	clothes_req = FALSE
+	range = -1
+	include_user = TRUE
+	action_icon_state = "telepathy"
+	action_background_icon_state = "bg_spell"
+	var/datum/brain_trauma/severe/split_personality/trauma
+	var/flufftext = "You hear an echoing voice in the back of your head..."
+
+/obj/effect/proc_holder/spell/targeted/personality_commune/New(datum/brain_trauma/severe/split_personality/T)
+	. = ..()
+	trauma = T
+
+// Pillaged and adapted from telepathy code
+/obj/effect/proc_holder/spell/targeted/personality_commune/cast(list/targets, mob/user)
+	if(!istype(trauma))
+		to_chat(user, "<span class='warning'>Something is wrong; Either due a bug or admemes, you are trying to cast this spell without a split personality!</span>")
+		return
+	var/msg = stripped_input(usr, "What would you like to tell your other self?", null , "")
+	if(!msg)
+		charge_counter = charge_max
+		return
+	to_chat(user, "<span class='boldnotice'>You concentrate and send thoughts to your other self:</span> <span class='notice'>[msg]</span>")
+	to_chat(trauma.owner, "<span class='boldnotice'>[flufftext]</span> <span class='notice'>[msg]</span>")
+	log_directed_talk(user, trauma.owner, msg, LOG_SAY ,"[name]")
+	for(var/ded in GLOB.dead_mob_list)
+		if(!isobserver(ded))
+			continue
+		to_chat(ded, "[FOLLOW_LINK(ded, user)] <span class='boldnotice'>[user] [name]:</span> <span class='notice'>\"[msg]\" to</span><span class='name'>[trauma]</span>")

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2995,6 +2995,7 @@
 #include "code\modules\spells\spell_types\lightning.dm"
 #include "code\modules\spells\spell_types\mime.dm"
 #include "code\modules\spells\spell_types\mind_transfer.dm"
+#include "code\modules\spells\spell_types\personality_commune.dm"
 #include "code\modules\spells\spell_types\projectile.dm"
 #include "code\modules\spells\spell_types\rod_form.dm"
 #include "code\modules\spells\spell_types\santa.dm"


### PR DESCRIPTION
# Document the changes in your pull request

Ports https://github.com/tgstation/tgstation/pull/46875

This allows split personalities that are in the backseat to send messages to those in the front seat. Those in the front seat still need to talk out loud though.

# Wiki Documentation

None.

# Changelog

:cl:  
rscadd: Ports split personality commune from tg. Split personalities in the 'backseat' (i.e. not in control) can now send messages to those in the front seat. Those in the 'front seat' (i.e. in control) will still need to talk out loud to those in the backseat.
/:cl:
