### PR TITLE
Shuts health analyzers up

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -111,7 +111,6 @@ GENE SCANNER
 
 /obj/item/healthanalyzer/attack(mob/living/M, mob/living/carbon/human/user)
 	flick("[icon_state]-scan", src)	//makes it so that it plays the scan animation upon scanning, including clumsy scanning
-	playsound(src, 'sound/effects/fastbeep.ogg', 20)
 
 	// Clumsiness/brain damage check
 	if ((HAS_TRAIT(user, TRAIT_CLUMSY) || HAS_TRAIT(user, TRAIT_DUMB)) && prob(50))


### PR DESCRIPTION
Whoever thought this was a good idea is either stupid or a masochist. Health analyzers are basically the number 1 spammed item in the game, and having medbay filled with annoying beeps is not a good way to encourage people to play medical roles.

# Changelog

:cl: Lucy
sounddel: Medbay is no longer filled with annoying beeps.
/:cl:
