### PR TITLE
fixes KA explosion always dealing maximum damage

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -408,7 +408,10 @@
 	if(modifier)
 		for(var/mob/living/L in range(1, target_turf) - K.firer - target)
 			var/armor = L.run_armor_check(K.def_zone, K.flag, "", "", K.armour_penetration)
-			L.apply_damage(K.damage*modifier, K.damage_type, K.def_zone, armor)
+			var/effective_modifier = modifier
+			if(K.pressure_decrease_active)
+				effective_modifier *= K.pressure_decrease
+			L.apply_damage(K.damage*effective_modifier, K.damage_type, K.def_zone, armor)
 			to_chat(L, span_userdanger("You're struck by a [K.name]!"))
 
 /obj/item/borg/upgrade/modkit/aoe/turfs


### PR DESCRIPTION
# Document the changes in your pull request

Turns out this specific modkit in particular didn't check pressure decrease before dealing damage
Nobody uses these so I don't think anyone really noticed it either

# Changelog

:cl:  
bugfix: the KA damage aoe no longer disrespects pressure damage reduction
/:cl:
