### PR TITLE
Converts the sleepy pen to a medipen

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -29,7 +29,7 @@
 
 		if("stealth")
 			new /obj/item/gun/energy/kinetic_accelerator/crossbow(src)
-			new /obj/item/pen/sleepy(src)
+			new /obj/item/reagent_containers/hypospray/medipen/sleepy(src)
 			new /obj/item/healthanalyzer/rad_laser(src)
 			new /obj/item/chameleon(src)
 			new /obj/item/soap/syndie(src)
@@ -325,7 +325,7 @@
 		/obj/item/storage/box/syndie_kit/throwing_weapons,
 		/obj/item/gun/syringe/syndicate,
 		/obj/item/pen/edagger,
-		/obj/item/pen/sleepy,
+		/obj/item/reagent_containers/hypospray/medipen/sleepy,
 		/obj/item/flashlight/emp,
 		/obj/item/reagent_containers/syringe/mulligan,
 		/obj/item/clothing/shoes/chameleon/noslip/syndicate,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -231,7 +231,7 @@
 					/obj/item/grenade/smokebomb,
 					/obj/item/grenade/smokebomb,
 					/obj/item/grenade/smokebomb,
-					/obj/item/pen/sleepy,
+					/obj/item/reagent_containers/hypospray/medipen/sleepy,
 					/obj/item/grenade/chem_grenade/incendiary)
 	crate_name = "emergency crate"
 	crate_type = /obj/structure/closet/crate/internals

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -152,6 +152,7 @@
  * Sleepypens
  */
 
+/*	Has been replaced by /obj/item/reagent_containers/hypospray/medipen/sleepy
 /obj/item/pen/sleepy/attack(mob/living/M, mob/user)
 	if(!is_syndicate(user)) // if non syndicate , it is just a regular pen as they don't know how to activate hidden payload.
 		. = ..()
@@ -174,6 +175,7 @@
 	reagents.add_reagent(/datum/reagent/toxin/staminatoxin, 10)
 	reagents.add_reagent(/datum/reagent/toxin/pancuronium, 7)
 	reagents.add_reagent(/datum/reagent/toxin/sodium_thiopental, 23)
+*/
 
 /*
  * (Alan) Edaggers

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -228,3 +228,13 @@
 	desc = "All-purpose snail medicine! Do not use on non-snails!"
 	list_reagents = list(/datum/reagent/snail = 10)
 	icon_state = "snail" */ //yogs we removed snail people cause we are bad people who hate fun
+
+/obj/item/reagent_containers/hypospray/medipen/sleepy
+	volume = 75
+	amount_per_transfer_from_this = 75
+	list_reagents = list(/datum/reagent/toxin/chloralhydrate = 20, /datum/reagent/toxin/mutetoxin = 15, /datum/reagent/toxin/staminatoxin = 10, /datum/reagent/toxin/pancuronium = 7, /datum/reagent/toxin/sodium_thiopental = 23)
+
+/obj/item/reagent_containers/hypospray/medipen/sleepy/examine(mob/user)
+	. = ..()
+	if(!(reagents && reagents.reagent_list.len) && in_range(src, user))
+		. += span_notice("There is a small 'S' ingraved on the needle.")

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -237,4 +237,4 @@
 /obj/item/reagent_containers/hypospray/medipen/sleepy/examine(mob/user)
 	. = ..()
 	if(!(reagents && reagents.reagent_list.len) && in_range(src, user))
-		. += span_notice("There is a small 'S' ingraved on the needle.")
+		. += span_notice("There is a small 'S' engraved on the needle.")

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -656,11 +656,10 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/stealthy_weapons/sleepy_pen
 	name = "Sleepy Pen"
-	desc = "A syringe disguised as a functional pen, filled with a potent mix of drugs, including a \
+	desc = "A medipen filled with a potent mix of drugs, including a \
 			strong anesthetic and a chemical that prevents the target from speaking. \
-			The pen holds one dose of the mixture. Note that before the target \
-			falls asleep, they will be able to move and act."
-	item = /obj/item/pen/sleepy
+			Note that before the target falls asleep they will be able to move and act."
+	item = /obj/item/reagent_containers/hypospray/medipen/sleepy
 	cost = 4
 	manufacturer = /datum/corporation/traitor/waffleco
 	exclude_modes = list(/datum/game_mode/nuclear)


### PR DESCRIPTION
# Document the changes in your pull request

Makes the sleepy pen a subtype of medipen instead of a regular pen, which It makes the hypospray sound when used. Also added a line to inspection when it is used and you're next to it. Is tested, does work.

![image](https://user-images.githubusercontent.com/14363906/155249731-5bb1f337-0fa1-4875-b13e-a2dda7fc8990.png)

# Wiki Documentation

The entry in the traitor items will need to be updated. 

# Changelog

:cl:  
tweak: the sleepy pen is now a type of medipen instead of a regular pen with chemicals inside
tweak: added a line to the inspection text for sleepy pens when it is used and you're next to it
/:cl:
