### PR TITLE
Beam rifles only get three shots

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -243,7 +243,7 @@
 /obj/item/stock_parts/cell/super
 	name = "super-capacity power cell"
 	icon_state = "scell"
-	maxcharge = 20000
+	maxcharge = 40000
 	materials = list(/datum/material/glass=300)
 	chargerate = 2000
 

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -243,7 +243,7 @@
 /obj/item/stock_parts/cell/super
 	name = "super-capacity power cell"
 	icon_state = "scell"
-	maxcharge = 40000
+	maxcharge = 20000
 	materials = list(/datum/material/glass=300)
 	chargerate = 2000
 
@@ -340,7 +340,7 @@
 /obj/item/stock_parts/cell/beam_rifle
 	name = "beam rifle capacitor"
 	desc = "A high powered capacitor that can provide huge amounts of energy in an instant."
-	maxcharge = 20000
+	maxcharge = 40000
 	chargerate = 5000	//Extremely energy intensive
 
 /obj/item/stock_parts/cell/beam_rifle/corrupt()

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -340,7 +340,7 @@
 /obj/item/stock_parts/cell/beam_rifle
 	name = "beam rifle capacitor"
 	desc = "A high powered capacitor that can provide huge amounts of energy in an instant."
-	maxcharge = 40000
+	maxcharge = 30000
 	chargerate = 5000	//Extremely energy intensive
 
 /obj/item/stock_parts/cell/beam_rifle/corrupt()

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -340,7 +340,7 @@
 /obj/item/stock_parts/cell/beam_rifle
 	name = "beam rifle capacitor"
 	desc = "A high powered capacitor that can provide huge amounts of energy in an instant."
-	maxcharge = 50000
+	maxcharge = 20000
 	chargerate = 5000	//Extremely energy intensive
 
 /obj/item/stock_parts/cell/beam_rifle/corrupt()

--- a/code/modules/projectiles/guns/misc/beam_rifle.dm
+++ b/code/modules/projectiles/guns/misc/beam_rifle.dm
@@ -413,7 +413,7 @@
 /obj/item/ammo_casing/energy/beam_rifle/hitscan
 	projectile_type = /obj/item/projectile/beam/beam_rifle/hitscan
 	select_name = "beam"
-	e_cost = 20000
+	e_cost = 10000
 	fire_sound = 'sound/weapons/beam_sniper.ogg'
 
 /obj/item/projectile/beam/beam_rifle

--- a/code/modules/projectiles/guns/misc/beam_rifle.dm
+++ b/code/modules/projectiles/guns/misc/beam_rifle.dm
@@ -413,7 +413,7 @@
 /obj/item/ammo_casing/energy/beam_rifle/hitscan
 	projectile_type = /obj/item/projectile/beam/beam_rifle/hitscan
 	select_name = "beam"
-	e_cost = 10000
+	e_cost = 20000
 	fire_sound = 'sound/weapons/beam_sniper.ogg'
 
 /obj/item/projectile/beam/beam_rifle


### PR DESCRIPTION
# Document the changes in your pull request
Clone of #13099 

The laser anti-material gun is used for nothing except BTFOing blobs and they are far too good at it, they're basically uncounterable if the wielder knows to keep their distance
This decreases its max cell charge to 30000 from 50000
So, three shots, down from five

# Wiki Documentation

If the beam rifle even has a mention of its ammo capacity, it is now down to three

# Changelog

:cl:   
tweak: The particle accelerator rifle now only has three shots per charge
tweak: Special thanks to blob overmind (49) for the code, rest in peace my man
/:cl: