### PR TITLE
fixes a bug where knuckle rooting would cause full damage to cyborgs

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -533,7 +533,7 @@
 
 /datum/action/item_action/visegrip
 	name = "Vise Grip"
-	desc = "Remotely detonate marked targets. People become rooted for 1 second. Nonhumanoids become rooted for 6 seconds and take hefty damage."
+	desc = "Remotely detonate marked targets. People become rooted for 1 second. Animals become rooted for 6 seconds and take hefty damage."
 	icon_icon = 'icons/effects/effects.dmi'
 	button_icon_state = "leghold"
 	

--- a/code/datums/status_effects/knuckleroot.dm
+++ b/code/datums/status_effects/knuckleroot.dm
@@ -18,7 +18,7 @@
 	cube.Scale(size_check.Width(), size_check.Height())
 	owner.add_overlay(cube)
 	owner.remove_status_effect(STATUS_EFFECT_KNUCKLED)
-	if(!ishuman(owner))
+	if(isanimal(owner))
 		duration = 6 SECONDS
 		owner.adjustBruteLoss(50)
 	return ..()


### PR DESCRIPTION
# Document the changes in your pull request

no

# Changelog

:cl:  
bugfix: cyborgs are no longer given the full effects of a knuckle root by the bloody knuckles
/:cl:
