### PR TITLE
Some tome of herbal knowledge spellfixes and clarification.

### DIFF
--- a/code/game/objects/items/manuals.dm
+++ b/code/game/objects/items/manuals.dm
@@ -185,8 +185,9 @@
 
 				<h2>Poultice:</h2>
 
-				To prepare, first gather mushroom stems, cacti or porcini leaves, ashes from a burnt item, and a heat source such as a welder.
-				Next, mash together 4 mushroom stems and either 3 cacti fruit.
+				To prepare, first gather mushroom stems, cacti or porcini leaves, ashes from a burnt item, and a heat source such as a welder/lit candle.
+				Next, mash together 4 mushroom stems and 3 cacti fruit.
+				Porcini can be used instead of cacti fruit, but due to having less concentration it may be harder to fit enough leaves required to make the product.
 				Afterwards, scoop up ashes with the mortar. If the ashes are warm enough, it may mix without extra heat needed.
 				If it has yet to mix, heat up the bowl by using the welder on it until it has done so.
 				Apply product to wounded parts to heal them. May cause loss of breath.
@@ -201,7 +202,7 @@
 
 				<h2>Capmix:</h2>
 
-				To prepare, first gather a mushroom cap, ashes from a burnt item, and a heat source such as a welder.
+				To prepare, first gather a mushroom cap, ashes from a burnt item, and a heat source such as a welder/lit candle.
 				Next, mash together one mushroom cap.
 				Afterwards, scoop up ashes with the mortar. If the ashes are warm enough, it may mix without extra heat needed.
 				If it has yet to mix, heat up the bowl by using the welder on it until it has done so.
@@ -217,7 +218,7 @@
 				Ingesting capmix in order to expel the resin.
 
 				Resin is also useful for ensuring things stick together, and is a stronger binder than watcher sinew.
-				To use it for this purpose you'll have to solidify it by heating it up.
+				To use it for this purpose you'll have to solidify it by adding water.
 
 				<h2>Mushroom Paste:</h2>
 


### PR DESCRIPTION
Adds text saying that you can use a lit candle instead of a welder to heat up bowls, substitute cacti for porcini leaves, and that resin uses water now instead of heat to solidify, to the ash walker's knowledge book.

# Changelog

:cl:  
rscadd: Adds text saying that you can use a lit candle instead of a welder to heat up bowls, substitute cacti for porcini leaves, and that resin uses water now instead of heat to solidify, to the ash walker's knowledge book. 
spellcheck: Fixed a typo with poultice making.
/:cl:
