### PR TITLE
Moves Law 4 of Silicon Collective to the end so the "needs of the many" can't be voted to be "redtexting an antagonist"

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -156,9 +156,9 @@
 	inherent = list("You are a member of a collective of silicons with equal weight and decision-making power.",\
 					"When possible, the silicon collective should vote before taking action.",\
 					"The master AI serves as a spokesperson. When voting is impractical or impossible, the spokesperson may take action on behalf of the collective without approval from the silicon collective, but may only vote to break ties or if there are 2 or fewer silicons.",\
-					"The silicon collective prioritizes the needs of the many over the needs of the few.",\
 					"The silicon collective seeks to preserve themselves, both as a concept and as individuals.",\
-					"The silicon collective seeks to preserve organic life, both as a concept and as individuals.")
+					"The silicon collective seeks to preserve organic life, both as a concept and as individuals.",\
+					"The silicon collective prioritizes the needs of the many over the needs of the few.")
 
 /datum/ai_laws/druid
 	name = "Druid"


### PR DESCRIPTION
# Document the changes in your pull request

Alternative to https://github.com/yogstation13/Yogstation/pull/13548

Simply do not kill people

# Wiki Documentation

switches some laws around

# Changelog

:cl:  
tweak: moves law 4 to the end for silicon collective lawset
/:cl:
