### PR TITLE
Xenomorph stun nerf

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -70,7 +70,7 @@
 					blocked = TRUE
 			if(!blocked)
 				L.visible_message("<span class ='danger'>[src] pounces on [L]!</span>", "<span class ='userdanger'>[src] pounces on you!</span>")
-				L.Paralyze(100)
+				L.Knockdown(100) //YOGS: Replace Paralyze with Knockdown
 				sleep(2)//Runtime prevention (infinite bump() calls on hulks)
 				step_towards(src,L)
 			else

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -71,6 +71,7 @@
 			if(!blocked)
 				L.visible_message("<span class ='danger'>[src] pounces on [L]!</span>", "<span class ='userdanger'>[src] pounces on you!</span>")
 				L.Knockdown(100) //YOGS: Replace Paralyze with Knockdown
+				L.Paralyze(1)
 				sleep(2)//Runtime prevention (infinite bump() calls on hulks)
 				step_towards(src,L)
 			else

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -184,7 +184,10 @@
 
 	if(!sterile)
 		M.take_bodypart_damage(strength,0) //done here so that humans in helmets take damage
-		M.Unconscious(MAX_IMPREGNATION_TIME/0.3) //something like 25 ticks = 20 seconds with the default settings
+		/*YOGS START*/
+		M.Knockdown(MAX_IMPREGNATION_TIME/0.3) //something like 25 ticks = 20 seconds with the default settings 
+		M.Stun(30) //So you get a chance to disarm them and drag them back to your nest
+		/*YOGS END*/
 
 	GoIdle() //so it doesn't jump the people that tear it off
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -324,9 +324,9 @@
 					return
 				playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
 				if(armour > 0)
-					Paralyze(50 + armour)
+					Knockdown(50 + armour)
 				else
-					Paralyze(50)
+					Knockdown(50)
 				//yogs end
 				log_combat(M, src, "tackled")
 				visible_message(span_danger("[M] has tackled down [src]!"), \

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -327,6 +327,7 @@
 					Knockdown(50 + armour)
 				else
 					Knockdown(50)
+				adjustStaminaLoss(35) //3 hits until they are stunned.	
 				//yogs end
 				log_combat(M, src, "tackled")
 				visible_message(span_danger("[M] has tackled down [src]!"), \

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3707,6 +3707,7 @@
 #include "yogstation\code\modules\projectiles\boxes_magazines\internal\misc.dm"
 #include "yogstation\code\modules\projectiles\guns\ballistic\launchers.dm"
 #include "yogstation\code\modules\projectiles\projectile\beams.dm"
+#include "yogstation\code\modules\projectiles\projectile\special\neurotoxin.dm"
 #include "yogstation\code\modules\projectiles\reusable\kineticspear.dm"
 #include "yogstation\code\modules\reagents\chemistry\reagents\alcohol_reagents.dm"
 #include "yogstation\code\modules\reagents\chemistry\reagents\food_reagents.dm"

--- a/yogstation/code/modules/projectiles/projectile/special/neurotoxin.dm
+++ b/yogstation/code/modules/projectiles/projectile/special/neurotoxin.dm
@@ -1,0 +1,8 @@
+/obj/item/projectile/bullet/neurotoxin
+	knockdown = 100
+
+/obj/item/projectile/bullet/neurotoxin/on_hit(atom/target, blocked = FALSE)
+	if(isalien(target))
+		knockdown = 0
+		nodamage = TRUE
+	return ..()


### PR DESCRIPTION
# Document the changes in your pull request

Xenomorphs have always been controversial and considered overpowered, with extremely lethal powers as well as extremely lethal stuns. This will encourage cooperation between alien hunters and other castes as they may have to work together to take down a heavily armed member of the crew instead of being a one man army. Some of these stuns were just ridiculous.

# Wiki Documentation
Most xenomorph stuns have been replaced with soft stuns.

# Changelog

:cl:  
tweak: Most xenomorph stuns replaced with soft stuns.
/:cl:
