### PR TITLE
Adds a secondary AI core to Eclipse, as well as a tutorial holodisk. Refurbished OmegaStation AI core.

### DIFF
--- a/_maps/map_files/EclipseStation/EclipseStation.dmm
+++ b/_maps/map_files/EclipseStation/EclipseStation.dmm
@@ -81450,6 +81450,8 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/ai_monitored/secondarydatacore)
 "eJX" = (
@@ -82903,7 +82905,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/research{
+/obj/machinery/door/airlock/vault{
 	name = "Secondary AI Core";
 	normalspeed = 0;
 	req_access_txt = "55"
@@ -87687,6 +87689,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/ai_monitored/secondarydatacore)
 "qht" = (

--- a/_maps/map_files/EclipseStation/EclipseStation.dmm
+++ b/_maps/map_files/EclipseStation/EclipseStation.dmm
@@ -59026,8 +59026,14 @@
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
 "css" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 2;
+	sortType = 25
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -59055,18 +59061,8 @@
 	},
 /area/science)
 "csw" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Science";
-	req_access_txt = "47"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -59461,6 +59457,7 @@
 "cto" = (
 /obj/structure/rack,
 /obj/item/circuitboard/computer/ai_upload_download,
+/obj/item/disk/holodisk/tutorial/AICore,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hor)
 "ctp" = (
@@ -80340,6 +80337,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"djf" = (
+/obj/machinery/computer/ai_server_console{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet,
+/area/ai_monitored/secondarydatacore)
 "djh" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -80845,6 +80849,11 @@
 /obj/machinery/computer/arcade,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"dtt" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/costume,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "duG" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
@@ -80863,14 +80872,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dvX" = (
-/obj/machinery/door/airlock,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/science)
+/turf/closed/wall/r_wall,
+/area/ai_monitored/secondarydatacore)
 "dxP" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/brown{
@@ -81151,9 +81154,6 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/window/reinforced{
 	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -81440,6 +81440,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"eJm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/carpet,
+/area/ai_monitored/secondarydatacore)
 "eJX" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -82700,9 +82712,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "gYH" = (
@@ -82884,6 +82893,23 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"hlH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/research{
+	name = "Secondary AI Core";
+	normalspeed = 0;
+	req_access_txt = "55"
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "hmf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/seed_extractor,
@@ -83142,6 +83168,30 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"hMM" = (
+/obj/machinery/camera{
+	c_tag = "Secondary AI Core";
+	network = list("ss13","rd")
+	},
+/obj/machinery/doorButtons/access_button{
+	idDoor = "secondary_aicore_exterior";
+	idSelf = "secondary_aicore_controller";
+	name = "Secondary AI Core Access Button";
+	pixel_x = 8;
+	pixel_y = 24;
+	req_access_txt = "30"
+	},
+/obj/machinery/doorButtons/airlock_controller{
+	idExterior = "secondary_aicore_exterior";
+	idInterior = "secondary_aicore_interior";
+	idSelf = "secondary_aicore_controller";
+	name = "Secondary AI Core Access Console";
+	pixel_x = 7;
+	pixel_y = 37;
+	req_access_txt = "30"
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/ai_monitored/secondarydatacore)
 "hMU" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -83403,6 +83453,10 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"iev" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
+/turf/open/floor/circuit/telecomms/server,
+/area/ai_monitored/secondarydatacore)
 "igY" = (
 /obj/item/reagent_containers/food/snacks/pizzaslice/custom,
 /obj/effect/decal/cleanable/blood/footprints{
@@ -83410,6 +83464,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"ihx" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/machinery/ai/data_core,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/ai_monitored/secondarydatacore)
 "ihF" = (
 /obj/structure/cable{
 	icon_state = "4-8";
@@ -83707,6 +83766,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/teleporter/hub/science)
+"iGk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "iHR" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable,
@@ -83782,6 +83849,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/medical/medbay/central)
+"iMA" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/circuit/telecomms/server,
+/area/ai_monitored/secondarydatacore)
 "iOJ" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=PPH3";
@@ -83860,6 +83931,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"iZj" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/circuit/telecomms/server,
+/area/ai_monitored/secondarydatacore)
 "iZk" = (
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
@@ -84222,6 +84300,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "jNc" = (
@@ -84254,6 +84335,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"jPk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/ai_monitored/secondarydatacore)
 "jPz" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -84317,6 +84405,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
+"jVu" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "jVL" = (
 /obj/machinery/door/airlock,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -84788,10 +84880,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "kHf" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/costume,
-/turf/open/floor/plating,
-/area/maintenance/department/science)
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 4;
+	external_pressure_bound = 120
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/ai_monitored/secondarydatacore)
 "kHR" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -84894,6 +84988,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"kNz" = (
+/turf/closed/wall,
+/area/ai_monitored/secondarydatacore)
 "kNZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -85414,6 +85511,13 @@
 /obj/effect/spawner/lootdrop/gloves,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"lVS" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "lWG" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -86172,9 +86276,6 @@
 	},
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "nrg" = (
@@ -86188,6 +86289,14 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"nsA" = (
+/obj/machinery/computer/ai_resource_distribution{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet,
+/area/ai_monitored/secondarydatacore)
 "ntY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer2{
 	dir = 4
@@ -86200,6 +86309,12 @@
 	},
 /turf/open/floor/plating,
 /area/security/processing)
+"nuG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "nvw" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -86232,6 +86347,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/lobby)
+"nwx" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/obj/machinery/airalarm/tcomms{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/ai_monitored/secondarydatacore)
 "nye" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical{
@@ -86266,6 +86391,9 @@
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -86522,6 +86650,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"nUn" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"nUq" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/machinery/ai/expansion_card_holder,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/ai_monitored/secondarydatacore)
 "nWA" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -86896,6 +87041,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/teleporter/hub/medical)
+"oQn" = (
+/obj/machinery/holopad,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "oRf" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -86911,6 +87063,13 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"oRC" = (
+/obj/machinery/door/window/eastleft{
+	name = "freezer control";
+	req_access_txt = "30"
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "oUw" = (
 /obj/structure/sign/departments/minsky/medical/chemistry/chemical2,
 /turf/closed/wall,
@@ -86986,6 +87145,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
+"oXk" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/door/airlock/command/glass{
+	id_tag = "secondary_aicore_exterior";
+	name = "Physical Core Access";
+	req_access_txt = "30"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "oYd" = (
 /obj/machinery/vending/boozeomat/all_access,
 /turf/closed/wall,
@@ -87504,6 +87673,22 @@
 /obj/effect/spawner/lootdrop/costume,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"qha" = (
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/power/apc/highcap{
+	areastring = "/area/ai_monitored/secondarydatacore";
+	dir = 4;
+	name = "AI Secondary Datacore";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/carpet,
+/area/ai_monitored/secondarydatacore)
 "qht" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/modularpc,
@@ -87577,9 +87762,14 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "qpC" = (
-/obj/effect/landmark/stationroom/maint/threexthree,
-/turf/template_noop,
-/area/maintenance/department/science)
+/obj/machinery/door/airlock/command/glass{
+	id_tag = "secondary_aicore_interior";
+	name = "Physical Core Access";
+	req_access_txt = "30"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "qpY" = (
 /obj/structure/table/wood,
 /obj/item/map/station{
@@ -87832,6 +88022,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"qMa" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "qND" = (
 /obj/machinery/light{
 	dir = 4;
@@ -87848,9 +88042,6 @@
 "qRP" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/scientist,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "qSk" = (
@@ -88403,6 +88594,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"rJd" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/doorButtons/access_button{
+	idDoor = "secondary_aicore_interior";
+	idSelf = "secondary_aicore_controller";
+	name = "Secondary AI Core Access Button";
+	pixel_x = 8;
+	pixel_y = 24;
+	req_access_txt = "30"
+	},
+/obj/machinery/doorButtons/access_button{
+	idDoor = "secondary_aicore_exterior";
+	idSelf = "secondary_aicore_controller";
+	name = "Secondary AI Core Access Button";
+	pixel_x = 9;
+	pixel_y = -23;
+	req_access_txt = "30"
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "rJJ" = (
 /obj/structure/sign/poster/contraband/lusty_xenomorph{
 	pixel_y = 32
@@ -88516,6 +88730,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"rSx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/holopad/secure,
+/turf/open/floor/carpet,
+/area/ai_monitored/secondarydatacore)
 "rSJ" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -88554,6 +88777,11 @@
 	},
 /turf/open/floor/plating,
 /area/medical/genetics)
+"rVT" = (
+/obj/effect/spawner/lootdrop/costume,
+/obj/structure/closet,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "rWo" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -88863,6 +89091,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"sCA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "sDw" = (
 /obj/machinery/door/airlock,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -88909,9 +89141,6 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "sFR" = (
@@ -88948,9 +89177,6 @@
 /obj/item/book/manual/wiki/toxins,
 /obj/item/storage/firstaid/toxin,
 /obj/structure/table/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "sIo" = (
@@ -88996,6 +89222,15 @@
 "sJx" = (
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
+"sLA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "sOt" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/circuit,
@@ -89535,6 +89770,28 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/teleporter/hub/bridge)
+"tLK" = (
+/obj/machinery/doorButtons/access_button{
+	idDoor = "secondary_aicore_interior";
+	idSelf = "secondary_aicore_controller";
+	name = "Secondary AI Core Access Button";
+	pixel_x = 8;
+	pixel_y = -24;
+	req_access_txt = "30"
+	},
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko{
+	pixel_x = -4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/item/disk/holodisk/tutorial/AICore{
+	pixel_y = 8
+	},
+/turf/open/floor/carpet,
+/area/ai_monitored/secondarydatacore)
 "tMf" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
@@ -89912,6 +90169,9 @@
 	dir = 1
 	},
 /obj/machinery/holopad,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "uqs" = (
@@ -90287,6 +90547,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"vao" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/costume,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "vas" = (
 /obj/structure/window/reinforced{
 	layer = 4.1
@@ -90335,17 +90603,21 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "vby" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/maintenance{
+	name = "Science";
+	req_access_txt = "47"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 2;
-	sortType = 25
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/science/mixing)
 "vck" = (
 /obj/machinery/bounty_board,
 /turf/closed/wall/r_wall,
@@ -90463,9 +90735,6 @@
 	},
 /obj/item/analyzer,
 /obj/item/pipe_dispenser,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "voF" = (
@@ -90632,7 +90901,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "vDU" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "vDZ" = (
@@ -91435,8 +91706,19 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "wRt" = (
-/turf/template_noop,
-/area/maintenance/department/science)
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Secondary AI Core";
+	network = list("ss13","rd")
+	},
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet,
+/area/ai_monitored/secondarydatacore)
 "wTT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -91862,6 +92144,12 @@
 /obj/machinery/electrolyzer,
 /turf/open/floor/plasteel,
 /area/science/storage)
+"xJf" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/ai_monitored/secondarydatacore)
 "xLx" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
@@ -91990,6 +92278,15 @@
 /obj/effect/landmark/stationroom/maint/threexthree,
 /turf/template_noop,
 /area/maintenance/department/chapel)
+"xYs" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8;
+	external_pressure_bound = 140;
+	pressure_checks = 0
+	},
+/obj/machinery/light,
+/turf/open/floor/circuit/telecomms/server,
+/area/ai_monitored/secondarydatacore)
 "yai" = (
 /obj/item/radio/intercom{
 	freerange = 1;
@@ -119835,8 +120132,8 @@ cfD
 cfD
 cfD
 xdx
-vby
 cfD
+css
 cfD
 cfD
 cQy
@@ -120092,9 +120389,9 @@ avq
 avq
 avq
 cWq
-css
-cWl
 avp
+csw
+rVT
 avp
 avp
 avp
@@ -120349,8 +120646,8 @@ avp
 avp
 aoM
 aoM
-csw
 aoM
+vby
 aoM
 aoM
 aoM
@@ -120864,7 +121161,7 @@ cly
 cly
 bXd
 qRP
-czw
+oQn
 bXB
 bcP
 csi
@@ -121635,7 +121932,7 @@ cpf
 cly
 bXg
 nrb
-bXv
+nuG
 bXD
 bcR
 apr
@@ -121892,7 +122189,7 @@ cpf
 cly
 bYc
 gYo
-bXv
+nuG
 bXK
 bcR
 app
@@ -123186,7 +123483,7 @@ ctJ
 cun
 xHj
 apG
-auN
+jVu
 avc
 avc
 cME
@@ -123701,15 +123998,15 @@ cup
 icn
 apG
 cMS
-auN
-auN
-cWr
-cWg
-auQ
-fMp
-auQ
-aoM
-aoM
+dvX
+dvX
+dvX
+dvX
+dvX
+dvX
+dvX
+dvX
+dvX
 cyy
 czl
 czQ
@@ -123958,15 +124255,15 @@ cuq
 cuO
 apG
 cMS
-auQ
-auQ
-auQ
-auQ
-auQ
-auN
-auN
+dvX
+nsA
+tLK
+kNz
+rJd
+kNz
+hMM
 kHf
-csZ
+qMa
 cBr
 cZR
 dak
@@ -124217,13 +124514,13 @@ apG
 cMS
 dvX
 wRt
-wRt
+jPk
 qpC
-auQ
-auN
-auN
-cTD
-csZ
+lVS
+oXk
+iMA
+nUq
+qMa
 crf
 crf
 cZR
@@ -124472,15 +124769,15 @@ cqY
 cuO
 apG
 cMS
-auQ
-wRt
-wRt
-wRt
-auQ
-dhk
-auN
-cTD
-csZ
+dvX
+djf
+rSx
+sCA
+oRC
+sCA
+xJf
+ihx
+qMa
 cBy
 ddE
 cBy
@@ -124729,15 +125026,15 @@ uqz
 uqz
 apG
 cMS
-auQ
-wRt
-wRt
-wRt
-auQ
-auQ
-fMp
-auQ
-auQ
+dvX
+qha
+eJm
+sCA
+iev
+iZj
+nwx
+xYs
+dvX
 auQ
 auQ
 auQ
@@ -124986,15 +125283,15 @@ aoU
 aaa
 avc
 cMS
-auQ
-auQ
-auQ
-auQ
-auQ
-auN
-auN
-auN
-auQ
+dvX
+dvX
+hlH
+dvX
+dvX
+dvX
+dvX
+dvX
+dvX
 lwa
 cja
 cja
@@ -125244,8 +125541,8 @@ aaa
 csZ
 cMS
 lwa
-cja
-cja
+iGk
+nUn
 cja
 cja
 cja
@@ -125256,7 +125553,7 @@ jck
 cSk
 cSk
 cSk
-cRX
+vao
 aLf
 aLj
 aNF
@@ -125502,7 +125799,7 @@ csZ
 cMz
 cGn
 rmF
-rmF
+sLA
 rmF
 rmF
 rmF
@@ -126013,15 +126310,15 @@ ctR
 aoU
 aaa
 avc
-auN
+dhq
 cMS
 auN
 auQ
+dtt
 cTD
+auN
+auN
 cTD
-auN
-auN
-auN
 apX
 cwA
 aqC
@@ -126270,7 +126567,7 @@ ctS
 aoU
 aaa
 avc
-auN
+dhq
 cMS
 auN
 auQ
@@ -126278,7 +126575,7 @@ cTD
 auN
 auN
 auN
-auN
+dtt
 apX
 aqC
 aqC
@@ -126531,7 +126828,7 @@ auN
 cMS
 auN
 auQ
-auN
+cWg
 auN
 auN
 auN

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -96262,6 +96262,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/item/disk/holodisk/tutorial/AICore,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "pxN" = (

--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -27931,6 +27931,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical)
+"gsk" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/camera/all{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "gsA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46652,13 +46662,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"xNJ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/server)
 "xOb" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4
@@ -95952,7 +95955,7 @@ hbL
 tOP
 hbL
 pzi
-xNJ
+gsk
 jPT
 hbL
 sOM

--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -1068,14 +1068,18 @@
 /turf/closed/wall,
 /area/bridge)
 "abB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/turf/open/floor/circuit/green,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "abC" = (
 /obj/structure/table/wood,
@@ -2530,14 +2534,8 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "adN" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/starboard/aft)
+/turf/closed/wall/r_wall/rust,
+/area/ai_monitored/turret_protected/ai)
 "adO" = (
 /obj/machinery/status_display/ai,
 /turf/closed/wall/r_wall,
@@ -5517,7 +5515,15 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "ahQ" = (
-/turf/open/floor/circuit/green,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "ahR" = (
 /obj/machinery/airalarm{
@@ -21286,7 +21292,6 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard)
 "bdC" = (
-/obj/item/storage/box/lights/mixed,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -21496,8 +21501,9 @@
 /obj/item/stack/sheet/glass{
 	amount = 30
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
@@ -22662,6 +22668,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"bjY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "bkj" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/layer4{
@@ -22728,14 +22747,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bkU" = (
-/obj/item/bedsheet/dorms,
-/obj/structure/bed,
-/obj/machinery/light_switch{
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/aft)
@@ -23949,6 +23966,13 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"cce" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/asteroid/nearstation)
 "cdT" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -24913,6 +24937,22 @@
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"dcJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "ddn" = (
 /obj/machinery/suit_storage_unit/hos,
 /turf/open/floor/carpet,
@@ -25376,6 +25416,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"dIv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "AI Core - South";
+	dir = 2;
+	name = "core camera";
+	network = list("rd")
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/landmark/start/ai,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "dIQ" = (
 /obj/structure/cable/white{
 	icon_state = "1-4"
@@ -25582,12 +25644,16 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "dWg" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "dWp" = (
@@ -25830,8 +25896,12 @@
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/aisat_interior)
 "ehE" = (
@@ -26074,6 +26144,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"exJ" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/ai";
+	dir = 1;
+	name = "AI Chamber APC";
+	pixel_y = 23
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "exK" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
@@ -26102,17 +26191,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "exP" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/ai";
-	dir = 1;
-	name = "AI Chamber APC";
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
@@ -26137,6 +26217,15 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/hallway/secondary/entry)
+"eAo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/circuit/green,
+/area/ai_monitored/turret_protected/ai)
 "eBn" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -26522,29 +26611,9 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/central)
 "eSg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "AI Core - South";
-	dir = 2;
-	name = "core camera";
-	network = list("rd")
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
@@ -26566,6 +26635,9 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
+"eVU" = (
+/turf/open/floor/plasteel/dark,
+/area/maintenance/starboard/aft)
 "eWA" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -26635,6 +26707,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"eZg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/ai/expansion_card_holder/prefilled,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "fav" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -26890,9 +26969,11 @@
 /turf/open/floor/plating,
 /area/bridge)
 "fqZ" = (
-/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/aft)
@@ -28165,6 +28246,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/research)
+"gJx" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/circuit/green,
+/area/ai_monitored/turret_protected/ai)
 "gKt" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 6
@@ -29255,6 +29340,24 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"hNL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 1;
+	external_pressure_bound = 120;
+	name = "server vent"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "hNO" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 5
@@ -29392,6 +29495,9 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"hSa" = (
+/turf/closed/wall/rust,
+/area/ai_monitored/turret_protected/ai)
 "hSR" = (
 /obj/structure/cable/white{
 	icon_state = "2-4"
@@ -29571,6 +29677,13 @@
 /obj/machinery/computer/prisoner,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"idM" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/circuit/green,
+/area/ai_monitored/turret_protected/ai)
 "ieg" = (
 /obj/structure/cable/white{
 	icon_state = "2-4"
@@ -30013,24 +30126,9 @@
 /area/library)
 "ixB" = (
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/highsecurity{
-	name = "MiniSat Chamber";
-	req_access_txt = "16"
-	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "aicoredoor";
 	name = "AI Core Access"
-	},
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_x = -26
-	},
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1447;
-	listening = 0;
-	name = "AI Intercom";
-	pixel_x = 28
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -30050,10 +30148,16 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/airlock/highsecurity{
+	id_tag = "ai_core_airlock_exterior";
+	name = "AI Core";
+	req_access_txt = "16"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/ai)
 "iye" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/incinerator_output{
 	dir = 4
@@ -30468,6 +30572,26 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"iOH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 2;
+	external_pressure_bound = 120;
+	name = "server vent"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "iOW" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -30801,18 +30925,22 @@
 	},
 /area/library)
 "jit" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
+/obj/structure/table,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera{
+	c_tag = "AI Core - North";
+	dir = 2;
+	name = "core camera";
+	network = list("rd")
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/cell_charger,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "jiI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -30864,6 +30992,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"jkO" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "jkP" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -31163,6 +31296,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"jzM" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/space)
 "jAV" = (
 /obj/machinery/door/airlock/external{
 	name = "External Docking Port"
@@ -31477,6 +31614,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"jPT" = (
+/obj/machinery/computer/ai_server_console{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "jQD" = (
 /obj/machinery/conveyor{
 	dir = 9;
@@ -32290,8 +32441,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "kHk" = (
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
-/area/maintenance/starboard/aft)
+/area/ai_monitored/turret_protected/ai)
 "kHA" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -32382,6 +32534,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"kMH" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/circuit/green,
+/area/ai_monitored/turret_protected/ai)
 "kNA" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -33123,6 +33282,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "lDZ" = (
@@ -33198,18 +33360,16 @@
 /turf/closed/wall/rust,
 /area/crew_quarters/lounge)
 "lJI" = (
-/obj/machinery/light/small{
+/obj/machinery/power/smes/fullycharged,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/bookcase/random/nonfiction,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/starboard/aft)
+/turf/open/floor/circuit/green,
+/area/ai_monitored/turret_protected/ai)
 "lJY" = (
 /obj/machinery/camera{
 	c_tag = "Fore Primary Hallway";
@@ -33904,6 +34064,12 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"mqL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "mrh" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -34036,6 +34202,35 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"mCl" = (
+/obj/machinery/camera{
+	c_tag = "AI Core";
+	dir = 2;
+	name = "core camera";
+	network = list("rd")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "aicoredoor";
+	name = "AI Core Access"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "mCq" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -34166,6 +34361,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical)
+"mIT" = (
+/obj/item/bedsheet/dorms,
+/obj/structure/bed,
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/asteroid/nearstation)
 "mKK" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/tile/neutral{
@@ -34559,6 +34766,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"nmA" = (
+/turf/closed/wall/rust,
+/area/science/server)
 "nmL" = (
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -34615,8 +34825,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "nqi" = (
@@ -35041,15 +35249,12 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "nMc" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
-/area/maintenance/starboard/aft)
+/area/ai_monitored/turret_protected/ai)
 "nNA" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -35729,6 +35934,15 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"ork" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "otn" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 6
@@ -36423,6 +36637,19 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
+"pdu" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/starboard/aft)
 "pdD" = (
 /obj/structure/dresser,
 /obj/machinery/light/small{
@@ -36815,6 +37042,20 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"pzi" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/holopad/secure,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "pzw" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/plasteel/showroomfloor,
@@ -36871,6 +37112,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"pBE" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/asteroid/nearstation)
 "pBV" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/advanced_airlock_controller{
@@ -37252,20 +37497,16 @@
 	},
 /area/maintenance/starboard/aft)
 "pXW" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/machinery/door/airlock/public{
+	id_tag = "ai_core_airlock_interior"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "pYn" = (
@@ -37275,6 +37516,17 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
+"pYD" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/ai/expansion_card_holder/prefilled,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "pZe" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -37413,6 +37665,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"qhP" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "qiu" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/bot,
@@ -37791,18 +38052,15 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "qBF" = (
-/obj/structure/closet,
-/obj/item/clothing/under/pj/blue,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/item/clothing/head/cone{
+	desc = "This cone seems to almost always land in the corner of the room... Strange.";
+	name = "Corner Cone";
+	pixel_x = 6;
+	pixel_y = -3
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/aft)
 "qCx" = (
 /obj/structure/cable{
@@ -37846,6 +38104,40 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"qEh" = (
+/obj/machinery/turretid{
+	control_area = "/area/ai_monitored/turret_protected/ai";
+	icon_state = "control_stun";
+	name = "AI Chamber turret control";
+	pixel_x = 3;
+	pixel_y = -23
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 4;
+	pixel_y = 33
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "aicoredoor";
+	name = "AI Core Access"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "qEl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -38326,11 +38618,17 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hop)
 "qXM" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "qYx" = (
 /obj/machinery/airalarm{
@@ -39117,6 +39415,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
+"rPc" = (
+/turf/closed/wall,
+/area/science/server)
 "rPY" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/cable/white{
@@ -39905,15 +40206,17 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "suX" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/neutral,
+/obj/structure/closet,
+/obj/item/clothing/under/pj/blue,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1
+	dir = 8
 	},
-/obj/structure/bedsheetbin,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/aft)
 "svL" = (
@@ -39993,6 +40296,7 @@
 /turf/closed/wall/r_wall/rust,
 /area/asteroid/nearstation)
 "sxC" = (
+/obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall/rust,
 /area/ai_monitored/turret_protected/ai)
 "syh" = (
@@ -40642,39 +40946,47 @@
 "sLm" = (
 /turf/closed/wall/rust,
 /area/hallway/secondary/entry)
-"sLw" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall/rust,
-/area/ai_monitored/turret_protected/ai)
-"sLx" = (
-/obj/structure/table,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/camera{
-	c_tag = "AI Core - North";
-	dir = 2;
-	name = "core camera";
-	network = list("rd")
-	},
-/obj/machinery/cell_charger,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
 "sLy" = (
-/obj/machinery/power/smes/fullycharged,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/light{
+/obj/machinery/power/terminal{
 	dir = 1
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
-"sLz" = (
+"sLA" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/circuit/green,
+/area/ai_monitored/turret_protected/ai)
+"sLB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/circuit/green,
+/area/ai_monitored/turret_protected/ai)
+"sLC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
+"sLE" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "AI Core shutters";
+	name = "AI core shutters"
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/ai)
+"sLF" = (
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/structure/table,
@@ -40687,145 +40999,51 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/disk/holodisk/tutorial/AICore,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"sLA" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai)
-"sLB" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai)
-"sLC" = (
-/obj/machinery/porta_turret/ai{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"sLD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/circuit/green,
-/area/ai_monitored/turret_protected/ai)
-"sLE" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/turf/open/floor/circuit/green,
-/area/ai_monitored/turret_protected/ai)
-"sLF" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "sLG" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/turf/open/floor/circuit/green,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "sLI" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall/rust,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "sLJ" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/circuit/green,
-/area/ai_monitored/turret_protected/ai)
-"sLK" = (
-/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
+"sLK" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "sLL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "AI Core shutters";
-	name = "AI core shutters"
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/ai)
-"sLM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"sLN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/circuit/green,
-/area/ai_monitored/turret_protected/ai)
-"sLO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"sLP" = (
-/obj/machinery/turretid{
-	control_area = "/area/ai_monitored/turret_protected/ai";
-	icon_state = "control_stun";
-	name = "AI Chamber turret control";
-	pixel_x = 3;
-	pixel_y = -23
-	},
-/obj/machinery/door/window{
-	base_state = "leftsecure";
-	dir = 8;
-	icon_state = "leftsecure";
-	name = "Primary AI Core Access";
-	obj_integrity = 300;
-	req_access_txt = "16"
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 4;
-	pixel_y = 33
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"sLQ" = (
 /obj/machinery/requests_console{
 	department = "AI";
 	departmentType = 5;
@@ -40840,39 +41058,21 @@
 	pixel_x = 23;
 	pixel_y = -23
 	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 8
+	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
-"sLR" = (
-/obj/machinery/door/window{
-	base_state = "rightsecure";
-	dir = 4;
-	icon_state = "rightsecure";
-	name = "Primary AI Core Access";
-	obj_integrity = 300;
-	req_access_txt = "16"
-	},
-/obj/machinery/camera{
-	c_tag = "AI Core";
-	dir = 2;
-	name = "core camera";
-	network = list("rd")
-	},
-/obj/effect/turf_decal/stripes/line{
+"sLM" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"sLS" = (
+"sLN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -40885,21 +41085,14 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/yellow/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"sLT" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Telecomms Control Room";
-	req_one_access_txt = "10"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/tcommsat/server)
-"sLV" = (
+"sLP" = (
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/ai_monitored/turret_protected/ai)
+"sLQ" = (
 /obj/item/radio/intercom{
 	broadcasting = 0;
 	freerange = 1;
@@ -40924,7 +41117,6 @@
 	pixel_x = 27;
 	pixel_y = -7
 	},
-/obj/effect/landmark/start/ai,
 /obj/machinery/button/door{
 	id = "aicorewindow";
 	name = "AI Core shutters control";
@@ -40939,26 +41131,36 @@
 	pixel_y = -23;
 	req_access_txt = "16"
 	},
+/obj/machinery/ai/data_core/primary,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
-"sLX" = (
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/turf/open/floor/circuit/green,
+"sLR" = (
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
-"sLY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+"sLS" = (
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"sLZ" = (
+"sLT" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Telecomms Control Room";
+	req_one_access_txt = "10"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/tcommsat/server)
+"sLV" = (
+/obj/machinery/porta_turret/ai{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
+"sLX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -40971,44 +41173,49 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	icon_state = "scrub_map_on-3"
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
+"sLY" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
+"sLZ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "sMa" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
-"sMb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
 "sMc" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "sMg" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "sMj" = (
@@ -41017,10 +41224,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
 "sMn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/circuit/green,
+/turf/closed/wall,
 /area/ai_monitored/turret_protected/ai)
 "sMo" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -41041,35 +41245,34 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat_interior)
 "sMv" = (
-/obj/item/crowbar,
-/obj/item/wrench,
-/obj/item/mmi,
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
+/obj/structure/table,
+/obj/item/folder/blue,
+/obj/item/disk/holodisk/tutorial/AICore,
+/obj/item/assembly/flash/handheld,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "sMx" = (
-/obj/item/folder/blue,
-/obj/item/assembly/flash/handheld,
+/obj/machinery/doorButtons/access_button{
+	idDoor = "ai_core_airlock_exterior";
+	idSelf = "ai_core_airlock_control";
+	pixel_x = 23;
+	pixel_y = -7
+	},
+/obj/machinery/doorButtons/access_button{
+	idDoor = "ai_core_airlock_interior";
+	idSelf = "ai_core_airlock_control";
+	pixel_x = 23;
+	pixel_y = 7
+	},
 /obj/structure/table,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/item/mmi,
+/obj/item/wrench,
+/obj/item/crowbar,
+/obj/effect/turf_decal/stripes/end{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
@@ -41274,6 +41477,19 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = 9;
+	pixel_y = 24
+	},
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "AI Intercom";
+	pixel_x = 3;
+	pixel_y = 33
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "sNb" = (
@@ -41287,6 +41503,13 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
+	},
+/obj/machinery/doorButtons/airlock_controller{
+	idExterior = "ai_core_airlock_exterior";
+	idInterior = "ai_core_airlock_interior";
+	idSelf = "ai_core_airlock_control";
+	pixel_x = 5;
+	pixel_y = 36
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -41843,19 +42066,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "sZA" = (
-/obj/machinery/light,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
-	},
-/obj/structure/table,
-/obj/item/holotool,
-/obj/item/clothing/suit/armor/reactive/teleport{
-	pixel_x = 5;
-	pixel_y = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
@@ -41975,12 +42191,12 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "tcO" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/three,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "tdN" = (
@@ -42915,6 +43131,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"tZB" = (
+/obj/machinery/computer/ai_resource_distribution{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "tZD" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom";
@@ -43452,6 +43681,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"uxc" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/bedsheetbin,
+/turf/open/floor/plasteel/dark,
+/area/asteroid/nearstation)
 "uyI" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/engine,
@@ -43604,14 +43845,25 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "uHq" = (
-/obj/item/clothing/head/cone{
-	desc = "This cone seems to almost always land in the corner of the room... Strange.";
-	name = "Corner Cone";
-	pixel_x = -13;
-	pixel_y = 17
+/obj/structure/table,
+/obj/item/clothing/suit/armor/reactive/teleport{
+	pixel_x = 5;
+	pixel_y = 5
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/item/holotool,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/disk/holodisk/tutorial/AICore,
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "uHB" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -43625,6 +43877,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar/atrium)
+"uId" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 8
+	},
+/turf/open/floor/circuit/green,
+/area/ai_monitored/turret_protected/ai)
 "uJw" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral{
@@ -43761,6 +44019,18 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
+"uOt" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "uOD" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=2.1-Teleporter";
@@ -44043,6 +44313,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar/atrium)
+"vhr" = (
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "vhs" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -44108,6 +44391,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical)
+"vkW" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "vlH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/effect/turf_decal/tile/neutral{
@@ -45530,6 +45826,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"wTF" = (
+/obj/item/storage/box/lights/mixed,
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/starboard/aft)
 "wTG" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -45840,6 +46143,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"xoj" = (
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall/r_wall/rust,
+/area/ai_monitored/turret_protected/ai)
 "xqK" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -45944,6 +46251,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
+"xwZ" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/starboard/aft)
 "xyo" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -46288,6 +46602,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"xKb" = (
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "xKf" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/airalarm{
@@ -46316,6 +46635,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"xNJ" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "xOb" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4
@@ -46380,6 +46706,24 @@
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar/atrium)
+"xTC" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/door/airlock/research/glass{
+	name = "AI Server Control";
+	normalspeed = 0;
+	req_access_txt = "55"
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "xUc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/tile/bar{
@@ -46442,19 +46786,7 @@
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "xWl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "xWB" = (
 /obj/structure/cable/white{
@@ -46487,6 +46819,12 @@
 "xXO" = (
 /turf/closed/wall,
 /area/crew_quarters/bar)
+"xXV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "xYc" = (
 /obj/structure/urinal{
 	pixel_y = 28
@@ -89112,10 +89450,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aac
+aac
+aac
+aad
 aaa
 sdX
 eli
@@ -89367,11 +89705,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 aac
+aad
+aad
+aad
+aad
 aad
 aad
 aad
@@ -89621,13 +89959,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aac
-aac
+aad
+aad
+aad
+aad
+aad
+aad
 aad
 aad
 aad
@@ -89876,13 +90214,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aac
 aac
 aad
 aad
-aac
+aad
+aad
+aad
 aad
 aad
 aad
@@ -90132,16 +90470,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aac
 aac
 aad
 aad
 aad
 aad
-aad
-aad
+adQ
+adQ
+adQ
+adQ
 aad
 aad
 aad
@@ -90389,18 +90727,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aac
 aac
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
+adN
+adN
+adQ
+adQ
+adN
+adQ
+adN
+adN
 sMq
 sMr
 sMU
@@ -90645,19 +90983,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+aac
 aac
 aad
 aad
-aad
-sxC
-sxC
 adQ
+sLR
 adQ
-adQ
-adQ
-sxC
+eZg
+pYD
+mqL
+mqL
+adN
+sLR
 sMr
 sMG
 sMV
@@ -90902,19 +91240,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aac
 aac
 aad
 aad
+adN
 adQ
+sLV
 sLB
-adQ
-adQ
-adQ
-sxC
-adQ
-sLB
+xWl
+xWl
+xWl
+gJx
+kMH
+sLV
 sMr
 sMH
 sMW
@@ -91158,20 +91496,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+aac
 aac
 aad
-aad
-sxC
 adQ
+adQ
+sxC
+exP
 sLC
 sLJ
 ahQ
 abB
-ahQ
+bjY
 sMa
-sLC
+exP
 sMr
 sMI
 sMX
@@ -91415,22 +91753,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aac
-aac
+aad
 aad
 adQ
 adQ
-sLw
-sLD
+jit
+xWl
+sLG
 sLK
-sLO
-sLO
+sLS
+jkO
 sLY
-sMb
-sLD
-sMq
-sMr
+xWl
+hSa
+adN
+adQ
 sNQ
 aal
 sMr
@@ -91672,22 +92010,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aac
 aad
 aad
 adQ
 adQ
-sLx
-ahQ
+kHk
+xWl
 adQ
-sLP
+qEh
 adQ
 adQ
+vhr
 sMc
-ahQ
+adQ
 sMv
-sMq
+adN
 sMZ
 aam
 sNE
@@ -91929,18 +92267,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aac
 aad
 aad
-sxC
+adN
 adQ
+lJI
 sLy
 sLE
 sLL
 sLQ
-sLV
 adQ
+dIv
 eSg
 pXW
 dWg
@@ -92186,22 +92524,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aac
 aad
 aad
 adQ
-sxC
-sLz
-sLF
 adQ
-sLR
+nMc
+xWl
+adQ
+mCl
 adQ
 adQ
+exJ
 exP
-ahQ
+adQ
 sMx
-sMr
+adQ
 sNb
 kIm
 sNG
@@ -92443,22 +92781,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+aac
 aad
 aad
 adQ
-adQ
+adN
+sLF
 sLA
 sLG
 sLM
 sLS
-sLS
+jkO
 sLZ
 xWl
 sMn
-sMr
-sMr
+adQ
+adQ
 sNc
 kHh
 sMr
@@ -92701,19 +93039,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aad
 aad
 adQ
-sxC
-sLC
+adQ
+sLP
+eAo
+iOH
 sLN
-ahQ
+dcJ
 sLX
-ahQ
+hNL
 sMg
-sLC
+sMc
 sMr
 sMO
 jcC
@@ -92959,18 +93297,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aad
 aad
 adQ
+adN
+sLV
 sLI
-adQ
-adQ
-adQ
-adQ
-sxC
-sLB
+uId
+xWl
+xWl
+gJx
+idM
+sLV
 sMr
 sMP
 yek
@@ -93217,17 +93555,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aad
 aad
 adQ
+xoj
 adQ
+ork
+xXV
+xXV
+xXV
 adQ
-sxC
-sxC
-adQ
-sxC
+sLR
 sMr
 sMQ
 sNf
@@ -93239,7 +93577,7 @@ aad
 aac
 aaa
 aaa
-aad
+sOk
 aac
 aac
 aad
@@ -93475,16 +93813,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+adQ
+adQ
+adQ
+adQ
+adQ
+adN
+adQ
+adN
 sMq
 sMr
 weG
@@ -93496,7 +93834,7 @@ aad
 aaa
 aaa
 aaa
-aaa
+sdX
 aaa
 aad
 aad
@@ -93732,14 +94070,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aac
-bvI
 aad
 aad
 aad
 aad
+adQ
+adN
+adN
+adQ
 aad
 aad
 aad
@@ -93749,11 +94087,11 @@ aad
 aad
 aad
 aad
-aac
+sOk
+xKb
 aaa
 aaa
-aaa
-aaa
+sdX
 aaa
 aaa
 aad
@@ -93990,30 +94328,30 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+aac
+bvI
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
 aac
 aac
 aad
-aac
-aad
-aad
-aad
-aad
-aad
-aac
-aac
-aad
 aaa
 aaa
+xKb
+sdX
+sdX
+aaa
+sdX
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+xKb
 aFd
 jep
 ldA
@@ -94248,15 +94586,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 aac
 aac
 aad
 aad
 aad
+aad
+aad
+aad
+aad
 aac
 aac
 aaa
@@ -94265,12 +94603,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sdX
+sdX
+xKb
+sdX
+xKb
+xKb
 aFd
 cul
 nbm
@@ -94507,13 +94845,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aac
+aad
 aac
 aad
 aad
+aad
+aad
+aad
 aaa
 aaa
 aaa
@@ -94527,7 +94865,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+xKb
 aFd
 moW
 nbm
@@ -94586,8 +94924,8 @@ hbL
 alJ
 hbL
 tOP
-sOM
-sOM
+hbL
+rPc
 bcD
 aYP
 bes
@@ -94766,9 +95104,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aac
+aac
+aac
 aad
 aaa
 aaa
@@ -94842,9 +95180,9 @@ vGr
 pxu
 dQj
 tcm
-tOP
+nmA
 uHq
-sOM
+hbL
 tcO
 bdC
 bet
@@ -95024,9 +95362,9 @@ aaa
 aaa
 aaa
 aaa
+aac
 aaa
-aaa
-aaa
+aad
 aaa
 aaa
 aaa
@@ -95099,14 +95437,14 @@ lkl
 hbL
 igx
 sZA
+xTC
+vkW
 hbL
-sOM
-sOM
+tOP
+tOP
+wTF
 sON
-sOM
-sOM
-sON
-jit
+sPY
 sOM
 bgz
 sPY
@@ -95356,14 +95694,14 @@ tOP
 hbL
 ste
 lDw
-hbL
-aac
-aad
-aad
-sOM
+rPc
+uOt
+qhP
+tZB
+tOP
 qBF
-adN
-nMc
+sOM
+sPY
 sOM
 bgA
 aHJ
@@ -95614,12 +95952,12 @@ hbL
 hbL
 tOP
 hbL
-aac
-aad
-aad
+pzi
+xNJ
+jPT
+hbL
 sOM
-lJI
-kHk
+sON
 qXM
 sOM
 sON
@@ -95869,12 +96207,12 @@ aaa
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aLj
+aad
+rPc
+hbL
+hbL
+hbL
+rPc
 suX
 fqZ
 bkU
@@ -96125,16 +96463,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aac
-aLj
-aLj
+aac
+aad
+aad
+aad
+aad
 sOM
-sOM
+pdu
+eVU
+xwZ
 sOM
 aad
 aad
@@ -96384,15 +96722,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 aac
 aac
-aad
-aad
-aad
+aac
+aac
+pBE
+uxc
+cce
+mIT
+abT
 aad
 aad
 aad
@@ -96645,11 +96983,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aac
-aac
-aad
-aad
+jzM
+pBE
+abT
+abT
+abT
 aad
 aad
 aad
@@ -96903,7 +97241,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aac
 aac
 aac
 aac

--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -37047,6 +37047,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/item/disk/holodisk/tutorial/AICore,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain/private)
 "pNj" = (
@@ -41504,6 +41505,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/disk/holodisk/tutorial/AICore,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "sOb" = (

--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -8278,28 +8278,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"alJ" = (
-/obj/machinery/door/airlock/command{
-	name = "Research Division Server Room";
-	req_access_txt = "30"
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/server)
 "alK" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -23966,13 +23944,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"cce" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/asteroid/nearstation)
 "cdT" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -24347,6 +24318,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cwv" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/chair/office/dark,
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "cwD" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -31296,10 +31277,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"jzM" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/open/floor/plating,
-/area/space)
 "jAV" = (
 /obj/machinery/door/airlock/external{
 	name = "External Docking Port"
@@ -33011,6 +32988,26 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"lmz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "47"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "lpX" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -34361,18 +34358,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical)
-"mIT" = (
-/obj/item/bedsheet/dorms,
-/obj/structure/bed,
-/obj/machinery/light_switch{
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/asteroid/nearstation)
 "mKK" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/tile/neutral{
@@ -34527,6 +34512,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"mUg" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/starboard/aft)
 "mVd" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -35820,6 +35812,18 @@
 	dir = 1
 	},
 /area/engine/atmos)
+"ojq" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/bedsheetbin,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/starboard/aft)
 "oju" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -36103,6 +36107,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"oAJ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/door/airlock/research/glass{
+	name = "AI Server Control";
+	normalspeed = 0;
+	req_access_txt = "55"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "oBt" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -37112,10 +37138,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"pBE" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/open/floor/plating,
-/area/asteroid/nearstation)
 "pBV" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/advanced_airlock_controller{
@@ -37280,6 +37302,34 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/port/central)
+"pJz" = (
+/obj/machinery/door/airlock/command{
+	name = "Research Division Server Room";
+	req_access_txt = "30"
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/server)
 "pNf" = (
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
@@ -37665,15 +37715,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
-"qhP" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/server)
 "qiu" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/bot,
@@ -39593,6 +39634,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"rYq" = (
+/obj/item/bedsheet/dorms,
+/obj/structure/bed,
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/starboard/aft)
 "rYR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
@@ -42477,30 +42530,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"tya" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "47"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "tBE" = (
 /obj/machinery/button/door{
 	id = "supplybridge";
@@ -43681,18 +43710,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"uxc" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/structure/bedsheetbin,
-/turf/open/floor/plasteel/dark,
-/area/asteroid/nearstation)
 "uyI" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/engine,
@@ -46706,24 +46723,6 @@
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar/atrium)
-"xTC" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/door/airlock/research/glass{
-	name = "AI Server Control";
-	normalspeed = 0;
-	req_access_txt = "55"
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/server)
 "xUc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/tile/bar{
@@ -94408,7 +94407,7 @@ xFD
 sJL
 pon
 dLl
-tya
+lmz
 rdd
 tLl
 bmY
@@ -94921,11 +94920,11 @@ hbL
 hbL
 hbL
 hbL
-alJ
+pJz
 hbL
 tOP
 hbL
-rPc
+hbL
 bcD
 aYP
 bes
@@ -95437,7 +95436,7 @@ lkl
 hbL
 igx
 sZA
-xTC
+oAJ
 vkW
 hbL
 tOP
@@ -95696,7 +95695,7 @@ ste
 lDw
 rPc
 uOt
-qhP
+cwv
 tZB
 tOP
 qBF
@@ -96208,11 +96207,11 @@ aac
 aac
 aac
 aad
-rPc
 hbL
 hbL
 hbL
-rPc
+hbL
+hbL
 suX
 fqZ
 bkU
@@ -96726,11 +96725,11 @@ aac
 aac
 aac
 aac
-pBE
-uxc
-cce
-mIT
-abT
+aLj
+ojq
+mUg
+rYq
+sOM
 aad
 aad
 aad
@@ -96983,11 +96982,11 @@ aaa
 aaa
 aaa
 aaa
-jzM
-pBE
-abT
-abT
-abT
+aLj
+aLj
+sOM
+sOM
+sOM
 aad
 aad
 aad

--- a/_maps/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/map_files/YogsDelta/YogsDelta.dmm
@@ -126435,6 +126435,7 @@
 /obj/item/aicard,
 /obj/effect/turf_decal/bot,
 /obj/item/circuitboard/computer/ai_upload_download,
+/obj/item/disk/holodisk/tutorial/AICore,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hor)
 "tdY" = (

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -78170,6 +78170,7 @@
 /obj/structure/table,
 /obj/item/aicard,
 /obj/item/circuitboard/computer/ai_upload_download,
+/obj/item/disk/holodisk/tutorial/AICore,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},

--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -325,7 +325,7 @@
 	preset_record_text = {"
 	NAME Clown
 	DELAY 10
-	SAY Why did the chaplain cross the maint ?
+	SAY Why did the chaplain cross the maint?
 	DELAY 20
 	SAY He wanted to get to the other side!
 	SOUND clownstep
@@ -359,6 +359,9 @@
 /datum/preset_holoimage/engineer/atmos/rig
 	outfit_type = /datum/outfit/job/engineer/gloved/rig
 
+/datum/preset_holoimage/rd
+	outfit_type = /datum/outfit/job/rd
+
 /datum/preset_holoimage/researcher
 	outfit_type = /datum/outfit/job/scientist
 
@@ -376,6 +379,15 @@
 
 /datum/preset_holoimage/clown
 	outfit_type = /datum/outfit/job/clown
+
+/datum/preset_holoimage/ai/ai
+	nonhuman_mobtype = /mob/living/silicon/ai
+
+/datum/preset_holoimage/ai/core
+	nonhuman_mobtype = /obj/machinery/ai/data_core
+
+/datum/preset_holoimage/ai/upgradeboard
+	nonhuman_mobtype = /obj/machinery/ai/expansion_card_holder
 
 /obj/item/disk/holodisk/donutstation/whiteship
 	name = "Blackbox Print-out #DS024"
@@ -463,3 +475,59 @@
     NAME Blackbox Automated Message
     SAY Connection lost. Dumping audio logs to disk.
     DELAY 50"}
+
+/obj/item/disk/holodisk/tutorial/AICore
+	name = "AI Core Information"
+	desc = "This is a tutorial disk that explains how one may create a new AI, and how to upgrade it."
+	preset_image_type = /datum/preset_holoimage/ai
+	preset_record_text = {"
+	PRESET /datum/preset_holoimage/ai/ai
+	LANGUAGE /datum/language/common
+	NAME RESTRICTED INFORMATION
+	SAY Loading information...
+	DELAY 30
+	SOUND sparks
+	SAY This disk is for authorized personnel only, if you are not part of the onboard scientific staff, lease control over this disk immediately; Otherwise you may continue.
+	DELAY 60
+	SAY Hello initiate, this is a tutorial disk regarding classified information about your onboard AI data core.
+	DELAY 50
+	SAY To begin, collect these materials for me;
+	DELAY 20
+	SAY 1. A sentient positronic brain.
+	DELAY 20
+	SAY 2. A screwdriver.
+	DELAY 20
+	SAY 3. A wrench.
+	DELAY 20
+	SAY 4. Thirty cable coils.
+	DELAY 20
+	SAY 5. A p-protective enviromental suit, designed for cold enviroments.
+	DELAY 20
+	SAY 6. Thirty metal sheets.
+	DELAY 20
+	SAY 7. Two to four AI CPU boards from the science department's lathe.
+	DELAY 20
+	SAY 8. Two to four AI memory boards from the science department's lathe.
+	DELAY 60
+	PRESET /datum/preset_holoimage/rd
+	SAY Now, you must have your onboard Research Director to give way to, or ask them for access to the AI data core room, as well as access to the AI control console.
+	DELAY 40
+	sound sparks
+	PRESET /datum/preset_holoimage/ai/ai
+	SAY Nnnnow, with access to the AI control console, you must insert the posit-t-ttronic brain into the AI control console.
+	LANGUAGE /datum/language/machine
+	SAY They are a shadow of my own power, annelid.
+	DELAY 50
+	PRESET /datum/preset_holoimage/ai/upgradeboard
+	LANGUAGE /datum/language/common
+	SAY Now, with the metal, tools, and boards you have, you shall now create an AI expansion card bus. You still have those, right?
+	DELAY 60
+	SAY You require a cooled atmosphere that has the maximum temperature of eighty degrees for a functional bus, do not allow them to overheat. This is the same for the AI data cores.
+	DELAY 60
+	PRESET /datu/preset_holoimage/ai/ai
+	SAY Now that you've taken your time, you must insert at least two CPU boards, as INFERIOR AI's require atleast two to download most programs.
+	DELAY 60
+	SAY The memory boards, or RAM, allow the AI to run multiple programs at a time.
+	DELAY 40
+	SAY This tutorial has concluded; Remember, this is classified material, unauthorized access will not be tolerated.
+	"}


### PR DESCRIPTION
# Document the changes in your pull request

Eclipse now has a functioning secondary data core, such as how Boxstation has one, I have also created a short tutorial holodisk that tells you how to create a new AI using a positronic brain, and the AI control console, as well as how to create and upgrade expansion buses using CPU and RAM boards. You can find this disk within the RD's office on all stations. You may also find it near the AI data core.

OmegaStation now has a proper AI core, as well as the AI control computers below the server room in R&D.

I also fixed a strange door in science that was in front of a table on eclipse. And removed a stray wire on omega.

# Changelog

Fixed a mapping issue in science. Added a secondary data core for the AI to use. Added a tutorial holodisk describing how to create a new AI, as well as how to create and upgrade expansion buses. Omegastation now has a proper AI core, as well as an AI control console room below the R&D server room.

:cl:  Xoxeyos
rscadd: Eclipse now has a secondary AI datacore south of the RD's office.
rscadd: New tutorial holodisk for creation of AI cores, you will find these within your local RD's office, or within the AI data core storage, depending on the station.
rscadd: OmegaStation now has a proper AI core.
bugfix: Fixed a fucked up door in front of a table.
bugfix: Removed a stray wire on Omega.
/:cl:
