### PR TITLE
Fix macros not loading if you join game before SSinput is started 

### DIFF
--- a/yogstation/code/controllers/subsystem/input.dm
+++ b/yogstation/code/controllers/subsystem/input.dm
@@ -15,7 +15,6 @@ SUBSYSTEM_DEF(input)
 	setup_default_movement_keys()
 
 	initialized = TRUE
-	
 	refresh_client_macro_sets()
 
 	return ..()

--- a/yogstation/code/controllers/subsystem/input.dm
+++ b/yogstation/code/controllers/subsystem/input.dm
@@ -15,6 +15,8 @@ SUBSYSTEM_DEF(input)
 	setup_default_movement_keys()
 
 	initialized = TRUE
+	
+	refresh_client_macro_sets()
 
 	return ..()
 
@@ -104,6 +106,12 @@ SUBSYSTEM_DEF(input)
 	)
 
 	movement_arrows = arrow_keys.Copy()
+
+/datum/controller/subsystem/input/proc/refresh_client_macro_sets()
+	var/list/clients = GLOB.clients
+	for(var/i in 1 to clients.len)
+		var/client/user = clients[i]
+		user.set_macros()
 
 /datum/controller/subsystem/input/fire()
 	var/list/clients = GLOB.clients // Let's sing the list cache song


### PR DESCRIPTION
Macros did not load when you joined the game before SSinput started, meaning you could not move or use hotkey mode while in game. 
# Changelog

:cl:  
bugfix: Fix macros not loading if you join game before SSinput is started 
/:cl:
