### PR TITLE
Wrestling belt in uplink

### DIFF
--- a/code/datums/martial/wrestling.dm
+++ b/code/datums/martial/wrestling.dm
@@ -448,9 +448,14 @@
 	name = "Wrestling Belt"
 	var/datum/martial_art/wrestling/style = new
 
+/obj/item/storage/belt/champion/wrestling/proc/can_learn(mob/user)
+	return TRUE
+
 /obj/item/storage/belt/champion/wrestling/equipped(mob/user, slot)
 	. = ..()
 	if(!ishuman(user))
+		return
+	if(!can_learn(user))
 		return
 	if(slot == SLOT_BELT)
 		var/mob/living/carbon/human/H = user

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3308,6 +3308,7 @@
 #include "yogstation\code\datums\diseases\advance\symptoms\confusion.dm"
 #include "yogstation\code\datums\diseases\advance\symptoms\heal.dm"
 #include "yogstation\code\datums\looping_sounds\darkspawn.dm"
+#include "yogstation\code\datums\martial\wrestling.dm"
 #include "yogstation\code\datums\mood_events\generic_positive_events.dm"
 #include "yogstation\code\datums\mutations\alcohol.dm"
 #include "yogstation\code\datums\mutations\extendoarm.dm"

--- a/yogstation/code/datums/martial/wrestling.dm
+++ b/yogstation/code/datums/martial/wrestling.dm
@@ -1,0 +1,19 @@
+/obj/item/storage/belt/champion/wrestling/dna_locked
+	var/dna_lock = null
+
+/obj/item/storage/belt/champion/wrestling/dna_locked/can_learn(mob/user)
+	. = ..()
+	var/mob/living/carbon/human/H = user
+	if (!istype(H))
+		return FALSE
+	if (!isnull(dna_lock) && dna_lock != H.dna.unique_enzymes) 
+		return FALSE
+
+/obj/item/storage/belt/champion/wrestling/dna_locked/equipped(mob/user, slot)
+	. = ..()
+	var/mob/living/carbon/human/H = user
+	if (!istype(H))
+		return
+	if (isnull(dna_lock))
+		dna_lock = H.dna.unique_enzymes
+		

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -143,3 +143,11 @@
 	item = /obj/item/melee/fryingpan/bananium
 	cost = 40
 	cant_discount = TRUE
+
+/datum/uplink_item/dangerous/wrestling_belt
+	name = "Wrestling Belt"
+	desc = "SNAP INTO A SLIM JIM!"
+	item = /obj/item/storage/belt/champion/wrestling/dna_locked
+	cost = 8
+	surplus = 20
+	exclude_modes = list(/datum/game_mode/infiltration)


### PR DESCRIPTION
# Document the changes in your pull request

Adds the wrestling belt to the uplink since it's too weak for admin shenanigans. 
Also nukies get it

# Wiki Documentation

Wresting belt is in the uplink for 8 TC.

# Changelog
:cl:  
rscadd: Wrestling belt is now in the uplink
/:cl:
