### PR TITLE
Fixes status topic runtime when reading revision

### DIFF
--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -223,8 +223,8 @@
 	.["host"] = world.host ? world.host : null
 	.["round_id"] = GLOB.round_id
 	.["players"] = GLOB.clients.len
-	.["revision"] = GLOB.revdata.commit
-	.["revision_date"] = GLOB.revdata.date
+	.["revision"] = GLOB.revdata?.commit
+	.["revision_date"] = GLOB.revdata?.date
 
 	var/list/adm = get_admin_counts()
 	var/list/presentmins = adm["present"]


### PR DESCRIPTION
# Document the changes in your pull request

Early in loading, revdata might be null

# Changelog

:cl:  
bugfix: fixed runtime in status world topic reading revdata 
/:cl:
