### PR TITLE
make sleepy pens make you sleepy, not make you dead

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -172,8 +172,7 @@
 	reagents.add_reagent(/datum/reagent/toxin/chloralhydrate, 20)
 	reagents.add_reagent(/datum/reagent/toxin/mutetoxin, 15)
 	reagents.add_reagent(/datum/reagent/toxin/staminatoxin, 10)
-	reagents.add_reagent(/datum/reagent/toxin/pancuronium, 7)
-	reagents.add_reagent(/datum/reagent/toxin/sodium_thiopental, 23)
+	reagents.add_reagent(/datum/reagent/toxin/sodium_thiopental, 30)
 
 /*
  * (Alan) Edaggers


### PR DESCRIPTION
# Document the changes in your pull request

sleepy pens have 7u pancuronium in them which makes you have a 20% chance every mob_life tick to deal oxygen damage, if your stabber throws you somewhere there's a chance you get permacritted even if you wake up. It doesn't even do anything else since you sleep before you get stunned anyway. Just kill them :))))))

# Changelog

:cl:  
tweak: replace 7u pancuronium in sleepy pens with 7u sodium thiopental (making 30u total) in sleepy pens
/:cl:
