### PR TITLE
Cut cult stun times in half

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -458,7 +458,7 @@
 					L.adjustBruteLoss(30)
 			else if(cult.cult_risen)
 				to_chat(user, span_cultitalic("In a dull flash of red, [L] falls to the ground!"))
-				L.Paralyze(80)
+				L.Paralyze(40) //YOGS: 80 to 40
 				L.flash_act(1,1)
 				if(issilicon(target))
 					var/mob/living/silicon/S = L
@@ -473,7 +473,7 @@
 					L.adjustBruteLoss(20)
 			else
 				to_chat(user, span_cultitalic("In a brilliant flash of red, [L] falls to the ground!"))
-				L.Paralyze(160)
+				L.Paralyze(80) //YOGS: 160 to 80
 				L.flash_act(1,1)
 				if(issilicon(target))
 					var/mob/living/silicon/S = L


### PR DESCRIPTION
# If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md


# Document the changes in your pull request
I cut cult stun times in half. You can already stack stuns with cult so you can stun someone for a full minute with change before changes, and we are moving away from hard stuns anyways. This leaves plenty of time to cuff and take off a headset, which was intended behaviour instead of dragging straight to a conversion rune after stacking 4 stun spells. This will make it easier to balance in future.

# Wiki Documentation
Cult stun times have been cut in half.

# Changelog

:cl: 
tweak: Cut cult stun times in half.
/:cl:
