### PR TITLE
Disable RCD on indestructible windows

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -73,6 +73,9 @@
 	return FALSE
 
 /obj/structure/window/rcd_act(mob/user, var/obj/item/construction/rcd/the_rcd)
+	if (resistance_flags & INDESTRUCTIBLE)
+		return FALSE
+
 	switch(the_rcd.mode)
 		if(RCD_DECONSTRUCT)
 			to_chat(user, span_notice("You deconstruct the window."))


### PR DESCRIPTION
RCDs were able to destroy indestructible windows, so crewmembers could bypass the luxury shuttle. This is no longer the case. 

:cl:  
tweak: Luxury shuttle windows now survive RCDs
/:cl:
Tested, working