### PR TITLE
Reduce vent lag

### DIFF
--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -159,7 +159,7 @@
 	if(hit)
 		lifetime++ //this is so the decrease from mobs hit and the natural decrease don't cumulate.
 	var/T = get_turf(src)
-	if(!(T in applied_atoms && one_apply_per_object))
+	if(!(one_apply_per_object && (T in applied_atoms)))
 		if(lifetime % reagent_divisor)
 			reagents.reaction(T, VAPOR, fraction)
 			applied_atoms += T

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -94,7 +94,7 @@
 	create_reagents(1000) //limited by the size of the reagent holder anyway.
 	START_PROCESSING(SSfastprocess, src)
 	playsound(src, 'sound/effects/bubbles2.ogg', 80, 1, -3)
-	LAZYINITLIST(applied_atoms)
+	applied_atoms = list()
 
 /obj/effect/particle_effect/foam/ComponentInitialize()
 	. = ..()

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -23,6 +23,8 @@
 	/turf/open/chasm,
 	/turf/open/lava))
 	var/slippery_foam = TRUE
+	var/one_apply_per_object = FALSE
+	var/list/applied_atoms
 
 /obj/effect/particle_effect/foam/firefighting
 	name = "firefighting foam"
@@ -92,6 +94,7 @@
 	create_reagents(1000) //limited by the size of the reagent holder anyway.
 	START_PROCESSING(SSfastprocess, src)
 	playsound(src, 'sound/effects/bubbles2.ogg', 80, 1, -3)
+	LAZYINITLIST(applied_atoms)
 
 /obj/effect/particle_effect/foam/ComponentInitialize()
 	. = ..()
@@ -139,12 +142,15 @@
 	for(var/obj/O in range(0,src))
 		if(O.type == src.type)
 			continue
+		if(O in applied_atoms && one_apply_per_object)
+			continue
 		if(isturf(O.loc))
 			var/turf/T = O.loc
 			if(T.intact && O.level == 1) //hidden under the floor
 				continue
 		if(lifetime % reagent_divisor)
 			reagents.reaction(O, VAPOR, fraction)
+			applied_atoms += O
 		CHECK_TICK
 	var/hit = 0
 	for(var/mob/living/L in range(0,src))
@@ -153,8 +159,10 @@
 	if(hit)
 		lifetime++ //this is so the decrease from mobs hit and the natural decrease don't cumulate.
 	var/T = get_turf(src)
-	if(lifetime % reagent_divisor)
-		reagents.reaction(T, VAPOR, fraction)
+	if(!(T in applied_atoms && one_apply_per_object))
+		if(lifetime % reagent_divisor)
+			reagents.reaction(T, VAPOR, fraction)
+			applied_atoms += T
 
 	if(--amount < 0)
 		return
@@ -189,6 +197,7 @@
 		reagents.copy_to(F, (reagents.total_volume))
 		F.add_atom_colour(color, FIXED_COLOUR_PRIORITY)
 		F.metal = metal
+		F.one_apply_per_object = one_apply_per_object
 
 
 /obj/effect/particle_effect/foam/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
@@ -207,6 +216,7 @@
 	var/obj/chemholder
 	effect_type = /obj/effect/particle_effect/foam
 	var/metal = 0
+	var/one_apply_per_object = FALSE
 
 
 /datum/effect_system/foam_spread/metal
@@ -247,6 +257,7 @@
 
 /datum/effect_system/foam_spread/start()
 	var/obj/effect/particle_effect/foam/F = new effect_type(location)
+	F.one_apply_per_object = one_apply_per_object
 	var/foamcolor = mix_color_from_reagents(chemholder.reagents.reagent_list)
 	chemholder.reagents.copy_to(F, chemholder.reagents.total_volume/amount)
 	F.add_atom_colour(foamcolor, FIXED_COLOUR_PRIORITY)

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -145,9 +145,11 @@
 				continue
 		if(lifetime % reagent_divisor)
 			reagents.reaction(O, VAPOR, fraction)
+		CHECK_TICK
 	var/hit = 0
 	for(var/mob/living/L in range(0,src))
 		hit += foam_mob(L)
+		CHECK_TICK
 	if(hit)
 		lifetime++ //this is so the decrease from mobs hit and the natural decrease don't cumulate.
 	var/T = get_turf(src)
@@ -156,6 +158,7 @@
 
 	if(--amount < 0)
 		return
+	CHECK_TICK
 	spread_foam()
 
 /obj/effect/particle_effect/foam/proc/foam_mob(mob/living/L)

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -142,7 +142,7 @@
 	for(var/obj/O in range(0,src))
 		if(O.type == src.type)
 			continue
-		if(O in applied_atoms && one_apply_per_object)
+		if(one_apply_per_object && (O in applied_atoms))
 			continue
 		if(isturf(O.loc))
 			var/turf/T = O.loc

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -41,6 +41,7 @@
 				R.add_reagent(pick(saferChems), reagentsAmount)
 
 			var/datum/effect_system/foam_spread/foam = new
+			foam.one_apply_per_object = TRUE
 			foam.set_up(200, get_turf(vent), R)
 			foam.start()
 
@@ -106,6 +107,7 @@
 			R.add_reagent(/datum/reagent/consumable/ethanol/beer, reagentsAmount)
 
 			var/datum/effect_system/foam_spread/foam = new
+			foam.one_apply_per_object = TRUE
 			foam.set_up(200, get_turf(vent), R)
 			foam.start()
 		CHECK_TICK

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -101,7 +101,7 @@
 /datum/round_event/vent_clog/beer/start()
 	for(var/obj/machinery/atmospherics/components/unary/vent in vents)
 		if(vent && vent.loc)
-			var/datum/reagents/R = new/datum/reagents(1000)
+			var/datum/reagents/R = new/datum/reagents(100)
 			R.my_atom = vent
 			R.add_reagent(/datum/reagent/consumable/ethanol/beer, reagentsAmount)
 
@@ -119,7 +119,7 @@
 /datum/round_event/vent_clog/cleaner/start()
 	for(var/obj/machinery/atmospherics/components/unary/vent in vents)
 		if(vent && vent.loc)
-			var/datum/reagents/R = new/datum/reagents(1000)
+			var/datum/reagents/R = new/datum/reagents(100)
 			R.my_atom = vent
 			R.add_reagent(/datum/reagent/space_cleaner, reagentsAmount)
 


### PR DESCRIPTION
Reduces the lag from the foam in vents event.

                                                     Profile results (total time)
Proc Name                                                                               Self CPU    Total CPU    Real Time     Overtime        Calls
-----------------------------------------------------------------------------------    ---------    ---------    ---------    ---------    ---------
/atom/proc/wash                                                                            1.871        3.078        3.523        0.000      1060766
/datum/reagents/proc/reaction                                                              1.509        7.616        7.819        0.000       448512
/turf/open/return_air                                                                      0.731        0.735        0.846        0.000       280707
/obj/effect/particle_effect/foam/process                                                   5.006       16.536       16.649        0.000       275251
/datum/gas_mixture/react                                                                   0.875        0.881        0.993        0.000       263893
/atom/movable/lighting_object/wash                                                         0.083        0.085        0.116        0.000       221146
/datum/reagent/space_cleaner/reaction_turf                                                 0.802        4.406        4.515        0.000       221146
/turf/wash                                                                                 1.496        3.603        3.684        0.000       221146
/datum/reagent/space_cleaner/reaction_obj                                                  0.345        1.597        1.682        0.000       200199

:cl:  
bugfix: Reduce vent foam event lag
/:cl:
