### PR TITLE
makes it so chaplain cant roll vampire on traitor+vamp rounds

### DIFF
--- a/yogstation/code/game/gamemodes/vampire/traitor_vamp.dm
+++ b/yogstation/code/game/gamemodes/vampire/traitor_vamp.dm
@@ -32,7 +32,10 @@
 	if(CONFIG_GET(flag/protect_assistant_from_antagonist))
 		restricted_jobs += "Assistant"
 
+	//yay lets add chaplain here so he cant be the vampire in traitor+vamps
+	restricted_jobs += "Chaplain"
 	var/list/datum/mind/possible_vamps = get_players_for_role(ROLE_VAMPIRE)
+	restricted_jobs -= "Chaplain"
 
 	var/num_vamp = 1
 


### PR DESCRIPTION
# Document the changes in your pull request

![image](https://user-images.githubusercontent.com/5091394/157593159-668e31c3-c170-4385-9612-62a68a785127.png)

# Changelog

:cl:   
bugfix: chaplains can no longer roll vampire on traitor+vamp rounds
/:cl:
