### PR TITLE
Fixes bad emitter math that makes every single tesla/singularity breach containment since January 26th

### DIFF
--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -239,9 +239,9 @@
 		P.fire(dir2angle(dir))
 	if(!manual)
 		last_shot = world.time
-		if(shot_number >= shots_before_reload)
+		shot_number++
+		if(shot_number < shots_before_reload)
 			fire_delay = delay_between_shots
-			shot_number ++
 		else
 			fire_delay = rand(minimum_reload_time,maximum_reload_time)
 			shot_number = 0


### PR DESCRIPTION
# Document the changes in your pull request

yeah so my shitcode makes it so that emitters are perpetually in a "reloading" state where they fire between 2 and 10 seconds unupgraded (normally they shoot 4 shots 2 seconds apart before "reloading" for 2-10 seconds). This obviously makes it so field generators eventually run out of power. Sowwy.

![devil](https://user-images.githubusercontent.com/5091394/163706726-0b0fe667-c9fd-4fd5-bf41-5963eecce609.gif)


# Changelog

:cl:  
bugfix: makes it so emitters arent always "reloading"
/:cl:
