### PR TITLE
Disables networked fibers

### DIFF
--- a/code/modules/antagonists/blob/blobstrains/networked_fibers.dm
+++ b/code/modules/antagonists/blob/blobstrains/networked_fibers.dm
@@ -1,4 +1,5 @@
 //does massive brute and burn damage, but can only expand manually
+/*
 /datum/blobstrain/reagent/networked_fibers
 	name = "Networked Fibers"
 	description = "will do high brute and burn damage and will generate resources quicker, but can only expand manually."
@@ -36,3 +37,4 @@
 	M.apply_damage(0.6*reac_volume, BRUTE, wound_bonus=CANT_WOUND)
 	if(M)
 		M.apply_damage(0.6*reac_volume, BURN, wound_bonus=CANT_WOUND)
+		*/


### PR DESCRIPTION
See rationale in #6620

# Wiki Documentation

Remove it from the blob chemicals list at https://wiki.yogstation.net/wiki/Blob#Blob_Chemicals

# Changelog
:cl:  
rscdel: Blob no longer has networked fibers
/:cl:
