### PR TITLE
Makes vampire use the antag rep system, and antag tokens

### DIFF
--- a/yogstation/code/game/gamemodes/vampire/vampire.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire.dm
@@ -55,7 +55,7 @@
 	for(var/j = 0, j < num_vamps, j++)
 		if (!antag_candidates.len)
 			break
-		var/datum/mind/vamp = pick(antag_candidates)
+		var/datum/mind/vamp = antag_pick(antag_candidates)
 		pre_vamps += vamp
 		vamp.special_role = "Vampire"
 		vamp.restricted_roles = restricted_jobs


### PR DESCRIPTION
# Document the changes in your pull request

antag_pick uses antag rep and antag tokens, vamp is currently just using pick()

# Changelog

:cl:  
bugfix: fixed vampire not using antag rep or antag tokens
/:cl:
