### PR TITLE
Miners no longer get full fire immunity

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -799,6 +799,7 @@
 	icon_state = "hardsuit-beserker"
 	item_state = "hardsuit-beserker"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/paranormal/beserker
+	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 
 /obj/item/clothing/head/helmet/space/hardsuit/ert/paranormal/beserker
 	name = "champion's helmet"


### PR DESCRIPTION
# Document the changes in your pull request

The fact that miners get a hardsuit that is fully immune to fire, outdoing both atmos suits and ce suits is pretty absurd and allows for situations where miners can become near invincible on station.

Judging by the way that stats are inherited this seems less than intentional.

# Wiki Documentation

None that i know of.

# Changelog


:cl:  
tweak: Miners can no longer get full fire immunity with the champion hardsuit.
/:cl:
