### PR TITLE
Make the X-01 multiphase energy gun use a regular powercell and have a regular energy consumption

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -202,12 +202,7 @@
 /obj/item/stock_parts/cell/mini_egun
 	name = "miniature energy gun power cell"
 	maxcharge = 600
-
-/obj/item/stock_parts/cell/hos_gun
-	name = "X-01 multiphase energy gun power cell"
-	maxcharge = 1200
-
-
+	
 /obj/item/stock_parts/cell/pulse //200 pulse shots
 	name = "pulse rifle power cell"
 	maxcharge = 40000

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -17,9 +17,6 @@
 	e_cost = 200
 	select_name = "kill"
 
-/obj/item/ammo_casing/energy/laser/hos
-	e_cost = 120
-
 /obj/item/ammo_casing/energy/laser/practice
 	projectile_type = /obj/item/projectile/beam/practice
 	select_name = "practice"

--- a/code/modules/projectiles/ammunition/energy/special.dm
+++ b/code/modules/projectiles/ammunition/energy/special.dm
@@ -5,7 +5,7 @@
 
 /obj/item/ammo_casing/energy/ion/hos
 	projectile_type = /obj/item/projectile/ion/weak
-	e_cost = 300
+	e_cost = 250
 
 /obj/item/ammo_casing/energy/declone
 	projectile_type = /obj/item/projectile/energy/declone

--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -22,8 +22,5 @@
 	fire_sound = 'sound/weapons/taser2.ogg'
 	harmful = FALSE
 
-/obj/item/ammo_casing/energy/disabler/hos
-	e_cost = 60
-
 /obj/item/ammo_casing/energy/disabler/cyborg
 	e_cost = 100

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -53,10 +53,9 @@
 /obj/item/gun/energy/e_gun/hos
 	name = "\improper X-01 MultiPhase Energy Gun"
 	desc = "This is an expensive, modern recreation of an antique laser gun. This gun has several unique firemodes, but lacks the ability to recharge over time."
-	cell_type = /obj/item/stock_parts/cell/hos_gun
 	icon_state = "hoslaser"
 	force = 10
-	ammo_type = list(/obj/item/ammo_casing/energy/disabler/hos, /obj/item/ammo_casing/energy/laser/hos, /obj/item/ammo_casing/energy/ion/hos)
+	ammo_type = list(/obj/item/ammo_casing/energy/disabler, /obj/item/ammo_casing/energy/laser, /obj/item/ammo_casing/energy/ion/hos)
 	ammo_x_offset = 4
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 


### PR DESCRIPTION
# Document the changes in your pull request

Did you know that the HoS gun had a special powercell with 20% more max charge? And that it didn't had any impact because it used 20% energy per shot? The HoS gun had uniques "ammo" and a unique battery to act exactly like a regular egun but with a ion mode, now it's really a regular egun but with ion mode as it should be in the code.
(It might make the gun charge a little bit faster but it's the HoS gun, let it be better than an egun for god's sake)
The gun still has 20 disabler shots, 10 laser shots and 4 ion shots like before, I just cleaned up arbitrary redundancy.

# Wiki Documentation

Nothing to document, HoS gun act exactly the same as before.

# Changelog

HoS gun now work as you would imagine from seeing it ingame.

:cl:  
rscdel: Removed the special battery and "ammo" of the X-01, and make it now use regular ones, tell me if you can manage to see the difference
/:cl:
