### PR TITLE
Fixes the radiation disease symptom not properly giving radiation stacks

### DIFF
--- a/code/datums/diseases/advance/symptoms/radiation.dm
+++ b/code/datums/diseases/advance/symptoms/radiation.dm
@@ -52,4 +52,4 @@
 /datum/symptom/radiation/proc/radiate(mob/living/carbon/M, chance)
 	if(prob(chance))
 		to_chat(M, span_danger("You feel a wave of pain throughout your body!"))
-		M.radiation += 4
+		M.rad_act(RAD_BACKGROUND_RADIATION + 4) // Yogs -- being irradiated actually causes radiation damage


### PR DESCRIPTION
## Summary

Fixes #13741.

Problem seems to have been that this symptom was just, like, adding an integer to the mob's radiation stack var, as if anyone is going to check that without you explicitly asking them to via `rad_act()`.

### Changelog
:cl: Altoids
bugfix: The Ionising Cellular Emission disease symptom now properly causes its host to become radioactive, as advertised.
/:cl:
