### PR TITLE
Fixes Engine Probabilties

### DIFF
--- a/yogstation/code/game/objects/effects/landmarks.dm
+++ b/yogstation/code/game/objects/effects/landmarks.dm
@@ -106,12 +106,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 		if(2)
 			return "Engine Singulo And Tesla"
 		if(3)
-			if(prob(33))
-				return "Engine SM"
-			if(prob(33))
-				return "Engine Singulo And Tesla"
-			if(prob(33))
-				return "Engine TEG"
+			return . //We let the normal choose() do the work if we want to have all of them in play
 		if(4)
 			return "Engine TEG"
 


### PR DESCRIPTION
# Document the changes in your pull request

Currently there's a 44% chance of SM, 33% of Sing/Tesla and 23% of TEG

# Wiki Documentation

# Changelog

:cl:  
bugfix: Engines on Boxstation once again have a 33% chance of rolling each
/:cl:
