### PR TITLE
Makes AI not get spammed when dying, plus changes the message for a data core failing

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -112,6 +112,8 @@
 	var/downloadSpeedModifier = 1
 
 	var/login_warned_temp = FALSE
+	//Did we get the death prompt?
+	var/is_dying = FALSE 
 
 
 /mob/living/silicon/ai/Initialize(mapload, datum/ai_laws/L, mob/target_ai, shunted)

--- a/code/modules/mob/living/silicon/ai/decentralized/ai_data_core.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/ai_data_core.dm
@@ -39,7 +39,8 @@ GLOBAL_VAR_INIT(primary_data_core, null)
 
 	for(var/mob/living/silicon/ai/AI in contents)
 		all_ais -= AI
-		AI.relocate()
+		if(!AI.is_dying)
+			AI.relocate()
 
 	to_chat(all_ais, span_userdanger("Warning! Data Core brought offline in [get_area(src)]! Please verify that no malicious actions were taken."))
 	
@@ -89,10 +90,13 @@ GLOBAL_VAR_INIT(primary_data_core, null)
 			use_power = IDLE_POWER_USE
 			update_icon()
 			for(var/mob/living/silicon/ai/AI in contents)
-				AI.relocate()
+				if(!AI.is_dying)
+					AI.relocate()
 		if(!warning_sent)
 			warning_sent = TRUE
-			to_chat(GLOB.ai_list, span_userdanger("Data core in [get_area(src)] is on the verge of failing! Please contact technical support."))
+			to_chat(GLOB.ai_list, span_userdanger("Data core in [get_area(src)] is on the verge of failing! Immediate action required to prevent failure."))
+			for(var/mob/living/silicon/ai/AI in GLOB.ai_list)
+				AI.playsound_local(AI, 'sound/machines/engine_alert2.ogg', 30)
 
 	if(!(stat & (BROKEN|NOPOWER|EMPED)))
 		var/turf/T = get_turf(src)

--- a/code/modules/mob/living/silicon/ai/decentralized_ai.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized_ai.dm
@@ -30,6 +30,7 @@
 	
 	if(!GLOB.data_cores.len)
 		INVOKE_ASYNC(src, /mob/living/silicon/ai.proc/death_prompt)
+		is_dying = TRUE
 		return
 
 
@@ -57,6 +58,7 @@
 	if(available_ai_cores())
 		to_chat(src, span_usernotice("Yes! I am alive!"))
 		relocate(TRUE)
+		is_dying = FALSE
 		return
 	to_chat(src, span_notice("They need me. No.. I need THEM."))
 	sleep(0.5 SECONDS)


### PR DESCRIPTION
# Document the changes in your pull request

In addition the sound is played when the warning is sent

# Wiki Documentation


# Changelog

:cl:  
bugfix: AI no longer gets told it's trying to relocate rapidly when dying.
tweak: An alert sound is now played for all AIs when a data core goes offline
/:cl:
