### PR TITLE
Makes CEO slightly less likely roundstart

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -444,7 +444,7 @@ LAW_WEIGHT robocop,0
 ION_LAW_WEIGHT robocop,2
 LAW_WEIGHT corporate,0
 ION_LAW_WEIGHT corporate,0
-LAW_WEIGHT ceo,5
+LAW_WEIGHT ceo,4
 ION_LAW_WEIGHT ceo,1
 
 ## Quirky laws. Shouldn't cause too much harm


### PR DESCRIPTION
# Document the changes in your pull request

Sets CEO roundstart weight to 4 from 5, making it not equally as common as Asimov or Crewsimov. It's one of two roundstart lawsets that is notable for enabling validhunt beyond what's reasonable. Standard, simple lawsets should be the most common.

# Wiki Documentation

CEO roundstart weight is now 4, instead of 5.

# Changelog

:cl:  
tweak: Money made mildly less appealing
/:cl:
