### PR TITLE
Makes AI download warning have a button to instantly finish the download

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -502,6 +502,13 @@
 			return
 		if(M)
 			M.transfer_ai(AI_MECH_HACK, src, usr) //Called om the mech itself.
+	
+	if(href_list["instant_download"])
+		if(!href_list["console"])
+			return
+		var/obj/machinery/computer/ai_control_console/C = locate(href_list["console"])
+		if(C.downloading == src)
+			C.finish_download()
 
 
 /mob/living/silicon/ai/proc/switchCamera(obj/machinery/camera/C)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -507,6 +507,8 @@
 		if(!href_list["console"])
 			return
 		var/obj/machinery/computer/ai_control_console/C = locate(href_list["console"])
+		if(!C)
+			return
 		if(C.downloading == src)
 			C.finish_download()
 

--- a/code/modules/mob/living/silicon/ai/decentralized/management/ai_controlpanel.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/management/ai_controlpanel.dm
@@ -343,7 +343,7 @@ GLOBAL_VAR_INIT(ai_control_code, random_nukecode(6))
 			if(!target.can_download)
 				return
 			downloading = target
-			to_chat(downloading, span_userdanger("Warning! Someone is attempting to download you from [get_area(src)]! (<a href='?src=[REF(src)];instant_download=1'>Click here to finish download instantly</a>)"))
+			to_chat(downloading, span_userdanger("Warning! Someone is attempting to download you from [get_area(src)]! (<a href='?src=[REF(downloading)];instant_download=1;console=[REF(src)]'>Click here to finish download instantly</a>)"))
 			user_downloading = usr
 			download_progress = 0
 			. = TRUE

--- a/code/modules/mob/living/silicon/ai/decentralized/management/ai_controlpanel.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/management/ai_controlpanel.dm
@@ -343,7 +343,7 @@ GLOBAL_VAR_INIT(ai_control_code, random_nukecode(6))
 			if(!target.can_download)
 				return
 			downloading = target
-			to_chat(downloading, span_userdanger("Warning! Someone is attempting to download you from [get_area(src)]!"))
+			to_chat(downloading, span_userdanger("Warning! Someone is attempting to download you from [get_area(src)]! (<a href='?src=[REF(src)];instant_download=1'>Click here to finish download instantly</a>)"))
 			user_downloading = usr
 			download_progress = 0
 			. = TRUE


### PR DESCRIPTION
# Document the changes in your pull request

# Wiki Documentation


# Changelog


:cl:  
tweak: The AI is now giving the option of instantly finishing the download process when being carded
/:cl:
