### PR TITLE
[Finally] Reworks pubby monastery into a proper space ruin and removes it from the space ruin blacklist (it will now spawn)

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/pubby_monastery.dmm
+++ b/_maps/RandomRuins/SpaceRuins/pubby_monastery.dmm
@@ -1,87 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ah" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Monastery Archives Port";
-	dir = 4;
-	network = list("ss13","monastery")
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"aF" = (
-/obj/structure/bookcase/random/nonfiction,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"aL" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"aT" = (
-/obj/structure/bookcase/random/religion,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"aY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"bi" = (
-/obj/effect/spawner/xmastree,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/carpet,
-/area/ruin/powered)
-"br" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"bs" = (
-/obj/structure/chair/wood/normal{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"bu" = (
-/obj/structure/lattice,
-/obj/structure/grille/broken,
-/turf/open/space,
-/area/ruin/unpowered/no_grav)
-"bv" = (
-/obj/machinery/atmospherics/components/binary/pump/on/layer2{
-	dir = 1;
-	icon_state = "pump_on_map-1";
-	name = "Air In"
-	},
-/turf/open/floor/plating,
-/area/ruin/powered)
-"bw" = (
-/obj/structure/bookcase/random/reference,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"bz" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	layer = 2.9;
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/pen,
-/turf/open/floor/carpet/black,
-/area/ruin/powered)
-"bE" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -93,83 +13,92 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/light/small/broken,
 /turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"bW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4;
-	icon_state = "vent_map_on-1"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"cp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"cx" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Monastery Cemetary";
-	opacity = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/area/ruin/space/has_grav/monastery/dock)
+"ai" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"cy" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"cz" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"aG" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/closed/wall/mineral/iron,
+/area/ruin/space/has_grav/monastery/maint)
+"aJ" = (
+/obj/structure/flora/ausbushes/genericbush,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"aM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"cH" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/area/ruin/space/has_grav/monastery)
+"aY" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Chapel";
+	opacity = 1
+	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/dock)
+"ba" = (
+/obj/structure/closet/crate/coffin,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"bn" = (
+/obj/machinery/power/terminal{
+	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/powered)
-"cR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+/area/ruin/space/has_grav/monastery/maint)
+"bt" = (
+/obj/structure/table/wood,
+/obj/machinery/light/small/broken{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"cT" = (
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"cV" = (
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/no_grav)
+"bu" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/turf/open/space,
+/area/ruin/unpowered/no_grav)
+"bw" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/saltshaker{
 	pixel_x = 3;
@@ -180,138 +109,12 @@
 	layer = 3.1
 	},
 /turf/open/floor/plasteel,
-/area/ruin/powered)
-"dg" = (
-/obj/docking_port/stationary{
-	dwidth = 2;
-	height = 6;
-	id = "monastery_shuttle_asteroid";
-	name = "monastery";
-	width = 5
-	},
-/turf/open/space,
-/area/space)
-"dh" = (
-/obj/structure/chair/wood/normal,
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1481;
-	name = "Confessional Intercom";
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"dr" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-08"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"ds" = (
-/obj/machinery/light/small{
-	dir = 2
-	},
+/area/ruin/space/has_grav/monastery)
+"bB" = (
+/obj/structure/table/wood,
 /turf/open/floor/carpet/black,
-/area/ruin/powered)
-"dJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"dQ" = (
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"dR" = (
-/obj/structure/table/wood/fancy,
-/obj/item/storage/book/bible,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/ruin/powered)
-"dT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"dX" = (
-/obj/structure/chair/wood/normal,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/ruin/powered)
-"eh" = (
-/obj/structure/chair/wood/normal{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"ek" = (
-/obj/structure/flora/ausbushes/leafybush,
-/turf/open/floor/plating/asteroid,
-/area/ruin/powered)
-"em" = (
-/obj/structure/transit_tube/horizontal,
-/obj/machinery/camera{
-	c_tag = "Monastery Transit";
-	dir = 1;
-	network = list("ss13","monastery")
-	},
-/obj/structure/transit_tube/horizontal,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"ev" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"eF" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"eG" = (
-/obj/structure/closet/emcloset,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"eN" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"eO" = (
-/obj/machinery/camera{
-	c_tag = "Monastery Kitchen";
-	dir = 4;
-	network = list("ss13","monastery")
-	},
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"eT" = (
+/area/ruin/space/has_grav/monastery/office)
+"bH" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -322,307 +125,40 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"eV" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
+/area/ruin/space/has_grav/monastery/dock)
+"bL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"eY" = (
-/obj/structure/lattice,
-/turf/closed/mineral,
-/area/ruin/unpowered/no_grav)
-"eZ" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Monastery APC";
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"fn" = (
-/obj/structure/flora/ausbushes/fernybush,
-/obj/machinery/camera{
-	c_tag = "Monastery Asteroid Starboard Aft";
-	dir = 1;
-	network = list("ss13","monastery")
-	},
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"fr" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ruin/powered)
-"fs" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Chapel Office APC";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"ft" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/area/ruin/space/has_grav/monastery/library)
+"bN" = (
+/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"fG" = (
-/obj/structure/transit_tube/station/reverse{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/powered)
-"fH" = (
-/obj/machinery/door/window/eastleft{
-	base_state = "right";
-	dir = 1;
-	icon_state = "right";
-	name = "Coffin Storage";
-	req_one_access_txt = "22"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"fL" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/grown/harebell,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"fM" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Chapel Crematorium";
-	dir = 2;
-	network = list("ss13","monastery")
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"fZ" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/transit_tube/station/reverse,
-/turf/open/space/basic,
-/area/ruin/unpowered/no_grav)
-"gc" = (
-/obj/machinery/camera{
-	c_tag = "Monastery Secondary Dock";
-	dir = 8;
-	network = list("ss13","monastery")
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"ge" = (
-/obj/structure/bookcase/random/religion,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"gf" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Garden APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"gg" = (
-/obj/machinery/camera{
-	c_tag = "Chapel Office";
-	dir = 8;
-	network = list("ss13","monastery")
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"gj" = (
-/obj/structure/table/wood/fancy,
-/obj/item/storage/box/fancy/candle_box,
-/turf/open/floor/carpet,
-/area/ruin/powered)
-"gn" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1;
-	icon_state = "vent_map_on-1"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"gt" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"gA" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"gH" = (
-/obj/machinery/door/airlock/external{
-	req_access_txt = "22"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ruin/powered)
-"gP" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"gR" = (
-/obj/item/shovel/spade,
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"gZ" = (
-/turf/open/space/basic,
-/area/space)
-"hq" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/wine{
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"hw" = (
-/obj/machinery/chem_master/condimaster,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"hB" = (
-/obj/structure/filingcabinet,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"hC" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Library"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"hE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
+/area/ruin/space/has_grav/monastery/office)
+"bO" = (
+/obj/machinery/door/airlock{
+	name = "Dining Room"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
-/area/ruin/powered)
-"hH" = (
-/obj/machinery/door/morgue{
-	name = "Confession Booth"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 1
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"hO" = (
-/obj/structure/table/wood,
-/obj/item/folder/yellow,
-/obj/item/pen,
-/obj/machinery/camera{
-	c_tag = "Monastery Library";
-	dir = 4;
-	network = list("ss13","monastery")
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"hY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/area/ruin/space/has_grav/monastery)
+"bP" = (
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/library)
+"bU" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -633,114 +169,47 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"ir" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/powered)
-"iv" = (
-/obj/structure/table,
-/obj/item/crowbar,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"iA" = (
-/obj/machinery/hydroponics/soil,
-/obj/machinery/light/small,
-/obj/item/seeds/poppy,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"iE" = (
-/obj/structure/chair/wood/normal,
-/turf/open/floor/plasteel/chapel{
-	dir = 8
-	},
-/area/ruin/powered)
-"iJ" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Monastery Cloister Starboard";
-	dir = 8;
-	network = list("ss13","monastery")
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"iN" = (
-/obj/structure/table/wood,
-/obj/item/disk/nuclear/fake,
-/obj/item/barcodescanner,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"iR" = (
+/area/ruin/space/has_grav/monastery/office)
+"cm" = (
 /obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/light/small,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /turf/open/floor/grass,
-/area/ruin/powered)
-"iS" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/item/storage/box/fancy/candle_box,
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"jt" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"jx" = (
+/area/hydroponics/garden/monastery)
+"cr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/carpet,
-/area/ruin/powered)
-"jy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/vacuum/external,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"jz" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/turf/open/floor/grass,
-/area/ruin/powered)
-"jD" = (
-/obj/structure/table/wood/fancy,
-/obj/item/storage/photo_album,
-/turf/open/floor/carpet,
-/area/ruin/powered)
-"jH" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Chapel Office Tunnel";
-	dir = 1;
-	network = list("ss13","monastery")
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/dock)
+"cv" = (
+/obj/machinery/light/small/broken,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"cH" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21";
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"cK" = (
+/obj/item/chair/wood,
+/turf/open/floor/carpet/black,
+/area/ruin/space/has_grav/monastery/office)
+"cL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -748,177 +217,57 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/ruin/powered)
-"jX" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Chapel Starboard";
-	dir = 8;
-	network = list("ss13","monastery")
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"jZ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock{
-	name = "Garden"
-	},
-/obj/effect/turf_decal/tile/neutral{
+/area/ruin/space/has_grav/monastery)
+"cQ" = (
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/floor/carpet/black,
+/area/ruin/space/has_grav/monastery/office)
+"cS" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery)
+"cU" = (
+/obj/structure/chair/wood/normal{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery/library)
+"cW" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/monastery/dock)
+"df" = (
+/obj/structure/flora/ausbushes/fernybush,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel,
+/area/ruin/powered)
+"dk" = (
+/obj/structure/chair/wood/normal{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"ka" = (
-/obj/structure/chair/wood/wings{
-	dir = 1
+/area/ruin/space/has_grav/monastery)
+"dp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery)
+"dq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"kc" = (
-/obj/structure/closet/crate/coffin,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"ke" = (
-/obj/structure/chair/wood/normal{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1481;
-	name = "Confessional Intercom";
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"ki" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/poppy,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"kk" = (
-/obj/structure/closet,
-/obj/machinery/light/small{
-	dir = 2
-	},
-/obj/item/storage/book/bible,
-/obj/item/storage/book/bible,
-/obj/item/storage/book/bible,
-/turf/open/floor/carpet,
-/area/ruin/powered)
-"kn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"ko" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Library"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"kv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"kB" = (
-/obj/machinery/door/airlock/external{
-	name = "Dock Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"kD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/ruin/powered)
-"kG" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plating/asteroid,
-/area/ruin/powered)
-"kO" = (
-/obj/machinery/light/small,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"kV" = (
+/area/ruin/space/has_grav/monastery)
+"ds" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -928,66 +277,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"lo" = (
-/obj/structure/chair/wood/normal,
-/turf/open/floor/carpet,
-/area/ruin/powered)
-"lp" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/ruin/powered)
-"lv" = (
-/obj/item/flashlight/lantern,
-/turf/open/floor/plasteel/chapel{
-	dir = 8
-	},
-/area/ruin/powered)
-"lw" = (
-/obj/machinery/shower{
-	dir = 8;
-	pixel_y = -4
-	},
-/obj/item/soap/homemade,
-/turf/open/floor/plasteel/showroomfloor,
-/area/ruin/powered)
-"lA" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"lE" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ruin/powered)
-"lX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"ma" = (
-/obj/machinery/door/airlock{
-	name = "Bathroom"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ruin/powered)
-"md" = (
+/area/ruin/space/has_grav/monastery)
+"dA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -996,633 +287,51 @@
 	icon_state = "inje_map-2"
 	},
 /turf/open/floor/plating/airless,
-/area/ruin/powered)
-"mp" = (
-/obj/structure/table/wood,
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-05";
-	pixel_y = 10
+/area/ruin/space/has_grav/monastery)
+"dF" = (
+/obj/structure/table/wood/fancy,
+/obj/item/storage/box/fancy/candle_box,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"dR" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/light/small/broken{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"ms" = (
-/obj/machinery/biogenerator,
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"mv" = (
-/obj/machinery/vending/games,
+/area/ruin/space/has_grav/monastery)
+"eb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"mY" = (
-/turf/open/floor/plasteel/chapel{
-	dir = 4
-	},
-/area/ruin/powered)
-"na" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/closed/wall/mineral/iron,
-/area/ruin/powered)
-"ng" = (
-/obj/machinery/door/airlock/external{
-	req_access_txt = "22"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"ny" = (
-/turf/open/floor/carpet/black,
-/area/ruin/powered)
-"nA" = (
-/obj/structure/table/wood/fancy,
-/obj/item/folder,
-/obj/item/pen,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"nB" = (
+/area/ruin/space/has_grav/monastery/library)
+"eg" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
-	},
-/obj/machinery/camera{
-	c_tag = "Monastery Archives Fore";
-	dir = 2;
-	network = list("ss13","monastery")
 	},
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"nH" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"nK" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"oj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4;
-	icon_state = "vent_map_on-1"
-	},
-/turf/open/floor/plasteel/chapel{
-	dir = 8
-	},
-/area/ruin/powered)
-"on" = (
-/obj/structure/table/wood/fancy,
-/obj/item/storage/box/matches{
-	pixel_x = -3;
-	pixel_y = 8
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"oo" = (
-/obj/structure/table/wood,
-/obj/item/instrument/saxophone,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"ov" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"oO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"oS" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 11;
-	height = 22;
-	id = "whiteship_home";
-	name = "monastery";
-	width = 35
-	},
-/turf/open/space/basic,
-/area/space)
-"pa" = (
-/mob/living/simple_animal/butterfly,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"pb" = (
-/obj/machinery/light/small,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/camera{
-	c_tag = "Monastery Cloister Aft";
-	dir = 1;
-	network = list("ss13","monastery")
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"pk" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"pl" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"po" = (
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/item/flashlight/lantern,
-/turf/open/floor/plasteel/grimy,
-/area/ruin/powered)
-"pp" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"pq" = (
-/obj/structure/transit_tube/horizontal,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"pu" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/sand,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"px" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/sugarcane,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/ruin/powered)
-"py" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/sand,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"pM" = (
-/obj/structure/chair/wood/normal,
-/turf/open/floor/plasteel/chapel{
-	dir = 4
-	},
-/area/ruin/powered)
-"pS" = (
-/obj/structure/table/wood,
-/obj/item/trash/plate,
-/obj/item/kitchen/fork,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"pT" = (
-/obj/structure/chair/wood/normal,
-/turf/open/floor/plasteel/chapel,
-/area/ruin/powered)
-"pZ" = (
-/turf/open/floor/plasteel/chapel{
-	dir = 1
-	},
-/area/ruin/powered)
-"qh" = (
-/obj/effect/spawner/structure/window/shutter,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"qk" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/closed/wall/mineral/iron,
-/area/ruin/powered)
-"ql" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"qs" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/cobweb,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"qE" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
-	},
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"qJ" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/carpet,
-/area/ruin/powered)
-"qN" = (
-/obj/machinery/door/airlock{
-	name = "Kitchen"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"qU" = (
-/obj/structure/destructible/cult/tome,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"qY" = (
-/obj/machinery/door/airlock/external{
-	name = "Pod Docking Bay"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"re" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 2;
-	piping_layer = 2
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"rD" = (
-/obj/item/wrench,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"rL" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = -32
-	},
-/obj/machinery/camera{
-	c_tag = "Monastery Cemetary";
-	dir = 4;
-	network = list("ss13","monastery")
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"rN" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"rU" = (
-/turf/closed/wall/mineral/iron,
-/area/ruin/powered)
-"rX" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"se" = (
-/obj/structure/table/wood/fancy,
-/obj/item/storage/box/fancy/candle_box,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"ss" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"sC" = (
-/obj/machinery/power/smes/fullycharged,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"sK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"sO" = (
-/obj/structure/chair/wood/normal{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/ruin/powered)
-"sW" = (
-/obj/structure/closet{
-	name = "beekeeping wardrobe"
-	},
-/obj/item/clothing/suit/beekeeper_suit,
-/obj/item/clothing/suit/beekeeper_suit,
-/obj/item/clothing/suit/beekeeper_suit,
-/obj/item/clothing/head/beekeeper_head,
-/obj/item/clothing/head/beekeeper_head,
-/obj/item/clothing/head/beekeeper_head,
-/obj/item/melee/flyswatter,
-/obj/item/melee/flyswatter,
-/obj/item/melee/flyswatter,
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"ta" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"ts" = (
-/obj/structure/table,
-/obj/item/trash/plate,
-/obj/item/kitchen/fork,
+/area/ruin/space/has_grav/monastery/library)
+"ek" = (
+/obj/structure/flora/ausbushes/leafybush,
 /turf/open/floor/plating/asteroid,
 /area/ruin/powered)
-"tu" = (
-/turf/closed/mineral,
-/area/ruin/powered)
-"tx" = (
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"ty" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Library APC";
-	pixel_x = 24
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"tE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"tN" = (
-/obj/structure/table/wood/fancy,
-/obj/item/candle,
-/obj/item/candle{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/candle{
-	pixel_x = -8;
-	pixel_y = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/ruin/powered)
-"tT" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"uf" = (
-/obj/item/clothing/suit/apron/chef,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"ug" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"ui" = (
-/obj/machinery/vending/wardrobe/curator_wardrobe,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"um" = (
-/obj/item/extinguisher,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"us" = (
-/obj/machinery/camera{
-	c_tag = "Monastery Asteroid Dock Staboard";
-	dir = 8;
-	network = list("ss13","monastery")
-	},
-/turf/open/floor/plating/asteroid,
-/area/ruin/powered)
-"uC" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"uJ" = (
-/obj/structure/dresser,
-/obj/structure/sign/plaques/deempisi{
-	pixel_y = 28
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/grimy,
-/area/ruin/powered)
-"uM" = (
+"en" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"uT" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/carpet,
-/area/ruin/powered)
-"uY" = (
-/obj/machinery/door/morgue{
-	name = "Confession Booth"
-	},
-/obj/machinery/door/firedoor/border_only{
+/area/ruin/space/has_grav/monastery/office)
+"er" = (
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"vc" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/ruin/powered)
-"vh" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"vk" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"vq" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Library"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"vG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"vK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -1635,431 +344,21 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"vR" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/palebush,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"wa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"wc" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	layer = 2.9;
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/pen,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"wf" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"wi" = (
-/obj/structure/table,
-/obj/item/storage/crayons,
-/obj/item/wrench,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"wk" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-10"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"wl" = (
-/turf/open/floor/plasteel/chapel,
-/area/ruin/powered)
-"wr" = (
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"wv" = (
-/turf/closed/wall/r_wall,
-/area/ruin/powered)
-"wD" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
-/obj/machinery/light/small,
-/obj/machinery/camera{
-	c_tag = "Monastery Dock";
-	dir = 1;
-	network = list("ss13","monastery")
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"wE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"wF" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel";
-	opacity = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"wJ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"wL" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"wV" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/trophy{
-	pixel_y = 8
-	},
-/turf/open/floor/carpet,
-/area/ruin/powered)
-"wZ" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	layer = 2.9;
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"xa" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/chapel{
-	dir = 4
-	},
-/area/ruin/powered)
-"xh" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"xl" = (
-/obj/structure/chair/wood/normal{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/ruin/powered)
-"xB" = (
-/obj/structure/flora/ausbushes,
-/turf/open/floor/plating/asteroid,
-/area/ruin/powered)
-"xW" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/breadslice/plain,
-/obj/item/reagent_containers/food/snacks/breadslice/plain{
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/snacks/breadslice/plain{
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"xX" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"eu" = (
+/obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"ye" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/area/ruin/space/has_grav/monastery/dock)
+"eB" = (
 /turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"yf" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"yq" = (
-/obj/structure/toilet{
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/ruin/powered)
-"yr" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/holywater{
-	name = "flask of holy water";
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/turf/open/floor/carpet/black,
-/area/ruin/powered)
-"yv" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"yy" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"yB" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/grown/poppy,
-/obj/item/reagent_containers/food/snacks/grown/harebell,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"yU" = (
-/obj/structure/chair/wood/normal,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"yY" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"yZ" = (
-/turf/closed/wall,
-/area/ruin/powered)
-"zf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"zm" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"zn" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/libraryscanner,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"zs" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"zw" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Library"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"zA" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"zB" = (
-/turf/open/floor/carpet,
-/area/ruin/powered)
-"zF" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Monastery Maintenance APC";
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/ruin/powered)
-"zM" = (
-/obj/item/wrench,
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"zT" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/camera{
-	c_tag = "Monastery Garden";
-	dir = 2;
-	network = list("ss13","monastery")
-	},
-/turf/open/floor/grass,
-/area/ruin/powered)
-"Ak" = (
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Ao" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"At" = (
-/obj/structure/table/wood,
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22";
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"AH" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Chapel Starboard Access";
-	dir = 2;
-	network = list("ss13","monastery")
-	},
-/obj/structure/chair/wood/normal,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"AX" = (
+/area/ruin/space/has_grav/monastery/office)
+"eO" = (
 /obj/machinery/door/airlock{
 	id_tag = "Cell2";
 	name = "Cell 2"
@@ -2076,852 +375,23 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/turf/open/floor/plasteel/grimy,
-/area/ruin/powered)
-"Bb" = (
-/obj/item/flashlight/lantern,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Bc" = (
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/floor/plating/asteroid,
-/area/ruin/powered)
-"Bq" = (
-/obj/machinery/mass_driver{
-	id = "chapelgun"
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"By" = (
-/obj/machinery/button/crematorium{
-	id = "foo";
-	pixel_x = 25
-	},
-/obj/structure/bodycontainer/crematorium{
-	id = "foo"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"BF" = (
-/obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = -32
-	},
-/turf/open/floor/carpet,
-/area/ruin/powered)
-"BO" = (
-/obj/structure/chair,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"BW" = (
-/obj/structure/table/wood/fancy,
-/obj/item/storage/box/bodybags,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"BZ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Cb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Cl" = (
-/obj/structure/grille/broken,
-/turf/open/space/basic,
-/area/ruin/unpowered/no_grav)
-"Ct" = (
-/obj/machinery/door/window/eastleft{
-	dir = 1;
-	name = "Coffin Storage";
-	req_one_access_txt = "22"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Cu" = (
-/obj/structure/flora/ausbushes,
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"Cz" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"CC" = (
-/obj/structure/bookcase/random/nonfiction,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"CD" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/powered)
-"CK" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"CR" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Monastery Dining Room";
-	dir = 8;
-	network = list("ss13","monastery")
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"CT" = (
-/obj/structure/sign/warning/vacuum/external,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"CZ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "Monastery Cloister Port";
-	dir = 4;
-	network = list("ss13","monastery")
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Dh" = (
-/obj/item/flashlight/lantern{
-	icon_state = "lantern-on"
-	},
-/turf/open/floor/plating/asteroid,
-/area/ruin/powered)
-"Di" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/ruin/powered)
-"Dk" = (
-/obj/structure/flora/tree/jungle/small,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"Ds" = (
-/obj/structure/table/wood,
-/obj/item/storage/book/bible,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/carpet,
-/area/ruin/powered)
-"Dy" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/door/window/northright{
-	base_state = "left";
-	dir = 2;
-	icon_state = "left";
-	name = "Curator Desk Door";
-	req_access_txt = "37"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"DH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4;
-	icon_state = "vent_map_on-1"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"DI" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/grown/poppy,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"DL" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel";
-	opacity = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"DW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Ea" = (
-/obj/machinery/shower{
-	dir = 8;
-	pixel_y = -4
-	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/obj/item/bikehorn/rubberducky,
-/turf/open/floor/plasteel/showroomfloor,
-/area/ruin/powered)
-"Eh" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"Ej" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"El" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/storage/box/lights/bulbs,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"Eo" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Eq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Ew" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/libraryconsole,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"EF" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"EJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/carpet,
-/area/ruin/powered)
-"EO" = (
-/obj/item/radio/intercom{
-	pixel_x = 27
-	},
-/obj/machinery/light/small,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"EQ" = (
-/obj/item/clothing/under/burial,
-/obj/item/clothing/under/burial,
-/obj/item/clothing/under/burial,
-/obj/item/clothing/under/burial,
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"ES" = (
-/obj/machinery/mass_driver{
-	id = "chapelgun"
-	},
-/obj/machinery/door/window/eastleft{
-	dir = 8;
-	name = "Mass Driver"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"ET" = (
-/obj/structure/flora/ausbushes/fernybush,
-/turf/open/floor/plating/asteroid,
-/area/ruin/powered)
-"Fc" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Fg" = (
-/obj/structure/chair/wood/normal{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Fo" = (
-/obj/structure/bookcase/random/religion,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Fr" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"Fy" = (
-/obj/structure/displaycase/trophy,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"FI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/ruin/powered)
-"FK" = (
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"FX" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Crematorium";
-	opacity = 1;
-	req_access_txt = "27"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Gm" = (
-/obj/structure/closet/secure_closet/freezer/fridge{
-	req_access = null
-	},
-/obj/machinery/light/small{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"Go" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Gp" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Library Lounge APC";
-	pixel_x = 24
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Gq" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Library"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Gv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/centcom{
-	name = "Chapel Office";
-	opacity = 1;
-	req_access_txt = "22"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"GA" = (
-/obj/structure/table/wood,
-/obj/item/stack/packageWrap,
-/obj/item/coin/gold,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"GP" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/harebell,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"GT" = (
-/obj/structure/chair,
-/turf/open/floor/plating/asteroid,
-/area/ruin/powered)
-"GV" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/door/window/northright{
-	base_state = "right";
-	dir = 2;
-	icon_state = "right";
-	name = "Curator Desk Door";
-	req_access_txt = "37"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Hd" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/fans/tiny,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/monastery)
+"eY" = (
+/obj/structure/lattice,
 /turf/closed/mineral,
-/area/ruin/powered)
-"Hk" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/area/ruin/unpowered/no_grav)
+"fi" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/trophy{
+	pixel_y = 8
 	},
-/turf/closed/wall/mineral/iron,
-/area/ruin/powered)
-"Hu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Hv" = (
-/obj/structure/flora/ausbushes/genericbush,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/ruin/powered)
-"HA" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel";
-	opacity = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"HD" = (
-/obj/machinery/vending/hydronutrients,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"HG" = (
-/obj/structure/bed,
-/obj/item/bedsheet/green,
-/turf/open/floor/plasteel/grimy,
-/area/ruin/powered)
-"HM" = (
-/obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/carpet,
-/area/ruin/powered)
-"HO" = (
-/obj/structure/lattice,
-/turf/open/space,
-/area/ruin/unpowered/no_grav)
-"HX" = (
-/obj/machinery/vending/dinnerware,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"Ip" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"IF" = (
-/obj/structure/chair/wood/normal{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/ruin/powered)
-"IH" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space,
-/area/ruin/unpowered/no_grav)
-"II" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"IR" = (
-/obj/structure/chair/wood/normal,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"IT" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"IX" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"IZ" = (
-/obj/structure/table/wood,
-/obj/item/folder/yellow,
-/obj/item/pen,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Jg" = (
-/turf/open/space,
-/area/space)
-"Jn" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel Access";
-	opacity = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Jo" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"Jy" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/wheat,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/ruin/powered)
-"JL" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/item/storage/crayons,
-/turf/open/floor/plasteel/grimy,
-/area/ruin/powered)
-"JM" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/powered)
-"JQ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"JU" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"JV" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ruin/powered)
-"Kb" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Kh" = (
-/obj/machinery/door/airlock{
-	name = "Garden"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/area/ruin/space/has_grav/monastery)
+"fk" = (
+/obj/machinery/door/morgue{
+	name = "Confession Booth"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -2930,871 +400,17 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Ki" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ruin/powered)
-"KK" = (
-/obj/structure/bookcase/random/fiction,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"KL" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/suit/chaplainsuit/holidaypriest,
-/obj/item/clothing/suit/chaplainsuit/nun,
-/obj/item/clothing/head/nun_hood,
-/obj/machinery/button/door{
-	id = "Cell2";
-	name = "Cell Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = -25;
-	specialfunctions = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ruin/powered)
-"KT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"KZ" = (
-/turf/open/floor/grass,
-/area/ruin/powered)
-"Li" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/wheat,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"Lk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Monastery Archives Access Tunnel";
-	dir = 4;
-	network = list("ss13","monastery")
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Ln" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/mug/tea,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Lp" = (
-/obj/machinery/bookbinder,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"LA" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
-/obj/item/stack/rods/fifty,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"LB" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Monastery Maintenance";
-	req_one_access_txt = "22;24;10;11;37"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"LF" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Chapel Office";
-	opacity = 1;
-	req_access_txt = "22"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"LN" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Mf" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel Garden";
-	opacity = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Ml" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/ruin/unpowered/no_grav)
-"Mt" = (
+/area/ruin/space/has_grav/monastery)
+"fs" = (
 /obj/structure/rack{
 	icon = 'icons/obj/stationobjs.dmi';
 	icon_state = "minibar";
 	name = "skeletal minibar"
 	},
 /obj/item/book/codex_gigas,
-/obj/machinery/camera{
-	c_tag = "Monastery Archives Aft";
-	dir = 1;
-	network = list("ss13","monastery")
-	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Mz" = (
-/obj/machinery/computer/shuttle/monastery_shuttle,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"MS" = (
-/obj/item/flashlight/lantern{
-	icon_state = "lantern-on"
-	},
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"MT" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/beebox,
-/obj/item/queen_bee/bought,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"Nf" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 1;
-	piping_layer = 2
-	},
-/turf/open/floor/plating,
-/area/ruin/powered)
-"Nl" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/pointybush,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"Nn" = (
-/obj/structure/chair/wood/normal,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Nt" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Nx" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21";
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Ny" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/watermelon/holy,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"NA" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"NE" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/closed/mineral,
-/area/ruin/unpowered/no_grav)
-"NR" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/sugarcane,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"NY" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4;
-	icon_state = "vent_map_on-1"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Oa" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Om" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"On" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/meter{
-	target_layer = 2
-	},
-/turf/open/floor/plating,
-/area/ruin/powered)
-"Op" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/tinted/fulltile,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Ou" = (
-/obj/structure/toilet{
-	pixel_y = 8
-	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/ruin/powered)
-"Ow" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1;
-	icon_state = "vent_map_on-1"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Oz" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"OB" = (
-/obj/structure/flora/ausbushes/pointybush,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"OK" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"OY" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Pe" = (
-/obj/structure/chair/wood/normal{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ruin/powered)
-"Pg" = (
-/obj/machinery/power/smes/fullycharged,
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/ruin/powered)
-"Pm" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Pn" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Chapel Port";
-	dir = 4;
-	network = list("ss13","monastery")
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Pt" = (
-/obj/structure/chair/wood/normal{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Py" = (
-/obj/item/seeds/banana,
-/obj/item/seeds/grass,
-/obj/item/seeds/grape,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"PG" = (
-/obj/structure/table/wood,
-/obj/item/camera,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"PK" = (
-/obj/structure/chair/wood/normal{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"PN" = (
-/obj/machinery/camera{
-	c_tag = "Monastery Asteroid Dock Port";
-	dir = 4;
-	network = list("ss13","monastery")
-	},
-/turf/open/floor/plating/asteroid,
-/area/ruin/powered)
-"QB" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Monastery Cloister Fore";
-	dir = 2;
-	network = list("ss13","monastery")
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"QF" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/transit_tube/horizontal,
-/turf/open/space,
-/area/ruin/unpowered/no_grav)
-"QG" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"QK" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/ruin/unpowered/no_grav)
-"QL" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/carpet,
-/area/ruin/powered)
-"QQ" = (
-/turf/closed/wall,
-/area/ruin/unpowered/no_grav)
-"QW" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/photocopier,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"QX" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/closed/wall,
-/area/ruin/powered)
-"Rc" = (
-/obj/structure/table/wood,
-/obj/item/storage/photo_album,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Rd" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Rj" = (
-/obj/structure/table/wood/fancy,
-/obj/item/flashlight/lantern{
-	icon_state = "lantern-on";
-	pixel_y = 8
-	},
-/turf/open/floor/carpet,
-/area/ruin/powered)
-"Rl" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Rr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ruin/powered)
-"Rw" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"RB" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Chapel Port Access";
-	dir = 2;
-	network = list("ss13","monastery")
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"RE" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"RL" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/button/massdriver{
-	id = "chapelgun";
-	pixel_x = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"RQ" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"RV" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel";
-	opacity = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"RX" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	layer = 3.1;
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 5;
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Sb" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/carpet/black,
-/area/ruin/powered)
-"Si" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-10"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Sm" = (
-/obj/machinery/light/small{
-	dir = 2
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Sy" = (
-/obj/item/storage/box/matches{
-	pixel_x = -3;
-	pixel_y = 8
-	},
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"SD" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel Access";
-	opacity = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"SM" = (
-/obj/item/flashlight/lantern,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"SV" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"SW" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"SX" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/easel,
-/obj/item/canvas/twentythreeXnineteen,
-/turf/open/floor/plasteel/grimy,
-/area/ruin/powered)
-"SY" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Tb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"Ts" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel Access";
-	opacity = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Tt" = (
-/obj/structure/sign/plaques/deempisi{
-	pixel_y = 28
-	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21";
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"TR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"TZ" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Ui" = (
-/obj/structure/table/wood/fancy,
-/turf/open/floor/carpet,
-/area/ruin/powered)
-"Uj" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/suit/chaplainsuit/holidaypriest,
-/obj/item/clothing/suit/chaplainsuit/nun,
-/obj/item/clothing/head/nun_hood,
-/obj/machinery/button/door{
-	id = "Cell1";
-	name = "Cell Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = -25;
-	specialfunctions = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ruin/powered)
-"Um" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/ruin/powered)
-"Uo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Us" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/carpet,
-/area/ruin/powered)
-"Uu" = (
-/obj/structure/chair/wood/normal{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Ux" = (
-/obj/structure/bookcase/random/adult,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Uz" = (
-/obj/machinery/holopad,
-/obj/item/flashlight/lantern,
-/turf/open/floor/plasteel/chapel,
-/area/ruin/powered)
-"UN" = (
-/obj/structure/sink/puddle,
-/obj/item/reagent_containers/glass/bucket,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"US" = (
-/obj/structure/chair/wood/normal,
-/turf/open/floor/plasteel/chapel{
-	dir = 1
-	},
-/area/ruin/powered)
-"UT" = (
+/area/ruin/space/has_grav/monastery/library)
+"ft" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Monastery Transit";
 	opacity = 1
@@ -3821,46 +437,33 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"UY" = (
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/flora/ausbushes/reedbush,
-/obj/machinery/camera{
-	c_tag = "Monastery Asteroid Primary Entrance";
-	dir = 1;
-	network = list("ss13","monastery")
+/area/ruin/space/has_grav/monastery/dock)
+"fw" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Chapel Access";
+	opacity = 1
 	},
-/turf/open/floor/plating/asteroid,
-/area/ruin/powered)
-"Vd" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/powered)
-"Vk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"fx" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Monastery APC";
+	pixel_y = 23
 	},
-/turf/open/floor/carpet,
-/area/ruin/powered)
-"Vo" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"Vv" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lantern{
-	pixel_y = 8
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -3872,135 +475,262 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Vw" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"VA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1;
-	icon_state = "vent_map_on-1"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"VB" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"VJ" = (
-/obj/structure/chair/wood/wings{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"VQ" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel";
-	opacity = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"VT" = (
-/obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"VU" = (
-/obj/machinery/door/poddoor{
-	id = "chapelgun";
-	name = "mass driver door"
-	},
-/turf/open/floor/plating,
-/area/ruin/powered)
-"VZ" = (
-/obj/structure/bookcase{
-	name = "Forbidden Knowledge"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Wb" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/area/ruin/space/has_grav/monastery)
+"fF" = (
 /turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Wg" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/item/stack/sheet/glass/fifty{
-	layer = 4
-	},
-/obj/item/stack/sheet/metal{
-	amount = 20;
-	layer = 3.1
-	},
-/turf/open/floor/plating,
-/area/ruin/powered)
-"Wi" = (
-/obj/structure/flora/ausbushes/sunnybush,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"Wj" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/carpet,
-/area/ruin/powered)
-"Wt" = (
+/area/ruin/space/has_grav/monastery/dock)
+"fQ" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Monastery Archives Starboard";
-	dir = 8;
-	network = list("ss13","monastery")
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"fS" = (
+/obj/structure/chair/wood/normal{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"WG" = (
+/area/ruin/space/has_grav/monastery)
+"fT" = (
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery)
+"ge" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"go" = (
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery/office)
+"gp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"gw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/carpet,
-/area/ruin/powered)
-"WL" = (
-/turf/open/floor/plating/asteroid,
-/area/ruin/powered)
-"WM" = (
+/area/ruin/space/has_grav/monastery/library)
+"gF" = (
+/turf/closed/wall/mineral/iron,
+/area/ruin/space/has_grav/monastery)
+"gO" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/monastery)
+"gZ" = (
+/turf/open/space/basic,
+/area/space)
+"ha" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"hb" = (
 /obj/structure/table/wood,
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22";
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"hc" = (
+/obj/structure/chair/wood/normal,
+/turf/open/floor/plasteel/chapel,
+/area/ruin/space/has_grav/monastery)
+"hh" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/item/instrument/violin,
-/turf/open/floor/plasteel/grimy,
-/area/ruin/powered)
-"WP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/monastery/dock)
+"hi" = (
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery)
+"hk" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/beebox,
+/obj/item/queen_bee/bought,
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"hp" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/effect/decal/cleanable/cobweb,
+/obj/machinery/light/small/broken{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"WQ" = (
-/turf/closed/mineral,
-/area/ruin/unpowered/no_grav)
-"WV" = (
-/turf/open/floor/plasteel/chapel{
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/monastery)
+"ht" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery)
+"hu" = (
+/turf/closed/wall/rust,
+/area/ruin/space/has_grav/monastery/maint)
+"hI" = (
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = -32
+	},
+/obj/machinery/light/small/broken{
 	dir = 8
 	},
-/area/ruin/powered)
-"WZ" = (
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"hL" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"hM" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"hN" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"hP" = (
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/obj/structure/bookcase,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"hT" = (
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/maint)
+"hU" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/maint)
+"hW" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"hX" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"ib" = (
+/obj/machinery/door/window/eastleft{
+	dir = 1;
+	name = "Coffin Storage"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"id" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/maint)
+"im" = (
+/obj/structure/table/wood,
+/obj/item/trash/plate,
+/obj/item/kitchen/fork,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"iz" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/carrot,
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"iI" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"iJ" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery)
+"iK" = (
+/turf/closed/wall,
+/area/ruin/space/has_grav/monastery)
+"iM" = (
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/maint)
+"iZ" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/grown/harebell,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"jc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"je" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -4011,234 +741,69 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4;
-	icon_state = "scrub_map_on-3"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Xa" = (
-/obj/machinery/door/airlock/external{
-	name = "Pod Docking Bay"
+/area/ruin/space/has_grav/monastery/office)
+"jl" = (
+/turf/open/floor/plasteel/chapel,
+/area/ruin/space/has_grav/monastery)
+"jm" = (
+/obj/item/hatchet,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/monastery)
+"jq" = (
+/turf/closed/wall/rust,
+/area/ruin/space/has_grav/monastery/office)
+"jv" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
-/area/ruin/powered)
-"Xd" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"jy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/chapel,
-/area/ruin/powered)
-"Xg" = (
-/obj/structure/closet{
-	name = "beekeeping supplies"
+/area/ruin/space/has_grav/monastery)
+"jB" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/obj/item/honey_frame,
-/obj/item/honey_frame,
-/obj/item/honey_frame,
-/obj/item/honey_frame,
-/obj/item/honey_frame,
-/obj/item/honey_frame,
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"jI" = (
+/obj/machinery/vending/dinnerware,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
-/area/ruin/powered)
-"Xp" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/carrot,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"Xu" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Library"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/area/ruin/space/has_grav/monastery)
+"jO" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Xy" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1;
-	icon_state = "vent_map_on-1"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"XC" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
-/obj/machinery/requests_console{
-	department = "Chapel";
-	departmentType = 2;
-	pixel_x = -32
-	},
-/obj/structure/closet,
-/obj/item/storage/backpack/cultpack,
-/obj/item/clothing/head/nun_hood,
-/obj/item/clothing/suit/chaplainsuit/nun,
-/obj/item/clothing/suit/chaplainsuit/holidaypriest,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"XD" = (
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/maint)
+"jU" = (
 /obj/machinery/door/airlock{
-	id_tag = "Cell1";
-	name = "Cell 1"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ruin/powered)
-"XK" = (
-/turf/open/floor/plating,
-/area/ruin/powered)
-"XW" = (
-/obj/structure/table/wood,
-/obj/item/nullrod,
-/turf/open/floor/carpet/black,
-/area/ruin/powered)
-"Yd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"Ye" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Yf" = (
-/obj/item/cultivator,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"Yo" = (
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"Yt" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Yy" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Monastery Docking Bay APC";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"YA" = (
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"YD" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"YF" = (
-/obj/structure/bed,
-/obj/item/bedsheet/yellow,
-/turf/open/floor/plasteel/grimy,
-/area/ruin/powered)
-"YI" = (
-/obj/structure/table/wood,
-/obj/item/storage/bag/books,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"YJ" = (
-/obj/item/storage/bag/plants,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
-/obj/item/storage/bag/plants/portaseeder,
-/obj/item/storage/bag/plants/portaseeder,
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"YN" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4,
-/turf/open/floor/plating/airless,
-/area/ruin/powered)
-"YS" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/libraryconsole/bookmanagement,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"YV" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"YZ" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/open/space,
-/area/ruin/unpowered/no_grav)
-"Zg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Zh" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/powered)
-"Zl" = (
-/obj/machinery/door/airlock{
-	name = "Dining Room"
+	name = "Kitchen"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -4253,108 +818,8 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"Zq" = (
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/transit_tube/horizontal,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"Zu" = (
-/obj/machinery/hydroponics/soil,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/seeds/watermelon/holy,
-/turf/open/floor/grass,
-/area/ruin/powered)
-"Zv" = (
-/obj/item/hatchet,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4;
-	icon_state = "vent_map_on-1"
-	},
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"Zy" = (
-/obj/machinery/seed_extractor,
-/turf/open/floor/plasteel,
-/area/ruin/powered)
-"ZA" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"ZC" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"ZD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"ZF" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"ZJ" = (
-/obj/structure/table/wood,
-/obj/item/clothing/head/pharaoh,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered)
-"ZP" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"ZX" = (
+/area/ruin/space/has_grav/monastery)
+"ko" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -4375,7 +840,3548 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"ku" = (
+/turf/open/floor/plasteel/chapel{
+	dir = 4
+	},
+/area/ruin/space/has_grav/monastery)
+"kA" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"kC" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/closed/wall/mineral/iron,
+/area/ruin/space/has_grav/monastery/maint)
+"kG" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid,
 /area/ruin/powered)
+"kH" = (
+/obj/item/chair/wood,
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"kW" = (
+/obj/machinery/door/window/eastleft{
+	base_state = "right";
+	dir = 1;
+	icon_state = "right";
+	name = "Coffin Storage"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"lc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery/library)
+"ld" = (
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"ln" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Chapel";
+	opacity = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/dock)
+"lw" = (
+/obj/structure/chair/wood/normal,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"lA" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery/library)
+"lK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"lU" = (
+/obj/machinery/button/massdriver{
+	id = "chapelgun";
+	pixel_x = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"mb" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/has_grav/monastery/library)
+"mo" = (
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"mu" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external,
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/ruin/powered)
+"mA" = (
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"mH" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery)
+"mS" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Monastery Cemetary";
+	opacity = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"mV" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"mX" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"ne" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/watermelon/holy,
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"np" = (
+/obj/item/flashlight/lantern,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"nt" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"nw" = (
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/monastery)
+"nI" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-10"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"nL" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery)
+"ob" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/wheat,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"oi" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/hydroponics/garden/monastery)
+"on" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/dock)
+"oo" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"ot" = (
+/obj/structure/chair/wood/normal,
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery/library)
+"ow" = (
+/turf/closed/wall,
+/area/ruin/space/has_grav/monastery/library)
+"oz" = (
+/obj/structure/table/wood/fancy,
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery)
+"oQ" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"oV" = (
+/obj/structure/table,
+/obj/item/storage/crayons,
+/obj/item/wrench,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"oW" = (
+/obj/machinery/vending/hydronutrients,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/monastery)
+"pd" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/kitchen/rollingpin,
+/obj/item/kitchen/knife,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/monastery)
+"ph" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Library Lounge APC";
+	pixel_x = 24
+	},
+/obj/machinery/airalarm/all_access{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"po" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/monastery/office)
+"pp" = (
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/monastery/office)
+"pq" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 2;
+	piping_layer = 2
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/dock)
+"pv" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/chapel{
+	dir = 4
+	},
+/area/ruin/space/has_grav/monastery)
+"pG" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"pI" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lantern{
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"pN" = (
+/obj/item/cultivator,
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"pW" = (
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"pY" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"qa" = (
+/turf/closed/wall,
+/area/ruin/space/has_grav/monastery/office)
+"qb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"qu" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"qv" = (
+/obj/machinery/door/airlock/external,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/office)
+"qy" = (
+/obj/structure/table/wood,
+/obj/item/clothing/head/pharaoh,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"qJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"qP" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"rc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"rd" = (
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/dock)
+"rg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"rl" = (
+/obj/item/candle{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery)
+"ru" = (
+/obj/structure/chair/wood/wings{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"ry" = (
+/turf/open/floor/plasteel/chapel{
+	dir = 8
+	},
+/area/ruin/space/has_grav/monastery)
+"rD" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"rE" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/poppy,
+/obj/machinery/light/small/broken,
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"rL" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"rN" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"rV" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	layer = 2.9;
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/pen,
+/turf/open/floor/carpet/black,
+/area/ruin/space/has_grav/monastery/office)
+"sf" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"sn" = (
+/obj/item/clothing/suit/apron/chef,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/monastery)
+"sB" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"sE" = (
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/monastery)
+"sK" = (
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/maint)
+"sM" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/obj/item/radio/intercom{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"sU" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/centcom{
+	name = "Chapel Office";
+	opacity = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"tf" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery)
+"tj" = (
+/obj/item/clothing/under/burial,
+/obj/item/clothing/under/burial,
+/obj/item/clothing/under/burial,
+/obj/item/clothing/under/burial,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"tp" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/sand,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/monastery/office)
+"ts" = (
+/obj/structure/table,
+/obj/item/trash/plate,
+/obj/item/kitchen/fork,
+/turf/open/floor/plating/asteroid,
+/area/ruin/powered)
+"tu" = (
+/turf/closed/mineral,
+/area/ruin/powered)
+"tC" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/monastery/office)
+"tE" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"tI" = (
+/obj/structure/chair/wood/normal{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"tT" = (
+/turf/open/floor/plasteel/chapel{
+	dir = 1
+	},
+/area/ruin/space/has_grav/monastery)
+"tX" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/watermelon/holy,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"ug" = (
+/obj/machinery/door/airlock/external{
+	name = "Pod Docking Bay"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/dock)
+"ui" = (
+/obj/machinery/light/small,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"un" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"ux" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Library"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"uO" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/breadslice/plain,
+/obj/item/reagent_containers/food/snacks/breadslice/plain{
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/snacks/breadslice/plain{
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"uP" = (
+/obj/structure/table/wood/fancy,
+/obj/item/storage/box/fancy/candle_box,
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery/library)
+"uX" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"va" = (
+/obj/structure/chair/wood/normal,
+/obj/item/storage/book/bible,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"ve" = (
+/obj/structure/closet,
+/obj/machinery/light/small{
+	dir = 2
+	},
+/obj/item/storage/book/bible,
+/obj/item/storage/book/bible,
+/obj/item/storage/book/bible,
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery/office)
+"vl" = (
+/obj/structure/table/wood/fancy,
+/obj/item/storage/book/bible,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery)
+"vn" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"vs" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/storage/box/fancy/candle_box,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"vt" = (
+/obj/structure/chair/wood/normal{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/ruin/space/has_grav/monastery/office)
+"vy" = (
+/obj/item/disk/nuclear/fake,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"vG" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/powered)
+"vK" = (
+/obj/item/wrench,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/monastery)
+"vP" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/tinted/fulltile,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"vQ" = (
+/obj/machinery/atmospherics/components/binary/pump/on/layer2{
+	dir = 1;
+	name = "Air In"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/maint)
+"vU" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/monastery/dock)
+"vY" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Library"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"wd" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"wk" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/computer{
+	desc = "A computer long since rendered non-functional due to lack of maintenance. Spitting out error messages.";
+	name = "Broken Computer"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/dock)
+"wr" = (
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel,
+/area/ruin/powered)
+"ws" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/pointybush,
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"wy" = (
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"wz" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"wA" = (
+/obj/machinery/holopad,
+/obj/item/flashlight/lantern,
+/turf/open/floor/plasteel/chapel,
+/area/ruin/space/has_grav/monastery)
+"wB" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"wH" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/dock)
+"wJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"wO" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"wP" = (
+/obj/structure/table/wood,
+/obj/item/storage/book/bible,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery)
+"wW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"wZ" = (
+/turf/closed/wall/rust,
+/area/ruin/space/has_grav/monastery)
+"xb" = (
+/obj/structure/table/wood,
+/obj/item/folder/yellow,
+/obj/item/pen,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"xh" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/monastery/office)
+"xq" = (
+/obj/machinery/power/smes/fullycharged,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/maint)
+"xt" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"xB" = (
+/obj/structure/flora/ausbushes,
+/turf/open/floor/plating/asteroid,
+/area/ruin/powered)
+"xC" = (
+/obj/item/storage/box/lights/bulbs,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/maint)
+"xG" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/library)
+"xS" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"xT" = (
+/obj/item/storage/bag/plants,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/obj/item/storage/bag/plants/portaseeder,
+/obj/item/storage/bag/plants/portaseeder,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/monastery)
+"xX" = (
+/obj/structure/table/wood,
+/obj/item/barcodescanner,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"yd" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Garden APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"yi" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Library"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"yj" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"ym" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"yo" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"yp" = (
+/turf/closed/wall,
+/area/hydroponics/garden/monastery)
+"yq" = (
+/obj/structure/closet{
+	name = "beekeeping supplies"
+	},
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/monastery)
+"yt" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/item/chair/wood,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"yE" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/dock)
+"yJ" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Chapel";
+	opacity = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"yP" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/office)
+"yR" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/sand,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/monastery/office)
+"yX" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"yZ" = (
+/obj/item/candle{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"zb" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery)
+"zl" = (
+/obj/machinery/door/poddoor{
+	id = "chapelgun";
+	name = "mass driver door"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery)
+"zz" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Chapel Access";
+	opacity = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"zC" = (
+/obj/structure/chair/wood/normal{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"zD" = (
+/obj/structure/chair/wood/normal{
+	dir = 4
+	},
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"zI" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"zL" = (
+/obj/machinery/door/morgue{
+	name = "Confession Booth"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"zM" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/closed/wall/mineral/iron,
+/area/ruin/space/has_grav/monastery/maint)
+"zO" = (
+/obj/item/extinguisher,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/maint)
+"zS" = (
+/turf/closed/mineral,
+/area/ruin/space/has_grav/monastery/dock)
+"zU" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/grown/poppy,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Ag" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external,
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery)
+"Ai" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Ap" = (
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Aq" = (
+/obj/machinery/light/small{
+	dir = 2
+	},
+/turf/open/floor/carpet/black,
+/area/ruin/space/has_grav/monastery/office)
+"AH" = (
+/obj/item/storage/firstaid/regular,
+/obj/machinery/airalarm/all_access{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/monastery)
+"AT" = (
+/obj/structure/chair/wood/normal,
+/turf/open/floor/plasteel/chapel{
+	dir = 4
+	},
+/area/ruin/space/has_grav/monastery)
+"AY" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-10"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"AZ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"Bc" = (
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/floor/plating/asteroid,
+/area/ruin/powered)
+"Bo" = (
+/obj/structure/chair/wood/normal,
+/turf/open/floor/plasteel/chapel{
+	dir = 1
+	},
+/area/ruin/space/has_grav/monastery)
+"Bq" = (
+/obj/structure/table/wood/fancy,
+/obj/item/folder,
+/obj/item/pen,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/monastery/office)
+"Bx" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"BA" = (
+/obj/item/shard,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/monastery/dock)
+"BK" = (
+/obj/machinery/vending/games,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"BN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/no_grav)
+"BO" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/monastery)
+"BU" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/dock)
+"BX" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/camera{
+	c_tag = "Monastery Garden";
+	dir = 2;
+	network = list("ss13","monastery")
+	},
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"BZ" = (
+/turf/closed/wall/rust,
+/area/ruin/unpowered/no_grav)
+"Ca" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"Cb" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/mug/tea,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Ck" = (
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"Cl" = (
+/obj/structure/grille/broken,
+/turf/open/space/basic,
+/area/ruin/unpowered/no_grav)
+"Cu" = (
+/obj/structure/flora/ausbushes,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel,
+/area/ruin/powered)
+"Cw" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Chapel Access";
+	opacity = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"CD" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"CE" = (
+/turf/closed/wall/rust,
+/area/ruin/space/has_grav/monastery/library)
+"CK" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/closed/wall,
+/area/ruin/space/has_grav/monastery/dock)
+"CN" = (
+/obj/item/flashlight/lantern,
+/turf/open/floor/plasteel/chapel{
+	dir = 8
+	},
+/area/ruin/space/has_grav/monastery)
+"CT" = (
+/obj/structure/sign/warning/vacuum/external,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/powered)
+"Dh" = (
+/obj/item/flashlight/lantern{
+	icon_state = "lantern-on"
+	},
+/turf/open/floor/plating/asteroid,
+/area/ruin/powered)
+"Dl" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery)
+"Dm" = (
+/obj/structure/chair/wood/normal,
+/turf/open/floor/plasteel/chapel{
+	dir = 8
+	},
+/area/ruin/space/has_grav/monastery)
+"Do" = (
+/obj/machinery/light/small,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/dock)
+"Dt" = (
+/obj/effect/spawner/structure/window/shutter,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/office)
+"Dw" = (
+/obj/structure/table/wood/fancy,
+/obj/item/storage/box/matches{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/machinery/light/small/broken,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"DB" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Chapel Garden";
+	opacity = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"DG" = (
+/obj/item/storage/box/lights/bulbs,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/maint)
+"DX" = (
+/obj/structure/table/wood,
+/obj/item/storage/bag/books,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"DY" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Library"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"Ea" = (
+/obj/item/storage/box/matches{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Ec" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/sugarcane,
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"Ed" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery/office)
+"Eh" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external,
+/turf/open/floor/plating,
+/area/ruin/powered)
+"Ej" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/monastery/dock)
+"Em" = (
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/monastery)
+"Eo" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"Ew" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"Ez" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"EI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/maint)
+"EL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/maint)
+"ET" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/floor/plating/asteroid,
+/area/ruin/powered)
+"EY" = (
+/obj/item/pen,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"Ff" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Fk" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Fy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"FI" = (
+/obj/structure/table/wood/fancy,
+/obj/item/storage/box/bodybags,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/monastery/office)
+"FV" = (
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"Gd" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"Gk" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Gs" = (
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"Gt" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Library APC";
+	pixel_x = 24
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"GD" = (
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"GG" = (
+/mob/living/simple_animal/hostile/carp,
+/turf/open/space/basic,
+/area/space)
+"GT" = (
+/obj/structure/chair,
+/turf/open/floor/plating/asteroid,
+/area/ruin/powered)
+"GV" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"Ha" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Chapel";
+	opacity = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Hd" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/closed/mineral,
+/area/ruin/powered)
+"Hg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"Hi" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/monastery/dock)
+"Hm" = (
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"Ho" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Chapel";
+	opacity = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Hz" = (
+/turf/closed/wall,
+/area/ruin/space/has_grav/monastery/dock)
+"HG" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Crematorium";
+	opacity = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"HI" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"HK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"HO" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/ruin/unpowered/no_grav)
+"HR" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/dock)
+"HX" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"HZ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"If" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Ig" = (
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"Io" = (
+/obj/structure/table/wood/fancy,
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery/library)
+"IB" = (
+/obj/structure/bookcase,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"IC" = (
+/turf/closed/wall/rust,
+/area/ruin/space/has_grav/monastery/dock)
+"IH" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/ruin/unpowered/no_grav)
+"IR" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"IZ" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/maint)
+"Jb" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/monastery)
+"Jg" = (
+/turf/open/space,
+/area/space)
+"Jl" = (
+/obj/structure/sign/plaques/deempisi{
+	pixel_y = 28
+	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21";
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"Jo" = (
+/obj/structure/bookcase/random/religion,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"Js" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/wheat,
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"JD" = (
+/obj/machinery/door/airlock/external,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/office)
+"JG" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"JM" = (
+/obj/structure/table/wood/fancy,
+/obj/item/storage/photo_album,
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery/library)
+"JQ" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	layer = 2.9;
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"JR" = (
+/obj/structure/destructible/cult/tome,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"JV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"JW" = (
+/turf/closed/wall/mineral/iron,
+/area/ruin/space/has_grav/monastery/maint)
+"Kq" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Chapel Office";
+	opacity = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"KJ" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Library"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"KN" = (
+/obj/machinery/door/airlock{
+	name = "Garden"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden/monastery)
+"KS" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/libraryscanner,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"KU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"KX" = (
+/obj/structure/table/wood,
+/obj/item/stack/packageWrap,
+/obj/item/coin/gold,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/library)
+"Lc" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/grown/poppy,
+/obj/item/reagent_containers/food/snacks/grown/harebell,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Lg" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Monastery Docking Bay APC";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/dock)
+"Lk" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/maint)
+"LK" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery)
+"LP" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/airalarm/all_access{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"LQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"LV" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"LY" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/sugarcane,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"LZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/dock)
+"Mc" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/chapel{
+	dir = 8
+	},
+/area/ruin/space/has_grav/monastery)
+"Md" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Mi" = (
+/obj/item/wrench,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/maint)
+"Ml" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/ruin/unpowered/no_grav)
+"Mn" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-08"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Mo" = (
+/obj/item/flashlight/lantern,
+/turf/open/floor/plating/asteroid,
+/area/ruin/powered)
+"Mw" = (
+/turf/closed/wall,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"MB" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/maint)
+"ML" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/monastery/office)
+"MM" = (
+/obj/structure/bookcase{
+	name = "Forbidden Knowledge"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"MQ" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/machinery/mass_driver{
+	id = "chapelgun"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"MR" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"MS" = (
+/obj/item/flashlight/lantern{
+	icon_state = "lantern-on"
+	},
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel,
+/area/ruin/powered)
+"MX" = (
+/obj/item/chair/wood,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"MY" = (
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"MZ" = (
+/turf/closed/wall/mineral/iron,
+/area/ruin/unpowered/no_grav)
+"Nc" = (
+/obj/machinery/door/airlock{
+	id_tag = "Cell1";
+	name = "Cell 1"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/monastery)
+"Ns" = (
+/obj/structure/closet/emcloset,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Nv" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Nw" = (
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"Nx" = (
+/obj/item/seeds/banana,
+/obj/item/seeds/grass,
+/obj/item/seeds/grape,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/monastery)
+"NE" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/closed/mineral,
+/area/ruin/unpowered/no_grav)
+"NI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"NK" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"NP" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"Og" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Om" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"On" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/dock)
+"Oz" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/mass_driver{
+	dir = 1;
+	id = "chapelgun"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"OB" = (
+/turf/closed/wall,
+/area/ruin/space/has_grav/monastery/maint)
+"OI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/item/chair/wood,
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery)
+"OM" = (
+/obj/item/flashlight/lantern,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"OQ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"OS" = (
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery)
+"OU" = (
+/obj/machinery/door/airlock/external{
+	name = "Pod Docking Bay"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/dock)
+"OW" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/stack/sheet/glass/fifty{
+	layer = 4
+	},
+/obj/item/stack/sheet/metal{
+	amount = 20;
+	layer = 3.1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/maint)
+"OX" = (
+/obj/effect/spawner/xmastree,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery/library)
+"OY" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"Pk" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/light/small,
+/obj/machinery/airalarm/all_access{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"Pu" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery/library)
+"Pz" = (
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/monastery/dock)
+"PB" = (
+/obj/structure/flora/ausbushes/pointybush,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"PC" = (
+/obj/structure/table/wood/fancy,
+/obj/item/flashlight/lantern{
+	icon_state = "lantern-on";
+	pixel_y = 8
+	},
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery/library)
+"PH" = (
+/obj/structure/chair/wood/normal{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"PO" = (
+/obj/structure/filingcabinet,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"PS" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"Qc" = (
+/obj/structure/closet,
+/obj/item/storage/backpack/cultpack,
+/obj/item/clothing/head/nun_hood,
+/obj/item/clothing/suit/chaplainsuit/nun,
+/obj/item/clothing/suit/chaplainsuit/holidaypriest,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"Ql" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/harebell,
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"Qx" = (
+/obj/structure/table,
+/obj/item/crowbar,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"QK" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/ruin/unpowered/no_grav)
+"QQ" = (
+/turf/closed/wall,
+/area/ruin/unpowered/no_grav)
+"QU" = (
+/obj/structure/bookcase/random/adult,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"QV" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Chapel";
+	opacity = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"QY" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"Rc" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/poppy,
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"Rg" = (
+/obj/machinery/door/window/northright{
+	base_state = "right";
+	dir = 2;
+	icon_state = "right";
+	name = "Curator Desk Door"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"Rh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"Rj" = (
+/obj/structure/closet{
+	name = "beekeeping wardrobe"
+	},
+/obj/item/clothing/suit/beekeeper_suit,
+/obj/item/clothing/suit/beekeeper_suit,
+/obj/item/clothing/suit/beekeeper_suit,
+/obj/item/clothing/head/beekeeper_head,
+/obj/item/clothing/head/beekeeper_head,
+/obj/item/clothing/head/beekeeper_head,
+/obj/item/melee/flyswatter,
+/obj/item/melee/flyswatter,
+/obj/item/melee/flyswatter,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/monastery)
+"Rk" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"Rl" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Ro" = (
+/obj/structure/chair/wood/normal,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Rr" = (
+/obj/structure/table/wood,
+/obj/item/storage/photo_album,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"RF" = (
+/obj/structure/table/wood,
+/obj/item/camera,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"RG" = (
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"RJ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"RO" = (
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"RQ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"RW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Sd" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/airalarm/all_access{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Sf" = (
+/obj/structure/chair/wood/normal,
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery)
+"Sj" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/monastery)
+"Sk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery)
+"Sn" = (
+/obj/item/folder/yellow,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"Sx" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"SF" = (
+/obj/machinery/light/small{
+	dir = 2
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"SJ" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	layer = 3.1;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"SL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/dock)
+"SO" = (
+/obj/structure/bookcase,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"SP" = (
+/obj/structure/table/wood,
+/obj/item/instrument/saxophone,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"SU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/no_grav)
+"SV" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"Tb" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel,
+/area/ruin/powered)
+"Td" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"Tm" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/dock)
+"To" = (
+/obj/machinery/bookbinder,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"TD" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"TE" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Chapel Access";
+	opacity = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"TM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/monastery/office)
+"Ua" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"Uc" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"Ud" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/item/reagent_containers/food/drinks/bottle/holywater{
+	name = "flask of holy water";
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"Ug" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/dock)
+"Uh" = (
+/obj/structure/closet/secure_closet/freezer/fridge{
+	req_access = null
+	},
+/obj/machinery/light/small/broken,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/monastery)
+"Uk" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Um" = (
+/obj/machinery/power/smes/fullycharged,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/maint)
+"Un" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"Ut" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/chair/wood/normal,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Uw" = (
+/obj/item/shovel/spade,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/monastery)
+"Ux" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"UJ" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"UQ" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"UX" = (
+/obj/machinery/door/window/northright{
+	base_state = "left";
+	dir = 2;
+	icon_state = "left";
+	name = "Curator Desk Door"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"UY" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"Vc" = (
+/obj/item/instrument/violin,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/no_grav)
+"Vf" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/meter{
+	target_layer = 2
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/maint)
+"Vg" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/ruin/unpowered/no_grav)
+"Vl" = (
+/obj/machinery/photocopier,
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"Vp" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/dock)
+"Vw" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/ruin/powered)
+"Vx" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/monastery)
+"VA" = (
+/obj/structure/sink/puddle,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"VU" = (
+/obj/machinery/door/airlock/external{
+	name = "Dock Access"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"VV" = (
+/turf/closed/wall/mineral/iron,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"VX" = (
+/obj/structure/chair/wood/wings{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"Wc" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"Wg" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"Wl" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Monastery Maintenance APC";
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/maint)
+"Wo" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"Wv" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Ww" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	layer = 2.9;
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/pen,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"Wz" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"WD" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/warning/vacuum/external,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/dock)
+"WE" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
+/area/ruin/space/has_grav/monastery/office)
+"WF" = (
+/obj/machinery/airalarm/all_access{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"WL" = (
+/turf/open/floor/plating/asteroid,
+/area/ruin/powered)
+"WO" = (
+/obj/machinery/vending/wardrobe/curator_wardrobe,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"WQ" = (
+/turf/closed/mineral,
+/area/ruin/unpowered/no_grav)
+"WU" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"WW" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Xd" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/palebush,
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"Xh" = (
+/turf/open/floor/carpet/black,
+/area/ruin/space/has_grav/monastery/office)
+"Xj" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/item/chair/wood,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"Xm" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Xq" = (
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/no_grav)
+"Xt" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/office)
+"Xv" = (
+/obj/structure/table/wood,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/item/storage/crayons,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/no_grav)
+"Xx" = (
+/obj/machinery/vending/wardrobe/chap_wardrobe,
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/monastery/office)
+"XD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock{
+	name = "Garden"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden/monastery)
+"XG" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Library"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"XK" = (
+/turf/open/floor/plating,
+/area/ruin/powered)
+"XL" = (
+/obj/structure/chair/wood/normal{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"XS" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"XT" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Monastery Maintenance"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/maint)
+"XU" = (
+/obj/structure/chair/wood/normal{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Yf" = (
+/obj/machinery/chem_master/condimaster,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/monastery)
+"YG" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"YW" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"YX" = (
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/monastery)
+"YY" = (
+/obj/machinery/airalarm/all_access{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"YZ" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space,
+/area/ruin/unpowered/no_grav)
+"Ze" = (
+/mob/living/simple_animal/butterfly,
+/turf/open/floor/grass,
+/area/hydroponics/garden/monastery)
+"Zf" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"Zg" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"Zn" = (
+/obj/structure/table/wood,
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-05";
+	pixel_y = 10
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/library)
+"Zr" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 1;
+	piping_layer = 2
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/maint)
+"Zs" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/monastery/library/lounge)
+"ZH" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/has_grav/monastery/dock)
+"ZI" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/obj/item/stack/rods/fifty,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/maint)
+"ZL" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Chapel Office APC";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery/office)
+"ZU" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/monastery)
+"ZW" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/monastery/dock)
 
 (1,1,1) = {"
 gZ
@@ -4585,7 +4591,7 @@ gZ
 gZ
 gZ
 gZ
-gZ
+WQ
 gZ
 gZ
 gZ
@@ -4673,6 +4679,9 @@ gZ
 gZ
 gZ
 gZ
+WQ
+WQ
+WQ
 gZ
 gZ
 gZ
@@ -4689,9 +4698,6 @@ gZ
 gZ
 gZ
 gZ
-gZ
-gZ
-oS
 gZ
 gZ
 gZ
@@ -4760,14 +4766,14 @@ gZ
 gZ
 gZ
 gZ
-gZ
-gZ
-gZ
-yZ
-yZ
-Vw
-yZ
-yZ
+WQ
+WQ
+WQ
+jq
+qa
+Xt
+qa
+qa
 gZ
 gZ
 gZ
@@ -4779,9 +4785,9 @@ gZ
 gZ
 WQ
 WQ
-Vw
-Eh
-Vw
+cS
+Ag
+cS
 WQ
 gZ
 gZ
@@ -4846,18 +4852,18 @@ gZ
 gZ
 gZ
 gZ
+WQ
+WQ
 gZ
-gZ
-gZ
-gZ
-gZ
-yZ
-yZ
-XC
-hB
-ye
-yZ
-yZ
+WQ
+WQ
+qa
+qa
+Qc
+PO
+qP
+qa
+qa
 gZ
 gZ
 gZ
@@ -4868,9 +4874,9 @@ WQ
 WQ
 WQ
 WQ
-Vw
-XK
-Vw
+cS
+OS
+cS
 WQ
 WQ
 gZ
@@ -4936,19 +4942,19 @@ gZ
 gZ
 gZ
 gZ
+WQ
+gZ
+Ml
+Ml
+Xt
+Xh
+Xh
+cK
+Xh
+Xh
+Xt
 gZ
 gZ
-gZ
-gZ
-Vw
-ny
-ny
-sO
-ny
-ny
-Vw
-gZ
-gZ
 WQ
 WQ
 WQ
@@ -4957,9 +4963,9 @@ WQ
 WQ
 WQ
 WQ
-Vw
-CD
-Vw
+cS
+fT
+cS
 WQ
 WQ
 gZ
@@ -5023,33 +5029,33 @@ gZ
 gZ
 gZ
 gZ
+GG
 gZ
-gZ
 WQ
+Ml
 WQ
-WQ
-yZ
-yZ
-Sb
-XW
-yr
-bz
-ds
-yZ
-yZ
-WQ
-WQ
-WQ
+jq
+qa
+WE
+bB
+cQ
+rV
+Aq
+qa
+qa
 WQ
 WQ
 WQ
 WQ
-yZ
-yZ
-Vw
-wL
-Vw
-yZ
+WQ
+WQ
+WQ
+iK
+wZ
+cS
+LK
+cS
+iK
 WQ
 WQ
 gZ
@@ -5113,32 +5119,32 @@ gZ
 gZ
 gZ
 gZ
-WQ
-yZ
-yZ
-yZ
-yZ
-Tt
-ny
-IF
-IF
-IF
-ny
-Nx
-yZ
-yZ
-WQ
-WQ
+gZ
+gZ
+ML
+qa
+qa
+Jl
+Xh
+Xh
+vt
+Xh
+Xh
+cH
+qa
+qa
 WQ
 WQ
 WQ
 WQ
-yZ
-eG
-RQ
-bW
-wi
-yZ
+WQ
+WQ
+iK
+Ns
+RG
+ym
+oV
+iK
 WQ
 WQ
 gZ
@@ -5200,34 +5206,34 @@ gZ
 gZ
 gZ
 gZ
-gZ
-gZ
-yZ
-yZ
-nA
-BW
-yZ
-eV
-Ak
-cz
-WZ
-eF
-jt
-zB
-HM
-yZ
-yZ
-yZ
-yZ
-yZ
-yZ
-yZ
-yZ
-iv
-nH
-sK
-VT
-yZ
+WQ
+WQ
+Ml
+Ml
+Bq
+FI
+qa
+YY
+Ud
+yt
+bU
+mV
+jB
+go
+Xx
+iK
+iK
+wZ
+iK
+iK
+iK
+wZ
+iK
+Qx
+Zf
+dq
+Gk
+wZ
 WQ
 WQ
 gZ
@@ -5290,35 +5296,35 @@ gZ
 gZ
 gZ
 gZ
-gZ
-Vw
-Nn
-lA
-tx
-yZ
-uM
-Ak
-cz
-ZF
-Xy
-jt
-zB
-kk
-yZ
-sW
-Xg
-Gm
-yZ
-qs
-ev
-yZ
-yZ
-gc
-lX
-yZ
-yZ
-yZ
-yZ
+WQ
+Ml
+ML
+tC
+pp
+qa
+en
+ld
+AZ
+pY
+rL
+Rk
+go
+ve
+wZ
+Rj
+yq
+Uh
+iK
+hp
+BO
+iK
+iK
+Ap
+LQ
+iK
+iK
+iK
+wZ
 gZ
 gZ
 gZ
@@ -5376,40 +5382,40 @@ gZ
 gZ
 gZ
 gZ
+GG
 gZ
 gZ
-gZ
-tu
-yZ
-fM
-Uo
-WP
-FX
-br
-Nt
-IT
-II
-eF
-jt
-zB
-qJ
-yZ
-ql
-cT
-Zv
-eO
-YA
-cV
-yZ
-yZ
-yZ
-kB
-yZ
-Sy
-yB
-yZ
-Vw
-Vw
+Ml
+ML
+ML
+xh
+po
+HG
+JV
+bN
+RQ
+Wg
+mV
+Xj
+go
+Ed
+iK
+AH
+YX
+jm
+nw
+nw
+bw
+iK
+iK
+iK
+VU
+iK
+Ea
+Lc
+iK
+cS
+cS
 gZ
 gZ
 gZ
@@ -5466,39 +5472,39 @@ gZ
 gZ
 gZ
 gZ
-gZ
+WQ
 tu
-tu
-yZ
-By
-tx
-vh
-yZ
-fs
-Go
-Eo
-ZX
-eF
-jt
-gg
-yZ
-yZ
-hw
-Py
-HD
-HX
-zM
-ta
-yZ
-kc
-Ct
-lX
-rL
-tx
-bW
-RQ
-SM
-Vw
+ML
+ML
+pp
+pp
+TM
+qa
+ZL
+lK
+Un
+ko
+mV
+Rk
+eB
+qa
+iK
+Yf
+Nx
+oW
+jI
+vK
+pd
+iK
+ba
+ib
+LQ
+hI
+MX
+ym
+pW
+np
+cS
 gZ
 gZ
 gZ
@@ -5558,37 +5564,37 @@ gZ
 gZ
 tu
 tu
-yZ
-yZ
-yZ
-yZ
-yZ
-yZ
-SY
-cz
-hY
-eF
-Sm
-yZ
-yZ
-yZ
-Zy
-YA
-gR
-uf
-YA
-pp
-yZ
-kc
-xh
-yU
-Nn
-nH
-Pm
-Eq
-DW
-Vw
-Vw
+qa
+jq
+qa
+qa
+qa
+qa
+Uc
+AZ
+je
+mV
+SF
+qa
+qa
+iK
+gO
+nw
+Uw
+sn
+nw
+Sj
+wZ
+ba
+wO
+lw
+va
+Zf
+hX
+KU
+Fy
+cS
+cS
 gZ
 gZ
 gZ
@@ -5650,34 +5656,34 @@ Hd
 Hd
 tu
 tu
-yZ
-Vd
-ng
-tx
-cz
-hY
-eF
-At
-yZ
+qa
+yP
+qv
+eB
+AZ
+je
+mV
+hb
+qa
 tu
-yZ
-ms
-YJ
-gA
-oO
-FK
-nK
-yZ
-kc
-Di
-dX
-lo
-zB
-dR
-yY
-ES
-Ow
-VU
+iK
+sE
+xT
+Vx
+cL
+Em
+Jb
+iK
+ba
+ht
+dp
+Sf
+rl
+vl
+RG
+Oz
+hN
+zl
 gZ
 gZ
 gZ
@@ -5739,34 +5745,34 @@ tu
 tu
 tu
 WL
-yZ
-gH
-yZ
-yZ
-yZ
-Gv
-yZ
-yZ
-yZ
+qa
+JD
+qa
+jq
+qa
+sU
+qa
+qa
+qa
 tu
-yZ
-yZ
-yZ
-yZ
-qN
-yZ
-yZ
-yZ
-kc
-Di
-dX
-lo
-zB
-tN
-yY
-Bq
-gn
-VU
+iK
+iK
+iK
+iK
+jU
+iK
+iK
+iK
+ba
+ht
+OI
+oz
+hi
+dp
+RG
+MQ
+Uk
+zl
 gZ
 gZ
 gZ
@@ -5832,30 +5838,30 @@ WL
 WL
 WL
 ek
-qh
-pu
-qh
+Dt
+yR
+Dt
 tu
 tu
 tu
+wZ
+RG
+zD
+RG
+rc
+pW
+NK
+iK
+ba
+wO
+lw
+Ro
 yZ
-tx
-PK
-tx
-TR
-RQ
-pk
-yZ
-kc
-xh
-yU
-Nn
-tx
-lX
-tx
-tx
-Vw
-Vw
+LQ
+wO
+RG
+cS
+cS
 gZ
 gZ
 gZ
@@ -5921,30 +5927,30 @@ WL
 WL
 ET
 WL
-qh
-jH
-qh
+Dt
+yR
+Dt
 tu
 tu
 tu
-yZ
-Nn
-pS
-bs
-OY
-tx
-Uu
-yZ
-kc
-fH
-yv
-JU
-br
-wa
-RL
-Bb
-Yd
-md
+iK
+Ro
+im
+XU
+qu
+RG
+fS
+wZ
+ba
+kW
+Ff
+hW
+NI
+Md
+lU
+OM
+Sk
+dA
 gZ
 gZ
 gZ
@@ -6010,29 +6016,29 @@ WL
 WL
 WL
 WL
-qh
-py
-qh
+Dt
+tp
+Dt
 tu
 tu
 tu
-yZ
-Nn
-Ln
-Fg
-TR
-Nn
-RX
-yZ
-yZ
-yZ
-cx
-yZ
-iS
-EQ
-yZ
-Vw
-Vw
+iK
+Ro
+Cb
+dk
+rc
+Ro
+SJ
+iK
+iK
+iK
+mS
+iK
+vs
+tj
+iK
+cS
+cS
 gZ
 gZ
 gZ
@@ -6099,27 +6105,27 @@ WL
 xB
 WL
 ET
-qh
-pu
-qh
+Dt
+yR
+Dt
 tu
 tu
 tu
-yZ
-tx
-eh
-CR
-TR
-tx
-eh
-yZ
-tE
-ft
-dT
-yZ
-yZ
-yZ
-yZ
+wZ
+RG
+PH
+mA
+rc
+RG
+PH
+iK
+wW
+qb
+Om
+iK
+iK
+wZ
+iK
 gZ
 gZ
 gZ
@@ -6184,37 +6190,37 @@ WL
 WL
 WL
 WL
-Dh
-yZ
-yZ
-yZ
-yZ
-LF
-yZ
-rU
-rU
-rU
-rU
-rU
-rU
-rU
-Zl
-rU
-rU
-rU
-Mf
-rU
-rU
-na
-Pg
-sC
-yZ
+Mo
+iK
+wZ
+iK
+iK
+Kq
+iK
+gF
+gF
+gF
+gF
+gF
+gF
+gF
+bO
+gF
+gF
+gF
+DB
+gF
+gF
+zM
+Um
+xq
+hu
 gZ
 gZ
 gZ
 gZ
 gZ
-gZ
+WQ
 gZ
 gZ
 WQ
@@ -6272,39 +6278,39 @@ WL
 WL
 WL
 WL
-yZ
-yZ
-yZ
-tx
-hH
-Uo
-EF
-cR
-rU
-wk
-vK
-cp
-kV
-CZ
-vK
-yy
-BZ
-cy
-kV
-zm
-vK
-SW
-qk
-lE
-lE
-yZ
-yZ
-yZ
+iK
+wZ
+iK
+RG
+zL
+qJ
+jc
+nt
+gF
+AY
+yX
+WU
+ds
+TD
+yX
+wz
+gp
+Xm
+dR
+WW
+yX
+ZU
+kC
+bn
+bn
+OB
+OB
+OB
 gZ
 gZ
 gZ
 gZ
-gZ
+WQ
 gZ
 WQ
 WQ
@@ -6361,39 +6367,39 @@ WL
 WL
 WL
 ET
-yZ
-dh
-Op
-ke
-yZ
-RB
-Oa
-cp
-Jn
-gP
+iK
+Ro
+vP
+tI
+iK
+Ap
+HZ
+WU
+fw
+oQ
+Rl
+Rl
+Rl
+OQ
+Rl
 rN
-rN
-rN
-rN
-rN
-aY
-rN
-rN
-rN
-rN
-rN
-kv
-Hk
-cH
-XK
-XK
-SV
-yZ
+Rl
+Rl
+Rl
+Rl
+Rl
+Wz
+aG
+Lk
+hT
+DG
+id
+OB
 WQ
 gZ
 gZ
 gZ
-gZ
+WQ
 gZ
 WQ
 WQ
@@ -6438,7 +6444,6 @@ Jg
 Vw
 Vw
 WL
-PN
 WL
 WL
 WL
@@ -6448,36 +6453,37 @@ WL
 WL
 WL
 WL
-yZ
-yZ
-yZ
-uY
-yZ
-yZ
-yZ
-yZ
-HA
-yZ
-rU
+WL
+iK
+iK
+iK
+fk
+iK
+iK
+iK
+iK
+Ho
+wZ
+gF
+RJ
 Rl
-rN
-yZ
-uC
-uC
-yZ
-jZ
-yZ
-uC
-uC
-yZ
-rN
+yp
+oi
+oi
+yp
+XD
+yp
+oi
+oi
+yp
 Rl
-rU
-Zh
-rD
-kD
-Nf
-yZ
+RJ
+JW
+EI
+Mi
+EL
+Zr
+hu
 WQ
 WQ
 WQ
@@ -6537,56 +6543,56 @@ WL
 WL
 WL
 WL
-yZ
-RQ
-tx
-tx
-Pn
-tx
-tx
-RQ
+wZ
+pW
+RG
+RG
+pW
+RG
+RG
+uX
+RJ
+iK
+gF
+fx
 Rl
-yZ
-rU
-eZ
-rN
-uC
+oi
+PB
+OY
+yd
+pG
+ob
+Ql
+Rc
+oi
+Rl
+Wz
+JW
+Wl
+iM
+Vf
+Zr
 OB
-zs
-gf
-jz
-Jy
-GP
-ki
-uC
-rN
-kv
-rU
-zF
-Yo
-On
-Nf
-yZ
 WQ
 WQ
 WQ
 WQ
 gZ
 gZ
+GG
 gZ
 gZ
-gZ
-yZ
-Vw
-yZ
-Vw
-yZ
-yZ
-Vw
-yZ
-Vw
-yZ
-Vw
+CE
+xG
+ow
+xG
+CE
+ow
+xG
+ow
+xG
+CE
+xG
 Ml
 Ml
 Ml
@@ -6607,14 +6613,14 @@ gZ
 gZ
 gZ
 gZ
-Vw
-Vw
-QX
-wv
-wv
-wv
-wv
-yZ
+on
+on
+CK
+ZH
+vU
+vU
+vU
+Hz
 WL
 Bc
 WL
@@ -6625,57 +6631,57 @@ WL
 Bc
 WL
 Bc
-yZ
-yZ
-tx
-US
-iE
-US
-iE
-pZ
-oj
+iK
+iK
+RG
+Bo
+Dm
+Bo
+Dm
+tT
+Mc
+RJ
+Mn
+gF
+mX
+JG
+oi
+OY
+hk
+tE
+Hm
+Hm
+YG
+OY
+oi
 Rl
-dr
-rU
-Ao
-rN
-uC
-zs
-MT
-QG
-KZ
-KZ
-Fr
-zs
-uC
-rN
-NA
-LB
-wf
-bv
-ir
-Nf
-yZ
+Nv
+XT
+jO
+vQ
+MB
+Zr
+OB
 QQ
 QQ
-QQ
+BZ
 QQ
 Ml
 Ml
 Ml
 Ml
-yZ
-yZ
-tx
-RQ
-tx
-tx
-tx
-tx
-ah
-tx
-yf
-Vw
+CE
+ow
+GD
+Gs
+GD
+GD
+GD
+GD
+GV
+GD
+yj
+xG
 gZ
 gZ
 Ml
@@ -6695,78 +6701,78 @@ gZ
 gZ
 gZ
 gZ
-dg
-qY
-XK
-Xa
-Wb
-NY
-tx
-wD
-yZ
-yZ
-Dh
+Jg
+ug
+rd
+OU
+wH
+yE
+fF
+ah
+Hz
+IC
+Mo
+WL
+WL
+WL
+Mo
 WL
 WL
 WL
 Dh
-WL
-WL
-WL
-Dh
-yZ
-tx
-tx
-pM
-pT
-pM
-Uz
-xa
-Xd
-OK
-on
-rU
-TZ
-rN
-yZ
-lp
-Dk
-IX
-KZ
-Li
-GP
-iA
-yZ
-rN
-pb
-rU
-El
-XK
-XK
-gt
-yZ
+iK
+RG
+RG
+AT
+hc
+AT
+wA
+pv
+jy
+jv
+Dw
+gF
+YW
+Rl
+yp
+iI
+Ua
+cm
+Hm
+Js
+Ql
+rE
+yp
+Rl
+ui
+JW
+xC
+hT
+zO
+hU
+hu
 WQ
 QQ
 WQ
+WQ
+WQ
 gZ
 gZ
 gZ
-gZ
-gZ
-yZ
-mv
-tx
-Fy
-tx
-lo
-Ui
-Ui
-xl
-tx
-tx
-yZ
-yZ
-Vw
+ow
+BK
+GD
+wd
+GD
+ot
+Io
+Io
+cU
+GD
+GD
+ow
+ow
+xG
 Ml
 gZ
 gZ
@@ -6785,15 +6791,15 @@ gZ
 gZ
 gZ
 gZ
-Vw
-Vw
-jy
-VB
-Cb
-wJ
-YD
-wJ
-RV
+on
+on
+WD
+HR
+On
+cr
+Ug
+cr
+aY
 Tb
 Tb
 Tb
@@ -6803,60 +6809,60 @@ Tb
 Tb
 Tb
 Tb
-DL
-YD
-Wj
-Wj
-Wj
-Wj
-Wj
-Wj
-Ds
-Um
-tx
-VQ
-lX
-rN
-uC
-zT
-MT
-Fr
-UN
-KZ
-KZ
-Oz
-uC
-rN
+Ha
+Ai
+nL
+nL
+nL
+nL
+nL
+nL
+wP
+mH
+RG
+yJ
+LQ
 Rl
-rU
-Wg
-LA
-um
-ZP
-yZ
+oi
+BX
+hk
+YG
+VA
+Hm
+Hm
+vn
+oi
+Rl
+RJ
+JW
+OW
+ZI
+sK
+IZ
+OB
 WQ
 QQ
 QQ
+WQ
+WQ
 Ml
+QQ
 Ml
-Ml
-Ml
-Ml
-yZ
-aF
-tx
-tx
-tx
-lo
-Ui
-gj
-xl
-tx
-tx
-Dy
-CK
-Vw
-yZ
+CE
+SO
+GD
+bP
+GD
+ot
+Io
+uP
+cU
+GD
+GD
+UX
+HX
+xG
+ow
 gZ
 gZ
 gZ
@@ -6874,15 +6880,15 @@ gZ
 gZ
 gZ
 gZ
-YN
-Yd
-Mz
-ZA
-eT
-rN
-tx
-rN
-wF
+Hi
+LZ
+wk
+BU
+Tm
+bH
+fF
+Vp
+ln
 wr
 wr
 wr
@@ -6892,61 +6898,61 @@ wr
 wr
 wr
 wr
-VQ
-tx
-zB
-zB
-zB
-zB
-zB
-zB
-wV
-FI
-tx
-VQ
-lX
-rN
-uC
-aL
-YV
-pa
-Wi
-QG
-tT
-zs
-uC
-rN
+QV
+RG
+hi
+hi
+hi
+hi
+hi
+hi
+fi
+dp
+RG
+yJ
+LQ
 Rl
-rU
-rU
-rU
-rU
-rU
-rU
-rU
-rU
+oi
+PS
+UJ
+Ze
+sf
+tE
+XS
+OY
+oi
+wB
+ha
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+WQ
 WQ
 gZ
 gZ
 gZ
 gZ
-gZ
-yZ
-CC
-tx
-Fy
-tx
-lo
-jD
-Rj
-xl
-bW
-rN
-mp
-tx
-dQ
-yZ
-Vw
+ow
+hP
+GD
+mb
+wd
+ot
+JM
+PC
+cU
+sB
+rD
+Zn
+GD
+cv
+ow
+xG
 gZ
 gZ
 gZ
@@ -6964,15 +6970,15 @@ gZ
 gZ
 gZ
 Jg
-Vw
-re
-Yy
-Om
-tx
-EO
-yZ
-yZ
-Dh
+on
+pq
+Lg
+SL
+eu
+Do
+Hz
+Hz
+Mo
 WL
 WL
 WL
@@ -6981,61 +6987,61 @@ WL
 WL
 WL
 Dh
-yZ
-tx
-tx
-US
-iE
-US
-lv
-pZ
-WV
-lX
-se
-rU
-QB
-rN
-yZ
-Zu
-Xp
-NR
-Yf
-KZ
-Jo
-iR
-yZ
-rN
-kO
-rU
-qE
-QW
-IR
-hO
-Pt
-zn
-rU
-rU
-yZ
-Vw
-Vw
-Vw
-yZ
-yZ
-nB
-tx
-tx
-tx
-tx
-tx
-tx
-tx
-Zg
-rN
-Vv
-bW
-tx
+iK
+RG
+RG
+Bo
+Dm
+Bo
+CN
+tT
+ry
+LQ
+dF
+gF
+Sx
+Rl
+yp
+tX
+iz
+Ec
+pN
+Hm
+ge
+Pk
+yp
+Rl
 ui
-Vw
+VV
+sM
+Vl
+HI
+xb
+XL
+KS
+VV
+VV
+gZ
+gZ
+Eo
+Eo
+Mw
+ow
+eg
+GD
+GD
+GD
+GD
+GD
+GD
+GD
+Ew
+rD
+pI
+sB
+GD
+WO
+xG
 Ml
 Ml
 Ml
@@ -7053,13 +7059,13 @@ gZ
 gZ
 gZ
 gZ
-wv
-wv
-wv
-UT
-yZ
-yZ
-yZ
+vU
+ZH
+vU
+ft
+Hz
+IC
+Hz
 WL
 Bc
 WL
@@ -7069,62 +7075,62 @@ Bc
 WL
 Bc
 WL
-UY
-yZ
-yZ
-tx
-pM
-pT
-pM
-pT
-mY
-wl
-lX
-dr
-rU
-Ao
-rN
-uC
-YV
-KZ
-KZ
-KZ
-IX
-YV
-vR
-uC
-rN
-kv
-vq
-zB
-zB
-zB
-zB
-zB
-BF
-zB
-Gq
-JQ
-DH
-Lk
-Hu
-bE
-ko
-WG
-WG
-WG
-WG
-WG
-WG
-bi
-Eq
-Ye
-Kb
-ZJ
-VJ
-tx
-qU
-Vw
+Bc
+iK
+iK
+RG
+AT
+hc
+AT
+hc
+ku
+jl
+LQ
+Mn
+gF
+Fk
+Rl
+oi
+UJ
+Hm
+Hm
+Hm
+cm
+UJ
+Xd
+oi
+Rl
+Wz
+KJ
+MY
+MY
+kH
+MY
+MY
+MY
+MY
+ux
+UQ
+Zs
+ai
+Wo
+QY
+yi
+gw
+gw
+gw
+gw
+gw
+gw
+OX
+eb
+SV
+Zg
+qy
+VX
+GD
+JR
+xG
 gZ
 gZ
 gZ
@@ -7141,79 +7147,79 @@ gZ
 gZ
 gZ
 gZ
-gZ
-gZ
-Vw
-tx
-TR
-eN
-fG
-yZ
-WL
-WL
-WL
-WL
-WL
-WL
-WL
-WL
-WL
-WL
-WL
-yZ
-Yt
-tx
-tx
-jX
-tx
-tx
-Yt
-lX
-yZ
-rU
-ov
-rN
-uC
-Ny
-Xp
-px
-KZ
-Hv
-Nl
-Vo
-uC
-rN
-Fc
-hC
-uT
-jx
-jx
-jx
-Vk
-jx
-jx
-Xu
-xX
-ZD
+WQ
+WQ
+zS
+zS
 Ej
-KT
-Cz
-zw
-QL
-Us
-EJ
-EJ
-EJ
-EJ
-EJ
-kn
-vk
-pl
-PG
-ka
-tx
-Mt
-Vw
+hh
+zS
+Hz
+WL
+WL
+WL
+WL
+WL
+WL
+WL
+WL
+WL
+WL
+WL
+wZ
+mA
+RG
+RG
+mA
+RG
+RG
+hM
+LQ
+iK
+gF
+Sd
+Rl
+oi
+ne
+iz
+LY
+Hm
+aJ
+ws
+kA
+oi
+Rl
+oo
+DY
+hL
+MR
+Ca
+MR
+Wc
+MR
+MR
+vY
+Gd
+rg
+HK
+CD
+er
+XG
+Pu
+lA
+lc
+lc
+lc
+lc
+lc
+bL
+Td
+yo
+RF
+ru
+GD
+fs
+xG
 gZ
 gZ
 gZ
@@ -7231,15 +7237,15 @@ gZ
 gZ
 gZ
 gZ
-gZ
-Vw
-BO
-wE
-eN
-em
-yZ
+Xq
+zS
+zS
+zS
+cW
+zS
+IC
 WL
-us
+WL
 WL
 WL
 WL
@@ -7249,60 +7255,60 @@ WL
 WL
 WL
 WL
-yZ
-yZ
-fL
-DI
-yZ
-xW
-hq
-yZ
-SD
-yZ
-rU
-lX
-rN
-yZ
-uC
-uC
-yZ
-Kh
-yZ
-uC
-uC
-yZ
-rN
-lX
-rU
-Gp
-pk
-tx
-Ew
-wE
-Lp
-rU
-rU
-yZ
-Vw
-Vw
-Vw
-yZ
-yZ
-yf
-aY
-tx
-tx
-tx
-tx
-tx
-tx
-zf
-rN
-Vv
-vh
-tx
-VZ
-Vw
+iK
+iK
+iZ
+zU
+iK
+uO
+Wv
+iK
+TE
+iK
+gF
+LQ
+Rl
+yp
+oi
+oi
+yp
+KN
+yp
+oi
+oi
+yp
+Rl
+LQ
+VV
+ph
+xt
+Hg
+RO
+Rh
+To
+VV
+VV
+Mw
+Eo
+Eo
+Eo
+gZ
+ow
+yj
+un
+GD
+GD
+GD
+EY
+GD
+Sn
+wJ
+rD
+pI
+NP
+GD
+MM
+xG
 gZ
 gZ
 WQ
@@ -7319,18 +7325,18 @@ gZ
 gZ
 gZ
 gZ
+Ml
 gZ
-gZ
-Vw
-rX
-vh
-RE
-pq
-wv
-Vw
+BA
+zS
+zS
+Pz
+ZW
+vU
 Vw
 Vw
 Vw
+Vw
 WL
 WL
 WL
@@ -7339,59 +7345,59 @@ WL
 WL
 WL
 WL
-yZ
-yZ
-yZ
-yZ
-yZ
-yZ
-yZ
-Rd
-tx
-Ts
-lX
-rN
-rN
-rN
-rN
-rN
-tx
-rN
-rN
-rN
-rN
-rN
-Ao
-rU
-rU
-ge
-tx
-bw
-vh
-Ux
-rU
+iK
+wZ
+iK
+iK
+iK
+iK
+iK
+LP
+RG
+Cw
+LQ
+Rl
+Rl
+Rl
+Rl
+Rl
+RG
+IR
+Rl
+Rl
+Rl
+Rl
+Fk
+VV
+VV
+FV
+Nw
+Ig
+UY
+IB
+VV
 WQ
 gZ
 gZ
 gZ
 gZ
-gZ
-yZ
-aT
-aY
-Fy
-tx
-ss
-wZ
-IZ
-YI
-vh
-rN
-mp
-tx
-dQ
-yZ
-Vw
+WQ
+ow
+hP
+un
+wd
+GD
+Bx
+JQ
+wy
+DX
+NP
+rD
+Zn
+GD
+cv
+CE
+xG
 gZ
 gZ
 WQ
@@ -7408,14 +7414,14 @@ gZ
 gZ
 gZ
 gZ
+WQ
 gZ
-gZ
-wv
-Vw
-Vw
-wv
-Zq
-wv
+ZH
+zS
+zS
+ZH
+cW
+zS
 HO
 HO
 Jg
@@ -7434,52 +7440,52 @@ WL
 ET
 WL
 wr
-Ts
-dJ
-VA
-rU
-LN
-br
-br
-JU
-Ip
-ug
-br
-ug
-Ip
-iJ
-br
-ug
-Si
-rU
-rU
-ge
-tx
-aF
-tx
+zz
+If
+Og
+gF
+LV
+NI
+NI
+hW
+Ez
 Ux
-rU
+NI
+xS
+Ez
+RW
+NI
+Ux
+nI
+gF
+VV
+IB
+Nw
+FV
+Nw
+IB
+VV
+QQ
 QQ
 Ml
 Ml
-Ml
-Ml
-Ml
-yZ
-ge
-aY
-tx
-tx
-YS
-eh
-eh
-oo
-tx
-tx
-GV
-CK
-Vw
-yZ
+WQ
+WQ
+ow
+SO
+un
+GD
+vy
+wy
+zC
+zC
+SP
+GD
+GD
+Rg
+HX
+xG
+ow
 Ml
 Ml
 Ml
@@ -7496,14 +7502,14 @@ gZ
 gZ
 gZ
 gZ
+Ml
 gZ
 gZ
 gZ
 Ml
-Ml
+Jg
 HO
-HO
-QF
+QK
 HO
 HO
 IH
@@ -7523,51 +7529,51 @@ WL
 WL
 WL
 wr
-Ts
-vh
-tx
-rU
-rU
-JV
-rU
-rU
-XD
-rU
-rU
-rU
-AX
-rU
-rU
-rU
-rU
-rU
-rU
-Fo
-Yt
-KK
-Yt
-Ux
-rU
+zz
+aM
+RG
+gF
+gF
+tf
+gF
+gF
+Nc
+gF
+gF
+gF
+eO
+gF
+gF
+gF
+gF
+gF
+VV
+Jo
+fQ
+IB
+mo
+QU
+VV
 WQ
 WQ
 gZ
 gZ
 gZ
-gZ
-yZ
-wc
-aY
-Fy
-tx
-iN
-tx
-tx
-GA
-tx
-tx
-yZ
-yZ
-Vw
+WQ
+CE
+Ww
+un
+wd
+GD
+xX
+GD
+mb
+KX
+GD
+GD
+CE
+ow
+xG
 Ml
 gZ
 gZ
@@ -7586,13 +7592,13 @@ gZ
 gZ
 gZ
 gZ
+GG
 gZ
 gZ
+Ml
 gZ
 gZ
-gZ
-gZ
-fZ
+Vg
 gZ
 Ml
 IH
@@ -7602,7 +7608,7 @@ Jg
 HO
 Vw
 Vw
-Dh
+Mo
 WL
 WL
 WL
@@ -7612,49 +7618,49 @@ wr
 WL
 WL
 MS
-yZ
-AH
-Rc
-yZ
-JM
-XK
-rU
-Uj
-Ki
-WM
-rU
-KL
-Ki
-JL
-rU
+wZ
+Ut
+Rr
+iK
+iJ
+OS
+gF
+Xq
+BN
+bt
+MZ
+Xq
+BN
+Xv
+MZ
 WQ
 WQ
 WQ
-rU
-rU
-rU
-rU
-rU
-rU
-rU
+VV
+VV
+VV
+VV
+VV
+VV
+VV
 QQ
-QQ
+BZ
 Ml
 Ml
 Ml
 Ml
-yZ
-yZ
-Rw
-ty
-tx
-zA
-ZC
-tx
-Wt
-tx
-yf
-Vw
+ow
+ow
+zI
+Gt
+GD
+WF
+GD
+GD
+Ck
+GD
+yj
+xG
 gZ
 gZ
 Ml
@@ -7677,15 +7683,15 @@ gZ
 gZ
 gZ
 gZ
+WQ
+WQ
+WQ
 gZ
 gZ
 gZ
-gZ
-gZ
-gZ
-gZ
-gZ
-gZ
+WQ
+WQ
+WQ
 HO
 HO
 HO
@@ -7701,21 +7707,21 @@ vG
 WL
 WL
 WL
-yZ
-vG
-yZ
-yZ
-yZ
-fr
-rU
-uJ
-hE
-Pe
-rU
-uJ
-hE
-Pe
-rU
+iK
+zb
+iK
+iK
+wZ
+Dl
+gF
+Xq
+Vc
+Xq
+MZ
+Xq
+SU
+Xq
+Xq
 WQ
 WQ
 WQ
@@ -7733,17 +7739,17 @@ gZ
 gZ
 gZ
 Ml
-yZ
-Vw
-yZ
-Vw
-yZ
-yZ
-Vw
-yZ
-Vw
-yZ
-Vw
+CE
+xG
+ow
+xG
+ow
+CE
+xG
+ow
+xG
+ow
+xG
 Ml
 Ml
 Ml
@@ -7766,15 +7772,15 @@ gZ
 gZ
 gZ
 gZ
+WQ
+WQ
+WQ
+Ml
 gZ
 gZ
 gZ
-gZ
-gZ
-gZ
-gZ
-gZ
-gZ
+WQ
+WQ
 gZ
 gZ
 HO
@@ -7785,7 +7791,7 @@ Vw
 Vw
 Vw
 Vw
-Vd
+XK
 vG
 WL
 WL
@@ -7796,17 +7802,17 @@ ts
 kG
 WL
 wr
-rU
-po
-Rr
-HG
-rU
-SX
-Rr
-YF
-rU
+gF
+Xq
+Xq
+Xq
+MZ
+Xq
+Xq
+Xq
+gZ
 WQ
-WQ
+gZ
 WQ
 WQ
 WQ
@@ -7819,8 +7825,8 @@ WQ
 WQ
 WQ
 gZ
-gZ
-gZ
+WQ
+WQ
 Ml
 gZ
 gZ
@@ -7856,14 +7862,14 @@ gZ
 gZ
 gZ
 gZ
+WQ
+WQ
 gZ
 gZ
+GG
 gZ
-gZ
-gZ
-gZ
-gZ
-gZ
+WQ
+Ml
 gZ
 gZ
 gZ
@@ -7874,28 +7880,28 @@ HO
 HO
 gZ
 Vw
-wL
+mu
 Vw
 WL
 WL
 WL
 WL
 WL
-Dh
+Mo
 WL
 WL
-fn
-rU
-rU
-ma
-rU
-rU
-rU
-ma
-rU
-rU
+df
+gF
 WQ
-WQ
+Xq
+Xq
+MZ
+Xq
+gZ
+Xq
+Ml
+gZ
+gZ
 WQ
 WQ
 WQ
@@ -7909,7 +7915,7 @@ WQ
 WQ
 gZ
 gZ
-gZ
+WQ
 Ml
 Ml
 Ml
@@ -7974,29 +7980,29 @@ WL
 WL
 ET
 Cu
-rU
-Ou
-vc
-lw
-rU
-yq
-vc
-Ea
-rU
-WQ
-WQ
-WQ
-WQ
-WQ
-WQ
-WQ
-WQ
-WQ
-WQ
-WQ
+gF
 WQ
 WQ
 gZ
+gZ
+Ml
+gZ
+gZ
+WQ
+gZ
+gZ
+gZ
+gZ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+GG
 gZ
 gZ
 Ml
@@ -8063,19 +8069,19 @@ Vw
 Vw
 Vw
 Vw
-rU
-rU
-rU
-rU
-rU
-rU
-rU
-rU
-rU
+gF
 WQ
 WQ
-WQ
-WQ
+Ml
+gZ
+Ml
+gZ
+gZ
+gZ
+gZ
+gZ
+gZ
+gZ
 WQ
 WQ
 gZ
@@ -8086,7 +8092,7 @@ WQ
 WQ
 gZ
 gZ
-gZ
+WQ
 gZ
 Ml
 gZ
@@ -8152,19 +8158,19 @@ gZ
 gZ
 gZ
 gZ
+Ml
+WQ
 gZ
 gZ
-WQ
-WQ
-WQ
-WQ
-WQ
-WQ
-WQ
-WQ
-WQ
-WQ
-WQ
+gZ
+gZ
+gZ
+gZ
+gZ
+gZ
+gZ
+gZ
+gZ
 WQ
 gZ
 gZ
@@ -8244,15 +8250,15 @@ gZ
 gZ
 gZ
 gZ
-WQ
-WQ
-WQ
-WQ
-WQ
-WQ
-WQ
-WQ
-WQ
+gZ
+gZ
+gZ
+gZ
+gZ
+gZ
+gZ
+gZ
+gZ
 gZ
 gZ
 gZ
@@ -8336,10 +8342,10 @@ gZ
 gZ
 gZ
 gZ
-WQ
-WQ
-WQ
-WQ
+gZ
+gZ
+gZ
+gZ
 gZ
 gZ
 gZ

--- a/_maps/RandomRuins/SpaceRuins/pubby_monastery.dmm
+++ b/_maps/RandomRuins/SpaceRuins/pubby_monastery.dmm
@@ -801,6 +801,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/monastery/maint)
+"jS" = (
+/obj/structure/cable,
+/obj/machinery/power/smes/fullycharged{
+	output_attempt = 0
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/maint)
 "jU" = (
 /obj/machinery/door/airlock{
 	name = "Kitchen"
@@ -1834,11 +1841,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/has_grav/monastery/office)
-"xq" = (
-/obj/machinery/power/smes/fullycharged,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/monastery/maint)
 "xt" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/dark,
@@ -3153,6 +3155,16 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/monastery)
+"Nz" = (
+/obj/machinery/power/smes/fullycharged{
+	output_attempt = 0
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/monastery/maint)
 "NE" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
@@ -3783,14 +3795,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/monastery)
-"Um" = (
-/obj/machinery/power/smes/fullycharged,
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/monastery/maint)
 "Un" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6209,8 +6213,8 @@ DB
 gF
 gF
 zM
-Um
-xq
+Nz
+jS
 hu
 gZ
 gZ

--- a/_maps/RandomRuins/SpaceRuins/pubby_monastery.dmm
+++ b/_maps/RandomRuins/SpaceRuins/pubby_monastery.dmm
@@ -2679,30 +2679,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/monastery/library/lounge)
-"HK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark/airless,
-/area/ruin/space/has_grav/monastery/library/lounge)
 "HO" = (
 /obj/structure/lattice,
 /turf/open/space,
@@ -3690,6 +3666,27 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/monastery/library)
+"Th" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/monastery/library/lounge)
 "Tm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -7201,7 +7198,7 @@ MR
 vY
 Gd
 rg
-HK
+Th
 CD
 er
 XG

--- a/code/game/area/areas/ruins/space.dm
+++ b/code/game/area/areas/ruins/space.dm
@@ -430,3 +430,32 @@
 /area/ruin/space/has_grav/powered/ancient_shuttle
 	name = "Ancient Shuttle"
 	icon_state = "yellow"
+
+//PUBBY MONASTERY
+
+/area/ruin/space/has_grav/monastery
+	name = "Monastery"
+	icon_state = "chapel"
+
+/area/ruin/space/has_grav/monastery/dock
+	name = "Monastery Dock"
+	icon_state = "construction"
+
+/area/ruin/space/has_grav/monastery/garden
+	name = "Monastery Garden"
+	icon_state = "hydro"
+
+/area/ruin/space/has_grav/monastery/office
+	name = "Monastery Office"
+	icon_state = "chapeloffice"
+
+/area/ruin/space/has_grav/monastery/maint
+	name = "Monastery Maintenance"
+	icon_state = "maint_monastery"
+
+/area/ruin/space/has_grav/monastery/library
+	name = "Monastery Library"
+	icon_state = "library"
+
+/area/ruin/space/has_grav/monastery/library/lounge
+	name = "Monastery Library Lounge"

--- a/config/spaceruinblacklist.txt
+++ b/config/spaceruinblacklist.txt
@@ -48,6 +48,6 @@
 #_maps/RandomRuins/SpaceRuins/whiteshipdock.dmm
 #_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
 #_maps/RandomRuins/SpaceRuins/gameroom.dmm
-_maps/RandomRuins/SpaceRuins/pubby_monastery.dmm
+#_maps/RandomRuins/SpaceRuins/pubby_monastery.dmm
 #_maps/RandomRuins/SpaceRuins/bigape.dmm
 #_maps/RandomRuins/SpaceRuins/nicelittlenest.dmm


### PR DESCRIPTION
# Document the changes in your pull request

Yes I understand this doesn't change anything on live, Jamie please update our secret config

Closes https://github.com/yogstation13/Yogstation/issues/11851

Does the thing wej said he was gonna do and reworks it into a space ruin

![dreamseeker_7RMECu3U3e](https://user-images.githubusercontent.com/5091394/167279348-b231cbff-8e47-4e65-a11b-13fe353cb96b.png)
![dreamseeker_qKJOYk4cmp](https://user-images.githubusercontent.com/5091394/167279349-09634401-3e4b-4630-b485-2ffdfb73a4d6.png)

![dreamseeker_tgFEaMjPJP](https://user-images.githubusercontent.com/5091394/167279350-86064094-a98d-4c12-8789-e8a284fb1cdc.png)
![dreamseeker_vCuZBwZTfU](https://user-images.githubusercontent.com/5091394/167279351-7bd50578-705e-4ffe-991a-5d4650ab4a0b.png)
![dreamseeker_FAAO4362BM](https://user-images.githubusercontent.com/5091394/167279353-f8e2dd6f-2a7e-493f-920a-9a60d8cb818d.png)



# Changelog

:cl:  
rscadd: removes pubby monastery from blacklist
/:cl:
