### PR TITLE
Buffs spellcards, lightning blast, and tesla blast

### DIFF
--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -616,7 +616,7 @@
 /obj/item/projectile/magic/aoe/lightning
 	name = "lightning bolt"
 	icon_state = "tesla_projectile"	//Better sprites are REALLY needed and appreciated!~
-	damage = 15
+	damage = 25
 	damage_type = BURN
 	nodamage = FALSE
 	speed = 0.3

--- a/code/modules/projectiles/projectile/magic/spellcard.dm
+++ b/code/modules/projectiles/projectile/magic/spellcard.dm
@@ -3,4 +3,4 @@
 	desc = "A piece of paper enchanted to give it extreme durability and stiffness, along with a very hot burn to anyone unfortunate enough to get hit by a charged one."
 	icon_state = "spellcard"
 	damage_type = BURN
-	damage = 3
+	damage = 4

--- a/code/modules/spells/spell_types/aimed.dm
+++ b/code/modules/spells/spell_types/aimed.dm
@@ -90,9 +90,9 @@
 
 /obj/effect/proc_holder/spell/aimed/lightningbolt
 	name = "Lightning Bolt"
-	desc = "Fire a lightning bolt at your foes! It will jump between targets, but can't knock them down."
+	desc = "Fire a lightning bolt at your foes! It will jump between targets, but can't knock them down. Insulated gloves can protect people from the blast."
 	school = "evocation"
-	charge_max = 120
+	charge_max = 100
 	clothes_req = FALSE
 	invocation = "UN'LTD P'WAH"
 	invocation_type = "shout"

--- a/code/modules/spells/spell_types/lightning.dm
+++ b/code/modules/spells/spell_types/lightning.dm
@@ -1,8 +1,8 @@
 /obj/effect/proc_holder/spell/targeted/tesla
 	name = "Tesla Blast"
-	desc = "Charge up a tesla arc and release it at a random nearby target! You can move freely while it charges. The arc jumps between targets and can knock them down."
+	desc = "Charge up a tesla arc and release it at a random nearby target! You can move freely while it charges. The arc jumps between targets and can knock them down if they do not have shock protection."
 	charge_type = "recharge"
-	charge_max	= 300
+	charge_max	= 200
 	clothes_req = TRUE
 	invocation = "UN'LTD P'WAH!"
 	invocation_type = "shout"


### PR DESCRIPTION
Increases spell card projectile damage from 3 to 4. Allowing up to 140 damage from 5 consecutive point blank hits.

Lightning blast direct hit damage increased to 25 from 15, and cooldown reduced to 10 from 12.

Tesla blast cooldown reduced to 20 from 30.

Both lightning blast and tesla blast can be completely nullified with insulated gloves so their descriptions have been changed to reflect that this can indeed happen.

# Changelog

:cl:  
rscadd: Added warning info to lightning blast and tesla blast.
tweak: spellcard, lightning blast, and tesla blast buffed.
/:cl:
