### PR TITLE
Podperson passive healing nerf 

### DIFF
--- a/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
@@ -92,12 +92,12 @@
 					H.adjustOxyLoss(min(3 * dark_damage_multiplier, 50 - H.getOxyLoss()), 1)
 			if (0.31 to 0.5)
 				//medium, average, doing nothing for now
-				light_level = 3	
+				light_level = 3
 				H.nutrition += light_amount * 2
 			if (0.51 to 0.75)
 				//high light, regen here
 				light_level = 4
-				H.nutrition += light_amount * 1.75				
+				H.nutrition += light_amount * 1.75
 				if ((H.stat != UNCONSCIOUS) && (H.stat != DEAD) && !no_light_heal)
 					H.adjustOxyLoss(-0.5 * light_heal_multiplier, 1)
 					H.heal_overall_damage(1 * light_heal_multiplier, 1 * light_heal_multiplier)
@@ -107,7 +107,7 @@
 			if (0.76 to 1)
 				//super high light
 				light_level = 5
-					H.nutrition += light_amount * 1.5
+				H.nutrition += light_amount * 1.5
 				if ((H.stat != UNCONSCIOUS) && (H.stat != DEAD) && !no_light_heal)
 					H.adjustOxyLoss(-0.5 * light_heal_multiplier, 1)
 					H.heal_overall_damage(1.5 * light_heal_multiplier, 1.5 * light_heal_multiplier)

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
@@ -86,21 +86,17 @@
 				//low light
 				light_level = 2
 				light_msg = span_warning("The ambient light levels are too low. Your breath is coming more slowly as your insides struggle to keep up on their own.")
-				if(H.nutrition > NUTRITION_LEVEL_STARVING)
 					H.nutrition -= light_amount * 3
 				//not enough to faint but enough to slow you down
 				if(H.getOxyLoss() < 50)
 					H.adjustOxyLoss(min(3 * dark_damage_multiplier, 50 - H.getOxyLoss()), 1)
 			if (0.31 to 0.5)
 				//medium, average, doing nothing for now
-				light_level = 3
-				if(H.nutrition <= NUTRITION_LEVEL_HUNGRY)	
-					//just enough to function			
+				light_level = 3	
 					H.nutrition += light_amount * 2
 			if (0.51 to 0.75)
 				//high light, regen here
 				light_level = 4
-				if(H.nutrition < NUTRITION_LEVEL_FED)
 					H.nutrition += light_amount * 1.75				
 				if ((H.stat != UNCONSCIOUS) && (H.stat != DEAD) && !no_light_heal)
 					H.adjustOxyLoss(-0.5 * light_heal_multiplier, 1)
@@ -111,8 +107,6 @@
 			if (0.76 to 1)
 				//super high light
 				light_level = 5
-				if(H.nutrition < NUTRITION_LEVEL_FED)
-					//this will give the positive fed moodlet instead of being stuck on "i'm so fat" for existing
 					H.nutrition += light_amount * 1.5
 				if ((H.stat != UNCONSCIOUS) && (H.stat != DEAD) && !no_light_heal)
 					H.adjustOxyLoss(-0.5 * light_heal_multiplier, 1)
@@ -123,7 +117,7 @@
 		//no light, this is baaaaaad
 		light_level = 0
 		light_msg = span_userdanger("Darkness! Your insides churn and your skin screams in pain!")
-		H.nutrition -= 10
+		H.nutrition -= 3
 		//enough to make you faint for good, and eventually die
 		if(H.getOxyLoss() < 60)
 			H.adjustOxyLoss(min(5 * dark_damage_multiplier, 60 - H.getOxyLoss()), 1)
@@ -140,6 +134,9 @@
 				last_light_message = world.time
 				to_chat(H, light_msg)
 
+	if(H.nutrition > NUTRITION_LEVEL_FULL)
+		H.nutrition = NUTRITION_LEVEL_FULL
+		
 	if(H.nutrition < NUTRITION_LEVEL_STARVING + 50)
 		if (H.stat != UNCONSCIOUS && H.stat != DEAD)
 			if(light_level != last_light_level)

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
@@ -86,18 +86,18 @@
 				//low light
 				light_level = 2
 				light_msg = span_warning("The ambient light levels are too low. Your breath is coming more slowly as your insides struggle to keep up on their own.")
-					H.nutrition -= light_amount * 3
+				H.nutrition -= light_amount * 3
 				//not enough to faint but enough to slow you down
 				if(H.getOxyLoss() < 50)
 					H.adjustOxyLoss(min(3 * dark_damage_multiplier, 50 - H.getOxyLoss()), 1)
 			if (0.31 to 0.5)
 				//medium, average, doing nothing for now
 				light_level = 3	
-					H.nutrition += light_amount * 2
+				H.nutrition += light_amount * 2
 			if (0.51 to 0.75)
 				//high light, regen here
 				light_level = 4
-					H.nutrition += light_amount * 1.75				
+				H.nutrition += light_amount * 1.75				
 				if ((H.stat != UNCONSCIOUS) && (H.stat != DEAD) && !no_light_heal)
 					H.adjustOxyLoss(-0.5 * light_heal_multiplier, 1)
 					H.heal_overall_damage(1 * light_heal_multiplier, 1 * light_heal_multiplier)

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
@@ -136,7 +136,7 @@
 
 	if(H.nutrition > NUTRITION_LEVEL_FULL)
 		H.nutrition = NUTRITION_LEVEL_FULL
-		
+
 	if(H.nutrition < NUTRITION_LEVEL_STARVING + 50)
 		if (H.stat != UNCONSCIOUS && H.stat != DEAD)
 			if(light_level != last_light_level)

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
@@ -121,7 +121,7 @@
 		//no light, this is baaaaaad
 		light_level = 0
 		light_msg = span_userdanger("Darkness! Your insides churn and your skin screams in pain!")
-		H.nutrition -= 3
+		H.nutrition -= 10
 		//enough to make you faint for good, and eventually die
 		if(H.getOxyLoss() < 60)
 			H.adjustOxyLoss(min(5 * dark_damage_multiplier, 60 - H.getOxyLoss()), 1)

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
@@ -94,7 +94,8 @@
 			if (0.31 to 0.5)
 				//medium, average, doing nothing for now
 				light_level = 3
-				if(H.nutrition <= NUTRITION_LEVEL_HUNGRY)				
+				if(H.nutrition <= NUTRITION_LEVEL_HUNGRY)	
+					//just enough to function			
 					H.nutrition += light_amount * 2
 			if (0.51 to 0.75)
 				//high light, regen here

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
@@ -28,7 +28,7 @@
 	species_language_holder = /datum/language_holder/pod
 
 	var/no_light_heal = FALSE
-	var/light_heal_multiplier = 1
+	var/light_heal_multiplier = 0.5
 	var/dark_damage_multiplier = 1
 	var/last_light_level = 0
 	var/last_light_message = -STATUS_MESSAGE_COOLDOWN
@@ -86,18 +86,21 @@
 				//low light
 				light_level = 2
 				light_msg = span_warning("The ambient light levels are too low. Your breath is coming more slowly as your insides struggle to keep up on their own.")
-				H.nutrition -= light_amount * 3
+				if(H.nutrition > NUTRITION_LEVEL_HUNGRY)
+					H.nutrition -= light_amount * 3
 				//not enough to faint but enough to slow you down
 				if(H.getOxyLoss() < 50)
 					H.adjustOxyLoss(min(3 * dark_damage_multiplier, 50 - H.getOxyLoss()), 1)
 			if (0.31 to 0.5)
 				//medium, average, doing nothing for now
 				light_level = 3
-				H.nutrition += light_amount * 2
+				if(H.nutrition < NUTRITION_LEVEL_FED)				
+					H.nutrition += light_amount * 2
 			if (0.51 to 0.75)
 				//high light, regen here
 				light_level = 4
-				H.nutrition += light_amount * 1.75
+				if(H.nutrition < NUTRITION_LEVEL_FED)
+					H.nutrition += light_amount * 1.75				
 				if ((H.stat != UNCONSCIOUS) && (H.stat != DEAD) && !no_light_heal)
 					H.adjustOxyLoss(-0.5 * light_heal_multiplier, 1)
 					H.heal_overall_damage(1 * light_heal_multiplier, 1 * light_heal_multiplier)
@@ -107,7 +110,8 @@
 			if (0.76 to 1)
 				//super high light
 				light_level = 5
-				H.nutrition += light_amount * 1.5
+				if(H.nutrition < NUTRITION_LEVEL_WELL_FED)
+					H.nutrition += light_amount * 1.5
 				if ((H.stat != UNCONSCIOUS) && (H.stat != DEAD) && !no_light_heal)
 					H.adjustOxyLoss(-0.5 * light_heal_multiplier, 1)
 					H.heal_overall_damage(1.5 * light_heal_multiplier, 1.5 * light_heal_multiplier)
@@ -133,9 +137,6 @@
 			if(light_msg)
 				last_light_message = world.time
 				to_chat(H, light_msg)
-
-	if(H.nutrition > NUTRITION_LEVEL_FULL)
-		H.nutrition = NUTRITION_LEVEL_FULL
 
 	if(H.nutrition < NUTRITION_LEVEL_STARVING + 50)
 		if (H.stat != UNCONSCIOUS && H.stat != DEAD)

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
@@ -86,7 +86,7 @@
 				//low light
 				light_level = 2
 				light_msg = span_warning("The ambient light levels are too low. Your breath is coming more slowly as your insides struggle to keep up on their own.")
-				if(H.nutrition > NUTRITION_LEVEL_HUNGRY)
+				if(H.nutrition > NUTRITION_LEVEL_STARVING)
 					H.nutrition -= light_amount * 3
 				//not enough to faint but enough to slow you down
 				if(H.getOxyLoss() < 50)
@@ -94,7 +94,7 @@
 			if (0.31 to 0.5)
 				//medium, average, doing nothing for now
 				light_level = 3
-				if(H.nutrition < NUTRITION_LEVEL_FED)				
+				if(H.nutrition <= NUTRITION_LEVEL_HUNGRY)				
 					H.nutrition += light_amount * 2
 			if (0.51 to 0.75)
 				//high light, regen here
@@ -110,7 +110,8 @@
 			if (0.76 to 1)
 				//super high light
 				light_level = 5
-				if(H.nutrition < NUTRITION_LEVEL_WELL_FED)
+				if(H.nutrition < NUTRITION_LEVEL_FED)
+					//this will give the positive fed moodlet instead of being stuck on "i'm so fat" for existing
 					H.nutrition += light_amount * 1.5
 				if ((H.stat != UNCONSCIOUS) && (H.stat != DEAD) && !no_light_heal)
 					H.adjustOxyLoss(-0.5 * light_heal_multiplier, 1)


### PR DESCRIPTION
Any amount of free passive healing is strong, so i'm cutting it in half. I've seen the Phytosian passive healing get complained about a number of times but no one ever does anything about it (also Truz asked me to nicely so i'm doing it), so i'm shooting myself and my people in the foot to hopefully put an end to the debate.

# Wiki Documentation

I don't think wiki had the actual healing values, so nothing if that's the case.

# Changelog

:cl:  
tweak: podperson healing cut by 50% across the board  
/:cl:
