### PR TITLE
Removes lich, you can now be a weak skeleton with magic mirrors

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -201,10 +201,10 @@
 	category = "Assistance"
 	cost = 1
 
-/datum/spellbook_entry/lichdom
-	name = "Bind Soul"
-	spell_type = /obj/effect/proc_holder/spell/targeted/lichdom
-	category = "Defensive"
+//datum/spellbook_entry/lichdom
+	//name = "Bind Soul"
+	//spell_type = /obj/effect/proc_holder/spell/targeted/lichdom
+	//category = "Defensive"
 
 /datum/spellbook_entry/teslablast
 	name = "Tesla Blast"

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -201,10 +201,10 @@
 	category = "Assistance"
 	cost = 1
 
-//datum/spellbook_entry/lichdom
-	//name = "Bind Soul"
-	//spell_type = /obj/effect/proc_holder/spell/targeted/lichdom
-	//category = "Defensive"
+/*datum/spellbook_entry/lichdom
+	name = "Bind Soul"
+	spell_type = /obj/effect/proc_holder/spell/targeted/lichdom
+	category = "Defensive"*/
 
 /datum/spellbook_entry/teslablast
 	name = "Tesla Blast"

--- a/code/modules/mob/living/carbon/human/species_types/skeletons.dm
+++ b/code/modules/mob/living/carbon/human/species_types/skeletons.dm
@@ -17,12 +17,13 @@
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | ERT_SPAWN
 
 /datum/species/skeleton/lowcalcium
-	// these are the ones players can be roundstart during halloween
+	// these are the ones players can be roundstart during halloween and can be picked from magic mirror
 	name = "Lesser Spooky Scary Skeleton"
 	id = "weakskeleton"
 	brutemod = 1.5 // Their low calcium bones are much weaker to being smashed.
 	punchdamagehigh = 5 // their weak bones don't let them punch very well.
 	limbs_id = "skeleton" //they are just normal skeletons but weaker
+	changesource_flags = MIRROR_BADMIN | WABBAJACK | ERT_SPAWN | MIRROR_PRIDE | MIRROR_MAGIC
 
 /datum/species/skeleton/lowcalcium/check_roundstart_eligible()
 	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])


### PR DESCRIPTION
Comments out the lich spell from the spellbook, meaning it cannot be normally obtained anymore. Badmins can still give it to people if they really want to for some reason.

This spell is literally just a crutch for wizards who can't handle not dying despite having a bunch of incredibly powerful spells at their disposal. If you still want to roleplay as a necromancer with necromantic stones and such, you can become a weak skeleton by using your magic mirror. Weak skeletons are normal skeletons but they take 50% extra brute damage and don't punch as hard.

# Changelog

:cl:  
rscadd: You can turn into a weak skeleton from magic mirrors
rscdel: Lich can no longer be bought from the spellbook
/:cl:
