### PR TITLE
Fixes Empaths not being able to detect deafness when it is temporary

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -331,8 +331,11 @@
 					SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "empath", /datum/mood_event/sad_empath, src)
 				if (HAS_TRAIT(src, TRAIT_BLIND))
 					msg += "[t_He] appear[p_s()] to be staring off into space.\n"
-				if (HAS_TRAIT(src, TRAIT_DEAF))
+				//Yogs -- Fixing being unable to detect some varieties of deafness
+				var/obj/item/organ/ears/ears = src.getorganslot(ORGAN_SLOT_EARS)
+				if (HAS_TRAIT(src, TRAIT_DEAF) || !istype(ears) || ears.deaf)
 					msg += "[t_He] appear[p_s()] to not be responding to noises.\n"
+				//Yogs end
 
 			msg += "</span>"
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/164153740-2d03294f-feb0-41ef-a091-c3eb0ad48892.png)

## Summary

Fixes #13786.

The issue seems to have been a gotcha in the organ code where there are actually two things that control deafness: a trait called TRAIT_DEAF which is for long-term or permanent deafness, and a variable in the ear, `ear.deaf`, which keeps track of temporary deafness frames. The Empath code was checking for the former but not the latter.

*Note: the attached bug report makes reference to blindness checks also not working, but I couldn't replicate it and couldn't see any issue with that code on-inspection. I'm still attaching a "fixes" here under the belief that such secondary bug doesn't actually exist.*

## Changelog
:cl: Altoids
bugfix: Empaths are now better at using their amazing abilities to notice that security has given you flashbang-induced deafness for the umpteenth time.
/:cl:
