### PR TITLE
modularizes big red button toy 

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1148,12 +1148,13 @@
 	icon_state = "bigred"
 	w_class = WEIGHT_CLASS_SMALL
 	var/cooldown = 0
+	var/boom_sound = 'sound/effects/explosionfar.ogg'
 
 /obj/item/toy/redbutton/attack_self(mob/user)
 	if (cooldown < world.time)
 		cooldown = (world.time + 300) // Sets cooldown at 30 seconds
 		user.visible_message(span_warning("[user] presses the big red button."), span_notice("You press the button, it plays a loud noise!"), span_italics("The button clicks loudly."))
-		playsound(src, 'sound/effects/explosionfar.ogg', 50, 0)
+		playsound(src, boom_sound, 50, 0)
 		for(var/mob/M in urange(10, src)) // Checks range
 			if(!M.stat && !isAI(M)) // Checks to make sure whoever's getting shaken is alive/not the AI
 				sleep(8) // Short delay to match up with the explosion sound


### PR DESCRIPTION
# Document the changes in your pull request

no reason

# Changelog


:cl:  
rscadd: big red button toy now has a variable that controls the sound
/:cl:
