### PR TITLE
Fixes gilded bike horn sprite

### DIFF
--- a/code/modules/instruments/items.dm
+++ b/code/modules/instruments/items.dm
@@ -239,7 +239,7 @@
 /obj/item/instrument/bikehorn
 	name = "gilded bike horn"
 	desc = "An exquisitely decorated bike horn, capable of honking in a variety of notes."
-	icon = 'icons/obj/janitor.dmi'
+	icon = 'icons/obj/toy.dmi'
 	icon_state = "bike_horn"
 	item_state = "bike_horn"
 	lefthand_file = 'icons/mob/inhands/equipment/horns_lefthand.dmi'

--- a/code/modules/instruments/items.dm
+++ b/code/modules/instruments/items.dm
@@ -239,7 +239,6 @@
 /obj/item/instrument/bikehorn
 	name = "gilded bike horn"
 	desc = "An exquisitely decorated bike horn, capable of honking in a variety of notes."
-	icon = 'icons/obj/toy.dmi'
 	icon_state = "bike_horn"
 	item_state = "bike_horn"
 	lefthand_file = 'icons/mob/inhands/equipment/horns_lefthand.dmi'


### PR DESCRIPTION
# Document the changes in your pull request

Fixes #13688

Untested changes that should fix gilded bike horns or at the very least give it a sprite.

# Wiki Documentation

Nothing. 

# Changelog

:cl:  
bugfix: fixed glided bike horns missing an icon
/:cl:
