### PR TITLE
Skip abstract station traits

### DIFF
--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -31,6 +31,8 @@ PROCESSING_SUBSYSTEM_DEF(station)
 /datum/controller/subsystem/processing/station/proc/SetupTraits()
 	for(var/i in subtypesof(/datum/station_trait))
 		var/datum/station_trait/trait_typepath = i
+		if (trait_typepath.trait_flags & STATION_TRAIT_ABSTRACT)
+			continue
 		selectable_traits_by_types[initial(trait_typepath.trait_type)][trait_typepath] = initial(trait_typepath.weight)
 
 	var/positive_trait_count = pick(12;0, 5;1, 1;2)


### PR DESCRIPTION
If the station loads an abstract station trait and only that it will make an empty announcement even though it has no message or effect.

:cl:  
bugfix: Remove empty station trait announcements
/:cl: