### PR TITLE
Makes Active Hulk locked so you can't roll it randomly

### DIFF
--- a/code/datums/mutations/hulk.dm
+++ b/code/datums/mutations/hulk.dm
@@ -70,6 +70,7 @@
 	quality = POSITIVE
 	instability = 30
 	class = MUT_OTHER
+	locked = TRUE
 	text_gain_indication = span_notice("Your muscles hurt!")
 	health_req = 1
 	var/health_based = 0


### PR DESCRIPTION
It's supposed to be something you can save and bottle up from someone who is hulked out, not randomly roll, since i'm not sure how losing it would work when your stamina bar wears off. and nothing hulk related should roll standardly anyway, it's wack

:cl:  
bugfix: Active Hulk genetics mutation is locked so you can't roll it in your DNA anymore
/:cl:
