### PR TITLE
Fixes organ efficiency bugs

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -54,11 +54,10 @@
 /mob/living/carbon/handle_breathing(times_fired)
 	var/next_breath = 4
 	var/obj/item/organ/lungs/L = getorganslot(ORGAN_SLOT_LUNGS)
-	if(L)
-		if(L.damage)
+	if(L?.damage)
 			next_breath *= L.get_organ_efficiency()
 
-	if((times_fired % next_breath) == 0 || failed_last_breath)
+	if(!next_breath || (times_fired % next_breath) == 0 || failed_last_breath)
 		breathe() //Breathe per 4 ticks if healthy, down to 1 based on lung damage, unless suffocating
 		if(failed_last_breath)
 			SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "suffocation", /datum/mood_event/suffocation)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -55,9 +55,9 @@
 	var/next_breath = 4
 	var/obj/item/organ/lungs/L = getorganslot(ORGAN_SLOT_LUNGS)
 	if(L?.damage)
-		next_breath *= L.get_organ_efficiency()
+		next_breath = max(next_breath * L.get_organ_efficiency(), 1)
 
-	if(!next_breath || (times_fired % next_breath) == 0 || failed_last_breath)
+	if((times_fired % next_breath) == 0 || failed_last_breath)
 		breathe() //Breathe per 4 ticks if healthy, down to 1 based on lung damage, unless suffocating
 		if(failed_last_breath)
 			SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "suffocation", /datum/mood_event/suffocation)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -55,7 +55,7 @@
 	var/next_breath = 4
 	var/obj/item/organ/lungs/L = getorganslot(ORGAN_SLOT_LUNGS)
 	if(L?.damage)
-			next_breath *= L.get_organ_efficiency()
+		next_breath *= L.get_organ_efficiency()
 
 	if(!next_breath || (times_fired % next_breath) == 0 || failed_last_breath)
 		breathe() //Breathe per 4 ticks if healthy, down to 1 based on lung damage, unless suffocating

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -196,9 +196,9 @@
 /obj/item/organ/item_action_slot_check(slot,mob/user)
 	return //so we don't grant the organ's action to mobs who pick up the organ.
 
-///returns an organ's efficiency, a percent value (rounded to the 10s) based on its damage and organ_efficiency
+///returns an organ's efficiency, a percent value (rounded to the 10s) based on damage that is multiplied by organ_efficiency
 /obj/item/organ/proc/get_organ_efficiency()
-	return damage < low_threshold ? organ_efficiency : round(organ_efficiency * (damage/maxHealth), 0.1)
+	return damage < low_threshold ? organ_efficiency : round(organ_efficiency * 1-(damage/maxHealth), 0.1)
 
 ///Adjusts an organ's damage by the amount "d", up to a maximum amount, which is by default max damage
 /obj/item/organ/proc/applyOrganDamage(var/d, var/maximum = maxHealth)	//use for damaging effects


### PR DESCRIPTION
# Document the changes in your pull request

division by 0 due to modulus idk WHY I hate math I hate math
also organ efficiency was based on damage rather than subtracted BY damage so your organs got better as they died

# Changelog

:cl:  
bugfix: runtime fix
bugfix: organ efficiency now calculates properly
/:cl:
