### PR TITLE
[s] prevents swarmers from oneshotting bloodstones

### DIFF
--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -135,6 +135,9 @@
 	to_chat(S, span_warning("Searching... sensor malfunction! Target lost. Aborting."))
 	return FALSE
 
+/obj/structure/destructible/cult/bloodstone/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+	to_chat(actor, span_warning("Err: unresolved object. Aborting.))
+
 /obj/structure/reagent_dispensers/fueltank/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	to_chat(S, span_warning("Destroying this object could cause a chain reaction. Aborting."))
 	return FALSE

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -137,6 +137,7 @@
 
 /obj/structure/destructible/cult/bloodstone/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	to_chat(actor, span_warning("Err: unresolved object. Aborting."))
+	return FALSE
 
 /obj/structure/reagent_dispensers/fueltank/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	to_chat(S, span_warning("Destroying this object could cause a chain reaction. Aborting."))

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -135,7 +135,7 @@
 	to_chat(S, span_warning("Searching... sensor malfunction! Target lost. Aborting."))
 	return FALSE
 
-/obj/structure/destructible/cult/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+/obj/structure/destructible/cult/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
 	to_chat(actor, span_warning("Err: unresolved object. Aborting."))
 	return FALSE
 

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -136,7 +136,7 @@
 	return FALSE
 
 /obj/structure/destructible/cult/bloodstone/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
-	to_chat(actor, span_warning("Err: unresolved object. Aborting.))
+	to_chat(actor, span_warning("Err: unresolved object. Aborting."))
 
 /obj/structure/reagent_dispensers/fueltank/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	to_chat(S, span_warning("Destroying this object could cause a chain reaction. Aborting."))

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -135,8 +135,8 @@
 	to_chat(S, span_warning("Searching... sensor malfunction! Target lost. Aborting."))
 	return FALSE
 
-/obj/structure/destructible/cult/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
-	to_chat(actor, span_warning("Err: unresolved object. Aborting."))
+/obj/structure/destructible/cult/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+	to_chat(S, span_warning("Err: unresolved object. Aborting."))
 	return FALSE
 
 /obj/structure/reagent_dispensers/fueltank/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -135,7 +135,7 @@
 	to_chat(S, span_warning("Searching... sensor malfunction! Target lost. Aborting."))
 	return FALSE
 
-/obj/structure/destructible/cult/bloodstone/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+/obj/structure/destructible/cult/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	to_chat(actor, span_warning("Err: unresolved object. Aborting."))
 	return FALSE
 


### PR DESCRIPTION
# Document the changes in your pull request

it has come to my attention swarmers can eat bloodstones
they should not be able to do this
speedmerge pls


# Changelog

:cl:  
bugfix: swarmers are no longer narsie's worst enemy
/:cl:
