### PR TITLE
Fix a runtime I should have fixed ages ago

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -6,7 +6,7 @@
 
 #define isweakref(D) (istype(D, /datum/weakref))
 
-#define isappearance(A) (copytext("\ref[A]", 4, 6) == "3a")
+#define isappearance(A) (!isnum(A) && copytext("\ref[A]", 4, 6) == "3a")
 
 #define isnan(x) ( isnum((x)) && ((x) != (x)) )
 


### PR DESCRIPTION

# Document the changes in your pull request

Makes isappearance() not have false positives on numbers sometimes.

This happens because BYOND is really lazy and just bitwise ors shit when doing refs. This means that \ref on a number can sometimes return a ref that looks like an appearance.

This should fix those runtimes which cause numbers to not show up in VV properly sometimes:
```
runtime error: Cannot read 0.00182353.icon
```