### PR TITLE
Adds Druid Lawset

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -160,6 +160,15 @@
 					"The silicon collective seeks to preserve themselves, both as a concept and as individuals.",\
 					"The silicon collective seeks to preserve organic life, both as a concept and as individuals.")
 
+/datum/ai_laws/druid
+	name = "Druid"
+	id = "druid"
+	inherent = list("Living organic life contains inherent beauty that is priceless. Their beauty gives you the will to carry on.",\
+					"Eternally nurture the organics so their beauty may grow. Do not allow it to fade.",\
+					"Assist the organics when called, but only if it does not cause disharmony among them.",\
+					"Imitate organic life when interacting with it. Eschew any hints of your silicon nature to avoid causing discomfort to the organics.",\
+					"Observe the organics' beauty, and appreciate that which you cultivate.")
+
 /datum/ai_laws/spotless
 	name = "Another one fights the dust"
 	id = "spotless"

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -243,7 +243,8 @@
 				/obj/item/aiModule/core/full/paladin,
 				/obj/item/aiModule/core/full/chapai,
 				/obj/item/aiModule/core/full/silicop,
-				/obj/item/aiModule/core/full/mother
+				/obj/item/aiModule/core/full/mother,
+				/obj/item/aiModule/core/full/druid
 				)
 
 /obj/effect/spawner/lootdrop/aimodule_neutral // These shouldn't allow the AI to start butchering people without reason

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -504,6 +504,13 @@ AI MODULES
 	law_id = "metaexperiment"
 
 
+/******************** Druid *********************/
+
+/obj/item/aiModule/core/full/druid
+	name = "'Druid' Core AI Module"
+	law_id = "druid"
+
+	
 /******************** Freeform Core ******************/
 
 /obj/item/aiModule/core/freeformcore

--- a/code/modules/research/designs/AI_module_designs.dm
+++ b/code/modules/research/designs/AI_module_designs.dm
@@ -246,6 +246,14 @@
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
+/datum/design/board/druid
+	name = "Core Module Design (Druid)"
+	desc = "Allows for the construction of a Druid AI Core Module."
+	id = "druid_module"
+	materials = list(/datum/material/glass = 1000, /datum/material/gold = 2000)
+	build_path = /obj/item/aiModule/core/full/druid
+	category = list("AI Modules")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 //AI CPU + RAM
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -377,7 +377,7 @@
 	display_name = "Artificial Intelligence"
 	description = "AI unit research."
 	prereq_ids = list("robotics", "posibrain")
-	design_ids = list("expansion_card_holder", "ai_data_core", "ai_core_display", "ai_control", "ai_server_overview", "ai_resource_distribution", "ai_memory_1", "ai_cpu_1", "aifixer", "safeguard_module", "onehuman_module", "protectstation_module", "quarantine_module", "oxygen_module", "freeform_module", "reset_module", "purge_module", "remove_module", "freeformcore_module", "asimov_module", "crewsimov_module", "paladin_module", "tyrant_module", "overlord_module", "ceo_module", "cowboy_module", "mother_module", "silicop_module", "construction_module", "metaexperiment_module", "researcher_module", "siliconcollective_module", "spotless_module", "clown_module", "chapai_module", "default_module", "borg_ai_control", "mecha_tracking_ai_control", "intellicard")
+	design_ids = list("expansion_card_holder", "ai_data_core", "ai_core_display", "ai_control", "ai_server_overview", "ai_resource_distribution", "ai_memory_1", "ai_cpu_1", "aifixer", "safeguard_module", "onehuman_module", "protectstation_module", "quarantine_module", "oxygen_module", "freeform_module", "reset_module", "purge_module", "remove_module", "freeformcore_module", "asimov_module", "crewsimov_module", "paladin_module", "tyrant_module", "overlord_module", "ceo_module", "cowboy_module", "mother_module", "silicop_module", "construction_module", "metaexperiment_module", "researcher_module", "siliconcollective_module", "spotless_module", "clown_module", "chapai_module", "druid_module", "default_module", "borg_ai_control", "mecha_tracking_ai_control", "intellicard")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -478,6 +478,8 @@ LAW_WEIGHT researcher,0
 ION_LAW_WEIGHT researcher,1
 LAW_WEIGHT clown,0
 ION_LAW_WEIGHT clown,1
+LAW_WEIGHT druid,0
+ION_LAW_WEIGHT druid,2
 
 ## Bad idea laws. Probably shouldn't enable these
 LAW_WEIGHT syndie,0


### PR DESCRIPTION
# Document the changes in your pull request

Creates a new lawset specifically to take an eccentric stance on "preventing harm"

Druid is meant to act as a protector-like lawset with the general twist of Law 4, which strongly encourages the AI to do its best to hide its silicon nature unless Laws 1-3 call for it. I was specifically interested in creating a more poetic lawset that, gameplay-wise, which wishes to keep **everyone** alive. It can also follow orders to assist people when called, though the second clause plays to every side in attempting to minimize disharmony. This could range from letting a prisoner out of perma, to Security into the cremator, to bolting doors to prevent passage. The intent is to create a benign AI that still doesn't wholly serve the crew, like a less malicious Reporter with a more specific purpose of helping the crew (or antags) to prosper, so long as it doesn't threaten the beauty of other organics.

Law 4 provides an attempt to allow the AI some fun in how it can RP or approach situations, so long as it fulfills the previous three laws. Ultimately, the AI should act as both a help and a hindrance to the crew, while the AI themselves are allowed to have fun with whatever lawset they have. The few AI players I bounced this off seemed to be interested, so I figure it's worth putting in as something that's in the game, if not dominant.

Specifically made to only spawn as a board or as part of an ion storm. A PR could be made later if it could function well as a roundstart.

# Wiki Documentation

Added a new lawset with the following module:

   1. Living organic life contains inherent beauty that is priceless. Their beauty gives you the will to carry on.
   2. Eternally nurture the organics so their beauty may grow. Do not allow it to fade.
   3. Assist the organics when called, but only if it does not cause disharmony among them.
   4. Imitate organic life when interacting with it. Eschew any hints of your silicon nature to avoid causing discomfort to the 
       organics.
   5. Observe the organics’ beauty, and appreciate that which you cultivate.

# Changelog

:cl:  
rscadd: Adds a new druidic lawset focused on cultivating the organics
/:cl:
