### PR TITLE
Admins no longer appear on mentorwho

### DIFF
--- a/yogstation/code/modules/client/verbs/who.dm
+++ b/yogstation/code/modules/client/verbs/who.dm
@@ -8,6 +8,8 @@
 			GLOB.mentors -= C
 			continue // weird runtime that happens randomly
 		var/suffix = ""
+		if(C.holder)
+			continue
 		if(holder)
 			if(isobserver(C.mob))
 				suffix += " - Observing"


### PR DESCRIPTION
# Document the changes in your pull request

Mentorwho sometimes shows admins, because they are also mentors, this fixes that

# Changelog

:cl:  
tweak: mentorwho no longer shows admins
/:cl:
