### PR TITLE
Makes the explosion bonus for mining double ores instead of adding 2

### DIFF
--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -71,7 +71,7 @@
 /turf/closed/mineral/proc/gets_drilled(mob/user, triggered_by_explosion = FALSE, override_bonus = FALSE)
 	if (mineralType && (mineralAmt > 0))
 		if(triggered_by_explosion && !override_bonus)
-			mineralAmt += 2 //bonus if it was exploded, USE EXPLOSIVES WOOO
+			mineralAmt *= 2 //bonus if it was exploded, USE EXPLOSIVES WOOO
 		new mineralType(src, mineralAmt)
 		SSblackbox.record_feedback("tally", "ore_mined", mineralAmt, mineralType)
 	for(var/obj/effect/temp_visual/mining_overlay/M in src)


### PR DESCRIPTION
# Document the changes in your pull request

From what I can tell the mining charge isn't exactly worth using outside harvesting magmite since it costs 500 points and is more likely than not going to return less than that

This increases the average amount of ores per rock mined with bombs from some smaller amount to some probably larger amount. Since this is reliant on the existing volume of material (which is randomized 1 to 5) it's more efficient to use in dense basalt areas since 1\*2 = 2 but 3\*2 = 6

Whether or not this is actually fair or balanced is debatable

# Wiki Documentation

bonus for mining rocks with explosives changed from +2 to *2

# Changelog

:cl:  
tweak: digging with bombs is now rewarded with a *2 mineral bonus rather than a +2 one
/:cl:
