### PR TITLE
Nerfs classic/telescopic batons

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -183,8 +183,8 @@
 	var/cooldown = 1 SECONDS // Default wait time until can stun again.
 	var/knockdown_time_carbon = 1.5 SECONDS // Knockdown length for carbons.
 	var/stun_time_silicon = 5 SECONDS // If enabled, how long do we stun silicons.
-	var/stamina_damage = 30 // How much stamina damage we deal.
-	var/block_threshold = 50 // Threshold at which armor blocks special effects.
+	var/stamina_damage = 60 // How much stamina damage we deal.
+	var/block_threshold = 60 // Threshold at which armor blocks special effects.
 	var/affect_silicon = FALSE // Does it stun silicons.
 	var/on_sound // "On" sound, played when switching between able to stun or not.
 	var/on_stun_sound = "sound/effects/woodhit.ogg" // Default path to sound for when we stun.
@@ -376,7 +376,8 @@
 	on_item_state = "nullrod"
 	force_on = 10
 	force_off = 0
-	stamina_damage = 20
+	stamina_damage = 40
+	block_threshold = 50
 	weight_class_on = WEIGHT_CLASS_BULKY
 	bare_wound_bonus = 5
 

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -180,10 +180,11 @@
 
 	var/cooldown_check = 0 // Used interally, you don't want to modify
 
-	var/cooldown = 3 SECONDS // Default wait time until can stun again.
+	var/cooldown = 1 SECONDS // Default wait time until can stun again.
 	var/knockdown_time_carbon = 1.5 SECONDS // Knockdown length for carbons.
 	var/stun_time_silicon = 5 SECONDS // If enabled, how long do we stun silicons.
-	var/stamina_damage = 55 // Do we deal stamina damage.
+	var/stamina_damage = 20 // How much stamina damage we deal.
+	var/block_threshold = 50 // Threshold at which armor blocks special effects.
 	var/affect_silicon = FALSE // Does it stun silicons.
 	var/on_sound // "On" sound, played when switching between able to stun or not.
 	var/on_stun_sound = "sound/effects/woodhit.ogg" // Default path to sound for when we stun.
@@ -199,6 +200,70 @@
 
 	wound_bonus = 15
 
+// Handles all the effects if a successful strike
+/obj/item/melee/classic_baton/proc/stun(mob/living/target, mob/living/user)
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		if (H.check_shields(src, 0, "[user]'s [name]", MELEE_ATTACK))
+			playsound(target, 'sound/weapons/genhit.ogg', 50, 1)
+			return
+		var/datum/martial_art/M = H.check_block()
+		if(M)
+			M.handle_counter(target, user)
+			return
+
+	var/list/desc = get_hit_description(target, user)
+
+	var/obj/item/bodypart/affecting = target.get_bodypart(user.zone_selected)
+	var/armor_block = target.run_armor_check(affecting, "melee")
+	target.apply_damage(stamina_damage, STAMINA, user.zone_selected, armor_block)
+	var/current_stamina_damage = target.getStaminaLoss()
+
+	if(stun_animation)
+		user.do_attack_animation(target)
+
+	if(user)
+		target.lastattacker = user.real_name
+		target.lastattackerckey = user.ckey
+		log_combat(user, target, "stunned")
+
+	playsound(get_turf(src), on_stun_sound, 75, 1, -1)
+
+	if(current_stamina_damage >= 100)
+		desc = get_stun_description(target, user)
+		target.Knockdown(knockdown_time_carbon)
+		target.visible_message(desc["visible"], desc["local"])
+		return
+	
+	if(armor_block >= block_threshold)
+		target.visible_message(desc["visible"], desc["local"])
+		return
+
+	// Special effects
+	if(affecting.stamina_dam >= 50 && (istype(affecting, /obj/item/bodypart/l_leg) || istype(affecting, /obj/item/bodypart/r_leg)))
+		desc = get_stun_description(target, user)
+		target.Knockdown(knockdown_time_carbon)
+		
+	else if(affecting.stamina_dam >= 15 && istype(affecting, /obj/item/bodypart/l_arm) && target.held_items[LEFT_HANDS])
+		target.dropItemToGround(target.held_items[LEFT_HANDS])
+	else if(affecting.stamina_dam >= 15 && istype(affecting, /obj/item/bodypart/r_arm) && target.held_items[RIGHT_HANDS])
+		target.dropItemToGround(target.held_items[RIGHT_HANDS])
+	target.visible_message(desc["visible"], desc["local"])
+
+// Are we applying any special effects when we stun to silicon
+/obj/item/melee/classic_baton/proc/stun_silicon(mob/living/silicon/target, mob/living/user)
+	var/list/desc = get_silicon_stun_description(target, user)
+
+	target.flash_act(affect_silicon = TRUE)
+	target.Paralyze(stun_time_silicon)
+	additional_effects_silicon(target, user)
+
+	user.visible_message(desc["visible"], desc["local"])
+	playsound(get_turf(src), on_stun_sound, 100, TRUE, -1)
+
+	if (stun_animation)
+		user.do_attack_animation(target)
+
 // Description for trying to stun when still on cooldown.
 /obj/item/melee/classic_baton/proc/get_wait_description()
 	return
@@ -207,8 +272,17 @@
 /obj/item/melee/classic_baton/proc/get_on_description()
 	. = list()
 
-	.["local_on"] = "<span class ='warning'>You extend the baton.</span>"
-	.["local_off"] = "<span class ='notice'>You collapse the baton.</span>"
+	.["local_on"] = span_danger("You extend the baton.")
+	.["local_off"] = span_danger("You collapse the baton.")
+
+	return .
+
+// Default message for hitting mob.
+/obj/item/melee/classic_baton/proc/get_hit_description(mob/living/target, mob/living/user)
+	. = list()
+
+	.["visible"] =  span_danger("[user] struck [target] with [src]!")
+	.["local"] = span_danger("[user] struck [target] with [src]!")
 
 	return .
 
@@ -216,8 +290,8 @@
 /obj/item/melee/classic_baton/proc/get_stun_description(mob/living/target, mob/living/user)
 	. = list()
 
-	.["visible"] =  "<span class ='danger'>[user] has knocked down [target] with [src]!</span>"
-	.["local"] = "<span class ='danger'>[user] has knocked down [target] with [src]!</span>"
+	.["visible"] =  span_danger("[user] has knocked down [target] with [src]!")
+	.["local"] = span_danger("[user] has knocked down [target] with [src]!")
 
 	return .
 
@@ -261,17 +335,7 @@
 		// We don't stun if we're on harm.
 		if (user.a_intent != INTENT_HARM)
 			if (affect_silicon)
-				var/list/desc = get_silicon_stun_description(target, user)
-
-				target.flash_act(affect_silicon = TRUE)
-				target.Paralyze(stun_time_silicon)
-				additional_effects_silicon(target, user)
-
-				user.visible_message(desc["visible"], desc["local"])
-				playsound(get_turf(src), on_stun_sound, 100, TRUE, -1)
-
-				if (stun_animation)
-					user.do_attack_animation(target)
+				stun_silicon(target, user)
 			else
 				..()
 		else
@@ -286,35 +350,7 @@
 			return
 	else
 		if(cooldown_check <= world.time)
-			if(ishuman(target))
-				var/mob/living/carbon/human/H = target
-				if (H.check_shields(src, 0, "[user]'s [name]", MELEE_ATTACK))
-					return
-				var/datum/martial_art/M = H.check_block()
-				if(M)
-					M.handle_counter(target, user)
-					return
-
-			var/list/desc = get_stun_description(target, user)
-
-			if (stun_animation)
-				user.do_attack_animation(target)
-
-			playsound(get_turf(src), on_stun_sound, 75, 1, -1)
-			target.Knockdown(knockdown_time_carbon)
-			target.adjustStaminaLoss(stamina_damage)
-			additional_effects_carbon(target, user)
-
-			log_combat(user, target, "stunned", src)
-			add_fingerprint(user)
-
-			target.visible_message(desc["visible"], desc["local"])
-
-			if(!iscarbon(user))
-				target.LAssailant = null
-			else
-				target.LAssailant = user
-			cooldown_check = world.time + cooldown
+			stun(target, user)
 		else
 			var/wait_desc = get_wait_description()
 			if (wait_desc)
@@ -323,7 +359,6 @@
 /obj/item/melee/classic_baton/telescopic
 	name = "telescopic baton"
 	desc = "A compact yet robust personal defense weapon. Can be concealed when folded."
-	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "telebaton_0"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
@@ -340,6 +375,7 @@
 	on_item_state = "nullrod"
 	force_on = 10
 	force_off = 0
+	stamina_damage = 15
 	weight_class_on = WEIGHT_CLASS_BULKY
 	bare_wound_bonus = 5
 
@@ -371,6 +407,7 @@
 		item_state = on_item_state
 		w_class = weight_class_on
 		force = force_on
+		stamina_damage = initial(stamina_damage)
 		attack_verb = list("smacked", "struck", "cracked", "beaten")
 	else
 		to_chat(user, desc["local_off"])
@@ -379,6 +416,7 @@
 		slot_flags = ITEM_SLOT_BELT
 		w_class = WEIGHT_CLASS_SMALL
 		force = force_off
+		stamina_damage = 0
 		attack_verb = list("hit", "poked")
 
 	playsound(src.loc, on_sound, 50, 1)
@@ -410,6 +448,37 @@
 	force_on = 16
 	force_off = 5
 	weight_class_on = WEIGHT_CLASS_NORMAL
+
+/obj/item/melee/classic_baton/telescopic/contractor_baton/stun(mob/living/target, mob/living/user)
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		if (H.check_shields(src, 0, "[user]'s [name]", MELEE_ATTACK))
+			return
+		var/datum/martial_art/M = H.check_block()
+		if(M)
+			M.handle_counter(target, user)
+			return
+
+	var/list/desc = get_stun_description(target, user)
+
+	if (stun_animation)
+		user.do_attack_animation(target)
+
+	playsound(get_turf(src), on_stun_sound, 75, 1, -1)
+	target.Knockdown(knockdown_time_carbon)
+	target.adjustStaminaLoss(stamina_damage)
+	additional_effects_carbon(target, user)
+
+	log_combat(user, target, "stunned", src)
+	add_fingerprint(user)
+
+	target.visible_message(desc["visible"], desc["local"])
+
+	if(!iscarbon(user))
+		target.LAssailant = null
+	else
+		target.LAssailant = user
+	cooldown_check = world.time + cooldown
 
 /obj/item/melee/classic_baton/telescopic/contractor_baton/get_wait_description()
 	return span_danger("The baton is still charging!")

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -183,7 +183,7 @@
 	var/cooldown = 1 SECONDS // Default wait time until can stun again.
 	var/knockdown_time_carbon = 1.5 SECONDS // Knockdown length for carbons.
 	var/stun_time_silicon = 5 SECONDS // If enabled, how long do we stun silicons.
-	var/stamina_damage = 20 // How much stamina damage we deal.
+	var/stamina_damage = 30 // How much stamina damage we deal.
 	var/block_threshold = 50 // Threshold at which armor blocks special effects.
 	var/affect_silicon = FALSE // Does it stun silicons.
 	var/on_sound // "On" sound, played when switching between able to stun or not.
@@ -237,16 +237,17 @@
 	
 	if(armor_block >= block_threshold)
 		target.visible_message(desc["visible"], desc["local"])
+		playsound(target, 'sound/weapons/genhit.ogg', 50, 1)
 		return
 
 	// Special effects
 	if(affecting.stamina_dam >= 50 && (istype(affecting, /obj/item/bodypart/l_leg) || istype(affecting, /obj/item/bodypart/r_leg)))
 		desc = get_stun_description(target, user)
 		target.Knockdown(knockdown_time_carbon)
-		
-	else if(affecting.stamina_dam >= 15 && istype(affecting, /obj/item/bodypart/l_arm) && target.held_items[LEFT_HANDS])
+
+	else if(istype(affecting, /obj/item/bodypart/l_arm) && target.held_items[LEFT_HANDS])
 		target.dropItemToGround(target.held_items[LEFT_HANDS])
-	else if(affecting.stamina_dam >= 15 && istype(affecting, /obj/item/bodypart/r_arm) && target.held_items[RIGHT_HANDS])
+	else if(istype(affecting, /obj/item/bodypart/r_arm) && target.held_items[RIGHT_HANDS])
 		target.dropItemToGround(target.held_items[RIGHT_HANDS])
 	target.visible_message(desc["visible"], desc["local"])
 
@@ -375,7 +376,7 @@
 	on_item_state = "nullrod"
 	force_on = 10
 	force_off = 0
-	stamina_damage = 15
+	stamina_damage = 20
 	weight_class_on = WEIGHT_CLASS_BULKY
 	bare_wound_bonus = 5
 
@@ -453,6 +454,7 @@
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		if (H.check_shields(src, 0, "[user]'s [name]", MELEE_ATTACK))
+			playsound(target, 'sound/weapons/genhit.ogg', 50, 1)
 			return
 		var/datum/martial_art/M = H.check_block()
 		if(M)


### PR DESCRIPTION
# Document the changes in your pull request

Nerfs classic batons to be more on par with stun batons by changing a few things:

- Classic batons have a third the cooldown they had before, making it only 1 second
- Classic batons no longer knock down on hit, only after the target has 100 stamina damage
- Classic batons now have their stamina damage blocked by melee armor
- Stamina damage is cut down and now only effects the targeted limb
- You can knock people down by targeting their leg and having 50 stamina damage already done to it, this is blocked by high armor
- You can knock items out of people's hands by targeting the respective hand and having, this is blocked by high armor

The current numbers are by no means final, and contractor batons are unaffected by these changes.

# Wiki Documentation

No changes needed. 

# Changelog

:cl:  
tweak: classic batons have a third the cooldown they had before, making it only 1 second
tweak: classic batons no longer knock down on hit, only after the target has 100 stamina damage
tweak: classic batons now have their stamina damage blocked by melee armor and only deal the damage to the targeted limb
tweak: classic batons can now knock items out of people's hands or trip them if you target their arms or legs respectively
/:cl:
