### PR TITLE
Fixes being unable to get new negative or neutral quirks when you have exactly 6 positive quirks

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1254,10 +1254,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	return bal
 
 /datum/preferences/proc/GetPositiveQuirkCount()
-	. = 0
+	var/sum = 0
 	for(var/q in all_quirks)
 		if(SSquirks.quirk_points[q] > 0)
-			.++
+			sum++
+	return sum
 
 /datum/preferences/Topic(href, href_list, hsrc)			//yeah, gotta do this I guess..
 	. = ..()
@@ -1352,7 +1353,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						if((quirk in L) && (Q in L) && !(Q == quirk)) //two quirks have lined up in the list of the list of quirks that conflict with each other, so return (see quirks.dm for more details)
 							to_chat(user, span_danger("[quirk] is incompatible with [Q]."))
 							return
-				var/value = SSquirks.quirk_points[quirk]
+				var/value = SSquirks.quirk_points[quirk] // The value of the chosen quirk.
 				var/balance = GetQuirkBalance()
 				if(quirk in all_quirks)
 					if(balance + value < 0)
@@ -1360,7 +1361,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						return
 					all_quirks -= quirk
 				else
-					if(GetPositiveQuirkCount() >= MAX_QUIRKS)
+					var/positive_count = GetPositiveQuirkCount() // Yogs -- fixes weird behaviour when at max positive quirks
+					if(positive_count > MAX_QUIRKS || (positive_count == MAX_QUIRKS && value > 0)) // Yogs
 						to_chat(user, span_warning("You can't have more than [MAX_QUIRKS] positive quirks!"))
 						return
 					if(balance - value < 0)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/162830656-c9c052be-5c55-40a8-b503-deff2bc575fb.png)

Fixes #13651

IMO, it probably should be the case that you can pick whatever set of quirks you want, and only when you click to confirm does it do all these checks, but... whatever.

## Changelog
:cl: Altoids
bugfix: It is now possible to select more negative quirks for yourself when you have exactly 6 positive ones enabled.
/:cl:
