### PR TITLE
AI Core Holodisk now appears on YogsBox.

### DIFF
--- a/_maps/map_files/YogsBox/YogsBox.dmm
+++ b/_maps/map_files/YogsBox/YogsBox.dmm
@@ -23942,6 +23942,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/item/disk/holodisk/tutorial/AICore,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
 "byt" = (
@@ -53524,6 +53525,7 @@
 	pixel_x = 6;
 	pixel_y = 2
 	},
+/obj/item/disk/holodisk/tutorial/AICore,
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "qoE" = (


### PR DESCRIPTION
# Document the changes in your pull request

The tutorial holodisk for the creation of an AI, and the explanation of how to upgrade one is now available on YogsBox.

# Changelog

The AI Core tutorial disk can now be found on YogsBox in the RD's office, and AI sat.

:cl: Xoxeyos
rscadd: AI Core Tutorial disk can now be found in the RD's office and AI sat on YogsBox.
/:cl:
