### PR TITLE
flying fang bite attack now causes bleeding as intended

### DIFF
--- a/code/datums/martial/flying_fang.dm
+++ b/code/datums/martial/flying_fang.dm
@@ -91,7 +91,7 @@
 	var/armor_block = D.run_armor_check(affecting, "melee", 30)
 	A.do_attack_animation(D, ATTACK_EFFECT_BITE)
 	playsound(D, 'sound/weapons/bite.ogg', 50, TRUE, -1)
-	D.apply_damage(30, A.dna.species.attack_type, BODY_ZONE_HEAD, armor_block)
+	D.apply_damage(30, A.dna.species.attack_type, BODY_ZONE_HEAD, armor_block, sharpness = SHARP_EDGED)
 	// D.bleed_rate += 10
 	D.visible_message(span_danger("[A] takes a large bite out of [D]'s neck!"), \
 					  span_userdanger("[A] takes a large bite out of your neck!"))


### PR DESCRIPTION
# Document the changes in your pull request

this wasn't in for a while because I finished ff before porting wounds and iirc didn't want to add generic bleeding to it since that sucks

I guess wound bleeding can end up sucking to a similar amount but it's manageable

# Wiki Documentation

lol

# Changelog

:cl:  
tweak: flying fang neck bite causes bleeding instead of skull crushing, which is being saved for the polys martial art
/:cl:
