### PR TITLE
Radaway renamed to Rad Scrub Plus

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_cafe_of_broken_dreams.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_cafe_of_broken_dreams.dmm
@@ -58,8 +58,8 @@
 /turf/open/floor/wood,
 /area/ruin/powered)
 "aF" = (
-/obj/item/reagent_containers/glass/bottle/radaway{
-	desc = "War. War never changes. But this can take away your radiation problems!";
+/obj/item/reagent_containers/glass/bottle/radscrub{
+	desc = "War. War never changes. But this can clean your radiation contamination problems!";
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1757,7 +1757,7 @@
 
 /datum/reagent/medicine/radscrub
 	name = "Rad Scrub Plus"
-	description = "Are your chairs, tables, bottles and assitants glowing green? Spray em down Donk Co's new patented cleaner, Rad Scrub Plus! WARNING: SWALLOWING OR INGESTING RAD SCRUB PLUS MAY RESULT IN LOSS OF BREATH, CANCER, OR MESOTHELIOMA"
+	description = "Are your chairs, tables, bottles and assitants glowing green? Spray em down Donk Co's new patented cleaner, Rad Scrub Plus! WARNING: SWALLOWING OR INGESTING RAD SCRUB PLUS MAY RESULT NAUSUA, POISONING, OR MESOTHELIOMA"
 	color = "#9f5a2f"
 	var/old_insulation = RAD_NO_INSULATION
 	taste_description = "metallic dust"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1755,36 +1755,36 @@
 				continue
 			movable_content.wash(clean_types)
 
-/datum/reagent/medicine/radaway
-	name = "RadAway"
-	description = "A potent but toxic chemical solution that binds with radioactive particles and render them inert. Applying this through spray or smoke will cleanse contaminanted surfaces."
+/datum/reagent/medicine/radscrub
+	name = "Rad Scrub Plus"
+	description = "Are your chairs, tables, bottles and assitants glowing green? Spray em down Donk Co's new patented cleaner, Rad Scrub Plus! WARNING: SWALLOWING OR INGESTING RAD SCRUB PLUS MAY RESULT IN LOSS OF BREATH, CANCER, OR MESOTHELIOMA"
 	color = "#9f5a2f"
 	var/old_insulation = RAD_NO_INSULATION
 	taste_description = "metallic dust"
 	self_consuming = TRUE
 
-/datum/reagent/medicine/radaway/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
+/datum/reagent/medicine/radscrub/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	if(method == TOUCH || method == VAPOR)
 		M.wash(CLEAN_RAD) //you only get decontaminated if it's spray based, can't spam out 100 1u pills
 	
-/datum/reagent/medicine/radaway/on_mob_life(mob/living/carbon/M)
+/datum/reagent/medicine/radscrub/on_mob_life(mob/living/carbon/M)
 	M.adjustToxLoss(1*REM, 0)
 	..()
 
-/datum/reagent/medicine/radaway/on_mob_add(mob/living/L)
+/datum/reagent/medicine/radscrub/on_mob_add(mob/living/L)
 	..()
 	//store the person's original insulation so they're only extra protected while it's in their system
 	old_insulation = L.rad_insulation
 	L.rad_insulation = RAD_LIGHT_INSULATION
 
-/datum/reagent/medicine/radaway/on_mob_end_metabolize(mob/living/L)
+/datum/reagent/medicine/radscrub/on_mob_end_metabolize(mob/living/L)
 	L.rad_insulation = old_insulation
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L
 		C.vomit(stun = FALSE) //it binds with the radioactive particles inside you, and they have to come out somehow
 	..()
 	
-/datum/reagent/medicine/radaway/reaction_obj(obj/O, reac_volume)
+/datum/reagent/medicine/radscrub/reaction_obj(obj/O, reac_volume)
 	//scrubs the contamination and applies a light treatment to it to mitigate immediate recontamination
 	var/datum/component/radioactive/radiation = O.GetComponent(/datum/component/radioactive)
 	if(radiation)

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -375,10 +375,10 @@
 	for(var/i in 1 to created_volume)
 		new /obj/item/stack/medical/bone_gel(location)
 
-/datum/chemical_reaction/radaway
-	name = "RadAway"
-	id = /datum/reagent/medicine/radaway
-	results = list(/datum/reagent/medicine/radaway = 3)
+/datum/chemical_reaction/radscrub
+	name = "Rad Scrub Plus"
+	id = /datum/reagent/medicine/radscrub
+	results = list(/datum/reagent/medicine/radscrub = 3)
 	required_reagents = list(/datum/reagent/medicine/potass_iodide = 1, /datum/reagent/space_cleaner = 1, /datum/reagent/medicine/c2/seiver = 1)
 	required_temp = 200
 	is_cold_recipe = 1

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -215,10 +215,10 @@
 	desc = "A small bottle of potassium iodide."
 	list_reagents = list(/datum/reagent/medicine/potass_iodide = 30)
 
-/obj/item/reagent_containers/glass/bottle/radaway
-	name = "RadAway bottle"
-	desc = "A small bottle of RadAway."
-	list_reagents = list(/datum/reagent/medicine/radaway = 30)
+/obj/item/reagent_containers/glass/bottle/radscrub
+	name = "Rad Scrub Plus bottle"
+	desc = "A small bottle of Donk Co's Rad Scrub Plus."
+	list_reagents = list(/datum/reagent/medicine/radscrub = 30)
 
 /obj/item/reagent_containers/glass/bottle/salglu_solution
 	name = "saline-glucose solution bottle"


### PR DESCRIPTION
Radaway made sense at first when it still also helped treat regular radiation, but that effect was cut out, so now i feel like it's misleading because people think it's like the fallout radaway instead of space cleaner for radioactive contamination. Hopefully this rebranding will make it's purpose a bit more evident at a glance

# Wiki Documentation

Radaway rebranded to Rad Scrub Plus (By Donk Co)

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
tweak: Radaway renamed to Rad Scrub Plus, so it's use as a radioactive contamination cleaner is more self-evident
/:cl:
