### PR TITLE
Lich spell cost increase to 4

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -205,6 +205,7 @@
 	name = "Bind Soul"
 	spell_type = /obj/effect/proc_holder/spell/targeted/lichdom
 	category = "Defensive"
+	cost = 4
 
 /datum/spellbook_entry/teslablast
 	name = "Tesla Blast"


### PR DESCRIPTION
Crutch spell that is used with the meta to deal unreasonable amounts of damage even by wizard standards. If you want to be unkillable whenever the crew is inept (most of the time), there will be a higher point investment now.

# Changelog

:cl:  
tweak: Lich spell cost doubled.
/:cl:
