### PR TITLE
Time Requirement for Antags - Malf AIs

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -56,6 +56,8 @@
 	/// Associative list of current players, in order: living players, living antagonists, dead players and observers.
 	var/list/list/current_players = list(CURRENT_LIVING_PLAYERS = list(), CURRENT_LIVING_ANTAGS = list(), CURRENT_DEAD_PLAYERS = list(), CURRENT_OBSERVERS = list())
 
+	var/time_required = 0 // Framework for future setting of required time for antag roles
+
 /datum/game_mode/proc/announce() //Shows the gamemode's name and a fast description.
 	to_chat(world, "<b>The gamemode is: <span class='[announce_span]'>[name]</span>!</b>")
 	to_chat(world, "<b>[announce_text]</b>")

--- a/code/game/gamemodes/malfunction/malf.dm
+++ b/code/game/gamemodes/malfunction/malf.dm
@@ -9,6 +9,7 @@
 	recommended_enemies = 1
 	reroll_friendly = FALSE
 	title_icon = "ss13"
+	exp_requirements = 300
 
 	announce_span = "danger"
 	announce_text = "The station's Artificial Intelligence is rogue!\n\
@@ -20,6 +21,8 @@
 	var/datum/job/ai/job = SSjob.GetJob("AI")
 	for(var/datum/mind/candidate in .)
 		if(is_banned_from(candidate.current.ckey, "AI") || QDELETED(candidate) || !job.player_old_enough(candidate.current.client) || job.required_playtime_remaining(candidate.current.client))
+			. -= candidate
+		if(candidate.current.client.prefs.exp["AI"] < 600) // Cant play AI unless you are over 10 hours.
 			. -= candidate
 	return .
 

--- a/code/game/gamemodes/malfunction/malf.dm
+++ b/code/game/gamemodes/malfunction/malf.dm
@@ -9,7 +9,7 @@
 	recommended_enemies = 1
 	reroll_friendly = FALSE
 	title_icon = "ss13"
-	exp_requirements = 300
+	time_required = 600
 
 	announce_span = "danger"
 	announce_text = "The station's Artificial Intelligence is rogue!\n\
@@ -22,7 +22,7 @@
 	for(var/datum/mind/candidate in .)
 		if(is_banned_from(candidate.current.ckey, "AI") || QDELETED(candidate) || !job.player_old_enough(candidate.current.client) || job.required_playtime_remaining(candidate.current.client))
 			. -= candidate
-		if(candidate.current.client.prefs.exp["AI"] < 600) // Cant play AI unless you are over 10 hours.
+		if(candidate.current.client.prefs.exp["AI"] < time_required) // Cant play AI unless you are over 10 hours.
 			. -= candidate
 	return .
 


### PR DESCRIPTION
Adds time requirement to malf AI of 10 hours of normal AI.

Also adds framework for future antags if we deem they need time requirements.

# Changelog

:cl:  
rscadd: Time requirement for malf AI now 10 hours. 
/:cl:
