### PR TITLE
Fixed vampire rejuvenate killing slimepeople

### DIFF
--- a/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -113,7 +113,7 @@
 		if(V.get_ability(/datum/vampire_passive/regen))
 			U.adjustBruteLoss(-1)
 			U.adjustOxyLoss(-2.5)
-			U.adjustToxLoss(-1)
+			U.adjustToxLoss(-1, TRUE, TRUE)
 			U.adjustFireLoss(-1)
 		sleep(7.5)
 


### PR DESCRIPTION
# Document the changes in your pull request

Vampire rejuvenate no longer does tox damage to slime people

# Changelog

:cl:  
bugfix: fixed vampire rejuvenate doing tox damage to slime people
/:cl:
