### PR TITLE
fixes pepper spray icon

### DIFF
--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -212,6 +212,7 @@
 /obj/item/reagent_containers/spray/pepper
 	name = "pepperspray"
 	desc = "Manufactured by UhangInc, used to blind and down an opponent quickly. Now contains red dye to mark fleeing suspects!"
+	icon = 'icons/obj/misc.dmi'
 	icon_state = "pepperspray"
 	item_state = "pepperspray"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'


### PR DESCRIPTION
# Document the changes in your pull request

killing of items and weapons does this to a person

/obj/item/reagent_containers/spray uses yogstation/icons/obj/janitor.dmi but pepper spray is in icons/obj/misc.dmi

# Changelog

:cl:  
bugfix: pepperspray is no longer invisible
/:cl:
