### PR TITLE
Gives Stargazers mindreading

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -580,6 +580,7 @@
 		project_thought.Remove(C)
 	if(link_minds)
 		link_minds.Remove(C)
+	C.RemoveSpell(/obj/effect/proc_holder/spell/targeted/mindread)
 
 /datum/species/jelly/stargazer/spec_death(gibbed, mob/living/carbon/human/H)
 	..()
@@ -594,6 +595,7 @@
 	link_minds.Grant(C)
 	slimelink_owner = C
 	link_mob(C)
+	C.AddSpell(/obj/effect/proc_holder/spell/targeted/mindread)
 
 /datum/species/jelly/stargazer/proc/link_mob(mob/living/M)
 	if(QDELETED(M) || M.stat == DEAD)

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -580,7 +580,7 @@
 		project_thought.Remove(C)
 	if(link_minds)
 		link_minds.Remove(C)
-	C.RemoveSpell(/obj/effect/proc_holder/spell/targeted/mindread)
+	C.RemoveSpell(mindread)
 
 /datum/species/jelly/stargazer/spec_death(gibbed, mob/living/carbon/human/H)
 	..()
@@ -595,7 +595,7 @@
 	link_minds.Grant(C)
 	slimelink_owner = C
 	link_mob(C)
-	C.AddSpell(/obj/effect/proc_holder/spell/targeted/mindread)
+	C.AddSpell(mindread)
 
 /datum/species/jelly/stargazer/proc/link_mob(mob/living/M)
 	if(QDELETED(M) || M.stat == DEAD)

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -571,6 +571,7 @@
 	var/list/datum/action/innate/linked_speech/linked_actions = list()
 	var/mob/living/carbon/human/slimelink_owner
 	var/current_link_id = 0
+	var/obj/effect/proc_holder/spell/targeted/mindread/mindread
 
 /datum/species/jelly/stargazer/on_species_loss(mob/living/carbon/C)
 	..()
@@ -580,7 +581,8 @@
 		project_thought.Remove(C)
 	if(link_minds)
 		link_minds.Remove(C)
-	C.RemoveSpell(mindread)
+	if(mindread)
+		C.RemoveSpell(mindread)
 
 /datum/species/jelly/stargazer/spec_death(gibbed, mob/living/carbon/human/H)
 	..()
@@ -595,6 +597,8 @@
 	link_minds.Grant(C)
 	slimelink_owner = C
 	link_mob(C)
+	mindread = new
+	mindread.charge_counter = 0
 	C.AddSpell(mindread)
 
 /datum/species/jelly/stargazer/proc/link_mob(mob/living/M)


### PR DESCRIPTION



# Document the changes in your pull request

Stargazers are the least powerful and used jellyperson race by far, this change should give them a bit of an edge while remaining lore friendly.

# Wiki Documentation

Add mention of mind read ability to the races guide for stargazers
# Changelog


:cl:  
rscadd: Stargazers now get mindread 
/:cl:
