### PR TITLE
CHEESIE honkers is now considered CHEESE for mice

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -233,6 +233,10 @@ GLOBAL_VAR_INIT(mouse_killed, 0)
 	M.cheese_up()
 	qdel(src)
 
+/obj/item/reagent_containers/food/snacks/cheesiehonkers/mouse_eat(mob/living/simple_animal/mouse/M)
+	M.cheese_up()
+	qdel(src)	
+
 /obj/item/grown/bananapeel/bluespace/mouse_eat(mob/living/simple_animal/mouse/M)
 	var/teleport_radius = max(round(seed.potency / 10), 1)
 	var/turf/T = get_turf(M)


### PR DESCRIPTION

# Document the changes in your pull request

Cheesie Honkers taste like cheese, are considered dairy and are said to be cheesie snacks, they have cheese in them. Therefore mice should be able to get on that cheese grind by eating them

# Wiki Documentation

mice now cheeses up on cheesie honkers

:cl:  
rscadd: mice now cheese up on cheesie honkers
/:cl:
