### PR TITLE
[AI] [Concept] Dead AIs drop a black box which is able to revive them if uploaded within 5 minutes

### DIFF
--- a/code/modules/mob/living/silicon/ai/decentralized_ai.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized_ai.dm
@@ -67,4 +67,4 @@
 
 	adjustOxyLoss(200) //Die!!
 
-	QDEL_IN(src, 2 SECONDS)
+	//QDEL_IN(src, 2 SECONDS)


### PR DESCRIPTION
# Document the changes in your pull request

AI drops a black box copy of itself at the last core it was in before dying.
Hit a control console with this black box after restoring the network and the AI will be revived.
If not done within 5 minutes the black box goes inactive and the AI is permanently dead.

# Wiki Documentation

# Changelog

:cl:  
experimental: AI drops a black box capable of recovering it for 5 minutes after death
/:cl:
