### PR TITLE
Properly fix remove_accessory runtime

### DIFF
--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -167,7 +167,7 @@
 			var/turf/T = get_turf(src)
 			if(!T)
 				T = get_turf(user)
-			A.forceMove(get_turf(src))
+			A.forceMove(T)
 		
 		if(ishuman(loc))
 			var/mob/living/carbon/human/H = loc

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -167,7 +167,8 @@
 			var/turf/T = get_turf(src)
 			if(!T)
 				T = get_turf(user)
-			A.forceMove(T)
+			if(T)
+				A.forceMove(T)
 		
 		if(ishuman(loc))
 			var/mob/living/carbon/human/H = loc


### PR DESCRIPTION
# Document the changes in your pull request

I put a null check in, then apparently didn't use the null checked variable

# Changelog

:cl:  
bugfix: fixed runtime in remove_accessory, for real this time
/:cl:
