### PR TITLE
Ports/Revives "Adds the "Unlock Antag HUD" verb to Ghosts that also blocks them from coming back into the round"

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -482,8 +482,10 @@
 	if(!(GLOB.ghost_role_flags & GHOSTROLE_STATION_SENTIENCE))
 		return candidates
 
-	for(var/mob/dead/observer/G in GLOB.player_list)
-		candidates += G
+	for(var/mob/dead/observer/ghost in GLOB.player_list)
+		if(ghost.antag_sight_unlocked) // ghosts with antag HUDs unlocked are disqualified
+			continue
+		candidates += ghost
 
 	return pollCandidates(Question, jobbanType, gametypeCheck, be_special_flag, poll_time, ignore_category, flashwindow, candidates)
 

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -298,6 +298,8 @@
 
 /datum/config_entry/flag/near_death_experience //If carbons can hear ghosts when unconscious and very close to death
 
+/datum/config_entry/flag/disable_ghost_unlock_antag_hud
+
 /datum/config_entry/flag/silent_ai
 /datum/config_entry/flag/silent_borg
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -94,7 +94,11 @@
 		source = LOGSRC_CLIENT
 	body += "<a href='?_src_=holder;[HrefToken()];individuallog=[REF(M)];log_src=[source]'>LOGS</a>\] <br>"
 
-	body += "<b>Mob type</b> = [M.type]<br><br>"
+	body += "<b>Mob type</b> = [M.type]<br>"
+	if(M.client)
+		var/datum/player_details/deets = LAZYACCESS(GLOB.player_details, M.ckey)
+		body += "<b>AntagHUD unlocked</b> = [deets?.antag_sight_unlocked ? "True" : "False"]<br>"
+	body += "<br>"
 
 	body += "<A href='?_src_=holder;[HrefToken()];boot2=[REF(M)]'>Kick</A> | "
 	if(M.client)

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -33,11 +33,14 @@
 	var/ghost_usable = TRUE
 
 //ATTACK GHOST IGNORING PARENT RETURN VALUE
-/obj/effect/mob_spawn/attack_ghost(mob/user)
+/obj/effect/mob_spawn/attack_ghost(mob/dead/observer/user)
 	if(!SSticker.HasRoundStarted() || !loc || !ghost_usable)
 		return
 	if(!(GLOB.ghost_role_flags & GHOSTROLE_SPAWNER) && !(flags_1 & ADMIN_SPAWNED_1))
 		to_chat(user, span_warning("An admin has temporarily disabled non-admin ghost roles!"))
+		return
+	if(user.antag_sight_unlocked)
+		to_chat(user, span_warning("You cannot spawn after unlocking the Antag HUD."))
 		return
 	if(!uses)
 		to_chat(user, span_warning("This spawner is out of charges!"))

--- a/code/modules/client/player_details.dm
+++ b/code/modules/client/player_details.dm
@@ -5,6 +5,7 @@
 	var/list/post_logout_callbacks = list()
 	var/list/played_names = list() //List of names this key played under this round
 	var/byond_version = "Unknown"
+	var/antag_sight_unlocked = FALSE
 
 /proc/log_played_names(ckey, ...)
 	if(!ckey)

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -87,7 +87,7 @@
 
 				for (var/_A in mind.antag_datums)
 					var/datum/antagonist/A = _A
-					if (A.show_to_ghosts)
+					if (A.show_to_ghosts || owner.antag_sight_unlocked)
 						was_antagonist = TRUE
 						serialized["antag"] = A.name
 						antagonists += list(serialized)

--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -82,7 +82,7 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	return FALSE
 
 //Two ways to activate a positronic brain. A clickable link in the ghost notif, or simply clicking the object itself.
-/obj/item/mmi/posibrain/proc/activate(mob/user)
+/obj/item/mmi/posibrain/proc/activate(mob/dead/observer/user)
 	if(QDELETED(brainmob))
 		return
 	if(is_occupied() || is_banned_from(user.ckey, ROLE_POSIBRAIN) || QDELETED(brainmob) || QDELETED(src) || QDELETED(user))
@@ -95,6 +95,9 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 		return
 	var/posi_ask = alert("Become a [name]? (Warning, You can no longer be cloned, and all past lives will be forgotten!)","Are you positive?","Yes","No")
 	if(posi_ask == "No" || QDELETED(src))
+		return
+	if(user.antag_sight_unlocked)
+		to_chat(user, span_warning("[src] cannot be used after unlocking the Antag HUD."))
 		return
 	if(brainmob.suiciding) //clear suicide status if the old occupant suicided.
 		brainmob.set_suicide(FALSE)

--- a/code/modules/swarmers/swarmer_objs.dm
+++ b/code/modules/swarmers/swarmer_objs.dm
@@ -68,9 +68,12 @@
   * Arguments:
   * * user - A reference to the ghost interacting with the beacon
   */
-/obj/structure/swarmer_beacon/proc/que_swarmer(mob/user)
+/obj/structure/swarmer_beacon/proc/que_swarmer(mob/dead/observer/user)
 	var/swarm_ask = alert("Become a swarmer?", "Do you wish to consume the station?", "Yes", "No")
 	if(swarm_ask == "No" || QDELETED(src) || QDELETED(user) || processing_swarmer)
+		return FALSE
+	if(user.antag_sight_unlocked)
+		to_chat(user, span_warning("You cannot spawn after unlocking the Antag HUD."))
 		return FALSE
 	var/mob/living/simple_animal/hostile/swarmer/newswarmer = new /mob/living/simple_animal/hostile/swarmer(src)
 	newswarmer.key = user.key

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -377,6 +377,9 @@ GHOST_INTERACTION
 ## Comment this out to disable mobs hearing ghosts when unconscious and very close to death
 #NEAR_DEATH_EXPERIENCE
 
+## Uncomment to disable the "Unlock Antag HUD" ghost verb
+#DISABLE_GHOST_UNLOCK_ANTAG_HUD
+
 ## NON-VOCAL SILICONS ###
 ## Uncomment these to stop the AI, or cyborgs, from having vocal communication.
 #SILENT_AI


### PR DESCRIPTION
# Document the changes in your pull request

[Ports "Adds the "Unlock Antag HUD" verb to Ghosts that also blocks them from coming back into the round" #60286](https://github.com/tgstation/tgstation/pull/60286) by [Wayland-Smithy](https://github.com/Wayland-Smithy), which adds a nice QoL feature for observers who don't want to interact with the game and would prefer to have more information. Could prevent ghosts who enable it from being seen by other ghosts or speaking in dead chat if necessary.

# Wiki Documentation

Don't know if it would need to be mentioned anywhere. 

# Changelog

:cl:  Wayland-Smithy
rscadd: added the "Unlock Antag HUD" ghost verb, that allows ghosts to see antag huds but preventing them from respawning or joining the round.
/:cl:
