### PR TITLE
Maybe makes computers not type when it's a ghost doing the typing

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -103,6 +103,8 @@
 
 // Plays a random interaction sound, which is by default a bunch of keboard clacking
 /obj/item/modular_computer/proc/play_interact_sound()
+	if(isobserver(usr))
+		return
 	playsound(loc, pick(interact_sounds), get_clamped_volume(), FALSE, -1)
 
 


### PR DESCRIPTION
# Document the changes in your pull request

On/Off sounds still do it because... why not


# Wiki Documentation

# Changelog

:cl:  
experimental: Ghosts should be unable to type on physical keyboards
/:cl:
