### PR TITLE
Fixed config runtime

### DIFF
--- a/code/__DEFINES/configuration.dm
+++ b/code/__DEFINES/configuration.dm
@@ -1,6 +1,7 @@
 //config files
 #define CONFIG_GET(X) global.config.Get(/datum/config_entry/##X)
 #define CONFIG_SET(X, Y) global.config.Set(/datum/config_entry/##X, ##Y)
+#define CONFIG_LOADED global.config.load_complete
 
 #define CONFIG_MAPS_FILE "maps.txt"
 

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -21,6 +21,8 @@
 	var/motd
 	var/policy
 
+	var/load_complete = FALSE
+
 /datum/controller/configuration/proc/admin_reload()
 	if(IsAdminAdvancedProcCall())
 		return
@@ -50,6 +52,8 @@
 	LoadMOTD()
 	LoadPolicy()
 	
+	load_complete = TRUE
+
 	if (Master)
 		Master.OnConfigLoad()
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -172,7 +172,7 @@ GLOBAL_VAR(restart_counter)
 			handler = topic_handlers[I]
 			break
 
-	if((!handler || initial(handler.log)) && config && CONFIG_GET(flag/log_world_topic))
+	if((!handler || initial(handler.log)) && config && CONFIG_LOADED && CONFIG_GET(flag/log_world_topic))
 		log_topic("\"[T]\", from:[addr], master:[master], key:[key]")
 
 	if(!handler)


### PR DESCRIPTION
# Document the changes in your pull request

Status topic triggers before config load, causing a runtime, now it won't check the config for the world topic until after its loaded

# Changelog

:cl:  
bugfix: fixed a runtime in the config/status world topic
/:cl:
