### PR TITLE
Fixes gamebreaking bug that has been in the game for 17 months

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -46,7 +46,7 @@
 	if(!istype(H) || H.shoes || !(H.mobility_flags & MOBILITY_STAND) || !H.dna.species.has_toes())
 		return
 	var/speed_multiplier = 2/H.cached_multiplicative_slowdown
-	var/blindness_multiplier = 0
+	var/blindness_multiplier = 1
 	if(H.eye_blurry)
 		blindness_multiplier = 4
 	if(H.eye_blind)


### PR DESCRIPTION
# Document the changes in your pull request
You can now stub your toe without eye damage

# Changelog

:cl:  
bugfix: fixed being unable to stub your toe without eye damage
/:cl:
