### PR TITLE
Fix macros not loading if you join game before SSinput is started

### DIFF
--- a/tgui/yarn.lock
+++ b/tgui/yarn.lock
@@ -1881,12 +1881,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^0.19.2":
-  version: 0.19.2
-  resolution: "axios@npm:0.19.2"
+"axios@npm:^0.21.2":
+  version: 0.21.4
+  resolution: "axios@npm:0.21.4"
   dependencies:
-    follow-redirects: 1.5.10
-  checksum: bad346deea24050f9953ce09bb8015f85a99a7b8f016806adccfab0b8981827d1fbee9c77c0ef7c70cc48392c1af6bbc65e07c3e88221d17282d2d5fd0a191f6
+    follow-redirects: ^1.14.0
+  checksum: e6d42b269b599d36eb13be0671c237781f32e6ae72be824297c55a3e1ce63b22ba4f46bad5ab28da7d3bae50a72637d55c792cf803be1cf9de6a8bcd6d0dcc1a
   languageName: node
   linkType: hard
 
@@ -3099,15 +3099,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:=3.1.0":
-  version: 3.1.0
-  resolution: "debug@npm:3.1.0"
-  dependencies:
-    ms: 2.0.0
-  checksum: 1295acd5e0531761255661d325cd0a80ac8c5f6de8942a53bb23c2197ccb97526972de662ed0e5d9393be83f3428a298a6e7185ecb02f0da6282019cd2ffb4a8
-  languageName: node
-  linkType: hard
-
 "debug@npm:^4.0.1, debug@npm:^4.1.0":
   version: 4.1.1
   resolution: "debug@npm:4.1.1"
@@ -4037,12 +4028,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:1.5.10":
-  version: 1.5.10
-  resolution: "follow-redirects@npm:1.5.10"
-  dependencies:
-    debug: =3.1.0
-  checksum: 6e58e02c31337b6b41ffc3d5f3d49920b7db428eddcf374537da00ef121fe473983e12d8557f4304287604168d3efcc288d1f009abaf4c9d61e5db0c0cee3c4a
+"follow-redirects@npm:^1.14.0":
+  version: 1.14.9
+  resolution: "follow-redirects@npm:1.14.9"
+  peerDependencies:
+    debug: "*"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: 1b602c548b4194c66d8d530d2c8f76b4116b6c498434acfa561f583f45b571fd9fc042fba778748cd863044051656cf4788ba11c8ff35407223ed0d38ffff0d4
   languageName: node
   linkType: hard
 
@@ -8318,7 +8312,7 @@ fsevents@~2.1.2:
   version: 0.0.0-use.local
   resolution: "tgui-dev-server@workspace:packages/tgui-dev-server"
   dependencies:
-    axios: ^0.19.2
+    axios: ^0.21.2
     common: "workspace:*"
     esm: ^3.2.25
     glob: ^7.1.4

--- a/yogstation/code/controllers/subsystem/input.dm
+++ b/yogstation/code/controllers/subsystem/input.dm
@@ -15,6 +15,8 @@ SUBSYSTEM_DEF(input)
 	setup_default_movement_keys()
 
 	initialized = TRUE
+	
+	refresh_client_macro_sets()
 
 	return ..()
 
@@ -104,6 +106,12 @@ SUBSYSTEM_DEF(input)
 	)
 
 	movement_arrows = arrow_keys.Copy()
+
+/datum/controller/subsystem/input/proc/refresh_client_macro_sets()
+	var/list/clients = GLOB.clients
+	for(var/i in 1 to clients.len)
+		var/client/user = clients[i]
+		user.set_macros()
 
 /datum/controller/subsystem/input/fire()
 	var/list/clients = GLOB.clients // Let's sing the list cache song


### PR DESCRIPTION
Macros did not load when you joined the game before SSinput started, meaning you could not move or use hotkey mode while in game. 
# Changelog

:cl:  
bugfix: Fix macros not loading if you join game before SSinput is started 
/:cl:
