### PR TITLE
Increases lesser form's chemical cost from 5 to 30 and DNA cost from 1 to 3

### DIFF
--- a/code/modules/antagonists/changeling/powers/lesserform.dm
+++ b/code/modules/antagonists/changeling/powers/lesserform.dm
@@ -1,10 +1,10 @@
 /datum/action/changeling/lesserform
 	name = "Lesser Form"
-	desc = "We debase ourselves and become lesser. We become a monkey. Costs 5 chemicals."
+	desc = "We debase ourselves and become lesser. We become a monkey. Costs 30 chemicals."
 	helptext = "The transformation greatly reduces our size, allowing us to slip out of cuffs and climb through vents."
 	button_icon_state = "lesser_form"
-	chemical_cost = 5
-	dna_cost = 1
+	chemical_cost = 30
+	dna_cost = 3 //effectively a straight upgrade from biodegrade
 	req_human = 1
 
 //Transform into a monkey.


### PR DESCRIPTION
# Document the changes in your pull request

Why buy biodegrade when momke mode does everything it does but has more utility
closes #13804
closes #13878

# Wiki Documentation

lesser form dna cost 3 from 1 and chemical cost 30 from 5

# Changelog

:cl:  
tweak: Increases lesser form's chemical cost from 5 to 30 and DNA cost from 1 to 3
/:cl:
