### PR TITLE
Grand Core organ faction handling fix

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1476,19 +1476,20 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 		Insert(user)
 
 /obj/item/organ/grandcore/Insert(mob/living/carbon/H, special = 0)
-	H.faction = list("blooded")
+	..()
+	H.faction |= "blooded"
 	H.AddSpell (new /obj/effect/proc_holder/spell/targeted/touch/raise)
 	H.AddSpell (new /obj/effect/proc_holder/spell/aoe_turf/horde)
-	..()
 	if(NOBLOOD in H.dna.species.species_traits)
 		to_chat(owner, "<span class ='userdanger'>Despite lacking blood, you were able to take in the grand core. You will pay for your power in killer headaches!</span>")
 	else
 		to_chat(owner, "<span class ='userdanger'>You've taken in the grand core, allowing you to control minions at the cost of your blood!</span>")
 
 /obj/item/organ/grandcore/Remove(mob/living/carbon/H, special = 0)
+	H.faction -= "blooded"
 	H.RemoveSpell (/obj/effect/proc_holder/spell/targeted/touch/raise, /obj/effect/proc_holder/spell/aoe_turf/horde)
 	H.RemoveSpell (new /obj/effect/proc_holder/spell/aoe_turf/horde)
-	return ..()
+	..()
 
 /datum/action/item_action/organ_action/threebloodlings
 	name = "Summon bloodlings"


### PR DESCRIPTION
World renowned shitcoder lazzen accidentally made the grand core change your faction list instead of add to it, so you get lit tf up by Raven shuttle turrets, and cause other friendly fire interactions that rely on faction checks, and also didn't include the faction removal check when it comes out of you, so you were forever an enemy of the state. 

Now the faction is added instead of replaced and you lose the faction if you lose the core

# Changelog

:cl:  Chubbygummibear, Lazzen
tweak: Grand Core organ adds the blooded faction tag instead of replacing your neutral faction 
tweak: Grand Core organ removes the blooded faction when it's removed from you
/:cl:
