### PR TITLE
Lowers cost of Crew Manifest Spoof to 4 TC

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1767,7 +1767,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Crew Manifest Spoof"
 	desc = "A button capable of adding a single person to the crew manifest."
 	item = /obj/item/service/manifest
-	cost = 15 //Maybe this is too cheap??
+	cost = 4
+	limited_stock = 1
 
 /datum/uplink_item/services/fake_ion
 	name = "Fake Ion Storm"


### PR DESCRIPTION
# Document the changes in your pull request

This should not cost the majority of your TC. Nobody ever uses it, and not being on the crew manifest gives _certain security players_ a reason to random search people who haven't even been seen doing anything suspicious yet.

You gotta actually put effort into unveiling the Syndicate's top-of-the-line infiltration team. Did you really expect to be able to find them _that_ easily?

# Changelog

:cl: Lucy
tweak: The Crew Manifest Spoof for infiltrators now costs 4 TC
/:cl:
