### PR TITLE
Replacing a borg's bulb actually fixes it

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -594,13 +594,14 @@
 			return
 		if(!opened)
 			to_chat(user, span_warning("You need to open the panel to repair the headlamp!"))
-		else if(lamp_cooldown <= world.time)
+		else if(lamp_cooldown <= world.time && lamp_functional)
 			to_chat(user, span_warning("The headlamp is already functional!"))
 		else
 			if(!user.temporarilyRemoveItemFromInventory(B))
 				to_chat(user, span_warning("[B] seems to be stuck to your hand. You'll have to find a different light."))
 				return
 			lamp_cooldown = 0
+			lamp_functional = TRUE
 			qdel(B)
 			to_chat(user, span_notice("You replace the headlamp bulb.")) //yogs end
 	else


### PR DESCRIPTION
# Document the changes in your pull request

Before this PR, replacing a borg's headlamp by placing a new bulb in would simply set the lamp's cooldown value to 0. This means that if the bulb was smashed, for example by a shadowling's light eater attack, replacing the bulb would not actually make the lamp functional again. This PR sets lamp_functional to True on top of reducing the cooldown to 0, which should actually fix the headlamp upon replacing the bulb.

Fixes #13504

Tested locally, works

# Wiki Documentation

The replacement of a borg's lamp doesn't seem to be documented on the wiki, at least in the guide to robotics. It is possible to replace a borg's bulb by simply opening its cover and placing a new bulb inside just as if you were placing a new cell in a borg.

# Changelog

:cl: NovaAzure
bugfix: Placing a new bulb into a borg fixes their headlamp
/:cl:
