### PR TITLE
Fixes regenerate_organs() making felinid tails disappear 

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -308,6 +308,8 @@ GLOBAL_LIST_EMPTY(mentor_races)
 		QDEL_NULL(tail)
 	if(should_have_tail && !tail)
 		tail = new mutanttail()
+		if(iscatperson(C))
+			tail.tail_type = C.dna.features["tail_human"]
 		if(ispolysmorph(C))
 			tail.tail_type = C.dna.features["tail_polysmorph"]
 		if(islizard(C))

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -308,8 +308,6 @@ GLOBAL_LIST_EMPTY(mentor_races)
 		QDEL_NULL(tail)
 	if(should_have_tail && !tail)
 		tail = new mutanttail()
-		if(iscatperson(C))
-			tail.tail_type = C.dna.features["tail_human"]
 		if(ispolysmorph(C))
 			tail.tail_type = C.dna.features["tail_polysmorph"]
 		if(islizard(C))

--- a/code/modules/surgery/organs/tails.dm
+++ b/code/modules/surgery/organs/tails.dm
@@ -29,7 +29,6 @@
 /obj/item/organ/tail/cat/Remove(mob/living/carbon/human/H,  special = 0)
 	..()
 	if(istype(H))
-		H.dna.features["tail_human"] = "None"
 		H.dna.species.mutant_bodyparts -= "tail_human"
 		color = H.hair_color
 		H.update_body()


### PR DESCRIPTION
Turns out it was a bad idea to start by removing the tail, which sets your feature to "none", and then asking your dna what icon to use for the tail ("none").
#13824 issue here, you're welcome snibby and truz

tested and it works and i made it a hard restore to cat tails because as far as i know felinid tails are not optional.


https://user-images.githubusercontent.com/46236974/167021919-932cf3b8-01d7-460b-83f0-80dece26e098.mp4

(before it would disappear the tail)

:cl:  
bugfix: regenerate_organs no longer disappears cat tails. antag felinids rejoice.
/:cl:
