### PR TITLE
Changelings can no longer readapt while in reviving stasis

### DIFF
--- a/code/modules/antagonists/changeling/cellular_emporium.dm
+++ b/code/modules/antagonists/changeling/cellular_emporium.dm
@@ -71,6 +71,8 @@
 		if("readapt")
 			if(changeling.canrespec)
 				changeling.readapt()
+			else
+				to_chat(changeling.owner.current,span_danger("You lack the power to readapt your evolutions!"))
 		if("evolve")
 			var/sting_name = params["name"]
 			changeling.purchase_power(sting_name)

--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -8,6 +8,7 @@
 	req_stat = DEAD
 	ignores_fakedeath = TRUE
 	var/revive_ready = FALSE
+	var/regain_respec = TRUE //variable to figure out if we give them the ability to respec again after they revive
 	
 
 //Fake our own death and fully heal. You will appear to be dead but regenerate fully after a short delay.
@@ -22,6 +23,9 @@
 		UpdateButtonIcon()
 		chemical_cost = 15
 		to_chat(user, span_notice("We have revived ourselves."))
+		var/datum/antagonist/changeling/C = user.mind.has_antag_datum(/datum/antagonist/changeling)
+		if(C)
+			C.canrespec = regain_respec
 	else
 		to_chat(user, span_notice("We begin our stasis, preparing energy to arise once more."))
 		if(user.stat != DEAD)
@@ -29,6 +33,10 @@
 		user.fakedeath("changeling") //play dead
 		user.update_stat()
 		user.update_mobility()
+		var/datum/antagonist/changeling/C = user.mind.has_antag_datum(/datum/antagonist/changeling)
+		if(C)
+			regain_respec = C.canrespec
+			C.canrespec = FALSE
 		addtimer(CALLBACK(src, .proc/ready_to_regenerate, user), LING_FAKEDEATH_TIME, TIMER_UNIQUE)
 	return TRUE
 


### PR DESCRIPTION
# Document the changes in your pull request

I solve the problem of losing your revive button from readapting by making it so you cant readapt when you're fakedead!

# Changelog

:cl:  
bugfix: readapting will no longer delete your revive button
/:cl:
