### PR TITLE
fixes a bad trophy description

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -422,7 +422,7 @@
 	bonus_value = 40
 
 /obj/item/crusher_trophy/malformed_bone/effect_desc()
-	return "mark detonation to have a <b>[bonus_value]</b>% chance to trigger a second detonation"
+	return "mark detonation to have a <b>[bonus_value]</b>% chance to mark nearby targets"
 
 /obj/item/crusher_trophy/malformed_bone/on_mark_detonation(mob/living/target, mob/living/user, obj/item/twohanded/required/kinetic_crusher/hammer_synced)
     if(hammer_synced)


### PR DESCRIPTION
# Document the changes in your pull request

realized the description of the legion trophy was something I forgot to update by the time it was finished so I fixed its description.

# Changelog

:cl:  
bugfix: fixed inaccurate description for legion megafauna trophy
/:cl:
