### PR TITLE
Makes AIs being downloaded get notified when the console downloading them is destroyed

### DIFF
--- a/code/modules/mob/living/silicon/ai/decentralized/management/ai_controlpanel.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/management/ai_controlpanel.dm
@@ -29,6 +29,10 @@ GLOBAL_VAR_INIT(ai_control_code, random_nukecode(6))
 	if(mapload)
 		cleared_for_use = TRUE
 
+/obj/machinery/computer/ai_control_console/Destroy()
+	stop_download()
+	. = ..()
+
 /obj/machinery/computer/ai_control_console/attackby(obj/item/W, mob/living/user, params)
 	if(istype(W, /obj/item/aicard))
 		if(intellicard)


### PR DESCRIPTION

# Document the changes in your pull request

see title

# Wiki Documentation


# Changelog

:cl:  
bugfix: AIs are notified when the console downloading them is consolen't
/:cl:
