### PR TITLE
Introducing the TagMaster 3.0! Converts the TagMaster 2.2 to use TGUI  [PORT]

### DIFF
--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -34,7 +34,7 @@
 
 		if(sortTag != O.currTag)
 			var/tag = uppertext(GLOB.TAGGERLOCATIONS[O.currTag])
-			to_chat(user, span_notice("*[tag]*"))
+			to_chat(user, span_notice("SELECTED DESTINATION: [tag]"))
 			sortTag = O.currTag
 			playsound(loc, 'sound/machines/twobeep_high.ogg', 100, 1)
 
@@ -127,7 +127,7 @@
 
 		if(sortTag != O.currTag)
 			var/tag = uppertext(GLOB.TAGGERLOCATIONS[O.currTag])
-			to_chat(user, span_notice("*[tag]*"))
+			to_chat(user, span_notice("SELECTED DESTINATION: [tag]"))
 			sortTag = O.currTag
 			playsound(loc, 'sound/machines/twobeep_high.ogg', 100, 1)
 
@@ -175,35 +175,31 @@
 /obj/item/destTagger/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] begins tagging [user.p_their()] final destination!  It looks like [user.p_theyre()] trying to commit suicide!"))
 	if (islizard(user))
-		to_chat(user, span_notice("*HELL*"))//lizard nerf
+		to_chat(user, span_notice("SELECTED DESTINATION: HELL"))//lizard nerf
 	else
-		to_chat(user, span_notice("*HEAVEN*"))
+		to_chat(user, span_notice("SELECTED DESTINATION: HEAVEN"))
 	playsound(src, 'sound/machines/twobeep_high.ogg', 100, 1)
 	return BRUTELOSS
 
-/obj/item/destTagger/proc/openwindow(mob/user)
-	var/dat = "<HTML><HEAD><meta charset='UTF-8'></HEAD><BODY><tt><center><h1><b>TagMaster 2.2</b></h1></center>"
+/obj/item/destTagger/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user,src,ui)
+	if(!ui)
+		ui = new(user,src,"DestinationTagger")
+		ui.open()
 
-	dat += "<table style='width:100%; padding:4px;'><tr>"
-	for (var/i = 1, i <= GLOB.TAGGERLOCATIONS.len, i++)
-		dat += "<td><a href='?src=[REF(src)];nextTag=[i]'>[GLOB.TAGGERLOCATIONS[i]]</a></td>"
-
-		if(i%4==0)
-			dat += "</tr><tr>"
-
-	dat += "</tr></table><br>Current Selection: [currTag ? GLOB.TAGGERLOCATIONS[currTag] : "None"]</tt>"
-	dat += "</BODY></HTML>"
-	user << browse(dat, "window=destTagScreen;size=450x350")
-	onclose(user, "destTagScreen")
-
-/obj/item/destTagger/attack_self(mob/user)
-	if(!locked_destination)
-		openwindow(user)
+/obj/item/destTagger/ui_act(action,list/params)
+	if(..())
 		return
+	switch(action)
+		if("ChangeSelectedTag")
+			var/selectedTag = GLOB.TAGGERLOCATIONS.Find(params["tag"])
+			if(selectedTag != 0)
+				currTag = selectedTag
+			world.log << params["tag"]
 
-/obj/item/destTagger/Topic(href, href_list)
-	add_fingerprint(usr)
-	if(href_list["nextTag"])
-		var/n = text2num(href_list["nextTag"])
-		currTag = n
-	openwindow(usr)
+/obj/item/destTagger/ui_data(mob/user)
+	var/list/data = list()
+	data["destinations"] = GLOB.TAGGERLOCATIONS
+	data["currentTag"] = currTag
+
+	return data

--- a/tgui/packages/tgui/interfaces/DestinationTagger.js
+++ b/tgui/packages/tgui/interfaces/DestinationTagger.js
@@ -1,0 +1,36 @@
+import { useBackend } from '../backend';
+import { Box, Button, Section, LabeledList } from '../components';
+import { GridColumn } from '../components/Grid';
+import { Window } from '../layouts';
+
+export const DestinationTagger = (props, context) => {
+  const { act, data } = useBackend(context);
+  const {
+    // data go here
+    currentTag,
+    destinations,
+  } = data;
+
+  const mapped_destinations = destinations.map(destination => {
+    return (
+      <Button width="144px" lineHeight={1.85} selected={destinations[currentTag - 1] === destination} key={destination} onClick={() => act('ChangeSelectedTag', { 'tag': destination })}>{destination}</Button>
+    );
+  });
+
+  return (
+    <Window title="TagMaster 3.0" width={450} height={350}>
+      <Window.Content>
+        <Section title="TagMaster 3.0 - The future, 20 years ago!">
+          <LabeledList>
+            <LabeledList.Item label="Current Destination">
+              {(currentTag) !== "" ? destinations[currentTag - 1] : "NONE"}
+            </LabeledList.Item>
+          </LabeledList>
+        </Section>
+        {mapped_destinations}
+
+
+      </Window.Content>
+    </Window>
+  );
+};


### PR DESCRIPTION
# Document the changes in your pull request

![image](https://user-images.githubusercontent.com/89947174/149432555-c7c8e27d-74c6-482d-bc08-5b43a3393603.png)
Ported from: https://github.com/yogstation13/Yogstation/pull/13082
I was doin some mail, and my eyes bled every time I opened the destination tagger!
Tested! 👍 
# Wiki Documentation

Less shiddy tagmaster

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
tweak: makes destination tagger use nice tgui instead of shitty Topic() that had no formatting
/:cl:
