### PR TITLE
Fixes chester breaking Last Resort when you're dead

### DIFF
--- a/code/modules/antagonists/changeling/powers/headcrab.dm
+++ b/code/modules/antagonists/changeling/powers/headcrab.dm
@@ -7,6 +7,7 @@
 	dna_cost = 1
 	req_human = 1
 	ignores_fakedeath = TRUE
+	req_stat = DEAD
 
 /datum/action/changeling/headcrab/sting_action(mob/user)
 	set waitfor = FALSE


### PR DESCRIPTION
# Document the changes in your pull request

Fixes #13829 

# Wiki Documentation

# Changelog

:cl:  
bugfix: You can once again headslug while dead.
/:cl:
