### PR TITLE
Floor Cluwne invalid area adjustment.

### DIFF
--- a/yogstation/code/modules/mob/living/simple_animal/hostile/floor_cluwne.dm
+++ b/yogstation/code/modules/mob/living/simple_animal/hostile/floor_cluwne.dm
@@ -38,7 +38,7 @@ GLOBAL_VAR_INIT(floor_cluwnes, 0)
 	var/stage = STAGE_HAUNT
 	var/interest = 0
 	var/target_area
-	var/invalid_area_typecache = list(/area/space, /area/lavaland, /area/centcom, /area/reebe, /area/shuttle/syndicate)
+	var/invalid_area_typecache = list(/area/space, /area/lavaland, /area/mine, /area/centcom, /area/reebe, /area/shuttle/syndicate)
 	var/eating = FALSE
 	var/obj/effect/dummy/floorcluwne_orbit/poi
 	var/obj/effect/temp_visual/fcluwne_manifest/cluwnehole


### PR DESCRIPTION
# Document the changes in your pull request

Floor Cluwne AI freaks the fuck out when on the mining station, as well as the mining pod, repeatedly teleporting to a target they can't interact with.

# Changelog

Floor Cluwnes can't glitch out on lavaland anymore.

:cl:  Xoxeyos
bugfix: Should fix the Floor Cluwne freaking the fuck out on Lavaland.
/:cl:
