### PR TITLE
Allows resonators to chain mine when manually detonatwd because wtf was i thinking

### DIFF
--- a/code/modules/mining/equipment/resonator.dm
+++ b/code/modules/mining/equipment/resonator.dm
@@ -122,4 +122,4 @@
 		return
 	for(var/turf/closed/mineral/T in orange(1, M))
 		if(istype(T) && M.mineralType == T.mineralType)
-			new /obj/effect/temp_visual/resonance(T, creator, null, burst_time)	//yogs end
+			new /obj/effect/temp_visual/resonance(T, creator, null, duration)	//yogs end

--- a/code/modules/mining/equipment/resonator.dm
+++ b/code/modules/mining/equipment/resonator.dm
@@ -71,7 +71,6 @@
 	transform = matrix()*0.75
 	animate(src, transform = matrix()*1.5, time = duration)
 	deltimer(timerid)
-	addtimer(CALLBACK(src, .proc/replicate, get_turf(src), creator, duration), duration, TIMER_STOPPABLE)//yogs: adds field replication
 	timerid = addtimer(CALLBACK(src, .proc/burst), duration, TIMER_STOPPABLE)
 
 /obj/effect/temp_visual/resonance/Destroy()
@@ -97,6 +96,7 @@
 	new /obj/effect/temp_visual/resonance_crush(T)
 	if(ismineralturf(T))
 		var/turf/closed/mineral/M = T
+		replicate(M)
 		M.gets_drilled(creator)
 	check_pressure(T)
 	playsound(T,'sound/weapons/resonator_blast.ogg',50,1)
@@ -117,10 +117,9 @@
 	transform = matrix()*1.5
 	animate(src, transform = matrix()*0.1, alpha = 50, time = 4)
 
-/obj/effect/temp_visual/resonance/proc/replicate(turf/closed/mineral/M, creator, timetoburst)	//yogs start: adds replication to resonator fields
-	if(!istype(M))
+/obj/effect/temp_visual/resonance/proc/replicate(turf/closed/mineral/M)	//yogs start: adds replication to resonator fields
+	if(!istype(M) || !M.mineralType) // so we don't end up in the ultimate chain reaction
 		return
 	for(var/turf/closed/mineral/T in orange(1, M))
-		if(istype(T))
-			if(M.mineralType == T.mineralType && M.mineralType != null) // so we don't end up in the ultimate chain reaction
-				new /obj/effect/temp_visual/resonance(T, creator, null, timetoburst)	//yogs end
+		if(istype(T) && M.mineralType == T.mineralType)
+			new /obj/effect/temp_visual/resonance(T, creator, null, burst_time)	//yogs end


### PR DESCRIPTION
# Document the changes in your pull request

Resonator bubbles that are manually detonated now chain mine nearby tiles of the same ore type, allowing for ore veins to be mined really quickly with them

Also redoes the replication code because i wrote it like 5 years ago or something and it was bad and long

# Wiki Documentation

Resonators now spawn new resonator fields on adjacent rocks with the same ores in them without any snowflake behavior like "waiting"

# Changelog

:cl:  
tweak: resonator field replication now works if you manually detonate the resonatoe field rather than only working if the field detonates naturally
/:cl:
