### PR TITLE
Adjusted Security Masks no longer hide your facial hair

### DIFF
--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -12,7 +12,7 @@
 	flags_1 = HEAR_1
 	w_class = WEIGHT_CLASS_SMALL
 	visor_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
-	visor_flags_inv = HIDEFACE
+	visor_flags_inv = HIDEFACIALHAIR|HIDEFACE
 	flags_cover = MASKCOVERSMOUTH
 	visor_flags_cover = MASKCOVERSMOUTH
 	var/aggressiveness = 2


### PR DESCRIPTION
### Captains and Security crew with beards are now buffed

Before:
![image](https://user-images.githubusercontent.com/29939414/161792273-d93d10f0-f473-43cb-9231-13c7936570d2.png)

After:
![image](https://user-images.githubusercontent.com/29939414/161792288-ad71e6eb-c6c4-4797-9362-f6f1b52d40d2.png)

It's a minor thing but it's been annoying me every time this stops me from seeing Gary Lafortune's beautiful pinkish beard.
### Changelog

:cl:  Altoids
imageadd: It is now possible to see your lovely facial hair with the security mask lowered.
/:cl:
