### PR TITLE
[admin] Improves admin notification of tickets

### DIFF
--- a/yogstation/code/modules/admin/verbs/adminhelp.dm
+++ b/yogstation/code/modules/admin/verbs/adminhelp.dm
@@ -206,7 +206,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			var/datum/admins/A = GLOB.deadmins[deadmin_ckey]
 			if(!A.check_for_rights(R_BAN))
 				continue
-			var/client = GLOB.directory[deadmin_ckey]
+			var/client/client = GLOB.directory[deadmin_ckey]
 			if(!client)
 				continue
 			if(client.prefs.toggles & SOUND_ADMINHELP)

--- a/yogstation/code/modules/admin/verbs/adminhelp.dm
+++ b/yogstation/code/modules/admin/verbs/adminhelp.dm
@@ -197,7 +197,8 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	if(. > 0)
 		return
 	send2irc_adminless_only(initiator_ckey, "Ticket #[id]: [name]")
-	if(adm["stealth"] > 0) // If there are stealthmins, do nothing
+	var/list/stealthmins = adm["stealth"]
+	if(stealthmins.len > 0) // If there are stealthmins, do nothing
 		return
 	// There are no admins online, try deadmins
 	var/found_deadmin = FALSE
@@ -211,7 +212,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 				continue
 			if(client.prefs.toggles & SOUND_ADMINHELP)
 				SEND_SOUND(client, sound('sound/effects/adminhelp.ogg'))
-			to_chat(client, span_notice("Ticket opened with no active admins. Ticket will be sent to discord in 30 seconds if not taken."), confidential=TRUE)
+			to_chat(client, span_danger("Ticket opened with no active admins. Ticket will be sent to discord in 30 seconds if not taken."), confidential=TRUE)
 			if(!found_deadmin)
 				found_deadmin = TRUE
 				addtimer(CALLBACK(src, .proc/send_to_discord), 30 SECONDS)
@@ -220,7 +221,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 /datum/admin_help/proc/send_to_discord()
 	if(state == AHELP_ACTIVE && !handling_admin)
-		webhook_send_ticket_unclaimed(id, initiator_ckey, name)
+		webhook_send_ticket_unclaimed(initiator_ckey, name, id)
 
 /datum/admin_help/Destroy()
 	GLOB.ahelp_tickets.tickets_list -= src

--- a/yogstation/code/modules/admin/verbs/adminhelp.dm
+++ b/yogstation/code/modules/admin/verbs/adminhelp.dm
@@ -191,7 +191,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	GLOB.ahelp_tickets.ticketAmount += 1
 
 /datum/admin_help/proc/check_admins_online()
-	var/list/adm = get_admin_counts(requiredflags)
+	var/list/adm = get_admin_counts(R_BAN)
 	var/list/activemins = adm["present"]
 	. = activemins.len
 	if(. > 0)
@@ -209,12 +209,12 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			var/client = GLOB.directory[deadmin_ckey]
 			if(!client)
 				continue
-			if(X.prefs.toggles & SOUND_ADMINHELP)
-				SEND_SOUND(X, sound('sound/effects/adminhelp.ogg'))
+			if(client.prefs.toggles & SOUND_ADMINHELP)
+				SEND_SOUND(client, sound('sound/effects/adminhelp.ogg'))
 			to_chat(client, span_notice("Ticket opened with no active admins. Ticket will be sent to discord in 30 seconds if not taken."), confidential=TRUE)
 			if(!found_deadmin)
 				found_deadmin = TRUE
-				add_timer(CALLBACK(src, .proc/send_to_discord), 30 SECONDS)
+				addtimer(CALLBACK(src, .proc/send_to_discord), 30 SECONDS)
 	if(!found_deadmin)
 		send_to_discord()
 

--- a/yogstation/code/modules/webhook/webhook.dm
+++ b/yogstation/code/modules/webhook/webhook.dm
@@ -29,7 +29,7 @@
 
 /proc/webhook_send_ticket_unclaimed(var/ckey, var/message, var/id)
 	var/list/query = webhook(ckey, message)
-	query.Add("id" = id)
+	query.Add(list("id" = id))
 	webhook_send("ticket_unclaimed", query)
 
 /////////////MENTORS/////////////

--- a/yogstation/code/modules/webhook/webhook.dm
+++ b/yogstation/code/modules/webhook/webhook.dm
@@ -27,6 +27,10 @@
 	var/list/query = webhook(ckey, message)
 	webhook_send("oocmessage", query)
 
+/proc/webhook_send_ticket_unclaimed(var/ckey, var/message, var/id)
+	var/list/query = webhook(ckey, message)
+	query.Add("id" = id)
+	webhook_send("ticket_unclaimed", query)
 
 /////////////MENTORS/////////////
 /proc/webhook_send_msay(var/ckey, var/message)


### PR DESCRIPTION
# Document the changes in your pull request

When a ticket comes in, if there are no present admins, or stealthmins, notifies the deadmins of the ticket
If there are no deadmins, or no deadmin claims the ticket in 30 seconds, the ticket is sent to the admin channel in discord
Does not touch current logging in admin-botspam or tickets, only adds additional logging to increase visibility of unclaimed tickets
Requires yogstation13/Yogbot-kt#54
Tested

# Changelog

:cl:  
rscadd: Added more notification methods for tickets with no present admins
/:cl:
