### PR TITLE
Fixes hemostat and cautery steps healing saw damage form random limbs

### DIFF
--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -52,7 +52,7 @@
 
 /datum/surgery_step/clamp_bleeders/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(locate(/datum/surgery_step/saw) in surgery.steps)
-			target.apply_damage(-20, BRUTE, "[target_zone]")
+		target.apply_damage(-20, BRUTE, "[target_zone]")
 	if (ishuman(target))
 		var/mob/living/carbon/human/H = target
 		var/obj/item/bodypart/BP = H.get_bodypart(target_zone)
@@ -94,7 +94,7 @@
 
 /datum/surgery_step/close/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(locate(/datum/surgery_step/saw) in surgery.steps)
-			target.apply_damage(-45, BRUTE, "[target_zone]")
+		target.apply_damage(-45, BRUTE, "[target_zone]")
 	if (ishuman(target))
 		var/mob/living/carbon/human/H = target
 		var/obj/item/bodypart/BP = H.get_bodypart(target_zone)

--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -52,7 +52,7 @@
 
 /datum/surgery_step/clamp_bleeders/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(locate(/datum/surgery_step/saw) in surgery.steps)
-		target.heal_bodypart_damage(20,0)
+			target.apply_damage(-20, BRUTE, "[target_zone]")
 	if (ishuman(target))
 		var/mob/living/carbon/human/H = target
 		var/obj/item/bodypart/BP = H.get_bodypart(target_zone)
@@ -94,7 +94,7 @@
 
 /datum/surgery_step/close/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(locate(/datum/surgery_step/saw) in surgery.steps)
-		target.heal_bodypart_damage(45,0)
+			target.apply_damage(-45, BRUTE, "[target_zone]")
 	if (ishuman(target))
 		var/mob/living/carbon/human/H = target
 		var/obj/item/bodypart/BP = H.get_bodypart(target_zone)


### PR DESCRIPTION
# Document the changes in your pull request

Heal bodypart damage selects from a random damaged limb then just blows all the healing it applies on thst limb specifically
Instead we try to heal the specific limb we are working on
# Changelog


:cl:  
bugfix: cauterizing and clamping a surgery that has had a saw step deal da,age will no longer try ro heal that damage off of a random limb rather than the target limb  
/:cl:
