### PR TITLE
Stops dynamic from giving latejoiners every valid latejoin antagonist (no more traitor/vampire/bloodsucker)

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -748,6 +748,8 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 
 				rule.candidates = list(newPlayer)
 				rule.trim_candidates()
+				if(!rule.candidates || isemptylist(rule.candidates))
+					continue
 				if (rule.ready())
 					drafted_rules[rule] = rule.get_weight()
 

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -754,6 +754,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 			if (drafted_rules.len > 0 && pick_latejoin_rule(drafted_rules))
 				var/latejoin_injection_cooldown_middle = 0.5*(latejoin_delay_max + latejoin_delay_min)
 				latejoin_injection_cooldown = round(clamp(EXP_DISTRIBUTION(latejoin_injection_cooldown_middle), latejoin_delay_min, latejoin_delay_max)) + world.time
+				return
 				
 /// Apply configurations to rule.
 /datum/game_mode/dynamic/proc/configure_ruleset(datum/dynamic_ruleset/ruleset)


### PR DESCRIPTION
# Document the changes in your pull request

It goes over every valid ruleset it could give a latejoiner and tries to give it to them. It doesn't stop if it was successful.
This (for some reason) makes it so the candidates for future checks get trimmed, which it never checks if there's NOBODY so it runtimes and fucks everything up. 

# Changelog

:cl:   
bugfix: stops dynamic giving a lucky latejoiner every valid latejoin antagonist
/:cl:
