### PR TITLE
fixes waddling component incorrectly resetting your transform

### DIFF
--- a/code/datums/components/waddling.dm
+++ b/code/datums/components/waddling.dm
@@ -10,6 +10,7 @@
     var/mob/living/L = parent
     if(L.incapacitated() || !(L.mobility_flags & MOBILITY_STAND))
         return
+    var/cached_transform = L.transform
     animate(L, pixel_z = 4, time = 0)
-    animate(pixel_z = 0, transform = turn(matrix(), pick(-12, 0, 12)), time=2)
-    animate(pixel_z = 0, transform = matrix(), time = 0)
+    animate(pixel_z = 0, transform = turn(cached_transform, pick(-12, 0, 12)), time=2)
+    animate(pixel_z = 0, transform = cached_transform, time = 0)


### PR DESCRIPTION
# Document the changes in your pull request
Closes: #13925 
if you have a non-normal transform and walk with clown shoes, your transform will be set back to regular.
if you're a dwarf you return to regular size,
if you're bigger from something you return to regular size.
if you're abusing the egg exploit you return to normal size and then shrink to kid form.

This fixes it.

# Changelog
:cl:  
bugfix: waddling component no longer messes up your transform
/:cl:
