### PR TITLE
Fixes station traits

### DIFF
--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -31,7 +31,7 @@ PROCESSING_SUBSYSTEM_DEF(station)
 /datum/controller/subsystem/processing/station/proc/SetupTraits()
 	for(var/i in subtypesof(/datum/station_trait))
 		var/datum/station_trait/trait_typepath = i
-		if (trait_typepath.trait_flags & STATION_TRAIT_ABSTRACT)
+		if (initial(trait_typepath.trait_flags) & STATION_TRAIT_ABSTRACT)
 			continue
 		selectable_traits_by_types[initial(trait_typepath.trait_type)][trait_typepath] = initial(trait_typepath.weight)
 


### PR DESCRIPTION
# Document the changes in your pull request

can't directly access variables of a typepath without initial()

# Wiki Documentation

# Changelog

:cl:  
bugfix: Station traits work again  
/:cl:
