### PR TITLE
Stops non interactable objects from being package wrapped

### DIFF
--- a/code/game/objects/items/stacks/wrap.dm
+++ b/code/game/objects/items/stacks/wrap.dm
@@ -50,16 +50,16 @@
 		return SHAME
 
 /obj/item/proc/can_be_package_wrapped() //can the item be wrapped with package wrapper into a delivery package
-	return 1
+	return TRUE
 
 /obj/item/storage/can_be_package_wrapped()
-	return 0
+	return FALSE
 
 /obj/item/storage/box/can_be_package_wrapped()
-	return 1
+	return TRUE
 
 /obj/item/smallDelivery/can_be_package_wrapped()
-	return 0
+	return FALSE
 
 /obj/item/stack/packageWrap/afterattack(obj/target, mob/user, proximity)
 	. = ..()
@@ -72,7 +72,7 @@
 
 	if(isitem(target))
 		var/obj/item/I = target
-		if(!I.can_be_package_wrapped())
+		if(!I.can_be_package_wrapped() || I.interaction_flags_item == NONE)
 			return
 		if(user.is_holding(I))
 			if(!user.dropItemToGround(I))


### PR DESCRIPTION
# Document the changes in your pull request

Stops things like mech chassis or any other object that isn't meant to be picked up from being package wrapped. Also updated wrap.dm so it uses proper booleans.

Closes #13016

# Wiki Documentation

None

# Changelog

:cl:  
bugfix: Stops non interactable objects from being package wrapped
/:cl:
