### PR TITLE
Vampire rebalance

### DIFF
--- a/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -417,6 +417,7 @@
 	blood_used = 30
 	action_background_icon_state = "bg_demon"
 	vamp_req = TRUE
+	jaunt_duration = 20
 
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/mistform/Initialize()
 	. = ..()

--- a/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -373,7 +373,6 @@
 				C.Knockdown(40)
 				C.adjustEarDamage(0, 30)
 				C.stuttering = 30
-				C.Paralyze(40)
 				C.Jitter(150)
 	for(var/obj/structure/window/W in view(4))
 		W.take_damage(75)

--- a/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -461,7 +461,7 @@
 			if(!do_mob(user, target, 70))
 				to_chat(user, span_danger("The pact has failed! [target] has not became a vampire."))
 				to_chat(target, span_notice("The visions stop, and you relax."))
-				vamp.usable_blood += blood_used / 2	// Refund half the cost
+				vamp.usable_blood += blood_used	// Refund half the cost
 				return
 		if(!QDELETED(user) && !QDELETED(target))
 			to_chat(user, span_notice(". . ."))

--- a/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -425,13 +425,13 @@
 
 
 /obj/effect/proc_holder/spell/targeted/vampirize
-	name = "Lilith's Pact (300)"
+	name = "Lilith's Pact (200)"
 	desc = "You drain a victim's blood, and fill them with new blood, blessed by Lilith, turning them into a new vampire."
 	gain_desc = "You have gained the ability to force someone, given time, to become a vampire."
 	action_icon = 'yogstation/icons/mob/vampire.dmi'
 	action_background_icon_state = "bg_demon"
 	action_icon_state = "oath"
-	blood_used = 300
+	blood_used = 200
 	vamp_req = TRUE
 
 /obj/effect/proc_holder/spell/targeted/vampirize/cast(list/targets, mob/user = usr)


### PR DESCRIPTION
# Document the changes in your pull request
To encourage thralling and to discourage facing security head on and being loud, I have rebalanced vampire. I have changed the following:
Mist Form now only lasts 2 seconds from 5, which was the exact same as the Wizard's jaunt including cooldown for only 30 blood.
Lilith's Pact went from 300 blood to 200 because I would like to encourage creating more vampires to get more people actively involved in the conflict and the round.
Chiropteran Screech has had the hard stun removed because it already has knockdown.

# Wiki Documentation
Lilith's Pact is now 200 blood.

# Changelog

:cl:  
tweak: Lilith's Pact is now 200 blood.
tweak: Chiropteran Screech now no longer hard stuns
tweak: Mist Form only lasts 2 seconds from 5.
/:cl:
