### PR TITLE
Reduces bloodsucker required enemies to 1 so it can actually roll if forced below 20 pop

### DIFF
--- a/code/game/gamemodes/bloodsuckers/bloodsucker.dm
+++ b/code/game/gamemodes/bloodsuckers/bloodsucker.dm
@@ -11,7 +11,7 @@
 		"Warden", "Security Officer", "Detective", "Brig Physician",
 	)
 	required_players = 25
-	required_enemies = 2
+	required_enemies = 1
 	recommended_enemies = 4
 	reroll_friendly = 1
 	round_ends_with_antag_death = FALSE


### PR DESCRIPTION
# Document the changes in your pull request

agmin issue

# Changelog

:cl:  
tweak: bloodsucker minimum vampire spawn 1 from 2 won't effect anything important
/:cl:
