### PR TITLE
Adds quiet round checks to all Dynamic rulesets

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -26,6 +26,9 @@
 		if ((exclusive_roles.len > 0) && !(P.mind.assigned_role in exclusive_roles)) // Is the rule exclusive to their job?
 			candidates.Remove(P)
 			continue
+		if(P.mind.quiet_round) //Does the candidate have quiet mode enabled?
+			candidates.Remove(P)
+			continue
 
 /datum/dynamic_ruleset/latejoin/ready(forced = 0)
 	if (!forced)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -57,6 +57,9 @@
 			if ((exclusive_roles.len > 0) && !(M.mind.assigned_role in exclusive_roles)) // Is the rule exclusive to their job?
 				trimmed_list.Remove(M)
 				continue
+			if(M.mind.quiet_round)
+				trimmed_list.Remove(M)
+				continue
 	return trimmed_list
 
 // You can then for example prompt dead players in execute() to join as strike teams or whatever


### PR DESCRIPTION

Fixes #13681

This is the 3rd time I've made a bugfix for quiet mode (:

## Changelog
:cl: Altoids
bugfix: Quiet mode is now always respected by Dynamic Mode.
/:cl:
