### PR TITLE
Flashbang rebalance: the war on stun combat rages on

### DIFF
--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -15,19 +15,17 @@
 	playsound(flashbang_turf, 'sound/weapons/flashbang.ogg', 100, TRUE, 8, 0.9)
 	new /obj/effect/dummy/lighting_obj (flashbang_turf, LIGHT_COLOR_WHITE, (flashbang_range + 2), 4, 2)
 	for(var/mob/living/M in get_hearers_in_view(flashbang_range, flashbang_turf))
-		if (istype(M.loc, /obj/vehicle/sealed) || istype(M.loc, /obj/mecha)) // being inside a sealed vehicle will dampen the effect enough
-			continue
 		bang(get_turf(M), M)
 	qdel(src)
 
 /obj/item/grenade/flashbang/proc/bang(turf/T , mob/living/M)
-	if(M.stat == DEAD) // They're dead!
+	if(M.stat == DEAD)	//They're dead!
 		return
 	M.show_message(span_userdanger("BANG"), MSG_AUDIBLE)
-	var/distance = max(0, get_dist(get_turf(src), T))
-	if(!distance || get_atom_on_turf(src, /mob) == M)
-		M.Paralyze(20 SECONDS)
-		M.soundbang_act(1, 20, 15, 30)
+	var/distance = max(0,get_dist(get_turf(src),T))
+	if(!distance || loc == M || loc == M.loc)	//Stop allahu akbarring rooms with this.
+		M.Paralyze(200)
+		M.soundbang_act(1, 20, 10, 15)
 		return
 	if(iscyborg(M))
 		var/mob/living/silicon/robot/C = M
@@ -40,10 +38,12 @@
 			addtimer(CALLBACK(C, /mob/living/silicon/robot/.proc/repair_all_cyborg_slots), 3 SECONDS)
 			return
 
-	var/flashed = M.flash_act(affect_silicon = TRUE)
-	var/banged = M.soundbang_act(1, 20 / max(1, distance), rand(0, 5))
-	if (flashed && M.eye_blurry < 2 SECONDS) // you can't stack a shitton of eye blur to half-blind someone for half an hour, sorry!
-		M.blur_eyes(10 SECONDS)
-	if (flashed || banged)
-		M.Knockdown(5 SECONDS)
-		M.Dizzy(flashed && banged ? 10 SECONDS : 5 SECONDS)
+	var/flashed = M.flash_act(affect_silicon = 1)
+	var/banged = M.soundbang_act(1, 20/max(1,distance), rand(0, 5))
+
+	// If missing two resists
+	if(flashed && banged)
+		M.Paralyze(max(150/max(1,distance), 60))
+	// If missing one resist
+	else if (flashed || banged)
+		M.Paralyze(max(50/max(1, distance), 30))

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -15,17 +15,19 @@
 	playsound(flashbang_turf, 'sound/weapons/flashbang.ogg', 100, TRUE, 8, 0.9)
 	new /obj/effect/dummy/lighting_obj (flashbang_turf, LIGHT_COLOR_WHITE, (flashbang_range + 2), 4, 2)
 	for(var/mob/living/M in get_hearers_in_view(flashbang_range, flashbang_turf))
+		if (istype(M.loc, /obj/vehicle/sealed) || istype(M.loc, /obj/mecha)) // being inside a sealed vehicle will dampen the effect enough
+			continue
 		bang(get_turf(M), M)
 	qdel(src)
 
 /obj/item/grenade/flashbang/proc/bang(turf/T , mob/living/M)
-	if(M.stat == DEAD)	//They're dead!
+	if(M.stat == DEAD) // They're dead!
 		return
 	M.show_message(span_userdanger("BANG"), MSG_AUDIBLE)
-	var/distance = max(0,get_dist(get_turf(src),T))
-	if(!distance || loc == M || loc == M.loc)	//Stop allahu akbarring rooms with this.
-		M.Paralyze(200)
-		M.soundbang_act(1, 20, 10, 15)
+	var/distance = max(0, get_dist(get_turf(src), T))
+	if(!distance || get_atom_on_turf(src, /mob) == M)
+		M.Paralyze(20 SECONDS)
+		M.soundbang_act(1, 20, 15, 30)
 		return
 	if(iscyborg(M))
 		var/mob/living/silicon/robot/C = M
@@ -38,12 +40,10 @@
 			addtimer(CALLBACK(C, /mob/living/silicon/robot/.proc/repair_all_cyborg_slots), 3 SECONDS)
 			return
 
-	var/flashed = M.flash_act(affect_silicon = 1)
-	var/banged = M.soundbang_act(1, 20/max(1,distance), rand(0, 5))
-
-	// If missing two resists
-	if(flashed && banged)
-		M.Paralyze(max(150/max(1,distance), 60))
-	// If missing one resist
-	else if (flashed || banged)
-		M.Paralyze(max(50/max(1, distance), 30))
+	var/flashed = M.flash_act(affect_silicon = TRUE)
+	var/banged = M.soundbang_act(1, 20 / max(1, distance), rand(0, 5))
+	if (flashed && M.eye_blurry < 2 SECONDS) // you can't stack a shitton of eye blur to half-blind someone for half an hour, sorry!
+		M.blur_eyes(10 SECONDS)
+	if (flashed || banged)
+		M.Knockdown(5 SECONDS)
+		M.Dizzy(flashed && banged ? 10 SECONDS : 5 SECONDS)

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3391,6 +3391,7 @@
 #include "yogstation\code\game\objects\items\devices\radio\encryptionkey.dm"
 #include "yogstation\code\game\objects\items\devices\radio\headset.dm"
 #include "yogstation\code\game\objects\items\devices\radio\radio.dm"
+#include "yogstation\code\game\objects\items\grenades\flashbang.dm"
 #include "yogstation\code\game\objects\items\grenades\glitterbombs.dm"
 #include "yogstation\code\game\objects\items\holotool\holotool.dm"
 #include "yogstation\code\game\objects\items\holotool\modes.dm"

--- a/yogstation/code/game/objects/items/grenades/flashbang.dm
+++ b/yogstation/code/game/objects/items/grenades/flashbang.dm
@@ -1,0 +1,32 @@
+/obj/item/grenade/flashbang/proc/bang(turf/T , mob/living/M)
+	if (M.stat == DEAD) // They're dead!
+		return
+	if (istype(M.loc, /obj/vehicle/sealed))
+		return
+	if (istype(M.loc, /obj/mecha))
+		var/obj/mecha/mech = M.loc
+		if (mech.enclosed)
+			return
+	M.show_message(span_userdanger("BANG"), MSG_AUDIBLE)
+	var/distance = max(0, get_dist(get_turf(src), T))
+	if (!distance || get_atom_on_turf(src, /mob) == M)
+		M.Paralyze(20 SECONDS)
+		M.soundbang_act(1, 20, 10, 15)
+		return
+	if (iscyborg(M))
+		var/mob/living/silicon/robot/C = M
+		if (C.sensor_protection)					//Do other annoying stuff that isnt a hard stun if they're protected
+			C.overlay_fullscreen("reducedbang", /obj/screen/fullscreen/flash/static)
+			C.uneq_all()
+			C.stop_pulling()
+			C.break_all_cyborg_slots(TRUE)
+			addtimer(CALLBACK(C, /mob/living/silicon/robot/.proc/clear_fullscreen, "reducedbang"), 3 SECONDS)
+			addtimer(CALLBACK(C, /mob/living/silicon/robot/.proc/repair_all_cyborg_slots), 3 SECONDS)
+			return
+	var/flashed = M.flash_act(affect_silicon = TRUE)
+	var/banged = M.soundbang_act(1, 20 / max(1, distance), rand(0, 5))
+	if (flashed && M.eye_blurry < 2 SECONDS) // you can't stack a shitton of eye blur to half-blind someone for half an hour, sorry!
+		M.blur_eyes(10 SECONDS)
+	if (flashed || banged)
+		M.Knockdown(5 SECONDS)
+		M.Dizzy(flashed && banged ? 10 SECONDS : 5 SECONDS)

--- a/yogstation/code/game/objects/items/grenades/flashbang.dm
+++ b/yogstation/code/game/objects/items/grenades/flashbang.dm
@@ -1,4 +1,4 @@
-/obj/item/grenade/flashbang/proc/bang(turf/T , mob/living/M)
+/obj/item/grenade/flashbang/bang(turf/T , mob/living/M)
 	if (M.stat == DEAD) // They're dead!
 		return
 	if (istype(M.loc, /obj/vehicle/sealed))


### PR DESCRIPTION
# Document the changes in your pull request

Flashbangs no longer stun - instead they knock down (no stun) and highly disorient people, making them dizzy and giving them blurry vision.

Also, the penalty for having a flashbang in your hand has been doubled.

# Changelog

:cl: Lucy
tweak: Flashbangs no longer hard-stun.
tweak: Instead, flashbangs knock down and disorient.
tweak: Flashbangs will also mess up someone's vision for a good bit, making it hard for them to see what they're doing, even after the initial bang.
tweak: You can't flashbang a sealed mech anymore.
/:cl:
