### PR TITLE
Reduces the nanite energy armor from refractive nanites from 25 to 15

### DIFF
--- a/code/modules/research/nanites/nanite_programs/buffing.dm
+++ b/code/modules/research/nanites/nanite_programs/buffing.dm
@@ -51,14 +51,14 @@
 	if(ishuman(host_mob))
 		var/mob/living/carbon/human/H = host_mob
 		H.physiology.armor.laser += 30
-		H.physiology.armor.energy += 25
+		H.physiology.armor.energy += 15
 
 /datum/nanite_program/refractive/disable_passive_effect()
 	. = ..()
 	if(ishuman(host_mob))
 		var/mob/living/carbon/human/H = host_mob
 		H.physiology.armor.laser -= 30
-		H.physiology.armor.energy -= 25
+		H.physiology.armor.energy -= 15
 
 /datum/nanite_program/coagulating
 	name = "Vein Repressurization"


### PR DESCRIPTION
# Document the changes in your pull request

In keeping with "normal design" energy armor has been reduced to account for the fact that it is reduced literally everywhere else

# Wiki Documentation

dermal reflective nanites energy armor 15 from 25

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
tweak: dermal reflective nanites energy armor 15 from 25
/:cl:
