### PR TITLE
makes emagged minesweeper blow up in the correct location

### DIFF
--- a/yogstation/code/game/machinery/computer/arcade.dm
+++ b/yogstation/code/game/machinery/computer/arcade.dm
@@ -423,5 +423,5 @@
 		for(var/x69=x-column_limit;x69<x+column_limit;x69++)
 			if(prob(mine_limit_v2))	//Probability of explosion happening, according to how many mines were on the board... up to a limit
 				var/explosionloc
-				explosionloc = locate(y69,x69,z)
-				explosion(explosionloc, ,rand(1,2),rand(1,5),rand(3,10), adminlog = FALSE)
+				explosionloc = locate(src.loc + x69,src.loc + y69,z)
+				explosion(explosionloc,0,rand(1,2),rand(1,5),rand(3,10), adminlog = FALSE)

--- a/yogstation/code/game/machinery/computer/arcade.dm
+++ b/yogstation/code/game/machinery/computer/arcade.dm
@@ -423,5 +423,5 @@
 		for(var/x69=x-column_limit;x69<x+column_limit;x69++)
 			if(prob(mine_limit_v2))	//Probability of explosion happening, according to how many mines were on the board... up to a limit
 				var/explosionloc
-				explosionloc = locate(x + x69,y + y69,z)
+				explosionloc = locate(x69,y69,z)
 				explosion(explosionloc,0,rand(1,2),rand(1,5),rand(3,10), adminlog = FALSE)

--- a/yogstation/code/game/machinery/computer/arcade.dm
+++ b/yogstation/code/game/machinery/computer/arcade.dm
@@ -423,5 +423,5 @@
 		for(var/x69=x-column_limit;x69<x+column_limit;x69++)
 			if(prob(mine_limit_v2))	//Probability of explosion happening, according to how many mines were on the board... up to a limit
 				var/explosionloc
-				explosionloc = locate(src.loc.x + x69,src.loc.y + y69,z)
+				explosionloc = locate(x + x69,y + y69,z)
 				explosion(explosionloc,0,rand(1,2),rand(1,5),rand(3,10), adminlog = FALSE)

--- a/yogstation/code/game/machinery/computer/arcade.dm
+++ b/yogstation/code/game/machinery/computer/arcade.dm
@@ -423,5 +423,5 @@
 		for(var/x69=x-column_limit;x69<x+column_limit;x69++)
 			if(prob(mine_limit_v2))	//Probability of explosion happening, according to how many mines were on the board... up to a limit
 				var/explosionloc
-				explosionloc = locate(src.loc + x69,src.loc + y69,z)
+				explosionloc = locate(src.loc.x + x69,src.loc.y + y69,z)
 				explosion(explosionloc,0,rand(1,2),rand(1,5),rand(3,10), adminlog = FALSE)


### PR DESCRIPTION
# Document the changes in your pull request

makes emagged minesweeper blow up in the correct location

what if we switched x and y

closes https://github.com/yogstation13/Yogstation/issues/13439

# Changelog

:cl:  
bugfix: 
bugfix: fixes shitty minesweeper formatting
/:cl:
