### PR TITLE
Felinids *wag is no longer stopped by stuns

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1969,7 +1969,6 @@ GLOBAL_LIST_EMPTY(mentor_races)
 		ToggleFlight(H)
 		flyslip(H)
 	. = stunmod * H.physiology.stun_mod * amount
-	stop_wagging_tail(H)
 
 //////////////
 //Space Move//

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -39,6 +39,10 @@
 
 	return randname
 
+/datum/species/lizard/spec_stun(mob/living/carbon/human/H, amount)
+	. = ..()
+	stop_wagging_tail(H)
+
 /*
  Lizard subspecies: ASHWALKERS
 */


### PR DESCRIPTION
https://forums.yogstation.net/threads/stuns-should-not-stop-tail-wagging.24737/#post-208622

# Document the changes in your pull request

this of course means that i just made it so species naturally don't stop wagging their tail, and then overriding that behavior for st*nky lizards to stop wagging (racism)

# Wiki Documentation

None

# Changelog

:cl:  ToasterBiome, Sniblet
rscadd: adds lizard specific tail wagging stoppage while stunned 
tweak: removes tail wagging from species spec_stun
/:cl:
