### PR TITLE
Makes mindbreaker toxin actually work against reality dissociation syndrome

### DIFF
--- a/code/datums/brain_damage/mild.dm
+++ b/code/datums/brain_damage/mild.dm
@@ -19,6 +19,26 @@
 	owner.hallucination = 0
 	..()
 
+/datum/brain_trauma/mild/reality_dissociation
+	name = "Reality Dissociation Syndrome"
+	desc = "Patient suffers from acute reality dissociation syndrome and experiences vivid hallucinations"
+	scan_desc = "reality dissociation syndrome"
+	gain_text = span_userdanger("...")
+	lose_text = span_notice("You feel in tune with the world again.")
+	random_gain = FALSE
+	resilience = TRAUMA_RESILIENCE_ABSOLUTE
+
+/datum/brain_trauma/mild/reality_dissociation/on_life()
+	if(owner.reagents.has_reagent(/datum/reagent/toxin/mindbreaker, needs_metabolizing = TRUE))
+		owner.hallucination = 0
+	else if(prob(2))
+		owner.hallucination += rand(10, 25)
+	..()
+
+/datum/brain_trauma/mild/reality_dissociation/on_lose()
+	owner.hallucination = 0
+	..()
+
 /datum/brain_trauma/mild/stuttering
 	name = "Stuttering"
 	desc = "Patient can't speak properly."

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -417,19 +417,14 @@
 	desc = "You suffer from a severe disorder that causes very vivid hallucinations. Mindbreaker toxin can suppress its effects, and you are immune to mindbreaker's hallucinogenic properties. <b>This is not a license to grief.</b>"
 	value = -2
 	//no mob trait because it's handled uniquely
-	gain_text = span_userdanger("...")
-	lose_text = span_notice("You feel in tune with the world again.")
+	gain_text = null //handled by trauma
+	lose_text = null
 	medical_record_text = "Patient suffers from acute Reality Dissociation Syndrome and experiences vivid hallucinations."
 
-/datum/quirk/insanity/on_process()
-	if(quirk_holder.reagents.has_reagent(/datum/reagent/toxin/mindbreaker, needs_metabolizing = TRUE))
-		quirk_holder.hallucination = 0
-		return
-	if(prob(2)) //we'll all be mad soon enough
-		madness()
-
-/datum/quirk/insanity/proc/madness()
-	quirk_holder.hallucination += rand(10, 25)
+/datum/quirk/insanity/add()
+	var/datum/brain_trauma/mild/reality_dissociation/T = new()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.gain_trauma(T, TRAUMA_RESILIENCE_ABSOLUTE)
 
 /datum/quirk/insanity/post_add() //I don't /think/ we'll need this but for newbies who think "roleplay as insane" = "license to kill" it's probably a good thing to have
 	if(!quirk_holder.mind || quirk_holder.mind.special_role)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -228,16 +228,14 @@
 
 /datum/reagent/toxin/mindbreaker
 	name = "Mindbreaker Toxin"
-	description = "A powerful hallucinogen. Not a thing to be messed with. For some mental patient,. it counteracts their symptoms and anchors them to reality."
+	description = "A powerful hallucinogen. Not a thing to be messed with. For some mental patients, it counteracts their symptoms and anchors them to reality."
 	color = "#B31008" // rgb: 139, 166, 233
 	toxpwr = 0
 	taste_description = "sourness"
 
 /datum/reagent/toxin/mindbreaker/on_mob_life(mob/living/carbon/M)
-	for(var/datum/brain_trauma/T in M.get_traumas())
-		if(istype(T, /datum/brain_trauma/mild/reality_dissociation))
-			return ..()
-	M.hallucination += 5
+	if(!M.has_trauma_type(/datum/brain_trauma/mild/reality_dissociation))
+		M.hallucination += 5
 	return ..()
 
 /datum/reagent/toxin/plantbgone

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -228,12 +228,15 @@
 
 /datum/reagent/toxin/mindbreaker
 	name = "Mindbreaker Toxin"
-	description = "A powerful hallucinogen. Not a thing to be messed with. For some mental patients. it counteracts their symptoms and anchors them to reality."
+	description = "A powerful hallucinogen. Not a thing to be messed with. For some mental patient,. it counteracts their symptoms and anchors them to reality."
 	color = "#B31008" // rgb: 139, 166, 233
 	toxpwr = 0
 	taste_description = "sourness"
 
 /datum/reagent/toxin/mindbreaker/on_mob_life(mob/living/carbon/M)
+	for(var/datum/brain_trauma/T in M.get_traumas())
+		if(istype(T, /datum/brain_trauma/mild/reality_dissociation))
+			return ..()
 	M.hallucination += 5
 	return ..()
 


### PR DESCRIPTION
# Document the changes in your pull request

Makes mindbreaker toxin not cause hallucinations if you have reality dissociation syndrome. Also makes it a brain trauma rather than the quirk itself causing the effects.

# Wiki Documentation

The wiki page about brain traumas may need to be updated.

# Changelog

:cl:  
bugfix: mindbreaker toxin no longer causes hallucinations if you have reality dissociation syndrome 
tweak: made reality dissociation syndrome a brain trauma unique to the quirk
/:cl:
