### PR TITLE
Fixes AI Control Console using placeholder AI name when downloading

### DIFF
--- a/tgui/packages/tgui/interfaces/AiControlPanel.js
+++ b/tgui/packages/tgui/interfaces/AiControlPanel.js
@@ -107,7 +107,7 @@ export const AiControlPanel = (props, context) => {
               )}>
                 {data.downloading && (
                   <Fragment>
-                    <NoticeBox mb={0.1} danger>Currently downloading {data.downloading]</NoticeBox>
+                    <NoticeBox mb={0.1} danger>Currently downloading {data.downloading}</NoticeBox>
                     <ProgressBar color="bad" minValue="0" value={data.download_progress} maxValue="100" />
                     <Button mt={0.5} fluid color="bad" icon="stop" tooltip="WARNING" textAlign="center" onClick={() => act("stop_download")}>Cancel Download</Button>
                     {!!data.current_ai_ref && data.current_ai_ref === data.downloading_ref && (

--- a/tgui/packages/tgui/interfaces/AiControlPanel.js
+++ b/tgui/packages/tgui/interfaces/AiControlPanel.js
@@ -107,7 +107,7 @@ export const AiControlPanel = (props, context) => {
               )}>
                 {data.downloading && (
                   <Fragment>
-                    <NoticeBox mb={0.1} danger>Currently downloading G2</NoticeBox>
+                    <NoticeBox mb={0.1} danger>Currently downloading {data.downloading]</NoticeBox>
                     <ProgressBar color="bad" minValue="0" value={data.download_progress} maxValue="100" />
                     <Button mt={0.5} fluid color="bad" icon="stop" tooltip="WARNING" textAlign="center" onClick={() => act("stop_download")}>Cancel Download</Button>
                     {!!data.current_ai_ref && data.current_ai_ref === data.downloading_ref && (


### PR DESCRIPTION
# Document the changes in your pull request

awkward

# Wiki Documentation

# Changelog


:cl:  
tweak: AI Control Console no longer shows 'G2' no matter which AI you're downloading
/:cl:
