### PR TITLE
Yalp Elor no longer instantaneously dies on-spawn, plus other bugfixes

### DIFF
--- a/code/modules/antagonists/fugitive/old_god.dm
+++ b/code/modules/antagonists/fugitive/old_god.dm
@@ -129,6 +129,12 @@
 	var/input = stripped_input(owner, "What do you wish to tell [target]?", null, "")
 	if(QDELETED(src) || !input || !IsAvailable())
 		return FALSE
+	if(isnotpretty(input)) // Yogs -- Pretty filter
+		to_chat(owner,span_warning("That's not a very nice thing to tell [target.p_them()]."))
+		var/log_message = "[key_name(owner)] just tripped a pretty filter: '[input]'."
+		message_admins(log_message)
+		log_say(log_message)
+		return FALSE // yogs end
 
 	transmit(owner, target, input)
 	return TRUE

--- a/code/modules/antagonists/fugitive/old_god.dm
+++ b/code/modules/antagonists/fugitive/old_god.dm
@@ -10,6 +10,7 @@
 	var/datum/action/innate/yalp_transmit/transmit
 	var/datum/action/innate/yalp_transport/transport
 	var/datum/action/cooldown/yalp_heal/heal
+	var/hunters_release_time // Yogs -- making Login() dialogue make more sense
 
 /mob/camera/yalp_elor/Initialize()
 	. = ..()
@@ -20,6 +21,7 @@
 	transport.Grant(src)
 	heal.Grant(src)
 	START_PROCESSING(SSobj, src)
+	hunters_release_time = world.time + 10 MINUTES // Yogs -- making Login() dialogue make more sense
 
 /mob/camera/yalp_elor/Destroy()
 	STOP_PROCESSING(SSobj, src)
@@ -37,11 +39,15 @@
 /mob/camera/yalp_elor/Process_Spacemove(movement_dir = 0)
 	return TRUE
 
-/mob/camera/yalp_elor/Login()
+/mob/camera/yalp_elor/Login() // Yogs -- better Login() dialogue
 	..()
-	to_chat(src, "<B>You must protect your followers from Nanotrasen!</B>")
-	to_chat(src, "<B>Only your followers can hear you, and you can speak to send messages to all of them, wherever they are. You can also locally whisper to anyone.</B>")
-	to_chat(src, "<B>Nanotrasen will reach you and your followers in about 10 minutes. Make sure they are ready when the time is up.</B>")
+	to_chat(src,span_boldnotice("You are [name], the old god!"))
+	to_chat(src,span_notice("You must protect your followers from Nanotrasen!"))
+	to_chat(src,span_notice("Only your followers can hear you, and you can speak to send messages to all of them, wherever they are. <i>You can also locally whisper to anyone.</i>"))
+	var/passed_time = hunters_release_time - world.time
+	if(passed_time > 0)
+		to_chat(src, span_warning("Nanotrasen will reach you and your followers in about [DisplayTimeText(passed_time)]. Make sure they are ready when the time is up."))
+//yogs end
 
 /mob/camera/yalp_elor/Move(NewLoc, direct)
 	if(!NewLoc)

--- a/code/modules/antagonists/fugitive/old_god.dm
+++ b/code/modules/antagonists/fugitive/old_god.dm
@@ -23,14 +23,11 @@
 	START_PROCESSING(SSobj, src)
 	hunters_release_time = world.time + 10 MINUTES // Yogs -- making Login() dialogue make more sense
 
-/mob/camera/yalp_elor/Destroy()
-	STOP_PROCESSING(SSobj, src)
-	return ..()
-
-/mob/camera/yalp_elor/Destroy()
+/mob/camera/yalp_elor/Destroy() // Yogs -- fixes duplicated Destroy() proc
 	QDEL_NULL(transmit)
 	QDEL_NULL(transport)
-	. = ..()
+	STOP_PROCESSING(SSobj, src)
+	return ..()
 
 /mob/camera/yalp_elor/CanPass(atom/movable/mover, turf/target)
 	SHOULD_CALL_PARENT(FALSE)

--- a/code/modules/events/fugitive_spawning.dm
+++ b/code/modules/events/fugitive_spawning.dm
@@ -33,7 +33,7 @@
 	var/member_size = min(candidates.len, 5)
 	var/leader
 	switch(backstory)
-		if("cultist" || "synth")
+		if("cultist","synth") // Yogs -- fixes this switch case
 			leader = pick_n_take(candidates)
 		if("waldo")
 			member_size = 0 //solo refugees have no leader so the member_size gets bumped to one a bit later


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/162335633-8e9f256d-09d8-4315-8a69-1bcd11decaf6.png)


## Summary

As per usual, I went foraging for bugfixes (fixes #13463) and found a few other bugs along the way.

## Changelog
:cl: Altoids  
bugfix: Yalp Elor no longer instantaneously dies on-spawn.
bugfix: Yalp Elor no longer dies if all of its followers go AFK, or adminghost, or anything like that.
bugfix: Yalp Elor can no longer whisper slurs to its followers.
bugfix: Yalp Elor now destructs properly on death, making SSobj slightly happier.
bugfix: Reconnecting as the Yalp Elor no longer erroneously informs you that the captor threat is always coming in ten minutes.
bugfix: Waldo fugitives probably work slightly better. I think. Maybe.
soundadd: Dying as the Yalp Elor now actually makes some sort of dramatic sound instead of just low-key qdel-ing you.
spellcheck: The Yalp Elor login dialogue now looks nicer.
/:cl:
