### PR TITLE
Increases death syphon modkit's damage per kill from 1.25 to 5 and the megafauna damage mod bonus from 4 to 5

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -490,7 +490,7 @@
 	name = "death syphon"
 	desc = "Killing or assisting in killing a creature permanently increases your damage against that type of creature."
 	denied_type = /obj/item/borg/upgrade/modkit/bounty
-	modifier = 1.25
+	modifier = 5
 	cost = 30
 	var/maximum_bounty = 25
 	var/list/bounties_reaped = list()
@@ -519,7 +519,7 @@
 /obj/item/borg/upgrade/modkit/bounty/proc/get_kill(mob/living/L)
 	var/bonus_mod = 1
 	if(ismegafauna(L)) //megafauna reward
-		bonus_mod = 4
+		bonus_mod = 5
 	if(!bounties_reaped[L.type])
 		bounties_reaped[L.type] = min(modifier * bonus_mod, maximum_bounty)
 	else


### PR DESCRIPTION
# Document the changes in your pull request

This modkit gives a 1.25 damage bonus per mob killed to that SPECIFIC kind of mob, capping at 25, with megafauna giving 5 gonus (4*1.25) per kill for 30% mod capacity

this is fucking terrible and bad and stupid and it's always better to use a damage mod since by the time you have broken even at 8 kills you could have just had a flat 10 damage FOR those 8 kills, and fighting the same megafauna 3 times is extremely situational, with MORE fights being even less likely. The point was likely to make killing the same mob easier as you do it more however the bonus damage is given so slowly it's not really worth getting the disk as a necro tendril drop, THEN taking it to science, THEN making a blood sacrifice, THEN having dead weight 30% mod capacity for a substantial amount of time

NOW: every kill gives a 5 damage bonus per mob killed to that SPECIFIC kind of mob, capping at 25, with megafauna giving 25 bonus (5*5) per kill for 30% mod capacity

This does not make the modkit any "stronger" it just allows it to reach its full capacity and eclipse damage mods fast enough to potentially be worth using

# Wiki Documentation

bounty/death syphon modkit gives 5 damage up from 1.25 per kill and 5* up from 4* damage gain from megafauna

# Changelog

:cl:  
tweak: bounty/death syphon modkit gives 5 damage up from 1.25 per kill and 5* up from 4* damage gain from megafauna 
/:cl:
