### PR TITLE
Clockwork rebalance

### DIFF
--- a/code/__DEFINES/clockcult.dm
+++ b/code/__DEFINES/clockcult.dm
@@ -104,7 +104,7 @@ GLOBAL_LIST_EMPTY(all_scripture)
 
 //Eminence defines
 /// How many walls can be superheated at once
-#define SUPERHEATED_CLOCKWORK_WALL_LIMIT 20
+#define SUPERHEATED_CLOCKWORK_WALL_LIMIT 30
 
 //misc clockcult stuff
 

--- a/code/modules/antagonists/clockcult/clock_items/integration_cog.dm
+++ b/code/modules/antagonists/clockcult/clock_items/integration_cog.dm
@@ -33,7 +33,7 @@
 		var/power_adjust = watts_per_second / 5
 		var/obj/item/stock_parts/cell/cell = apc.cell
 		if(cell && (cell.charge / cell.maxcharge > COG_MAX_SIPHON_THRESHOLD))
-			cell.use(1)
+			cell.use(2)
 			adjust_clockwork_power(power_adjust) //Power is shared, so only do it once; this runs very quickly so it's about 10 W/second
 			
 		else

--- a/code/modules/antagonists/clockcult/clock_items/integration_cog.dm
+++ b/code/modules/antagonists/clockcult/clock_items/integration_cog.dm
@@ -6,12 +6,14 @@
 	desc = "A small cogwheel that fits in the palm of your hand."
 	clockwork_desc = "A small cogwheel that can be inserted into an open APC to siphon power from it passively.<br>\
 	<span class='brass'>It can be used on a locked APC to open its cover!</span><br>\
-	<span class='brass'>Siphons <b>10 W</b> of power per second while in a powered APC.</span><br>\
-	<span class='brass'>Siphons <b>5 W</b> of power per second while in an unpowered APC.</span>"
+	<span class='brass'>Siphons <b>20 W</b> of power per second while in a powered APC.</span><br>\
+	<span class='brass'>Siphons <b>10 W</b> of power per second while in an unpowered APC.</span>"
 	icon_state = "wall_gear"
 	w_class = WEIGHT_CLASS_TINY
 	item_flags = NOBLUDGEON
 	var/obj/machinery/power/apc/apc
+	var/watts_per_second = 20
+	var/depowered_multiplier = 0.5
 
 /obj/item/clockwork/integration_cog/Initialize()
 	. = ..()
@@ -28,11 +30,13 @@
 		else
 			STOP_PROCESSING(SSfastprocess, src)
 	else
+		var/power_adjust = watts_per_second / 5
 		var/obj/item/stock_parts/cell/cell = apc.cell
 		if(cell && (cell.charge / cell.maxcharge > COG_MAX_SIPHON_THRESHOLD))
 			cell.use(1)
-			adjust_clockwork_power(2) //Power is shared, so only do it once; this runs very quickly so it's about 10 W/second
+			adjust_clockwork_power(power_adjust) //Power is shared, so only do it once; this runs very quickly so it's about 10 W/second
+			
 		else
-			adjust_clockwork_power(1) //Continue generating power when the cell has run dry; 5 W/second
+			adjust_clockwork_power(power_adjust * depowered_multiplier) //Continue generating power when the cell has run dry; 5 W/second
 
 #undef COG_MAX_SIPHON_THRESHOLD

--- a/code/modules/antagonists/clockcult/clock_items/judicial_visor.dm
+++ b/code/modules/antagonists/clockcult/clock_items/judicial_visor.dm
@@ -196,7 +196,7 @@
 				L.visible_message(span_warning("Strange energy flows into [L]'s [I.name]!"), \
 				span_userdanger("Your [I.name] shields you from [src]!"))
 			continue
-		L.Paralyze(15) //knocks down briefly when exploding
+		L.Knockdown(50) //knocks down briefly when exploding
 		if(!iscultist(L))
 			L.visible_message(span_warning("[L] is struck by a judicial explosion!"), \
 			span_userdanger("[!issilicon(L) ? "An unseen force slams you into the ground!" : "ERROR: Motor servos disabled by external source!"]"))

--- a/code/modules/antagonists/clockcult/clock_items/judicial_visor.dm
+++ b/code/modules/antagonists/clockcult/clock_items/judicial_visor.dm
@@ -196,7 +196,7 @@
 				L.visible_message(span_warning("Strange energy flows into [L]'s [I.name]!"), \
 				span_userdanger("Your [I.name] shields you from [src]!"))
 			continue
-		L.Knockdown(50) //knocks down briefly when exploding
+		L.Paralyze(15) //knocks down briefly when exploding
 		if(!iscultist(L))
 			L.visible_message(span_warning("[L] is struck by a judicial explosion!"), \
 			span_userdanger("[!issilicon(L) ? "An unseen force slams you into the ground!" : "ERROR: Motor servos disabled by external source!"]"))


### PR DESCRIPTION
# Document the changes in your pull request

Clockwork cult have a low win rate and I believe this is due to the fact that stargazers are gone so power is usually low because there is no alternative, which means less defenses and less marauders. I also believe the visor is somewhat of a noob trap because it does not really do that much overall, too easy to avoid and even if you don't avoid it, it only does 20 damage and 1.5 second stun. I also increased the superheated wall limit to help counter hulks and mechs who usually crush cults under feet, but this might be because the cult has an eminence so I am thinking about making it auto activate.

I might also add a way to convert the new AI system

# Wiki Documentation
Integration cogs now give double the power

# Changelog

:cl:  
tweak: 10 more superheated walls for clockcult
tweak: Integration cogs give double the power
/:cl:
