### PR TITLE
[s] Bluespace RPED no longer will remotely exchange beakers if the replacement beakers have reagents in them

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -476,6 +476,9 @@ Class Procs:
 						break
 				for(var/obj/item/B in W.contents)
 					if(istype(B, P) && istype(A, P))
+						//won't replace beakers if they have reagents in them to prevent funny explosions
+						if(istype(B,/obj/item/reagent_containers) && !isemptylist(B.reagents?.reagent_list)) 
+							continue
 						// If it's a corrupt or rigged cell, attempting to send it through Bluespace could have unforeseen consequences.
 						if(istype(B, /obj/item/stock_parts/cell) && W.works_from_distance)
 							var/obj/item/stock_parts/cell/checked_cell = B

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -484,8 +484,6 @@ Class Procs:
 								checked_cell.charge = checked_cell.maxcharge
 								checked_cell.explode()
 						if(B.get_part_rating() > A.get_part_rating())
-							if(istype(B,/obj/item/reagent_containers) && !isemptylist(B.reagents?.reagent_list)) 
-								continue
 							if(istype(B,/obj/item/stack)) //conveniently this will mean A is also a stack and I will kill the first person to prove me wrong
 								var/obj/item/stack/SA = A
 								var/obj/item/stack/SB = B

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -484,6 +484,8 @@ Class Procs:
 								checked_cell.charge = checked_cell.maxcharge
 								checked_cell.explode()
 						if(B.get_part_rating() > A.get_part_rating())
+							if(istype(B,/obj/item/reagent_containers) && !isemptylist(B.reagents?.reagent_list)) 
+								continue
 							if(istype(B,/obj/item/stack)) //conveniently this will mean A is also a stack and I will kill the first person to prove me wrong
 								var/obj/item/stack/SA = A
 								var/obj/item/stack/SB = B


### PR DESCRIPTION
# Document the changes in your pull request

You can still explode people by manually putting them in, or Bluespace RPEDing a normal construction (have to be next to it anyway) which will still make it boom.

# Changelog

:cl:  
rscadd: Bluespace RPED no longer will remotely exchange beakers if the replacement beakers have reagents in them
/:cl:
