### PR TITLE
Adds a spriter-proof script for installing the DMI merge driver

### DIFF
--- a/tools/hooks/install_only_icon_merger.bat
+++ b/tools/hooks/install_only_icon_merger.bat
@@ -1,0 +1,12 @@
+@echo off
+cd %~dp0
+for %%f in (*.merge) do (
+	echo Installing merge driver: %%~nf
+	echo [merge "%%~nf"]^
+
+	driver = tools/hooks/%%f %%P %%O %%A %%B %%L >> ..\..\.git\config
+)
+echo Installing Python dependencies
+python -m pip install -r ..\mapmerge2\requirements.txt
+echo Done
+pause

--- a/tools/hooks/install_only_icon_merger.sh
+++ b/tools/hooks/install_only_icon_merger.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+shopt -s nullglob
+cd "$(dirname "$0")"
+for f in *.merge; do
+	echo Installing merge driver: ${f%.merge}
+	git config --replace-all merge.${f%.merge}.driver "tools/hooks/$f %P %O %A %B %L"
+done
+
+echo "Installing tgui hooks"
+../../tgui/bin/tgui --install-git-hooks
+
+echo "Installing Python dependencies"
+./python.sh -m pip install -r ../mapmerge2/requirements.txt
+echo "Done"


### PR DESCRIPTION

# Document the changes in your pull request

Run the "install_only_icon_merger" in tools/hooks

# Wiki Documentation

Mention that we have it for a start.

# Changelog