### PR TITLE
shadowling movement is update on move rather than spec life

### DIFF
--- a/yogstation/code/game/gamemodes/shadowling/shadowling.dm
+++ b/yogstation/code/game/gamemodes/shadowling/shadowling.dm
@@ -209,7 +209,7 @@ Made by Xhuis
 /datum/species/shadow/ling/proc/apply_darkness_speed(mob/living/carbon/C)
 	var/turf/T = get_turf(C)
 	var/light_amount = T.get_lumcount()
-	if(light_amount > LIGHT_DAM_THRESHOLD) //Can survive in very small light levels. Also doesn't take damage while incorporeal, for shadow walk purposes
+	if(light_amount > LIGHT_DAM_THRESHOLD)
 		H.remove_movespeed_modifier(id)
 	else
 		H.add_movespeed_modifier(id, update=TRUE, priority=100, multiplicative_slowdown=-2, blacklisted_movetypes=(FLYING|FLOATING))

--- a/yogstation/code/game/gamemodes/shadowling/shadowling.dm
+++ b/yogstation/code/game/gamemodes/shadowling/shadowling.dm
@@ -166,7 +166,7 @@ Made by Xhuis
 /datum/species/shadow/ling/on_species_loss(mob/living/carbon/human/C)
 	C.draw_yogs_parts(FALSE)
 	UnregisterSignal(C, COMSIG_MOVABLE_MOVED)
-	H.remove_movespeed_modifier(id)
+	C.remove_movespeed_modifier(id)
 	if(eyes_overlay)
 		C.cut_overlay(eyes_overlay)
 		QDEL_NULL(eyes_overlay)
@@ -210,9 +210,9 @@ Made by Xhuis
 	var/turf/T = get_turf(C)
 	var/light_amount = T.get_lumcount()
 	if(light_amount > LIGHT_DAM_THRESHOLD)
-		H.remove_movespeed_modifier(id)
+		C.remove_movespeed_modifier(id)
 	else
-		H.add_movespeed_modifier(id, update=TRUE, priority=100, multiplicative_slowdown=-2, blacklisted_movetypes=(FLYING|FLOATING))
+		C.add_movespeed_modifier(id, update=TRUE, priority=100, multiplicative_slowdown=-2, blacklisted_movetypes=(FLYING|FLOATING))
 	
 
 /datum/species/shadow/ling/lesser //Empowered thralls. Obvious, but powerful

--- a/yogstation/code/game/gamemodes/shadowling/shadowling.dm
+++ b/yogstation/code/game/gamemodes/shadowling/shadowling.dm
@@ -160,11 +160,13 @@ Made by Xhuis
 	C.draw_yogs_parts(TRUE)
 	eyes_overlay = mutable_appearance('yogstation/icons/mob/sling.dmi', "eyes", 25)
 	C.add_overlay(eyes_overlay)
+	RegisterSignal(C, COMSIG_MOVABLE_MOVED, .proc/apply_darkness_speed)
 	. = ..()
 
 /datum/species/shadow/ling/on_species_loss(mob/living/carbon/human/C)
 	C.draw_yogs_parts(FALSE)
-	C.remove_movespeed_modifier(id)
+	UnregisterSignal(C, COMSIG_MOVABLE_MOVED)
+	H.remove_movespeed_modifier(id)
 	if(eyes_overlay)
 		C.cut_overlay(eyes_overlay)
 		QDEL_NULL(eyes_overlay)
@@ -177,7 +179,6 @@ Made by Xhuis
 		var/light_amount = T.get_lumcount()
 		if(light_amount > LIGHT_DAM_THRESHOLD) //Can survive in very small light levels. Also doesn't take damage while incorporeal, for shadow walk purposes
 			H.take_overall_damage(0, LIGHT_DAMAGE_TAKEN)
-			H.remove_movespeed_modifier(id)
 			if(H.stat != DEAD)
 				to_chat(H, span_userdanger("The light burns you!")) //Message spam to say "GET THE FUCK OUT"
 				H.playsound_local(get_turf(H), 'sound/weapons/sear.ogg', 150, 1, pressure_affected = FALSE)
@@ -189,7 +190,6 @@ Made by Xhuis
 			H.SetKnockdown(0)
 			H.SetStun(0)
 			H.SetParalyzed(0)
-			H.add_movespeed_modifier(id, update=TRUE, priority=100, multiplicative_slowdown=-2, blacklisted_movetypes=(FLYING|FLOATING))
 	var/charge_time = 400 - ((SSticker.mode.thralls && SSticker.mode.thralls.len) || 0)*10
 	if(world.time >= charge_time+last_charge)
 		shadow_charges = min(shadow_charges + 1, 3)
@@ -205,6 +205,15 @@ Made by Xhuis
 			shadow_charges = min(shadow_charges - 1, 0)
 			return -1
 	return 0
+
+/datum/species/shadow/ling/proc/apply_darkness_speed(mob/living/carbon/C)
+	var/turf/T = get_turf(C)
+	var/light_amount = T.get_lumcount()
+	if(light_amount > LIGHT_DAM_THRESHOLD) //Can survive in very small light levels. Also doesn't take damage while incorporeal, for shadow walk purposes
+		H.remove_movespeed_modifier(id)
+	else
+		H.add_movespeed_modifier(id, update=TRUE, priority=100, multiplicative_slowdown=-2, blacklisted_movetypes=(FLYING|FLOATING))
+	
 
 /datum/species/shadow/ling/lesser //Empowered thralls. Obvious, but powerful
 	name = "Lesser Shadowling"


### PR DESCRIPTION
# Document the changes in your pull request

Shadowlings can no longer run halfway through a lit hallway before losing their speed buff
You have a jaunt, you have the nightmare jaunt, you have like 3 different ways of removing light, being in light should actually be bad for you

# Changelog
:cl:  
bugfix: shadowling speed is now updated on switching tiles, no more being slow in the dark and/or fast in the light
/:cl:
