### PR TITLE
fixes regal rats making minor mapping take 140+ seconds and breaking the stat panel until right when the round starts

### DIFF
--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -1,15 +1,15 @@
-#define REGAL_RAT_CHANCE 5
+#define REGAL_RAT_CHANCE 2
 SUBSYSTEM_DEF(minor_mapping)
 	name = "Minor Mapping"
 	init_order = INIT_ORDER_MINOR_MAPPING
 	flags = SS_NO_FIRE
 
 /datum/controller/subsystem/minor_mapping/Initialize(timeofday)
-	trigger_migration(CONFIG_GET(number/mice_roundstart))
+	trigger_migration(CONFIG_GET(number/mice_roundstart),FALSE) //we dont want roundstart regal rats
 	place_satchels()
 	return ..()
 
-/datum/controller/subsystem/minor_mapping/proc/trigger_migration(num_mice=10)
+/datum/controller/subsystem/minor_mapping/proc/trigger_migration(num_mice=10, regal=TRUE)
 	var/list/exposed_wires = find_exposed_wires()
 
 	var/mob/living/simple_animal/M
@@ -19,7 +19,7 @@ SUBSYSTEM_DEF(minor_mapping)
 	while((num_mice > 0) && exposed_wires.len)
 		proposed_turf = pick_n_take(exposed_wires)
 		if(!M)
-			if(prob(REGAL_RAT_CHANCE))
+			if(regal && prob(REGAL_RAT_CHANCE))
 				M = new /mob/living/simple_animal/hostile/regalrat/controlled(proposed_turf)
 			else
 				M = new /mob/living/simple_animal/mouse(proposed_turf)

--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -1,4 +1,4 @@
-#define PROB_MOUSE_SPAWN 98
+#define REGAL_RAT_CHANCE 5
 SUBSYSTEM_DEF(minor_mapping)
 	name = "Minor Mapping"
 	init_order = INIT_ORDER_MINOR_MAPPING
@@ -12,24 +12,22 @@ SUBSYSTEM_DEF(minor_mapping)
 /datum/controller/subsystem/minor_mapping/proc/trigger_migration(num_mice=10)
 	var/list/exposed_wires = find_exposed_wires()
 
-	var/mob/living/simple_animal/mouse/mouse
-	var/turf/open/proposed_turf
+	var/mob/living/simple_animal/M
+	var/turf/proposed_turf
 
 
 	while((num_mice > 0) && exposed_wires.len)
 		proposed_turf = pick_n_take(exposed_wires)
-
-		if(!istype(proposed_turf))
-			continue
-
-		if(prob(PROB_MOUSE_SPAWN))
-			if(!mouse)
-				mouse = new(proposed_turf)
+		if(!M)
+			if(prob(REGAL_RAT_CHANCE))
+				M = new /mob/living/simple_animal/hostile/regalrat/controlled(proposed_turf)
 			else
-				mouse.forceMove(proposed_turf)
+				M = new /mob/living/simple_animal/mouse(proposed_turf)
 		else
-			mouse = new /mob/living/simple_animal/hostile/regalrat/controlled(proposed_turf)
-
+			M.forceMove(proposed_turf)
+		if(M.environment_is_safe())
+			num_mice -= 1
+			M = null
 
 /datum/controller/subsystem/minor_mapping/proc/place_satchels(amount=10)
 	var/list/turfs = find_satchel_suitable_turfs()
@@ -64,3 +62,5 @@ SUBSYSTEM_DEF(minor_mapping)
 				suitable += t
 
 	return shuffle(suitable)
+
+#undef REGAL_RAT_CHANCE 

--- a/code/modules/events/mice_migration.dm
+++ b/code/modules/events/mice_migration.dm
@@ -25,4 +25,4 @@
 		'sound/effects/mousesqueek.ogg')
 
 /datum/round_event/mice_migration/start()
-	SSminor_mapping.trigger_migration(rand(minimum_mice, maximum_mice))
+	SSminor_mapping.trigger_migration(rand(minimum_mice, maximum_mice),TRUE)

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -226,7 +226,7 @@ GLOBAL_VAR_INIT(mouse_killed, 0)
 
 	GLOB.mouse_spawned += mice
 	GLOB.food_for_next_mouse = max(GLOB.food_for_next_mouse - FOODPERMOUSE * mice, 0)
-	SSminor_mapping.trigger_migration(mice)
+	SSminor_mapping.trigger_migration(mice,TRUE)
 
 /mob/living/simple_animal/mouse/proc/cheese_up()
 	regen_health(15)


### PR DESCRIPTION
# Document the changes in your pull request

Minor Mapping subsystem does a funny infinite loop that decides to quit between 140 and 170 seconds, this fixes it.
Also fixes up the code, because it had a 98% chance to make a regal rat instead of a normal rat, which is obviously wrong.
Also makes it so there's no roundstart ones, because the TG wiki page doesn't mention it and alludes that it should only happen during mice migration and when migrations are triggered through mice eating cheese

# Changelog

:cl:  
bugfix: regal rats no longer spawn roundstart
bugfix: regal rats no longer occur 98% of the time instead of 2% like they should
bugfix: regal rats haver a 5% chance to spawn and no longer cause an infinite loop
/:cl:
