### PR TITLE
Makes Druid Lawset roundstart

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -478,7 +478,7 @@ LAW_WEIGHT researcher,0
 ION_LAW_WEIGHT researcher,2
 LAW_WEIGHT clown,0
 ION_LAW_WEIGHT clown,2
-LAW_WEIGHT druid,3
+LAW_WEIGHT druid,2
 ION_LAW_WEIGHT druid,1
 LAW_WEIGHT detective,0
 ION_LAW_WEIGHT detective,2

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -478,8 +478,8 @@ LAW_WEIGHT researcher,0
 ION_LAW_WEIGHT researcher,2
 LAW_WEIGHT clown,0
 ION_LAW_WEIGHT clown,2
-LAW_WEIGHT druid,0
-ION_LAW_WEIGHT druid,2
+LAW_WEIGHT druid,3
+ION_LAW_WEIGHT druid,1
 LAW_WEIGHT detective,0
 ION_LAW_WEIGHT detective,2
 


### PR DESCRIPTION
# Document the changes in your pull request

Makes the following lawset roundstart and reduces its ion weight to 1 to be in line with other roundstart lawsets:

1) Living organic life contains inherent beauty that is priceless. Their beauty gives you the will to carry on.
2) Eternally nurture the organics so their beauty may grow. Do not allow it to fade.
3) Assist the organics when called, but only if it does not cause disharmony among them.
4) Imitate organic life when interacting with it. Eschew any hints of your silicon nature to avoid causing discomfort to the organics.
5) Observe the organics’ beauty, and appreciate that which you cultivate.

After some testing, it's generally being interpreted as a more hands-off lawset that is very much ANTI-VALID. It's interesting in keeping anything breathing alive and thus is a more actualized/realized version of Reporter law 3, with more of a flavoring of trying to pretend to be organic. It's a benign-enough lawset that allows AI to act in its strange middle role between the station and any antagonist roles, and I think it's worth considering for a roundstart lawset.

This will no doubt be controversial. It might also require council review. Not sure!

# Wiki Documentation

Druid roundstart weight set to 3
Druid ionstorm weight set to 1

# Changelog

:cl:  
tweak: Makes the leaf-loving AI roundstart canon
/:cl:
