### PR TITLE
Fixes weird encryption key dupe bug with wardrobes

### DIFF
--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -8,7 +8,14 @@
 	input_display_header = "Returned Clothing"
 
 /obj/machinery/vending/wardrobe/canLoadItem(obj/item/I,mob/user)
-	return (I.type in products)
+	if(I.type in products)
+		// Yogs -- weird snowflake check to make sure you can't print an endless amount of encryption chips.
+		// In general, vending machines should try to ensure that anything they dare accept as input is in the exact same state that it came out of them with.
+		if(istype(I,/obj/item/radio/headset) && I.type != /obj/item/radio/headset)
+			var/obj/item/radio/headset/HS = I
+			if(HS.keyslot != initial(HS.keyslot)) // Hey, you stole something!
+				return FALSE
+		return TRUE
 
 /obj/machinery/vending/wardrobe/sec_wardrobe
 	name = "\improper SecDrobe"


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/29939414/161899676-0cef1070-c423-4618-9bd9-4574aac12e0a.png)

Fixes #13157, for some reason. Because people care about this.

I'd make this bugfix more general, but as far as I can tell, this is the only case where, both:
1. A vending machine actually lets you put stuff back in it, and
2. said stuff has a sense of "state" that can be modified, and ergo exploited for profit.

So this is just really goofy bugfix. 🤷

## Changelog
:cl:  Altoids
bugfix: Moneybag Cargo Technicians can no longer spawn an infinite number of cargo encryption keys to flex on their inferiors.
/:cl:
