### PR TITLE
Phytosians no longer get 2x regen on all damage types for tasting a crumb of sugar once

### DIFF
--- a/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
@@ -235,8 +235,8 @@
 		
 		//if there's none left after the removal, the light multiplier needs to go back to the default
 		if(!H.reagents.has_reagent(/datum/reagent/consumable/sugar)) 
-			light_heal_multiplier = 1
-			dark_damage_multiplier = 2
+			light_heal_multiplier = initial(light_heal_multiplier)
+			dark_damage_multiplier = initial(dark_damage_multiplier)
 		return 1
 
 	if(istype(chem, /datum/reagent/consumable/ethanol)) //istype so all alcohols work

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
@@ -231,7 +231,12 @@
 		light_heal_multiplier = 2
 		dark_damage_multiplier = 3
 		H.reagents.remove_reagent(chem.type, chem.metabolization_rate * REAGENTS_METABOLISM)
-		//removal is handled in /datum/reagent/sugar/on_mob_delete()
+		//removal is handled in /datum/reagent/sugar/on_mob_delete() //so that was a lie
+		
+		//if there's none left after the removal, the light multiplier needs to go back to the default
+		if(!H.reagents.has_reagent(/datum/reagent/consumable/sugar)) 
+			light_heal_multiplier = 1
+			dark_damage_multiplier = 2
 		return 1
 
 	if(istype(chem, /datum/reagent/consumable/ethanol)) //istype so all alcohols work


### PR DESCRIPTION
Someone forgor to set the light healing multiplier back to 1
:cl:  
bugfix: Pods only get 2x light healing from sugar while it's processing
/:cl:
