### PR TITLE
Abductor baton hardstun nerf

### DIFF
--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -498,7 +498,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	L.lastattacker = user.real_name
 	L.lastattackerckey = user.ckey
 
-	L.Paralyze(140)
+	L.Knockdown(140) //YOGS: Paralyze to Knockdown
 	L.apply_effect(EFFECT_STUTTER, 7)
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK)
 
@@ -513,7 +513,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	log_combat(user, L, "stunned")
 
 /obj/item/abductor/baton/proc/SleepAttack(mob/living/L,mob/living/user)
-	if(L.incapacitated(TRUE, TRUE))
+	if(L.incapacitated(TRUE, TRUE) || L.IsKnockdown()) //YOGS: Add || L.IsKnockdown, replacing hard stun with knockdown.
 		if(L.anti_magic_check(FALSE, FALSE, TRUE))
 			to_chat(user, span_warning("The specimen's tinfoil protection is interfering with the sleep inducement!"))
 			L.visible_message(span_danger("[user] tried to induced sleep in [L] with [src], but [L.p_their()] tinfoil protection [L.p_them()]!"), \


### PR DESCRIPTION
# Document the changes in your pull request

Abductors have always been one of the more frustrating antagonists to play against because of their instant-win stick, and with the recent changes to hard stuns I thought I'd do the same to abductors. They still have a good baton, it just takes two hits because you need to put them to sleep, leaving you room for counterplay to get away from the abductor or alert the crew since it is no longer a hard stun, but it is also not overly punishing on abductors either.

# Wiki Documentation

The stun mode on abductor batons doesn't paralyze, only knocks down.

# Changelog
:cl:  
tweak: Abductor batons no longer hard stun but only knockdown.
/:cl:
