### PR TITLE
Ruinous knife additions

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -184,6 +184,24 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
+/datum/crafting_recipe/greatruinousknife
+	name = "Great Ruinous Knife"
+	result = /obj/item/kitchen/knife/ritual/holy/strong
+	reqs = list(/obj/item/kitchen/knife/ritual/holy = 1,
+	            /obj/item/stack/sheet/ruinous_metal = 1)
+	time = 4 SECONDS
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+
+/datum/crafting_recipe/bloodyruinousknife
+	name = "Blood Soaked Ruinous Knife"
+	result = /obj/item/kitchen/knife/ritual/holy/strong/blood
+	reqs = list(/obj/item/kitchen/knife/ritual/holy/strong = 1,
+	            /obj/item/stack/sheet/runed_metal = 1)
+	time = 4 SECONDS
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+
 /datum/crafting_recipe/ed209
 	name = "ED209"
 	result = /mob/living/simple_animal/bot/ed209

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -135,13 +135,11 @@
 	name = "great ruinous knife" 
 	desc = "A heavy knife inscribed with dozens of runes."
 	force = 15
-	wound_bonus = 15 //same stats as butcher cleaver, though since cargo always hacks their autolathe it is probably actually easier to just get a cleaver
 
 /obj/item/kitchen/knife/ritual/holy/strong/blood
 	name = "blood-soaked ruinous knife" 
 	desc = "Runes stretch across the surface of the knife, seemingly endless."
-	wound_bonus = 20
-	bare_wound_bonus = 25 //a decent bit better than a butcher cleaver, you've earned it for finding blood cult metal and doing the previous steps
+	wound_bonus = 20 //a bit better than a butcher cleaver, you've earned it for finding blood cult metal and doing the previous steps
 
 /obj/item/kitchen/knife/ritual/holy/Initialize()
 	. = ..()

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -128,9 +128,24 @@
 	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/kitchen/knife/ritual/holy
-	name = "ruinous knife"
-	desc = "The runes inscribed on the knife radiate a strange power."
-	force = 12
+	name = "ruinous knife" 
+	desc = "The runes inscribed on the knife radiate a strange power. It looks like it could have more runes inscribed upon it..."
+
+/obj/item/kitchen/knife/ritual/holy/strong
+	name = "great ruinous knife" 
+	desc = "A heavy knife inscribed with dozens of runes."
+	force = 15
+	wound_bonus = 15 //same stats as butcher cleaver, though since cargo always hacks their autolathe it is probably actually easier to just get a cleaver
+
+/obj/item/kitchen/knife/ritual/holy/strong/blood
+	name = "blood-soaked ruinous knife" 
+	desc = "Runes stretch across the surface of the knife, seemingly endless."
+	wound_bonus = 20
+	bare_wound_bonus = 25 //a decent bit better than a butcher cleaver, you've earned it for finding blood cult metal and doing the previous steps
+
+/obj/item/kitchen/knife/ritual/holy/Initialize()
+	. = ..()
+	AddComponent(/datum/component/butchering, 70, 110) //the old gods demandeth more flesh output
 
 /obj/item/kitchen/knife/bloodletter
 	name = "bloodletter"

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -428,7 +428,7 @@
 
 /datum/religion_rites/ruinousknife
 	name = "Ruinous Knife"
-	desc = "Creates a knife that is mostly cosmetic, but is also a weapon."
+	desc = "Creates a knife that is mostly cosmetic, but is also a weapon. It is extra effective as a butchering tool, and can be upgraded with crafting alongside a piece of ruinous metal."
 	ritual_length = 5 SECONDS
 	invoke_msg = "please, old ones, lend us a tool of holy creation."
 	favor_cost = 50


### PR DESCRIPTION
The old gods chaplain sect ruinous knife has been changed a bit

-Base damage reduced to 10 from 12
-Ruinous knife gets bonuses for butchering dead stuff
-You can now craft a piece of ruinous metal with a ruinous knife to get an upgraded version that deals 5 more damage, same as the butcher's cleaver without added wounding bonus (which can be gotten from a hacked autolathe or a dinner ware vendor)
-The upgraded version can be further upgraded for more wound bonuses by crafting it with runed metal (the blood cult metal). In this state it'll be slightly better than a butcher's cleaver.

# Changelog

:cl:  
rscadd: Adds upgraded versions of the ruinous knife from the old gods chaplain sect.
tweak: Ruinous knife damage lowered, extra butcher rewards.
/:cl:
