### PR TITLE
The initial subsystem loading now gives an approximate % to completion, among other style tweaks

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -184,6 +184,11 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 
 	// Sort subsystems by init_order, so they initialize in the correct order.
 	sortTim(subsystems, /proc/cmp_subsystem_init)
+	//yogs -- loading progress stuff; have to initialize this static
+	for(var/s in subsystems)
+		var/datum/controller/subsystem/SS = s
+		SS.total_loading_points += SS.loading_points
+	//yogs end
 
 	var/start_timeofday = REALTIMEOFDAY
 	// Initialize subsystems.

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -35,6 +35,12 @@
 
 	var/static/list/failure_strikes //How many times we suspect a subsystem type has crashed the MC, 3 strikes and you're out!
 
+	//yogs start -- loading time stuff
+	var/static/total_loading_points_progress = 0 //! How much progress we've made in loading all the subsystems so far.
+	var/static/total_loading_points = 0 //! The total amount of loading points among all subsystems. Should be defined by MC before subsystem inits.
+	var/loading_points = 0 //! The amount of loading points this subsystem has, measured in deciseconds of approximate load time. This being 0 is fine.
+//yogs end
+
 //Do not override
 ///datum/controller/subsystem/New()
 
@@ -159,15 +165,24 @@
 /// Called after the config has been loaded or reloaded.
 /datum/controller/subsystem/proc/OnConfigLoad()
 
-//used to initialize the subsystem AFTER the map has loaded
+///used to initialize the subsystem AFTER the map has loaded
+///This should be called by the derived subsystem class AFTER it has done its own initialization.
 /datum/controller/subsystem/Initialize(start_timeofday)
 	initialized = TRUE
 	SEND_SIGNAL(src, COMSIG_SUBSYSTEM_POST_INITIALIZE, start_timeofday)
-	var/time = (REALTIMEOFDAY - start_timeofday) / 10
-	var/msg = "Initialized [name] subsystem within [time] second[time == 1 ? "" : "s"]!"
-	to_chat(world, span_boldannounce("[msg]"))
+	var/time = (REALTIMEOFDAY - start_timeofday)/10
+	var/msg = "Initialized [name] subsystem within [time] second[time == 1 ? "" : "s"]!" // Yogs -- quieter subsystem initialization
+	to_chat(GLOB.admins,
+		type = MESSAGE_TYPE_DEBUG,
+		html = span_notice(msg),
+		confidential = FALSE) 
 	log_world(msg)
-	return time
+	if(!loading_points) // We're probably one of those crappy subsystems that take 0 seconds, so return
+		return time
+	total_loading_points_progress += loading_points
+	var/percent = round(total_loading_points_progress / total_loading_points * 100)
+	to_chat(world,span_boldnotice("Subsystem initialization at [percent]%..."))
+	return time // Yogs end
 
 
 /datum/controller/subsystem/stat_entry(msg)

--- a/code/controllers/subsystem/adjacent_air.dm
+++ b/code/controllers/subsystem/adjacent_air.dm
@@ -4,6 +4,9 @@ SUBSYSTEM_DEF(adjacent_air)
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 	wait = 10
 	priority = FIRE_PRIORITY_ATMOS_ADJACENCY
+
+	loading_points = 0.7 SECONDS // Yogs -- loading times
+
 	var/list/queue = list()
 
 /datum/controller/subsystem/adjacent_air/stat_entry(msg)

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -6,6 +6,8 @@ SUBSYSTEM_DEF(air)
 	flags = SS_BACKGROUND
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 
+	loading_points = 4.2 SECONDS // Yogs -- loading times
+
 	var/cached_cost = 0
 	var/cost_turfs = 0
 	var/cost_groups = 0

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -391,9 +391,14 @@ SUBSYSTEM_DEF(air)
 			//EG.dismantle()
 			CHECK_TICK*/
 
-		var/msg = "HEY! LISTEN! [DisplayTimeText(world.timeofday - timer)] were wasted processing [starting_ats] turf(s) (connected to [ending_ats] other turfs) with atmos differences at round start."
-		to_chat(world, span_boldannounce("[msg]"))
-		warning(msg)
+		//Yogs start -- prettier atmos notices
+		var/msg = "HEY! LISTEN! [(world.timeofday - timer)/10] seconds were wasted processing [starting_ats] turf(s) (connected to [ending_ats] other turfs) with atmos differences at round start."
+		to_chat(GLOB.admins,
+		type = MESSAGE_TYPE_DEBUG,
+		html = span_notice(msg),
+		confidential = FALSE) 
+		warning(msg) // This logs it
+		//yogs end
 
 /turf/open/proc/resolve_active_graph()
 	. = list()

--- a/code/controllers/subsystem/assets.dm
+++ b/code/controllers/subsystem/assets.dm
@@ -2,6 +2,9 @@ SUBSYSTEM_DEF(assets)
 	name = "Assets"
 	init_order = INIT_ORDER_ASSETS
 	flags = SS_NO_FIRE
+
+	loading_points = 3 SECONDS // Yogs -- loading times
+
 	var/list/cache = list()
 	var/list/preload = list()
 	var/datum/asset_transport/transport = new()

--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -7,6 +7,7 @@ SUBSYSTEM_DEF(atoms)
 	name = "Atoms"
 	init_order = INIT_ORDER_ATOMS
 	flags = SS_NO_FIRE
+	loading_points = 30 SECONDS // Yogs -- smarter loading times
 
 	var/old_initialized
 

--- a/code/controllers/subsystem/demo.dm
+++ b/code/controllers/subsystem/demo.dm
@@ -5,6 +5,8 @@ SUBSYSTEM_DEF(demo)
 	init_order = INIT_ORDER_DEMO
 	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
 
+	loading_points = 12.6 SECONDS // Yogs -- loading times
+
 	var/list/pre_init_lines = list() // stuff like chat before the init
 	var/list/icon_cache = list()
 	var/list/icon_state_caches = list()

--- a/code/controllers/subsystem/icon_smooth.dm
+++ b/code/controllers/subsystem/icon_smooth.dm
@@ -5,6 +5,8 @@ SUBSYSTEM_DEF(icon_smooth)
 	priority = FIRE_PRIOTITY_SMOOTHING
 	flags = SS_TICKER
 
+	loading_points = 3.3 SECONDS // Yogs -- loading times
+
 	var/list/smooth_queue = list()
 	var/list/deferred = list()
 

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -8,6 +8,8 @@ SUBSYSTEM_DEF(lighting)
 	init_order = INIT_ORDER_LIGHTING
 	flags = SS_TICKER
 
+	loading_points = 6 SECONDS // Yogs -- loading times
+
 /datum/controller/subsystem/lighting/stat_entry(msg)
 	msg = "L:[GLOB.lighting_update_lights.len]|C:[GLOB.lighting_update_corners.len]|O:[GLOB.lighting_update_objects.len]"
 	return ..()

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -3,6 +3,8 @@ SUBSYSTEM_DEF(mapping)
 	init_order = INIT_ORDER_MAPPING
 	flags = SS_NO_FIRE
 
+	loading_points = 11 SECONDS // Yogs -- loading times
+
 	var/list/nuke_tiles = list()
 	var/list/nuke_threats = list()
 

--- a/code/controllers/subsystem/overlays.dm
+++ b/code/controllers/subsystem/overlays.dm
@@ -5,6 +5,8 @@ SUBSYSTEM_DEF(overlays)
 	priority = FIRE_PRIORITY_OVERLAYS
 	init_order = INIT_ORDER_OVERLAY
 
+	loading_points = 2.3 SECONDS // Yogs -- loading times
+
 	var/list/queue
 	var/list/stats
 	var/list/overlay_icon_state_caches

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -6,6 +6,8 @@ SUBSYSTEM_DEF(shuttle)
 	init_order = INIT_ORDER_SHUTTLE
 	flags = SS_KEEP_TIMING|SS_NO_TICK_CHECK
 
+	loading_points = 4.9 SECONDS // Yogs -- loading times
+
 	var/list/mobile = list()
 	var/list/stationary = list()
 	var/list/beacons = list()

--- a/yogstation/code/controllers/subsystem/yogs.dm
+++ b/yogstation/code/controllers/subsystem/yogs.dm
@@ -6,7 +6,7 @@ SUBSYSTEM_DEF(Yogs)
 	flags = SS_BACKGROUND
 	init_order = -101 //last subsystem to initialize, and first to shut down
 
-	loading_points = 0.1 SECONDS
+	loading_points = 0.1 SECONDS // Yogs -- loading times
 
 	var/list/mentortickets //less of a ticket, and more just a log of everything someone has mhelped, and the responses
 	var/endedshift = FALSE //whether or not we've announced that the shift can be ended

--- a/yogstation/code/controllers/subsystem/yogs.dm
+++ b/yogstation/code/controllers/subsystem/yogs.dm
@@ -6,6 +6,8 @@ SUBSYSTEM_DEF(Yogs)
 	flags = SS_BACKGROUND
 	init_order = -101 //last subsystem to initialize, and first to shut down
 
+	loading_points = 0.1 SECONDS
+
 	var/list/mentortickets //less of a ticket, and more just a log of everything someone has mhelped, and the responses
 	var/endedshift = FALSE //whether or not we've announced that the shift can be ended
 	var/last_rebwoink = 0 // Last time we bwoinked all admins about unclaimed tickets


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/162549260-b79ab951-07b5-446c-a6f4-cbb67689fecb.png)


## Summary

Doesn't it look a bit... trash, to anyone else, that while people are in OOC waiting for the game to boot, it's barfing out these loud, red debug messages about, how long each particular subsystem takes and whether it had to do any atmos equalization?

There's a lot of debug dialogues and things all about the code, but this is the only real example of us vomiting it to to the whole world via a ``to_chat(world,...)`` call.

What's important to the players is that:
- the game is in fact booting up, and
- their client isn't broken or crashed.

And so that's what this dialogue is: a nicer-looking series of percentages that give a basic, approximate time before the server is booted up and the ready-up timer starts ticking down. The actual timers are visible to users with admin permissions, so coders booting up private copies of the codebase will be able to see these diagnostics just fine, should they want to improve the performance of subsystem code. 

This is a lot of what first-time players of the server see when they join, so I think it can be meaningful to make it look as nice and professional as this stupid game engine can allow.

# Changelog

:cl: Altoids
spellcheck: The loading screen now provides a lovely percent-completion as the game boots up.
spellcheck: The strange atmospherics equalization demon has been quieted.
/:cl:
