### PR TITLE
Fix runtime in remove_accessory

### DIFF
--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -164,6 +164,9 @@
 			to_chat(user, span_notice("You detach [A] from [src]."))
 		else
 			to_chat(user, span_notice("You detach [A] from [src] and it falls on the floor."))
+			var/turf/T = get_turf(src)
+			if(!T)
+				T = get_turf(user)
 			A.forceMove(get_turf(src))
 		
 		if(ishuman(loc))


### PR DESCRIPTION
# Document the changes in your pull request

get_turf(src) can apparently return null, likely due to src being destroyed.

# Changelog

:cl:  
bugfix: fixed runtime in remove_accessory
/:cl:
