### PR TITLE
fixes bad wire under singulo door on box so it doesnt go boom

### DIFF
--- a/_maps/RandomRuins/StationRuins/BoxStation/engine_singulo_tesla.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/engine_singulo_tesla.dmm
@@ -1046,20 +1046,6 @@
 /obj/machinery/the_singularitygen/tesla,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"YC" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_access_txt = "10;13"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/engine/engineering)
 
 (1,1,1) = {"
 ab
@@ -1794,7 +1780,7 @@ ab
 Mi
 wN
 Mi
-YC
+Jk
 gc
 kd
 zz


### PR DESCRIPTION
# Document the changes in your pull request

wasn't connected

# Changelog

:cl:  
bugfix: add wire under singulo on box so emitters get power
/:cl:
