### PR TITLE
Adds area restriction to Particle Accelerator, now you can only grief the engine room

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -7921,19 +7921,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation)
-"tT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/particle_accelerator/end_cap,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/engineering,
-/obj/structure/particle_accelerator/fuel_chamber,
-/obj/structure/particle_accelerator/particle_emitter/center,
-/obj/structure/particle_accelerator/particle_emitter/right,
-/obj/structure/particle_accelerator/power_box,
-/obj/structure/particle_accelerator/particle_emitter/left,
-/obj/machinery/particle_accelerator/control_box,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/deltacorridor)
 "tW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -8665,6 +8652,19 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
+/area/ruin/space/has_grav/ancientstation/deltacorridor)
+"SX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/particle_accelerator/end_cap,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/engineering,
+/obj/structure/particle_accelerator/fuel_chamber,
+/obj/structure/particle_accelerator/particle_emitter/center,
+/obj/structure/particle_accelerator/particle_emitter/right,
+/obj/structure/particle_accelerator/power_box,
+/obj/structure/particle_accelerator/particle_emitter/left,
+/obj/machinery/particle_accelerator/control_box/charlie,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "Td" = (
 /obj/item/stack/rods,
@@ -12808,7 +12808,7 @@ dh
 dh
 dh
 dh
-tT
+SX
 bE
 Ve
 dh

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -19,6 +19,10 @@
 	var/strength = 0
 	var/powered = FALSE
 	mouse_opacity = MOUSE_OPACITY_OPAQUE
+	var/area_restricted = TRUE //is this PA locked to area/engine or not?
+	var/locked = TRUE //can are_restricted be toggled?
+	req_access = list(ACCESS_CE)
+	var/mob/living/operator
 
 /obj/machinery/particle_accelerator/control_box/Initialize()
 	. = ..()
@@ -118,6 +122,10 @@
 			toggle_power()
 			update_icon()
 			return
+		if(area_restricted && !istype(get_turf(src),/area/engine))
+			investigate_log("had its area restriction turned on while in an invalid area; It <font color='red'>powered down</font>.", INVESTIGATE_SINGULO)
+			toggle_power()
+			update_icon()
 		//emit some particles
 		for(var/obj/structure/particle_accelerator/particle_emitter/PE in connected_parts)
 			PE.emit_particle(strength)
@@ -173,6 +181,11 @@
 
 
 /obj/machinery/particle_accelerator/control_box/proc/toggle_power()
+	if(area_restricted)
+		var/area/A = get_area(src)
+		if(!istype(A,/area/engine))
+			src.visible_message("Restricted area detected! Aborting.")
+			return
 	active = !active
 	investigate_log("turned [active?"<font color='green'>ON</font>":"<font color='red'>OFF</font>"] by [usr ? key_name(usr) : "outside forces"] at [AREACOORD(src)]", INVESTIGATE_SINGULO)
 	message_admins("PA Control Computer turned [active ?"ON":"OFF"] by [usr ? ADMIN_LOOKUPFLW(usr) : "outside forces"] in [ADMIN_VERBOSEJMP(src)]")
@@ -260,6 +273,16 @@
 
 	..()
 
+/obj/machinery/particle_accelerator/control_box/emag_act(mob/user)
+	if(obj_flags & EMAGGED)
+		return
+	obj_flags |= EMAGGED
+	visible_message(span_warning("Sparks fly out of [src]!"), span_notice("You emag [src], disabling its safeties."))
+	locked = FALSE
+	area_restricted = FALSE
+	playsound(src, "sparks", 50, 1)
+
+
 /obj/machinery/particle_accelerator/control_box/blob_act(obj/structure/blob/B)
 	if(prob(50))
 		qdel(src)
@@ -281,9 +304,12 @@
 /obj/machinery/particle_accelerator/control_box/ui_status(mob/user)
 	if(is_interactive(user))
 		return ..()
+	if(operator == user)
+		operator = null
 	return UI_CLOSE
 
 /obj/machinery/particle_accelerator/control_box/ui_interact(mob/user, datum/tgui/ui)
+	operator = user
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "ParticleAccelerator", name)
@@ -294,6 +320,8 @@
 	data["assembled"] = assembled
 	data["power"] = active
 	data["strength"] = strength
+	data["locked"] = locked
+	data["area_restricted"] = area_restricted
 	return data
 
 /obj/machinery/particle_accelerator/control_box/ui_act(action, params)
@@ -319,8 +347,38 @@
 				return
 			remove_strength()
 			. = TRUE
+		if("toggle_lock")
+			if(!operator)
+				return
+			if(!allowed(operator))
+				to_chat(operator, span_danger("Access denied."))
+				return
+			if(obj_flags & EMAGGED)
+				to_chat(operator,"The locking mechanism glitches out.")
+				area_restricted = FALSE //sanity check
+				return
+			locked = !locked
+			to_chat(operator, "You [locked ? "enable" : "disable"] the toggle lock.")
+			. = TRUE
+		if("toggle_arearestriction")
+			if(!operator) 
+				return
+			if(obj_flags & EMAGGED)
+				to_chat(operator,"The area restriction mechanism glitches out.")
+				area_restricted = FALSE //sanity check
+				return
+			if(locked)
+				to_chat(operator, "The toggle is locked!")
+				return
+			area_restricted = !area_restricted
+			to_chat(operator, "You [locked ? "enable" : "disable"] the area restriction.");
+			. = TRUE
 
 	update_icon()
+
+/obj/machinery/particle_accelerator/control_box/charlie //for charlie station
+	locked = FALSE
+	area_restricted = FALSE
 
 #undef PA_CONSTRUCTION_UNSECURED
 #undef PA_CONSTRUCTION_UNWIRED

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -355,7 +355,7 @@
 				return
 			if(obj_flags & EMAGGED)
 				to_chat(operator,"The locking mechanism glitches out.")
-				area_restricted = FALSE //sanity check
+				locked = FALSE //sanity check
 				return
 			locked = !locked
 			to_chat(operator, "You [locked ? "enable" : "disable"] the toggle lock.")

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -181,7 +181,7 @@
 
 
 /obj/machinery/particle_accelerator/control_box/proc/toggle_power()
-	if(area_restricted)
+	if(active && area_restricted)
 		var/area/A = get_area(src)
 		if(!istype(A,/area/engine))
 			src.visible_message("Restricted area detected! Aborting.")

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -181,7 +181,7 @@
 
 
 /obj/machinery/particle_accelerator/control_box/proc/toggle_power()
-	if(active && area_restricted)
+	if(!active && area_restricted)
 		var/area/A = get_area(src)
 		if(!istype(A,/area/engine))
 			src.visible_message("Restricted area detected! Aborting.")

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -273,16 +273,6 @@
 
 	..()
 
-/obj/machinery/particle_accelerator/control_box/emag_act(mob/user)
-	if(obj_flags & EMAGGED)
-		return
-	obj_flags |= EMAGGED
-	visible_message(span_warning("Sparks fly out of [src]!"), span_notice("You emag [src], disabling its safeties."))
-	locked = FALSE
-	area_restricted = FALSE
-	playsound(src, "sparks", 50, 1)
-
-
 /obj/machinery/particle_accelerator/control_box/blob_act(obj/structure/blob/B)
 	if(prob(50))
 		qdel(src)

--- a/tgui/packages/tgui/interfaces/ParticleAccelerator.js
+++ b/tgui/packages/tgui/interfaces/ParticleAccelerator.js
@@ -9,11 +9,14 @@ export const ParticleAccelerator = (props, context) => {
     assembled,
     power,
     strength,
+    locked,
+    area_restricted
   } = data;
+
   return (
     <Window
       width={350}
-      height={185}>
+      height={200}>
       <Window.Content>
         <Section>
           <LabeledList>
@@ -30,6 +33,26 @@ export const ParticleAccelerator = (props, context) => {
                   ? "Ready - All parts in place"
                   : "Unable to detect all parts"}
               </Box>
+            </LabeledList.Item>
+          </LabeledList>
+        </Section>
+        <Section>
+          <LabeledList>
+            <LabeledList.Item
+              label="Area Restriction"
+              buttons={(
+                <Button
+                  icon={"sync"}
+                  tooltip="Requires CE level access."
+                  content={locked ? "Disable Restriction" : "Enable Restriction"}
+                  selected={locked}
+                  onClick={() => act('toggle_lock')} />
+              )}>
+              <Button
+                icon={area_restricted ? 'power-off' : 'times'}
+                content={area_restricted ? 'On' : 'Off'}
+                selected={area_restricted}
+                onClick={() => act('toggle_arearestriction')} />
             </LabeledList.Item>
           </LabeledList>
         </Section>

--- a/tgui/packages/tgui/interfaces/ParticleAccelerator.js
+++ b/tgui/packages/tgui/interfaces/ParticleAccelerator.js
@@ -10,7 +10,7 @@ export const ParticleAccelerator = (props, context) => {
     power,
     strength,
     locked,
-    area_restricted
+    area_restricted,
   } = data;
 
   return (

--- a/tgui/packages/tgui/interfaces/ParticleAccelerator.js
+++ b/tgui/packages/tgui/interfaces/ParticleAccelerator.js
@@ -16,7 +16,7 @@ export const ParticleAccelerator = (props, context) => {
   return (
     <Window
       width={350}
-      height={200}>
+      height={220}>
       <Window.Content>
         <Section>
           <LabeledList>

--- a/yogstation/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/yogstation/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -5,6 +5,8 @@
 	if(obj_flags & EMAGGED)
 		return
 	to_chat(user, span_danger("The laws of physics no longer apply in the future, god help you..."))
+	locked = FALSE
+	area_restricted = FALSE
 	SSachievements.unlock_achievement(/datum/achievement/engineering/pa_emag, user.client)
 	do_sparks(5, 0, src)
 	obj_flags |= EMAGGED


### PR DESCRIPTION
# Document the changes in your pull request

Particle Accelerator only turns on if it is in an /area/engine. This includes pretty much all of engineering (and not cargo shuttle).

For cargo fuckery, get captain/CE/AI/rogue guy that has AA to unlock the area restriction for you by pressing "Disable Restriction". Anyone is then able to toggle the area restriction. Emagging also perma unlocks and disables the restriction.

![image](https://user-images.githubusercontent.com/5091394/155034848-d688f17b-dc72-49b9-932c-816f32db54f9.png)


Charlie station gets a special control box that is already unlocked and unrestricted, for making their own singulo. That's the map change.

# Wiki Documentation

new controls, will have to be added to the "how to control PA" part.

# Changelog

:cl:  
rscadd: toggleable area restriction on particle accelerator
/:cl:
