### PR TITLE
[s] Fixed pretty filter bypassing spam filter

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -458,6 +458,7 @@
 		if(type_override)
 			emote_type = type_override
 	if(isnotpretty(message))
+		user.client.handle_spam_prevention("PRETTY FILTER", MUTE_ALL) // Constant message mutes someone faster for not pretty messages
 		to_chat(usr, span_notice("You fumble over your action. <a href='https://forums.yogstation.net/help/rules/#rule-0_1'>See rule 0.1</a>."))
 		var/log_message = "[key_name(usr)] just tripped a pretty filter: '[message]'."
 		message_admins(log_message)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -7,6 +7,7 @@
 
 	//yogs start - pretty filter
 	if(isnotpretty(message))
+		client.handle_spam_prevention("PRETTY FILTER", MUTE_ALL) // Constant message mutes someone faster for not pretty messages
 		to_chat(usr, span_notice("You fumble over your words. <a href='https://forums.yogstation.net/help/rules/#rule-0_1'>See rule 0.1</a>."))
 		var/log_message = "[key_name(usr)] just tripped a pretty filter: '[message]'."
 		message_admins(log_message)
@@ -28,6 +29,7 @@
 
 	//yogs start - pretty filter
 	if(isnotpretty(message))
+		client.handle_spam_prevention("PRETTY FILTER", MUTE_ALL) // Constant message mutes someone faster for not pretty messages
 		to_chat(usr, span_notice("You fumble over your words. <a href='https://forums.yogstation.net/help/rules/#rule-0_1'>See rule 0.1</a>."))
 		var/log_message = "[key_name(usr)] just tripped a pretty filter: '[message]'."
 		message_admins(log_message)

--- a/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
@@ -41,7 +41,7 @@
 				return
 			//yogs start
 			if(isnotpretty(message))
-				usr.handle_spam_prevention("PRETTY FILTER", MUTE_ALL) // Constant message mutes someone faster for not pretty messages
+				usr.client.handle_spam_prevention("PRETTY FILTER", MUTE_ALL) // Constant message mutes someone faster for not pretty messages
 				to_chat(usr, "<span class='notice'>Your fingers slip. <a href='https://forums.yogstation.net/help/rules/#rule-0_1'>See rule 0.1</a>.</span>")
 				var/log_message = "[key_name(usr)] just tripped a pretty filter: '[message]'."
 				message_admins(log_message)
@@ -82,7 +82,7 @@
 				return
 			//yogs start
 			if(isnotpretty(channel_title))
-				usr.handle_spam_prevention("PRETTY FILTER", MUTE_ALL) // Constant message mutes someone faster for not pretty messages
+				usr.client.handle_spam_prevention("PRETTY FILTER", MUTE_ALL) // Constant message mutes someone faster for not pretty messages
 				to_chat(usr, "<span class='notice'>Your fingers slip. <a href='https://forums.yogstation.net/help/rules/#rule-0_1'>See rule 0.1</a>.</span>")
 				var/log_message = "[key_name(usr)] just tripped a pretty filter: '[channel_title]'."
 				message_admins(log_message)
@@ -114,7 +114,7 @@
 				return
 			//yogs start
 			if(isnotpretty(newname))
-				usr.handle_spam_prevention("PRETTY FILTER", MUTE_ALL) // Constant message mutes someone faster for not pretty messages
+				usr.client.handle_spam_prevention("PRETTY FILTER", MUTE_ALL) // Constant message mutes someone faster for not pretty messages
 				to_chat(usr, "<span class='notice'>Your fingers slip. <a href='https://forums.yogstation.net/help/rules/#rule-0_1'>See rule 0.1</a>.</span>")
 				var/log_message = "[key_name(usr)] just tripped a pretty filter: '[newname]'."
 				message_admins(log_message)
@@ -159,7 +159,7 @@
 				return
 			//yogs start
 			if(isnotpretty(newname))
-				usr.handle_spam_prevention("PRETTY FILTER", MUTE_ALL) // Constant message mutes someone faster for not pretty messages
+				usr.client.handle_spam_prevention("PRETTY FILTER", MUTE_ALL) // Constant message mutes someone faster for not pretty messages
 				to_chat(usr, "<span class='notice'>Your fingers slip. <a href='https://forums.yogstation.net/help/rules/#rule-0_1'>See rule 0.1</a>.</span>")
 				var/log_message = "[key_name(usr)] just tripped a pretty filter: '[newname]'."
 				message_admins(log_message)
@@ -184,7 +184,7 @@
 
 			//yogs start
 			if(isnotpretty(new_password))
-				usr.handle_spam_prevention("PRETTY FILTER", MUTE_ALL) // Constant message mutes someone faster for not pretty messages
+				usr.client.handle_spam_prevention("PRETTY FILTER", MUTE_ALL) // Constant message mutes someone faster for not pretty messages
 				to_chat(usr, "<span class='notice'>Your fingers slip. <a href='https://forums.yogstation.net/help/rules/#rule-0_1'>See rule 0.1</a>.</span>")
 				var/log_message = "[key_name(usr)] just tripped a pretty filter: '[new_password]'."
 				message_admins(log_message)

--- a/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
@@ -41,6 +41,7 @@
 				return
 			//yogs start
 			if(isnotpretty(message))
+				usr.handle_spam_prevention("PRETTY FILTER", MUTE_ALL) // Constant message mutes someone faster for not pretty messages
 				to_chat(usr, "<span class='notice'>Your fingers slip. <a href='https://forums.yogstation.net/help/rules/#rule-0_1'>See rule 0.1</a>.</span>")
 				var/log_message = "[key_name(usr)] just tripped a pretty filter: '[message]'."
 				message_admins(log_message)
@@ -81,6 +82,7 @@
 				return
 			//yogs start
 			if(isnotpretty(channel_title))
+				usr.handle_spam_prevention("PRETTY FILTER", MUTE_ALL) // Constant message mutes someone faster for not pretty messages
 				to_chat(usr, "<span class='notice'>Your fingers slip. <a href='https://forums.yogstation.net/help/rules/#rule-0_1'>See rule 0.1</a>.</span>")
 				var/log_message = "[key_name(usr)] just tripped a pretty filter: '[channel_title]'."
 				message_admins(log_message)
@@ -112,6 +114,7 @@
 				return
 			//yogs start
 			if(isnotpretty(newname))
+				usr.handle_spam_prevention("PRETTY FILTER", MUTE_ALL) // Constant message mutes someone faster for not pretty messages
 				to_chat(usr, "<span class='notice'>Your fingers slip. <a href='https://forums.yogstation.net/help/rules/#rule-0_1'>See rule 0.1</a>.</span>")
 				var/log_message = "[key_name(usr)] just tripped a pretty filter: '[newname]'."
 				message_admins(log_message)
@@ -156,6 +159,7 @@
 				return
 			//yogs start
 			if(isnotpretty(newname))
+				usr.handle_spam_prevention("PRETTY FILTER", MUTE_ALL) // Constant message mutes someone faster for not pretty messages
 				to_chat(usr, "<span class='notice'>Your fingers slip. <a href='https://forums.yogstation.net/help/rules/#rule-0_1'>See rule 0.1</a>.</span>")
 				var/log_message = "[key_name(usr)] just tripped a pretty filter: '[newname]'."
 				message_admins(log_message)
@@ -180,6 +184,7 @@
 
 			//yogs start
 			if(isnotpretty(new_password))
+				usr.handle_spam_prevention("PRETTY FILTER", MUTE_ALL) // Constant message mutes someone faster for not pretty messages
 				to_chat(usr, "<span class='notice'>Your fingers slip. <a href='https://forums.yogstation.net/help/rules/#rule-0_1'>See rule 0.1</a>.</span>")
 				var/log_message = "[key_name(usr)] just tripped a pretty filter: '[new_password]'."
 				message_admins(log_message)

--- a/code/modules/shuttle/shuttle_creation/shuttle_creator.dm
+++ b/code/modules/shuttle/shuttle_creation/shuttle_creator.dm
@@ -271,6 +271,7 @@ GLOBAL_LIST_EMPTY(custom_shuttle_machines)		//Machines that require updating (He
 		return FALSE
 //Yogs Start: Runs the name through the petty filter. If they trip it, it will cause the shuttle creation to fail, messages the admins, and put the RSD on cooldown.
 	if(isnotpretty(str))
+		handle_spam_prevention("PRETTY FILTER", MUTE_ALL) // Constant message mutes someone faster for not pretty messages
 		to_chat(user, "<span class='warning'>Nanotrasen prohibited words are in use in this shuttle name, blares the [src] in a slightly offended tone.</span>")
 		message_admins("[ADMIN_LOOKUPFLW(user)] attempted to created a new shuttle with a [src] at [ADMIN_VERBOSEJMP(user)], but failed because of not passing the pretty filter")
 		log_say("[key_name(usr)] just tripped a pretty filter: '[str]'.")

--- a/code/modules/shuttle/shuttle_creation/shuttle_creator.dm
+++ b/code/modules/shuttle/shuttle_creation/shuttle_creator.dm
@@ -271,7 +271,7 @@ GLOBAL_LIST_EMPTY(custom_shuttle_machines)		//Machines that require updating (He
 		return FALSE
 //Yogs Start: Runs the name through the petty filter. If they trip it, it will cause the shuttle creation to fail, messages the admins, and put the RSD on cooldown.
 	if(isnotpretty(str))
-		handle_spam_prevention("PRETTY FILTER", MUTE_ALL) // Constant message mutes someone faster for not pretty messages
+		user.client.handle_spam_prevention("PRETTY FILTER", MUTE_ALL) // Constant message mutes someone faster for not pretty messages
 		to_chat(user, "<span class='warning'>Nanotrasen prohibited words are in use in this shuttle name, blares the [src] in a slightly offended tone.</span>")
 		message_admins("[ADMIN_LOOKUPFLW(user)] attempted to created a new shuttle with a [src] at [ADMIN_VERBOSEJMP(user)], but failed because of not passing the pretty filter")
 		log_say("[key_name(usr)] just tripped a pretty filter: '[str]'.")


### PR DESCRIPTION
# Document the changes in your pull request

Currently hitting the pretty filter causes a return before hitting the anti-spam proc, allowing targeted mass spam at admins. This fix triggers the pretty filter, and with a common message, so any pretty filtered message will be treated as the same message, and hitting the automute will mute from everything, to prevent switching to another means of communication to avoid the mute.

# Changelog

:cl:  
bugfix: fixed being able to spam admins with pretty filter logs
/:cl:
