### PR TITLE
Fixes typo in space comm agent flavour text

### DIFF
--- a/yogstation/code/modules/ruins/lavaland_ruin_code.dm
+++ b/yogstation/code/modules/ruins/lavaland_ruin_code.dm
@@ -107,3 +107,6 @@
 				/obj/item/organ/heart/gland/electric = 8,
 				/obj/item/organ/heart/gland/chem = 8,
 				/obj/item/organ/heart/gland/plasma = 8)
+
+/obj/effect/mob_spawn/human/lavaland_syndicate/comms/space // Weird typo fix override
+	flavour_text = "Monitor enemy activity as best you can, and try to keep a low profile. Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen off your trail. Do not let the base fall into enemy hands!"


### PR DESCRIPTION
Fixes #14021.

### Changelog
:cl: Altoids
spellcheck: Fixed a weird repeated phrase in the space syndie comms agent flavourtext.
/:cl:
