### PR TITLE
Rebalances the security ebow

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -109,13 +109,15 @@
 
 /obj/item/gun/energy/kinetic_accelerator/crossbow/large
 	name = "energy crossbow"
-	desc = "A reverse engineered weapon using syndicate technology."
+	desc = "A reverse engineered weapon using syndicate technology, substantially bulkier than its illegal counterpart."
 	icon_state = "crossbowlarge"
 	w_class = WEIGHT_CLASS_BULKY
 	materials = list(/datum/material/iron=4000)
 	suppressed = null
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt/large)
 	pin = null
+	weapon_weight = WEAPON_LARGE
+	overheat_time = 10 SECONDS
 
 
 /obj/item/gun/energy/plasmacutter

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -116,6 +116,7 @@
 	suppressed = null
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt/large)
 	pin = null
+	holds_charge = FALSE
 	weapon_weight = WEIGHT_CLASS_HUGE
 	overheat_time = 10 SECONDS
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -111,7 +111,7 @@
 	name = "energy crossbow"
 	desc = "A reverse engineered weapon using syndicate technology."
 	icon_state = "crossbowlarge"
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
 	materials = list(/datum/material/iron=4000)
 	suppressed = null
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt/large)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -116,7 +116,7 @@
 	suppressed = null
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt/large)
 	pin = null
-	weapon_weight = WEAPON_LARGE
+	weapon_weight = WEIGHT_CLASS_HUGE
 	overheat_time = 10 SECONDS
 
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -117,6 +117,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt/large)
 	pin = null
 	holds_charge = FALSE
+	unique_frequency = FALSE
 	weapon_weight = WEIGHT_CLASS_HUGE
 	overheat_time = 10 SECONDS
 

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -15,5 +15,3 @@
 
 /obj/item/projectile/energy/bolt/large
 	damage = 30 //we already deal 60 stamina damage per hit
-	knockdown = 0
-	immobilize = 1 SECONDS

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -14,4 +14,6 @@
 	icon_state = "candy_corn"
 
 /obj/item/projectile/energy/bolt/large
-	damage = 40
+	damage = 30 //we already deal 60 stamina damage per hit
+	knockdown = 0
+	immobilize = 1 SECONDS


### PR DESCRIPTION
# Document the changes in your pull request

Printable ebow has been redesigned from a nerfed taser into a specialist weapon for high alpha damage at the start of a fight (kind of the same except it's slower)

Damage decreased to 30 from 40, increasing its hits 2 crit from 3 to 4
Stamina damage unchanged
Cooldown increased from 2 seconds to 10 seconds
Size increased to bulky
Weapon size ALSO increased to bulky (cannot be fired with something in your offhand)
Loses its charge if dropped, must  be carried on back/belt/wherever else it would fit
Charge timer increased per large ebow on your person

closes #13814
# Wiki Documentation

security large energy crossbow stats
Damage decreased to 30 from 40
Stamina damage unchanged
Cooldown increased from 1.6 seconds to 10 seconds
Size increased to bulky
Weapon size ALSO increased to bulky (cannot be fired with something in your offhand)
Loses charge if dropped
Charge timer increased per large ebow on your person

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
tweak: large energy crossbow damage reduced to 30 from 40
tweak: large energy crossbow cooldown increased from 2 seconds to 10 seconds
tweak: large energy crossbow size increased from normal to bulky
tweak: large energy crossbows can no longer be fired with items in the offhand
tweak: large energy crossbows will lose charge if dropped
tweak: large energy crossbows now get increased reload time for carrying several
/:cl:
