### PR TITLE
Emagged sleepers now actually hurt people

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -193,7 +193,7 @@
 			C.remove_status_effect(STATUS_EFFECT_STASIS)
 		if(obj_flags & EMAGGED)
 			var/existing = C.reagents.get_reagent_amount(/datum/reagent/toxin/amanitin)
-			C.reagents.add_reagent(/datum/reagent/toxin/amanitin, max(0, 1 - existing)) //this should be enough that you immediately eat shit on exiting but not before
+			C.reagents.add_reagent(/datum/reagent/toxin/amanitin, max(0, 1.5 - existing)) //this should be enough that you immediately eat shit on exiting but not before
 		switch(active_treatment)
 			if(SLEEPER_TEND)
 				C.heal_bodypart_damage(SLEEPER_HEAL_RATE,SLEEPER_HEAL_RATE) //this is slow as hell, use the rest of medbay you chumps
@@ -213,6 +213,8 @@
 							break
 			if(SLEEPER_CHEMPURGE)
 				C.adjustToxLoss(-SLEEPER_HEAL_RATE)
+				if(obj_flags & EMAGGED)
+					return
 				var/purge_rate = 0.5 * efficiency
 				for(var/datum/reagent/R in C.reagents.reagent_list)
 					if(istype(R, /datum/reagent/toxin))


### PR DESCRIPTION
# Document the changes in your pull request

increases the amount of amanitin from 1 to 1.5 per cycle so the sleeper will actually hurt people in it rather than doing literally nothing

chem purge no longer works when a sleeper is emagged, it will still heal toxin damage

# Changelog

:cl:  
tweak: emagged sleepers now inject 1.5 units of amanitin instead of 1
tweak: emagged sleepers will no longer purge chemicals, they will still however heal toxin damage
/:cl:
