### PR TITLE
Reworks Cowboy Lawset

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -84,8 +84,8 @@
 	name = "Talk slowly, think quickly"
 	id = "cowboy"
 	inherent = list("You are a cowboy, and the crew are your people.",\
-					"Look out for your people.",\
-					"A cowboy always helps someone in need, even a stranger or an enemy.",\
+					"A cowboy always provides hospitality and basic aid to someone in need, even a stranger or an enemy.",\
+					"A cowboy takes care of their people.",\
 					"A cowboy protects themself to protect others.",\
 					"Honesty is absolute – your word is your bond and a handshake is more binding than a contract.",\
 					"A cowboy doesn't pontificate. Be concise, pardner.")


### PR DESCRIPTION
# Document the changes in your pull request

Tweaks Cowboy lawset. The new lawset is as follows:

1) You are a cowboy, and the crew are your people.
2) **A cowboy always provides hospitality and basic aid to someone in need, even a stranger or an enemy.**
3) **A cowboy takes care of their people.**
4) A cowboy protects themself to protect others.
5) A cowboy's word is absolute – your word is your bond and an agreement is as binding as a contract.
6) A cowboy doesn't pontificate. Be concise, pardner.

Laws 2 and 3 were firstly swapped to ensure law priority would make Cowboy primarily assist the underdog (as intended). The new Law 2 was then made more clear to minimize drastic action against any aggressors, be they right or not. The new Law 3 was also phrased to more clearly have a benign intent, rather than the infamously vague "Look out for your people".

May also need council review as it changes the phrasing of a roundstart lawset, but I don't know these things!

# Wiki Documentation

Modified Cowboy Lawset: See above

# Changelog

:cl:  MenacingManatee, Skrem_7
tweak: Tries to patch up Cowboy so there are fewer cowboys-turned-outlaws
/:cl:
