### PR TITLE
The mining conscription kit's access card now has access to the cargo office because it didn't for some reason

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -425,6 +425,7 @@
 		I.access |= ACCESS_MECH_MINING
 		I.access |= ACCESS_MINERAL_STOREROOM
 		I.access |= ACCESS_CARGO
+		I.access |= ACCESS_MAILSORTING
 		to_chat(user, "You upgrade [I] with mining access.")
 		qdel(src)
 


### PR DESCRIPTION
# Document the changes in your pull request

Fixes miner conscription kit access cards not having access to the one way to get into mining

# Wiki Documentation

No
# Changelog
:cl:  
bugfix: mining access card now actually can get you to mining
/:cl:
