### PR TITLE
Fixes mining medic's PDA not being assigned to them roundstart

### DIFF
--- a/yogstation/code/modules/jobs/job_types/mining_medic.dm
+++ b/yogstation/code/modules/jobs/job_types/mining_medic.dm
@@ -48,3 +48,4 @@
 	satchel = /obj/item/storage/backpack/satchel/med
 	duffelbag = /obj/item/storage/backpack/duffelbag/med
 	box = /obj/item/storage/box/survival_mining
+	pda_slot = SLOT_L_STORE


### PR DESCRIPTION
# Document the changes in your pull request

Should fix mining medic's PDA not being assigned to them round start. Untested, should work

# Wiki Documentation

No changes needed. 

# Changelog

:cl:  
bugfix: fixed mining medic's PDA not being assigned to them round start  
/:cl:
