### PR TITLE
Traitor item cost rebalance

### DIFF
--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -54,6 +54,9 @@
 /datum/uplink_item/stealthy_weapons/dart_pistol
 	cost = 2
 
+/datum/uplink_item/explosives/pizza_bomb
+	cost = 2
+
 //////////////////////////
 /////////New Items////////
 //////////////////////////

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -68,6 +68,9 @@
 
 /datum/uplink_item/race_restricted/flyingfang
 	cost = 16
+
+/datum/uplink_item/device_tools/surgerybag
+	cost = 1
 //////////////////////////
 /////////New Items////////
 //////////////////////////

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -65,6 +65,9 @@
 
 /datum/uplink_item/implants/stealthimplant
 	cost = 5
+
+/datum/uplink_item/race_restricted/flyingfang
+	cost = 16
 //////////////////////////
 /////////New Items////////
 //////////////////////////

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -60,6 +60,9 @@
 /datum/uplink_item/stealthy_tools/chameleon
 	cost = 1
 
+/datum/uplink_item/device_tools/rad_laser
+	cost = 3
+
 //////////////////////////
 /////////New Items////////
 //////////////////////////

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -71,6 +71,9 @@
 
 /datum/uplink_item/device_tools/surgerybag
 	cost = 1
+
+/datum/uplink_item/stealthy_tools/jammer
+	cost = 3
 //////////////////////////
 /////////New Items////////
 //////////////////////////

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -74,6 +74,12 @@
 
 /datum/uplink_item/stealthy_tools/jammer
 	cost = 3
+
+/datum/uplink_item/stealthy_weapons/combatglovesplus
+	cost = 2
+
+/datum/uplink_item/dangerous/throwingweapons
+	cost = 2
 //////////////////////////
 /////////New Items////////
 //////////////////////////

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -48,6 +48,12 @@
 /datum/uplink_item/device_tools/fakenucleardisk
 	surplus_nullcrates = 0
 
+/datum/uplink_item/suits/space_suit
+	cost = 1
+
+/datum/uplink_item/stealthy_weapons/dart_pistol
+	cost = 2
+
 //////////////////////////
 /////////New Items////////
 //////////////////////////

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -57,6 +57,9 @@
 /datum/uplink_item/explosives/pizza_bomb
 	cost = 2
 
+/datum/uplink_item/stealthy_tools/chameleon
+	cost = 1
+
 //////////////////////////
 /////////New Items////////
 //////////////////////////

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -80,6 +80,11 @@
 
 /datum/uplink_item/dangerous/throwingweapons
 	cost = 2
+
+/datum/uplink_item/dangerous/doublesword
+	cost = 18
+
+
 //////////////////////////
 /////////New Items////////
 //////////////////////////

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -63,6 +63,8 @@
 /datum/uplink_item/device_tools/rad_laser
 	cost = 3
 
+/datum/uplink_item/implants/stealthimplant
+	cost = 5
 //////////////////////////
 /////////New Items////////
 //////////////////////////


### PR DESCRIPTION
# Document the changes in your pull request
Many of these items are criminally underused, and it's no mistake that they happen to be the stealthy items. Most times that there are traitors, they are mostly going loud with CQC, martial arts and e-swords and emagging everything in sight whereas I would be happier to encourage stealthier gameplay and I have chosen to do this by decreasing the cost of items that are underused because they're stealth items and increased the cost for obvious items that are murderboney, to penalise players who go loud and encourage players who stay quiet. I especially like some of the roleplay items such as pizza bomb.

# Wiki Documentation

Dart pistol TC from 4 to 2, space suit from 4 to 1.
Pizza bomb from 6!!! TC to 2
Chameleon kit from 2 TC to 1. 
Rad laser from 4 to 3
Stealth implant, 8 TC to 5.
Flying Fang from 14 to 16
Surgery kit from 2 TC to 1.
Radio jammer from 5 TC to 3 TC. 
Throwing weapons, 3 to 2 TC
Double esword, 16 to 18 TC

# Changelog

:cl:  
tweak: Traitor item costs have been rebalanced.
tweak: Dart pistol TC from 4 to 2, space suit from 4 to 1.
tweak: Pizza bomb from 6!!! TC to 2
tweak: Chameleon kit from 2 TC to 1. 
tweak: Rad laser from 4 to 3
tweak: Stealth implant, 8 TC to 5.
tweak: Flying Fang from 14 to 16
tweak: Surgery kit from 2 TC to 1.
tweak: Radio jammer from 5 TC to 3 TC. 
tweak: Throwing weapons, 3 to 2 TC
tweak: Double esword, 16 to 18 TC
/:cl:
