### PR TITLE
Adds the yarn.lock file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,4 @@ tgui/.yarn/*
 
 # Common build tooling
 !/tools/build
+tgui/yarn.lock


### PR DESCRIPTION
:cl:  Hopek
bugfix: For coders, the yarn.lock file is now being ignored by git since it changes every time you compile.
/:cl:
