### PR TITLE
Gives syndie surgery duffel tools speed boost like toolbox tools

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -473,28 +473,21 @@
 	item_state = "duffel-syndiemed"
 
 /obj/item/storage/backpack/duffelbag/syndie/surgery/PopulateContents()
-	var/obj/item/I
-	I = new /obj/item/scalpel(src)
-	I.toolspeed = 0.5
-	I = new /obj/item/hemostat(src)
-	I.toolspeed = 0.5
-	I = new /obj/item/retractor(src)
-	I.toolspeed = 0.5
-	I = new /obj/item/circular_saw(src)
-	I.toolspeed = 0.5
-	I = new /obj/item/bonesetter(src)
-	I.toolspeed = 0.5
-	I = new /obj/item/surgicaldrill(src)
-	I.toolspeed = 0.5
-	I = new /obj/item/cautery(src)
-	I.toolspeed = 0.5
-	I = new /obj/item/stack/medical/bone_gel(src) // likely extremely temperamental due to the nature of stacks but it might be useful once
-	I.toolspeed = 0.5
+	new /obj/item/scalpel(src)
+	new /obj/item/hemostat(src)
+	new /obj/item/retractor(src)
+	new /obj/item/circular_saw(src)
+	new /obj/item/bonesetter(src)
+	new /obj/item/surgicaldrill(src)
+	new /obj/item/cautery(src)
+	new /obj/item/stack/medical/bone_gel(src)
 	new /obj/item/surgical_drapes(src)
 	new /obj/item/clothing/suit/straight_jacket(src)
 	new /obj/item/clothing/mask/muzzle(src)
 	new /obj/item/mmi/syndie(src)
 	new /obj/item/implantcase(src)
+	for(var/obj/item/I in contents)
+		I.toolspeed = 0.5
 
 /obj/item/storage/backpack/duffelbag/syndie/ammo
 	name = "ammunition duffel bag"

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -473,18 +473,27 @@
 	item_state = "duffel-syndiemed"
 
 /obj/item/storage/backpack/duffelbag/syndie/surgery/PopulateContents()
-	new /obj/item/scalpel(src)
-	new /obj/item/hemostat(src)
-	new /obj/item/retractor(src)
-	new /obj/item/circular_saw(src)
-	new /obj/item/bonesetter(src)
-	new /obj/item/surgicaldrill(src)
-	new /obj/item/cautery(src)
+	var/obj/item/I
+	I = new /obj/item/scalpel(src)
+	I.toolspeed = 0.5
+	I = new /obj/item/hemostat(src)
+	I.toolspeed = 0.5
+	I = new /obj/item/retractor(src)
+	I.toolspeed = 0.5
+	I = new /obj/item/circular_saw(src)
+	I.toolspeed = 0.5
+	I = new /obj/item/bonesetter(src)
+	I.toolspeed = 0.5
+	I = new /obj/item/surgicaldrill(src)
+	I.toolspeed = 0.5
+	I = new /obj/item/cautery(src)
+	I.toolspeed = 0.5
+	I = new /obj/item/stack/medical/bone_gel(src) // likely extremely temperamental due to the nature of stacks but it might be useful once
+	I.toolspeed = 0.5
 	new /obj/item/surgical_drapes(src)
 	new /obj/item/clothing/suit/straight_jacket(src)
 	new /obj/item/clothing/mask/muzzle(src)
 	new /obj/item/mmi/syndie(src)
-	new /obj/item/stack/medical/bone_gel(src)
 	new /obj/item/implantcase(src)
 
 /obj/item/storage/backpack/duffelbag/syndie/ammo

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -166,21 +166,16 @@
 	STR.silent = TRUE
 
 /obj/item/storage/toolbox/syndicate/PopulateContents()
-	//YOGS start - toolspeed
-	var/obj/item/I
 	new /obj/item/screwdriver/nuke(src)
-	I = new /obj/item/wrench(src)
-	I.toolspeed = 0.5
-	I = new /obj/item/weldingtool/largetank(src)
-	I.toolspeed = 0.5
-	I = new /obj/item/crowbar/red(src)
-	I.toolspeed = 0.5
-	I = new /obj/item/wirecutters(src, "red")
-	I.toolspeed = 0.5
-	I = new /obj/item/multitool(src)
-	I.toolspeed = 0.5
-	I = new /obj/item/clothing/gloves/combat(src)
-	I.toolspeed = 0.5
+	new /obj/item/wrench(src)
+	new /obj/item/weldingtool/largetank(src)
+	new /obj/item/crowbar/red(src)
+	new /obj/item/wirecutters(src, "red")
+	new /obj/item/multitool(src)
+	new /obj/item/clothing/gloves/combat(src)
+	//YOGS start - toolspeed
+	for(var/obj/item/I in contents)
+		I.toolspeed = 0.5
 
 /obj/item/storage/toolbox/drone
 	name = "mechanical toolbox"


### PR DESCRIPTION
# Document the changes in your pull request

This kit does effectively nothing you cant already do with an emag and autolathe

Unlike the syndie toolbox, which gets slightly higher damage, a smaller size so it can be hidden, and faster tools, the syndie surgery duffel gets.... a bunch of tools you can already make on station and a 0 slowdown duffel which granted can be useful is also extremely obviously a syndicate duffel bag

So i take the 0.5 toolspeed modifier from the syndie toolbox and apply it to the syndie surgery tools as well, making them objectively better than normal (and potentially upgraded) surgical tools so it can be less of a noob trap/meme item

# Wiki Documentation

Syndie surgery duffel's tools have doubled speed

# Changelog


:cl:  theos buffing something he uses again
tweak: syndicate surgery duffel surgery tools are now twice as fast as normal tools because you are buying a syndicate surgical kit inside a duffel bag not just a syndicate duffel bag that happens to be occupied
/:cl:
