### PR TITLE
Donor purrbation toggle does not change nonhuman characters

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -110,7 +110,7 @@
 		to_chat(H, "Something is nya~t right.")
 		playsound(get_turf(H), 'sound/effects/meow1.ogg', 50, 1, -1)
 
-	if(!ishumanbasic(H) || onlyhumans = FALSE)
+	if(!ishumanbasic(H) || onlyhumans == FALSE)
 		var/obj/item/organ/cattification = new /obj/item/organ/tail/cat()
 		var/old_part = H.getorganslot(ORGAN_SLOT_TAIL)
 		cattification.Insert(H)

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -103,14 +103,14 @@
 		. = FALSE
 
 ///turns our poor spaceman into a CATGIRL. Point and laugh.
-/proc/purrbation_apply(mob/living/carbon/human/H, silent = FALSE)
+/proc/purrbation_apply(mob/living/carbon/human/H, silent = FALSE, onlyhumans = FALSE)
 	if(iscatperson(H))
 		return
 	if(!silent)
 		to_chat(H, "Something is nya~t right.")
 		playsound(get_turf(H), 'sound/effects/meow1.ogg', 50, 1, -1)
 
-	if(!ishumanbasic(H))
+	if(!ishumanbasic(H) || onlyhumans = FALSE)
 		var/obj/item/organ/cattification = new /obj/item/organ/tail/cat()
 		var/old_part = H.getorganslot(ORGAN_SLOT_TAIL)
 		cattification.Insert(H)

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -86,31 +86,41 @@
 		CHECK_TICK
 
 ///used to transmogrificate spacemen into or from catboys/girls. Arguments H = target spaceman and silent = TRUE/FALSE whether or not we alert them to their transformation with cute flavortext
-/proc/purrbation_toggle(mob/living/carbon/human/H, silent = FALSE, onlyhumans = FALSE)
+/proc/purrbation_toggle(mob/living/carbon/human/H, silent = FALSE)
 	if(!ishumanbasic(H))
 		var/catgirlcheck = istype(H.getorganslot(ORGAN_SLOT_EARS), /obj/item/organ/ears/cat) || istype(H.getorganslot(ORGAN_SLOT_TAIL), /obj/item/organ/tail/cat) //if they've got cat parts they are likely an unfortunate victim of admin black magic AKA "fun", turn them back
 		if(catgirlcheck)
 			purrbation_remove(H, silent)
 			return FALSE
 		else
-			purrbation_apply(H, silent, onlyhumans)
+			purrbation_apply(H, silent)
 			return TRUE
 	if(!iscatperson(H))
-		purrbation_apply(H, silent, onlyhumans)
+		purrbation_apply(H, silent)
+		. = TRUE
+	else
+		purrbation_remove(H, silent)
+		. = FALSE
+
+/proc/purrbation_toggle_onlyhumans(mob/living/carbon/human/H, silent = FALSE) //same as above but doesn't work on nonhumans - used by donor purrbation to reduce *accidental* double-cursed double-mutants
+	if(!ishumanbasic(H))
+		return
+	if(!iscatperson(H))
+		purrbation_apply(H, silent)
 		. = TRUE
 	else
 		purrbation_remove(H, silent)
 		. = FALSE
 
 ///turns our poor spaceman into a CATGIRL. Point and laugh.
-/proc/purrbation_apply(mob/living/carbon/human/H, silent = FALSE, onlyhumans = FALSE)
+/proc/purrbation_apply(mob/living/carbon/human/H, silent = FALSE)
 	if(iscatperson(H))
 		return
 	if(!silent)
 		to_chat(H, "Something is nya~t right.")
 		playsound(get_turf(H), 'sound/effects/meow1.ogg', 50, 1, -1)
 
-	if(!ishumanbasic(H) && !onlyhumans)
+	if(!ishumanbasic(H))
 		var/obj/item/organ/cattification = new /obj/item/organ/tail/cat()
 		var/old_part = H.getorganslot(ORGAN_SLOT_TAIL)
 		cattification.Insert(H)

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -86,17 +86,17 @@
 		CHECK_TICK
 
 ///used to transmogrificate spacemen into or from catboys/girls. Arguments H = target spaceman and silent = TRUE/FALSE whether or not we alert them to their transformation with cute flavortext
-/proc/purrbation_toggle(mob/living/carbon/human/H, silent = FALSE)
+/proc/purrbation_toggle(mob/living/carbon/human/H, silent = FALSE, onlyhumans = FALSE)
 	if(!ishumanbasic(H))
 		var/catgirlcheck = istype(H.getorganslot(ORGAN_SLOT_EARS), /obj/item/organ/ears/cat) || istype(H.getorganslot(ORGAN_SLOT_TAIL), /obj/item/organ/tail/cat) //if they've got cat parts they are likely an unfortunate victim of admin black magic AKA "fun", turn them back
 		if(catgirlcheck)
 			purrbation_remove(H, silent)
 			return FALSE
 		else
-			purrbation_apply(H, silent)
+			purrbation_apply(H, silent, onlyhumans)
 			return TRUE
 	if(!iscatperson(H))
-		purrbation_apply(H, silent)
+		purrbation_apply(H, silent, onlyhumans)
 		. = TRUE
 	else
 		purrbation_remove(H, silent)

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -110,7 +110,7 @@
 		to_chat(H, "Something is nya~t right.")
 		playsound(get_turf(H), 'sound/effects/meow1.ogg', 50, 1, -1)
 
-	if(!ishumanbasic(H) || onlyhumans == FALSE)
+	if(!ishumanbasic(H) && !onlyhumans)
 		var/obj/item/organ/cattification = new /obj/item/organ/tail/cat()
 		var/old_part = H.getorganslot(ORGAN_SLOT_TAIL)
 		cattification.Insert(H)

--- a/yogstation/code/modules/jobs/job_types/_job.dm
+++ b/yogstation/code/modules/jobs/job_types/_job.dm
@@ -9,7 +9,7 @@
 		return
 
 	if(C.prefs.purrbation)
-		purrbation_toggle(H)
+		purrbation_toggle(H, onlyhumans = TRUE)
 
 	if(C.prefs.donor_hat)
 		var/obj/item/storage/backpack/BP = locate(/obj/item/storage/backpack) in H.GetAllContents()

--- a/yogstation/code/modules/jobs/job_types/_job.dm
+++ b/yogstation/code/modules/jobs/job_types/_job.dm
@@ -9,7 +9,7 @@
 		return
 
 	if(C.prefs.purrbation)
-		purrbation_toggle(H, onlyhumans = TRUE)
+		purrbation_toggle_onlyhumans(H)
 
 	if(C.prefs.donor_hat)
 		var/obj/item/storage/backpack/BP = locate(/obj/item/storage/backpack) in H.GetAllContents()


### PR DESCRIPTION
# Document the changes in your pull request
![(Humans Only)](https://user-images.githubusercontent.com/36427443/166158881-09f67ea6-7f6e-43ae-ba87-664127d7d6e3.png)
I think we can all agree that letting donators join as lizards with cat parts is too far
Personally I say this because I've lost two rounds to forgetting to turn off purrbation when playing as a nonhuman, but the rest of you probably have regular moral objections

- [x] tested
- [x] works

If we do for whatever reason think this should be allowed, someone tell me how to make a separate Purrbation (Nonhumans Too) switch and I'll do it

Problem this is responding to is a result of #13820 , I guess you could call it a partial revert

# Changelog

:cl:  
tweak: only admins can give purrbation to nonhumans
/:cl: