### PR TITLE
makes marker beacons get turned off by veil

### DIFF
--- a/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
@@ -175,6 +175,10 @@
 		if(istype(LO, /obj/machinery/power/floodlight))
 			var/obj/machinery/power/floodlight/FL = LO
 			FL.change_setting(2) // Set floodlight to lowest setting
+		if(istype(LO, /obj/item/stack/marker_beacon))
+			LO.set_light(0)
+			continue
+			
 
 	for(var/obj/structure/glowshroom/G in orange(7, user)) //High radius because glowshroom spam wrecks shadowlings
 		if(!istype(G, /obj/structure/glowshroom/shadowshroom))


### PR DESCRIPTION
fixes #13260
decided not to do spraypaint since you can also just pick em up to turn em off

:cl:  
bugfix: veil now darkens marker beacons  
/:cl:
