### PR TITLE
Makes buy privately button do something

### DIFF
--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -9,6 +9,7 @@
 		cannot transport live organisms, human remains, classified nuclear weaponry \
 		or homing beacons. Additionally, remove any privately ordered crates from the shuttle."
 	var/blockade_warning = "Bluespace instability detected. Shuttle movement impossible."
+	var/self_paid = FALSE
 
 	light_color = "#E2853D"//orange
 
@@ -63,7 +64,7 @@
 	if(D)
 		data["points"] = D.account_balance
 	data["away"] = SSshuttle.supply.getDockedId() == "supply_away"
-	//data["self_paid"] = self_paid //This is present on TG, but not here, we'll see if it's necessary.
+	data["self_paid"] = self_paid
 	data["docked"] = SSshuttle.supply.mode == SHUTTLE_IDLE
 	data["loan"] = !!SSshuttle.shuttle_loan
 	data["loan_dispatched"] = SSshuttle.shuttle_loan && SSshuttle.shuttle_loan.dispatched
@@ -228,6 +229,9 @@
 					break
 		if("denyall")
 			SSshuttle.requestlist.Cut()
+			. = TRUE
+		if("toggleprivate")
+			self_paid = !self_paid
 			. = TRUE
 	if(.)
 		post_signal("supply")

--- a/tgui/packages/tgui/interfaces/Cargo.js
+++ b/tgui/packages/tgui/interfaces/Cargo.js
@@ -109,7 +109,7 @@ const CargoStatus = (props, context) => {
               <Box color="bad">
                 Loaned to Centcom
               </Box>
-          )}
+            )}
           </LabeledList.Item>
         )}
       </LabeledList>
@@ -368,7 +368,7 @@ const CargoCart = (props, context) => {
             <Box opacity={0.5}>
               Shuttle in {location}.
             </Box>
-        )}
+          )}
         </Box>
       )}
     </Section>

--- a/tgui/packages/tgui/interfaces/Cargo.js
+++ b/tgui/packages/tgui/interfaces/Cargo.js
@@ -189,7 +189,7 @@ export const CargoCatalog = (props, context) => {
                       tooltipPosition="left"
                       onClick={() => act('add', {
                         id: pack.id,
-                        self_paid: self_paid
+                        self_paid: self_paid,
                       })}>
                       {formatMoney(self_paid && !pack.goody
                         ? Math.round(pack.cost * 1.1)

--- a/tgui/packages/tgui/interfaces/Cargo.js
+++ b/tgui/packages/tgui/interfaces/Cargo.js
@@ -280,7 +280,7 @@ const CargoCartButtons = (props, context) => {
     requestonly,
   } = data;
   const cart = data.cart || [];
-  const total = cart.reduce((total, entry) => total + (entry.paid == null ? entry.cost : 0), 0);
+  const total = cart.reduce((total, entry) => total + (entry.paid ? entry.cost : 0), 0);
   if (requestonly) {
     return null;
   }

--- a/tgui/packages/tgui/interfaces/Cargo.js
+++ b/tgui/packages/tgui/interfaces/Cargo.js
@@ -106,10 +106,10 @@ const CargoStatus = (props, context) => {
                 disabled={!(away && docked)}
                 onClick={() => act('loan')} />
             ) || (
-                <Box color="bad">
-                  Loaned to Centcom
-                </Box>
-              )}
+              <Box color="bad">
+                Loaned to Centcom
+              </Box>
+          )}
           </LabeledList.Item>
         )}
       </LabeledList>
@@ -365,10 +365,10 @@ const CargoCart = (props, context) => {
               content="Confirm the order"
               onClick={() => act('send')} />
           ) || (
-              <Box opacity={0.5}>
-                Shuttle in {location}.
-              </Box>
-            )}
+            <Box opacity={0.5}>
+              Shuttle in {location}.
+            </Box>
+        )}
         </Box>
       )}
     </Section>

--- a/tgui/packages/tgui/interfaces/Cargo.js
+++ b/tgui/packages/tgui/interfaces/Cargo.js
@@ -109,7 +109,7 @@ const CargoStatus = (props, context) => {
               <Box color="bad">
                 Loaned to Centcom
               </Box>
-            )}
+          )}
           </LabeledList.Item>
         )}
       </LabeledList>
@@ -368,7 +368,7 @@ const CargoCart = (props, context) => {
             <Box opacity={0.5}>
               Shuttle in {location}.
             </Box>
-          )}
+        )}
         </Box>
       )}
     </Section>

--- a/tgui/packages/tgui/interfaces/Cargo.js
+++ b/tgui/packages/tgui/interfaces/Cargo.js
@@ -109,7 +109,7 @@ const CargoStatus = (props, context) => {
               <Box color="bad">
                 Loaned to Centcom
               </Box>
-              )}
+            )}
           </LabeledList.Item>
         )}
       </LabeledList>
@@ -368,7 +368,7 @@ const CargoCart = (props, context) => {
             <Box opacity={0.5}>
               Shuttle in {location}.
             </Box>
-            )}
+          )}
         </Box>
       )}
     </Section>

--- a/tgui/packages/tgui/interfaces/Cargo.js
+++ b/tgui/packages/tgui/interfaces/Cargo.js
@@ -106,10 +106,10 @@ const CargoStatus = (props, context) => {
                 disabled={!(away && docked)}
                 onClick={() => act('loan')} />
             ) || (
-              <Box color="bad">
-                Loaned to Centcom
-              </Box>
-          )}
+                <Box color="bad">
+                  Loaned to Centcom
+                </Box>
+              )}
           </LabeledList.Item>
         )}
       </LabeledList>
@@ -365,10 +365,10 @@ const CargoCart = (props, context) => {
               content="Confirm the order"
               onClick={() => act('send')} />
           ) || (
-            <Box opacity={0.5}>
-              Shuttle in {location}.
-            </Box>
-        )}
+              <Box opacity={0.5}>
+                Shuttle in {location}.
+              </Box>
+            )}
         </Box>
       )}
     </Section>

--- a/tgui/packages/tgui/interfaces/Cargo.js
+++ b/tgui/packages/tgui/interfaces/Cargo.js
@@ -106,9 +106,9 @@ const CargoStatus = (props, context) => {
                 disabled={!(away && docked)}
                 onClick={() => act('loan')} />
             ) || (
-                <Box color="bad">
-                  Loaned to Centcom
-                </Box>
+              <Box color="bad">
+                Loaned to Centcom
+              </Box>
               )}
           </LabeledList.Item>
         )}
@@ -365,9 +365,9 @@ const CargoCart = (props, context) => {
               content="Confirm the order"
               onClick={() => act('send')} />
           ) || (
-              <Box opacity={0.5}>
-                Shuttle in {location}.
-              </Box>
+            <Box opacity={0.5}>
+              Shuttle in {location}.
+            </Box>
             )}
         </Box>
       )}

--- a/tgui/packages/tgui/interfaces/Cargo.js
+++ b/tgui/packages/tgui/interfaces/Cargo.js
@@ -106,10 +106,10 @@ const CargoStatus = (props, context) => {
                 disabled={!(away && docked)}
                 onClick={() => act('loan')} />
             ) || (
-              <Box color="bad">
-                Loaned to Centcom
-              </Box>
-            )}
+                <Box color="bad">
+                  Loaned to Centcom
+                </Box>
+              )}
           </LabeledList.Item>
         )}
       </LabeledList>
@@ -189,6 +189,7 @@ export const CargoCatalog = (props, context) => {
                       tooltipPosition="left"
                       onClick={() => act('add', {
                         id: pack.id,
+                        self_paid: self_paid
                       })}>
                       {formatMoney(self_paid && !pack.goody
                         ? Math.round(pack.cost * 1.1)
@@ -279,7 +280,7 @@ const CargoCartButtons = (props, context) => {
     requestonly,
   } = data;
   const cart = data.cart || [];
-  const total = cart.reduce((total, entry) => total + entry.cost, 0);
+  const total = cart.reduce((total, entry) => total + (entry.paid == null ? entry.cost : 0), 0);
   if (requestonly) {
     return null;
   }
@@ -339,7 +340,7 @@ const CargoCart = (props, context) => {
                 )}
               </Table.Cell>
               <Table.Cell collapsing textAlign="right">
-                {formatMoney(entry.cost)} cr
+                {formatMoney(entry.paid ? Math.round(entry.cost * 1.1) : entry.cost)} cr
               </Table.Cell>
               <Table.Cell collapsing>
                 <Button
@@ -364,10 +365,10 @@ const CargoCart = (props, context) => {
               content="Confirm the order"
               onClick={() => act('send')} />
           ) || (
-            <Box opacity={0.5}>
-              Shuttle in {location}.
-            </Box>
-          )}
+              <Box opacity={0.5}>
+                Shuttle in {location}.
+              </Box>
+            )}
         </Box>
       )}
     </Section>


### PR DESCRIPTION
# Document the changes in your pull request

whoever ported it never added the functionality so it's been a dead button

private crates are 10% more than their label price, and charge your bank account instead. the manifest says who's it is (so you know who deliver to) requesting something privately adds it to the purchase list, not the request list, so there's pretty much 0 reason why you would be denied anything since it only costs you money and not cargo

# Wiki Documentation

can now buy privately

# Changelog

:cl:  
rscadd: Added Buy Privately functionality to Cargo Console
/:cl:
