### PR TITLE
Reduces the costs of pathfinder gear since it was SUPPOSED to be a sort of half point between megafauna gear and basic gear but is excessively expensive

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -700,9 +700,9 @@
 	name = "Pathfinder Kasa"
 	result = /obj/item/clothing/head/helmet/kasa
 	time = 5 SECONDS
-	reqs = list(/obj/item/stack/sheet/bone = 12,
-				/obj/item/stack/sheet/sinew = 12,
-				/obj/item/stack/sheet/animalhide/weaver_chitin = 12)
+	reqs = list(/obj/item/stack/sheet/bone = 8,
+				/obj/item/stack/sheet/sinew = 4,
+				/obj/item/stack/sheet/animalhide/weaver_chitin = 10) //3 spiders assuming you get leather from one
 	category = CAT_PRIMAL
 
 /datum/crafting_recipe/pathcloak
@@ -710,7 +710,7 @@
 	result = /obj/item/clothing/suit/armor/pathfinder
 	time = 5 SECONDS
 	reqs = list(/obj/item/clothing/suit/hooded/cloak/goliath = 1,
-				/obj/item/stack/sheet/animalhide/goliath_hide = 4, //2 plates for the cloak plus 4 here plus 3 for plating the armor = 9 total
+				/obj/item/stack/sheet/animalhide/goliath_hide = 2, //2 plates for the cloak plus 2 here plus 3 for plating the armor = 7 total
 				/obj/item/stack/sheet/sinew = 6)
 	category = CAT_PRIMAL
 
@@ -718,8 +718,8 @@
 	name = "Pathfinder Treads"
 	result = /obj/item/clothing/shoes/pathtreads
 	time = 5 SECONDS
-	reqs = list(/obj/item/stack/sheet/sinew = 12,
-				/obj/item/stack/sheet/animalhide/weaver_chitin = 16)
+	reqs = list(/obj/item/stack/sheet/sinew = 2,
+				/obj/item/stack/sheet/animalhide/weaver_chitin = 2)
 	category = CAT_PRIMAL
 
 /datum/crafting_recipe/bonesword


### PR DESCRIPTION
# Document the changes in your pull request

I was told to do this like a year ago but forgot
Pathfinder gear is intended to be the halfway point between megafauna tier armor and basic, non-ashproof armor. Instead of requiring you to fight one big monster it's a bunch of normal monsters that are slightly less big and able to kill you in the case people don't want to/can't get megafauna armor but also don't want to lose out on ashproofing

# Wiki Documentation

kasa
bones reduced 8 from 12
sinew 6 from 12
chitin 10 from 12
cloak
plates 2 from 4
boots reduced massively since they don't actually do much to 2 sinew 2 chitin

# Changelog

:cl:  
tweak: pathfinder gear all around less difficult to craft
/:cl:
