### PR TITLE
Removes the formaldehyde from medipens so you dont take like 3 toxin damage every time you use one

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1488,8 +1488,7 @@
 // helps bleeding wounds clot faster
 /datum/reagent/medicine/coagulant
 	name = "Sanguirite"
-	description = "A coagulant used to help open cuts clot faster."
-	description = "A proprietary coagulant used to help bleeding wounds clot faster."
+	description = "A proprietary coagulant used to help bleeding wounds clot faster, as well as slow organ decay."
 	reagent_state = LIQUID
 	color = "#bb2424"
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
@@ -1502,11 +1501,13 @@
 	var/was_working
 
 /datum/reagent/medicine/coagulant/on_mob_metabolize(mob/living/M)
-	ADD_TRAIT(M, TRAIT_COAGULATING, /datum/reagent/medicine/coagulant)
+	ADD_TRAIT(M, TRAIT_COAGULATING, type)
+	ADD_TRAIT(M, TRAIT_PRESERVED_ORGANS, type)
 	return ..()
 
 /datum/reagent/medicine/coagulant/on_mob_end_metabolize(mob/living/M)
-	REMOVE_TRAIT(M, TRAIT_COAGULATING, /datum/reagent/medicine/coagulant)
+	REMOVE_TRAIT(M, TRAIT_COAGULATING, type)
+	REMOVE_TRAIT(M, TRAIT_PRESERVED_ORGANS, type)
 	return ..()
 
 /datum/reagent/medicine/coagulant/on_mob_life(mob/living/carbon/M)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -105,12 +105,12 @@
 	item_state = "medipen"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
-	amount_per_transfer_from_this = 15
-	volume = 15
+	amount_per_transfer_from_this = 12
+	volume = 12
 	ignore_flags = 1 //so you can medipen through hardsuits
 	reagent_flags = DRAWABLE
 	flags_1 = null
-	list_reagents = list(/datum/reagent/medicine/epinephrine = 10, /datum/reagent/toxin/formaldehyde = 3, /datum/reagent/medicine/coagulant = 2)
+	list_reagents = list(/datum/reagent/medicine/epinephrine = 10, /datum/reagent/medicine/coagulant = 2)
 	custom_price = 40
 
 /obj/item/reagent_containers/hypospray/medipen/suicide_act(mob/living/carbon/user)


### PR DESCRIPTION
# Document the changes in your pull request

Also lets coagulant stabilize organs

This is mainly because formaldehyde has a small chance to try to murder you when metabolized and while it usually wont succeed its chances are best when attacking someone who is already wounded which is the likely use case of the medipen

Shouldnt effect medbay otherwise because you cant make coagulant without botany and botany legally doesnt exist for any other department so if you really need corpses to not decay you still have to use formaldehyde

# Wiki Documentation

Emergency medipens no longer have 3 units of formaldehyde inside them
Coagulants stop organ decay because blood magic

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
Tweak: epinephrine medipens now use coagulant rather than formaldehyde to prevent organ decay, also coagulant now prevents organ decay due to blood magic
/:cl:
