### PR TITLE
Fixes a bad switch case

### DIFF
--- a/code/datums/components/construction.dm
+++ b/code/datums/components/construction.dm
@@ -82,13 +82,12 @@
 				. = user.transferItemToLoc(I, parent)
 				if(.)
 					qdel(I)
-
 			if(ITEM_MOVE_INSIDE)
 				. = user.transferItemToLoc(I, parent)
-
-			// Using stacks
-			else if(istype(I, /obj/item/stack))
-				. = I.use_tool(parent, user, 0, volume=50, amount=current_step["amount"])
+			else
+				// Using stacks
+				if(istype(I, /obj/item/stack))
+					. = I.use_tool(parent, user, 0, volume=50, amount=current_step["amount"])
 
 
 	// Going backwards? Undo the last action. Drop/respawn the items used in last action, if any.

--- a/code/datums/components/construction.dm
+++ b/code/datums/components/construction.dm
@@ -103,8 +103,9 @@
 				if(located_item)
 					located_item.forceMove(drop_location())
 
-			else if(ispath(target_step_key, /obj/item/stack))
-				new target_step_key(drop_location(), target_step["amount"])
+			else 
+				if(ispath(target_step_key, /obj/item/stack))
+					new target_step_key(drop_location(), target_step["amount"])
 
 /datum/component/construction/proc/spawn_result()
 	// Some constructions result in new components being added.


### PR DESCRIPTION
`else if()` is not a valid switch case and in some circumstances can cause unintended behavior. This specific example doesn't but I'm fixing it anyways because OpenDream warns for it.