### PR TITLE
Revert "Slightly alters the height dwarfism sets you to"

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -92,14 +92,14 @@
 /datum/mutation/human/dwarfism/on_acquiring(mob/living/carbon/human/owner)
 	if(..())
 		return
-	owner.transform = owner.transform.Scale(0.8, 0.8)
+	owner.transform = owner.transform.Scale(1, 0.8)
 	passtable_on(owner, GENETIC_MUTATION)
 	owner.visible_message(span_danger("[owner] suddenly shrinks!"), span_notice("Everything around you seems to grow.."))
 
 /datum/mutation/human/dwarfism/on_losing(mob/living/carbon/human/owner)
 	if(..())
 		return
-	owner.transform = owner.transform.Scale(1.25, 1.25)
+	owner.transform = owner.transform.Scale(1, 1.25)
 	passtable_off(owner, GENETIC_MUTATION)
 	owner.visible_message(span_danger("[owner] suddenly grows!"), span_notice("Everything around you seems to shrink.."))
 


### PR DESCRIPTION
# Document the changes in your pull request

![image](https://user-images.githubusercontent.com/5091394/164955649-176ac04f-50d5-4e29-b6ba-6760bc631815.png)

it took 2 days for y'all to start roleplaying that you were smol little beans, i can only shutter at the sort of hijinks darkstick will get up to with the little kid mutator

so now you get to look weird and squished instead of "just smaller" like god intended. Dwarves aren't just smaller. They're squished. also parity with tg (the other pr is not modular)

# Changelog
:cl:  
tweak: Scientists have altered the Dwarfism gene back to its original original genetic code
/:cl: