### PR TITLE
Making holes in the SM chamber will provide a lot of +*=FUN=*+

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -82,6 +82,8 @@
 #define SUPERMATTER_COUNTDOWN_TIME 30 SECONDS
 #define SUPERMATTER_ACCENT_SOUND_MIN_COOLDOWN 2 SECONDS ///to prevent accent sounds from layering
 
+#define MAX_SPACE_EXPOSURE_DAMAGE 2
+
 GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 /obj/machinery/power/supermatter_crystal
@@ -441,7 +443,26 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			if(combined_gas < MOLE_PENALTY_THRESHOLD)
 				damage = max(damage + (min(removed.return_temperature() - (T0C + HEAT_PENALTY_THRESHOLD), 0) / 150 ), 0)
 
-			//capping damage
+			//Check for holes in the SM inner chamber
+			for(var/t in RANGE_TURFS(1, loc))
+				if(!isspaceturf(t))
+					continue
+				var/turf/turf_to_check = t
+				if(LAZYLEN(turf_to_check.atmos_adjacent_turfs))
+					var/integrity = get_integrity()
+					if(integrity < 10)
+						damage += clamp((power * 0.0005) * DAMAGE_INCREASE_MULTIPLIER, 0, MAX_SPACE_EXPOSURE_DAMAGE)
+					else if(integrity < 25)
+						damage += clamp((power * 0.0009) * DAMAGE_INCREASE_MULTIPLIER, 0, MAX_SPACE_EXPOSURE_DAMAGE)
+					else if(integrity < 45)
+						damage += clamp((power * 0.005) * DAMAGE_INCREASE_MULTIPLIER, 0, MAX_SPACE_EXPOSURE_DAMAGE)
+					else if(integrity < 75)
+						damage += clamp((power * 0.002) * DAMAGE_INCREASE_MULTIPLIER, 0, MAX_SPACE_EXPOSURE_DAMAGE)
+					break
+			//caps damage rate
+
+			//Takes the lower number between archived damage + (1.8) and damage
+			//This means we can only deal 1.8 damage per function call
 			damage = min(damage_archived + (DAMAGE_HARDCAP * explosion_point),damage)
 
 


### PR DESCRIPTION
Making a hole in the supermatter chamber to vent it and so to slow down the delamination will instead make the delamination way faster, more so if the SM power is very high and the power level is high too.

Fix an old unintended feature where you could just vent to space the SM chamber to slow down or even stop a delamination (sometimes you could just make a hole in the chamber and it would stabilize while delaminating), the SM is easily fixable just by looking at the pipe and the meters, no need to vent to space. (Lemons note, in some cases a vent to space is needed,  but it should not be a long term thing)

# Document the changes in your pull request

Port of https://github.com/tgstation/tgstation/pull/53725
Finally removes the supermatter cheese of if delam, then space

# Wiki Documentation
Do not space the supermatter anymore

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl: Ghilker
rscadd: SM will now delaminate faster if exposed to space
/:cl:
