### PR TITLE
Revert "Re-enables the wizard academy"

### DIFF
--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -313,6 +313,7 @@
 		of the area exists in any records. After all, it's not like \
 		some doofus with an EVA suit and jetpack can just waltz around \
 		in space and find it..."
+	unpickable = TRUE
 
 /datum/map_template/ruin/space/spacebar
 	id = "spacebar"


### PR DESCRIPTION
Reverts yogstation13/Yogstation#13664

Hey turns out a large ruin with the sole purpose of holding wizard loot is not a good idea to let players have

:cl:
Rscdel: wizard ruin out of rotation bye bye
/:cl: