### PR TITLE
makes box cloning pod actually link at roundstart

### DIFF
--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -118,9 +118,9 @@
 	var/obj/machinery/clonepod/podf = null
 
 	if(extended_search)
-		for(var/obj/machinery/clonepod/podf in view(3,src))
-			if(!isnull(podf) && podf.is_operational())
-				AttachCloner(podf)
+		for(var/obj/machinery/clonepod/pod in view(3,src))
+			if(!isnull(pod) && pod.is_operational())
+				AttachCloner(pod)
 	else
 		for(var/direction in GLOB.cardinals)
 			podf = locate(/obj/machinery/clonepod, get_step(src, direction))

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -98,7 +98,7 @@
 	else
 		START_PROCESSING(SSmachines, src)
 
-/obj/machinery/computer/cloning/proc/findscanner(extended_search = FALSE)
+/obj/machinery/computer/cloning/proc/findscanner()
 	var/obj/machinery/dna_scannernew/scannerf = null
 
 	// Loop through every direction

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -120,7 +120,7 @@
 	if(extended_search)
 		for(var/obj/machinery/clonepod/podf in view(3,src))
 			if(!isnull(podf) && podf.is_operational())
-				attachCloner(podf)
+				AttachCloner(podf)
 	else
 		for(var/direction in GLOB.cardinals)
 			podf = locate(/obj/machinery/clonepod, get_step(src, direction))

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -92,7 +92,7 @@
 /obj/machinery/computer/cloning/proc/updatemodules(findfirstcloner,mapload)
 	scanner = findscanner()
 	if(findfirstcloner && !LAZYLEN(pods))
-		findcloner(extended_search = mapload)
+		findcloner(mapload)
 	if(!autoprocess)
 		STOP_PROCESSING(SSmachines, src)
 	else

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -26,9 +26,9 @@
 
 	light_color = LIGHT_COLOR_BLUE
 
-/obj/machinery/computer/cloning/Initialize()
+/obj/machinery/computer/cloning/Initialize(mapload)
 	. = ..()
-	updatemodules(TRUE)
+	updatemodules(TRUE,mapload)
 
 /obj/machinery/computer/cloning/Destroy()
 	if(pods)
@@ -89,16 +89,16 @@
 			records -= R
 
 
-/obj/machinery/computer/cloning/proc/updatemodules(findfirstcloner)
+/obj/machinery/computer/cloning/proc/updatemodules(findfirstcloner,mapload)
 	scanner = findscanner()
 	if(findfirstcloner && !LAZYLEN(pods))
-		findcloner()
+		findcloner(extended_search = mapload)
 	if(!autoprocess)
 		STOP_PROCESSING(SSmachines, src)
 	else
 		START_PROCESSING(SSmachines, src)
 
-/obj/machinery/computer/cloning/proc/findscanner()
+/obj/machinery/computer/cloning/proc/findscanner(extended_search = FALSE)
 	var/obj/machinery/dna_scannernew/scannerf = null
 
 	// Loop through every direction
@@ -114,14 +114,18 @@
 	// If no scanner was found, it will return null
 	return null
 
-/obj/machinery/computer/cloning/proc/findcloner()
+/obj/machinery/computer/cloning/proc/findcloner(extended_search = FALSE) //extened_search is for things like box where the console is multiple tiles away from the actual pod
 	var/obj/machinery/clonepod/podf = null
 
-	for(var/direction in GLOB.cardinals)
-
-		podf = locate(/obj/machinery/clonepod, get_step(src, direction))
-		if (!isnull(podf) && podf.is_operational())
-			AttachCloner(podf)
+	if(extended_search)
+		for(var/obj/machinery/clonepod/podf in view(3,src))
+			if(!isnull(podf) && podf.is_operational())
+				attachCloner(podf)
+	else
+		for(var/direction in GLOB.cardinals)
+			podf = locate(/obj/machinery/clonepod, get_step(src, direction))
+			if (!isnull(podf) && podf.is_operational())
+				AttachCloner(podf)
 
 /obj/machinery/computer/cloning/proc/AttachCloner(obj/machinery/clonepod/pod)
 	if(!pod.connected)


### PR DESCRIPTION
# Document the changes in your pull request

mapload cloners get super range finder to link properly

# Changelog


:cl:  
rscadd: makes cloners able to scan for pods not directly among them but only on roundstart
/:cl:
