### PR TITLE
Added sec, engi and atmos hardsuit crates buyable at cargo

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -647,7 +647,7 @@
 	crate_name = "stun mine crate"
 
 /datum/supply_pack/security/armory/hardsuit
-ame = "Security Hardsuit Crate"
+	name = "Security Hardsuit Crate"
 	desc = "Contains a reinforced security hardsuit, a security gasmask and a set of combat magboots for combat in low pressure environments. Requires Armory access to open."
 	cost = 3000
 	contains = list(/obj/item/clothing/suit/space/hardsuit/security,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -806,7 +806,7 @@
 	desc = "Contains an atmospheric hardsuit, a breath mask and a set of magboots for working in high temperature low pressure environments. Requires Atmospheric access to open."
 	cost = 3000
 	access = ACCESS_ATMOSPHERICS
-	contains = list(/obj/item/clothing/suit/space/hardsuit/atmos,
+	contains = list(/obj/item/clothing/suit/space/hardsuit/engine/atmos,
 					/obj/item/clothing/mask/breath,
 					/obj/item/clothing/shoes/magboots)
 	crate_name = "atmospheric hardsuit crate"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -646,10 +646,19 @@
 					/obj/item/deployablemine/stun)
 	crate_name = "stun mine crate"
 
+/datum/supply_pack/security/armory/hardsuit
+ame = "Security Hardsuit Crate"
+	desc = "Contains a reinforced security hardsuit, a security gasmask and a set of combat magboots for combat in low pressure environments. Requires Armory access to open."
+	cost = 3000
+	contains = list(/obj/item/clothing/suit/space/hardsuit/security,
+					/obj/item/clothing/mask/gas/sechailer,
+					/obj/item/clothing/shoes/magboots/security)
+	crate_name = "security hardsuit crate
+
 /datum/supply_pack/security/armory/swat
 	name = "SWAT Crate"
 	desc = "Contains two fullbody sets of tough, fireproof, pressurized suits designed in a joint effort by IS-ERI and Nanotrasen. Each set contains a suit, helmet, mask, combat belt, and combat gloves. Requires Armory access to open."
-	cost = 6000
+	cost = 8000
 	contains = list(/obj/item/clothing/head/helmet/swat/nanotrasen,
 					/obj/item/clothing/head/helmet/swat/nanotrasen,
 					/obj/item/clothing/suit/space/swat,
@@ -781,6 +790,26 @@
 					/obj/item/clothing/gloves/color/yellow)
 	crate_name = "insulated gloves crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
+
+/datum/supply_pack/engineering/hardsuit_engi
+	name = "Engineering Hardsuit Crate"
+	desc = "Contains an engineering hardsuit, a breath mask and a set of magboots for working in irradiated low pressure environments. Requires Construction access to open."
+	cost = 3000
+	access = ACCESS_CONSTRUCTION
+	contains = list(/obj/item/clothing/suit/space/hardsuit/engine,
+					/obj/item/clothing/mask/breath,
+					/obj/item/clothing/shoes/magboots)
+	crate_name = "engineering hardsuit crate"
+
+/datum/supply_pack/engineering/hardsuit_atmos
+	name = "Atmospheric Hardsuit Crate"
+	desc = "Contains an atmospheric hardsuit, a breath mask and a set of magboots for working in high temperature low pressure environments. Requires Atmospheric access to open."
+	cost = 3000
+	access = ACCESS_ATMOSPHERICS
+	contains = list(/obj/item/clothing/suit/space/hardsuit/atmos,
+					/obj/item/clothing/mask/breath,
+					/obj/item/clothing/shoes/magboots)
+	crate_name = "atmospheric hardsuit crate"
 
 /obj/item/stock_parts/cell/inducer_supply
 	maxcharge = 5000

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -649,7 +649,7 @@
 /datum/supply_pack/security/armory/hardsuit
 	name = "Security Hardsuit Crate"
 	desc = "Contains a reinforced security hardsuit, a security gasmask and a set of combat magboots for combat in low pressure environments. Requires Armory access to open."
-	cost = 3000
+	cost = 5000
 	contains = list(/obj/item/clothing/suit/space/hardsuit/security,
 					/obj/item/clothing/mask/gas/sechailer,
 					/obj/item/clothing/shoes/magboots/security)
@@ -658,7 +658,7 @@
 /datum/supply_pack/security/armory/swat
 	name = "SWAT Crate"
 	desc = "Contains two fullbody sets of tough, fireproof, pressurized suits designed in a joint effort by IS-ERI and Nanotrasen. Each set contains a suit, helmet, mask, combat belt, and combat gloves. Requires Armory access to open."
-	cost = 8000
+	cost = 12000
 	contains = list(/obj/item/clothing/head/helmet/swat/nanotrasen,
 					/obj/item/clothing/head/helmet/swat/nanotrasen,
 					/obj/item/clothing/suit/space/swat,
@@ -794,7 +794,7 @@
 /datum/supply_pack/engineering/hardsuit_engi
 	name = "Engineering Hardsuit Crate"
 	desc = "Contains an engineering hardsuit, a breath mask and a set of magboots for working in irradiated low pressure environments. Requires Construction access to open."
-	cost = 3000
+	cost = 5000
 	access = ACCESS_CONSTRUCTION
 	contains = list(/obj/item/clothing/suit/space/hardsuit/engine,
 					/obj/item/clothing/mask/breath,
@@ -804,7 +804,7 @@
 /datum/supply_pack/engineering/hardsuit_atmos
 	name = "Atmospheric Hardsuit Crate"
 	desc = "Contains an atmospheric hardsuit, a breath mask and a set of magboots for working in high temperature low pressure environments. Requires Atmospheric access to open."
-	cost = 3000
+	cost = 5000
 	access = ACCESS_ATMOSPHERICS
 	contains = list(/obj/item/clothing/suit/space/hardsuit/engine/atmos,
 					/obj/item/clothing/mask/breath,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -653,7 +653,7 @@
 	contains = list(/obj/item/clothing/suit/space/hardsuit/security,
 					/obj/item/clothing/mask/gas/sechailer,
 					/obj/item/clothing/shoes/magboots/security)
-	crate_name = "security hardsuit crate
+	crate_name = "security hardsuit crate"
 
 /datum/supply_pack/security/armory/swat
 	name = "SWAT Crate"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -646,15 +646,6 @@
 					/obj/item/deployablemine/stun)
 	crate_name = "stun mine crate"
 
-/datum/supply_pack/security/armory/hardsuit
-	name = "Security Hardsuit Crate"
-	desc = "Contains a reinforced security hardsuit, a security gasmask and a set of combat magboots for combat in low pressure environments. Requires Armory access to open."
-	cost = 5000
-	contains = list(/obj/item/clothing/suit/space/hardsuit/security,
-					/obj/item/clothing/mask/gas/sechailer,
-					/obj/item/clothing/shoes/magboots/security)
-	crate_name = "security hardsuit crate"
-
 /datum/supply_pack/security/armory/swat
 	name = "SWAT Crate"
 	desc = "Contains two fullbody sets of tough, fireproof, pressurized suits designed in a joint effort by IS-ERI and Nanotrasen. Each set contains a suit, helmet, mask, combat belt, and combat gloves. Requires Armory access to open."
@@ -790,26 +781,6 @@
 					/obj/item/clothing/gloves/color/yellow)
 	crate_name = "insulated gloves crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
-
-/datum/supply_pack/engineering/hardsuit_engi
-	name = "Engineering Hardsuit Crate"
-	desc = "Contains an engineering hardsuit, a breath mask and a set of magboots for working in irradiated low pressure environments. Requires Construction access to open."
-	cost = 5000
-	access = ACCESS_CONSTRUCTION
-	contains = list(/obj/item/clothing/suit/space/hardsuit/engine,
-					/obj/item/clothing/mask/breath,
-					/obj/item/clothing/shoes/magboots)
-	crate_name = "engineering hardsuit crate"
-
-/datum/supply_pack/engineering/hardsuit_atmos
-	name = "Atmospheric Hardsuit Crate"
-	desc = "Contains an atmospheric hardsuit, a breath mask and a set of magboots for working in high temperature low pressure environments. Requires Atmospheric access to open."
-	cost = 5000
-	access = ACCESS_ATMOSPHERICS
-	contains = list(/obj/item/clothing/suit/space/hardsuit/engine/atmos,
-					/obj/item/clothing/mask/breath,
-					/obj/item/clothing/shoes/magboots)
-	crate_name = "atmospheric hardsuit crate"
 
 /obj/item/stock_parts/cell/inducer_supply
 	maxcharge = 5000

--- a/yogstation/code/modules/cargo/cargo_packs.dm
+++ b/yogstation/code/modules/cargo/cargo_packs.dm
@@ -1,3 +1,32 @@
+datum/supply_pack/security/armory/hardsuit
+	name = "Security Hardsuit Crate"
+	desc = "Contains a reinforced security hardsuit, a security gasmask and a set of combat magboots for combat in low pressure environments. Requires Armory access to open."
+	cost = 5000
+	contains = list(/obj/item/clothing/suit/space/hardsuit/security,
+					/obj/item/clothing/mask/gas/sechailer,
+					/obj/item/clothing/shoes/magboots/security)
+	crate_name = "security hardsuit crate"
+
+/datum/supply_pack/engineering/hardsuit_engi
+	name = "Engineering Hardsuit Crate"
+	desc = "Contains an engineering hardsuit, a breath mask and a set of magboots for working in irradiated low pressure environments. Requires Construction access to open."
+	cost = 5000
+	access = ACCESS_CONSTRUCTION
+	contains = list(/obj/item/clothing/suit/space/hardsuit/engine,
+					/obj/item/clothing/mask/breath,
+					/obj/item/clothing/shoes/magboots)
+	crate_name = "engineering hardsuit crate"
+
+/datum/supply_pack/engineering/hardsuit_atmos
+	name = "Atmospheric Hardsuit Crate"
+	desc = "Contains an atmospheric hardsuit, a breath mask and a set of magboots for working in high temperature low pressure environments. Requires Atmospheric access to open."
+	cost = 5000
+	access = ACCESS_ATMOSPHERICS
+	contains = list(/obj/item/clothing/suit/space/hardsuit/engine/atmos,
+					/obj/item/clothing/mask/breath,
+					/obj/item/clothing/shoes/magboots)
+	crate_name = "atmospheric hardsuit crate"
+
 /datum/supply_pack/misc/miscclothing
 	name = "Designer clothes"
 	desc = "Contains a variety of overpriced sneakers and clothing items, show your brand loyalty like never before!"


### PR DESCRIPTION
# Document the changes in your pull request

The hardsuits are extremely useful for each department however theres not really any reliable mean of getting more if they need to be remplaced should they be destroyed or if the department has lots of people needing them.
They all have the access requirement of the rooms each hardsuits are normally found at roundstart.
Also upped the cost of the SWAT crate to 12000 credits so that there's a reason to take the sec hardsuit crate over the SWAT crate.

# Wiki Documentation
each crate cost 5000 credits
Security Hardsuit Crate in the armory section
Engineering Hardsuit Crate and Atmospheric Hardsuit Crate in the engineering section
SWAT crate now cost 8000 credits

# Changelog

Let people buy sec, engi and atmos hardsuits at cargo for 5000 credits, the crates have the access requirement normally needed to get the hardsuits of the stations at roundstart.

:cl:  
rscadd: Added sec, engi and atmos hardsuit crates at cargo
tweak: changed SWAT crate cost to 12000 
/:cl:
