### PR TITLE
fixes an airlock to space on meta

### DIFF
--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -127397,7 +127397,7 @@ dbQ
 sOy
 bvo
 lpT
-uBz
+aTq
 mGy
 jLQ
 qpv
@@ -127654,7 +127654,7 @@ tzg
 eAD
 eUw
 kui
-uBz
+aTq
 vGz
 sqn
 qDJ
@@ -127911,7 +127911,7 @@ bif
 qHZ
 aTq
 iqf
-uBz
+aTq
 ujk
 xWx
 pzL
@@ -128168,7 +128168,7 @@ bjL
 mDB
 aTq
 uyP
-uBz
+aTq
 taN
 dBR
 uUY
@@ -128425,7 +128425,7 @@ aZi
 aNC
 aTq
 roF
-uBz
+aTq
 hDU
 mRy
 taj


### PR DESCRIPTION
fixes #13291


:cl:  
bugfix: fixes an airlock to space on meta
/:cl:
