### PR TITLE
Make sleeping carp have a pop requirement and cost 17 TC, make HP bullet cost 2 TC

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -615,7 +615,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "This scroll contains the secrets of an ancient martial arts technique. You will master unarmed combat, \
 			deflecting all ranged weapon fire when throwmode is enabled, but you also refuse to use dishonorable ranged weaponry."
 	item = /obj/item/book/granter/martial/carp
-	cost = 14
+	player_minimum = 25
+	cost = 17
 	surplus = 0
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops, /datum/game_mode/infiltration) // yogs: infiltration
 
@@ -704,7 +705,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "An additional 8-round 10mm magazine; compatible with the Stechkin Pistol. \
 			These rounds are more damaging but ineffective against armour."
 	item = /obj/item/ammo_box/magazine/m10mm/hp
-	cost = 3
+	cost = 2
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 
 /datum/uplink_item/ammo/pistolsleepy


### PR DESCRIPTION
# Document the changes in your pull request

Desword is nukie only, cost 16 TC, require 25 players and can't perfectly deflect bullets, so let's make an item that deflect literally everything, is stealthier, got a billion stun move to win instantly and then let's make it available to traitors for less TC  even on lowpop because what is balance really?
Now you won't be able to buy this bullshit and still have enough TC to buy an emag to get null crates on lowpop where there's only one secoff.
Also make sketchin HP magazine cost 2 TC because this is only useful to kill unarmored targets slightly faster which isn't that incredible since the standard sketchin bullets do that just fine and can literally be printed in infinite quantities

# Wiki Documentation

Sleeping carp cost 17 TC and require 25 players.
HP bullet for the sketchin cost 2 TC.

# Changelog

Sleeping carp is locked behind 25 pop and cost 17 TC, HP mag cost now 2 TC.

:cl:  
tweak: Make sleeping carp require 25 players and cost 17 TC, HP bullets now cost 2 TC 
/:cl:
