### PR TITLE
morph objective rework

### DIFF
--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -37,6 +37,8 @@
 	var/eat_while_disguised = FALSE
 	var/atom/movable/form = null
 	var/morph_time = 0
+	var/eat_count = 0
+	var/corpse_eat_count = 0
 	var/static/list/blacklist_typecache = typecacheof(list(
 	/obj/screen,
 	/obj/singularity,
@@ -199,15 +201,23 @@
 		if(L.stat == DEAD)
 			if(do_after(src, 3 SECONDS, target = L))
 				if(eat(L))
+					eat_count++
+					corpse_eat_count++
 					adjustHealth(-50)
 			return
 	else if(isitem(target)) //Eat items just to be annoying
 		var/obj/item/I = target
 		if(!I.anchored)
 			if(do_after(src, 2 SECONDS, target = I))
-				eat(I)
+				if(eat(I))
+					eat_count++
 			return
 	return ..()
+
+/mob/living/simple_animal/hostile/morph/get_status_tab_items()
+	. = ..()
+	. += "Things eaten: [eat_count]"
+	. += "Corpses eaten: [corpse_eat_count]"
 
 //Spawn Event
 

--- a/code/modules/antagonists/morph/morph_antag.dm
+++ b/code/modules/antagonists/morph/morph_antag.dm
@@ -60,7 +60,7 @@
 	..()
 	if(!target_things)
 		target_things = rand(20,60)
-	explanation_text = "Eat [target_things] things."
+	explanation_text = "Eat at least [target_things] things."
 
 /datum/objective/morph_eat_things/check_completion()
 	if(..())
@@ -80,7 +80,7 @@
 	..()
 	if(!target_corpses)
 		target_corpses = rand(2,6)
-	explanation_text = "Eat [target_corpses] corpses."
+	explanation_text = "Eat at least [target_corpses] corpses."
 
 /datum/objective/morph_eat_corpses/check_completion()
 	if(..())

--- a/code/modules/antagonists/morph/morph_antag.dm
+++ b/code/modules/antagonists/morph/morph_antag.dm
@@ -22,18 +22,22 @@
 	if(prob(33)) // Get both objectives
 		var/datum/objective/morph_eat_things/eat = new
 		eat.owner = owner
+		eat.update_explanation_text()
 		objectives += eat // Consume x objects
 		var/datum/objective/morph_eat_things/eatcorpses = new
 		eatcorpses.owner = owner
+		eatcorpses.update_explanation_text()
 		objectives += eatcorpses // Consume x corpses
 	else
 		if(prob(50))
 			var/datum/objective/morph_eat_things/eat = new
 			eat.owner = owner
+			eat.update_explanation_text()
 			objectives += eat // Consume x objects
 		else
 			var/datum/objective/morph_eat_things/eatcorpses = new
 			eatcorpses.owner = owner
+			eatcorpses.update_explanation_text()
 			objectives += eatcorpses // Consume x corpses
 
 	var/datum/objective/survive/survival = new

--- a/code/modules/antagonists/morph/morph_antag.dm
+++ b/code/modules/antagonists/morph/morph_antag.dm
@@ -4,20 +4,84 @@
 	show_in_antagpanel = FALSE
 	show_to_ghosts = TRUE
 
-/datum/antagonist/morph/proc/forge_objectives()
-	var/datum/objective/new_objective = new
-	new_objective.owner = owner
-	new_objective.completed = TRUE
-	objectives += new_objective
-	new_objective.explanation_text = "Consume everything." // you can do whatever
-	var/datum/objective/survive/survival = new
-	survival.owner = owner
-	objectives += survival // just dont die doing it
+/datum/antagonist/morph/roundend_report()
+	var/list/parts = list()
+	parts += printplayer(owner)
+	if(istype(owner.current, /mob/living/simple_animal/hostile/morph))
+		var/mob/living/simple_animal/hostile/morph/M = owner.current
+		parts += "Things eaten: [M.eat_count]"
+		parts += "Corpses eaten: [M.corpse_eat_count]"
+	parts += printobjectives(objectives)
+	return parts.Join("<br>")
 
 /datum/antagonist/morph/on_gain()
 	forge_objectives()
 	. = ..()
 
-/datum/antagonist/nightmare/greet()
+/datum/antagonist/morph/proc/forge_objectives()
+	if(prob(33)) // Get both objectives
+		var/datum/objective/morph_eat_things/eat = new
+		eat.owner = owner
+		objectives += eat // Consume x objects
+		var/datum/objective/morph_eat_things/eatcorpses = new
+		eatcorpses.owner = owner
+		objectives += eatcorpses // Consume x corpses
+	else
+		if(prob(50))
+			var/datum/objective/morph_eat_things/eat = new
+			eat.owner = owner
+			objectives += eat // Consume x objects
+		else
+			var/datum/objective/morph_eat_things/eatcorpses = new
+			eatcorpses.owner = owner
+			objectives += eatcorpses // Consume x corpses
+
+	var/datum/objective/survive/survival = new
+	survival.owner = owner
+	objectives += survival // Don't die, idiot
+
+
+
+/datum/antagonist/morph/greet()
 	owner.announce_objectives()
-	SEND_SOUND(owner.current, sound('sound/magic/demon_consume.ogg'))
+
+
+// Consume x objects
+/datum/objective/morph_eat_things
+	name = "morph eat objective"
+	explanation_text = "Eat things."
+	var/target_things
+
+/datum/objective/morph_eat_things/update_explanation_text()
+	..()
+	if(!target_things)
+		target_things = rand(20,60)
+	explanation_text = "Eat [target_things] things."
+
+/datum/objective/morph_eat_things/check_completion()
+	if(..())
+		return TRUE
+	if(istype(owner.current, /mob/living/simple_animal/hostile/morph))
+		var/mob/living/simple_animal/hostile/morph/M = owner.current
+		return M.eat_count >= target_things
+
+
+// Consume x corpses
+/datum/objective/morph_eat_corpses
+	name = "morph eat corpses objective"
+	explanation_text = "Eat corpses."
+	var/target_corpses
+
+/datum/objective/morph_eat_corpses/update_explanation_text()
+	..()
+	if(!target_corpses)
+		target_corpses = rand(2,6)
+	explanation_text = "Eat [target_corpses] corpses."
+
+/datum/objective/morph_eat_corpses/check_completion()
+	if(..())
+		return TRUE
+	if(istype(owner.current, /mob/living/simple_animal/hostile/morph))
+		var/mob/living/simple_animal/hostile/morph/M = owner.current
+		return M.corpse_eat_count >= target_corpses
+


### PR DESCRIPTION
# Document the changes in your pull request

2 new morph objectives
Eat x things (20-60)
Eat x corpses (2-6)
Count of each in status bar
Count of each show up in round end report

~33% to get either both objectives, one, or the other

Numbers susceptible to tweaking

# Wiki Documentation

Morphs now have two new potential objectives: eat & eat corpses
eat can have 20-60 req
eat corpses can have 2-6 req
Count of each also shows up in status bar

# Changelog

:cl:  
rscadd: Added a new morph objective, eat a certain number of things
rscadd: Added a new morph objective, eat a certain number of corpses
rscadd: Morphs can now see how many things & corpses they have eaten in their status bar
bugfix: Morphs now have a proper greeting
tweak: tweaked a few things  
/:cl:
