### PR TITLE
Fixes automute bug

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -22,7 +22,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	))
 
 /atom/movable/proc/say(message, bubble_type, var/list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
-	if(!can_speak())
+	if(!can_speak(message))
 		return
 	if(message == "" || !message)
 		return

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -317,7 +317,7 @@ GLOBAL_LIST_INIT(special_radio_keys, list(
 		if(client.prefs.muted & MUTE_IC)
 			to_chat(src, span_danger("You cannot speak in IC (muted)."))
 			return FALSE
-		if(!ignore_spam && client.handle_spam_prevention(message,MUTE_IC))
+		if(!ignore_spam && message != null && client.handle_spam_prevention(message,MUTE_IC))
 			return FALSE
 
 	return TRUE

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -126,7 +126,7 @@
 /proc/voice_of_god(message, mob/living/user, list/span_list, base_multiplier = 1, include_speaker = FALSE, message_admins = TRUE, forced_span = FALSE)
 	var/cooldown = 0
 
-	if(!user || !user.can_speak() || user.stat)
+	if(!user || !user.can_speak(message) || user.stat)
 		return 0 //no cooldown
 
 	var/log_message = uppertext(message)


### PR DESCRIPTION
# Document the changes in your pull request

Calling can speak with no arguments multiple times incremented the message counter for null, so just checking if someone can speak could get them muted, this has been fixed.

# Changelog

:cl:  
bugfix: fixed automute false positives
/:cl:
