### PR TITLE
inverts a stupid check

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -95,7 +95,7 @@
 
 	//Blood loss still happens in locker, floor stays clean
 	if(isturf(loc) && prob(sqrt(amt)*BLOOD_DRIP_RATE_MOD))
-		add_splatter_floor(loc, (amt >= 10))
+		add_splatter_floor(loc, (amt <= 10))
 
 /mob/living/carbon/human/bleed(amt)
 	amt *= physiology.bleed_mod


### PR DESCRIPTION
# Document the changes in your pull request

turns out the reason you'd bleed big from minor cuts is actually because the check for making a big splat is inverted

# Changelog

:cl:  
bugfix: blood splatters/droplets are now created to the correct severity of the amount of bleeding present
/:cl:
