### PR TITLE
Fixes Clown Ops not being able to use medbeams

### DIFF
--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3724,6 +3724,7 @@
 #include "yogstation\code\modules\projectiles\ammunition\caseless\misc.dm"
 #include "yogstation\code\modules\projectiles\boxes_magazines\internal\misc.dm"
 #include "yogstation\code\modules\projectiles\guns\ballistic\launchers.dm"
+#include "yogstation\code\modules\projectiles\guns\misc\medbeam.dm"
 #include "yogstation\code\modules\projectiles\projectile\beams.dm"
 #include "yogstation\code\modules\projectiles\reusable\kineticspear.dm"
 #include "yogstation\code\modules\reagents\chemistry\reagents\alcohol_reagents.dm"

--- a/yogstation/code/modules/projectiles/guns/misc/medbeam.dm
+++ b/yogstation/code/modules/projectiles/guns/misc/medbeam.dm
@@ -1,0 +1,5 @@
+/obj/item/gun/medbeam
+    clumsy_check = FALSE
+
+/obj/item/gun/medbeam/check_botched(mob/living/user, params) // The clown can't shoot themself in the foot with a medical device. Ever.
+	return


### PR DESCRIPTION
Fixes #13933.

The whole "clowns can't use guns consistently" thing is cute and funny but I don't think it really makes sense to apply to things that aren't really guns, like this.

## Changelog

:cl: Altoids
bugfix: Clown Ops (and clowns in general) no longer shoot themselves in the foot with the medical beamgun.
/:cl:
