### PR TITLE
Fixes some weird behaviour, spellfixes of the "Jump To Network" AI verb

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -675,43 +675,44 @@
 	set name = "Jump To Network"
 	unset_machine()
 	cameraFollow = null
-	var/cameralist[0]
+	var/list/network_list = list()
 
 	if(incapacitated())
 		return
 
 	var/mob/living/silicon/ai/U = usr
 
-	for (var/obj/machinery/camera/C in GLOB.cameranet.cameras)
-		var/list/tempnetwork = C.network
-		if(!(is_station_level(C.z) || is_mining_level(C.z) || ("ss13" in tempnetwork)))
-			continue
-		if(!C.can_use())
-			continue
-
-		tempnetwork.Remove("rd", "toxins", "prison")
-		if(tempnetwork.len)
-			for(var/i in C.network)
-				cameralist[i] = i
-	var/old_network = network
-	network = input(U, "Which network would you like to view?") as null|anything in cameralist
-
+	//Yogs -- refactors this fucking decade-old, looney camera code
 	if(!U.eyeobj)
 		U.view_core()
 		return
 
-	if(isnull(network))
-		network = old_network // If nothing is selected
-	else
-		for(var/obj/machinery/camera/C in GLOB.cameranet.cameras)
-			if(!C.can_use())
-				continue
-			if(network in C.network)
-				U.eyeobj.setLoc(get_turf(C))
-				break
-	to_chat(src, span_notice("Switched to the \"[uppertext(network)]\" camera network."))
-//End of code by Mord_Sith
+	for (var/x in GLOB.cameranet.cameras)
+		var/obj/machinery/camera/C = x
+		if(!(is_station_level(C.z) || is_mining_level(C.z) || ("ss13" in C.network)))
+			continue
+		if(!C.can_use())
+			continue
+		var/list/tempnetwork = C.network
+		tempnetwork.Remove("rd", "toxins", "prison")
+		if(tempnetwork.len)
+			network_list |= tempnetwork
+	if(network_list.len < 2)
+		return
 
+	var/viewed_network = input(U, "Which network would you like to view?") as null|anything in network_list
+	if(!viewed_network)
+		return
+	for(var/obj/machinery/camera/C in GLOB.cameranet.cameras)
+		if(!C.can_use())
+			continue
+		if(viewed_network in C.network)
+			U.eyeobj.setLoc(get_turf(C))
+			to_chat(src, span_notice("Switched to a camera in the \"[uppertext(viewed_network)]\" camera network."))
+			return
+	to_chat(src, span_warning("Failed to find any camera on the \"[uppertext(viewed_network)]\" camera network!")) // This is a bug, if it happens.
+//End of code by Mord_Sith and others :^)
+//yogs end
 
 /mob/living/silicon/ai/proc/choose_modules()
 	set category = "Malfunction"


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/29939414/162343671-c2c19a2b-c98a-4ce5-a500-5f25c49b2971.png)

## Summary

This code is so old. Ignoring the Great Newline Commit of Alexkar, a lot of this has genuinely not been touched since AIs became a freefloating ghost-like camera, over a decade ago.

And it really shows; a lot of this seems to reference old ways of handling the AI's camera network that no longer exist. Also, initializing a ``/list`` by doing ``var/var_name[0]``? Ew.

So that's all cleaned up and good to go! :)

## Changelog

:cl:  Altoids
bugfix: Using the "Jump to Network" verb as an AI no longer clobbers the AI's network variable with mistyped data.
spellcheck: Cancelling a jump to another camera network as the AI no longer tells you that you're "switching to the /list" network.
/:cl:
