### PR TITLE
brazil will no longer hold crew who have lost more marbles than they have

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -349,7 +349,7 @@
 	return TRUE
 
 /datum/status_effect/brazil_penance/tick()
-	if(!penance_left)
+	if(penance_left <= 0)
 		apply_effects()
 		qdel(src)
 


### PR DESCRIPTION
# Document the changes in your pull request

fuck

:cl:  
bugfix: escaping brazil no longer requires exactly 0 marbles, now accepts negative numbers
/:cl:
