### PR TITLE
Changes Power Control Module to APC module for consistency

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1528,7 +1528,7 @@
 
 /*Power module, used for APC construction*/
 /obj/item/electronics/apc
-	name = "power control module"
+	name = "APC module"
 	icon_state = "power_mod"
 	custom_price = 5
 	desc = "Heavy-duty switching circuits for power control."

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -168,7 +168,7 @@
 	category = list("initial","Tools")
 
 /datum/design/apc_board
-	name = "Power Control Module"
+	name = "APC Module"
 	id = "power control"
 	build_type = AUTOLATHE | PROTOLATHE
 	materials = list(/datum/material/iron = 100, /datum/material/glass = 100)

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -168,7 +168,7 @@
 	category = list("initial","Tools")
 
 /datum/design/apc_board
-	name = "APC Module"
+	name = "Power Control Module"
 	id = "power control"
 	build_type = AUTOLATHE | PROTOLATHE
 	materials = list(/datum/material/iron = 100, /datum/material/glass = 100)


### PR DESCRIPTION
# Document the changes in your pull request

This changes the name of the power control module to APC module. That's it.


# Wiki Documentation

Ideally all instances of power control module would be changed to reflect the new name


# Changelog

:cl:  
spellcheck: Changed power control module to APC module
/:cl:
