### PR TITLE
Modifies MMI/Positronic brain behavior, allows for memory removal

### DIFF
--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -15,6 +15,10 @@
 	var/overrides_aicore_laws = TRUE // Whether the laws on the MMI are transferred when it's uploaded as an AI
 	var/override_cyborg_laws = FALSE // Do custom laws uploaded to the MMI get transferred to borgs? If yes the borg will be unlinked and have lawsync disabled.
 	var/can_update_laws = TRUE //Can we use a lawboard to change the laws of this MMI?
+	var/remove_time = 2 SECONDS /// The time to remove the brain or reset the posi brain
+	var/rebooting = FALSE /// If the MMI is rebooting after being deconstructed
+	var/remove_window = 10 SECONDS /// The window in which someone has to remove the brain to lose memory of being killed as a borg
+	var/reboot_timer = null
 
 /obj/item/mmi/update_icon()
 	if(!brain)
@@ -93,10 +97,19 @@
 		radio.on = !radio.on
 		to_chat(user, span_notice("You toggle [src]'s radio system [radio.on==1 ? "on" : "off"]."))
 	else
-		eject_brain(user)
-		update_icon()
-		name = initial(name)
-		to_chat(user, span_notice("You unlock and upend [src], spilling the brain onto the floor."))
+		user.visible_message(span_notice("[user] begins to remove the brain from [src]"), span_danger("You begin to pry the brain out of [src], ripping out the wires and probes"))
+		to_chat(brainmob, span_userdanger("You feel your mind failing as you are slowly ripped from the [src]"))
+		if(do_after(user, remove_time, target = src))
+			if(!brainmob) return
+			to_chat(brainmob, span_userdanger("Due to the traumatic danger of your removal, all memories of the events leading to your brain being removed are lost[rebooting ? ", along with all memories of the events leading to your death as a cyborg" : ""]"))
+			eject_brain(user)
+			update_icon()
+			name = initial(name)
+			user.visible_message(span_notice("[user] rips the brain out of [src]"), span_danger("You successfully remove the brain from the [src][rebooting ? ", interrupting the reboot process" : ""]"))
+			if(rebooting)
+				rebooting = FALSE
+				deltimer(reboot_timer)
+				reboot_timer = null
 
 /obj/item/mmi/proc/eject_brain(mob/user)
 	brainmob.container = null //Reset brainmob mmi var.
@@ -108,6 +121,7 @@
 	brainmob.add_to_dead_mob_list()
 	brain.brainmob = brainmob //Set the brain to use the brainmob
 	brainmob = null //Set mmi brainmob var to null
+	brain.setOrganDamage(brain.maxHealth) // Kill the brain, requiring mannitol
 	if(user)
 		user.put_in_hands(brain) //puts brain in the user's hand or otherwise drops it on the user's turf
 	else
@@ -218,6 +232,26 @@
 
 /obj/item/mmi/relaymove(mob/user)
 	return //so that the MMI won't get a warning about not being able to move if it tries to move
+
+/obj/item/mmi/proc/beginReboot()
+	rebooting = TRUE
+	visible_message(span_danger("The indicator lights on [src] begin to glow faintly as the reboot process begins"))
+	to_chat(brainmob, span_userdanger("You begin to reboot after being removed from the destroyed body"))
+	reboot_timer = addtimer(CALLBACK(src, .proc/halfwayReboot), remove_window / 2, TIMER_STOPPABLE)
+
+/obj/item/mmi/proc/halfwayReboot()
+	visible_message(span_danger("The indicator lights on [src] begin to glow stronger and the reboot process approaches the halfway point"))
+	reboot_timer = addtimer(CALLBACK(src, .proc/rebootNoReturn), remove_window / 2, TIMER_STOPPABLE)
+
+/obj/item/mmi/proc/rebootNoReturn()
+	visible_message(span_danger("The indicator lights on [src] begin to blink as the reboot process nears completion"))
+	reboot_timer = addtimer(CALLBACK(src, .proc/rebootFinish), remove_time, TIMER_STOPPABLE)
+
+/obj/item/mmi/proc/rebootFinish()
+	visible_message(span_danger("The indicator lights on [src] return to normal as the reboot process completes"))
+	to_chat(brainmob, span_userdanger("You return to normal functionality now that your reboot process has completed"))
+	rebooting = FALSE
+	reboot_timer = null
 
 /obj/item/mmi/syndie
 	name = "\improper Syndicate Man-Machine Interface"

--- a/code/modules/mob/living/brain/brain.dm
+++ b/code/modules/mob/living/brain/brain.dm
@@ -112,7 +112,7 @@
 	if(container)
 		. += "[container.type]"
 
-/mob/living/brain/say()
+/mob/living/brain/say(message, bubble_type, var/list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
 	if(container && container.rebooting)
 		to_chat(src, span_danger("Speech synthesizers still offine, wait for the reboot process to complete"))
 		return

--- a/code/modules/mob/living/brain/brain.dm
+++ b/code/modules/mob/living/brain/brain.dm
@@ -111,3 +111,9 @@
 
 	if(container)
 		. += "[container.type]"
+
+/mob/living/brain/say()
+	if(container && container.rebooting)
+		to_chat(src, span_danger("Speech synthesizers still offine, wait for the reboot process to complete"))
+		return
+	return ..()

--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -44,7 +44,11 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	if(!brainmob)
 		brainmob = new(src)
 	if(is_occupied())
-		to_chat(user, span_warning("This [name] is already active!"))
+		user.visible_message(span_danger("[user] begins to reset [src]'s memory banks"), span_danger("You begin to reset [src]'s memory banks"))
+		to_chat(brainmob, span_userdanger("[user] begins to reset your memory banks"))
+		if(do_after(user, remove_time, target = src))
+			user.visible_message(span_danger("[user] resets [src]'s memory banks"), span_danger("You successfully reset [src]'s memory banks"))
+			to_chat(brainmob, span_userdanger("Your memory banks have been cleared, you have no memories of anything before this moment."))
 		return
 	if(next_ask > world.time)
 		to_chat(user, recharge_message)
@@ -73,7 +77,7 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	activate(user)
 
 /obj/item/mmi/posibrain/proc/is_occupied()
-	if(brainmob.key)
+	if(brainmob.key && brainmob.client)
 		return TRUE
 	if(iscyborg(loc))
 		var/mob/living/silicon/robot/R = loc

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -205,6 +205,7 @@
 			to_chat(src, span_boldannounce("Oops! Something went very wrong, your MMI was unable to receive your mind. You have been ghosted. Please make a bug report so we can fix this bug."))
 			ghostize()
 			stack_trace("Borg MMI lacked a brainmob")
+		mmi.beginReboot()
 		mmi = null
 	if(modularInterface)
 		QDEL_NULL(modularInterface)
@@ -508,7 +509,7 @@
 			return
 		else
 			to_chat(user, span_notice("You start to unfasten [src]'s securing bolts..."))
-			if(W.use_tool(src, user, 50, volume=50) && !cell)
+			if(W.use_tool(src, user, 5 SECONDS, volume=50) && !cell)
 				user.visible_message("[user] deconstructs [src]!", span_notice("You unfasten the securing bolts, and [src] falls to pieces!"))
 				deconstruct()
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -179,7 +179,7 @@ NORESPAWN
 # GUEST_JOBBAN
 
 ## Uncomment this to stop people connecting to your server without a registered ckey. (i.e. guest-* are all blocked from connecting)
-GUEST_BAN
+# GUEST_BAN
 
 ## Comment this out to disable checking for the cid randomizer dll. (disabled if database isn't enabled or connected)
 CHECK_RANDOMIZER

--- a/config/config.txt
+++ b/config/config.txt
@@ -179,7 +179,7 @@ NORESPAWN
 # GUEST_JOBBAN
 
 ## Uncomment this to stop people connecting to your server without a registered ckey. (i.e. guest-* are all blocked from connecting)
-# GUEST_BAN
+GUEST_BAN
 
 ## Comment this out to disable checking for the cid randomizer dll. (disabled if database isn't enabled or connected)
 CHECK_RANDOMIZER


### PR DESCRIPTION
# Document the changes in your pull request

Using a posi brain in hand wipes the full memory of the posi brain, as if a new ghost possessed it
Using an MMI in hand removes the brain, killing it (fixed with mannitol), wipes recent memories
Both options take time (currently 2 seconds)
When deconstructing a borg, the mmi/posi must 'reboot' for a period of time (currently 12 seconds)
While rebooting the mmi/posi is unable to speak
Removing the brain from the MMI during the reboot results in memory loss of dying as borg as well
The removal/reset needs to be started in enough time to allow it to complete before the reboot does to cause the larger memory loss

Activating an SSD posi brain will re-poll ghosts

# Wiki info

2 seconds to remove brain/reset posi
10 second window to start the reset on a posi brain, giving a 12 second reboot timeer

# Changelog

:cl:  
tweak: Removing a brain from an MMI kills the brain (fixable with mannitol), and removes recent memories
tweak: Positronic brains can now have all their memories reset
tweak: MMIs and Positronic Brains must 'reboot' after their body is deconstructed, preventing them from speaking
tweak: Removing the brain from an MMI during the reboot, will make the brain forget the borg death as well
tweak: SSD Positronic brains will poll for a new ghost when activated
/:cl:
