### PR TITLE
fixes the upgraded cybernetic sotmach design not  being named upgraded cybernetic stomach

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -566,7 +566,7 @@
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
 /datum/design/cybernetic_stomach_u
-	name = "Cybernetic Ears"
+	name = "Upgraded Cybernetic Stomach"
 	desc = "An upgraded cybernetic stomach"
 	id = "cybernetic_stomach_u"
 	build_type = PROTOLATHE | MECHFAB


### PR DESCRIPTION
# Document the changes in your pull request

MEME
REVIEW



:cl:  
bugfix: upgraded cybernetic stomachs now get printed properly
/:cl:
