### PR TITLE
Ports "Ports updates to the cameranet"

### DIFF
--- a/code/__DEFINES/sight.dm
+++ b/code/__DEFINES/sight.dm
@@ -29,7 +29,3 @@
 #define VISOR_DARKNESSVIEW	(1<<3)
 #define VISOR_INVISVIEW		(1<<4)
 
-//for whether AI eyes see static, and whether it is mouse-opaque or not
-#define USE_STATIC_NONE			0
-#define USE_STATIC_TRANSPARENT	1
-#define USE_STATIC_OPAQUE		2

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -43,11 +43,8 @@
 	if(!can_see(A))
 		if(isturf(A)) //On unmodified clients clicking the static overlay clicks the turf underneath
 			return //So there's no point messaging admins
-		message_admins("[ADMIN_LOOKUPFLW(src)] was kicked because they failed can_see on AI click of [A] (Turf Loc: [ADMIN_VERBOSEJMP(pixel_turf)]))")
-		log_admin("[key_name(src)] was kicked because they failed can_see on AI click of [A] (Turf Loc: [AREACOORD(pixel_turf)])")
-		to_chat(src, span_reallybig("You have been automatically kicked because you clicked a turf you shouldn't have been able to see as an AI. You should reconnect automatically. If you do not, you can reconnect using the File --> Reconnect button."))
-		winset(usr, null, "command=.reconnect")
-		QDEL_IN(client, 3 SECONDS) //fallback if the reconnection doesnt work
+		message_admins("[ADMIN_LOOKUPFLW(src)] failed can_see on AI click of [A] (Turf Loc: [ADMIN_VERBOSEJMP(pixel_turf)]))")
+		log_admin("[key_name(src)] failed can_see on AI click of [A] (Turf Loc: [AREACOORD(pixel_turf)])")
 		return
 
 	var/list/modifiers = params2list(params)

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -118,7 +118,7 @@
 	if(!eyeobj.eye_initialized)
 		var/camera_location
 		var/turf/myturf = get_turf(src)
-		if(eyeobj.use_static != USE_STATIC_NONE)
+		if(eyeobj.use_static != FALSE)
 			if((!z_lock.len || (myturf.z in z_lock)) && GLOB.cameranet.checkTurfVis(myturf))
 				camera_location = myturf
 			else
@@ -177,7 +177,7 @@
 	user.see_invisible = SEE_INVISIBLE_LIVING //can't see ghosts through cameras
 	user.sight = SEE_TURFS | SEE_BLACKNESS
 	user.see_in_dark = 2
-	return 1
+	return TRUE
 
 /mob/camera/aiEye/remote/Destroy()
 	if(origin && eye_user)
@@ -198,14 +198,16 @@
 			forceMove(T)
 		else
 			moveToNullspace()
+
 		update_ai_detect_hud()
-		if(use_static != USE_STATIC_NONE)
+
+		if(use_static)
 			GLOB.cameranet.visibility(src, GetViewerClient(), null, use_static)
-		if(visible_icon)
-			if(eye_user.client)
-				eye_user.client.images -= user_image
-				user_image = image(icon,loc,icon_state,FLY_LAYER)
-				eye_user.client.images += user_image
+
+		if(visible_icon && eye_user.client)
+			eye_user.client.images -= user_image
+			user_image = image(icon,loc,icon_state,FLY_LAYER)
+			eye_user.client.images += user_image
 
 /mob/camera/aiEye/remote/relaymove(mob/user,direct)
 	var/initial = initial(sprint)

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -126,7 +126,7 @@
 			detect_state = PROXIMITY_ON_SCREEN
 			return
 
-	for(var/mob/camera/ai_eye/AI_eye as anything in GLOB.ai_eyes)
+	for(var/mob/camera/aiEye/AI_eye as anything in GLOB.aiEyes)
 		if(!AI_eye.ai_detector_visible)
 			continue
 

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -44,8 +44,6 @@
 // Syndicate device disguised as a multitool; it will turn red when an AI camera is nearby.
 
 /obj/item/multitool/ai_detect
-	var/track_cooldown = 0
-	var/track_delay = 10 //How often it checks for proximity
 	var/detect_state = PROXIMITY_NONE
 	var/rangealert = 8	//Glows red when inside
 	var/rangewarning = 20 //Glows yellow when inside
@@ -56,12 +54,12 @@
 
 /obj/item/multitool/ai_detect/Initialize()
 	. = ..()
-	START_PROCESSING(SSobj, src)
+	START_PROCESSING(SSfastprocess, src)
 	eye = new /mob/camera/aiEye/remote/ai_detector()
 	toggle_action = new /datum/action/item_action/toggle_multitool(src)
 
 /obj/item/multitool/ai_detect/Destroy()
-	STOP_PROCESSING(SSobj, src)
+	STOP_PROCESSING(SSfastprocess, src)
 	if(hud_on && ismob(loc))
 		remove_hud(loc)
 	QDEL_NULL(toggle_action)
@@ -81,15 +79,16 @@
 	if(hud_on)
 		remove_hud(user)
 
+/obj/item/multitool/ai_detect/update_icon()
+	icon_state = "[initial(icon_state)][detect_state]"
+
 /obj/item/multitool/ai_detect/process()
-	if(track_cooldown > world.time)
-		return
-	detect_state = PROXIMITY_NONE
+	var/old_detect_state = detect_state
 	if(eye.eye_user)
 		eye.setLoc(get_turf(src))
 	multitool_detect()
-	update_icon()
-	track_cooldown = world.time + track_delay
+	if(detect_state != old_detect_state)
+		update_icon()
 
 /obj/item/multitool/ai_detect/proc/toggle_hud(mob/user)
 	hud_on = !hud_on
@@ -103,7 +102,7 @@
 /obj/item/multitool/ai_detect/proc/show_hud(mob/user)
 	if(user && hud_type)
 		var/obj/screen/plane_master/camera_static/PM = user.hud_used.plane_masters["[CAMERA_STATIC_PLANE]"]
-		PM.alpha = 150
+		PM.alpha = 64
 		var/datum/atom_hud/H = GLOB.huds[hud_type]
 		if(!H.hudusers[user])
 			H.add_hud_to(user)
@@ -122,31 +121,32 @@
 
 /obj/item/multitool/ai_detect/proc/multitool_detect()
 	var/turf/our_turf = get_turf(src)
-	for(var/mob/living/silicon/ai/AI in GLOB.ai_list)
+	for(var/mob/living/silicon/ai/AI as anything in GLOB.ai_list)
 		if(AI.cameraFollow == src)
+			detect_state = PROXIMITY_ON_SCREEN
+			return
+
+	for(var/mob/camera/ai_eye/AI_eye as anything in GLOB.ai_eyes)
+		if(!AI_eye.ai_detector_visible)
+			continue
+
+		var/distance = get_dist(our_turf, get_turf(AI_eye))
+
+		if(distance == -1) //get_dist() returns -1 for distances greater than 127 (and for errors, so assume -1 is just max range)
+			continue
+
+		if(distance < rangealert) //ai should be able to see us
 			detect_state = PROXIMITY_ON_SCREEN
 			break
 
-	if(detect_state)
-		return
-	var/datum/camerachunk/chunk = GLOB.cameranet.chunkGenerated(our_turf.x, our_turf.y, our_turf.z)
-	if(chunk && chunk.seenby.len)
-		for(var/mob/camera/aiEye/A in chunk.seenby)
-			if(!A.ai_detector_visible)
-				continue
-			var/turf/detect_turf = get_turf(A)
-			if(get_dist(our_turf, detect_turf) < rangealert)
-				detect_state = PROXIMITY_ON_SCREEN
-				break
-			if(get_dist(our_turf, detect_turf) < rangewarning)
-				detect_state = PROXIMITY_NEAR
-				break
+		if(distance < rangewarning) //ai cant see us but is close
+			detect_state = PROXIMITY_NEAR
 
 /mob/camera/aiEye/remote/ai_detector
 	name = "AI detector eye"
 	ai_detector_visible = FALSE
-	use_static = USE_STATIC_TRANSPARENT
 	visible_icon = FALSE
+	use_static = FALSE
 
 /datum/action/item_action/toggle_multitool
 	name = "Toggle AI detector HUD"
@@ -155,11 +155,11 @@
 
 /datum/action/item_action/toggle_multitool/Trigger()
 	if(!..())
-		return 0
+		return FALSE
 	if(target)
 		var/obj/item/multitool/ai_detect/M = target
 		M.toggle_hud(owner)
-	return 1
+	return TRUE
 
 /obj/item/multitool/cyborg
 	name = "multitool"

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -404,18 +404,12 @@ GLOBAL_LIST_EMPTY(station_turfs)
 
 /turf/proc/visibilityChanged()
 	GLOB.cameranet.updateVisibility(src)
-	// The cameranet usually handles this for us, but if we've just been
-	// recreated we should make sure we have the cameranet vis_contents.
-	var/datum/camerachunk/C = GLOB.cameranet.chunkGenerated(x, y, z)
-	if(C)
-		if(C.obscuredTurfs[src])
-			vis_contents += GLOB.cameranet.vis_contents_objects
-		else
-			vis_contents -= GLOB.cameranet.vis_contents_objects
 
 /turf/proc/burn_tile()
+	return
 
 /turf/proc/is_shielded()
+	return
 
 /turf/contents_explosion(severity, target)
 	for(var/thing in contents)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1111,7 +1111,7 @@
 		target_ai = src //cheat! just give... ourselves as the spawned AI, because that's technically correct
 
 /mob/living/silicon/ai/proc/camera_visibility(mob/camera/aiEye/moved_eye)
-	GLOB.cameranet.visibility(moved_eye, client, all_eyes, USE_STATIC_OPAQUE)
+	GLOB.cameranet.visibility(moved_eye, client, all_eyes, TRUE)
 
 /mob/living/silicon/ai/forceMove(atom/destination)
 	. = ..()

--- a/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
@@ -7,37 +7,26 @@
 GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new)
 
 /datum/cameranet
-	var/name = "Camera Net" // Name to show for VV and stat()
+	/// Name to show for VV and stat()
+	var/name = "Camera Net"
 
-	// The cameras on the map, no matter if they work or not. Updated in obj/machinery/camera.dm by New() and Del().
+	/// The cameras on the map, no matter if they work or not. Updated in obj/machinery/camera.dm by New() and Del().
 	var/list/cameras = list()
-	// The chunks of the map, mapping the areas that the cameras can see.
+	/// The chunks of the map, mapping the areas that the cameras can see.
 	var/list/chunks = list()
 	var/ready = 0
-
 	// The object used for the clickable stat() button.
 	var/obj/effect/statclick/statclick
-
-	// The objects used in vis_contents of obscured turfs
-	var/list/vis_contents_objects
-	var/obj/effect/overlay/camera_static/vis_contents_opaque
-	var/obj/effect/overlay/camera_static/vis_contents_transparent
-	// The image given to the effect in vis_contents on AI clients
+	///The image given to the effect in vis_contents on AI clients
 	var/image/obscured
-	var/image/obscured_transparent
 
 /datum/cameranet/New()
-	vis_contents_opaque = new /obj/effect/overlay/camera_static()
-	vis_contents_transparent = new /obj/effect/overlay/camera_static/transparent()
-	vis_contents_objects = list(vis_contents_opaque, vis_contents_transparent)
-
-	obscured = new('icons/effects/cameravis.dmi', vis_contents_opaque, null, CAMERA_STATIC_LAYER)
+	obscured = new('icons/effects/cameravis.dmi')
 	obscured.plane = CAMERA_STATIC_PLANE
+	obscured.appearance_flags = RESET_TRANSFORM | RESET_ALPHA | RESET_COLOR | KEEP_APART
+	obscured.override = TRUE
 
-	obscured_transparent = new('icons/effects/cameravis.dmi', vis_contents_transparent, null, CAMERA_STATIC_LAYER)
-	obscured_transparent.plane = CAMERA_STATIC_PLANE
-
-// Checks if a chunk has been Generated in x, y, z.
+/// Checks if a chunk has been Generated in x, y, z.
 /datum/cameranet/proc/chunkGenerated(x, y, z)
 	x &= ~(CHUNK_SIZE - 1)
 	y &= ~(CHUNK_SIZE - 1)
@@ -53,9 +42,8 @@ GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new)
 	if(!.)
 		chunks[key] = . = new /datum/camerachunk(x, y, z)
 
-// Updates what the aiEye can see. It is recommended you use this when the aiEye moves or it's location is set.
-
-/datum/cameranet/proc/visibility(list/moved_eyes, client/C, list/other_eyes, use_static = USE_STATIC_OPAQUE)
+/// Updates what the ai_eye can see. It is recommended you use this when the ai_eye moves or it's location is set.
+/datum/cameranet/proc/visibility(list/moved_eyes, client/C, list/other_eyes, use_static = TRUE)
 	if(!islist(moved_eyes))
 		moved_eyes = moved_eyes ? list(moved_eyes) : list()
 	if(islist(other_eyes))
@@ -63,15 +51,7 @@ GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new)
 	else
 		other_eyes = list()
 
-	if(C)
-		switch(use_static)
-			if(USE_STATIC_TRANSPARENT)
-				C.images += obscured_transparent
-			if(USE_STATIC_OPAQUE)
-				C.images += obscured
-
-	for(var/V in moved_eyes)
-		var/mob/camera/aiEye/eye = V
+	for(var/mob/camera/aiEye/eye as anything in moved_eyes)
 		var/list/visibleChunks = list()
 		if(eye.loc)
 			var/x_value = eye.x
@@ -92,25 +72,13 @@ GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new)
 		var/list/remove = eye.visibleCameraChunks - visibleChunks
 		var/list/add = visibleChunks - eye.visibleCameraChunks
 
-		for(var/chunk in remove)
-			var/datum/camerachunk/c = chunk
-			c.remove(eye, FALSE)
+		for(var/datum/camerachunk/chunk as anything in remove)
+			chunk.remove(eye, FALSE)
 
-		for(var/chunk in add)
-			var/datum/camerachunk/c = chunk
-			c.add(eye)
+		for(var/datum/camerachunk/chunk as anything in add)
+			chunk.add(eye)
 
-		if(!eye.visibleCameraChunks.len)
-			var/client/client = eye.GetViewerClient()
-			if(client)
-				switch(eye.use_static)
-					if(USE_STATIC_TRANSPARENT)
-						client.images -= GLOB.cameranet.obscured_transparent
-					if(USE_STATIC_OPAQUE)
-						client.images -= GLOB.cameranet.obscured
-
-// Updates the chunks that the turf is located in. Use this when obstacles are destroyed or	when doors open.
-
+/// Updates the chunks that the turf is located in. Use this when obstacles are destroyed or	when doors open.
 /datum/cameranet/proc/updateVisibility(atom/A, opacity_check = 1)
 	if(!SSticker || (opacity_check && !A.opacity))
 		return
@@ -122,29 +90,27 @@ GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new)
 		return
 	chunk.hasChanged()
 
-// Removes a camera from a chunk.
-
+/// Removes a camera from a chunk.
 /datum/cameranet/proc/removeCamera(obj/machinery/camera/c)
 	majorChunkChange(c, 0)
 
-// Add a camera to a chunk.
-
+/// Add a camera to a chunk.
 /datum/cameranet/proc/addCamera(obj/machinery/camera/c)
 	if(c.can_use())
 		majorChunkChange(c, 1)
 
-// Used for Cyborg cameras. Since portable cameras can be in ANY chunk.
-
+/// Used for Cyborg cameras. Since portable cameras can be in ANY chunk.
 /datum/cameranet/proc/updatePortableCamera(obj/machinery/camera/c)
 	if(c.can_use())
 		majorChunkChange(c, 1)
 
-// Never access this proc directly!!!!
-// This will update the chunk and all the surrounding chunks.
-// It will also add the atom to the cameras list if you set the choice to 1.
-// Setting the choice to 0 will remove the camera from the chunks.
-// If you want to update the chunks around an object, without adding/removing a camera, use choice 2.
-
+/**
+ * Never access this proc directly!!!!
+ * This will update the chunk and all the surrounding chunks.
+ * It will also add the atom to the cameras list if you set the choice to 1.
+ * Setting the choice to 0 will remove the camera from the chunks.
+ * If you want to update the chunks around an object, without adding/removing a camera, use choice 2.
+ */
 /datum/cameranet/proc/majorChunkChange(atom/c, choice)
 	if(!c)
 		return
@@ -167,8 +133,7 @@ GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new)
 						chunk.cameras |= c
 					chunk.hasChanged()
 
-// Will check if a mob is on a viewable turf. Returns 1 if it is, otherwise returns 0.
-
+/// Will check if a mob is on a viewable turf. Returns 1 if it is, otherwise returns 0.
 /datum/cameranet/proc/checkCameraVis(mob/living/target)
 	var/turf/position = get_turf(target)
 	return checkTurfVis(position)
@@ -180,8 +145,8 @@ GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new)
 		if(chunk.changed)
 			chunk.hasChanged(1) // Update now, no matter if it's visible or not.
 		if(chunk.visibleTurfs[position])
-			return 1
-	return 0
+			return TRUE
+	return FALSE
 
 /datum/cameranet/proc/stat_entry()
 	if(!statclick)
@@ -202,6 +167,3 @@ GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new)
 
 	layer = CAMERA_STATIC_LAYER
 	plane = CAMERA_STATIC_PLANE
-
-/obj/effect/overlay/camera_static/transparent
-	mouse_opacity = MOUSE_OPACITY_TRANSPARENT

--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -1,4 +1,4 @@
-#define UPDATE_BUFFER 25 // 2.5 seconds
+#define UPDATE_BUFFER_TIME (2.5 SECONDS)
 
 // CAMERA CHUNK
 //
@@ -6,100 +6,128 @@
 // Allows the AI Eye to stream these chunks and know what it can and cannot see.
 
 /datum/camerachunk
+	///turfs our cameras cant see but are inside our grid. associative list of the form: list(obscured turf = static image on that turf)
 	var/list/obscuredTurfs = list()
+	///turfs our cameras can see inside our grid
 	var/list/visibleTurfs = list()
+	///cameras that can see into our grid
 	var/list/cameras = list()
+	///list of all turfs
 	var/list/turfs = list()
+	///camera mobs that can see turfs in our grid
 	var/list/seenby = list()
-	var/changed = 0
+	///images created to represent obscured turfs
+	var/list/inactive_static_images = list()
+	///images currently in use on obscured turfs.
+	var/list/active_static_images = list()
+
+	var/changed = FALSE
 	var/x = 0
 	var/y = 0
 	var/z = 0
 
-// Add an AI eye to the chunk, then update if changed.
-
+/// Add an AI eye to the chunk, then update if changed.
 /datum/camerachunk/proc/add(mob/camera/aiEye/eye)
 	eye.visibleCameraChunks += src
 	seenby += eye
 	if(changed)
 		update()
 
-// Remove an AI eye from the chunk, then update if changed.
+	var/client/client = eye.GetViewerClient()
+	if(client && eye.use_static)
+		client.images += active_static_images
 
+/// Remove an AI eye from the chunk
 /datum/camerachunk/proc/remove(mob/camera/aiEye/eye, remove_static_with_last_chunk = TRUE)
 	eye.visibleCameraChunks -= src
 	seenby -= eye
-	if(remove_static_with_last_chunk && !eye.visibleCameraChunks.len)
-		var/client/client = eye.GetViewerClient()
-		if(client)
-			switch(eye.use_static)
-				if(USE_STATIC_TRANSPARENT)
-					client.images -= GLOB.cameranet.obscured_transparent
-				if(USE_STATIC_OPAQUE)
-					client.images -= GLOB.cameranet.obscured
 
-// Called when a chunk has changed. I.E: A wall was deleted.
+	var/client/client = eye.GetViewerClient()
+	if(client && eye.use_static)
+		client.images -= active_static_images
 
+/// Called when a chunk has changed. I.E: A wall was deleted.
 /datum/camerachunk/proc/visibilityChanged(turf/loc)
 	if(!visibleTurfs[loc])
 		return
 	hasChanged()
 
-// Updates the chunk, makes sure that it doesn't update too much. If the chunk isn't being watched it will
-// instead be flagged to update the next time an AI Eye moves near it.
-
+/**
+ * Updates the chunk, makes sure that it doesn't update too much. If the chunk isn't being watched it will
+ * instead be flagged to update the next time an AI Eye moves near it.
+ */
 /datum/camerachunk/proc/hasChanged(update_now = 0)
 	if(seenby.len || update_now)
-		addtimer(CALLBACK(src, .proc/update), UPDATE_BUFFER, TIMER_UNIQUE)
+		addtimer(CALLBACK(src, .proc/update), UPDATE_BUFFER_TIME, TIMER_UNIQUE)
 	else
-		changed = 1
+		changed = TRUE
 
-// The actual updating. It gathers the visible turfs from cameras and puts them into the appropiate lists.
-
+/// The actual updating. It gathers the visible turfs from cameras and puts them into the appropiate lists.
 /datum/camerachunk/proc/update()
-	var/list/newVisibleTurfs = list()
+	var/list/updated_visible_turfs = list()
 
-	for(var/camera in cameras)
-		var/obj/machinery/camera/c = camera
-
-		if(!c)
-			continue
-
-		if(!c.can_use())
+	for(var/obj/machinery/camera/current_camera as anything in cameras)
+		if(!current_camera || !current_camera.can_use())
 			continue
 
 		var/turf/point = locate(src.x + (CHUNK_SIZE / 2), src.y + (CHUNK_SIZE / 2), src.z)
-		if(get_dist(point, c) > CHUNK_SIZE + (CHUNK_SIZE / 2))
+		if(get_dist(point, current_camera) > CHUNK_SIZE + (CHUNK_SIZE / 2))
 			continue
 
-		for(var/turf/t in c.can_see())
-			// Possible optimization: if(turfs[t]) here, rather than &= turfs afterwards.
-			// List associations use a tree or hashmap of some sort (alongside the list itself)
-			//  so are surprisingly fast. (significantly faster than var/thingy/x in list, in testing)
-			newVisibleTurfs[t] = t
+		for(var/turf/vis_turf in current_camera.can_see())
+			if(turfs[vis_turf])
+				updated_visible_turfs[vis_turf] = vis_turf
 
-	// Removes turf that isn't in turfs.
-	newVisibleTurfs &= turfs
+	///new turfs that we couldnt see last update but can now
+	var/list/newly_visible_turfs = updated_visible_turfs - visibleTurfs
+	///turfs that we could see last update but cant see now
+	var/list/newly_obscured_turfs = visibleTurfs - updated_visible_turfs
 
-	var/list/visAdded = newVisibleTurfs - visibleTurfs
-	var/list/visRemoved = visibleTurfs - newVisibleTurfs
+	for(var/mob/camera/ai_eye/client_eye as anything in seenby)
+		var/client/client = client_eye.ai?.client || client_eye.client
+		if(!client)
+			continue
 
-	visibleTurfs = newVisibleTurfs
-	obscuredTurfs = turfs - newVisibleTurfs
+		client.images -= active_static_images
 
-	for(var/turf in visAdded)
-		var/turf/t = turf
-		t.vis_contents -= GLOB.cameranet.vis_contents_objects
+	for(var/turf/visible_turf as anything in newly_visible_turfs)
+		var/image/static_image_to_deallocate = obscuredTurfs[visible_turf]
+		if(!static_image_to_deallocate)
+			continue
 
-	for(var/turf in visRemoved)
-		var/turf/t = turf
-		if(obscuredTurfs[t] && !istype(t, /turf/open/ai_visible))
-			t.vis_contents += GLOB.cameranet.vis_contents_objects
+		static_image_to_deallocate.loc = null
+		active_static_images -= static_image_to_deallocate
+		inactive_static_images += static_image_to_deallocate
 
-	changed = 0
+		obscuredTurfs -= visible_turf
 
-// Create a new camera chunk, since the chunks are made as they are needed.
+	for(var/turf/obscured_turf as anything in newly_obscured_turfs)
+		if(obscuredTurfs[obscured_turf] || istype(obscured_turf, /turf/open/ai_visible))
+			continue
 
+		var/image/static_image_to_allocate = inactive_static_images[length(inactive_static_images)]
+		if(!static_image_to_allocate)
+			stack_trace("somehow a camera chunk ran out of static images!")
+			break
+
+		obscuredTurfs[obscured_turf] = static_image_to_allocate
+		static_image_to_allocate.loc = obscured_turf
+
+		inactive_static_images -= static_image_to_allocate
+		active_static_images += static_image_to_allocate
+
+	visibleTurfs = updated_visible_turfs
+
+	changed = FALSE
+
+	for(var/mob/camera/ai_eye/client_eye as anything in seenby)
+		var/client/client = client_eye.ai?.client || client_eye.client
+		if(!client)
+			continue
+
+		client.images += active_static_images
+
+/// Create a new camera chunk, since the chunks are made as they are needed.
 /datum/camerachunk/New(x, y, z)
 	x &= ~(CHUNK_SIZE - 1)
 	y &= ~(CHUNK_SIZE - 1)
@@ -108,35 +136,30 @@
 	src.y = y
 	src.z = z
 
-	for(var/obj/machinery/camera/c in urange(CHUNK_SIZE, locate(x + (CHUNK_SIZE / 2), y + (CHUNK_SIZE / 2), z)))
-		if(c.can_use())
-			cameras += c
+	for(var/obj/machinery/camera/camera in urange(CHUNK_SIZE, locate(x + (CHUNK_SIZE / 2), y + (CHUNK_SIZE / 2), z)))
+		if(camera.can_use())
+			cameras += camera
 
-	for(var/turf/t in block(locate(max(x, 1), max(y, 1), z), locate(min(x + CHUNK_SIZE - 1, world.maxx), min(y + CHUNK_SIZE - 1, world.maxy), z)))
+	for(var/turf/t as anything in block(locate(max(x, 1), max(y, 1), z), locate(min(x + CHUNK_SIZE - 1, world.maxx), min(y + CHUNK_SIZE - 1, world.maxy), z)))
 		turfs[t] = t
 
-	for(var/camera in cameras)
-		var/obj/machinery/camera/c = camera
-		if(!c)
+	for(var/turf in turfs)//one for each 16x16 = 256 turfs this camera chunk encompasses
+		inactive_static_images += new/image(GLOB.cameranet.obscured)
+
+	for(var/obj/machinery/camera/camera as anything in cameras)
+		if(!camera || !camera.can_use())
 			continue
 
-		if(!c.can_use())
-			continue
+		for(var/turf/vis_turf in camera.can_see())
+			if(turfs[vis_turf])
+				visibleTurfs[vis_turf] = vis_turf
 
-		for(var/turf/t in c.can_see())
-			// Possible optimization: if(turfs[t]) here, rather than &= turfs afterwards.
-			// List associations use a tree or hashmap of some sort (alongside the list itself)
-			//  so are surprisingly fast. (significantly faster than var/thingy/x in list, in testing)
-			visibleTurfs[t] = t
+	for(var/turf/obscured_turf as anything in turfs - visibleTurfs)
+		var/image/new_static = inactive_static_images[inactive_static_images.len]
+		new_static.loc = obscured_turf
+		active_static_images += new_static
+		inactive_static_images -= new_static
+		obscuredTurfs[obscured_turf] = new_static
 
-	// Removes turf that isn't in turfs.
-	visibleTurfs &= turfs
-
-	obscuredTurfs = turfs - visibleTurfs
-
-	for(var/turf in obscuredTurfs)
-		var/turf/t = turf
-		t.vis_contents += GLOB.cameranet.vis_contents_objects
-
-#undef UPDATE_BUFFER
+#undef UPDATE_BUFFER_TIME
 #undef CHUNK_SIZE

--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -83,7 +83,7 @@
 	///turfs that we could see last update but cant see now
 	var/list/newly_obscured_turfs = visibleTurfs - updated_visible_turfs
 
-	for(var/mob/camera/ai_eye/client_eye as anything in seenby)
+	for(var/mob/camera/aiEye/client_eye as anything in seenby)
 		var/client/client = client_eye.ai?.client || client_eye.client
 		if(!client)
 			continue
@@ -120,7 +120,7 @@
 
 	changed = FALSE
 
-	for(var/mob/camera/ai_eye/client_eye as anything in seenby)
+	for(var/mob/camera/aiEye/client_eye as anything in seenby)
 		var/client/client = client_eye.ai?.client || client_eye.client
 		if(!client)
 			continue

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -13,7 +13,7 @@
 	var/list/visibleCameraChunks = list()
 	var/mob/living/silicon/ai/ai = null
 	var/relay_speech = FALSE
-	var/use_static = USE_STATIC_OPAQUE
+	var/use_static = TRUE
 	var/static_visibility_range = 16
 	var/ai_detector_visible = TRUE
 	var/ai_detector_color = COLOR_RED
@@ -33,17 +33,18 @@
 		QDEL_LIST(old_images)
 		return
 
-	if(!hud.hudusers.len)
-		//no one is watching, do not bother updating anything
-		return
+	if(!length(hud.hudusers))
+		return //no one is watching, do not bother updating anything
+
 	hud.remove_from_hud(src)
 
-	var/static/list/vis_contents_objects = list()
-	var/obj/effect/overlay/ai_detect_hud/hud_obj = vis_contents_objects[ai_detector_color]
+	var/static/list/vis_contents_opaque = list()
+	var/obj/effect/overlay/ai_detect_hud/hud_obj = vis_contents_opaque[ai_detector_color]
+
 	if(!hud_obj)
 		hud_obj = new /obj/effect/overlay/ai_detect_hud()
 		hud_obj.color = ai_detector_color
-		vis_contents_objects[ai_detector_color] = hud_obj
+		vis_contents_opaque[ai_detector_color] = hud_obj
 
 	var/list/new_images = list()
 	var/list/turfs = get_visible_turfs()
@@ -80,7 +81,7 @@
 			forceMove(T)
 		else
 			moveToNullspace()
-		if(use_static != USE_STATIC_NONE)
+		if(use_static)
 			ai.camera_visibility(src)
 		if(ai.client && !ai.multicam_on)
 			ai.client.eye = src

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -271,7 +271,7 @@
 
 /mob/camera/aiEye/remote/shuttle_docker
 	visible_icon = FALSE
-	use_static = USE_STATIC_NONE
+	use_static = FALSE
 	var/list/placement_images = list()
 	var/list/placed_images = list()
 

--- a/code/modules/shuttle/shuttle_creation/shuttle_creator_console.dm
+++ b/code/modules/shuttle/shuttle_creation/shuttle_creator_console.dm
@@ -17,7 +17,7 @@
 /obj/machinery/computer/camera_advanced/shuttle_creator/CreateEye()
 	eyeobj = new /mob/camera/aiEye/remote/shuttle_creation(get_turf(owner_rsd))
 	eyeobj.origin = src
-	eyeobj.use_static = USE_STATIC_NONE
+	eyeobj.use_static = FALSE
 
 /obj/machinery/computer/camera_advanced/shuttle_creator/is_operational()
 	return TRUE


### PR DESCRIPTION
# Document the changes in your pull request

Maims the AI detector traitor item but we get less lag n stuff.

Might fix the AI static going away which is cool, so this also removes the kick

Unlike Bee I didn't test this at all so a test merge would be good. UPDATE: I tested it for 30 seconds and the static still works

**Original description:**
Ports:
https://github.com/tgstation/tgstation/pull/59165
https://github.com/tgstation/tgstation/pull/59204
https://github.com/tgstation/tgstation/pull/63666


I did a very basic test that AI static still works. I'll leave it up to the other code jannies to decide if it's testmerge-worthy.

Improves maptick significantly and generally cleans up the code.

# Wiki Documentation


# Changelog

:cl:  Kylerace, ported by ike709 to Beestation, ported by TheGamerdk to Yogstation
rscdel: For performance reasons, AI detectors no longer see AI static.
bugfix: AI detectors now change appearance when AIs come closer.
bugfix: Fixed AI static intermittently deciding to stop working.
experimental: Generally cleaned up cameranet code and improved maptick significantly.
/:cl:
