### PR TITLE
Removes (humans only) from purrbation toggle

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -887,7 +887,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					qdel(temp_item)
 				dat += "<b>Fancy PDA:</b> "
 				dat += "<a href='?_src_=prefs;preference=donor;task=pda'>[GLOB.donor_pdas[donor_pda]]</a><BR>"
-				dat += "<b>Purrbation (Humans only)</b> "
+				dat += "<b>Purrbation</b> "
 				dat += "<a href='?_src_=prefs;preference=donor;task=purrbation'>[purrbation ? "Yes" : "No"]</a><BR>"
 			else
 				dat += "<b><a href='http://www.yogstation.net/donate'>Donate here</b>"


### PR DESCRIPTION
# Document the changes in your pull request

hey it's no longer locked to humans now

# Changelog

:cl:  
bugfix: purrbation no longer shows up as human only in donor preferences
/:cl:
