### PR TITLE
replaces yogs meta bridge Rwindows+grille with Rwindows+grille+Shutter

### DIFF
--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -27917,89 +27917,8 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"bfr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/bridge)
-"bfs" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/bridge)
-"bft" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/turf/open/floor/plating,
-/area/bridge)
-"bfu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/turf/open/floor/plating,
-/area/bridge)
 "bfv" = (
 /turf/closed/wall/r_wall,
-/area/bridge)
-"bfw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/turf/open/floor/plating,
-/area/bridge)
-"bfx" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
 /area/bridge)
 "bfy" = (
 /obj/structure/table/wood,
@@ -28772,15 +28691,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"bhg" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/structure/cable/yellow,
-/turf/open/floor/plating,
-/area/bridge)
 "bhh" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -28921,18 +28831,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/bridge)
-"bhs" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/structure/cable/yellow,
-/turf/open/floor/plating,
 /area/bridge)
 "bht" = (
 /obj/structure/table/wood,
@@ -29809,17 +29707,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"biY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/turf/open/floor/plating,
-/area/bridge)
 "biZ" = (
 /obj/item/folder/white{
 	pixel_x = 4;
@@ -70212,6 +70099,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"fmW" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/bridge)
 "fnc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -70720,6 +70618,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"fRk" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/bridge)
 "fRs" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -71275,6 +71184,20 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
+"gCe" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/bridge)
 "gDk" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -72711,6 +72634,20 @@
 /obj/item/clothing/gloves/color/black,
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
+"ixt" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/bridge)
 "iyf" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Library"
@@ -73242,6 +73179,17 @@
 "jkf" = (
 /turf/template_noop,
 /area/maintenance/port/fore)
+"jkn" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/bridge)
 "jkG" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide{
 	valve_open = 1
@@ -74141,6 +74089,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"kxf" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/bridge)
 "kyR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 4
@@ -74722,6 +74684,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"lru" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/bridge)
 "lsu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -76107,6 +76086,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"nvl" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/structure/cable/yellow,
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/bridge)
 "nvJ" = (
 /obj/structure/table/wood,
 /obj/item/bikehorn,
@@ -77879,6 +77870,15 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"pZK" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/structure/cable/yellow,
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/bridge)
 "qax" = (
 /obj/structure/rack,
 /obj/structure/rack,
@@ -109735,7 +109735,7 @@ bcu
 aaf
 aaf
 aaf
-biY
+fmW
 bkC
 bmw
 bop
@@ -109990,8 +109990,8 @@ aVC
 aLR
 bcu
 aaf
-bfr
-bhg
+gCe
+pZK
 bfv
 bkD
 bmz
@@ -110247,7 +110247,7 @@ aVE
 aLR
 bcu
 aaf
-bfs
+lru
 bhh
 biZ
 bkE
@@ -110504,7 +110504,7 @@ aWM
 aLR
 bcu
 aaf
-bft
+kxf
 bhi
 bja
 bjc
@@ -110761,7 +110761,7 @@ aWQ
 aLR
 bcu
 aaf
-bfu
+fRk
 bhj
 bjb
 bjc
@@ -111275,7 +111275,7 @@ aWX
 aLR
 bcu
 aaf
-bfw
+jkn
 bhl
 aUh
 bjO
@@ -111532,7 +111532,7 @@ aXb
 aMp
 bcu
 aaf
-bfs
+lru
 bhm
 bjd
 bkF
@@ -111789,7 +111789,7 @@ aXd
 aMw
 bcu
 aaf
-bfu
+fRk
 bhn
 bjb
 bjc
@@ -112303,7 +112303,7 @@ aXk
 aMw
 bcu
 aaf
-bfw
+jkn
 bhp
 bjb
 dCK
@@ -112560,7 +112560,7 @@ aVE
 aMw
 bcu
 aaf
-bft
+kxf
 bhq
 bje
 bjc
@@ -112817,7 +112817,7 @@ aVE
 aMw
 bcu
 aaf
-bft
+kxf
 bhr
 bjf
 bkG
@@ -113074,8 +113074,8 @@ aVE
 aMw
 bcu
 aaf
-bfx
-bhs
+ixt
+nvl
 bfv
 qkk
 blV
@@ -113333,7 +113333,7 @@ bcu
 aaf
 aaf
 aaf
-biY
+fmW
 bkI
 aXj
 aYc


### PR DESCRIPTION
…ters



# Document the changes in your pull request

replaces the bridge windows on yogs meta to the Rwindows that have the see through auto closing anti breach shutters because the main hall has them but the bridge doesnt

# Wiki Documentation

n/a

# Changelog

:cl:  
rscadd: Rwindows with autoclose breach shutters to meta bridge 
rscdel: Removed old windows 
/:cl:
