### PR TITLE
Makes only the core drop the cores instead of every blob tile

### DIFF
--- a/code/modules/antagonists/blob/structures/_blob.dm
+++ b/code/modules/antagonists/blob/structures/_blob.dm
@@ -45,8 +45,6 @@
 		overmind.blobs_legit -= src  //if it was in the legit blobs list, it isn't now
 	GLOB.blobs -= src //it's no longer in the all blobs list either
 	playsound(src.loc, 'sound/effects/splat.ogg', 50, 1) //Expand() is no longer broken, no check necessary.
-	var/obj/item/assembly/signaler/anomaly/drop = new /obj/item/assembly/signaler/anomaly(src.loc)
-	drop.name = "Blob Anomaly Core"
 	return ..()
 
 /obj/structure/blob/blob_act()

--- a/code/modules/antagonists/blob/structures/core.dm
+++ b/code/modules/antagonists/blob/structures/core.dm
@@ -44,6 +44,8 @@
 	overmind = null
 	STOP_PROCESSING(SSobj, src)
 	GLOB.poi_list -= src
+	var/obj/item/assembly/signaler/anomaly/drop = new /obj/item/assembly/signaler/anomaly(src.loc)
+	drop.name = "Blob Anomaly Core"
 	return ..()
 
 /obj/structure/blob/core/ex_act(severity, target)


### PR DESCRIPTION
# Document the changes in your pull request

Sssshhhhhite

# Changelog

:cl:   
bugfix: fixes anomaly cores dropping on every blob tile destruction
/:cl:
