### PR TITLE
Nicotine Overdose additionally causes heart damage

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -61,6 +61,7 @@
 	M.adjustToxLoss(0.1*REM, 0)
 	M.adjustOxyLoss(1.1*REM, 0)
 	M.adjustOrganLoss(ORGAN_SLOT_LUNGS, 2*REM)
+	M.adjustOrganLoss(ORGAN_SLOT_HEART, 1.25*REM)
 	..()
 	. = 1
 


### PR DESCRIPTION
Too much smoking is now bad for both the spaceman's lungs and the heart (at a lesser rate). 
Chainsmokers often have damaged lungs, _and_ malignant build up on the heart (and other organs), so this PR seeks to emulate that somewhat.
If you're going to smoke, do so safely, everyone.

# Document the changes in your pull request

Adds heart damage to nicotine overdose at 1.25xREM - a bit over half the rate of lung damage accrual (2xREM).

# Wiki Documentation

Notate heart damage alongside lung damage on nicotine OD entry.

# Changelog

:cl:  
rscadd: Too much smoking is bad for the heart, as well as the lungs
/:cl:
