### PR TITLE
Fixes laptop vendor not giving ID slot and printer for phones

### DIFF
--- a/code/modules/modular_computers/laptop_vendor.dm
+++ b/code/modules/modular_computers/laptop_vendor.dm
@@ -208,11 +208,11 @@
 					fabricated_phone.install_component(new/obj/item/computer_hardware/network_card/advanced)
 				total_price += 149
 		if(dev_printer)
-			fabricated_tablet.install_component(new/obj/item/computer_hardware/printer/mini)
+			fabricated_phone.install_component(new/obj/item/computer_hardware/printer/mini)
 		if(dev_card)
 			total_price += 199
 			if(fabricate)
-				fabricated_tablet.install_component(new/obj/item/computer_hardware/card_slot/secondary)
+				fabricated_phone.install_component(new/obj/item/computer_hardware/card_slot/secondary)
 		return total_price
 	return 0
 


### PR DESCRIPTION
# Document the changes in your pull request

Fixes #13072

Looks like someone did some copypasta and forgot to change the path.

# Wiki Documentation

None

# Changelog

:cl:  
bugfix: The laptop vendor should now properly install nanoprinters and the auxiliary ID slot for phones.
/:cl:
