### PR TITLE
gives the saw automatic fire mode

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -233,6 +233,7 @@
 	mag_display = TRUE
 	mag_display_ammo = TRUE
 	tac_reloads = FALSE
+	automatic = TRUE
 	fire_sound = 'sound/weapons/rifleshot.ogg'
 	rack_sound = 'sound/weapons/chunkyrack.ogg'
 


### PR DESCRIPTION
# Document the changes in your pull request

1 round burst time lets gooooooooooooooooooo
I gutted the 3 roudn burst a while ago because as it turns out super fast bursts effectively mean each click is 3 attacks and the SAW already has massive damage
Far as I know automatic fires as fast as the gun can normally fire rather than blasting out several bullets near instantly so it'd be like "fine" probably

# Wiki Documentation

L6 SAW now fires automatically

# Changelog

:cl:  
tweak: the SAW has been given automatic fire, BRRRRRRRRRRRRT
/:cl:
