### PR TITLE
Ports Ninja allegiance logging

### DIFF
--- a/code/modules/ninja/ninja_event.dm
+++ b/code/modules/ninja/ninja_event.dm
@@ -77,8 +77,8 @@ Contents:
 		CRASH("Ninja created with incorrect mind")
 
 	spawned_mobs += Ninja
-	message_admins("[ADMIN_LOOKUPFLW(Ninja)] has been made into a ninja by an event.")
-	log_game("[key_name(Ninja)] was spawned as a ninja by an event.")
+	message_admins("[ADMIN_LOOKUPFLW(Ninja)] has been made into a ninja by an event. They are employed by [ninjadatum.helping_station?"Nanotrasen":"The Syndicate"].")
+	log_game("[key_name(Ninja)] was spawned as a ninja by an event. They are employed by [ninjadatum.helping_station?"Nanotrasen":"The Syndicate"]")
 
 	return SUCCESSFUL_SPAWN
 


### PR DESCRIPTION
# Document the changes in your pull request

[Nice idea from Beestation](https://github.com/BeeStation/BeeStation-Hornet/pull/5873/) that [DatBoiTim](https://github.com/DatBoiTim) has created, admins are now told which faction Ninjas are aligned with, when first created.


# Changelog

Admins are now told which faction Ninjas are aligned with, when first created.

:cl: Xoxeyos, DatBoiTim
rscadd: Admins are now told which faction Ninjas are aligned with, when first created.
/:cl:
