### PR TITLE
RPEDs now work on APCs

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -108,6 +108,7 @@ Class Procs:
 	var/wire_compatible = FALSE
 
 	var/list/component_parts = null //list of all the parts used to build it, if made from certain kinds of frames.
+	var/works_with_rped_anyways = FALSE //whether it has special RPED behavior despite not having component parts
 	var/panel_open = FALSE
 	var/state_open = FALSE
 	var/critical_machine = FALSE //If this machine is critical to station operation and should have the area be excempted from power failures.

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -328,7 +328,7 @@
 						// 2 if we need to update the overlays
 	if(!update)
 		icon_update_needed = FALSE
-		returnd
+		return
 
 	if(update & 1) // Updating the icon state
 		if(update_state & UPSTATE_ALLGOOD)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -313,6 +313,9 @@
 			SEND_SIGNAL(W, COMSIG_TRY_STORAGE_INSERT, cell, null, null, TRUE)
 			to_chat(user, span_notice("[capitalize(cell.name)] replaced with [best_cell.name]."))
 		best_cell.forceMove(src)
+		var/amount_to_charge = min(best_cell.maxcharge - best_cell.charge, cell.charge)
+		if (cell.use(amount_to_charge))
+			best_cell.give(amount_to_charge)
 		cell = best_cell
 		W.play_rped_sound()
 

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -15,7 +15,7 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 	var/alt_sound = null
 
 /obj/item/storage/part_replacer/pre_attack(obj/machinery/T, mob/living/user, params)
-	if(!istype(T) || !T.component_parts)
+	if(!istype(T) || (!T.component_parts && !T.works_with_rped_anyways))
 		return ..()
 	if(user.Adjacent(T)) // no TK upgrading.
 		if(works_from_distance)
@@ -25,7 +25,7 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 	return ..()
 
 /obj/item/storage/part_replacer/afterattack(obj/machinery/T, mob/living/user, adjacent, params)
-	if(adjacent || !istype(T) || !T.component_parts)
+	if(adjacent || !istype(T) || (!T.component_parts && !T.works_with_rped_anyways))
 		return ..()
 	if(works_from_distance)
 		user.Beam(T, icon_state = "rped_upgrade", time = 5)


### PR DESCRIPTION
# Document the changes in your pull request

RPEDs can now replace cells in APCs. Hopefully, science/engineering will actually upgrade APCs now.

The new cell is recharged by the old cell, so you can't use this to sabotage stuff by putting an empty bluespace cell in an BRPED and going ham.

# Changelog

:cl: Lucy
rcsadd: RPEDs are now capable of changing the power cells in APCs now!
/:cl:
