### PR TITLE
Powerful holoparasites can now smash their master out of restraints

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -1,6 +1,7 @@
 /obj/item/restraints
 	icon = 'icons/obj/handcuffs.dmi'
 	breakouttime = 600
+	var/break_strength = 2 // Minimum strength required for a holopara to break it
 
 /obj/item/restraints/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] is strangling [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
@@ -37,6 +38,7 @@
 	materials = list(/datum/material/iron=500)
 	breakouttime = 600 //Deciseconds = 60s = 1 minute
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
+	break_strength = 4
 	var/cuffsound = 'sound/weapons/handcuffs.ogg'
 	var/trashtype = null //for disposable cuffs
 
@@ -118,6 +120,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	materials = list(/datum/material/iron=150, /datum/material/glass=75)
 	breakouttime = 300 //Deciseconds = 30s
+	break_strength = 2
 	cuffsound = 'sound/weapons/cablecuff.ogg'
 
 /obj/item/restraints/handcuffs/cable/Initialize(mapload, param_color)
@@ -171,6 +174,7 @@
 	name = "fake handcuffs"
 	desc = "Fake handcuffs meant for gag purposes."
 	breakouttime = 10 //Deciseconds = 1s
+	break_strength = 1
 
 /obj/item/restraints/handcuffs/cable/attackby(obj/item/I, mob/user, params)
 	..()
@@ -213,6 +217,7 @@
 	breakouttime = 450 //Deciseconds = 45s
 	trashtype = /obj/item/restraints/handcuffs/cable/zipties/used
 	item_color = "white"
+	break_strength = 3
 
 /obj/item/restraints/handcuffs/cable/zipties/used
 	desc = "A pair of broken zipties."
@@ -236,6 +241,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	slowdown = 7
 	breakouttime = 300	//Deciseconds = 30s = 0.5 minute
+	break_strength = 4
 
 /obj/item/restraints/legcuffs/beartrap
 	name = "bear trap"
@@ -243,6 +249,7 @@
 	throw_range = 1
 	icon_state = "beartrap"
 	desc = "A trap used to catch bears and other legged creatures."
+	break_strength = 4
 	var/armed = 0
 	var/trap_damage = 20
 
@@ -314,6 +321,7 @@
 	breakouttime = 30
 	item_flags = DROPDEL
 	flags_1 = NONE
+	break_strength = 2
 
 /obj/item/restraints/legcuffs/beartrap/energy/Initialize()
 	. = ..()
@@ -336,6 +344,7 @@
 	icon_state = "bola"
 	breakouttime = 35//easy to apply, easy to break out of
 	gender = NEUTER
+	break_strength = 3
 	var/immobilize = 0
 
 /obj/item/restraints/legcuffs/bola/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, quickstart = TRUE)
@@ -363,6 +372,7 @@
 	icon_state = "bola_r"
 	breakouttime = 70
 	immobilize = 20
+	break_strength = 4
 
 /obj/item/restraints/legcuffs/bola/energy //For Security
 	name = "energy bola"
@@ -371,6 +381,7 @@
 	hitsound = 'sound/weapons/taserhit.ogg'
 	w_class = WEIGHT_CLASS_SMALL
 	breakouttime = 60
+	break_strength = 2
 
 /obj/item/restraints/legcuffs/bola/energy/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	if(iscarbon(hit_atom))

--- a/yogstation/code/modules/guardian/guardian.dm
+++ b/yogstation/code/modules/guardian/guardian.dm
@@ -376,6 +376,24 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 			to_chat(src, span_bolddanger("You can't attack yourself!"))
 			return FALSE
 		else if (target == summoner?.current)
+			if (iscarbon(target))
+				var/mob/living/carbon/stando_master = target
+				if (stando_master.handcuffed || stando_master.legcuffed)
+					if (stats.damage >= 4) // only A or B
+						playsound(stando_master, 'sound/effects/bang.ogg', 50, TRUE)
+						if (stando_master.handcuffed)
+							visible_message(span_danger("[src] smashes \the [stando_master.handcuffed] restraining [stando_master]!"))
+							QDEL_NULL(stando_master.handcuffed)
+							stando_master.update_handcuffed()
+						else if (stando_master.legcuffed) // you gotta do it twice for both hand and leg cuffs
+							visible_message(span_danger("[src] smashes \the [stando_master.legcuffed] restraining [stando_master]!"))
+							QDEL_NULL(stando_master.legcuffed)
+							stando_master.update_inv_legcuffed()
+						if (stando_master.pulledby && stando_master.pulledby != src)
+							stando_master.pulledby.stop_pulling()
+					else
+						to_chat(src, span_warning("You are not strong enough to free your master from their restraints..."))
+					return
 			to_chat(src, span_bolddanger("You can't attack your summoner!"))
 			return FALSE
 		else if (istype(target, /mob/living/simple_animal/hostile/guardian))

--- a/yogstation/code/modules/guardian/guardian.dm
+++ b/yogstation/code/modules/guardian/guardian.dm
@@ -359,6 +359,17 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 		return
 	return ..()
 
+/mob/living/simple_animal/hostile/guardian/proc/break_cuffs(mob/living/carbon/target, obj/item/restraints/cuffs)
+	. = TRUE
+	if (!target || !istype(target) || !cuffs || !istype(cuffs))
+		return FALSE
+	if (stats.damage < cuffs.break_strength)
+		to_chat(src, span_warning("You are not strong enough to free your master from their restraints..."))
+		return FALSE
+	playsound(target, 'sound/effects/bang.ogg', 50, TRUE)
+	visible_message(span_danger("[src] smashes \the [cuffs] restraining [target]!"))
+	qdel(cuffs)
+
 /mob/living/simple_animal/hostile/guardian/AttackingTarget()
 	if (transforming)
 		to_chat(src, span_italics(span_holoparasite("No... no... you can't!")))
@@ -379,20 +390,18 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 			if (iscarbon(target))
 				var/mob/living/carbon/stando_master = target
 				if (stando_master.handcuffed || stando_master.legcuffed)
-					if (stats.damage >= 4) // only A or B
-						playsound(stando_master, 'sound/effects/bang.ogg', 50, TRUE)
-						if (stando_master.handcuffed)
-							visible_message(span_danger("[src] smashes \the [stando_master.handcuffed] restraining [stando_master]!"))
-							QDEL_NULL(stando_master.handcuffed)
-							stando_master.update_handcuffed()
-						else if (stando_master.legcuffed) // you gotta do it twice for both hand and leg cuffs
-							visible_message(span_danger("[src] smashes \the [stando_master.legcuffed] restraining [stando_master]!"))
-							QDEL_NULL(stando_master.legcuffed)
-							stando_master.update_inv_legcuffed()
-						if (stando_master.pulledby && stando_master.pulledby != src)
-							stando_master.pulledby.stop_pulling()
-					else
-						to_chat(src, span_warning("You are not strong enough to free your master from their restraints..."))
+					if (stando_master.handcuffed && break_cuffs(stando_master, stando_master.handcuffed))
+						stando_master.handcuffed = null
+						stando_master.update_handcuffed()
+						for (var/zone in list(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
+							stando_master.apply_damage(5, BRUTE, zone)
+					else if (stando_master.legcuffed && break_cuffs(stando_master, stando_master.legcuffed)) // you gotta do it twice for both hand and leg cuffs
+						stando_master.legcuffed = null
+						stando_master.update_inv_legcuffed()
+						for (var/zone in list(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG))
+							stando_master.apply_damage(5, BRUTE, zone)
+					if (stando_master.pulledby && stando_master.pulledby != src)
+						stando_master.pulledby.stop_pulling()
 					return
 			to_chat(src, span_bolddanger("You can't attack your summoner!"))
 			return FALSE


### PR DESCRIPTION
# Document the changes in your pull request

Holoparasites can now click on their master to smash them out of any sort of restraints. Whether they can do so or not depends on the holopara's strength and the type of restraints.

 - Handcuffs: B
   - Fake handcuffs: F
 - Cablecuffs: D
 - Zipties: C
 - Legcuffs: B
 - Bear trap: B
 - Energy Snare: D
 - Bola: C
 - Reinforced bola: B
 - Energy bola: B

This is very loud, if it wasn't obvious - obvious visible message, and a BANG sound. Also, it deals 10 brute damage (split across either both arms or both legs, depending on type of restraint)

:cl:  
rscadd: Strong holoparasites can now smash objects that restrain their master (click on them as if you were attacking)
/:cl:
