### PR TITLE
Makes revs not end due to head of staff/revheads disconnecting

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -274,7 +274,7 @@ GLOBAL_LIST_EMPTY(objectives)
 /datum/objective/mutiny/check_completion()
 	if(..())
 		return TRUE
-	if(!target || !considered_alive(target) || considered_afk(target))
+	if(!target || !considered_alive(target))
 		return TRUE
 	var/turf/T = get_turf(target.current)
 	return !T || !is_station_level(T.z)

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -195,7 +195,7 @@
 /datum/game_mode/revolution/proc/check_heads_victory()
 	for(var/datum/mind/rev_mind in revolution.head_revolutionaries())
 		var/turf/T = get_turf(rev_mind.current)
-		if(!considered_afk(rev_mind) && considered_alive(rev_mind) && is_station_level(T.z))
+		if(considered_alive(rev_mind) && is_station_level(T.z))
 			if(ishuman(rev_mind.current) || ismonkey(rev_mind.current))
 				return FALSE
 	return TRUE


### PR DESCRIPTION
# Document the changes in your pull request

It no longer counts afk revs/heads of staff as dead

:cl:  
tweak: afk revheads/heads of staff no longer end a revs round
/:cl:
