### PR TITLE
Fix handcannon not being reloadable and makes the reload text cooler

### DIFF
--- a/code/modules/projectiles/ammunition/caseless/rocket.dm
+++ b/code/modules/projectiles/ammunition/caseless/rocket.dm
@@ -22,7 +22,7 @@
 /obj/item/ammo_casing/caseless/cannonball
 	name = "cannonball"
 	desc = "A big ball of lead, perfect for shooting through windows and doors."
-	caliber = "30mm"
+	caliber = "100mm"
 	icon = 'icons/obj/ammo.dmi'
 	icon_state = "cannonball"
 	projectile_type = /obj/item/projectile/bullet/cball

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -112,5 +112,6 @@
 	tac_reloads = FALSE
 	can_suppress = FALSE
 	force = 10
+	cartridge_wording = "cannonball"
 	fire_sound = 'sound/effects/bang.ogg'
 	pin = /obj/item/firing_pin


### PR DESCRIPTION
turns out the calibers have to match, if only some coder hadn't recommended he change it to 100mm at the last second 
cough @ToasterBiome cough
~~we love you anyway~~

tested and works
![image](https://user-images.githubusercontent.com/46236974/163118070-1a59af8e-f24a-4665-aa11-45767c2c4294.png)


:cl:  Chubbygummibear, Lazennsky
bugfix: handcannon can now reload
/:cl: