### PR TITLE
Bluespace locker spawns are now more reasonable

### DIFF
--- a/yogstation/code/controllers/subsystem/bluespace_locker.dm
+++ b/yogstation/code/controllers/subsystem/bluespace_locker.dm
@@ -14,16 +14,27 @@ SUBSYSTEM_DEF(bluespace_locker)
 	if(external_locker)
 		return
 	// basically any normal-looking locker that isn't a secure one
-	var/list/valid_lockers = typecacheof(typesof(/obj/structure/closet) - typesof(/obj/structure/closet/body_bag)\
-	- typesof(/obj/structure/closet/secure_closet) - typesof(/obj/structure/closet/cabinet)\
-	- typesof(/obj/structure/closet/cardboard) - typesof(/obj/structure/closet/crate)\
-	- typesof(/obj/structure/closet/supplypod) - typesof(/obj/structure/closet/stasis)\
-	- typesof(/obj/structure/closet/abductor) - typesof(/obj/structure/closet/bluespace), only_root_path = TRUE)
+	var/list/valid_lockers = typecacheof(typesof(/obj/structure/closet) - typesof(/obj/structure/closet/body_bag) \
+		- typesof(/obj/structure/closet/secure_closet) - typesof(/obj/structure/closet/cabinet) \
+		- typesof(/obj/structure/closet/cardboard) - typesof(/obj/structure/closet/crate) \
+		- typesof(/obj/structure/closet/supplypod) - typesof(/obj/structure/closet/stasis) \
+		- typesof(/obj/structure/closet/abductor) - typesof(/obj/structure/closet/bluespace), only_root_path = TRUE)
+	var/list/valid_areas = typecacheof(list(/area/maintenance, /area/hallway, /area/crew_quarters/dorms, \
+		/area/crew_quarters/toilet, /area/crew_quarters/locker, /area/crew_quarters/lounge, /area/crew_quarters/fitness, \
+		/area/vacant_room))
 
 	var/list/lockers_list = list()
 	for(var/obj/structure/closet/L in GLOB.lockers)
-		if(is_station_level(L.z) && is_type_in_typecache(L, valid_lockers))
-			lockers_list += L
+		if (!is_station_level(L.z))
+			continue
+		if (!is_type_in_typecache(L, valid_lockers))
+			continue
+		var/area/A = get_area(L)
+		if (!is_type_in_typecache(A, valid_areas))
+			continue
+		if (L.secure || L.welded || L.locked || L.wall_mounted)
+			continue
+		lockers_list += L
 	if(!lockers_list.len)
 		// Congratulations, you managed to destroy all the lockers somehow.
 		// Now let's make a new one.

--- a/yogstation/code/controllers/subsystem/bluespace_locker.dm
+++ b/yogstation/code/controllers/subsystem/bluespace_locker.dm
@@ -32,9 +32,12 @@ SUBSYSTEM_DEF(bluespace_locker)
 		var/area/A = get_area(L)
 		if (is_type_in_typecache(A, invalid_areas))
 			continue
-		if (L.secure || L.welded || L.locked || L.wall_mounted)
+		if (L.secure || L.welded || L.wall_mounted)
 			continue
-		lockers_list += L
+		var/score = 1
+		if (L.locked)
+			score -= 0.25
+		lockers_list[L] = score
 	if(!lockers_list.len)
 		// Congratulations, you managed to destroy all the lockers somehow.
 		// Now let's make a new one.
@@ -44,8 +47,8 @@ SUBSYSTEM_DEF(bluespace_locker)
 				targetturf = get_turf(pick(GLOB.blobstart))
 			else
 				CRASH("Unable to find a blobstart landmark")
-		lockers_list += new /obj/structure/closet(targetturf)
-	var/obj/structure/closet/L = pick(lockers_list)
+		lockers_list[new /obj/structure/closet(targetturf)] = 1
+	var/obj/structure/closet/L = pickweight(lockers_list)
 
 	var/obj/structure/closet/bluespace/external/E = new(L.loc)
 	E.contents = L.contents

--- a/yogstation/code/controllers/subsystem/bluespace_locker.dm
+++ b/yogstation/code/controllers/subsystem/bluespace_locker.dm
@@ -19,9 +19,9 @@ SUBSYSTEM_DEF(bluespace_locker)
 		- typesof(/obj/structure/closet/cardboard) - typesof(/obj/structure/closet/crate) \
 		- typesof(/obj/structure/closet/supplypod) - typesof(/obj/structure/closet/stasis) \
 		- typesof(/obj/structure/closet/abductor) - typesof(/obj/structure/closet/bluespace), only_root_path = TRUE)
-	var/list/valid_areas = typecacheof(list(/area/maintenance, /area/hallway, /area/crew_quarters/dorms, \
-		/area/crew_quarters/toilet, /area/crew_quarters/locker, /area/crew_quarters/lounge, /area/crew_quarters/fitness, \
-		/area/vacant_room))
+	var/list/invalid_areas = typecacheof(list(/area/bridge, /area/crew_quarters/heads, /area/comms, /area/server, \
+		/area/engine/engine_smes, /area/engine/gravity_generator, /area/teleporter, /area/gateway, /area/medical/virology, \
+		/area/security, /area/quartermaster/qm, /area/storage/eva, /area/ai_monitored, /area/tcommsat))
 
 	var/list/lockers_list = list()
 	for(var/obj/structure/closet/L in GLOB.lockers)
@@ -30,7 +30,7 @@ SUBSYSTEM_DEF(bluespace_locker)
 		if (!is_type_in_typecache(L, valid_lockers))
 			continue
 		var/area/A = get_area(L)
-		if (!is_type_in_typecache(A, valid_areas))
+		if (is_type_in_typecache(A, invalid_areas))
 			continue
 		if (L.secure || L.welded || L.locked || L.wall_mounted)
 			continue


### PR DESCRIPTION
# Document the changes in your pull request

This adds more criteria to bluespace lockers. A bluespace locker candidate must be:

 - A non-secure locker (no lock at all on it)
 - Not welded, locked, or wall-mounted
 - Not in a secure area - generally anywhere sec would immediately be on your ass big-time if you broke into it.
   Here's a general list of banned areas:
   - Security (including checkpoints and armory)
   - Bridge
   - Any Head Office
   - SMES room, gravgen
   - Teleporter
   - Gateway
   - AI satellite
   - Tcomms
   - Virology
   - EVA

# Why?

Because the bluespace locker is really fun. You know what's not fun? The damned thing spawning in the one area nobody will ever even look, or in an area like only 2 people have access to (and they certainly won't be looking inside the lockers).

From my experience, bluespace lockers usually result in creativity and fun gimmicks. We need more of that.

# Changelog
:cl: Lucy
tweak: The bluespace locker is now more likely to spawn in a generally reasonable area.
/:cl:
