### PR TITLE
Fixes the gorilla(people) slime reaction

### DIFF
--- a/yogstation/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/yogstation/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -1,7 +1,7 @@
 /datum/chemical_reaction/slime/slimegorilla
 	name = "Gorilla Mutation Toxin"
 	id = "gorillamuttoxin"
-	results = list("gorillamutationtoxin" = 1)
+	results = list(/datum/reagent/mutationtoxin/gorilla = 1)
 	required_reagents = list(/datum/reagent/consumable/milk = 1)
 	required_other = TRUE
 	required_container = /obj/item/slime_extract/green


### PR DESCRIPTION
# Document the changes in your pull request

Closes #13050

Apparently this reaction was a thing? I'm just going to leave this PR up for now, I have no idea whether people want to keep gorilla people as a thing. Or if people even knew that gorilla people were a thing. 

# Wiki Documentation

Uh. It turns out this reaction was never documented to begin with. So yeah.

# Changelog

:cl:    
bugfix: Did you know that you can use milk on a green slime extract to make gorillapeople mutation toxin? Well that reaction actually works now.
/:cl:
