### PR TITLE
AI agreeing to an instant download now has an extra prompt

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -546,6 +546,10 @@
 		var/obj/machinery/computer/ai_control_console/C = locate(href_list["console"])
 		if(!C)
 			return
+		if(C.downloading != src)
+			return
+		if(alert("Are you sure you want to be downloaded? This puts you at the mercy of the person downloading you!", "Confirm Download", "No", "Yes") != "Yes")
+			return
 		if(C.downloading == src)
 			C.finish_download()
 


### PR DESCRIPTION
# Document the changes in your pull request

Wouldn't want any AIs getting instantly downloaded when they're malf

Fixes #13513
(Well, makes it less likely at least)

# Wiki Documentation


# Changelog


:cl:  
tweak: Added a confirm button to being instantly downloaded
/:cl:
