### PR TITLE
Lesser form cannot be used while cuffed or stunned

### DIFF
--- a/code/modules/antagonists/changeling/powers/lesserform.dm
+++ b/code/modules/antagonists/changeling/powers/lesserform.dm
@@ -6,6 +6,7 @@
 	chemical_cost = 5
 	dna_cost = 1
 	req_human = 1
+	check_flags = AB_CHECK_RESTRAINED | AB_CHECK_STUNNED
 
 //Transform into a monkey.
 /datum/action/changeling/lesserform/sting_action(mob/living/carbon/human/user)

--- a/code/modules/antagonists/changeling/powers/lesserform.dm
+++ b/code/modules/antagonists/changeling/powers/lesserform.dm
@@ -6,7 +6,7 @@
 	chemical_cost = 5
 	dna_cost = 1
 	req_human = 1
-	check_flags = AB_CHECK_RESTRAINED | AB_CHECK_STUNNED
+	check_flags = AB_CHECK_RESTRAINED | AB_CHECK_STUN
 
 //Transform into a monkey.
 /datum/action/changeling/lesserform/sting_action(mob/living/carbon/human/user)

--- a/code/modules/antagonists/changeling/powers/lesserform.dm
+++ b/code/modules/antagonists/changeling/powers/lesserform.dm
@@ -1,7 +1,7 @@
 /datum/action/changeling/lesserform
 	name = "Lesser Form"
-	desc = "We debase ourselves and become lesser. We become a monkey. Costs 5 chemicals."
-	helptext = "The transformation greatly reduces our size, allowing us to slip out of cuffs and climb through vents."
+	desc = "We debase ourselves and become lesser. We become a monkey. Cannot be used while cuffed or stunned. Costs 5 chemicals."
+	helptext = "The transformation greatly reduces our size, allowing us to climb through vents."
 	button_icon_state = "lesser_form"
 	chemical_cost = 5
 	dna_cost = 1


### PR DESCRIPTION
# Document the changes in your pull request

closes #13875
closes #13804

Prevents spamming lesser form to escape or delay being captured by security because spamming the uncuff ability is fun and intuitive game design

# Wiki Documentation

Lesser form will not work while cuffed or stunned

# Changelog

:cl:  
tweak: Lesser form will not work while cuffed or stunned
/:cl:
