### PR TITLE
Fixes tails being able to start wagging when stunned or paralyzed

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1990,6 +1990,8 @@ GLOBAL_LIST_EMPTY(mentor_races)
 ////////////////
 
 /datum/species/proc/can_wag_tail(mob/living/carbon/human/H)
+	if(H.IsParalyzed() || H.IsStun())
+		return FALSE
 	return (H.getorganslot(ORGAN_SLOT_TAIL))
 
 /datum/species/proc/is_wagging_tail(mob/living/carbon/human/H)


### PR DESCRIPTION
Credit for finding this oversight goes to @Sniblet in #13341 :
![image](https://user-images.githubusercontent.com/24533979/155865621-96b1f9ac-a3d1-4dcf-9eb1-4fcf8ed648ca.png)


:cl:  Hopek
bugfix: You can no longer start moving your tail muscles to wag while you are stunned or paralyzed. 
/:cl:
