### PR TITLE
Makes the nukie ship count as near miss

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -477,7 +477,7 @@
 		var/area/fabric_of_reality/fabric = A
 		new /obj/singularity(fabric.origin, 2000) // Stage five singulo back on the station, as a gift
 	else if(bomb_location && is_station_level(bomb_location.z))
-		if(istype(A, /area/space))
+		if(istype(A, /area/space) || istype(A, /area/shuttle/syndicate))
 			off_station = NUKE_NEAR_MISS
 		if((bomb_location.x < (128-NUKERANGE)) || (bomb_location.x > (128+NUKERANGE)) || (bomb_location.y < (128-NUKERANGE)) || (bomb_location.y > (128+NUKERANGE)))
 			off_station = NUKE_NEAR_MISS


### PR DESCRIPTION
# Document the changes in your pull request

Doesn't make sense that nukies nuking their own ship counts as a direct hit, while being one tile into space counts as a near miss.

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
tweak: Nukies can no longer nuke themselves for a win
/:cl:
