### PR TITLE
idk if this does anything BUT gives roundstart gantsters the role ROLE_GANG pre-setup  becaues I think it does something

### DIFF
--- a/yogstation/code/game/gamemodes/gangs/gangs.dm
+++ b/yogstation/code/game/gamemodes/gangs/gangs.dm
@@ -43,6 +43,7 @@ GLOBAL_LIST_EMPTY(gangs)
 		var/datum/mind/boss = antag_pick(antag_candidates)
 		antag_candidates -= boss
 		gangboss_candidates += boss
+		boss.special_role = ROLE_GANG
 		boss.restricted_roles = restricted_jobs
 
 	if(gangboss_candidates.len < 1) //Need at least one gangs


### PR DESCRIPTION

# Document the changes in your pull request

if this doesn't work I give up

:cl:  
bugfix: gang leaders should no longer spawn as security/fail to spawn. if this fails ping theos on the discord
/:cl:
