### PR TITLE
Fixed paraplegic not working under many conditions

### DIFF
--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -321,7 +321,7 @@
 
 /obj/item/bodypart/proc/attach_limb(mob/living/carbon/C, special)
 	moveToNullspace()
-	owner = C
+	set_owner(C)
 	C.bodyparts += src
 	if(held_index)
 		if(held_index > C.hand_bodyparts.len)


### PR DESCRIPTION
# Document the changes in your pull request

Paraplegic doesn't work if `set_owner` isn't called on the legs. This makes `attach_limb` call `set_owner` so that paraplegic doesn't break if `attach_limb` is used.

Fixes #13223 

# Changelog

:cl:  
bugfix: fixed paraplegic not working in some cases
/:cl:
