### PR TITLE
Halves the price of entry to the luxurious shuttle

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -240,8 +240,8 @@
 /datum/map_template/shuttle/emergency/luxury
 	suffix = "luxury"
 	name = "Luxury Shuttle"
-	description = "A luxurious golden shuttle complete with an indoor swimming pool. Each crewmember wishing to board must bring 500 credits, payable in cash and mineral coin."
-	extra_desc = "This shuttle costs 500 credits to board."
+	description = "A luxurious golden shuttle complete with an indoor swimming pool. Each crewmember wishing to board must bring 250 credits, payable in cash and mineral coin."
+	extra_desc = "This shuttle costs 250 credits to board."
 	admin_notes = "Due to the limited space for non paying crew, this shuttle may cause a riot."
 	credit_cost = 50000
 

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -211,7 +211,7 @@
 	locked = TRUE
 	use_power = FALSE
 	resistance_flags = INDESTRUCTIBLE
-	var/threshold = 500
+	var/threshold = 250
 	var/static/list/approved_passengers = list()
 	var/static/list/check_times = list()
 	var/list/payees = list()


### PR DESCRIPTION
# Document the changes made in your pull request

The price to board the luxury escape shuttle is now 250 from 500. 

This change is good for the game because 500 is a steep and stupid price to enter the shuttle, and those who don't pay are locked in a cesspool for 6 minutes. This will still be a high price to enter the shuttle as the only roles that really get this kind of payment are engi, science, sec and command roles, meaning everybody and their mother won't be able to just outright board the shuttle.

# Wiki Documentation



:cl:  
tweak: the luxury shuttle now costs 250 to board instead of 500
/:cl:
