### PR TITLE
Fix rough metal walls and fake rough metal walls dropping the wrong number of rods

### DIFF
--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -296,7 +296,7 @@
 	icon = 'icons/turf/walls/iron_wall.dmi'
 	icon_state = "iron"
 	mineral = /obj/item/stack/rods
-	mineral_amount = 5
+	mineral_amount = 2
 	walltype = /turf/closed/wall/mineral/iron
 	canSmoothWith = list(/obj/structure/falsewall/iron, /turf/closed/wall/mineral/iron)
 

--- a/code/game/turfs/simulated/wall/mineral_walls.dm
+++ b/code/game/turfs/simulated/wall/mineral_walls.dm
@@ -157,6 +157,7 @@
 	icon = 'icons/turf/walls/iron_wall.dmi'
 	icon_state = "iron"
 	sheet_type = /obj/item/stack/rods
+	sheet_amount = 5
 	canSmoothWith = list(/turf/closed/wall/mineral/iron, /obj/structure/falsewall/iron)
 
 /turf/closed/wall/mineral/snow


### PR DESCRIPTION
# Document the changes in your pull request

False walls were made with 2, but desconstructed into 5
Real walls were made with 5 but deconstructed into 2

Both now deconstruct into the amount they were made with

Fixes #13230 

# Changelog

:cl:  
bugfix: fixed rough metal walls and false rough metal walls dropping the wrong amount of rods when deconstructed
/:cl:
