### PR TITLE
Donor hats now get placed on borgs

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -840,6 +840,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<h2>Donator Preferences</h2>"
 			if(is_donator(user.client))
 				dat += "<b>Quiet round:</b> <a href='?_src_=prefs;preference=donor;task=quiet_round'>[(src.yogtoggles & QUIET_ROUND) ? "Yes" : "No"]</a><br>"
+				dat += "Wear fancy hat as borg: "
+				dat += "<a href='?_src_=prefs;preference=donor;task=borghat'>[borg_hat ? "Yes" : "No"]</a><br>"
 				dat += "<b>Fancy Hat:</b> "
 				///This is the typepath of the donor's hat that they may choose to spawn with.
 				var/typehat = donor_hat
@@ -1240,7 +1242,10 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	if(href_list["preference"] == "donor")
 		if(is_donator(user))
 			var/client/C = (istype(user, /client)) ? user : user.client
+			message_admins("Donor task [href_list["task"]]")
 			switch(href_list["task"])
+				if("borghat")
+					borg_hat = !borg_hat
 				if("hat")
 					C.custom_donator_item()
 				if("item")

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -223,6 +223,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	// yogs start - Donor features
 	READ_FILE(S["donor_pda"], donor_pda)
 	READ_FILE(S["donor_hat"], donor_hat)
+	READ_FILE(S["borg_hat"], borg_hat)
 	READ_FILE(S["donor_item"], donor_item)
 	READ_FILE(S["purrbation"], purrbation)
 	READ_FILE(S["yogtoggles"], yogtoggles)
@@ -358,6 +359,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["yogtoggles"], yogtoggles)
 	WRITE_FILE(S["donor_pda"], donor_pda)
 	WRITE_FILE(S["donor_hat"], donor_hat)
+	WRITE_FILE(S["borg_hat"], borg_hat)
 	WRITE_FILE(S["donor_item"], donor_item)
 	WRITE_FILE(S["purrbation"], purrbation)
 

--- a/code/modules/jobs/job_types/cyborg.dm
+++ b/code/modules/jobs/job_types/cyborg.dm
@@ -34,3 +34,24 @@
 
 /datum/job/cyborg/radio_help_message(mob/M)
 	to_chat(M, "<b>Prefix your message with :b to speak with other cyborgs and AI.</b>")
+
+/datum/job/cyborg/give_donor_stuff(mob/living/silicon/robot/H, mob/M)
+	if(!istype(H))
+		return
+
+	var/client/C = M.client
+	if(!C)
+		C = H.client
+		if(!C)
+			return // nice
+
+	if(!is_donator(C))
+		return
+
+	if(C.prefs.donor_hat)
+		var/type = C.prefs.donor_hat
+		if(type)
+			var/obj/item/hat = new type()
+			if(istype(hat) && hat.slot_flags & ITEM_SLOT_HEAD && H.hat_offset != INFINITY && !is_type_in_typecache(hat, H.blacklisted_hats))
+				H.place_on_head(hat)
+

--- a/code/modules/jobs/job_types/cyborg.dm
+++ b/code/modules/jobs/job_types/cyborg.dm
@@ -48,7 +48,7 @@
 	if(!is_donator(C))
 		return
 
-	if(C.prefs.donor_hat)
+	if(C.prefs.donor_hat && C.prefs.borg_hat)
 		var/type = C.prefs.donor_hat
 		if(type)
 			var/obj/item/hat = new type()

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -38,6 +38,8 @@
 
 	var/syndicate_module = FALSE /// If the borg should blow emag size regardless of emag state
 
+	var/obj/item/hat // Keeps track of the hat while transforming, to attempt to place back on the borg's head
+
 /obj/item/robot_module/Initialize()
 	. = ..()
 	for(var/i in basic_modules)
@@ -213,8 +215,10 @@
 /obj/item/robot_module/proc/do_transform_animation()
 	var/mob/living/silicon/robot/R = loc
 	if(R.hat)
-		R.hat.forceMove(get_turf(R))
+		hat = R.hat
 		R.hat = null
+		hat.moveToNullspace()
+
 	R.cut_overlays()
 	R.setDir(SOUTH)
 	do_transform_delay()

--- a/yogstation/code/modules/client/preferences.dm
+++ b/yogstation/code/modules/client/preferences.dm
@@ -1,6 +1,7 @@
 /datum/preferences
 	var/donor_hat = 0
 	var/donor_item = null
+	var/borg_hat = FALSE
 	var/donor_pda = null
 	var/quiet_round = FALSE
 	var/yogtoggles = YOGTOGGLES_DEFAULT

--- a/yogstation/code/modules/mob/living/silicon/robot/robot.dm
+++ b/yogstation/code/modules/mob/living/silicon/robot/robot.dm
@@ -42,6 +42,12 @@
 	. = ..()
 	var/mob/living/silicon/robot/R = loc
 	R.PickBorgSkin()
+	if(hat)
+		if(R.hat_offset == INFINITY)
+			R.forceMove(get_turf(R))
+		else
+			R.place_on_head(hat)
+		hat = null
 
 /mob/living/silicon/robot/update_icons() //Need to change this, as it's killing donorborgs
 	var/old_icon = icon_state


### PR DESCRIPTION
# Document the changes in your pull request

Roundstart borgs get their selected donor hat, and hats are no longer dropped on module selection

# Changelog

:cl:  
tweak: borgs can spawn with donor hats if enabled in preferences
tweak: borgs no longer drop hats on module change
/:cl:
