### PR TITLE
Big warning comment at the top of the podpeople.dm file to let people know that's not the player race file

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -1,4 +1,9 @@
 // yogs - This file is mirrored to plantpeople.dm
+/*
+THIS FILE IS UNUSED AND NOT THE CORRECT FILE FOR WORKING WITH THE PLAYER CONTROLLED PODPEOPLE.
+yogstation\code\modules\mob\living\carbon\human\species_types\plantpeople.dm IS THE PLAYER RACE FOR PLANT PEOPLE
+DISREGUARD THIS FILE IF YOU'RE INTENDING TO CHANGE ASPECTS OF PLAYER CONTROLLED POD PEOPLE
+*/
 /datum/species/pod
 	// A mutation caused by a human being ressurected in a revival pod. These regain health in light, and begin to wither in darkness.
 	name = "Podperson"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/46236974/155433470-d1a20692-18e2-43c1-88d4-6a5889dd4b78.png)
![image](https://user-images.githubusercontent.com/46236974/155433515-a52188b9-ff5e-48f2-9082-7038ead60c4b.png)
![image](https://user-images.githubusercontent.com/46236974/155433545-6f5ba58b-337b-43c9-b516-46eb70ac243f.png)

There now you don't have to Reed

We can try just removing the file later since it's seemingly unused, but for now a big warning sticker

# Changelog

:cl:  
rscadd: Big warning comment on plantpeople.dm letting people know that's not the right file for player controlled plant people
/:cl:
