### PR TITLE
Fix capitalisation in malf round report

### DIFF
--- a/code/game/gamemodes/malfunction/malf.dm
+++ b/code/game/gamemodes/malfunction/malf.dm
@@ -58,6 +58,6 @@
 		SSticker.mode_result = "loss - evacuation - AI killed"
 
 /datum/game_mode/malf/generate_report()
-	return "a [pick(list("Huge electrical storm","Photon emitter","Meson generator","Blue swirly thing"))] was recently picked up by a nearby station's sensors in your sector. \
+	return "A [pick(list("huge electrical storm","photon emitter","meson generator","blue swirly thing"))] was recently picked up by a nearby station's sensors in your sector. \
 	If it came into contact with your station or electrical equipment, it may have had hazardarous and unpredictable effect. \
 	Closely observe any non carbon based life forms for signs of unusual behaviour, but keep this information discreet at all times due to this possibly dangerous scenario."


### PR DESCRIPTION
Small capitalisation changes in the malf round report
:cl:  
spellcheck: Fix capitalisation in malf round report
/:cl:
