### PR TITLE
Sensor nanites now use 0.2 volume

### DIFF
--- a/code/modules/research/nanites/nanite_programs/sensor.dm
+++ b/code/modules/research/nanites/nanite_programs/sensor.dm
@@ -3,7 +3,7 @@
 	desc = "These nanites send a signal code when a certain condition is met."
 	unique = FALSE
 	extra_settings = list("Sent Code")
-
+	use_rate = 0.2
 	var/sent_code = 0
 
 /datum/nanite_program/sensor/set_extra_setting(user, setting)


### PR DESCRIPTION
# If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md


# Document the changes in your pull request
Currently nanites are used as free healing without any downsides, due to the creator's vision of you having to trade the potential negative of sabotage with the healing completely thrown out the window with nobody sabotaging the nanites; thus free healing which results in less interactions with med-bay and makes it more complex for antagonists for the simple price of stepping into a chamber and leaving. This will make it so healing nanites are less powerful as they can't as easily mix and match sensor nanites for their desired effect.

# Wiki Documentation
Sensor nanites now use 0.2 volume
# Changelog

:cl:  
tweak: Sensor nanites now use 0.2 volume
/:cl:
