### PR TITLE
Adds a button to convert a blood brother into a traitor

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -191,6 +191,12 @@ GLOBAL_LIST_EMPTY(objectives)
 				var/obj/O = new eq_path
 				H.equip_in_one_of_slots(O, slots)
 
+/// Copy the target from the other objective
+/datum/objective/proc/copy_target(datum/objective/old_obj)
+	target = old_obj.get_target()
+	target_amount = old_obj.target_amount
+	explanation_text = explanation_text
+
 /datum/objective/assassinate
 	name = "assassinate"
 	var/target_role_type=FALSE
@@ -530,6 +536,10 @@ GLOBAL_LIST_EMPTY(objectives)
 /datum/objective/escape/escape_with_identity/admin_edit(mob/admin)
 	admin_simple_target_pick(admin)
 
+/datum/objective/escape/escape_with_identity/copy_target(datum/objective/escape/escape_with_identity/old_obj)
+	target_real_name = old_obj.target_real_name
+	target_missing_id = old_obj.target_missing_id
+
 /datum/objective/survive
 	name = "survive"
 	explanation_text = "Stay alive until the end."
@@ -624,6 +634,10 @@ GLOBAL_LIST_EMPTY(possible_items)
 	else
 		explanation_text = "Free objective"
 		return
+
+/datum/objective/steal/copy_target(datum/objective/steal/old_obj)
+	. = ..()
+	set_target(old_obj.targetinfo)
 
 /datum/objective/steal/admin_edit(mob/admin)
 	var/list/possible_items_all = GLOB.possible_items+"custom"
@@ -1217,6 +1231,9 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 		return TRUE
 	return !record || !(record in GLOB.data_core.security)
 
+/datum/objective/minor/secrecords/copy_target(datum/objective/minor/secrecords/old_obj)
+	. = ..()
+	record = old_obj.record
 
 /**
   * # Kill Pet
@@ -1272,7 +1289,11 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 
 /datum/objective/minor/pet/update_explanation_text()
 	explanation_text = "Assassinate the important animal, [pet.name]"
-	
+
+/datum/objective/minor/pet/copy_target(datum/objective/minor/pet/old_obj)
+	. = ..()
+	pet = old_obj.pet
+
 /**
   * Check whether Pet is dead
   */

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -89,6 +89,29 @@
 	message_admins("[key_name_admin(admin)] made [key_name_admin(new_owner)] and [key_name_admin(bro)] into blood brothers.")
 	log_admin("[key_name(admin)] made [key_name(new_owner)] and [key_name(bro)] into blood brothers.")
 
+/datum/antagonist/brother/get_admin_commands()
+	. = ..()
+	.["Convert To Traitor"] = CALLBACK(src, .proc/make_traitor)
+
+/datum/antagonist/brother/proc/make_traitor()
+	if(alert("Are you sure? This will turn the blood borther into a traitor with the same objectives!",,"Yes","No") != "Yes")
+		return
+
+	var/datum/antagonist/traitor/tot = new()
+	tot.give_objectives = FALSE
+	
+	for(var/datum/objective/obj in objectives)
+		var/obj_type = obj.type
+		var/datum/objective/new_obj = new obj_type()
+		new_obj.owner = owner
+		new_obj.copy_target(obj)
+		tot.add_objective(new_obj)
+		qdel(obj)
+	objectives.Cut()
+	
+	owner.add_antag_datum(tot)
+	owner.remove_antag_datum(/datum/antagonist/brother)
+
 /datum/antagonist/brother/proc/give_pinpointer()
 	if(owner && owner.current)
 		var/datum/status_effect/agent_pinpointer/brother/P = owner.current.apply_status_effect(/datum/status_effect/agent_pinpointer/brother)

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -94,7 +94,7 @@
 	.["Convert To Traitor"] = CALLBACK(src, .proc/make_traitor)
 
 /datum/antagonist/brother/proc/make_traitor()
-	if(alert("Are you sure? This will turn the blood borther into a traitor with the same objectives!",,"Yes","No") != "Yes")
+	if(alert("Are you sure? This will turn the blood brother into a traitor with the same objectives!",,"Yes","No") != "Yes")
 		return
 
 	var/datum/antagonist/traitor/tot = new()


### PR DESCRIPTION
# Document the changes in your pull request
Adds a button that turns a blood brother into a traitor, in the event their partner leaves and cannot be replaced.

:cl:  
rscadd: Added button to convert blood brother into traitor
/:cl:
