### PR TITLE
Fixes some modular computer stuff

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -221,6 +221,9 @@
 	. += get_modular_computer_parts_examine(user)
 
 /obj/item/modular_computer/update_icon()
+	if(!physical)
+		return
+
 	SSvis_overlays.remove_vis_overlay(physical, physical.managed_vis_overlays)
 	var/program_overlay = ""
 	var/is_broken = obj_integrity <= integrity_failure
@@ -560,4 +563,3 @@
 			active_program = program
 			program.alert_pending = FALSE
 			enabled = TRUE
-			update_icon()

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -14,7 +14,7 @@
 
 // Operates TGUI
 /obj/item/modular_computer/ui_interact(mob/user, datum/tgui/ui)
-	if (!can_show_ui(user, ui))
+	if (!can_show_ui(user))
 		if(ui)
 			ui.close()
 		return

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -2,25 +2,21 @@
 	. = ..()
 	ui_interact(user)
 
-/obj/item/modular_computer/proc/can_show_ui(mob/user, datum/tgui/ui)
+/obj/item/modular_computer/proc/can_show_ui(mob/user)
 	if(!enabled)
-		if(ui)
-			ui.close()
 		return FALSE
 	if(!use_power())
-		if(ui)
-			ui.close()
 		return FALSE
 	// Robots don't really need to see the screen, their wireless connection works as long as computer is on.
 	if(!screen_on && !issilicon(user))
-		if(ui)
-			ui.close()
 		return FALSE
 	return TRUE
 
 // Operates TGUI
 /obj/item/modular_computer/ui_interact(mob/user, datum/tgui/ui)
 	if (!can_show_ui(user, ui))
+		if(ui)
+			ui.close()
 		return
 	// If we have an active program switch to it now.
 	if(active_program)

--- a/code/modules/modular_computers/computers/item/laptop.dm
+++ b/code/modules/modular_computers/computers/item/laptop.dm
@@ -16,7 +16,7 @@
 	// No running around with open laptops in hands.
 	item_flags = SLOWS_WHILE_IN_HAND
 
-	screen_on = 0 		// Starts closed
+	screen_on = FALSE 		// Starts closed
 	var/start_open = TRUE	// unless this var is set to 1
 	var/icon_state_closed = "laptop-closed"
 	var/w_class_open = WEIGHT_CLASS_BULKY
@@ -95,10 +95,15 @@
 		to_chat(user, span_notice("You close \the [src]."))
 		slowdown = initial(slowdown)
 		w_class = initial(w_class)
+		icon_state = icon_state_closed
 	else
 		to_chat(user, span_notice("You open \the [src]."))
 		slowdown = slowdown_open
 		w_class = w_class_open
+		if(enabled)
+			icon_state = icon_state_powered
+		else
+			icon_state = icon_state_unpowered
 
 	screen_on = !screen_on
 	update_icon()

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -197,7 +197,7 @@
 
 /datum/computer_file/program/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
-	if (!computer.can_show_ui(user, ui))
+	if (!computer.can_show_ui(user))
 		if(ui)
 			ui.close()
 		return

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -198,6 +198,8 @@
 /datum/computer_file/program/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if (!computer.can_show_ui(user, ui))
+		if(ui)
+			ui.close()
 		return
 	if(!ui && tgui_id)
 		ui = new(user, src, tgui_id, filedesc)
@@ -214,10 +216,12 @@
 	if(computer)
 		switch(action)
 			if("PC_exit")
+				computer.play_interact_sound()
 				computer.kill_program()
 				ui.close()
 				return TRUE
 			if("PC_shutdown")
+				computer.play_interact_sound()
 				computer.shutdown_computer()
 				ui.close()
 				return TRUE
@@ -225,7 +229,7 @@
 				var/mob/user = usr
 				if(!computer.active_program || !computer.all_components[MC_CPU])
 					return
-
+				computer.play_interact_sound()
 				computer.idle_threads.Add(computer.active_program)
 				program_state = PROGRAM_STATE_BACKGROUND // Should close any existing UIs
 
@@ -245,5 +249,7 @@
 
 /datum/computer_file/program/ui_status(mob/user)
 	if(program_state != PROGRAM_STATE_ACTIVE) // Our program was closed. Close the ui if it exists.
+		return UI_CLOSE
+	if(!computer.can_show_ui(user))
 		return UI_CLOSE
 	return ..()


### PR DESCRIPTION
# Document the changes in your pull request
Fixes a few issues with modular computers that I have noticed while using them, mainly being able to use programs on laptops while the lid is shut. The one person who uses laptops will probably be seething at that nerf (I'm that one person, and I am seething). Is tested, does work.

- Laptops now have the correct icons when opened
- You can no longer use programs when the laptop lid is shut (RIP laptops being used ever)
- Fixes round start runtimes caused by updating icons when the physical is null
- Adds an interact sound to a few buttons I missed

# Wiki Documentation

No changes needed. 

# Changelog

:cl:   
bugfix: modular laptops now use the correct icons when opened
bugfix: you can no longer use programs on a modular laptop with its lid is shut
bugfix: fixed some buttons not having interaction sounds
/:cl:
