### PR TITLE
Change default FPS to 40

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -99,7 +99,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	var/list/ignoring = list()
 
-	var/clientfps = 0
+	var/clientfps = 40
 
 	var/parallax
 


### PR DESCRIPTION
20 FPS is ugly and barely resembles motion. Maybe helps player retention.

:cl:  
bugfix: Default FPS is now 40
/:cl:
