### PR TITLE
Fixes the mining base infirmary

### DIFF
--- a/_maps/RandomRuins/LavaRuins/miningbase.dmm
+++ b/_maps/RandomRuins/LavaRuins/miningbase.dmm
@@ -1592,6 +1592,13 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/mine/infirmary)
+"sC" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table/optable,
+/turf/open/floor/plasteel/white,
+/area/mine/infirmary)
 "sU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -3365,15 +3372,6 @@
 	},
 /turf/open/floor/plating,
 /area/mine/storage)
-"SP" = (
-/obj/structure/table/optable{
-	name = "Robotics Operating Table"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/mine/infirmary)
 "SV" = (
 /obj/structure/table,
 /obj/machinery/light/small{
@@ -5003,7 +5001,7 @@ RO
 kD
 kD
 xv
-SP
+sC
 ML
 oU
 TQ


### PR DESCRIPTION
# Document the changes in your pull request

Fixes a game breaking issue that makes mining medic unplayable, that being the surgery table not being named incorrectly. Untested, should work.

# Wiki Documentation

No changes needed. 

# Changelog

:cl:  
bugfix: fixed the surgery table on the mining base not being named incorrectly    
/:cl:
