### PR TITLE
Lasers/Eguns cannot be dual wielded anymore

### DIFF
--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -7,6 +7,7 @@
 	modifystate = 1
 	can_flashlight = TRUE
 	ammo_x_offset = 3
+	weapon_weight = WEAPON_MEDIUM
 	flight_x_offset = 15
 	flight_y_offset = 10
 
@@ -16,6 +17,7 @@
 	icon_state = "mini"
 	item_state = "gun"
 	w_class = WEIGHT_CLASS_SMALL
+	var/weapon_weight = WEAPON_LIGHT
 	cell_type = /obj/item/stock_parts/cell/mini_egun
 	ammo_x_offset = 2
 	charge_sections = 3

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -17,7 +17,7 @@
 	icon_state = "mini"
 	item_state = "gun"
 	w_class = WEIGHT_CLASS_SMALL
-	var/weapon_weight = WEAPON_LIGHT
+	weapon_weight = WEAPON_LIGHT
 	cell_type = /obj/item/stock_parts/cell/mini_egun
 	ammo_x_offset = 2
 	charge_sections = 3

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -4,6 +4,7 @@
 	icon_state = "laser"
 	item_state = "laser"
 	w_class = WEIGHT_CLASS_NORMAL
+	weapon_weight = WEAPON_MEDIUM
 	materials = list(/datum/material/iron=2000)
 	ammo_type = list(/obj/item/ammo_casing/energy/lasergun)
 	ammo_x_offset = 1
@@ -85,6 +86,7 @@
 	icon_state = "lasercannon"
 	item_state = "laser"
 	w_class = WEIGHT_CLASS_BULKY
+	weapon_weight = WEAPON_MEDIUM
 	force = 10
 	flags_1 =  CONDUCT_1
 	slot_flags = ITEM_SLOT_BACK
@@ -114,6 +116,7 @@
 	desc = "A high-power laser gun capable of expelling concentrated X-ray blasts that pass through multiple soft targets and heavier materials."
 	icon_state = "xray"
 	item_state = null
+	weapon_weight = WEAPON_MEDIUM
 	ammo_type = list(/obj/item/ammo_casing/energy/xray)
 	pin = null
 	ammo_x_offset = 3


### PR DESCRIPTION
# Document the changes in your pull request

Dual-wielding is hilariously unbalanced in its current state, currently you can dual-wield lasers for 40 damage PER SHOT, allowing you to get what amounts to better melee/short range damage than an esword, which is probably bad.
You can still duel wield disablers.

# Wiki Documentation

Probably none

# Changelog

:cl:  
tweak: You cannot dual-wield lasers for 40 damage anymore
/:cl:
