### PR TITLE
Removes bombanas from silver slime food pool

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1486,7 +1486,8 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 		/obj/item/reagent_containers/food/snacks/store/bread,
 		/obj/item/reagent_containers/food/snacks/grown/nettle
 		)
-	blocked |= typesof(/obj/item/reagent_containers/food/snacks/customizable)
+	blocked |= typesof(/obj/item/reagent_containers/food/snacks/customizable,
+	/obj/item/reagent_containers/food/snacks/grown/banana/bombanana)
 
 	return pick(subtypesof(/obj/item/reagent_containers/food/snacks) - blocked)
 


### PR DESCRIPTION
# Document the changes in your pull request

At least I think this does that?
Relevant code to look at:
https://github.com/yogstation13/Yogstation/blob/master/code/game/gamemodes/clown_ops/clown_weapons.dm
https://github.com/yogstation13/Yogstation/blob/master/code/modules/reagents/chemistry/recipes/slime_extracts.dm
https://github.com/yogstation13/Yogstation/blob/master/code/__HELPERS/unsorted.dm

One one hand xenobiologists deserve it, on the other it's funny, but on my third hand this is just cruel to leave in

# Changelog

:cl:  
rscdel: Central Command Ordinance #13254: Xenobiological Lifeforms are forbidden from producing deadly explosives concealed in the guise of plant life of the genus Musa.
/:cl: