### PR TITLE
Rev flashes

### DIFF
--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -243,6 +243,7 @@
 
 	if(give_flash)
 		var/obj/item/assembly/flash/handheld/T = new(H)
+		T.name = "revolutionary flash"
 		var/list/slots = list (
 			"backpack" = SLOT_IN_BACKPACK,
 			"left pocket" = SLOT_L_STORE,

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -198,7 +198,7 @@
 			var/datum/antagonist/rev/head/converter = user.mind.has_antag_datum(/datum/antagonist/rev/head)
 			if(!converter)
 				var/datum/antagonist/rev/underling = user.mind.has_antag_datum(/datum/antagonist/rev)
-				if(underling)
+				if(underling || name == "revolutionary flash")
 					to_chat(user, span_warning("Only head revolutionaries can convert with flashes!"))
 				return
 			if(!H.client)

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -197,6 +197,9 @@
 		if(user.mind)
 			var/datum/antagonist/rev/head/converter = user.mind.has_antag_datum(/datum/antagonist/rev/head)
 			if(!converter)
+				var/datum/antagonist/rev/underling = user.mind.has_antag_datum(/datum/antagonist/rev)
+				if(underling)
+					to_chat(user, span_warning("Only head revolutionaries can convert with flashes!"))
 				return
 			if(!H.client)
 				to_chat(user, span_warning("This mind is so vacant that it is not susceptible to influence!"))
@@ -209,6 +212,12 @@
 			else
 				to_chat(user, span_warning("This mind seems resistant to the flash!"))
 
+/obj/item/assembly/flash/pickup(mob/user)
+	. = ..()
+	if(user.mind)
+		var/datum/antagonist/rev/head/converter = user.mind.has_antag_datum(/datum/antagonist/rev/head)
+		if(converter)
+			name = "revolutionary flash" // Anything you touch becomes part of the revolution. Viva
 
 /obj/item/assembly/flash/cyborg
 


### PR DESCRIPTION
# Document the changes in your pull request

rev flashes havent existed since prebase afaik but rev metashield has always been an incredibly hot topic
i won't go too into detail but basically when it is appropriate to call out revs for flashing has never really been clear and has just been a feel-out thing, but no one really knows the threshold

if you've not read the metashield guide for some reason, allow me to introduce you to the fact that "revolution flashers" and whatever the hell "revolution flash hijackers" are are still listed as examples of when revs should be spotted

this will solve most of our problems

also includes a message when revs try to use flashes that says they can't convert

also includes a message when a non-rev tries to use a flash named "revolutionary flash" that says they can't convert

discussion in #public can be seen here onwards because people dont like posting comments in prs ig idk make a #quickfire-vote if you really care
https://discord.com/channels/134720091576205312/134720091576205312/972551115709243432

## Gameplay flow intention

report of flash assault -> security moves in to confiscate the restricted weapon -> the weapon is found to be a rev flash -> revs called

## How does it work?

any flash that a head rev picks up become "revolutionary flash", this includes the flash they start with

# Changelog

:cl:  
tweak: Flashes used by head revolutionaries are now classed as "revolutionary flashes"
/:cl:
