### PR TITLE
Makes zombie flesh death symptom work

### DIFF
--- a/code/datums/diseases/advance/presets.dm
+++ b/code/datums/diseases/advance/presets.dm
@@ -35,6 +35,8 @@
 	var/list/datum/symptom/possible_symptoms = list()
 	for(var/symptom in subtypesof(/datum/symptom))
 		var/datum/symptom/S = symptom
+		if(!naturally_occuring)
+			continue
 		if(initial(S.level) > max_level)
 			continue
 		if(initial(S.level) <= 0) //unobtainable symptoms

--- a/code/datums/diseases/advance/presets.dm
+++ b/code/datums/diseases/advance/presets.dm
@@ -35,7 +35,7 @@
 	var/list/datum/symptom/possible_symptoms = list()
 	for(var/symptom in subtypesof(/datum/symptom))
 		var/datum/symptom/S = symptom
-		if(!naturally_occuring)
+		if(!initial(S.naturally_occuring))
 			continue
 		if(initial(S.level) > max_level)
 			continue

--- a/code/datums/diseases/advance/symptoms/flesh_eating.dm
+++ b/code/datums/diseases/advance/symptoms/flesh_eating.dm
@@ -100,6 +100,7 @@ Bonus
 
 /datum/symptom/flesh_death/zombie
 	zombie = TRUE
+	naturally_occuring = FALSE
 
 /datum/symptom/flesh_death/Start(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/flesh_eating.dm
+++ b/code/datums/diseases/advance/symptoms/flesh_eating.dm
@@ -98,6 +98,9 @@ Bonus
 		"Stealth 5" = "The symptom remains hidden until active.",
 	)
 
+/datum/symptom/flesh_death/zombie
+	zombie = TRUE
+
 /datum/symptom/flesh_death/Start(datum/disease/advance/A)
 	. = ..()
 	if(!.)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1769,6 +1769,13 @@
 		ZI.Insert(H)
 	..()
 
+/datum/reagent/romerol/on_mob_life(mob/living/carbon/human/H)
+	if(!H.getorganslot(ORGAN_SLOT_ZOMBIE))
+		var/obj/item/organ/zombie_infection/nodamage/ZI = new()
+		ZI.Insert(H)
+	if(holder)
+		holder.remove_reagent(type, INFINITY) //By default it slowly disappears.
+
 /datum/reagent/magillitis
 	name = "Magillitis"
 	description = "An experimental serum which causes rapid muscular growth in Hominidae. Side-affects may include hypertrichosis, violent outbursts, and an unending affinity for bananas."


### PR DESCRIPTION
# Document the changes in your pull request

Autophagocytosis Necrosis now has a zombie variant for bus purposes, and it now actually works

# Changelog

:cl:  
rscadd: Added subtype of APN that will zombify people
bugfix: Fixed APN zombie mode not making zombies
tweak: Romerol now tries to make tumor on mob life, then metabolizes fully
/:cl:
