### PR TITLE
Fix runtime in clock_cult.dm

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -45,6 +45,8 @@ Credit where due:
 ///////////
 
 /proc/is_servant_of_ratvar(mob/M)
+	if(!istype(M))
+		return FALSE
 	return M?.mind?.has_antag_datum(/datum/antagonist/clockcult)
 
 /proc/is_eligible_servant(mob/M)


### PR DESCRIPTION
# Document the changes in your pull request

Apparently something is checking if a virtualspeaker is a servant of ratvar, but those don't have minds

Runtime in clock_cult.dm, line 48: undefined variable /atom/movable/virtualspeaker/var/mind

# Changelog

:cl:  
bugfix: fixed a runtime when checking if a mob is a clockie
/:cl:
