### PR TITLE
Fixes being able to steal AIs out of other intellicards if you're both trying to download it

### DIFF
--- a/code/modules/mob/living/silicon/ai/decentralized/management/ai_controlpanel.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/management/ai_controlpanel.dm
@@ -205,6 +205,9 @@ GLOBAL_VAR_INIT(ai_control_code, random_nukecode(6))
 
 /obj/machinery/computer/ai_control_console/proc/finish_download()
 	if(intellicard)
+		if(!isaicore(get_turf(downloading)))
+			stop_download(TRUE)
+			return
 		downloading.transfer_ai(AI_TRANS_TO_CARD, user_downloading, null, intellicard)
 		intellicard.forceMove(get_turf(src))
 		intellicard.update_icon()

--- a/code/modules/mob/living/silicon/ai/decentralized/management/ai_controlpanel.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/management/ai_controlpanel.dm
@@ -205,7 +205,7 @@ GLOBAL_VAR_INIT(ai_control_code, random_nukecode(6))
 
 /obj/machinery/computer/ai_control_console/proc/finish_download()
 	if(intellicard)
-		if(!isaicore(get_turf(downloading)))
+		if(!isaicore(downloading.loc))
 			stop_download(TRUE)
 			return
 		downloading.transfer_ai(AI_TRANS_TO_CARD, user_downloading, null, intellicard)


### PR DESCRIPTION
# Document the changes in your pull request

Fixes #13422


# Wiki Documentation

# Changelog

:cl:  
tweak: Fixes issue where you could end up downloading an AI out of an intellicard
/:cl:
