### PR TITLE
Slips stun instead of paralyzing

### DIFF
--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -1,13 +1,13 @@
 /datum/component/slippery
 	var/force_drop_items = FALSE
 	var/knockdown_time = 0
-	var/paralyze_time = 0
+	var/stun_time = 0
 	var/lube_flags
 	var/datum/callback/callback
 
-/datum/component/slippery/Initialize(_knockdown, _lube_flags = NONE, datum/callback/_callback, _paralyze, _force_drop = FALSE)
+/datum/component/slippery/Initialize(_knockdown, _lube_flags = NONE, datum/callback/_callback, _stun, _force_drop = FALSE)
 	knockdown_time = max(_knockdown, 0)
-	paralyze_time = max(_paralyze, 0)
+	stun_time = max(_stun, 0)
 	force_drop_items = _force_drop
 	lube_flags = _lube_flags
 	callback = _callback
@@ -15,5 +15,5 @@
 
 /datum/component/slippery/proc/Slip(datum/source, atom/movable/AM)
 	var/mob/victim = AM
-	if(istype(victim) && !victim.is_flying() && victim.slip(knockdown_time, parent, lube_flags, paralyze_time, force_drop_items) && callback)
+	if(istype(victim) && !victim.is_flying() && victim.slip(knockdown_time, parent, lube_flags, stun_time, force_drop_items) && callback)
 		callback.Invoke(victim)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -574,7 +574,7 @@
 		step(AM, turn(AM.dir, 180))
 
 ///Handle the atom being slipped over
-/atom/proc/handle_slip(mob/living/carbon/C, knockdown_amount, obj/O, lube, paralyze, force_drop)
+/atom/proc/handle_slip(mob/living/carbon/C, knockdown_amount, obj/O, lube, stun, force_drop)
 	return
 
 ///returns the mob's dna info as a list, to be inserted in an object's blood_DNA list

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -414,7 +414,7 @@
 		movable_content.wash(CLEAN_WASH)
 	return TRUE
 
-/turf/open/handle_slip(mob/living/carbon/C, knockdown_amount, obj/O, lube, paralyze_amount, force_drop)
+/turf/open/handle_slip(mob/living/carbon/C, knockdown_amount, obj/O, lube, stun_amount, force_drop)
 	if(C.movement_type & FLYING)
 		return 0
 	if(has_gravity(src))
@@ -441,7 +441,7 @@
 		C.moving_diagonally = 0 //If this was part of diagonal move slipping will stop it.
 		if(!(lube & SLIDE_ICE))
 			C.Knockdown(knockdown_amount)
-			C.Paralyze(paralyze_amount)
+			C.Stun(stun_amount)
 			C.stop_pulling()
 		else
 			C.Knockdown(20)

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -10,12 +10,12 @@
 		if(legcuffed)
 			. += legcuffed.slowdown
 
-/mob/living/carbon/slip(knockdown_amount, obj/O, lube, paralyze, force_drop)
+/mob/living/carbon/slip(knockdown_amount, obj/O, lube, stun, force_drop)
 	if(movement_type & FLYING)
 		return 0
 	if(!(lube&SLIDE_ICE))
 		log_combat(src, (O ? O : get_turf(src)), "slipped on the", null, ((lube & SLIDE) ? "(LUBE)" : null))
-	return loc.handle_slip(src, knockdown_amount, O, lube, paralyze, force_drop)
+	return loc.handle_slip(src, knockdown_amount, O, lube, stun, force_drop)
 
 /mob/living/carbon/Process_Spacemove(movement_dir = 0)
 	if(..())

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -12,7 +12,7 @@
 	if(dna && dna.species)
 		. += dna.species.movement_delay(src)
 
-/mob/living/carbon/human/slip(knockdown_amount, obj/O, lube, paralyze, forcedrop)
+/mob/living/carbon/human/slip(knockdown_amount, obj/O, lube, stun, forcedrop)
 	if(HAS_TRAIT(src, TRAIT_NOSLIPALL))
 		return 0
 	if (!(lube & GALOSHES_DONT_HELP))

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -337,7 +337,7 @@
 	return FALSE
 
 /// Called when this mob slips over, override as needed
-/mob/proc/slip(knockdown_amount, obj/O, lube, paralyze, force_drop)
+/mob/proc/slip(knockdown_amount, obj/O, lube, stun, force_drop)
 	return
 
 /// Update the gravity status of this mob


### PR DESCRIPTION
# Document the changes in your pull request

Replaces the 0-second paralyze caused by slipping with a 0-second stun.

Tested:

- This has no effect that I know of on how slips work currently, because it does a knockdown anyway.
- Space lube works the same too.
- A bananium sword on a flying angel didn't work before, and it doesn't work with this.
- Would interact with #13363 by making slips no longer terminate *wag.

# Changelog

:cl:  
tweak: Slips now stun instead of paralyzing
/:cl: