### PR TITLE
Remove the requirement of 2FA to open the permissions panel, editing anything still requires 2FA

### DIFF
--- a/code/modules/admin/permissionedit.dm
+++ b/code/modules/admin/permissionedit.dm
@@ -2,7 +2,7 @@
 	set category = "Server"
 	set name = "Permissions Panel"
 	set desc = "Edit admin permissions"
-	if(!check_rights(R_PERMISSIONS) || !mfa_query()) // Require MFA to access the permissions panel
+	if(!check_rights(R_PERMISSIONS))
 		return
 	usr.client.holder.edit_admin_permissions()
 


### PR DESCRIPTION
# Document the changes in your pull request

Having to enter your 2FA code twice is redundant

# Changelog

:cl:  
rscdel: Removed 2FA requirement to open the permissions panel, still required to edit permissions
/:cl:
