### PR TITLE
Prpbanly fixes runtime in say.dm

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -2,7 +2,7 @@
 	if(LAZYLEN(dna.species.rare_say_mod))
 		for(var/rare in dna.species.rare_say_mod)
 			if(prob(dna.species.rare_say_mod[rare]))
-				verb_say = rare_verb	
+				verb_say = rare
 	if(slurring)
 		return "slurs"
 	else

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -1,11 +1,8 @@
 /mob/living/carbon/human/say_mod(input, message_mode)
-	var/rare_verb = pick(dna.species.rare_say_mod)
-	
-	if(rare_verb && prob(dna.species.rare_say_mod[rare_verb]))
-		verb_say = rare_verb
-	else
-		verb_say = dna.species.say_mod
-	
+	if(LAZYLEN(dna.species.rare_say_mod))
+		for(var/rare in dna.species.rare_say_mod)
+			if(prob(dna.species.rare_say_mod[rare]))
+				verb_say = rare_verb	
 	if(slurring)
 		return "slurs"
 	else


### PR DESCRIPTION
Assuming this is causing problems with other stuff also it makes it smaller
:cl:  
Bugfix: probably fixes say verbs not showing up
/:cl:
