### PR TITLE
Fixes AIs being able to steal cards from modular computers

### DIFF
--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -68,7 +68,7 @@
 		to_chat(user, span_warning("There are no cards in \the [src]."))
 		return FALSE
 
-	if(user)
+	if(user && user.CanReach(src))
 		user.put_in_hands(stored_card)
 	else
 		stored_card.forceMove(drop_location())


### PR DESCRIPTION
# Document the changes in your pull request

Adds a user.CanReach(src) to the check to see if the card should be put on the ground, fixing the issue.

# Wiki Documentation

None needed. 

# Changelog

:cl:  
bugfix: fixed AIs being able to steal cards from modular computers
/:cl:
