### PR TITLE
fixes jamie's wires for the singularity/tesla engine on box 

### DIFF
--- a/_maps/RandomRuins/StationRuins/BoxStation/engine_singulo_tesla.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/engine_singulo_tesla.dmm
@@ -1269,7 +1269,7 @@ ad
 Jy
 co
 jA
-bu
+je
 ad
 ad
 ad


### PR DESCRIPTION
# Document the changes in your pull request

where wire

![image](https://user-images.githubusercontent.com/5091394/164879051-b768c977-d442-4d4d-9dd5-928e6f7d8f56.png)


# Changelog

:cl:  
bugfix: adds missing wire to tesla/singularity emitters so it doesn't explode the station
/:cl:
