### PR TITLE
Nerfs Large Ebow

### DIFF
--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -14,4 +14,4 @@
 	icon_state = "candy_corn"
 
 /obj/item/projectile/energy/bolt/large
-	damage = 40
+	damage = 20


### PR DESCRIPTION


# Document the changes in your pull request

This pr nerfs large ebows, having a 40 toxin damage normal sized item that has infinite ammo and does stamina damage is overpowered. you can't easily deal with toxin damage and its quite lethal for a sec weapon.


# Wiki Documentation
Update damage value for the large ebow.

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
tweak: large ebow now does 20 damage instead of 40. 

/:cl:
