### PR TITLE
Fixes runtime in keyloop triggered by Baiomu

### DIFF
--- a/yogstation/code/modules/keybindings/bindings_client.dm
+++ b/yogstation/code/modules/keybindings/bindings_client.dm
@@ -49,7 +49,7 @@
 
 	if(holder)
 		holder.key_down(I, src)
-	if(mob.focus)
+	if(mob?.focus)
 		mob.focus.key_down(I, src)
 
 /client/verb/keyUp(_key as text)
@@ -77,7 +77,7 @@
 
 	if(holder)
 		holder.key_up(I, src)
-	if(mob.focus)
+	if(mob?.focus)
 		mob.focus.key_up(I, src)
 
 // Called every game tick

--- a/yogstation/code/modules/keybindings/bindings_client.dm
+++ b/yogstation/code/modules/keybindings/bindings_client.dm
@@ -84,5 +84,5 @@
 /client/keyLoop()
 	if(holder)
 		holder.keyLoop(src)
-	if(mob.focus)
+	if(mob?.focus)
 		mob.focus.keyLoop(src)


### PR DESCRIPTION
# Document the changes in your pull request

Apparently baiomu likes not having a mob, so now it won't break

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
bugfix: fixed runtime caused by having a mobless client
/:cl:
