### PR TITLE
makes all traitor-available autosurgeons one-use

### DIFF
--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -108,5 +108,5 @@
 	starting_organ = /obj/item/organ/cyberimp/arm/syndie_mantis/l
 
 /obj/item/autosurgeon/plasmavessel //Yogs Start: Just an autosurgeon with a plasma vessel in it, used in /obj/item/storage/box/syndie_kit/xeno_organ_kit
-	uses = 1
+	uses = 3
 	starting_organ = /obj/item/organ/alien/plasmavessel //Yogs End

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -96,13 +96,17 @@
 	starting_organ = /obj/item/organ/cyberimp/chest/reviver
 
 /obj/item/autosurgeon/medibeam
+	uses = 1
 	starting_organ = /obj/item/organ/cyberimp/arm/medibeam
 
 /obj/item/autosurgeon/organ/syndicate/syndie_mantis
+	uses = 1
 	starting_organ = /obj/item/organ/cyberimp/arm/syndie_mantis
 
 /obj/item/autosurgeon/organ/syndicate/syndie_mantis/l
+	uses = 1
 	starting_organ = /obj/item/organ/cyberimp/arm/syndie_mantis/l
 
 /obj/item/autosurgeon/plasmavessel //Yogs Start: Just an autosurgeon with a plasma vessel in it, used in /obj/item/storage/box/syndie_kit/xeno_organ_kit
+	uses = 1
 	starting_organ = /obj/item/organ/alien/plasmavessel //Yogs End


### PR DESCRIPTION
# Document the changes in your pull request

All autosurgeons that are available to traitors (nukie ones are safe) are now one-use, like CMO autosurgeon

As it stands, traitors can buy these autosurgeons and not only receive the organ they purchased but also any other organ they put into it without having to go through the arduous tasks a typical crewmember would have to go through (like socializing)

This means medical/sci access = free x-ray, all implants/organ upgrades of your dreams, etc

Bless the maintainers that merged this shit

# Wiki Documentation

Medbeam arm implant, mantis blades, and plasmavessel autosurgeons are now one use

# Changelog

:cl:  
tweak: All traitor-available autosurgeons are now corrected to be one-time-use
/:cl:
