### PR TITLE
Removes the last L word reference in yog

### DIFF
--- a/strings/phobia.json
+++ b/strings/phobia.json
@@ -78,6 +78,7 @@
 	],
 	"lizards": [
 		"lizard",
+		"lizma",
 		"hiss",
 		"hissed",
 		"hissing",

--- a/strings/phobia.json
+++ b/strings/phobia.json
@@ -78,7 +78,6 @@
 	],
 	"lizards": [
 		"lizard",
-		"ligger",
 		"hiss",
 		"hissed",
 		"hissing",


### PR DESCRIPTION
Buffs lizards by removing the last noticeable instance of the L word

# Changelog

:cl:  
rscdel: Removes slur
/:cl:
