### PR TITLE
Fixes roundstart rod stacking

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -27,6 +27,7 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 	throw_range = 7
 	materials = list(/datum/material/iron=1000)
 	max_amount = 50
+	merge_type = /obj/item/stack/rods
 	attack_verb = list("hit", "bludgeoned", "whacked")
 	hitsound = 'sound/weapons/grenadelaunch.ogg'
 	novariants = TRUE


### PR DESCRIPTION
# Document the changes in your pull request

Fixes roundstart rod stacking by setting the merge type to it's parent.
Closes #12951

# Wiki Documentation

None

# Changelog

:cl:    
bugfix: Roundstart rods that spawn should now stack with other normal rods
/:cl:
