### PR TITLE
rodform cooldown increased by 5 seconds

### DIFF
--- a/code/modules/spells/spell_types/rod_form.dm
+++ b/code/modules/spells/spell_types/rod_form.dm
@@ -3,7 +3,7 @@
 	desc = "Take on the form of an immovable rod, destroying all in your path. Purchasing this spell multiple times will also increase the rod's damage and travel range."
 	clothes_req = TRUE
 	human_req = FALSE
-	charge_max = 350
+	charge_max = 300
 	cooldown_min = 100
 	range = -1
 	include_user = TRUE

--- a/code/modules/spells/spell_types/rod_form.dm
+++ b/code/modules/spells/spell_types/rod_form.dm
@@ -3,7 +3,7 @@
 	desc = "Take on the form of an immovable rod, destroying all in your path. Purchasing this spell multiple times will also increase the rod's damage and travel range."
 	clothes_req = TRUE
 	human_req = FALSE
-	charge_max = 250
+	charge_max = 350
 	cooldown_min = 100
 	range = -1
 	include_user = TRUE


### PR DESCRIPTION
Rodform doesn't need to have a faster cooldown than jaunt when it already has the benefits of being unblockable with holy water and stuns, and the ability to insta crit people most of the time. 

# Changelog

:cl:  
tweak: rodform cooldown increased to 30 seconds, to match ethereal jaunt.
/:cl:
