### PR TITLE
Holotool multitools now work better, can hold a buffer

### DIFF
--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -85,9 +85,9 @@
 	if(.)
 		return
 
-	if(!issilicon(operator))
-		if(!istype(operator.get_active_held_item(), /obj/item/multitool))
-			return
+	//if(!issilicon(operator)) // Yogs -- deleted old multitool code in favour of actually trusting get_multitool's output
+		//if(!istype(operator.get_active_held_item(), /obj/item/multitool))
+			//return
 
 	var/obj/item/multitool/heldmultitool = get_multitool(operator)
 
@@ -157,11 +157,13 @@
 						links += T
 						log_game("[key_name(operator)] linked [src] for [T] at [AREACOORD(src)].")
 						. = TRUE
-		if("buffer")
-			heldmultitool.buffer = src
+		if("buffer") // Yogs start -- holotool support
+			if(heldmultitool)
+				heldmultitool.buffer = src
 			. = TRUE
 		if("flush")
-			heldmultitool.buffer = null
+			if(heldmultitool)
+				heldmultitool.buffer = null // Yogs end
 			. = TRUE
 
 	add_act(action, params)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -131,7 +131,12 @@
 		if(I.tool_behaviour == quality && I.toolspeed < best_quality)
 			best_item = I
 			best_quality = I.toolspeed
-
+//yogs start -- fucking stupid but modular holotool patch
+	if(quality == TOOL_MULTITOOL)
+		if(istype(best_item,/obj/item/holotool))
+			var/obj/item/holotool/H = best_item
+			return H.internal_multitool
+//yogs end
 	return best_item
 
 

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3363,6 +3363,7 @@
 #include "yogstation\code\game\machinery\doors\poddoor.dm"
 #include "yogstation\code\game\machinery\doors\spacepod.dm"
 #include "yogstation\code\game\machinery\pipe\construction.dm"
+#include "yogstation\code\game\machinery\telecomms\machine_interactions.dm"
 #include "yogstation\code\game\machinery\telecomms\computers\logbrowser.dm"
 #include "yogstation\code\game\machinery\telecomms\computers\telemonitor.dm"
 #include "yogstation\code\game\machinery\telecomms\computers\traffic_control.dm"

--- a/yogstation/code/game/machinery/telecomms/machine_interactions.dm
+++ b/yogstation/code/game/machinery/telecomms/machine_interactions.dm
@@ -1,0 +1,14 @@
+/obj/machinery/telecomms/get_multitool(mob/user) // Proc override, to improve compatibility with holotools and other silly multitool-like devices
+    if(isAI(user))
+        var/mob/living/silicon/ai/U = user
+        return U.aiMulti
+    if(iscyborg(user) && in_range(user,src)) // I couldn't tell you why this has a range requirement, that's just what was in the original code.
+        var/obj/held_thing = user.get_active_held_item()
+        if(istype(held_thing,/obj/item/multitool))
+            return held_thing
+        else
+            return
+    var/obj/item/multitool/held_thing = user.is_holding_tool_quality(TOOL_MULTITOOL)
+    if(istype(held_thing))
+        return held_thing
+    return

--- a/yogstation/code/game/objects/items/devices/scanners.dm
+++ b/yogstation/code/game/objects/items/devices/scanners.dm
@@ -33,7 +33,7 @@ TRICORDER
 	var/medicalTricorder = FALSE	//Set to TRUE for normal medical scanner, set to FALSE for a gutted version
 
 
-obj/item/multitool/tricorder/suicide_act(mob/living/carbon/user)
+/obj/item/multitool/tricorder/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] thinks today IS a good day to die!"))
 	return BRUTELOSS
 

--- a/yogstation/code/game/objects/items/holotool/holotool.dm
+++ b/yogstation/code/game/objects/items/holotool/holotool.dm
@@ -12,10 +12,19 @@
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 
 	var/datum/holotool_mode/current_tool
+	var/obj/item/multitool/internal_multitool // A kludge caused by the statefulness of multitools,
+	// to be retained until we have the hubris to abstract all multitool functionality into some /datum/component, and break modularity in a hundred ways
 	var/list/available_modes
 	var/list/mode_names
 	var/list/radial_modes
 	var/current_color = "#48D1CC" //mediumturquoise
+/obj/item/holotool/Initialize()
+	. = ..()
+	internal_multitool = new /obj/item/multitool(src)
+
+/obj/item/holotool/Destroy()
+	. = ..()
+	qdel(internal_multitool)
 
 /obj/item/holotool/examine(mob/user)
 	..()


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/29939414/166119310-75c6c85e-5ea1-49a0-85aa-6aa3048a3705.png)

## Summary
Fixes #13888.

At first I thought this was telecomms code being old, but it turns out, the Holotool wasn't really trying to keep track of the more stateful tools that it has (like the multitool and its buffer).

Ideally, multitool functionality would be shunted into a `/datum/component` and then interacted with generically, but doing so would require a lot of changes to /tg/ code that would be immodular and tiresome to do. So I've elected to stuff a secret multitool into the holotool and have it return *that* whenever `is_holding_tool_quality(TOOL_MULTITOOL)` is called.

This might fix functionality in other places in the code, I'm not sure, but I know for certain it fixes my precious, precious telecomms.

## Changelog
:cl: Altoids
bugfix: Fixed telecommunication machines not respecting your fancy holotool as being a real multitool.
bugfix: Fixed wires being discriminatory towards your fancy holotool.
bugfix: Holotools are much better at being multitools.
/:cl:
