### PR TITLE
Adds binary valves to AI sats

### DIFF
--- a/_maps/map_files/EclipseStation/EclipseStation.dmm
+++ b/_maps/map_files/EclipseStation/EclipseStation.dmm
@@ -71919,11 +71919,11 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/valve/digital/layer2{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
@@ -85873,6 +85873,15 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"mzm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/machinery/atmospherics/components/binary/valve/digital/layer2,
+/turf/open/floor/plasteel,
+/area/tcommsat/entrance)
 "mBx" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -135570,7 +135579,7 @@ aaa
 caG
 cJv
 cLB
-cMR
+mzm
 cNB
 cMR
 cMR

--- a/_maps/map_files/IceBox/IceBox.dmm
+++ b/_maps/map_files/IceBox/IceBox.dmm
@@ -62978,8 +62978,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/components/binary/valve/digital/layer2,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "uNH" = (

--- a/_maps/map_files/YogsBox/YogsBox.dmm
+++ b/_maps/map_files/YogsBox/YogsBox.dmm
@@ -49561,8 +49561,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "nWL" = (
-/obj/machinery/atmospherics/components/binary/valve/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/components/binary/valve/digital/layer2,
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
 "nXu" = (

--- a/_maps/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/map_files/YogsDelta/YogsDelta.dmm
@@ -60081,7 +60081,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/atmospherics/components/binary/valve/digital/layer2{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -77500,12 +77500,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "rkZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/mapping_helpers/teleport_anchor,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/binary/valve/digital/layer2{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)


### PR DESCRIPTION
# Document the changes in your pull request

Adds binary valves to all the pipe nets that lead from distro into the AI sat.
Also changes YogsBox's simple valve into a binary so the AI can interact with it.

# Wiki Documentation

None needed, a repicture if you really want but its litteraly just one pipe.

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
rscadd: AI sats that lead into distro now have valves seperating distro and AI sat, YogsBox's valve has been changed to a digital one.
/:cl:
