### PR TITLE
Amanitin and entropic polypnium also work for DNA recovery

### DIFF
--- a/code/modules/surgery/advanced/dna_recovery.dm
+++ b/code/modules/surgery/advanced/dna_recovery.dm
@@ -35,7 +35,7 @@
 	name = "recover DNA"
 	implements = list(/obj/item/reagent_containers/syringe = 100, /obj/item/pen = 30)
 	time = 150
-	chems_needed = list(/datum/reagent/medicine/rezadone)
+	chems_needed = list(/datum/reagent/medicine/rezadone, /datum/reagent/medicine/earthsblood)
 	require_all_chems = FALSE
 
 /datum/surgery_step/dna_recovery/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/advanced/dna_recovery.dm
+++ b/code/modules/surgery/advanced/dna_recovery.dm
@@ -35,7 +35,7 @@
 	name = "recover DNA"
 	implements = list(/obj/item/reagent_containers/syringe = 100, /obj/item/pen = 30)
 	time = 150
-	chems_needed = list(/datum/reagent/medicine/rezadone, /datum/reagent/medicine/earthsblood, /datum/reagent/medicine/grubjuice)
+	chems_needed = list(/datum/reagent/medicine/rezadone, /datum/reagent/medicine/earthsblood, /datum/reagent/consumable/entpoly)
 	require_all_chems = FALSE
 
 /datum/surgery_step/dna_recovery/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/advanced/dna_recovery.dm
+++ b/code/modules/surgery/advanced/dna_recovery.dm
@@ -35,7 +35,7 @@
 	name = "recover DNA"
 	implements = list(/obj/item/reagent_containers/syringe = 100, /obj/item/pen = 30)
 	time = 150
-	chems_needed = list(/datum/reagent/medicine/rezadone, /datum/reagent/medicine/earthsblood, /datum/reagent/consumable/entpoly)
+	chems_needed = list(/datum/reagent/medicine/rezadone, /datum/reagent/toxin/amanitin, /datum/reagent/consumable/entpoly)
 	require_all_chems = FALSE
 
 /datum/surgery_step/dna_recovery/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/advanced/dna_recovery.dm
+++ b/code/modules/surgery/advanced/dna_recovery.dm
@@ -35,7 +35,7 @@
 	name = "recover DNA"
 	implements = list(/obj/item/reagent_containers/syringe = 100, /obj/item/pen = 30)
 	time = 150
-	chems_needed = list(/datum/reagent/medicine/rezadone, /datum/reagent/medicine/earthsblood)
+	chems_needed = list(/datum/reagent/medicine/rezadone, /datum/reagent/medicine/earthsblood, /datum/reagent/medicine/grubjuice)
 	require_all_chems = FALSE
 
 /datum/surgery_step/dna_recovery/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)


### PR DESCRIPTION
# Document the changes in your pull request

What if changelings but they only round removed their targets?

Rezadone never happens because carpotoxin doesn't happen and when it does it's because botany has all of chemistry's braincells.
Amanitin requires only the botanists to go out of their way. In real life, it works by blocking out DNA, so you do a bit of experimental surgery whatever and wow it does the opposite.
This slightly reduces the likelihood of it being yet another round where ze husk goes in ze morgue, and also gives botanists a new convincing lie regarding why they're growing horrific toxins.

Mqiib says this still isn't going to happen, and I half believe it.
And entropic polypnium is um... from a magic fungus lol
Therefore mining also has an option to help, and they have an interest in helping due to lava and changeling miners existing.
Still another rarity? Yes. What do you want from me, the next step down is like haloperidol

Don't get me started on burnhusks, **100** synthflesh for everyone who died in a 20-meter radius of a fire? What do you think the medbay is made of, attention span?

# Wiki Documentation

Amanitin and entropic polypnium also work for DNA recovery. Maybe note that both are mean toxins.

# Changelog

:cl:  
tweak: Amanitin and entropic polypnium also work for DNA recovery
/:cl: