### PR TITLE
Ports "fixes toggling flashlight removing bayonet overlay"

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -506,6 +506,7 @@
 		flashlight_overlay.pixel_x = flight_x_offset
 		flashlight_overlay.pixel_y = flight_y_offset
 		add_overlay(flashlight_overlay, TRUE)
+		add_overlay(knife_overlay, TRUE)
 	else
 		set_light(0)
 		cut_overlays(flashlight_overlay, TRUE)


### PR DESCRIPTION
# Document the changes in your pull request

Fixes #13369.

Ports ["fixes toggling flashlight removing bayonet overlay" #47053](https://github.com/tgstation/tgstation/pull/47053) by [IradT/Kaffe-work](https://github.com/Kaffe-work) from TG, which fixes toggling gun flashlights removing bayonet. Is tested, does work.

![image](https://user-images.githubusercontent.com/14363906/156621888-5a4af4fb-09cb-401b-857c-8dc83e58b77b.png)

# Wiki Documentation

No changes needed.

# Changelog

:cl:  IradT
bugfix: fixed sprites on guns with both bayonet and toggle-able lights removing the bayonet when toggled.
/:cl:
