### PR TITLE
removes the plasmaman mutation toxin recipe before someone uses it and i get told its an "i ded pr" and that i am a "terrible biased headcoder" because honestly it is a terrible bad terrible no idea no no

### DIFF
--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -80,14 +80,6 @@
 	required_reagents = list(/datum/reagent/consumable/cilk = 1) //full of cilk
 	required_other = TRUE
 	required_container = /obj/item/slime_extract/green
-	
-/datum/chemical_reaction/slime/slimeplasmaman
-	name = "Plasmaman Mutation Toxin"
-	id = "plasmammuttoxin"
-	results = list(/datum/reagent/mutationtoxin/plasma = 1)
-	required_reagents = list(/datum/reagent/stable_plasma = 1) //stable plasma makes the stable race
-	required_other = TRUE
-	required_container = /obj/item/slime_extract/green
 
 /datum/chemical_reaction/slime/slimeethereal
 	name = "Ethereal Mutation Toxin"


### PR DESCRIPTION
THE instantkill button for xenobio, as if they don't already have enough

# Changelog
:cl:  
rscdel: no more xenobio plasmaman mutation toxin
/:cl:
