### PR TITLE
Slightly Changes Requirements for Meteors and Rods

### DIFF
--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -10,10 +10,10 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 /datum/round_event_control/immovable_rod
 	name = "Immovable Rod"
 	typepath = /datum/round_event/immovable_rod
-	min_players = 15
-	max_occurrences = 5
+	min_players = 18
+	max_occurrences = 3
+	earliest_start = 20 MINUTES
 	var/atom/special_target
-
 
 /datum/round_event_control/immovable_rod/admin_setup()
 	if(!check_rights(R_FUN))

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -4,9 +4,9 @@
 	name = "Meteor Wave: Normal"
 	typepath = /datum/round_event/meteor_wave
 	weight = 4
-	min_players = 10 //yogs
+	min_players = 10
 	max_occurrences = 3
-	//earliest_start = 25 MINUTES //yogs
+	earliest_start = 25 MINUTES
 
 /datum/round_event/meteor_wave
 	startWhen		= 6
@@ -56,10 +56,10 @@
 /datum/round_event_control/meteor_wave/threatening
 	name = "Meteor Wave: Threatening"
 	typepath = /datum/round_event/meteor_wave/threatening
-	weight = 2 //yogs
+	weight = 2
 	min_players = 20
 	max_occurrences = 3
-	//earliest_start = 35 MINUTES //yogs
+	earliest_start = 35 MINUTES
 
 /datum/round_event/meteor_wave/threatening
 	wave_name = "threatening"
@@ -67,10 +67,10 @@
 /datum/round_event_control/meteor_wave/catastrophic
 	name = "Meteor Wave: Catastrophic"
 	typepath = /datum/round_event/meteor_wave/catastrophic
-	weight = 1 //yogs
+	weight = 1
 	min_players = 25
 	max_occurrences = 3
-	//earliest_start = 45 MINUTES //yogs
+	earliest_start = 45 MINUTES
 
 /datum/round_event/meteor_wave/catastrophic
 	wave_name = "catastrophic"

--- a/yogstation/code/modules/events/immovable_duck.dm
+++ b/yogstation/code/modules/events/immovable_duck.dm
@@ -2,7 +2,7 @@
 	name = "Immovable Duck"
 	typepath = /datum/round_event/immovable_rod/duck
 	weight = 2
-	max_occurrences = 1
+	max_occurrences = 3
 
 /datum/round_event_control/immovable_rod/duck/admin_setup()
 	if(!check_rights(R_FUN))


### PR DESCRIPTION
Upped Duck to max 3 times per shift to make it equal to Rod (lowered to 3 from 5)
Added minimum round times, just to make sure the shift is going before they start
Upped minimum players for rod 18 from 15

:cl:  
tweak: Rod and Duck minimum players and max occurrences
tweak: Added small delay to meteors happening on station
/:cl:
