### PR TITLE
You can no longer use camera consoles with the Bluespace Rapid Part Exchange Device

### DIFF
--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -19,7 +19,11 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 		return ..()
 	if(user.Adjacent(T)) // no TK upgrading.
 		if(works_from_distance)
-			user.Beam(T, icon_state = "rped_upgrade", time = 5)
+			if(T in_view_range(user, T))
+				user.Beam(T, icon_state = "rped_upgrade", time = 5)
+			else
+				to_chat("Out of range!")
+				return
 		T.exchange_parts(user, src)
 		return FALSE
 	return ..()

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -19,7 +19,7 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 		return ..()
 	if(user.Adjacent(T)) // no TK upgrading.
 		if(works_from_distance)
-			if(T in_view_range(user, T))
+			if(in_view_range(user, T))
 				user.Beam(T, icon_state = "rped_upgrade", time = 5)
 			else
 				to_chat("Out of range!")

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -22,7 +22,7 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 			if(in_view_range(user, T))
 				user.Beam(T, icon_state = "rped_upgrade", time = 5)
 			else
-				to_chat("Out of range!")
+				to_chat(user, span_warning("Out of range!"))
 				return
 		T.exchange_parts(user, src)
 		return FALSE


### PR DESCRIPTION
No longer use camera consoles with the Bluespace Rapid Part Exchange Device

Fed up of lazy scientists using the console, go out and do something, go interreact with departments instead of just clicking in a dark room.

:cl:  
tweak: You no longer use camera consoles with the Bluespace Rapid Part Exchange Device
/:cl:
