### PR TITLE
Fixes broken "? canister" bug

### DIFF
--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -304,7 +304,7 @@
 	if(stat & BROKEN)
 		cut_overlays()
 		SSvis_overlays.remove_vis_overlay(src, managed_vis_overlays)
-		if(!findtext(icon_state,"-1")) //a wise man always if it already broke, don't break it more.
+		if(!findtext(icon_state,"-1")) //A wise man once said, if it's already broke, don't break it more.
 			icon_state = "[icon_state]-1"
 		return
 

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -304,7 +304,8 @@
 	if(stat & BROKEN)
 		cut_overlays()
 		SSvis_overlays.remove_vis_overlay(src, managed_vis_overlays)
-		icon_state = "[icon_state]-1"
+		if(!findtext(icon_state,"-1")) //a wise man always if it already broke, don't break it more.
+			icon_state = "[icon_state]-1"
 		return
 
 	var/last_update = update


### PR DESCRIPTION
# Document the changes in your pull request

if you update the icon of a broken canister after it's already been updated after breaking, it will try to change it to the "broke" version of the canister sprite, which already is a broken version of the canister sprite, so the sprite breaks. 

# Changelog

:cl:  
bugfix: broken canisters no longer want to become more broken and break their sprite
/:cl:
