### PR TITLE
Bible is only antimagic if you are a true worshipper

### DIFF
--- a/code/datums/components/anti_magic.dm
+++ b/code/datums/components/anti_magic.dm
@@ -7,8 +7,9 @@
 	var/blocks_self = TRUE
 	var/datum/callback/reaction
 	var/datum/callback/expire
+	var/special_role = 0
 
-/datum/component/anti_magic/Initialize(_magic = FALSE, _holy = FALSE, _psychic = FALSE, _allowed_slots, _charges, _blocks_self = TRUE, datum/callback/_reaction, datum/callback/_expire)
+/datum/component/anti_magic/Initialize(_magic = FALSE, _holy = FALSE, _psychic = FALSE, _allowed_slots, _charges, _blocks_self = TRUE, datum/callback/_reaction, datum/callback/_expire, _special_role = 0)
 	if(isitem(parent))
 		RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, .proc/on_equip)
 		RegisterSignal(parent, COMSIG_ITEM_DROPPED, .proc/on_drop)
@@ -27,12 +28,14 @@
 	blocks_self = _blocks_self
 	reaction = _reaction
 	expire = _expire
+	special_role = _special_role
 
 /datum/component/anti_magic/proc/on_equip(datum/source, mob/equipper, slot)
 	if(!CHECK_BITFIELD(allowed_slots, slotdefine2slotbit(slot))) //Check that the slot is valid for antimagic
 		UnregisterSignal(equipper, COMSIG_MOB_RECEIVE_MAGIC)
 		return
-	RegisterSignal(equipper, COMSIG_MOB_RECEIVE_MAGIC, .proc/protect, TRUE)
+	if(equipper.mind?.holy_role >= special_role) //CONVERT OR DIE
+		RegisterSignal(equipper, COMSIG_MOB_RECEIVE_MAGIC, .proc/protect, TRUE)
 
 /datum/component/anti_magic/proc/on_drop(datum/source, mob/user)
 	UnregisterSignal(user, COMSIG_MOB_RECEIVE_MAGIC)

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -43,7 +43,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 
 /obj/item/storage/book/bible/Initialize()
 	. = ..()
-	AddComponent(/datum/component/anti_magic, FALSE, TRUE)
+	AddComponent(/datum/component/anti_magic, FALSE, TRUE, FALSE, null, null, TRUE, null, null, HOLY_ROLE_PRIEST)
 
 /obj/item/storage/book/bible/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] is offering [user.p_them()]self to [deity_name]! It looks like [user.p_theyre()] trying to commit suicide!"))


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5091394/153690421-d9559348-478e-46e6-97a4-c123363fd5f9.png)
# Document the changes in your pull request

atheists after saying "lol god isn't real" when someone say wizard is on station

![image](https://user-images.githubusercontent.com/5091394/153690600-efbfc00b-260b-4439-bb8c-07f3dd79d91b.png)

you only get the antimagic benefits if you are a true believer of your god

# Wiki Documentation

bible only work if you are a chad

# Changelog

:cl:  
tweak: no bible antimagic if you are a powergamer
/:cl:
