### PR TITLE
Fix error if gloves aren't gloves

### DIFF
--- a/code/datums/components/forensics.dm
+++ b/code/datums/components/forensics.dm
@@ -85,7 +85,7 @@
 		add_fibers(H)
 		if(H.gloves) //Check if the gloves (if any) hide fingerprints
 			var/obj/item/clothing/gloves/G = H.gloves
-			if(G.transfer_prints)
+			if(istype(G) && G.transfer_prints)
 				ignoregloves = TRUE
 			if(!ignoregloves)
 				H.gloves.add_fingerprint(H, TRUE) //ignoregloves = 1 to avoid infinite loop.


### PR DESCRIPTION
# Document the changes in your pull request

Sometimes gloves aren't gloves, this makes sure gloves are gloves

# Changelog

:cl:  
bugfix: fixed fingerprints not working properly when gloves aren't gloves
/:cl:
