### PR TITLE
Fixes the Crew Monitoring Console showing dead crew members as alive

### DIFF
--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -45,10 +45,19 @@ export const jobToColor = jobId => {
   return COLORS.department.other;
 };
 
-export const healthToColor = (oxy, tox, burn, brute) => {
-  const healthSum = oxy + tox + burn + brute;
-  const level = Math.min(Math.max(Math.ceil(healthSum / 25), 0), 5);
-  return HEALTH_COLOR_BY_LEVEL[level];
+export const healthToColor = (oxy, tox, burn, brute, is_alive) => { // Yogs -- show deadness
+  if (is_alive === null || is_alive)
+  {
+    if (oxy === null) // No damage data -- just show that they're alive
+    {
+      return HEALTH_COLOR_BY_LEVEL[0];
+    }
+    const healthSum = oxy + tox + burn + brute;
+    const level = Math.min(Math.max(Math.ceil(healthSum / 25), 0), 5);
+    return HEALTH_COLOR_BY_LEVEL[level];
+  }
+  return HEALTH_COLOR_BY_LEVEL[5]; // Dead is dead, son
+  // Yogs end
 };
 
 export const HealthStat = props => {
@@ -132,15 +141,12 @@ export const CrewConsoleContent = (props, context) => {
                 </Table.Cell>
                 <Table.Cell collapsing textAlign="center">
                   <ColorBox
-                    color={sensor.oxydam !== null
-                      ? healthToColor(
-                        sensor.oxydam,
-                        sensor.toxdam,
-                        sensor.burndam,
-                        sensor.brutedam) : (
-                        sensor.life_status
-                          ? HEALTH_COLOR_BY_LEVEL[0]
-                          : HEALTH_COLOR_BY_LEVEL[5])} />
+                    color={healthToColor( // yogs -- show death when dead
+                      sensor.oxydam,
+                      sensor.toxdam,
+                      sensor.burndam,
+                      sensor.brutedam,
+                      sensor.life_status)} />
                 </Table.Cell>
                 <Table.Cell collapsing textAlign="center">
                   {sensor.oxydam !== null ? (


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/29939414/162951883-4a723c6e-eb40-431e-96fd-d617749715fc.png)

## Summary
Fixes #13417 by making the little health box next to the damage read-out always be red when the person is actually toast.

This may seem weird, but without doing something like this, it's actually the case that having your suit sensors on binary would actually convey your death *more* clearly, since it would take into account things like organ failure and cloning damage. Obviously this is not the intent; there's no reason for the sensors to give your brute damage to the decimal but not even indicate vaguely whether you're dead or not.

## Changelog

:cl: Altoids
bugfix: People who have died from traumatic brain injury no longer appear happy and healthy on crew monitoring consoles.
/:cl:
