### PR TITLE
fixes bloodsucker not being able to be run lmao

### DIFF
--- a/code/game/gamemodes/bloodsuckers/bloodsucker.dm
+++ b/code/game/gamemodes/bloodsuckers/bloodsucker.dm
@@ -36,11 +36,7 @@
 	for(var/i = 0, i < recommended_enemies, i++)
 		if(!antag_candidates.len)
 			break
-		var/datum/mind/bloodsucker = pick(antag_candidates)
-		// Can we even BE a bloodsucker?
-		if(!bloodsucker.can_make_bloodsucker(bloodsucker))
-			antag_candidates -= bloodsucker
-			continue
+		var/datum/mind/bloodsucker = antag_pick(antag_candidates)
 		bloodsuckers += bloodsucker
 		bloodsucker.restricted_roles = restricted_jobs
 		log_game("[bloodsucker.key] (ckey) has been selected as a Bloodsucker.")


### PR DESCRIPTION
# Document the changes in your pull request
this is the part wher eI make some super prideful comment about how good of a coder i am

can_make_bloodsucker requires a mob which isn't present during pre_setup, it's called in make_bloodsucker anyway and handles turning nonapplicables (plasmamen) into their human backups so we don't even need to call it

# Changelog

:cl:  
bugfix: bloodsucker mode can now actually run
/:cl:
