### PR TITLE
Triples AI Core grace period

### DIFF
--- a/code/__DEFINES/ai.dm
+++ b/code/__DEFINES/ai.dm
@@ -6,7 +6,7 @@
 
 
 ///How many ticks can an AI data core store? When this amount of ticks have passed while it's in an INVALID state it can no longer be used by an AI
-#define MAX_AI_DATA_CORE_TICKS 15
+#define MAX_AI_DATA_CORE_TICKS 45
 ///How much power does the AI date core use while being in a valid state. This is also the base heat output. (Divide by heat capacity to get actual temperature increase)
 #define AI_DATA_CORE_POWER_USAGE 7500
 


### PR DESCRIPTION
# Document the changes in your pull request

Should allow AI to do emergency repairs or similar in case the APC toggles equipment or the freezer is offline

# Wiki Documentation


# Changelog

:cl:  
tweak: AI data cores get a 45 tick grace period, up from 15 ticks
/:cl:
