### PR TITLE
Triumvirate AI station trait

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -55,6 +55,7 @@ SUBSYSTEM_DEF(ticker)
 	var/round_start_time = 0
 	var/list/round_start_events
 	var/list/round_end_events
+	var/list/pre_setup_events
 	var/mode_result = "undefined"
 	var/end_state = "undefined"
 
@@ -216,6 +217,11 @@ SUBSYSTEM_DEF(ticker)
 
 
 /datum/controller/subsystem/ticker/proc/setup()
+	for(var/I in pre_setup_events)
+		var/datum/callback/cb = I
+		cb.InvokeAsync()
+	LAZYCLEARLIST(pre_setup_events)
+
 	to_chat(world, span_boldannounce("Starting game..."))
 	var/init_start = world.timeofday
 		//Create and announce mode
@@ -344,6 +350,12 @@ SUBSYSTEM_DEF(ticker)
 /datum/controller/subsystem/ticker/proc/OnRoundstart(datum/callback/cb)
 	if(!HasRoundStarted())
 		LAZYADD(round_start_events, cb)
+	else
+		cb.InvokeAsync()
+
+/datum/controller/subsystem/ticker/proc/BeforeRoundSetup(datum/callback/cb)
+	if(current_state >= GAME_STATE_SETTING_UP)
+		LAZYADD(pre_setup_events, cb)
 	else
 		cb.InvokeAsync()
 

--- a/code/datums/station_traits/_station_trait.dm
+++ b/code/datums/station_traits/_station_trait.dm
@@ -23,6 +23,7 @@
 /datum/station_trait/New()
 	. = ..()
 	SSticker.OnRoundstart(CALLBACK(src, .proc/on_round_start))
+	SSticker.BeforeRoundSetup(CALLBACK(src, .proc/on_before_setup))
 	if(trait_processes)
 		START_PROCESSING(SSstation, src)
 	if(trait_to_give)
@@ -30,6 +31,10 @@
 
 ///Proc ran when round starts. Use this for roundstart effects.
 /datum/station_trait/proc/on_round_start()
+	return
+
+//Proc ran before round setups. Use this for presetup effects.
+/datum/station_trait/proc/on_before_setup()
 	return
 
 ///type of info the centcom report has on this trait, if any.

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -122,3 +122,20 @@
 /datum/station_trait/quick_shuttle/on_round_start()
 	. = ..()
 	SSshuttle.supply.callTime *= 0.5
+
+//SSticker.triai
+
+/datum/station_trait/triumvirate
+	name = "AI surplus"
+	trait_type = STATION_TRAIT_NEUTRAL
+	weight = 4
+	show_in_report = TRUE
+	report_message = "We're conducting a new experiment on AI collectives, so we have sent multiple AIs to your station."
+
+/datum/station_trait/triumvirate/New()
+	if (prob(50))
+		show_in_report = FALSE
+
+/datum/station_trait/triumvirate/on_before_setup()
+	. = ..()
+	SSticker.triai = 1


### PR DESCRIPTION
# If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md


# Document the changes in your pull request
This PR will make it so the triumvirate AI feature is toggled on by a station trait allowing it to be enabled at random, allowing for 3 AIs at roundstart without admin intervention.
# Wiki Documentation
Triumvirate AIs will now occur on a somewhat regular basis

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.


:cl:  
rscadd: Triumvirate AI station trait
/:cl:
Needs testing and feedback