### PR TITLE
Revert "Bible is only antimagic if you are a true worshipper"

### DIFF
--- a/code/datums/components/anti_magic.dm
+++ b/code/datums/components/anti_magic.dm
@@ -7,9 +7,8 @@
 	var/blocks_self = TRUE
 	var/datum/callback/reaction
 	var/datum/callback/expire
-	var/special_role = 0
 
-/datum/component/anti_magic/Initialize(_magic = FALSE, _holy = FALSE, _psychic = FALSE, _allowed_slots, _charges, _blocks_self = TRUE, datum/callback/_reaction, datum/callback/_expire, _special_role = 0)
+/datum/component/anti_magic/Initialize(_magic = FALSE, _holy = FALSE, _psychic = FALSE, _allowed_slots, _charges, _blocks_self = TRUE, datum/callback/_reaction, datum/callback/_expire)
 	if(isitem(parent))
 		RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, .proc/on_equip)
 		RegisterSignal(parent, COMSIG_ITEM_DROPPED, .proc/on_drop)
@@ -28,14 +27,12 @@
 	blocks_self = _blocks_self
 	reaction = _reaction
 	expire = _expire
-	special_role = _special_role
 
 /datum/component/anti_magic/proc/on_equip(datum/source, mob/equipper, slot)
 	if(!CHECK_BITFIELD(allowed_slots, slotdefine2slotbit(slot))) //Check that the slot is valid for antimagic
 		UnregisterSignal(equipper, COMSIG_MOB_RECEIVE_MAGIC)
 		return
-	if(equipper.mind?.holy_role >= special_role) //CONVERT OR DIE
-		RegisterSignal(equipper, COMSIG_MOB_RECEIVE_MAGIC, .proc/protect, TRUE)
+	RegisterSignal(equipper, COMSIG_MOB_RECEIVE_MAGIC, .proc/protect, TRUE)
 
 /datum/component/anti_magic/proc/on_drop(datum/source, mob/user)
 	UnregisterSignal(user, COMSIG_MOB_RECEIVE_MAGIC)

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -43,7 +43,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 
 /obj/item/storage/book/bible/Initialize()
 	. = ..()
-	AddComponent(/datum/component/anti_magic, FALSE, TRUE, FALSE, null, null, TRUE, null, null, HOLY_ROLE_PRIEST)
+	AddComponent(/datum/component/anti_magic, FALSE, TRUE)
 
 /obj/item/storage/book/bible/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] is offering [user.p_them()]self to [deity_name]! It looks like [user.p_theyre()] trying to commit suicide!"))


### PR DESCRIPTION
Reverts yogstation13/Yogstation#13264

Antimagic is sepwrated into like 3 different "types" making the actual power of having itkind of confusing. However, i hate cult and know every antimagic item in the game and what each type of antimagic protects against

Antimagic: protects against nearly every magical attack and cult conversion, found in nullrods, certain lavaland artifacts, a brain trauma, etc
Psionic antimagic: used by the defunct hivemind gamemode. Protects against mindreading, telepathy, and abductors,found in the tinfoil hat
Holy antimagic: protects against cult conversions, ocular wardens, revenants and some devil stuff, found in the bible and wings

So why tf are we deciding to nerf the bible when it does the equivalent of literally nothing

:cl:
tweak: the bible's holy antimagic effect now works on normal people again
/:cl: