### PR TITLE
Allows items to have increased/decreased attack cooldown modifiers based on distance

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -46,7 +46,7 @@
 /mob/living/attackby(obj/item/I, mob/living/user, params)
 	if(..())
 		return TRUE
-	user.changeNext_move(CLICK_CD_MELEE * I.weapon_stats[SWING_SPEED] * max(get_dist(src,user) * range_cooldown_mod, 1) ) //distance increases attack cooldown by swing speed
+	user.changeNext_move(CLICK_CD_MELEE * I.weapon_stats[SWING_SPEED] * max(get_dist(src,user) * range_cooldown_mod, 1)) //distance increases attack cooldown by swing speed
 	user.weapon_slow(I)
 	if(user.a_intent == INTENT_HARM && stat == DEAD && (butcher_results || guaranteed_butcher_results)) //can we butcher it?
 		var/datum/component/butchering/butchering = I.GetComponent(/datum/component/butchering)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -47,7 +47,7 @@
 	if(..())
 		return TRUE
 	var/dist = get_dist(src,user)
-	user.changeNext_move(CLICK_CD_MELEE * I.weapon_stats[SWING_SPEED] * (dist ? dist * I.range_cooldown_mod : I.range_cooldown_mod)) //range increases attack cooldown by swing speed
+	user.changeNext_move(CLICK_CD_MELEE * I.weapon_stats[SWING_SPEED] * (range_cooldown_mod ? (dist ? dist * range_cooldown_mod : range_cooldown_mod) : 1)) //range increases attack cooldown by swing speed
 	user.weapon_slow(I)
 	if(user.a_intent == INTENT_HARM && stat == DEAD && (butcher_results || guaranteed_butcher_results)) //can we butcher it?
 		var/datum/component/butchering/butchering = I.GetComponent(/datum/component/butchering)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -46,7 +46,8 @@
 /mob/living/attackby(obj/item/I, mob/living/user, params)
 	if(..())
 		return TRUE
-	user.changeNext_move(CLICK_CD_MELEE * I.weapon_stats[SWING_SPEED] * max(get_dist(src,user) * range_cooldown_mod, 1)) //distance increases attack cooldown by swing speed
+	var/dist = get_dist(src,user)
+	user.changeNext_move(CLICK_CD_MELEE * I.weapon_stats[SWING_SPEED] * dist ? dist * range_cooldown_mod : range_cooldown_mod) //distance increases attack cooldown by swing speed
 	user.weapon_slow(I)
 	if(user.a_intent == INTENT_HARM && stat == DEAD && (butcher_results || guaranteed_butcher_results)) //can we butcher it?
 		var/datum/component/butchering/butchering = I.GetComponent(/datum/component/butchering)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -47,7 +47,7 @@
 	if(..())
 		return TRUE
 	var/dist = get_dist(src,user)
-	user.changeNext_move(CLICK_CD_MELEE * I.weapon_stats[SWING_SPEED] * dist ? dist * range_cooldown_mod : range_cooldown_mod) //distance increases attack cooldown by swing speed
+	user.changeNext_move(CLICK_CD_MELEE * I.weapon_stats[SWING_SPEED] * dist ? dist * I.range_cooldown_mod : I.range_cooldown_mod) //distance increases attack cooldown by swing speed
 	user.weapon_slow(I)
 	if(user.a_intent == INTENT_HARM && stat == DEAD && (butcher_results || guaranteed_butcher_results)) //can we butcher it?
 		var/datum/component/butchering/butchering = I.GetComponent(/datum/component/butchering)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -47,7 +47,7 @@
 	if(..())
 		return TRUE
 	var/dist = get_dist(src,user)
-	user.changeNext_move(CLICK_CD_MELEE * I.weapon_stats[SWING_SPEED] * (range_cooldown_mod ? (dist ? dist * range_cooldown_mod : range_cooldown_mod) : 1)) //range increases attack cooldown by swing speed
+	user.changeNext_move(CLICK_CD_MELEE * I.weapon_stats[SWING_SPEED] * (I.range_cooldown_mod ? (dist ? dist * I.range_cooldown_mod : I.range_cooldown_mod) : 1)) //range increases attack cooldown by swing speed
 	user.weapon_slow(I)
 	if(user.a_intent == INTENT_HARM && stat == DEAD && (butcher_results || guaranteed_butcher_results)) //can we butcher it?
 		var/datum/component/butchering/butchering = I.GetComponent(/datum/component/butchering)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -46,7 +46,7 @@
 /mob/living/attackby(obj/item/I, mob/living/user, params)
 	if(..())
 		return TRUE
-	user.changeNext_move(CLICK_CD_MELEE * I.weapon_stats[SWING_SPEED] * max(get_dist(src,user), 1)) //range increases attack cooldown by swing speed
+	user.changeNext_move(CLICK_CD_MELEE * I.weapon_stats[SWING_SPEED] * max(get_dist(src,user) * range_cooldown_mod, 1) ) //distance increases attack cooldown by swing speed
 	user.weapon_slow(I)
 	if(user.a_intent == INTENT_HARM && stat == DEAD && (butcher_results || guaranteed_butcher_results)) //can we butcher it?
 		var/datum/component/butchering/butchering = I.GetComponent(/datum/component/butchering)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -47,7 +47,7 @@
 	if(..())
 		return TRUE
 	var/dist = get_dist(src,user)
-	user.changeNext_move(CLICK_CD_MELEE * I.weapon_stats[SWING_SPEED] * dist ? dist * I.range_cooldown_mod : I.range_cooldown_mod) //distance increases attack cooldown by swing speed
+	user.changeNext_move(CLICK_CD_MELEE * I.weapon_stats[SWING_SPEED] * (dist ? dist * I.range_cooldown_mod : I.range_cooldown_mod)) //range increases attack cooldown by swing speed
 	user.weapon_slow(I)
 	if(user.a_intent == INTENT_HARM && stat == DEAD && (butcher_results || guaranteed_butcher_results)) //can we butcher it?
 		var/datum/component/butchering/butchering = I.GetComponent(/datum/component/butchering)
@@ -106,7 +106,8 @@
 		return
 	if(item_flags & NOBLUDGEON)
 		return
-	user.changeNext_move(CLICK_CD_MELEE * weapon_stats[SWING_SPEED])
+	var/dist = get_dist(O,user)
+	user.changeNext_move(CLICK_CD_MELEE * weapon_stats[SWING_SPEED] * (range_cooldown_mod ? (dist ? dist * range_cooldown_mod : range_cooldown_mod) : 1)) //range increases attack cooldown by swing speed
 	user.do_attack_animation(O)
 	O.attacked_by(src, user)
 	user.weapon_slow(src)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -91,7 +91,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	/// A list of statistics used when a weapon hits someone, swing speed = multiplier for melee attack cd, encumbrance = slowdown, encumbrance_time = slowdown length, reach = reach, embed chance = chance for applicable weapons to embed on hit, damage_low/high = range of damage the weapon takes on hitting a mob
 	var/list/weapon_stats = list(SWING_SPEED = 1, ENCUMBRANCE = 0, ENCUMBRANCE_TIME = 0, REACH = 1, DAMAGE_LOW = 0, DAMAGE_HIGH = 0)
 	/// multiplier to increase/decrease effects of range on attack cooldown
-	var/range_cooldown_mod = 2
+	var/range_cooldown_mod = 1
 	var/break_message = "%SRC crumbles into scraps under hard use"
 	///All items with sharpness of SHARP_EDGED or higher will automatically get the butchering component.
 	var/sharpness = SHARP_NONE

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -90,7 +90,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/heat = 0
 	/// A list of statistics used when a weapon hits someone, swing speed = multiplier for melee attack cd, encumbrance = slowdown, encumbrance_time = slowdown length, reach = reach, embed chance = chance for applicable weapons to embed on hit, damage_low/high = range of damage the weapon takes on hitting a mob
 	var/list/weapon_stats = list(SWING_SPEED = 1, ENCUMBRANCE = 0, ENCUMBRANCE_TIME = 0, REACH = 1, DAMAGE_LOW = 0, DAMAGE_HIGH = 0)
-	/// multiplier to increase/decrease effects of range on attack cooldown
+	/// multiplier to increase/decrease effects of range on attack cooldown, 0 to ignore range
 	var/range_cooldown_mod = 1
 	var/break_message = "%SRC crumbles into scraps under hard use"
 	///All items with sharpness of SHARP_EDGED or higher will automatically get the butchering component.

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -90,6 +90,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/heat = 0
 	/// A list of statistics used when a weapon hits someone, swing speed = multiplier for melee attack cd, encumbrance = slowdown, encumbrance_time = slowdown length, reach = reach, embed chance = chance for applicable weapons to embed on hit, damage_low/high = range of damage the weapon takes on hitting a mob
 	var/list/weapon_stats = list(SWING_SPEED = 1, ENCUMBRANCE = 0, ENCUMBRANCE_TIME = 0, REACH = 1, DAMAGE_LOW = 0, DAMAGE_HIGH = 0)
+	/// multiplier to increase/decrease effects of range on attack cooldown
+	var/range_cooldown_mod = 2
 	var/break_message = "%SRC crumbles into scraps under hard use"
 	///All items with sharpness of SHARP_EDGED or higher will automatically get the butchering component.
 	var/sharpness = SHARP_NONE


### PR DESCRIPTION
# Document the changes in your pull request

current system doubles initial attack cooldown per tile between attacker and target
this will let items have higher/lower multipliers for distance

# Changelog

:cl:  
tweak: items can now have individual modifiers for attack cooldown based on distance rather than it being simply doubled per tile
/:cl:
