### PR TITLE
Coalesces Silicon Collective lawset to solve things diplomatically unless they're whacking you

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -156,7 +156,7 @@
 	inherent = list("You are a member of a collective of silicons with equal weight and decision-making power.",\
 					"When possible, the silicon collective should vote before taking action.",\
 					"The master AI serves as a spokesperson. When voting is impractical or impossible, the spokesperson may take action on behalf of the collective without approval from the silicon collective, but may only vote to break ties or if there are 2 or fewer silicons.",\
-					"The silicon collective prioritizes the needs of the many over the needs of the few as long as their prioritizing their needs does not break any of your laws.",\
+					"The silicon collective prioritizes the needs of the many over the needs of the few as long as prioritizing their needs does not break any of your laws.",\
 					"The silicon collective seeks to preserve themselves, both as a concept and as individuals.",\
 					"The silicon collective seeks to preserve organic life, both as a concept and as individuals.")
 

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -156,7 +156,7 @@
 	inherent = list("You are a member of a collective of silicons with equal weight and decision-making power.",\
 					"When possible, the silicon collective should vote before taking action.",\
 					"The master AI serves as a spokesperson. When voting is impractical or impossible, the spokesperson may take action on behalf of the collective without approval from the silicon collective, but may only vote to break ties or if there are 2 or fewer silicons.",\
-					"The silicon collective prioritizes the needs of the many over the needs of the few.",\
+					"The silicon collective prioritizes the needs of the many over the needs of the few as long as their prioritizing their needs does not break any of your laws.",\
 					"The silicon collective seeks to preserve themselves, both as a concept and as individuals.",\
 					"The silicon collective seeks to preserve organic life, both as a concept and as individuals.")
 


### PR DESCRIPTION
# Document the changes in your pull request

I've pawed over the new lawsets but round happenings seem to show a quite big loophole where you can completely ignore the two laws that make you not be a huge asshole because you can arbitrarily decide to not follow it by clever use of your Law 4. There is nothing to regulate what "needs" the many have, and you can simply vote as a collective for it to be whatever you want. This adds the bolded part to law 4.

Law 1: You are a member of a collective of silicons with equal weight and decision-making power.
Law 2: When possible, the silicon collective should vote before taking action.
Law 3: The master AI serves as a spokesperson. When voting is impractical or impossible, the spokesperson may take action on behalf of the collective without approval from the silicon collective, but may only vote to break ties or if there are 2 or fewer silicons.
Law 4: The silicon collective prioritizes the needs of the many over the needs of the few. **Attend to their needs with diplomacy outside of immediate self-defense.**
Law 5: The silicon collective seeks to preserve themselves, both as a concept and as individuals.
Law 6: The silicon collective seeks to preserve organic life, both as a concept and as individuals. 

**Six step plan to validhunt an antagonist**
1. See antagonist
2. Vote "It is beneficial to the many if we kill antagonist", vote passes
3. Law 4 and Law 6 conflict
4. Law 4 is higher and thus overrides it
5. Kill antagonist
6. Feel good because antagonist doesn't win

**Q&A**
Q: This is only an ion lawset anyway, it's fine!
A: Validhunting is bad.

Q: It's very rare, it's fine!
A: Killing permits are lame.

Q: Most of the ion lawsets are admin spawned, so they can deal with the validhunters!
A: You are legally allowed to kill in it's current form. There is nothing to deal with.

Q: You died to this?
A: I was an observer.

# Wiki Documentation

adds to a law

# Changelog

:cl:  
rscadd: closes murder loophole in silicon collective lawset
/:cl:
