### PR TITLE
Fixes some bugs with the Station Charter, including a missing pretty-filter

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -103,7 +103,7 @@
 #define MAX_MESSAGE_LEN			1024
 #define MAX_NAME_LEN			42
 #define MAX_BROADCAST_LEN		512
-#define MAX_CHARTER_LEN			80
+#define MAX_CHARTER_LEN			64
 
 // Audio/Visual Flags. Used to determine what sense are required to notice a message.
 #define MSG_VISUAL (1<<0)

--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -15,6 +15,7 @@
 	var/approval_time = 600
 
 	var/static/regex/standard_station_regex
+	var/datum/callback/rename_callback // Yogs -- We actually keep track of this in order to be able to manually call this callback if an admin choses to do so.
 
 /obj/item/station_charter/Initialize()
 	. = ..()
@@ -37,17 +38,26 @@
 		to_chat(user, "You're still waiting for approval from your employers about your proposed name change, it'd be best to wait for now.")
 		return
 
-	var/new_name = stripped_input(user, message="What do you want to name \
+	//Yogs start -- Better Charter
+	var/new_name = input(user, "What do you want to name \
 		[station_name()]? Keep in mind particularly terrible names may be \
 		rejected by your employers, while names using the standard format, \
-		will automatically be accepted.", max_length=MAX_CHARTER_LEN)
+		will automatically be accepted.", "Set Station Name") as text|null
+	if(!new_name)
+		return
+	new_name = strip_html_simple(new_name,MAX_CHARTER_LEN)
+	if(!length(new_name)) // <><><><><> is such a weird name for a station, don't you think?
+		return
+
+	if(isnotpretty(new_name)) // Yogs bigotry filter
+		to_chat(user,"That's not a terribly good name for a space station.")
+		message_admins("[ADMIN_LOOKUPFLW(user)] just attempted to name the station something bad: '[new_name]'")
+		return
 
 	if(response_timer_id)
 		to_chat(user, "You're still waiting for approval from your employers about your proposed name change, it'd be best to wait for now.")
 		return
 
-	if(!new_name)
-		return
 	log_game("[key_name(user)] has proposed to name the station as \
 		[new_name]")
 
@@ -58,14 +68,36 @@
 
 	to_chat(user, "Your name has been sent to your employers for approval.")
 	// Autoapproves after a certain time
-	response_timer_id = addtimer(CALLBACK(src, .proc/rename_station, new_name, user.name, user.real_name, key_name(user)), approval_time, TIMER_STOPPABLE)
-	to_chat(GLOB.admins, span_adminnotice("<b><font color=orange>CUSTOM STATION RENAME:</font></b>[ADMIN_LOOKUPFLW(user)] proposes to rename the [name_type] to [new_name] (will autoapprove in [DisplayTimeText(approval_time)]). [ADMIN_SMITE(user)] (<A HREF='?_src_=holder;[HrefToken(TRUE)];reject_custom_name=[REF(src)]'>REJECT</A>) [ADMIN_CENTCOM_REPLY(user)]"))
+	rename_callback = CALLBACK(src, .proc/rename_station, new_name, user.name, user.real_name, key_name(user))
+	response_timer_id = addtimer(rename_callback, approval_time, TIMER_STOPPABLE)
+	to_chat(GLOB.admins,
+		span_adminnotice("<b><font color=orange>CUSTOM STATION RENAME:</font></b>[ADMIN_LOOKUPFLW(user)] proposes to rename the [name_type] to [new_name] (will auto-approve in [DisplayTimeText(approval_time)]).\
+		(<a HREF='?_src_=holder;[HrefToken(TRUE)];accept_custom_name=[REF(src)]'>ACCEPT</a> or <a HREF='?_src_=holder;[HrefToken(TRUE)];reject_custom_name=[REF(src)]'>REJECT</a>) [ADMIN_SMITE(user)] [ADMIN_CENTCOM_REPLY(user)]"))
+
+/obj/item/station_charter/proc/accept_proposed(user)
+	if(!user)
+		return
+	if(!response_timer_id)
+		return
+	deltimer(response_timer_id)
+	response_timer_id = null
+
+	var/m = "[key_name(user)] has manually accepted the proposed station name."
+	message_admins(m)
+	log_admin(m)
+
+	rename_callback.Invoke()
+	rename_callback = null
 
 /obj/item/station_charter/proc/reject_proposed(user)
 	if(!user)
 		return
 	if(!response_timer_id)
 		return
+	deltimer(response_timer_id) // Doing this first to make sure we're not having a race with all the rubbish below
+	response_timer_id = null
+	rename_callback = null
+
 	var/turf/T = get_turf(src)
 	T.visible_message("<span class='warning'>The proposed changes disappear \
 		from [src]; it looks like they've been rejected.</span>")
@@ -73,9 +105,6 @@
 
 	message_admins(m)
 	log_admin(m)
-
-	deltimer(response_timer_id)
-	response_timer_id = null
 
 /obj/item/station_charter/proc/rename_station(designation, uname, ureal_name, ukey)
 	set_station_name(designation)

--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -1,4 +1,4 @@
-#define STATION_RENAME_TIME_LIMIT 3000
+#define STATION_RENAME_TIME_LIMIT 6000 // Deciseconds
 
 /obj/item/station_charter
 	name = "station charter"
@@ -31,7 +31,7 @@
 	if(used)
 		to_chat(user, "The [name_type] has already been named.")
 		return
-	if(!ignores_timeout && (world.time-SSticker.round_start_time > STATION_RENAME_TIME_LIMIT)) //5 minutes
+	if(!ignores_timeout && (world.time-SSticker.round_start_time > STATION_RENAME_TIME_LIMIT)) //10 minutes
 		to_chat(user, "The crew has already settled into the shift. It probably wouldn't be good to rename the [name_type] right now.")
 		return
 	if(response_timer_id)

--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -1,4 +1,4 @@
-#define STATION_RENAME_TIME_LIMIT 6000 // Deciseconds
+#define STATION_RENAME_TIME_LIMIT (10 MINUTES)
 
 /obj/item/station_charter
 	name = "station charter"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1430,7 +1430,12 @@
 
 		var/mob/M = locate(href_list["HeadsetMessage"])
 		usr.client.admin_headset_message(M)
-
+	else if(href_list["accept_custom_name"]) // yogs start
+		if(!check_rights(R_ADMIN))
+			return
+		var/obj/item/station_charter/charter = locate(href_list["accept_custom_name"])
+		if(istype(charter))
+			charter.accept_proposed(usr) // yogs end
 	else if(href_list["reject_custom_name"])
 		if(!check_rights(R_ADMIN))
 			return


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/161778747-5afd21ce-fda7-4a8e-a3aa-03e021b6f9c5.png)

## Summary
This does some polishing of how the Station Charter works. Most notably, apostrophes and so on are no longer destroyed by ``html_encode()``. It is also now possible for admins to manually approve station names.

## Changelog
:cl:  Altoids
bugfix: You can no longer name the space station your favourite ethnic slur.
bugfix: Apostrophes, etc. within custom station names are no longer clobbered into nonsense.
tweak: The Captain now has ten minutes to rename the station, up from five minutes.
spellcheck: The admin dialog for station renaming is now a bit clearer and allows you to manually approve a station name.
/:cl:
