### PR TITLE
Fixes Engine Probabilities but we get actually interesting engines more often like it is currently

### DIFF
--- a/yogstation/code/game/objects/effects/landmarks.dm
+++ b/yogstation/code/game/objects/effects/landmarks.dm
@@ -106,7 +106,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 		if(2)
 			return "Engine Singulo And Tesla"
 		if(3)
-			pickweight(template_names)
+			return .
 		if(4)
 			return "Engine TEG"
 

--- a/yogstation/code/game/objects/effects/landmarks.dm
+++ b/yogstation/code/game/objects/effects/landmarks.dm
@@ -94,7 +94,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 	return TRUE
 
 /obj/effect/landmark/stationroom/box/engine
-	template_names = list("Engine SM", "Engine Singulo And Tesla", "Engine TEG")
+	template_names = list("Engine SM" = 50, "Engine Singulo And Tesla" = 30, "Engine TEG" = 20)
 	icon = 'yogstation/icons/rooms/box/engine.dmi'
 
 /obj/effect/landmark/stationroom/box/engine/choose()
@@ -106,12 +106,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 		if(2)
 			return "Engine Singulo And Tesla"
 		if(3)
-			if(prob(33))
-				return "Engine SM"
-			if(prob(33))
-				return "Engine Singulo And Tesla"
-			if(prob(33))
-				return "Engine TEG"
+			pickweight(template_names)
 		if(4)
 			return "Engine TEG"
 

--- a/yogstation/code/game/objects/effects/landmarks.dm
+++ b/yogstation/code/game/objects/effects/landmarks.dm
@@ -106,7 +106,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 		if(2)
 			return "Engine Singulo And Tesla"
 		if(3)
-			return .
+			return . //We let the normal choose() do the work if we want to have all of them in play
 		if(4)
 			return "Engine TEG"
 


### PR DESCRIPTION
# Document the changes in your pull request

alternate to https://github.com/yogstation13/Yogstation/pull/13436

33% of each means 66% of the time you'll have a shitty engine that has no complexity or depth 

this pr makes it so you only have a shitty engine 50% of the time (you decide which one)

Supermatter: 50%
Tesla/Singularity: 30%
TEG: 20%

# Changelog

:cl: ToasterBiome, TheGamerdk
bugfix: fixes engine template failing 28% of the time and picking weird weights for engines
rscadd: legitimizes weird engine weights
/:cl:
