### PR TITLE
Dynamic won't run unless it has 37 players on the server.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -20,6 +20,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	name = "dynamic mode"
 	config_tag = "dynamic"
 	report_type = "dynamic"
+	required_players = 37
 	title_icon = "ss13"
 
 	announce_span = "danger"


### PR DESCRIPTION
# Document the changes in your pull request

Lowpop 95 dynamic is not what I look forwards to when I want dynamic.

# Changelog
Dynamic now requires atleast 37 players on the server.

:cl:  Xoxeyos
tweak: Dynamic now requires atleast 37 players on the server.
/:cl:
