### PR TITLE
[Concept] AI downloading is done by intercepting it between data cores

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1579,3 +1579,9 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	return call(source, proctype)(arglist(arguments))
 
 #define TURF_FROM_COORDS_LIST(List) (locate(List[1], List[2], List[3]))
+
+///Convert a location into a list with the format list(x, y)
+/proc/to_coord_list(atom/loc)
+	. = list(loc.x, loc.y)
+	.[1] = loc.x
+	.[2] = loc.y

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -112,6 +112,8 @@
 	var/downloadSpeedModifier = 1
 
 	var/login_warned_temp = FALSE
+	//Did we get the death prompt?
+	var/is_dying = FALSE 
 
 
 /mob/living/silicon/ai/Initialize(mapload, datum/ai_laws/L, mob/target_ai, shunted)

--- a/code/modules/mob/living/silicon/ai/ai_triangulation.dm
+++ b/code/modules/mob/living/silicon/ai/ai_triangulation.dm
@@ -1,0 +1,49 @@
+GLOBAL_VAR_INIT(ai_triangulation_width, 4)
+/atom/proc/can_triangulate()
+
+	var/obj/machinery/ai/data_core/n1 
+	var/obj/machinery/ai/data_core/n2 
+
+	for(var/obj/machinery/ai/data_core/D in GLOB.data_cores)
+		if(!n1)
+			n1 = D
+			continue
+		if(!n2)
+			n2 = D
+			continue
+
+	var/direction = get_dir(n1, n2)
+
+
+	
+	var/atom/n1_p1 = get_step(get_step(n1, turn(direction, 90)), turn(direction, 90))
+	var/atom/n1_p2 = get_step(get_step(n1, turn(direction, -90)), turn(direction, -90))
+	n1_p1.color = "#FF0000"
+	n1_p2.color = "#FF0000"
+
+
+	var/atom/n2_p1 = get_step(get_step(n2, turn(direction, 90)), turn(direction, 90))
+	var/atom/n2_p2 = get_step(get_step(n2, turn(direction, -90)), turn(direction, -90))
+	n2_p1.color = "#FF0000"
+	n2_p2.color = "#FF0000"
+
+	if(get_dist(n1_p1, n2_p1) > get_dist(n1_p1, n2_p2))
+		var/atom/temp = n2_p1
+		n2_p1 = n2_p2
+		n2_p2 = temp
+
+	var/odd = FALSE
+	var/list/point = list(src.x, src.y)
+	var/list/polygon = list(to_coord_list(n1_p1), to_coord_list(n1_p2), to_coord_list(n2_p1), to_coord_list(n2_p2))
+
+	var/j = polygon.len
+	for(var/i = 1, i < (polygon.len + 1), i++)
+		if(((polygon[i][2] >= point[2]) != (polygon[j][2] >= point[2])) && (point[1] <= ((polygon[j][1] - polygon[i][1]) * (point[2] - polygon[i][2]) / (polygon[j][2] - polygon[i][2]) + polygon[i][1])))
+			if(!odd)
+				odd = TRUE
+			else
+				odd = FALSE
+		j = i
+	
+	if(odd)
+		src.color = "#00FF00"

--- a/code/modules/mob/living/silicon/ai/decentralized/ai_data_core.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/ai_data_core.dm
@@ -39,7 +39,8 @@ GLOBAL_VAR_INIT(primary_data_core, null)
 
 	for(var/mob/living/silicon/ai/AI in contents)
 		all_ais -= AI
-		AI.relocate()
+		if(!AI.is_dying)
+			AI.relocate()
 
 	to_chat(all_ais, span_userdanger("Warning! Data Core brought offline in [get_area(src)]! Please verify that no malicious actions were taken."))
 	
@@ -89,10 +90,13 @@ GLOBAL_VAR_INIT(primary_data_core, null)
 			use_power = IDLE_POWER_USE
 			update_icon()
 			for(var/mob/living/silicon/ai/AI in contents)
-				AI.relocate()
+				if(!AI.is_dying)
+					AI.relocate()
 		if(!warning_sent)
 			warning_sent = TRUE
-			to_chat(GLOB.ai_list, span_userdanger("Data core in [get_area(src)] is on the verge of failing! Please contact technical support."))
+			to_chat(GLOB.ai_list, span_userdanger("Data core in [get_area(src)] is on the verge of failing! Immediate action required to prevent failure."))
+			for(var/mob/living/silicon/ai/AI in GLOB.ai_list)
+				AI.playsound_local(AI, 'sound/machines/engine_alert2.ogg', 30)
 
 	if(!(stat & (BROKEN|NOPOWER|EMPED)))
 		var/turf/T = get_turf(src)

--- a/code/modules/mob/living/silicon/ai/decentralized_ai.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized_ai.dm
@@ -30,6 +30,7 @@
 	
 	if(!GLOB.data_cores.len)
 		INVOKE_ASYNC(src, /mob/living/silicon/ai.proc/death_prompt)
+		is_dying = TRUE
 		return
 
 
@@ -57,6 +58,7 @@
 	if(available_ai_cores())
 		to_chat(src, span_usernotice("Yes! I am alive!"))
 		relocate(TRUE)
+		is_dying = FALSE
 		return
 	to_chat(src, span_notice("They need me. No.. I need THEM."))
 	sleep(0.5 SECONDS)

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2322,6 +2322,7 @@
 #include "code\modules\mob\living\silicon\ai\ai.dm"
 #include "code\modules\mob\living\silicon\ai\ai_defense.dm"
 #include "code\modules\mob\living\silicon\ai\ai_portrait_picker.dm"
+#include "code\modules\mob\living\silicon\ai\ai_triangulation.dm"
 #include "code\modules\mob\living\silicon\ai\death.dm"
 #include "code\modules\mob\living\silicon\ai\decentralized_ai.dm"
 #include "code\modules\mob\living\silicon\ai\examine.dm"


### PR DESCRIPTION
# Document the changes in your pull request
Removes the AI upload/download console.
Uploading an AI is now done by hitting a data core with the MMI or posibrain.
AI is now no longer automatically hooked up to all other data cores. It can hook itself up to 2 others (For a total of 3 cores)
Hooking up is permanent unless the data core is destroyed.

Downloading is now done by intercepting the AI using a modular console. You do this by running the program while standing in the rectangle or triangle formed by the data cores.  (Rectangle in the case of 2, triangle in the case of 3) 
If the AI is only in 1 core you can download it by hitting that core with an intellicard.

Example of roundstart download area:
![image](https://user-images.githubusercontent.com/5618080/149403647-5e58a5db-40a6-4a8a-b14f-6c3744f4e872.png)


Goals:
Preventing AI core spam.
Removing the stupid AI control console
Creating a trade-off between physical safety and ease of download.

# Wiki Documentation

# Changelog

:cl:  
experimental: todo
/:cl:
