### PR TITLE
Adds mutation toxins and green slime extract reactions for the rest of the organic round start races

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -552,6 +552,20 @@
 	race = /datum/species/pod
 	mutationtext = span_danger("The pain subsides. You feel... plantlike.")
 
+/datum/reagent/mutationtoxin/ethereal
+	name = "Ethereal Mutation Toxin"
+	description = "An electrifying toxin."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/ethereal
+	mutationtext = span_danger("The pain subsides. You feel... ecstatic.")
+
+/datum/reagent/mutationtoxin/polysmorph
+	name = "Polysmorph Mutation Toxin"
+	description = "An acidic toxin."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/polysmorph
+	mutationtext = span_danger("The pain subsides. You feel... alien.")
+
 /datum/reagent/mutationtoxin/jelly
 	name = "Imperfect Mutation Toxin"
 	description = "An jellyfying toxin."

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -564,7 +564,7 @@
 	description = "An acidic toxin."
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/polysmorph
-	mutationtext = span_danger("The pain subsides. You feel... alien.")
+	mutationtext = span_danger("The pain subsides. You feel... Alien.")
 
 /datum/reagent/mutationtoxin/jelly
 	name = "Imperfect Mutation Toxin"

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -73,6 +73,53 @@
 	required_other = TRUE
 	required_container = /obj/item/slime_extract/green
 
+/datum/chemical_reaction/slime/slimefelinid
+	name = "Felinid Mutation Toxin"
+	id = "felinidmuttoxin"
+	results = list(/datum/reagent/mutationtoxin/felinid = 1)
+	required_reagents = list(/datum/reagent/consumable/cilk = 1) //full of cilk
+	required_other = TRUE
+	required_container = /obj/item/slime_extract/green
+	
+/datum/chemical_reaction/slime/slimeplasmaman
+	name = "Plasmaman Mutation Toxin"
+	id = "plasmammuttoxin"
+	results = list(/datum/reagent/mutationtoxin/plasma = 1)
+	required_reagents = list(/datum/reagent/stable_plasma = 1) //stable plasma makes the stable race
+	required_other = TRUE
+	required_container = /obj/item/slime_extract/green
+
+/datum/chemical_reaction/slime/slimeethereal
+	name = "Ethereal Mutation Toxin"
+	id = "etherealmuttoxin"
+	results = list(/datum/reagent/mutationtoxin/ethereal = 1)
+	required_reagents = list(/datum/reagent/lithium = 1) //battery material makes electricity people
+	required_other = TRUE
+	required_container = /obj/item/slime_extract/green
+
+/datum/chemical_reaction/slime/slimemoth
+	name = "Moth Mutation Toxin"
+	id = "mothmuttoxin"
+	results = list(/datum/reagent/mutationtoxin/moth = 1)
+	required_reagents = list(/datum/reagent/silicon = 1) //silicon can be found from grinding up lightbulbs so that's the best reagent joke i could come up with
+	required_other = TRUE
+	required_container = /obj/item/slime_extract/green
+
+/datum/chemical_reaction/slime/slimepoly
+	name = "Polysmorph Mutation Toxin"
+	id = "polymuttoxin"
+	results = list(/datum/reagent/mutationtoxin/polysmorph = 1)
+	required_reagents = list(/datum/reagent/toxin/acid = 1) //acid blood
+	required_other = TRUE
+	required_container = /obj/item/slime_extract/green
+
+/datum/chemical_reaction/slime/slimepod
+	name = "Podperson Mutation Toxin"
+	id = "podmuttoxin"
+	results = list(/datum/reagent/mutationtoxin/pod = 1)
+	required_reagents = list(/datum/reagent/diethylamine = 1) //fertilizer makes plant people
+	required_other = TRUE
+	required_container = /obj/item/slime_extract/green
 //Metal
 /datum/chemical_reaction/slime/slimemetal
 	name = "Slime Metal"


### PR DESCRIPTION
# Document the changes in your pull request

Green slimes are currently the catalyst for mutation toxins, but only support slime people, humans, and lizards (and maybe gorillas?). I think the green slime extract should just be a pretty safe way to get whichever round start race toxin you might need. There are instances where this could come in handy with wizards, disguising yourself, or a braindead botanist rolls moth mutation toxin and decides to put it in prickled slippery plants for no fucking reason.

I tried to make the ingredients correspond to the race in some way so:

Felinid require cilk (full of cilk)
Plasmamen require stable plasma (not regular ground up plasma because that's how you get slime people)
Ethereals require lithium (because batteries. Originally it was teslium until I discovered what a nightmare that is to make)
Moths require silicon (because lightbulbs)
Podpeople require diethylamine (fertilizer juice)
Polysmorphs require sulphuric acid (cause it's their blood)

I left out praternis because they're manufactured, not created from DNA, but if desired I could easily add it with like iron being their reacting chem


Also if you're fearing people would abuse this to grief others, this change would also make it easier to undo the griefing, and I've never seen people use the xenobio toxins to grief thus far. It's only ever botanists who get the toxins from strange seeds

# Wiki Documentation

Add the rest of the mutation toxin reactions under the current ones in the chemistry wiki page

# Changelog

:cl:  
rscadd: Added mutation toxins for Ethereal and Polysmorph  
rscadd: Added green slime extract reactions for Felinid, Plasmamen, Ethereal, Podpeople, Moths, and Polysmorphs 
/:cl:
