### PR TITLE
Rodform and fireball nerf. Tesla blast, lightning bolt, and spellcards buff.

### DIFF
--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -616,7 +616,7 @@
 /obj/item/projectile/magic/aoe/lightning
 	name = "lightning bolt"
 	icon_state = "tesla_projectile"	//Better sprites are REALLY needed and appreciated!~
-	damage = 15
+	damage = 25
 	damage_type = BURN
 	nodamage = FALSE
 	speed = 0.3

--- a/code/modules/projectiles/projectile/magic/spellcard.dm
+++ b/code/modules/projectiles/projectile/magic/spellcard.dm
@@ -3,4 +3,4 @@
 	desc = "A piece of paper enchanted to give it extreme durability and stiffness, along with a very hot burn to anyone unfortunate enough to get hit by a charged one."
 	icon_state = "spellcard"
 	damage_type = BURN
-	damage = 3
+	damage = 4

--- a/code/modules/spells/spell_types/aimed.dm
+++ b/code/modules/spells/spell_types/aimed.dm
@@ -110,12 +110,11 @@
 	name = "Fireball"
 	desc = "This spell fires an explosive fireball at a target."
 	school = "evocation"
-	charge_max = 60
-	clothes_req = FALSE
+	charge_max = 80
 	invocation = "ONI SOMA"
 	invocation_type = "shout"
 	range = 20
-	cooldown_min = 20 //10 deciseconds reduction per rank
+	cooldown_min = 20 //15 deciseconds reduction per rank
 	projectile_type = /obj/item/projectile/magic/aoe/fireball
 	action_icon = 'icons/mob/actions/humble/actions_humble.dmi'
 	base_icon_state = "fireball"

--- a/code/modules/spells/spell_types/lightning.dm
+++ b/code/modules/spells/spell_types/lightning.dm
@@ -2,7 +2,7 @@
 	name = "Tesla Blast"
 	desc = "Charge up a tesla arc and release it at a random nearby target! You can move freely while it charges. The arc jumps between targets and can knock them down."
 	charge_type = "recharge"
-	charge_max	= 300
+	charge_max	= 250
 	clothes_req = TRUE
 	invocation = "UN'LTD P'WAH!"
 	invocation_type = "shout"

--- a/code/modules/spells/spell_types/rod_form.dm
+++ b/code/modules/spells/spell_types/rod_form.dm
@@ -3,8 +3,8 @@
 	desc = "Take on the form of an immovable rod, destroying all in your path. Purchasing this spell multiple times will also increase the rod's damage and travel range."
 	clothes_req = TRUE
 	human_req = FALSE
-	charge_max = 250
-	cooldown_min = 100
+	charge_max = 400
+	cooldown_min = 200
 	range = -1
 	include_user = TRUE
 	invocation = "CLANG!"


### PR DESCRIPTION
rodform cooldown increased to 40 seconds from 25. It literally was just a better jaunt before hand.

Fireball cooldown increased to 8 seconds from 6, and is no longer robeless. There are other robeless spells to use that don't instantly one shot people.

Damage per card from spellcards increased to 4 damage from 3. Which would now allow it to deal up to 140 damage after 5 point blank hits.

Lightning bolt spell direct hits are slightly more powerful, dealing 25 damage (plus zap damage) instead of 15.

Tesla blast cooldown reduced to 25 seconds from 30


# Changelog

:cl:  
tweak: Rodform and fireball nerf. Tesla blast, lightning bolt, and spellcards buff.
/:cl:
