### PR TITLE
Makes the AFK verb delay the cryo despawn timer

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -906,6 +906,33 @@
 
 		// yogs - offer control moved up
 
+		else if(href_list["set_afk"])
+			if(!check_rights(R_ADMIN))
+				return
+			
+			var/mob/M = locate(href_list["set_afk"]) in GLOB.mob_list
+			if(!istype(M))
+				to_chat(usr, "This can only be used on instances of type /mob")
+				return
+			
+			if(!M.mind)
+				to_chat(usr, "This cannot be used on mobs without a mind")
+				return
+			
+			var/timer = input("Input AFK length in minutes, 0 to cancel the current timer", text("Input"))  as num|null
+			if(timer == null) // Explicit null check for cancel, rather than generic truthyness, so 0 is handled differently
+				return
+
+			deltimer(M.mind.afk_verb_timer)
+			M.mind.afk_verb_used = FALSE
+
+			if(!timer)
+				return
+			
+			M.mind.afk_verb_used = TRUE
+			M.mind.afk_verb_timer = addtimer(VARSET_CALLBACK(M.mind, afk_verb_used, FALSE), timer MINUTES, TIMER_STOPPABLE);
+
+
 		else if (href_list["modarmor"])
 			if(!check_rights(NONE))
 				return

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -84,6 +84,11 @@
 	/// Is set to true if an antag was used to get this person picked as an antag
 	var/token_picked = FALSE
 
+	/// If they have used the afk verb recently
+	var/afk_verb_used = FALSE
+	/// The timer for the afk verb
+	var/afk_verb_timer
+
 /datum/mind/New(key)
 	src.key = key
 	soulOwner = src

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -239,7 +239,7 @@ GLOBAL_VAR_INIT(cryopods_enabled, FALSE)
 					//Player is a jackass that noone wants the body of, restart the timer
 					despawn_timer = addtimer(VARSET_CALLBACK(src, ready, TRUE), (time_till_despawn * 0.1), TIMER_STOPPABLE)
 		else
-			if(mob.mind.afk_verb_used) // If they used the afk verb, don't start the timer yet
+			if(mob_occupant.mind.afk_verb_used) // If they used the afk verb, don't start the timer yet
 				afk_hold = TRUE
 				return
 			despawn_timer = addtimer(VARSET_CALLBACK(src, ready, TRUE), time_till_despawn, TIMER_STOPPABLE)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -178,6 +178,11 @@ GLOBAL_VAR_INIT(cryopods_enabled, FALSE)
 	var/obj/machinery/computer/cryopod/control_computer
 	var/cooldown = FALSE
 
+	/// If the timer is on hold due to the occupant using the afk verb
+	var/afk_hold = FALSE
+
+	var/despawn_timer
+
 /obj/machinery/cryopod/Initialize()
 	..()
 	GLOB.cryopods += src
@@ -227,20 +232,28 @@ GLOBAL_VAR_INIT(cryopods_enabled, FALSE)
 		if(!occupant) //Check they still exist
 			return
 		if(mob_occupant.client)//if they're logged in
-			var/offertimer = addtimer(VARSET_CALLBACK(src, ready, TRUE), time_till_despawn_online, TIMER_STOPPABLE)
+			despawn_timer = addtimer(VARSET_CALLBACK(src, ready, TRUE), time_till_despawn_online, TIMER_STOPPABLE)
 			if(alert(mob_occupant, "Do you want to offer yourself to ghosts?", "Ghost Offer", "Yes", "No") == "Yes")
-				deltimer(offertimer) //Player wants to offer, cancel the timer
+				deltimer(despawn_timer) //Player wants to offer, cancel the timer
 				if(!offer_control(occupant))
 					//Player is a jackass that noone wants the body of, restart the timer
-					addtimer(VARSET_CALLBACK(src, ready, TRUE), (time_till_despawn * 0.1))
+					despawn_timer = addtimer(VARSET_CALLBACK(src, ready, TRUE), (time_till_despawn * 0.1), TIMER_STOPPABLE)
 		else
-			addtimer(VARSET_CALLBACK(src, ready, TRUE), time_till_despawn)
+			if(mob.mind.afk_verb_used) // If they used the afk verb, don't start the timer yet
+				afk_hold = TRUE
+				return
+			despawn_timer = addtimer(VARSET_CALLBACK(src, ready, TRUE), time_till_despawn, TIMER_STOPPABLE)
 
 /obj/machinery/cryopod/open_machine()
 	..()
 	icon_state = GLOB.cryopods_enabled ? "cryopod-open" : "cryopod-off"
 	density = TRUE
 	name = initial(name)
+
+	// Clear the afk hold and ready flag/timer
+	afk_hold = FALSE
+	deltimer(despawn_timer)
+	ready = FALSE
 
 /obj/machinery/cryopod/container_resist(mob/living/user)
 	visible_message(span_notice("[occupant] emerges from [src]!"),
@@ -256,6 +269,10 @@ GLOBAL_VAR_INIT(cryopods_enabled, FALSE)
 
 	var/mob/living/mob_occupant = occupant
 	if(mob_occupant)
+		if(afk_hold && !mob_occupant.mind.afk_verb_used) // AFK hold ended
+			despawn_timer = addtimer(VARSET_CALLBACK(src, ready, TRUE), time_till_despawn, TIMER_STOPPABLE)
+			afk_hold = FALSE
+			
 		// Eject dead people
 		if(mob_occupant.stat == DEAD)
 			open_machine()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1199,6 +1199,7 @@
 	.["Toggle Build Mode"] = "?_src_=vars;[HrefToken()];build_mode=[REF(src)]"
 	.["Assume Direct Control"] = "?_src_=vars;[HrefToken()];direct_control=[REF(src)]"
 	.["Offer Control to Ghosts"] = "?_src_=vars;[HrefToken()];offer_control=[REF(src)]"
+	.["Set AFK Timer"] = "?_src_=vars;[HrefToken()];set_afk=[REF(src)]"
 
 /**
   * extra var handling for the logging var

--- a/yogstation/code/modules/client/verbs/afk.dm
+++ b/yogstation/code/modules/client/verbs/afk.dm
@@ -93,5 +93,23 @@
 			var/normal_role = special_role || M.job || initial(M.name) || "unknown job"
 			message_admins("[ADMIN_LOOKUPFLW(src)] has used the AFK verb as '[normal_role]' for duration of '[time]'")
 			log_game("[key_name(src)] has used the AFK verb as '[normal_role]' for duration of '[time]'")
+		
+		/// Amount of time in time units they selected
+		var/afk_time = list(
+			"5 minutes" = 5 MINUTES,
+			"10 minutes" = 10 MINUTES,
+			"15 minutes" = 15 MINUTES,
+			"30 minutes" = 30 MINUTES,
+			"Whole round" = 0 MINUTES, // No cryo protections for whole round
+			"Unknown" = 15 MINUTES // Middleish ground
+		)[time]
+
+		if(!time || !mob.mind)
+			return
+		
+		deltimer(mob.mind.afk_verb_timer) // In case they used the verb again
+		mob.mind.afk_verb_used = TRUE
+		mob.mind.afk_verb_timer = addtimer(VARSET_CALLBACK(mob.mind, afk_verb_used, FALSE), afk_time, TIMER_STOPPABLE);
+
 	else
 		to_chat(src, span_boldnotice("It is not necessary to report being AFK if you are not in the game."))


### PR DESCRIPTION
# Document the changes in your pull request
Using the AFK verb will now add a delay before the cryo despawn timer if you are placed in cryo while afk. So if you use the afk verb for 5 minutes, then get immediately cryoed, you won't be despawned until 20 minutes has elapsed. Picking "Unkown" gives 15 minute protections, "Whole round" gives none because you should be cryoing yourself anyway.

# Changelog

:cl:    
tweak: tweaked the afk verb to add a delay before the cryo pod despawn timer
bugfix: Fixed bug where cryo despawn timer wasn't properly resetting
/:cl:
