### PR TITLE
Medical analyzer beeps have a cooldown #KeepTheBeep

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -94,6 +94,7 @@ GENE SCANNER
 	materials = list(/datum/material/iron=200)
 	var/scanmode = 0
 	var/advanced = FALSE
+	var/beep_cooldown = 0
 
 /obj/item/healthanalyzer/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] begins to analyze [user.p_them()]self with [src]! The display shows that [user.p_theyre()] dead!"))
@@ -111,7 +112,9 @@ GENE SCANNER
 
 /obj/item/healthanalyzer/attack(mob/living/M, mob/living/carbon/human/user)
 	flick("[icon_state]-scan", src)	//makes it so that it plays the scan animation upon scanning, including clumsy scanning
-	playsound(src, 'sound/effects/fastbeep.ogg', 20)
+	if(beep_cooldown<world.time)
+		playsound(src, 'sound/effects/fastbeep.ogg', 20)
+		beep_cooldown = world.time+40
 
 	// Clumsiness/brain damage check
 	if ((HAS_TRAIT(user, TRAIT_CLUMSY) || HAS_TRAIT(user, TRAIT_DUMB)) && prob(50))


### PR DESCRIPTION
alternative PR to Lucy's so we can Keep the Beep

I think the beeps are good, sounds that accompany player actions make the world feel alive. I can agree the beeping can be excessive because if you full scan someone who comes into medbay that's like 3-4 rapid beeps per patient, and more if another doctor walks up to scan them. 

I added a ~4 second cooldown to the beep noise so you will probably only hear a beep or two per patient scanning cycle. This is easily changeable if it's still too short, or maybe people would rather have an analyzer mute button instead, although i would rather keep some kind of audibility to actions.

I tested on a monkey and it worked, and the monkey is ok

# Changelog

:cl:  
tweak: cooldown on health analyzer beep so medbay isn't constant beeping
/:cl:
