### PR TITLE
Wormhole jaunters no longer need to be placed on the belt to save you from chasms

### DIFF
--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -80,11 +80,10 @@
 		if(ishuman(AM))
 			var/mob/living/carbon/human/H = AM
 			for(var/obj/item/wormhole_jaunter/J in H.GetAllContents())
-				if(istype(J))
-					//To freak out any bystanders
-					H.visible_message(span_boldwarning("[H] falls into [parent]!"))
-					J.chasm_react(H)
-					return FALSE
+				//To freak out any bystanders
+				H.visible_message(span_boldwarning("[H] falls into [parent]!"))
+				J.chasm_react(H)
+				return FALSE
 	return TRUE
 
 /datum/component/chasm/proc/drop(atom/movable/AM)

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -79,12 +79,12 @@
 			return FALSE
 		if(ishuman(AM))
 			var/mob/living/carbon/human/H = AM
-			if(istype(H.belt, /obj/item/wormhole_jaunter))
-				var/obj/item/wormhole_jaunter/J = H.belt
-				//To freak out any bystanders
-				H.visible_message(span_boldwarning("[H] falls into [parent]!"))
-				J.chasm_react(H)
-				return FALSE
+			for(var/obj/item/wormhole_jaunter/J in H.GetAllContents())
+				if(istype(J))
+					//To freak out any bystanders
+					H.visible_message(span_boldwarning("[H] falls into [parent]!"))
+					J.chasm_react(H)
+					return FALSE
 	return TRUE
 
 /datum/component/chasm/proc/drop(atom/movable/AM)

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -1,7 +1,7 @@
 /**********************Jaunter**********************/
 /obj/item/wormhole_jaunter
 	name = "wormhole jaunter"
-	desc = "A single use device harnessing outdated wormhole technology, Nanotrasen has since turned its eyes to bluespace for more accurate teleportation. The wormholes it creates are unpleasant to travel through, to say the least.\nThanks to modifications provided by the Free Golems, this jaunter can be worn on the belt to provide protection from chasms."
+	desc = "A single use device harnessing outdated wormhole technology, Nanotrasen has since turned its eyes to bluespace for more accurate teleportation. The wormholes it creates are unpleasant to travel through, to say the least.\nThanks to modifications provided by the Free Golems, this jaunter provides protection from chasms."
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "Jaunter"
 	item_state = "electronic"

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -70,12 +70,9 @@
 			activate(M)
 
 /obj/item/wormhole_jaunter/proc/chasm_react(mob/user)
-	if(user.get_item_by_slot(SLOT_BELT) == src)
-		to_chat(user, "Your [name] activates, saving you from the chasm!</span>")
-		SSblackbox.record_feedback("tally", "jaunter", 1, "Chasm") // chasm automatic activation
-		activate(user, FALSE)
-	else
-		to_chat(user, "[src] is not attached to your belt, preventing it from saving you from the chasm. RIP.</span>")
+	to_chat(user, "Your [name] activates, saving you from the chasm!</span>")
+	SSblackbox.record_feedback("tally", "jaunter", 1, "Chasm") // chasm automatic activation
+	activate(user, FALSE)
 
 //jaunter tunnel
 /obj/effect/portal/jaunt_tunnel


### PR DESCRIPTION
# Document the changes in your pull request

The belt slot is sacred and specifically for the use of holding the KA as god intended

also 750 points to not permadie to bad game design is already enough of a price to not die to bad game design

# Wiki Documentation

Wormhole jaunters are not required to be placed on the belt to protect you from chasms

# Changelog

:cl:  
tweak: the wormhole jaunter will always activate when on your person if you fall into a chasm
/:cl:
