### PR TITLE
moves sci wardrobe vending machine from toxins room to experimentor room

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -22194,17 +22194,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/science/lab)
-"brz" = (
-/obj/structure/table,
-/obj/item/pen,
-/obj/machinery/camera{
-	c_tag = "Experimentor Lab";
-	network = list("ss13","rd")
-	},
-/obj/item/hand_labeler,
-/obj/item/stack/packageWrap,
-/turf/open/floor/plasteel/white/side,
-/area/science/explab)
 "brB" = (
 /obj/structure/closet/l3closet/scientist,
 /turf/open/floor/plasteel/white/side,
@@ -56436,6 +56425,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"sbK" = (
+/obj/structure/table,
+/obj/machinery/camera{
+	c_tag = "Experimentor Lab";
+	network = list("ss13","rd")
+	},
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/obj/item/hand_labeler,
+/obj/item/stack/packageWrap,
+/turf/open/floor/plasteel/white/side,
+/area/science/explab)
 "scv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -117257,7 +117261,7 @@ hoc
 hoc
 bjT
 bqe
-brz
+sbK
 blN
 cBt
 bvN

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -22205,13 +22205,6 @@
 /obj/item/stack/packageWrap,
 /turf/open/floor/plasteel/white/side,
 /area/science/explab)
-"brA" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/white/corner,
-/area/science/explab)
 "brB" = (
 /obj/structure/closet/l3closet/scientist,
 /turf/open/floor/plasteel/white/side,
@@ -25809,14 +25802,6 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"bEy" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "bEC" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing)
@@ -26735,10 +26720,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"bJU" = (
-/obj/machinery/vending/wardrobe/science_wardrobe,
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "bJW" = (
 /obj/item/transfer_valve{
 	pixel_x = -5
@@ -52712,6 +52693,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
+"pQf" = (
+/obj/machinery/vending/wardrobe/science_wardrobe,
+/turf/open/floor/plasteel/white/corner,
+/area/science/explab)
 "pQy" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Escape Podbay"
@@ -56947,6 +56932,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"ssa" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "sti" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -59478,6 +59471,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"tYF" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "tYQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -116241,7 +116239,7 @@ byt
 byt
 byt
 byt
-bEy
+tYF
 bFU
 bsA
 bsU
@@ -116498,7 +116496,7 @@ bzO
 bzO
 bzO
 bqe
-bJU
+ssa
 bFU
 bFU
 wOx
@@ -117002,7 +117000,7 @@ hoc
 ncq
 bjS
 bqe
-brA
+pQf
 blD
 buw
 bvO


### PR DESCRIPTION
# Document the changes in your pull request

although experimentor room still has a higher than normal chance to explode, it will not in 70% of shifts while toxins will be spaced within the first 15 minutes on 70% of shifts. 

this of course comes with the removal of a single paper bin in experimentor which was vital to gameplay and thus changes the balance of the entire game

![image](https://user-images.githubusercontent.com/5091394/148297791-6f350ee3-73ed-4b82-8701-64c0a802b2b4.png)

also gives toxins another air pump (power creep) 

# Wiki Documentation

image has to be changed

# Changelog


:cl:  
rscadd: add an extra air pump to toxins
tweak: moves paper bin one tile to the right
tweak: moved sci wardrobe vending machine to experimentor room
/:cl:
