### PR TITLE
Changes portal storm summon spell to 1 spell point.

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -504,7 +504,7 @@
 /datum/spellbook_entry/summon/portals
 	name = "Summon Portal Storm"
 	desc = "Terrorize the crew with a portal storm! Whatever crawls out of these portals will be a threat not just to the crew, but you as well!"
-	cost = 3
+	cost = 1
 
 /datum/spellbook_entry/summon/portals/IsAvailible()
 	if(!SSticker.mode)


### PR DESCRIPTION
# Document the changes in your pull request

Portal Storm spell now costs only one spell point.

# Changelog

Portal Storm spell now costs only one spell point.

:cl:  Xoxeyos
tweak: Portal Storm spell now costs only one spell point.
/:cl:
