### PR TITLE
Disallows mice from emptying boxes on tables

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -541,6 +541,8 @@
 			return FALSE
 		if(ismecha(M.loc)) // stops inventory actions in a mech
 			return FALSE
+		if(ismouse(M) && (locate(/obj/structure/table) in get_turf(parent))) // Prevents mice using storages on tables
+			return FALSE
 		// this must come before the screen objects only block, dunno why it wasn't before
 		if(over_object == M)
 			user_show_to_mob(M)


### PR DESCRIPTION
# Document the changes in your pull request

Mice can't eat from tables, why should they be able to empty boxes on tables

# Changelog

:cl:  
tweak: mice can no longer empty boxes on tables
/:cl:
