### PR TITLE
gives cursed heart the correct sprite so it isn't invisible

### DIFF
--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -103,7 +103,7 @@
 /obj/item/organ/heart/cursed
 	name = "cursed heart"
 	desc = "A heart that, when inserted, will force you to pump it manually."
-	icon_state = "cursedheart-off"
+	icon_state = "cursedheart"
 	icon_base = "cursedheart"
 	decay_factor = 0
 	actions_types = list(/datum/action/item_action/organ_action/cursed_heart)


### PR DESCRIPTION
# Document the changes in your pull request

title, theos broke it when he was doing other heart icons

# Changelog

:cl:   
bugfix: cursed heart has correct sprite now
/:cl:
