### PR TITLE
Zombie nerf

### DIFF
--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3775,5 +3775,6 @@
 #include "yogstation\code\modules\webhook\webhook.dm"
 #include "yogstation\code\modules\xenoarch\loot\gigadrill.dm"
 #include "yogstation\code\modules\xenoarch\loot\guns.dm"
+#include "yogstation\code\modules\zombie\items.dm"
 #include "yogstation\interface\interface.dm"
 // END_INCLUDE

--- a/yogstation/code/modules/zombie/items.dm
+++ b/yogstation/code/modules/zombie/items.dm
@@ -1,0 +1,2 @@
+/obj/item/zombie_hand
+	infect_chance = 50

--- a/yogstation/code/modules/zombie/items.dm
+++ b/yogstation/code/modules/zombie/items.dm
@@ -1,2 +1,2 @@
 /obj/item/zombie_hand
-	infect_chance = 50
+	infect_chance = 60


### PR DESCRIPTION
# Document the changes in your pull request

Due to their 100% infection rate, zombies snowball extremely quickly with most security members being completely overwhelmed. I have changed it to 60% so that medbay is not overwhelmed, but you can still infect dead bodies. This additionally opens up riot armor as viable for security because it only gives you a 10% chance of being infected allowing you to take more damage from zombies before becoming infected, making it more of a war against zombies and not "Oh I missed the first zombie and he infected 2 people, we're doomed." I hope to see longer rounds when zombies are in play.

# Wiki Documentation
Zombies only have a 60% chance to infect

# Changelog

:cl:  
tweak: Zombies only have a 60% chance to infect
/:cl:
