### PR TITLE
Round Start SMES 30% more Power

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -32042,6 +32042,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"gun" = (
+/obj/machinery/power/smes/engineering{
+	charge = 5e+006;
+	input_level = 25000;
+	output_level = 10000
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/storage/satellite)
 "gus" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
@@ -38711,20 +38722,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"jGD" = (
-/obj/machinery/power/smes/engineering{
-	charge = 5e+006;
-	input_level = 25000;
-	output_level = 25000
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "0-8"
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/ai_monitored/turret_protected/ai)
 "jGO" = (
 /obj/effect/turf_decal/tile/darkblue{
 	dir = 8
@@ -44469,6 +44466,20 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"mFN" = (
+/obj/machinery/power/smes/engineering{
+	charge = 5e+006;
+	input_level = 10000;
+	output_level = 5000
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "0-8"
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/ai_monitored/turret_protected/ai)
 "mFO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -46684,21 +46695,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"nKB" = (
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/power/smes/engineering{
-	output_attempt = 0
-	},
-/obj/structure/cable/orange{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nKM" = (
 /obj/effect/landmark/start/station_engineer,
 /obj/effect/turf_decal/stripes/corner{
@@ -50051,6 +50047,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"pzv" = (
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/power/smes/engineering{
+	input_level = 10000;
+	output_attempt = 0;
+	output_level = 5000
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "pzw" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -55672,15 +55685,6 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"soT" = (
-/obj/machinery/power/smes/engineering{
-	charge = 5e+006
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
 "soW" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/light/small{
@@ -94531,7 +94535,7 @@ tBp
 bCs
 uzc
 ccw
-nKB
+pzv
 cjM
 ckB
 eZD
@@ -107660,7 +107664,7 @@ aaa
 aaa
 pEf
 tgv
-soT
+gun
 cBP
 uIU
 xgS
@@ -111008,7 +111012,7 @@ jXD
 cva
 cva
 iXp
-jGD
+mFN
 iXp
 cva
 cva

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -429,7 +429,7 @@
 	log_smes()
 
 /obj/machinery/power/smes/engineering
-	charge = 3e7 // Engineering starts with some charge for singulo
+	charge = 5e7 // Engineering starts with some charge for singulo
 
 /obj/machinery/power/smes/fullycharged
 	charge = 5e8 // A fully charged SMES


### PR DESCRIPTION
Due to the new SMES in AI and in Engineering for the emitters, station power is at a 100kw disadvantage, this should help not reduce the station to no power within 10 minutes.

:cl:  
tweak: Added more power to round start SMES to help with new powernet
/:cl:
