### PR TITLE
Blood Brothers will now spawn with makeshift weapons 101 in their backpack.

### DIFF
--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -23,8 +23,22 @@
 	owner.special_role = special_role
 	if(owner.current)
 		give_pinpointer()
+		equip_brother()
 	finalize_brother()
 	return ..()
+
+/datum/antagonist/brother/proc/equip_brother()
+	var/mob/living/carbon/H = owner.current
+	if(!istype(H))
+		return
+	. += brother_give_item(/obj/item/book/granter/crafting_recipe/weapons, H)
+	
+/datum/antagonist/brother/proc/brother_give_item(obj/item/item_path, mob/living/carbon/human/H)
+	var/list/slots = list(
+		"backpack" = SLOT_IN_BACKPACK,
+		"left pocket" = SLOT_L_STORE,
+		"right pocket" = SLOT_R_STORE
+	)
 
 /datum/antagonist/brother/on_removal()
 	SSticker.mode.brothers -= owner

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -39,7 +39,19 @@
 		"left pocket" = SLOT_L_STORE,
 		"right pocket" = SLOT_R_STORE
 	)
-
+	
+	var/T = new item_path(H)
+	var/item_name = initial(item_path.name)
+	var/where = H.equip_in_one_of_slots(T, slots)
+	if(!where)
+		to_chat(H, span_userdanger("Unfortunately, you weren't able to get a [item_name]. This is very bad and you should adminhelp immediately (press F1)."))
+		return FALSE
+	else
+		to_chat(H, span_danger("You have a [item_name] in your [where]."))
+		if(where == "backpack")
+			SEND_SIGNAL(H.back, COMSIG_TRY_STORAGE_SHOW, H)
+		return TRUE
+		
 /datum/antagonist/brother/on_removal()
 	SSticker.mode.brothers -= owner
 	if(owner.current)


### PR DESCRIPTION

# Document the changes in your pull request

Blood brother is, currently, one of the weakest antagonists in the game. Most of their armaments come from improvisation, which is either laughably easy if you're a chemist or scientist, or soul crushingly difficult. This PR aims to give blood brothers a bit of a boost in terms of weapons, since now they will be able to craft better improvised weapons, which should help them succeed.

# Wiki Documentation

make it obvious on the wiki that bloodbrothers spawn with makeshift weapons 101 in their backpack
# Changelog

:cl:  
rscadd: Blood brothers will now spawn with a copy of makeshift weapons 101 in their backpacks.
/:cl:
