### PR TITLE
Adds a forgor clause to heretic sacrifices

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -399,7 +399,7 @@
 
 /datum/status_effect/brazil_penance/on_remove()
 	. = ..()
-	to_chat(owner, "<span class='revenbignotice'>You suddenly snap back to something familiar.</span>")
+	to_chat(owner, "<span class='revenbignotice'>You suddenly snap back to something familiar, with no recollection of your death prior to entering that strange place.</span>")
 	owner.Unconscious(2 SECONDS, ignore_canstun = TRUE)
 	var/turf/safe_turf = get_safe_random_station_turf(typesof(/area/hallway) - typesof(/area/hallway/secondary)) //teleport back into a main hallway, secondary hallways include botany's techfab room which could trap someone
 	if(safe_turf)


### PR DESCRIPTION
# Document the changes in your pull request

This is probanly required

:cl:  
tweak: being sacrificed by a heretic now prevents you from remembering the dying to a heretic part
/:cl:
