### PR TITLE
That's it I'm taking the meteor waves

### DIFF
--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -3,7 +3,7 @@
 /datum/round_event_control/meteor_wave
 	name = "Meteor Wave: Normal"
 	typepath = /datum/round_event/meteor_wave
-	weight = 6
+	weight = 7
 	min_players = 10 //yogs
 	max_occurrences = 3 //yogs
 	//earliest_start = 25 MINUTES //yogs

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -3,9 +3,9 @@
 /datum/round_event_control/meteor_wave
 	name = "Meteor Wave: Normal"
 	typepath = /datum/round_event/meteor_wave
-	weight = 4
+	weight = 6
 	min_players = 10 //yogs
-	max_occurrences = 2 //yogs
+	max_occurrences = 3 //yogs
 	//earliest_start = 25 MINUTES //yogs
 
 /datum/round_event/meteor_wave

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -5,7 +5,7 @@
 	typepath = /datum/round_event/meteor_wave
 	weight = 4
 	min_players = 10 //yogs
-	max_occurrences = 3
+	max_occurrences = 2 //yogs
 	//earliest_start = 25 MINUTES //yogs
 
 /datum/round_event/meteor_wave
@@ -23,9 +23,9 @@
 /datum/round_event/meteor_wave/proc/determine_wave_type()
 	if(!wave_name)
 		wave_name = pickweight(list(
-			"normal" = 50,
-			"threatening" = 40,
-			"catastrophic" = 10))
+			"normal" = 100,
+			"threatening" = 0,
+			"catastrophic" = 0))
 	switch(wave_name)
 		if("normal")
 			wave_type = GLOB.meteors_normal
@@ -56,7 +56,7 @@
 /datum/round_event_control/meteor_wave/threatening
 	name = "Meteor Wave: Threatening"
 	typepath = /datum/round_event/meteor_wave/threatening
-	weight = 2 //yogs
+	weight = 0 //yogs
 	min_players = 20
 	max_occurrences = 3
 	//earliest_start = 35 MINUTES //yogs
@@ -67,7 +67,7 @@
 /datum/round_event_control/meteor_wave/catastrophic
 	name = "Meteor Wave: Catastrophic"
 	typepath = /datum/round_event/meteor_wave/catastrophic
-	weight = 1 //yogs
+	weight = 0 //yogs
 	min_players = 25
 	max_occurrences = 3
 	//earliest_start = 45 MINUTES //yogs


### PR DESCRIPTION
# Document the changes in your pull request

+It gives engineering something to do
-It doesn't let anyone do anything including move for about 10 minutes realtime (2 minutes gametime)
-It forces a shuttle call because engineering doesn't do anything

Only normal meteor waves naturally happen. They can now only naturally happen twice a round instead of three times.

# Wiki Documentation

Only normal meteor waves naturally happen.

# Changelog

:cl:  
tweak: Only normal meteor waves naturally happen.
tweak: Normal meteor waves can only naturally happen twice a round instead of three times.
/:cl: