### PR TITLE
The "HEY LISTEN" roundstart dialog no longer complains about something taking no time at all

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -390,9 +390,15 @@ SUBSYSTEM_DEF(air)
 			//EG.self_breakdown(space_is_all_consuming = 1)
 			//EG.dismantle()
 			CHECK_TICK*/
-
-		var/msg = "HEY! LISTEN! [DisplayTimeText(world.timeofday - timer)] were wasted processing [starting_ats] turf(s) (connected to [ending_ats] other turfs) with atmos differences at round start."
-		to_chat(world, span_boldannounce("[msg]"))
+		var/time_msg = DisplayTimeText(world.timeofday - timer) // Yogs -- Nicer atmos complaining text
+		var/msg = ""
+		if(time_msg == "right now")
+			msg = "hi c: No time was wasted at all processing [starting_ats] turf(s) (connected to [ending_ats] other turfs) with atmos differences at round start."
+			to_chat(world,span_notice(msg))
+		else
+			msg = "HEY! LISTEN! [time_msg] were wasted processing [starting_ats] turf(s) (connected to [ending_ats] other turfs) with atmos differences at round start."
+			to_chat(world, span_boldannounce(msg))
+		//yogs end
 		warning(msg)
 
 /turf/open/proc/resolve_active_graph()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/161906120-9b9db537-3f27-4c2a-b917-2a17351be228.png)

Currently on ``master``, this weird atmos debug line is outputting "HEY LISTEN right now was *wasted*--" which is a bit stupid. So I've replaced it with something that is stupid for new and better reasons.

## Changelog
:cl:  Altoids
spellcheck: The strange atmospherics demon that complains about atmos turf equalization at roundstart is now slightly better-tempered.
/:cl:
