### PR TITLE
Adds variation to traitor motives

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -246,13 +246,13 @@
 	owner.announce_objectives()
 	if(should_give_codewords)
 		give_codewords()
-	if obj_severity <= 3
+	if obj_severity <= (3)
 		to_chat(owner.current, span_notice("Your employer [initial(company.name)] will be paying you an extra [initial(company.paymodifier)]x your nanotrasen paycheck."))
-	else if obj_severity = 4
+	else if obj_severity = (4)
 		to_chat(owner.current, span_notice("Your employer [initial(company.name)] have made some ominous threats and kindly encouraged you to succeed."))
-	else if obj_severity <= 6
+	else if obj_severity <= (6)
 		to_chat(owner.current, span_notice("Your employer [initial(company.name)] have taken someone close to you. This is the only way to save them."))
-	else if obj_severity >= 7
+	else if obj_severity >= (7)
 		to_chat(owner.current, span_notice("Your masters at [initial(company.name)] have done something strange and wonderful to your mind... you owe them so much more than they are asking of you."))
 		
 

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -211,7 +211,7 @@
 			steal_objective.owner = owner
 			steal_objective.find_target()
 			add_objective(steal_objective)
-			obj_severity += 1
+			obj_severity += 2
 
 /datum/antagonist/traitor/proc/forge_single_AI_objective()
 	.=1

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -129,7 +129,7 @@
 		var/datum/objective/martyr/martyr_objective = new
 		martyr_objective.owner = owner
 		add_objective(martyr_objective)
-		obj_severity += 5
+		obj_severity += 6
 		return
 
 	else

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -115,7 +115,7 @@
 			var/datum/objective/hijack/hijack_objective = new
 			hijack_objective.owner = owner
 			add_objective(hijack_objective)
-			obj_severity = obj_severity + 5
+			obj_severity += 5
 			return
 
 
@@ -129,7 +129,7 @@
 		var/datum/objective/martyr/martyr_objective = new
 		martyr_objective.owner = owner
 		add_objective(martyr_objective)
-		obj_severity = obj_severity + 5
+		obj_severity += 5
 		return
 
 	else
@@ -185,7 +185,7 @@
 			destroy_objective.owner = owner
 			destroy_objective.find_target()
 			add_objective(destroy_objective)
-			obj_severity = obj_severity + 2
+			obj_severity += 2
 		else if(prob(30))
 			var/datum/objective/maroon/maroon_objective = new
 			maroon_objective.owner = owner
@@ -248,7 +248,7 @@
 		give_codewords()
 	if (obj_severity <= 3)
 		to_chat(owner.current, span_notice("Your employer [initial(company.name)] will be paying you an extra [initial(company.paymodifier)]x your nanotrasen paycheck."))
-	else if (obj_severity = 4)
+	else if (obj_severity == 4)
 		to_chat(owner.current, span_notice("Your employer [initial(company.name)] have made some ominous threats and kindly encouraged you to succeed."))
 	else if (obj_severity <= 6)
 		to_chat(owner.current, span_notice("Your employer [initial(company.name)] have taken someone close to you. This is the only way to save them."))

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -191,27 +191,27 @@
 			maroon_objective.owner = owner
 			maroon_objective.find_target()
 			add_objective(maroon_objective)
-			obj_severity = obj_severity += 2
+			obj_severity += 2
 		else
 			var/N = pick(/datum/objective/assassinate, /datum/objective/assassinate/cloned, /datum/objective/assassinate/once)
 			var/datum/objective/assassinate/kill_objective = new N
 			kill_objective.owner = owner
 			kill_objective.find_target()
 			add_objective(kill_objective)
-			obj_severity = obj_severity += 4
+			obj_severity += 4
 	else
 		if(prob(15) && !(locate(/datum/objective/download) in objectives) && !(owner.assigned_role in list("Research Director", "Scientist", "Roboticist")))
 			var/datum/objective/download/download_objective = new
 			download_objective.owner = owner
 			download_objective.gen_amount_goal()
 			add_objective(download_objective)
-			obj_severity = obj_severity += 1
+			obj_severity += 1
 		else
 			var/datum/objective/steal/steal_objective = new
 			steal_objective.owner = owner
 			steal_objective.find_target()
 			add_objective(steal_objective)
-			obj_severity = obj_severity += 1
+			obj_severity += 1
 
 /datum/antagonist/traitor/proc/forge_single_AI_objective()
 	.=1

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -246,13 +246,13 @@
 	owner.announce_objectives()
 	if(should_give_codewords)
 		give_codewords()
-	if obj_severity <= (3)
+	if (obj_severity <= 3)
 		to_chat(owner.current, span_notice("Your employer [initial(company.name)] will be paying you an extra [initial(company.paymodifier)]x your nanotrasen paycheck."))
-	else if obj_severity = (4)
+	else if (obj_severity = 4)
 		to_chat(owner.current, span_notice("Your employer [initial(company.name)] have made some ominous threats and kindly encouraged you to succeed."))
-	else if obj_severity <= (6)
+	else if (obj_severity <= 6)
 		to_chat(owner.current, span_notice("Your employer [initial(company.name)] have taken someone close to you. This is the only way to save them."))
-	else if obj_severity >= (7)
+	else if (obj_severity >= 7)
 		to_chat(owner.current, span_notice("Your masters at [initial(company.name)] have done something strange and wonderful to your mind... you owe them so much more than they are asking of you."))
 		
 

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -9,6 +9,7 @@
 	antag_moodlet = /datum/mood_event/focused
 	var/special_role = ROLE_TRAITOR
 	var/employer = "The Syndicate"
+	var/obj_severity = 0
 	var/give_objectives = TRUE
 	var/should_give_codewords = TRUE
 	var/should_equip = TRUE
@@ -114,6 +115,7 @@
 			var/datum/objective/hijack/hijack_objective = new
 			hijack_objective.owner = owner
 			add_objective(hijack_objective)
+			obj_severity = obj_severity + 5
 			return
 
 
@@ -127,6 +129,7 @@
 		var/datum/objective/martyr/martyr_objective = new
 		martyr_objective.owner = owner
 		add_objective(martyr_objective)
+		obj_severity = obj_severity + 5
 		return
 
 	else
@@ -182,28 +185,33 @@
 			destroy_objective.owner = owner
 			destroy_objective.find_target()
 			add_objective(destroy_objective)
+			obj_severity = obj_severity + 2
 		else if(prob(30))
 			var/datum/objective/maroon/maroon_objective = new
 			maroon_objective.owner = owner
 			maroon_objective.find_target()
 			add_objective(maroon_objective)
+			obj_severity = obj_severity + 2
 		else
 			var/N = pick(/datum/objective/assassinate, /datum/objective/assassinate/cloned, /datum/objective/assassinate/once)
 			var/datum/objective/assassinate/kill_objective = new N
 			kill_objective.owner = owner
 			kill_objective.find_target()
 			add_objective(kill_objective)
+			obj_severity = obj_severity + 4
 	else
 		if(prob(15) && !(locate(/datum/objective/download) in objectives) && !(owner.assigned_role in list("Research Director", "Scientist", "Roboticist")))
 			var/datum/objective/download/download_objective = new
 			download_objective.owner = owner
 			download_objective.gen_amount_goal()
 			add_objective(download_objective)
+			obj_severity = obj_severity + 1
 		else
 			var/datum/objective/steal/steal_objective = new
 			steal_objective.owner = owner
 			steal_objective.find_target()
 			add_objective(steal_objective)
+			obj_severity = obj_severity + 1
 
 /datum/antagonist/traitor/proc/forge_single_AI_objective()
 	.=1
@@ -238,7 +246,15 @@
 	owner.announce_objectives()
 	if(should_give_codewords)
 		give_codewords()
-	to_chat(owner.current, span_notice("Your employer [initial(company.name)] will be paying you an extra [initial(company.paymodifier)]x your nanotrasen paycheck."))
+	if obj_severity <= 3
+		to_chat(owner.current, span_notice("Your employer [initial(company.name)] will be paying you an extra [initial(company.paymodifier)]x your nanotrasen paycheck."))
+	else if obj_severity = 4
+		to_chat(owner.current, span_notice("Your employer [initial(company.name)] have made some ominous threats and kindly encouraged you to succeed."))
+	else if obj_severity <= 6
+		to_chat(owner.current, span_notice("Your employer [initial(company.name)] have taken someone close to you. This is the only way to save them."))
+	else if obj_severity >= 7
+		to_chat(owner.current, span_notice("Your masters at [initial(company.name)] have done something strange and wonderful to your mind... you owe them so much more than they are asking of you."))
+		
 
 /datum/antagonist/traitor/proc/update_traitor_icons_added(datum/mind/traitor_mind)
 	var/datum/atom_hud/antag/traitorhud = GLOB.huds[ANTAG_HUD_TRAITOR]

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -191,27 +191,27 @@
 			maroon_objective.owner = owner
 			maroon_objective.find_target()
 			add_objective(maroon_objective)
-			obj_severity = obj_severity + 2
+			obj_severity = obj_severity += 2
 		else
 			var/N = pick(/datum/objective/assassinate, /datum/objective/assassinate/cloned, /datum/objective/assassinate/once)
 			var/datum/objective/assassinate/kill_objective = new N
 			kill_objective.owner = owner
 			kill_objective.find_target()
 			add_objective(kill_objective)
-			obj_severity = obj_severity + 4
+			obj_severity = obj_severity += 4
 	else
 		if(prob(15) && !(locate(/datum/objective/download) in objectives) && !(owner.assigned_role in list("Research Director", "Scientist", "Roboticist")))
 			var/datum/objective/download/download_objective = new
 			download_objective.owner = owner
 			download_objective.gen_amount_goal()
 			add_objective(download_objective)
-			obj_severity = obj_severity + 1
+			obj_severity = obj_severity += 1
 		else
 			var/datum/objective/steal/steal_objective = new
 			steal_objective.owner = owner
 			steal_objective.find_target()
 			add_objective(steal_objective)
-			obj_severity = obj_severity + 1
+			obj_severity = obj_severity += 1
 
 /datum/antagonist/traitor/proc/forge_single_AI_objective()
 	.=1


### PR DESCRIPTION
# Document the changes in your pull request

https://forums.yogstation.net/threads/expand-on-the-last-line-of-the-traitor-alert.24591/
> -Add a greater variety of incentives for traitors.
> -Make the strength of the traitor’s incentive scale to their objectives - it’s fine and good for variety if the incentive is more than strong enough, but lowballing it like we do is just insane.

I don't know how to code but this is an attempt at a foundation of that

# Changelog

:cl:  
rscadd: Traitors will now require a bit more than a small pay bonus to kill the entire station
/:cl:
