### PR TITLE
Fixes smoker trait nicotine addiction changing when cloned

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -543,9 +543,7 @@
 
 /datum/quirk/junkie/on_clone(data)
 	var/mob/living/carbon/human/H = quirk_holder
-	reagent_id = data
-	var/datum/reagent/prot_holder = GLOB.chemical_reagents_list[reagent_id]
-	reagent_type = prot_holder.type
+	reagent_type = data
 	reagent_instance = new reagent_type()
 	H.reagents.addiction_list.Add(reagent_instance)
 

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -539,7 +539,7 @@
 		++tick_counter
 
 /datum/quirk/junkie/clone_data()
-	return reagent_id
+	return reagent_type
 
 /datum/quirk/junkie/on_clone(data)
 	var/mob/living/carbon/human/H = quirk_holder


### PR DESCRIPTION
# Document the changes in your pull request

Closes #12828

Okay so the smoker trait inherits from the junkie trait, so it rolls a random reagent_id. That reagent_id was being used instead of reagent_type. This doesn't break junkie, since it sets reagent_type to reagent_id in it's OnSpawn().

# Wiki Documentation

None

# Changelog

:cl:  
bugfix: Fixes the smoker trait's nicotine addiction being changed to another addiction after being cloned.  
/:cl:
