### PR TITLE
removes duplicate blood regeneration effect from hearts

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -50,7 +50,7 @@
 				nutrition_ratio *= 1.25
 			nutrition_ratio *= heart_ratio
 			adjust_nutrition(-nutrition_ratio * HUNGER_FACTOR)
-			blood_volume = min(BLOOD_VOLUME_NORMAL(src), blood_volume + 0.5 * nutrition_ratio * heart_ratio)
+			blood_volume = min(BLOOD_VOLUME_NORMAL(src), blood_volume + 0.5 * nutrition_ratio)
 
 		//Effects of bloodloss
 		var/word = pick("dizzy","woozy","faint")


### PR DESCRIPTION
# Document the changes in your pull request

I've been going over my old organ efficiency code because I hate myself and found out that apparently I made the heart's efficiency modifier apply twice when regenerating blood

I have no idea how this happened but it did

# Changelog

:cl:  
bugfix: the heart's organ efficiency rating only effects blood regen once instead of twice
/:cl:
