### PR TITLE
Fairygrass shuttle floor fix and added missing cherry bulbs.

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -68,7 +68,9 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	if(requires_activation)
 		CALCULATE_ADJACENT_TURFS(src)
 		SSair.add_to_active(src)
-
+	if(color)
+		add_atom_colour(color, FIXED_COLOUR_PRIORITY)
+	
 	if (light_power && light_range)
 		update_light()
 
@@ -85,7 +87,8 @@ GLOBAL_LIST_EMPTY(station_turfs)
 		has_opaque_atom = TRUE
 
 	ComponentInitialize()
-
+	if(color)
+		add_atom_colour(color, FIXED_COLOUR_PRIORITY)
 	return INITIALIZE_HINT_NORMAL
 
 /turf/proc/Initalize_Atmos(times_fired)

--- a/code/modules/hydroponics/grown/berries.dm
+++ b/code/modules/hydroponics/grown/berries.dm
@@ -122,7 +122,7 @@
 	icon_grow = "cherry-grow"
 	icon_dead = "cherry-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	mutatelist = list(/obj/item/seeds/cherry/blue)
+	mutatelist = list(/obj/item/seeds/cherry/blue, /obj/item/seeds/cherry/bulb)
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.07, /datum/reagent/consumable/sugar = 0.07)
 
 /obj/item/reagent_containers/food/snacks/grown/cherries

--- a/code/modules/hydroponics/grown/grass_carpet.dm
+++ b/code/modules/hydroponics/grown/grass_carpet.dm
@@ -88,7 +88,6 @@
 			if(/datum/plant_gene/trait/glow/shadow)
 				stacktype = /obj/item/stack/tile/fairygrass/dark
 		
-
 	. = ..()
 	
 // Carpet


### PR DESCRIPTION
Added missing cherry bulbs and fixed a bug with fairygrass messing up the shuttle floors. https://github.com/BeeStation/BeeStation-Hornet/pull/5640

# Document the changes in your pull request

Short version: Fixes the issue where fairygrass destroyed the floor when shuttles took off.

Long version: /turf/Initialize() didn't include a check for adding the color variable to atom_colors unlike atom/Initialize(). When shuttles took off and tried to copy the turfs involved, it would runtime as the color variable was set but atom_colors was null, this should hopefully fix that and not break anything else. 


# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  Pirill
fix: Fixes fairygrass shuttle flight runtime 
rscadd: Added missing cherry bulbs to the mutatelist of cherries.
/:cl:
