### PR TITLE
[1984] Appearance banned people can no longer set their accents alt PR

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -522,6 +522,7 @@
 			return
 	if(frn)
 		client.prefs.random_character()
+		client.prefs.accent = pick(assoc_list_strip_value(GLOB.accents_name2file))
 		client.prefs.real_name = client.prefs.pref_species.random_name(gender,1)
 	client.prefs.copy_to(H)
 


### PR DESCRIPTION
Alternative to #13405
Making this PR because @TheGamerdk  didn't acknowledge my feedback so it is my duty to create an alternative PR

Appearance banned people get a random accent instead of having a forced no accent.
This makes sense in my opinion because appearance-banned people get everything randomized, so why not a random accent.

:cl:  Hopek
tweak: Appearance ban applies to accent choice too. They get a random accent because it's funny
/:cl:
