### PR TITLE
Adds the pie stain back into the maint bedroom

### DIFF
--- a/_maps/RandomRuins/StationRuins/maint/3x3/3x3_naughtyroom.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/3x3/3x3_naughtyroom.dmm
@@ -25,9 +25,10 @@
 /obj/item/clothing/under/schoolgirl/red,
 /turf/open/floor/carpet/purple,
 /area/template_noop)
-"S" = (
+"K" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
+/obj/effect/decal/cleanable/food/pie_smudge,
 /turf/open/floor/carpet/purple,
 /area/template_noop)
 
@@ -38,7 +39,7 @@ e
 "}
 (2,1,1) = {"
 b
-S
+K
 b
 "}
 (3,1,1) = {"


### PR DESCRIPTION
# Document the changes in your pull request

Adds the pie stain back into the maint bedroom

before:
![firefox_UwRPGauhix](https://user-images.githubusercontent.com/48154165/164676728-51d21e65-38c3-4847-b8ee-02151bb358c2.png)

after:
![firefox_qd1vf2boOW](https://user-images.githubusercontent.com/48154165/164676737-ac0e1397-ae5d-4843-b4a2-c9fec051dd20.png)


# Wiki Documentation
nothing

# Changelog

:cl:  
bugfix: Adds the pie stain back into the maint bedroom
/:cl:
