### PR TITLE
Makes some spellfix & /examine() changes for Eldritch Horrors

### DIFF
--- a/code/modules/antagonists/horror/horror.dm
+++ b/code/modules/antagonists/horror/horror.dm
@@ -94,7 +94,7 @@
 			to_chat(src, span_warning("You are already within a host."))
 			return
 
-		to_chat(src, span_warning("You slither your tentacles up [C] and begin probing at their ear canal..."))
+		to_chat(src, span_warning("You slither your tentacles up [C] and begin probing at [C.p_their()] ear canal...")) // Yogs -- pronouns
 
 		if(!do_mob(src, C, 4 SECONDS))
 			to_chat(src, span_warning("As [C] moves away, you are dislodged and fall to the ground."))
@@ -174,7 +174,7 @@
 		target = pick(selected_targets)
 
 	if(target)
-		to_chat(src, span_warning("You caught their scent. Go and consume [target.current.real_name], the [target.assigned_role]'s soul!"))
+		to_chat(src, span_warning("You caught [target.p_their()] scent. Go and consume [target.current.real_name], the [target.assigned_role]'s soul!"))//Yogs -- pronoun police, open up
 		apply_status_effect(/datum/status_effect/agent_pinpointer/horror)
 		for(var/datum/status_effect/agent_pinpointer/horror/status in status_effects)
 			status.scan_target = target.current
@@ -497,7 +497,7 @@
 		to_chat(src, span_danger("You decide against leaving your host."))
 		return
 
-	to_chat(src, span_danger("You begin disconnecting from [victim]'s synapses and prodding at their internal ear canal."))
+	to_chat(src, span_danger("You begin disconnecting from [victim]'s synapses and prodding at [victim.p_their()] internal ear canal.")) //Yogs -- pronouns
 
 	if(victim.stat != DEAD && !has_upgrade("invisible_exit"))
 		to_chat(victim, span_userdanger("An odd, uncomfortable pressure begins to build inside your skull, behind your ear..."))
@@ -610,7 +610,7 @@
 		return
 
 	if(victim.stat == DEAD)
-		to_chat(src, span_warning("Your host brain is unresponsive. They are dead!"))
+		to_chat(src, span_warning("Your host brain is unresponsive. [victim.p_they(TRUE)] are dead!")) // Yogs -- pronouns
 		return
 
 	if(prob(20))
@@ -712,7 +712,7 @@
 	else
 		RegisterSignal(victim, COMSIG_MOB_APPLY_DAMAGE, .proc/hit_detatch)
 		log_game("[src]/([src.ckey]) assumed control of [victim]/([victim.ckey] with eldritch powers.")
-		to_chat(src, span_warning("You plunge your probosci deep into the cortex of the host brain, interfacing directly with their nervous system."))
+		to_chat(src, span_warning("You plunge your probosci deep into the cortex of the host brain, interfacing directly with [victim.p_their()] nervous system.")) // Yogs -- pronouns
 		to_chat(victim, span_userdanger("You feel a strange shifting sensation behind your eyes as an alien consciousness displaces yours."))
 
 		clothing = victim.get_equipped_items()

--- a/code/modules/antagonists/horror/horror.dm
+++ b/code/modules/antagonists/horror/horror.dm
@@ -85,6 +85,16 @@
 	victim = null
 	return ..()
 
+//Yogs -- slightly fancier examine
+/mob/living/simple_animal/horror/examine(mob/user) // Return a more... positive description when the examiner is themselves an eldritch horror.
+	if(user == src) // Hey, that's me!
+		return list("[icon2html(src, user)] That's [src.real_name], \a [initial(src.name)].","I'm so beautiful!")
+	else if(ishorror(user))
+		return list("[get_examine_string(user, TRUE)].","What a handsome rogue.")
+	else
+		return ..()
+//Yogs end
+	
 /mob/living/simple_animal/horror/AltClickOn(atom/A)
 	if(iscarbon(A))
 		var/mob/living/carbon/C = A


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/29939414/161886981-890230d4-33b1-4ffe-a047-6583671a725e.png)

This was originally a bug hunt for [lazarus not working with Eldritch Horrors](https://github.com/yogstation13/Yogstation/issues/13224), but I couldn't replicate it, so here's all the little extra things I added, instead.

This is mostly a spellcheck-ey kinda PR: Various Eldritch Horror dialogues now make correct use of ``p_their()`` and, most notably, Eldritch Horrors now actually show a positive opinion of themselves and each other on-examine. Further, examining yourself as a Horror quickly shows you what your ``real_name`` is.


## Changelog

:cl: Altoids  
spellcheck: Eldritch Horrors have been taught to have a more positive opinion of themselves when examining each other.
spellcheck: Lovecraftian horrors living in your cerebral cortex now respect your pronouns more often.
/:cl:
