### PR TITLE
AI is now able to turn its APC back online when it goes off, and is no longer blinded when the APC goes offline if they have other active cores. You also don't get spammed when dying

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -914,7 +914,7 @@
 	return 0
 
 /mob/living/silicon/ai/incapacitated(ignore_restraints = FALSE, ignore_grab = FALSE, check_immobilized = FALSE, ignore_stasis = FALSE)
-	if(aiRestorePowerRoutine)
+	if(aiRestorePowerRoutine && !available_ai_cores())
 		return TRUE
 	return ..()
 

--- a/code/modules/mob/living/silicon/ai/decentralized/ai_data_core.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/ai_data_core.dm
@@ -46,6 +46,8 @@ GLOBAL_VAR_INIT(primary_data_core, null)
 
     
 	for(var/mob/living/silicon/ai/AI in all_ais)
+		if(AI.is_dying)
+			continue
 		if(!AI.mind && AI.deployed_shell.mind)
 			to_chat(AI.deployed_shell, span_userdanger("Warning! Data Core brought offline in [get_area(src)]! Please verify that no malicious actions were taken."))
 		else
@@ -111,6 +113,8 @@ GLOBAL_VAR_INIT(primary_data_core, null)
 			warning_sent = TRUE
 			var/list/send_to = GLOB.ai_list.Copy()
 			for(var/mob/living/silicon/ai/AI in send_to)
+				if(AI.is_dying)
+					continue
 				if(!AI.mind && AI.deployed_shell.mind)
 					to_chat(AI.deployed_shell, span_userdanger("Data core in [get_area(src)] is on the verge of failing! Immediate action required to prevent failure."))
 				else

--- a/code/modules/mob/living/silicon/ai/decentralized_ai.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized_ai.dm
@@ -25,6 +25,8 @@
 
 
 /mob/living/silicon/ai/proc/relocate(silent = FALSE)
+	if(is_dying)
+		return
 	if(!silent)
 		to_chat(src, span_userdanger("Connection to data core lost. Attempting to reaquire connection..."))
 	
@@ -39,6 +41,7 @@
 
 	if(!new_data_core || (new_data_core && !new_data_core.can_transfer_ai()))
 		INVOKE_ASYNC(src, /mob/living/silicon/ai.proc/death_prompt)
+		is_dying = TRUE
 		return
 
 	if(!silent)

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -112,7 +112,7 @@
 	see_invisible = initial(see_invisible)
 	see_in_dark = initial(see_in_dark)
 	sight = initial(sight)
-	if(aiRestorePowerRoutine)
+	if(aiRestorePowerRoutine && !available_ai_cores())
 		sight = sight&~SEE_TURFS
 		sight = sight&~SEE_MOBS
 		sight = sight&~SEE_OBJS
@@ -127,8 +127,8 @@
 	to_chat(src, "Backup battery online. Scanners, camera, and radio interface offline. Beginning fault-detection.")
 	end_multicam()
 	sleep(50)
-	var/turf/T = get_turf(src)
-	var/area/AIarea = get_area(src)
+	var/turf/T = get_turf(loc)
+	var/area/AIarea = get_area(loc)
 	if(AIarea && AIarea.power_equip)
 		if(!isspaceturf(T))
 			ai_restore_power()
@@ -137,7 +137,7 @@
 	sleep(20)
 	to_chat(src, "Emergency control system online. Verifying connection to power network.")
 	sleep(50)
-	T = get_turf(src)
+	T = get_turf(loc)
 	if(isspaceturf(T))
 		to_chat(src, "Unable to verify! No power connection detected!")
 		aiRestorePowerRoutine = POWER_RESTORATION_SEARCH_APC
@@ -148,8 +148,8 @@
 
 	var/PRP //like ERP with the code, at least this stuff is no more 4x sametext
 	for (PRP=1, PRP<=4, PRP++)
-		T = get_turf(src)
-		AIarea = get_area(src)
+		T = get_turf(loc)
+		AIarea = get_area(loc)
 		if(AIarea)
 			for (var/obj/machinery/power/apc/APC in AIarea)
 				if (!(APC.stat & BROKEN))
@@ -199,7 +199,9 @@
 /mob/living/silicon/ai/proc/ai_lose_power()
 	disconnect_shell()
 	aiRestorePowerRoutine = POWER_RESTORATION_START
-	blind_eyes(1)
+	if(!available_ai_cores())
+		blind_eyes(1)
+	
 	update_sight()
 	to_chat(src, "You've lost power!")
 	addtimer(CALLBACK(src, .proc/start_RestorePowerRoutine), 20)


### PR DESCRIPTION
# Document the changes in your pull request


# Wiki Documentation



# Changelog


:cl:  
tweak: AI is no longer blinded when their APC goes offline, provided they have another core online
bugfix: AI can restore their APC when it is offline
/:cl:
