### PR TITLE
Adds visual spell cooldowns on all spell casts and all bloodsucker abilities

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -20,6 +20,7 @@
 	var/button_icon_state = "default" //And this is the state for the action icon
 	var/mob/owner
 	var/syndicate = FALSE // are these buttons only for syndicates?
+	var/obj/screen/cooldown_overlay/cooldown_overlay
 
 /datum/action/New(Target)
 	link_to(Target)

--- a/code/modules/antagonists/bloodsuckers/powers/_powers.dm
+++ b/code/modules/antagonists/bloodsuckers/powers/_powers.dm
@@ -44,6 +44,7 @@
 /datum/action/bloodsucker/New(Target)
 	. = ..()
 	UpdateDesc()
+	START_PROCESSING(SSfastprocess, src)
 
 /datum/action/bloodsucker/proc/UpdateDesc()
 	desc = initial(desc)
@@ -58,7 +59,12 @@
 
 /datum/action/bloodsucker/Destroy()
 	bloodsuckerdatum_power = null
+	STOP_PROCESSING(SSfastprocess, src)
 	return ..()
+
+/datum/action/bloodsucker/process()
+	cooldown_overlay?.tick()
+	
 
 /datum/action/bloodsucker/IsAvailable()
 	return TRUE
@@ -154,9 +160,12 @@
 
 	// Wait for cooldown
 	COOLDOWN_START(src, bloodsucker_power_cooldown, this_cooldown)
+	cooldown_overlay = start_cooldown(button,world.time + this_cooldown)
 	addtimer(CALLBACK(src, .proc/alpha_in), this_cooldown)
 
 /datum/action/bloodsucker/proc/alpha_in()
+	if(cooldown_overlay)
+		QDEL_NULL(cooldown_overlay)
 	button.color = rgb(255,255,255,255)
 	button.alpha = 255
 

--- a/code/modules/antagonists/bloodsuckers/powers/targeted/lunge.dm
+++ b/code/modules/antagonists/bloodsuckers/powers/targeted/lunge.dm
@@ -15,6 +15,7 @@
 	cooldown = 10 SECONDS
 	target_range = 6
 	power_activates_immediately = FALSE
+	var/casting = FALSE //yogs - special snowflake!!!
 
 /*
  *	Level 1: Grapple level 2
@@ -77,7 +78,7 @@
 	PowerActivatedSuccessfully()
 
 /datum/action/bloodsucker/targeted/lunge/proc/prepare_target_lunge(atom/target_atom)
-	START_PROCESSING(SSprocessing, src)
+	casting = TRUE;
 	to_chat(owner, span_notice("You prepare to lunge!"))
 	//animate them shake
 	var/base_x = owner.pixel_x
@@ -90,13 +91,16 @@
 
 	if(!do_after(owner, 4 SECONDS, extra_checks = CALLBACK(src, .proc/CheckCanTarget, target_atom)))
 		animate(owner, pixel_x = base_x, pixel_y = base_y, time = 1)
-		STOP_PROCESSING(SSprocessing, src)
+		casting = FALSE
 		return FALSE
 	animate(owner, pixel_x = base_x, pixel_y = base_y, time = 1)
-	STOP_PROCESSING(SSprocessing, src)
+	casting = FALSE
 	return TRUE
 
 /datum/action/bloodsucker/targeted/lunge/process()
+	..()
+	if(!casting) //snowflake code for cooldowns
+		return
 	if(prob(75))
 		owner.spin(8, 1)
 		owner.visible_message(

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -320,7 +320,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	if(user && user.ckey)
 		user.log_message(span_danger("cast the spell [name]."), LOG_ATTACK)
 	if(recharge)
-		recharging = TRUE
+		start_recharge()
 	if(sound)
 		playMagSound()
 	cast(targets,user=user)


### PR DESCRIPTION
# Document the changes in your pull request

Adds https://github.com/yogstation13/Yogstation/pull/13038 to every visual spell (it was missing one) this makes it definitely work with all vampire abilites but i don't know if it worked that way before

also adds them to all bloodsucker abilities even with their dynamic cooldown, with extensibility to all datum/actions (coming later)


# Changelog

:cl:  
rscadd: Adds visual spell cooldowns on all spell casts and all bloodsucker abilities
/:cl:
