### PR TITLE
Just removes beam rifles (2)

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -184,16 +184,6 @@
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
-/datum/design/beamrifle
-	name = "Beam Marksman Rifle"
-	desc = "A powerful long ranged anti-material rifle that fires charged particle beams to obliterate targets."
-	id = "beamrifle"
-	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 10000, /datum/material/glass = 5000, /datum/material/diamond = 5000, /datum/material/uranium = 8000, /datum/material/silver = 4500, /datum/material/gold = 5000)
-	build_path = /obj/item/gun/energy/beam_rifle
-	category = list("Weapons")
-	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
-
 /datum/design/decloner
 	name = "Decloner"
 	desc = "Your opponent will bubble into a messy pile of goop."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -727,15 +727,6 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
-/datum/techweb_node/adv_beam_weapons
-	id = "adv_beam_weapons"
-	display_name = "Advanced Beam Weaponry"
-	description = "Various advanced beam weapons"
-	prereq_ids = list("beam_weapons")
-	design_ids = list("beamrifle")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
-	export_price = 5000
-
 /datum/techweb_node/explosive_weapons
 	id = "explosive_weapons"
 	display_name = "Explosive & Pyrotechnical Weaponry"
@@ -898,9 +889,9 @@
 	id = "mech_laser_heavy"
 	display_name = "Exosuit Weapon (CH-LC \"Solaris\" Laser Cannon)"
 	description = "An advanced piece of mech weaponry"
-	prereq_ids = list("adv_beam_weapons")
+	prereq_ids = list("beam_weapons")
 	design_ids = list("mech_laser_heavy")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 	export_price = 5000
 
 /datum/techweb_node/mech_xray


### PR DESCRIPTION
# Document the changes in your pull request
Another attempt of #13100 and #13102
The laser anti-material gun is used for nothing except BTFOing blobs and they are far too good at it, they're basically uncounterable if the wielder knows to keep their distance
I am not intelligent enough to rework them in a way that doesn't, according to sec mains in OOC, make them useless
Therefore, the alternative to a [big nerf](https://github.com/yogstation13/Yogstation/pull/13101) (although I personally prefer tweaks to deletions): just remove them (from lathes)
"Advanced beam weaponry" no longer exists due to being made redundant by this, accordingly the Solaris cannon tech now costs 5000 more points and is prereq'd by basic beam tech

# Wiki Documentation

Just remove them

# Changelog

:cl:  
rscdel: The Centcom prototype documents for particle accelerator rifles have mysteriously decayed due to an unidentified fungal growth
rscdel: Special thanks to blob overmind (49) for the code, rest in peace my man
/:cl: