### PR TITLE
Revert "Hypospray starts filled with basic chems instead of omnizine"

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -69,9 +69,7 @@
 				log_game("[user.real_name] ([user.ckey]) injected [M.real_name] ([M.ckey]) with [viruslist]")
 // yogs end
 /obj/item/reagent_containers/hypospray/CMO
-	list_reagents = list(/datum/reagent/medicine/c2/libital = 10,
-						/datum/reagent/medicine/c2/aiuri = 10,
-						/datum/reagent/medicine/salbutamol = 10)
+	list_reagents = list(/datum/reagent/medicine/omnizine = 30)
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
 /obj/item/reagent_containers/hypospray/combat


### PR DESCRIPTION
Reverts yogstation13/Yogstation#11859
Iirc this change was done during the strange reagent nerfing phase of the codebase to reduce the availability of roundstart omnizine, which no longer matters as strange reagent no longer requires omnizine, and while it may be slower it has more use for experienced cmos/med staff than a simple heal mix
Also if they want a simple heal mix they can just like make it and put it into the hypo thats the whole point of it

:cl:
tweak: the cmo hypospray comes with 30 u its of omnizine again
/:cl: