### PR TITLE
blood/vomitcrawlers no longer prevent hijack while crawling

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -271,6 +271,8 @@
 	for(var/mob/living/player in GLOB.player_list)
 		if(player.mind)
 			if(player.stat != DEAD)
+				if(istype(player.loc, /obj/effect/dummy/crawling))
+					continue
 				if(issilicon(player)) //Borgs are technically dead anyways
 					continue
 				if(isanimal(player)) //animals don't count


### PR DESCRIPTION
# Document the changes in your pull request

This is a miner nerf so you all have to agree to it

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
tweak: crawling inside blood or vomit prevents you from counting against hijack
/:cl:
