### PR TITLE
[Admin] Refactors the "Check AI Laws" adminverb to actually work and look nice

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -804,7 +804,7 @@
 	message_admins(span_adminnotice("[key_name_admin(usr)] toggled guests game entering [!new_guest_ban ? "" : "dis"]allowed."))
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Guests", "[!new_guest_ban ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-/datum/admins/proc/output_ai_laws()
+/datum/admins/proc/output_ai_laws() // Yogs -- Overridden in yogstation/code/modules/admin/admin.dm
 	var/ai_number = 0
 	for(var/i in GLOB.silicon_mobs)
 		var/mob/living/silicon/S = i

--- a/yogstation/code/modules/admin/admin.dm
+++ b/yogstation/code/modules/admin/admin.dm
@@ -25,3 +25,48 @@
 	log_admin("[key_name(usr)] toggled Dead LOOC.")
 	message_admins("[key_name_admin(usr)] toggled Dead LOOC.")
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Dead LOOC", "[GLOB.dlooc_allowed ? "Enabled" : "Disabled"]"))
+
+/datum/admins/output_ai_laws() // Proc override
+	if(!GLOB.silicon_mobs.len)
+		to_chat(usr, span_adminnotice("No silicons located.") , confidential=TRUE)
+		return
+	to_chat_immediate(usr,span_admin("Silicon Laws:"))
+	for(var/i in GLOB.silicon_mobs)
+		var/mob/living/silicon/S = i
+		var/msg = span_adminnotice("[key_name(S,usr)] laws:")
+		var/do_show_laws = TRUE
+		if(isAI(S))
+			msg = span_adminnotice("<font color='tomato'>AI</font> [key_name(S,usr)] laws:")
+		else if(isAIShell(S)) // done separately from cyborgs since it's a bit of a snowflake case
+			var/mob/living/silicon/robot/R = S
+			do_show_laws = FALSE
+			if(R.connected_ai)
+				msg = span_adminnotice("<font color='tomato'>AI SHELL</font> [key_name(S,usr)] laws are synced with [R.connected_ai].")
+			else if(S.ckey) // wtf??
+				msg = span_adminnotice("<font color='tomato'>AI SHELL</font> [key_name(S,usr)] is not properly connected to the AI that controls it. Laws:")
+				do_show_laws = TRUE
+			else
+				msg = span_adminnotice("<font color='tomato'>AI SHELL</font> [S] is empty.")
+		else if(iscyborg(S))
+			var/mob/living/silicon/robot/R = S
+			if(R.connected_ai)
+				if(R.lawupdate)
+					msg = span_adminnotice("<font color='tomato'>CYBORG</font> [key_name(S,usr)] laws are synced with [R.connected_ai].")
+					do_show_laws = FALSE
+				else
+					msg = span_adminnotice("<font color='tomato'>CYBORG</font> [key_name(S,usr)] is <font color='tomato'>desynced</font> but enslaved to [R.connected_ai], with following laws:")
+			else
+				msg = span_adminnotice("<font color='tomato'>CYBORG</font> [key_name(S,usr)] is <font color='white'>independent</font> with following laws:")
+		else if (ispAI(S))
+			msg = span_adminnotice("<font color='tomato'>pAI</font> [key_name(S, usr)] laws:")
+		to_chat_immediate(usr,msg, confidential=TRUE) // Say the first message
+		if(do_show_laws) // now the laws
+			if(!S.laws)
+				to_chat_immediate(usr,span_adminnotice("Silicon has no laws datum. Probably a bug?"), confidential=TRUE)
+				continue
+			var/list/printable_laws = S.laws.get_law_list(include_zeroth = TRUE)
+			if(!printable_laws.len)
+				to_chat_immediate(usr,span_warning("Lawset has no laws."), confidential=TRUE)
+				continue
+			for(var/law in printable_laws)
+				to_chat_immediate(usr,span_notice(law), confidential=TRUE) // We use to_chat_immediate to make sure that no batching takes place between identical lawsets.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/163917744-53f0f086-5cab-4c52-af86-770ab82a285f.png)
## Summary
Fixes #13775.

I traced the "no apparent lawset" problem down to an issue with this function using ``to_chat``. Lawsets which were identical would be batched together into one of those funky "x2" or "x3" combo messages, which would mess up the order and cause some AIs to seemingly have no laws.

The secondary issue, with cyborgs seemingly being improperly shown as synced, comes from the fact that this function was not really caring about the state of ``lawupdate``, which can cause lawset desync with cyborgs which are otherwise enslaved to an AI. That was also fixed.

In general, the verb now gives a nicer-looking, human-legible output. :)

## Changelog
:cl: Altoids
bugfix: Admins are no longer informed that you have no laws as an AI just because you have an AI shell or enslaved cyborg.
bugfix: Admins are no longer convinced that you, as a cyborg, are entirely synced and enslaved to an AI when you are not.
spellcheck: Admins will now have a more enjoyable UX when determining that you should be a better doorknob as an AI.
/:cl: