### PR TITLE
Updates wizard spellbook hardsuit description to include the fact that it has anti-magic protection

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -359,7 +359,7 @@
 
 /datum/spellbook_entry/item/armor
 	name = "Mastercrafted Armor Set"
-	desc = "An artefact suit of armor that allows you to cast spells while providing more protection against attacks and the void of space. Additionally provides anti magic protection, though this may interfere with magic you cast on yourself (i.e Mutate or wands)."
+	desc = "An artifact suit of armor that allows you to cast spells while providing more protection against attacks and the void of space. Additionally provides anti-magic protection, though this may interfere with magic you cast on yourself (i.e Mutate or wands)."
 	item_path = /obj/item/clothing/suit/space/hardsuit/wizard
 	cost = 1
 	category = "Defensive"

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -359,7 +359,7 @@
 
 /datum/spellbook_entry/item/armor
 	name = "Mastercrafted Armor Set"
-	desc = "An artefact suit of armor that allows you to cast spells while providing more protection against attacks and the void of space."
+	desc = "An artefact suit of armor that allows you to cast spells while providing more protection against attacks and the void of space. Additionally provides anti magic protection, though this may interfere with magic you cast on yourself (i.e Mutate or wands)."
 	item_path = /obj/item/clothing/suit/space/hardsuit/wizard
 	cost = 1
 	category = "Defensive"


### PR DESCRIPTION
# Document the changes in your pull request

Closes #12925 (I guess)

The gemsuit having anti-magic protection confused people when they casted Mutate on themselves. Technically the only other wand the gem hardsuit blocks is the wand of healing, but let's just pretend that's out of scope for now.

# Wiki Documentation

Maybe a note in the wiki that this hardsuit provides antimagic protection

# Changelog

:cl:  
spellcheck: Updates the wizard spellbook entry on the mastercrafted armour set. Did you know it gave you anti magic protection?
/:cl:
