### PR TITLE
Makes the Paraplegic quirk incompatiable with prosthetic limbs quirk

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -17,7 +17,20 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 	if(!quirks.len)
 		SetupQuirks()
 
-	quirk_blacklist = list(list("Blind","Nearsighted"),list("Jolly","Depression","Apathetic","Hypersensitive"),list("Ageusia","Vegetarian","Deviant Tastes"),list("Ananas Affinity","Ananas Aversion"),list("Alcohol Tolerance","Light Drinker"),list("Prosthetic Limb (Left Arm)","Prosthetic Limb"),list("Prosthetic Limb (Right Arm)","Prosthetic Limb"),list("Prosthetic Limb (Left Leg)","Prosthetic Limb"),list("Prosthetic Limb (Right Leg)","Prosthetic Limb"))
+	quirk_blacklist = list(
+		list("Blind","Nearsighted"),
+		list("Jolly","Depression","Apathetic","Hypersensitive"),
+		list("Ageusia","Vegetarian","Deviant Tastes"),
+		list("Ananas Affinity","Ananas Aversion"),
+		list("Alcohol Tolerance","Light Drinker"),
+		list("Prosthetic Limb (Left Arm)","Prosthetic Limb"),
+		list("Prosthetic Limb (Right Arm)","Prosthetic Limb"),
+		list("Prosthetic Limb (Left Leg)","Prosthetic Limb"),
+		list("Prosthetic Limb (Right Leg)","Prosthetic Limb"),
+		list("Prosthetic Limb (Left Leg)","Paraplegic"),
+		list("Prosthetic Limb (Right Leg)","Paraplegic"),
+		list("Prosthetic Limb","Paraplegic")
+	)
 	return ..()
 
 /datum/controller/subsystem/processing/quirks/proc/SetupQuirks()


### PR DESCRIPTION
# Document the changes in your pull request

Fixes #12890

You can't take paraplegic with prosthetics legs anymore to ignore it's downsides. The balance to whether replacing your legs should completely bypass paraplegic though is out of scope for now.

# Wiki Documentation

None 

# Changelog

:cl:  
tweak: Paraplegic is now incompatible with the Prosthetic, Prosthetic (Right Leg), and Prosthetic (Left Leg) perks.
/:cl:
