### PR TITLE
Catgirlification bugfixes

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -897,8 +897,8 @@
 			admin_ticket_log(src, "[key_name(usr)] has modified the species of [src] to [result]") // yogs - Yog Tickets
 			set_species(newtype)
 	if(href_list[VV_HK_PURRBATION] && check_rights(R_SPAWN))
-		if(!ishumanbasic(src))
-			to_chat(usr, "This can only be done to the basic human species at the moment.")
+		if(!ishuman(src))
+			to_chat(usr, "Unfortunately xeno/monkey catgirls are not supported by the codebase yet.")
 			return
 
 		var/success = purrbation_toggle(src)

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -128,18 +128,18 @@
 	if(!silent)
 		to_chat(H, "You are no longer a cat.")
 	if(!ishumanbasic(H)) //not a basic human, nonhumans tend to have different appearances so turning them into humans would be lazy. Give them their normal ears and shit back
-		var/obj/item/organ/decattification = H.dna?.species.mutantears
+		var/obj/item/organ/decattification = H.dna?.species.mutanttail
 		var/old_part = H.getorganslot(ORGAN_SLOT_TAIL)
+		qdel(old_part) //do this here since they potentially don't normally have a tail
 		if(decattification)
 			decattification = new decattification
 			decattification.Insert(H)
-			qdel(old_part)
-		decattification = H.dna?.species.mutanttail
+		decattification = H.dna?.species.mutantears
+		old_part = H.getorganslot(ORGAN_SLOT_EARS)
+		qdel(old_part) //do this here since they potentially don't normally have ears which would SUCK
 		if(decattification)
 			decattification = new decattification
-			old_part = H.getorganslot(ORGAN_SLOT_EARS)
 			decattification.Insert(H)
-			qdel(old_part)
 		return
 
 	H.set_species(/datum/species/human)

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -103,6 +103,8 @@
 
 ///turns our poor spaceman into a CATGIRL. Point and laugh.
 /proc/purrbation_apply(mob/living/carbon/human/H, silent = FALSE)
+	if(iscatperson(H))
+		return
 	if(!silent)
 		to_chat(H, "Something is nya~t right.")
 		playsound(get_turf(H), 'sound/effects/meow1.ogg', 50, 1, -1)
@@ -126,14 +128,16 @@
 	if(!silent)
 		to_chat(H, "You are no longer a cat.")
 	if(!ishumanbasic(H)) //not a basic human, nonhumans tend to have different appearances so turning them into humans would be lazy. Give them their normal ears and shit back
-		var/obj/item/organ/decattification = new H.dna?.species.mutantears
+		var/obj/item/organ/decattification = H.dna?.species.mutantears
+		var/old_part = H.getorganslot(ORGAN_SLOT_TAIL)
 		if(decattification)
-			var/old_part = H.getorganslot(ORGAN_SLOT_TAIL)
+			decattification = new decattification
 			cattification.Insert(H)
 			qdel(old_part)
-		decattification = new H.dna?.species.mutanttail
+		decattification = H.dna?.species.mutanttail
 		if(decattification)
-			var/old_part = H.getorganslot(ORGAN_SLOT_EARS)
+			decattification = new decattification
+			old_part = H.getorganslot(ORGAN_SLOT_EARS)
 			cattification.Insert(H)
 			qdel(old_part)
 		return

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -132,13 +132,13 @@
 		var/old_part = H.getorganslot(ORGAN_SLOT_TAIL)
 		if(decattification)
 			decattification = new decattification
-			cattification.Insert(H)
+			decattification.Insert(H)
 			qdel(old_part)
 		decattification = H.dna?.species.mutanttail
 		if(decattification)
 			decattification = new decattification
 			old_part = H.getorganslot(ORGAN_SLOT_EARS)
-			cattification.Insert(H)
+			decattification.Insert(H)
 			qdel(old_part)
 		return
 

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -92,7 +92,7 @@
 			purrbation_remove(H, silent)
 			return FALSE
 		else
-			purrbation_apply_mutant(H, silent)
+			purrbation_apply(H, silent)
 			return TRUE
 	if(!iscatperson(H))
 		purrbation_apply(H, silent)

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -70,22 +70,30 @@
 		else
 			tail.Remove(H)
 
+///turn everyone into catgirls. Technically not girls specifically but you get the point.
 /proc/mass_purrbation()
 	for(var/M in GLOB.mob_list)
-		if(ishumanbasic(M))
+		if(ishuman(M))
 			purrbation_apply(M)
 		CHECK_TICK
 
+///turn all catgirls back
 /proc/mass_remove_purrbation()
 	for(var/M in GLOB.mob_list)
-		if(ishumanbasic(M))
+		if(ishuman(M))
 			purrbation_remove(M)
 		CHECK_TICK
 
+///used to transmogrificate spacemen into or from catboys/girls. Arguments H = target spaceman and silent = TRUE/FALSE whether or not we alert them to their transformation with cute flavortext
 /proc/purrbation_toggle(mob/living/carbon/human/H, silent = FALSE)
-	if(!ishumanbasic(H) && !iscatperson(H))
-		purrbation_apply_mutant(H, silent)
-		return TRUE
+	if(!ishumanbasic(H))
+		var/catgirlcheck = istype(H.getorganslot(ORGAN_SLOT_EARS), /obj/item/organ/ears/cat) || istype(H.getorganslot(ORGAN_SLOT_TAIL), /obj/item/organ/tail/cat) //if they've got cat parts they are likely an unfortunate victim of admin black magic AKA "fun", turn them back
+		if(catgirlcheck)
+			purrbation_remove(H, silent)
+			return FALSE
+		else
+			purrbation_apply_mutant(H, silent)
+			return TRUE
 	if(!iscatperson(H))
 		purrbation_apply(H, silent)
 		. = TRUE
@@ -93,39 +101,45 @@
 		purrbation_remove(H, silent)
 		. = FALSE
 
+///turns our poor spaceman into a CATGIRL. Point and laugh.
 /proc/purrbation_apply(mob/living/carbon/human/H, silent = FALSE)
-	if(!ishuman(H) || iscatperson(H))
+	if(!silent)
+		to_chat(H, "Something is nya~t right.")
+		playsound(get_turf(H), 'sound/effects/meow1.ogg', 50, 1, -1)
+
+	if(!ishumanbasic(H))
+		var/obj/item/organ/cattification = new /obj/item/organ/tail/cat()
+		var/old_part = H.getorganslot(ORGAN_SLOT_TAIL)
+		cattification.Insert(H)
+		qdel(old_part)
+		cattification = new /obj/item/organ/ears/cat()
+		old_part = H.getorganslot(ORGAN_SLOT_EARS)
+		cattification.Insert(H)
+		qdel(old_part)
+		H.regenerate_icons()
 		return
+
 	H.set_species(/datum/species/human/felinid)
 
-	if(!silent)
-		to_chat(H, "Something is nya~t right.")
-		playsound(get_turf(H), 'sound/effects/meow1.ogg', 50, 1, -1)
-
-/proc/purrbation_apply_mutant(mob/living/carbon/human/H, silent = FALSE)
-	var/obj/item/organ/cattification = new /obj/item/organ/tail()
-	var/old_part = H.getorganslot(ORGAN_SLOT_TAIL)
-	cattification.Insert(H)
-	qdel(old_part)
-	cattification = new /obj/item/organ/ears/cat()
-	old_part = H.getorganslot(ORGAN_SLOT_EARS)
-	cattification.Insert(H)
-	qdel(old_part)
-	H.regenerate_icons()
-
-	if(!silent)
-		to_chat(H, "Something is nya~t right.")
-		playsound(get_turf(H), 'sound/effects/meow1.ogg', 50, 1, -1)
-
+///return the degenerates to their original form
 /proc/purrbation_remove(mob/living/carbon/human/H, silent = FALSE)
-	if(!ishuman(H) || !iscatperson(H))
+	if(!silent)
+		to_chat(H, "You are no longer a cat.")
+	if(!ishumanbasic(H)) //not a basic human, nonhumans tend to have different appearances so turning them into humans would be lazy. Give them their normal ears and shit back
+		var/obj/item/organ/decattification = new H.dna?.species.mutantears
+		if(decattification)
+			var/old_part = H.getorganslot(ORGAN_SLOT_TAIL)
+			cattification.Insert(H)
+			qdel(old_part)
+		decattification = new H.dna?.species.mutanttail
+		if(decattification)
+			var/old_part = H.getorganslot(ORGAN_SLOT_EARS)
+			cattification.Insert(H)
+			qdel(old_part)
 		return
 
 	H.set_species(/datum/species/human)
 
-	if(!silent)
-		to_chat(H, "You are no longer a cat.")
-		
 /datum/species/human/felinid/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
 	. = ..()
 	if(H.reagents.has_reagent(/datum/reagent/consumable/ethanol/catsip))


### PR DESCRIPTION
# Document the changes in your pull request

Refines and documents purrbation toggles
Fixes a minor bug where catgirlifying nonhumans would produce a non-cat tail (invisible)
allows vv toggle purrbation to work on nonhumans


# Changelog

:cl:  
bugfix: admins can now use toggle purrbation on nonhumans in their vv menu
bugfix: nonhumans now get the correct cat tail
bugfix: adds support for removing purrbation from nonhumans
/:cl:
