### PR TITLE
fixes a bug wherein heretic living hearts check z levels directly rather than using turfs

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -14,10 +14,12 @@
 	if(!target)
 		to_chat(user,span_warning("No target could be found. Put the living heart on the rune and use the rune to recieve a target."))
 		return
-	var/dist = get_dist(get_turf(user),get_turf(target))
-	var/dir = get_dir(get_turf(user),get_turf(target))
+	var/userturf = get_turf(user)
+	var/targetturf = get_turf(target)
+	var/dist = get_dist(userturf,targetturf)
+	var/dir = get_dir(userturf,targetturf)
 
-	if(user.z != target.z)
+	if(userturf.z != targetturf.z)
 		to_chat(user,span_warning("[target.real_name] is ... vertical to you?"))
 	else
 		switch(dist)

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -14,7 +14,7 @@
 	if(!target)
 		to_chat(user,span_warning("No target could be found. Put the living heart on the rune and use the rune to recieve a target."))
 		return
-	var/userturf = get_turf(user)
+	var/turf/userturf = get_turf(user)
 	var/targetturf = get_turf(target)
 	var/dist = get_dist(userturf,targetturf)
 	var/dir = get_dir(userturf,targetturf)

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -15,7 +15,7 @@
 		to_chat(user,span_warning("No target could be found. Put the living heart on the rune and use the rune to recieve a target."))
 		return
 	var/turf/userturf = get_turf(user)
-	var/targetturf = get_turf(target)
+	var/turf/targetturf = get_turf(target)
 	var/dist = get_dist(userturf,targetturf)
 	var/dir = get_dir(userturf,targetturf)
 


### PR DESCRIPTION
# Document the changes in your pull request

major skill issue


# Changelog

:cl:  
bugfix: being inside a locker/mech will no longer cause the heretic heart to display "vertical?" for people on the same z level as you
/:cl:
