### PR TITLE
Buffs TRAC rounds and allows dets to use the tracking program

### DIFF
--- a/code/game/objects/items/implants/implant_track.dm
+++ b/code/game/objects/items/implants/implant_track.dm
@@ -2,13 +2,13 @@
 	name = "tracking implant"
 	desc = "Track with this."
 	activated = FALSE
-	var/lifespan_postmortem = 10 MINUTES //for how many deciseconds after user death will the implant work?
+	var/lifespan_postmortem = 10 MINUTES //for how long after user death will the implant work?
 	var/allow_teleport = TRUE //will people implanted with this act as teleporter beacons?
 
 /obj/item/implant/tracking/c38
 	name = "TRAC implant"
 	desc = "A smaller tracking implant that supplies power for only a few minutes."
-	var/lifespan = 15 MINUTES //how many deciseconds does the implant last?
+	var/lifespan = 15 MINUTES //how long does the implant last?
 	allow_teleport = FALSE
 
 /obj/item/implant/tracking/c38/Initialize()

--- a/code/game/objects/items/implants/implant_track.dm
+++ b/code/game/objects/items/implants/implant_track.dm
@@ -2,13 +2,13 @@
 	name = "tracking implant"
 	desc = "Track with this."
 	activated = FALSE
-	var/lifespan_postmortem = 1 MINUTES //for how many deciseconds after user death will the implant work?
+	var/lifespan_postmortem = 10 MINUTES //for how many deciseconds after user death will the implant work?
 	var/allow_teleport = TRUE //will people implanted with this act as teleporter beacons?
 
 /obj/item/implant/tracking/c38
 	name = "TRAC implant"
 	desc = "A smaller tracking implant that supplies power for only a few minutes."
-	var/lifespan = 5 MINUTES //how many deciseconds does the implant last?
+	var/lifespan = 15 MINUTES //how many deciseconds does the implant last?
 	allow_teleport = FALSE
 
 /obj/item/implant/tracking/c38/Initialize()

--- a/code/game/objects/items/implants/implant_track.dm
+++ b/code/game/objects/items/implants/implant_track.dm
@@ -2,13 +2,13 @@
 	name = "tracking implant"
 	desc = "Track with this."
 	activated = FALSE
-	var/lifespan_postmortem = 6000 //for how many deciseconds after user death will the implant work?
+	var/lifespan_postmortem = 1 MINUTES //for how many deciseconds after user death will the implant work?
 	var/allow_teleport = TRUE //will people implanted with this act as teleporter beacons?
 
 /obj/item/implant/tracking/c38
 	name = "TRAC implant"
 	desc = "A smaller tracking implant that supplies power for only a few minutes."
-	var/lifespan = 3000 //how many deciseconds does the implant last?
+	var/lifespan = 5 MINUTES //how many deciseconds does the implant last?
 	allow_teleport = FALSE
 
 /obj/item/implant/tracking/c38/Initialize()

--- a/code/modules/jobs/job_types/detective.dm
+++ b/code/modules/jobs/job_types/detective.dm
@@ -53,7 +53,8 @@
 	r_pocket = /obj/item/lighter
 	backpack_contents = list(/obj/item/storage/box/evidence=1,\
 		/obj/item/detective_scanner=1,\
-		/obj/item/melee/classic_baton=1)
+		/obj/item/melee/classic_baton=1,\
+		/obj/item/modular_computer/tablet/pda/preset/basic=1)
 	mask = /obj/item/clothing/mask/cigarette
 
 	implants = list(/obj/item/implant/mindshield)

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -7,7 +7,7 @@
 	requires_ntnet = TRUE
 	transfer_access = null
 	available_on_ntnet = FALSE
-	usage_flags = PROGRAM_LAPTOP | PROGRAM_TABLET | PROGRAM_PHONE | PROGRAM_INTEGRATED
+	usage_flags = PROGRAM_LAPTOP | PROGRAM_TABLET | PROGRAM_PHONE | PROGRAM_PDA | PROGRAM_INTEGRATED
 	network_destination = "tracking program"
 	size = 5
 	tgui_id = "NtosRadar"
@@ -314,7 +314,7 @@
 	filedesc = "Implant Tracker"
 	extended_desc = "This program allows for tracking those implanted with tracking implants."
 	requires_ntnet = TRUE
-	transfer_access = ACCESS_SECURITY
+	transfer_access = ACCESS_BRIG
 	available_on_ntnet = TRUE
 	program_icon = "microchip"
 


### PR DESCRIPTION
# Document the changes in your pull request

Changes an underused ammunition type to be more useful and tweaks some modular computer stuff. Is tested.

- TRAC implant now lasts 5 minutes
- Detectives now start with a modular PDA
- Radar programs (Lifeline, Fission360, and of course the Implant Tracker program) now work on PDAs
- Implant Tracking program now only requires brig access (can just give det a disk with the program instead if preferred)

# Wiki Documentation

If it is mentioned what detectives start with, it would be a good idea to update that with the PDA.

# Changelog

:cl:  
tweak: TRAC implant now lasts 15 minutes 
tweak:  Detectives now start with a modular PDA
tweak: Radar programs now work on PDAs and the implant tracking program now only requires brig access
/:cl:
