### PR TITLE
buffs shitcurity jumpsuit to be on par with the normal security jumpsuit

### DIFF
--- a/yogstation/code/modules/clothing/under/miscellaneous.dm
+++ b/yogstation/code/modules/clothing/under/miscellaneous.dm
@@ -625,6 +625,7 @@
 	icon_state = "altsecurity"
 	item_state = "altsecurity"
 	item_color = "altsecurity"
+	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 30, "wound" = 10)
 
 /obj/item/clothing/under/yogs/victoriouscaptainuniform
 	name = "very fancy captain uniform"


### PR DESCRIPTION
buffs the shitcurity jumpsuit to be on par armor-wise with other security unforms, as it is only obtainable by sec from their vendor and it makes no sense for it to be lesser.

(my snowflake armor was weak now it is strong)

# Wiki Documentation

if there are any mentions of shitcurity jumpsuit's armor value, changes them to be up to date.

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  cark
rscadd: Added new things  
tweak: tweaked a few things  

/:cl:
