### PR TITLE
locks clown car to 25 pop

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2000,6 +2000,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			Premium features can be unlocked with a cryptographic sequencer!"
 	item = /obj/vehicle/sealed/car/clowncar
 	cost = 20
+	player_minimum = 25
 	restricted_roles = list("Clown")
 
 /datum/uplink_item/role_restricted/concealed_weapon_bay
@@ -2032,7 +2033,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 20
 	restricted_roles = list("Chaplain")
 	surplus = 5 //Very low chance to get it in a surplus crate even without being the chaplain
-	
+
 /datum/uplink_item/role_restricted/horror
 	name = "Horror-in-a-box"
 	desc = "When dissecting the head of a dead Nanotrasen scientist, our surgeons noticed an incredibly peculiar creature inside and managed to extract it into safe containment. \


### PR DESCRIPTION
# Document the changes in your pull request

Locks the clown car to where it can only be bought on station populations of 25+, as when the car is bought it is almost always used to kidnap the whole crew.  This can be annoying on lowpop, as you can spend ages trapped in a car with no security to help you.

This will prevent admin intervention from being needed in future to save the round of the poor lowpop player.

Yes this is technically an ided pr.

# Wiki Documentation

change the https://wiki.yogstation.net/wiki/Syndicate_Items page to mention the population requirement is 25.

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  Cark
tweak: The clown car can now only be bought with a station population of 25+.
/:cl:
