### PR TITLE
Podpeople don't feed off light so much that they are perpetually fat

### DIFF
--- a/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
@@ -86,18 +86,22 @@
 				//low light
 				light_level = 2
 				light_msg = span_warning("The ambient light levels are too low. Your breath is coming more slowly as your insides struggle to keep up on their own.")
-				H.nutrition -= light_amount * 3
+				if(H.nutrition > NUTRITION_LEVEL_STARVING)
+					H.nutrition -= light_amount * 3
 				//not enough to faint but enough to slow you down
 				if(H.getOxyLoss() < 50)
 					H.adjustOxyLoss(min(3 * dark_damage_multiplier, 50 - H.getOxyLoss()), 1)
 			if (0.31 to 0.5)
 				//medium, average, doing nothing for now
 				light_level = 3
-				H.nutrition += light_amount * 2
+				if(H.nutrition <= NUTRITION_LEVEL_HUNGRY)	
+					//just enough to function			
+					H.nutrition += light_amount * 2
 			if (0.51 to 0.75)
 				//high light, regen here
 				light_level = 4
-				H.nutrition += light_amount * 1.75
+				if(H.nutrition < NUTRITION_LEVEL_FED)
+					H.nutrition += light_amount * 1.75				
 				if ((H.stat != UNCONSCIOUS) && (H.stat != DEAD) && !no_light_heal)
 					H.adjustOxyLoss(-0.5 * light_heal_multiplier, 1)
 					H.heal_overall_damage(1 * light_heal_multiplier, 1 * light_heal_multiplier)
@@ -107,7 +111,9 @@
 			if (0.76 to 1)
 				//super high light
 				light_level = 5
-				H.nutrition += light_amount * 1.5
+				if(H.nutrition < NUTRITION_LEVEL_FED)
+					//this will give the positive fed moodlet instead of being stuck on "i'm so fat" for existing
+					H.nutrition += light_amount * 1.5
 				if ((H.stat != UNCONSCIOUS) && (H.stat != DEAD) && !no_light_heal)
 					H.adjustOxyLoss(-0.5 * light_heal_multiplier, 1)
 					H.heal_overall_damage(1.5 * light_heal_multiplier, 1.5 * light_heal_multiplier)
@@ -117,7 +123,7 @@
 		//no light, this is baaaaaad
 		light_level = 0
 		light_msg = span_userdanger("Darkness! Your insides churn and your skin screams in pain!")
-		H.nutrition -= 3
+		H.nutrition -= 10
 		//enough to make you faint for good, and eventually die
 		if(H.getOxyLoss() < 60)
 			H.adjustOxyLoss(min(5 * dark_damage_multiplier, 60 - H.getOxyLoss()), 1)

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
@@ -86,8 +86,7 @@
 				//low light
 				light_level = 2
 				light_msg = span_warning("The ambient light levels are too low. Your breath is coming more slowly as your insides struggle to keep up on their own.")
-				if(H.nutrition > NUTRITION_LEVEL_STARVING)
-					H.nutrition -= light_amount * 3
+				H.nutrition -= light_amount * 3
 				//not enough to faint but enough to slow you down
 				if(H.getOxyLoss() < 50)
 					H.adjustOxyLoss(min(3 * dark_damage_multiplier, 50 - H.getOxyLoss()), 1)


### PR DESCRIPTION
Tones down light feeding to the point where pods stop feeding at "fed" when in full light, and at weaker light it's just enough to not be hungry. Now the vegetable people can actually eat if they choose to.


# Wiki Documentation

We could remove the

"If mood is enabled, a phytosian will often receive the "I'm so fat" negative moodlet, making them slower than usual."

snippet

# Changelog

:cl:  
tweak: Podpeople feeding off light toned down. You feed a decent amount off light, but not so much you're fat. So pods can actually eat a bit now without incurring obesity.
/:cl:
