### PR TITLE
Revolutionary heads now start with a flash implant in their arm

### DIFF
--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -242,17 +242,9 @@
 		H.dna.remove_mutation(CLOWNMUT)
 
 	if(give_flash)
-		var/obj/item/assembly/flash/handheld/T = new(H)
-		var/list/slots = list (
-			"backpack" = SLOT_IN_BACKPACK,
-			"left pocket" = SLOT_L_STORE,
-			"right pocket" = SLOT_R_STORE
-		)
-		var/where = H.equip_in_one_of_slots(T, slots)
-		if (!where)
-			to_chat(H, "The Syndicate were unfortunately unable to get you a flash.")
-		else
-			to_chat(H, "The flash in your [where] will help you to persuade the crew to join your cause.")
+		var/obj/item/organ/cyberimp/arm/flash/T = new(H)
+		T.Insert(H, special = FALSE, drop_if_replaced = FALSE)
+			to_chat(H, "The flash implant in your arm will help you to persuade the crew to join your cause.")
 
 	if(give_hud)
 		var/obj/item/organ/cyberimp/eyes/hud/security/syndicate/S = new(H)

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -244,7 +244,7 @@
 	if(give_flash)
 		var/obj/item/organ/cyberimp/arm/flash/T = new(H)
 		T.Insert(H, special = FALSE, drop_if_replaced = FALSE)
-			to_chat(H, "The flash implant in your arm will help you to persuade the crew to join your cause.")
+		to_chat(H, "The flash implant in your arm will help you to persuade the crew to join your cause.")
 
 	if(give_hud)
 		var/obj/item/organ/cyberimp/eyes/hud/security/syndicate/S = new(H)

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -122,7 +122,7 @@
 
 /datum/antagonist/rev/head/proc/admin_take_flash(mob/admin)
 	var/list/L = owner.current.get_contents()
-	var/obj/item/assembly/flash/flash = locate() in L
+	var/obj/item/assembly/flash/armimplant/rev/flash = locate() in L
 	if (!flash)
 		to_chat(admin, span_danger("Deleting flash failed!"))
 		return

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -242,7 +242,7 @@
 		H.dna.remove_mutation(CLOWNMUT)
 
 	if(give_flash)
-		var/obj/item/organ/cyberimp/arm/flash/T = new(H)
+		var/obj/item/assembly/flash/armimplant/rev/T = new(H)
 		T.Insert(H, special = FALSE, drop_if_replaced = FALSE)
 		to_chat(H, "The flash implant in your arm will help you to persuade the crew to join your cause.")
 

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -122,7 +122,7 @@
 
 /datum/antagonist/rev/head/proc/admin_take_flash(mob/admin)
 	var/list/L = owner.current.get_contents()
-	var/obj/item/assembly/flash/armimplant/rev/flash = locate() in L
+	var/obj/item/organ/cyberimp/arm/flash/rev/flash = locate() in L
 	if (!flash)
 		to_chat(admin, span_danger("Deleting flash failed!"))
 		return
@@ -242,7 +242,7 @@
 		H.dna.remove_mutation(CLOWNMUT)
 
 	if(give_flash)
-		var/obj/item/assembly/flash/armimplant/rev/T = new(H)
+		var/obj/item/organ/cyberimp/arm/flash/rev/T = new(H)
 		T.Insert(H, special = FALSE, drop_if_replaced = FALSE)
 		to_chat(H, "The flash implant in your arm will help you to persuade the crew to join your cause.")
 

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -279,6 +279,8 @@
 	overheat = FALSE
 
 /obj/item/assembly/flash/armimplant/rev
+	name = "syndicate brainwashing flash"
+	desc = "Viva!"
 	can_convert = TRUE
 
 /obj/item/assembly/flash/hypnotic

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -11,13 +11,22 @@
 	materials = list(/datum/material/iron = 300, /datum/material/glass = 300)
 	light_color = LIGHT_COLOR_WHITE
 	light_power = FLASH_LIGHT_POWER
+	///flicked when we flash
 	var/flashing_overlay = "flash-f"
-	var/times_used = 0 //Number of times it's been used.
-	var/burnt_out = FALSE     //Is the flash burnt out?
+	///Number of times the flash has been used.
+	var/times_used = 0
+	///Is the flash burnt out?
+	var/burnt_out = FALSE
+	///reduction to burnout % chance
 	var/burnout_resistance = 0
-	var/last_used = 0 //last world.time it was used.
+	///last world.time this flash was used
+	var/last_used = 0
+	///self explanatory, cooldown on flash use
 	var/cooldown = 0
-	var/last_trigger = 0 //Last time it was successfully triggered.
+	///last time we actually flashed
+	var/last_trigger = 0
+	///can we convert people to revolution
+	var/can_convert = FALSE
 
 /obj/item/assembly/flash/suicide_act(mob/living/user)
 	if(burnt_out)
@@ -193,21 +202,24 @@
 	AOE_flash()
 
 /obj/item/assembly/flash/proc/terrible_conversion_proc(mob/living/carbon/H, mob/user)
-	if(istype(H) && H.stat != DEAD)
-		if(user.mind)
-			var/datum/antagonist/rev/head/converter = user.mind.has_antag_datum(/datum/antagonist/rev/head)
-			if(!converter)
-				return
-			if(!H.client)
-				to_chat(user, span_warning("This mind is so vacant that it is not susceptible to influence!"))
-				return
-			if(H.stat != CONSCIOUS)
-				to_chat(user, span_warning("They must be conscious before you can convert [H.p_them()]!"))
-				return
-			if(converter.add_revolutionary(H.mind))
-				times_used -- //Flashes less likely to burn out for headrevs when used for conversion
-			else
-				to_chat(user, span_warning("This mind seems resistant to the flash!"))
+	if(!can_convert)
+		return
+	if(H?.stat == DEAD)
+		return
+	if(user.mind)
+		var/datum/antagonist/rev/head/converter = user.mind.has_antag_datum(/datum/antagonist/rev/head)
+		if(!converter)
+			return
+		if(!H.client)
+			to_chat(user, span_warning("This mind is so vacant that it is not susceptible to influence!"))
+			return
+		if(H.stat != CONSCIOUS)
+			to_chat(user, span_warning("They must be conscious before you can convert [H.p_them()]!"))
+			return
+		if(converter.add_revolutionary(H.mind))
+			times_used -- //Flashes less likely to burn out for headrevs when used for conversion
+		else
+			to_chat(user, span_warning("This mind seems resistant to the flash!"))
 
 
 /obj/item/assembly/flash/cyborg
@@ -265,6 +277,9 @@
 
 /obj/item/assembly/flash/armimplant/proc/cooldown()
 	overheat = FALSE
+
+/obj/item/assembly/flash/armimplant/rev
+	can_convert = TRUE
 
 /obj/item/assembly/flash/hypnotic
 	desc = "A modified flash device, programmed to emit a sequence of subliminal flashes that can send a vulnerable target into a hypnotic trance."

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -362,6 +362,11 @@
 		var/obj/item/assembly/flash/armimplant/F = locate(/obj/item/assembly/flash/armimplant) in items_list
 		F.I = src
 
+/obj/item/organ/cyberimp/arm/flash/rev
+	name = "revolutionary brainwashing implant"
+	desc = "An integrated flash projector used alongside syndicate subliminal messaging training to convert loyal crew into violent syndicate activists."
+	syndicate_implant = TRUE
+
 /obj/item/organ/cyberimp/arm/baton
 	name = "arm electrification implant"
 	desc = "An illegal combat implant that allows the user to administer disabling shocks from their arm."

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -365,6 +365,7 @@
 /obj/item/organ/cyberimp/arm/flash/rev
 	name = "revolutionary brainwashing implant"
 	desc = "An integrated flash projector used alongside syndicate subliminal messaging training to convert loyal crew into violent syndicate activists."
+	contents = newlist(/obj/item/assembly/flash/armimplant/rev)
 	syndicate_implant = TRUE
 
 /obj/item/organ/cyberimp/arm/baton


### PR DESCRIPTION
# Document the changes in your pull request

Easily searchable roundstart equipment = BAD
not "meta-able" but visible-when-used gear = GOOD

~~you can still use normal flashes currently idk if good or bad~~ can't use normal flashes have to use the arm one (it won't run out)

revolution flash now called "syndicate brainwashing flash" so flashing people in front of 12 other people is a BAD idea

This also inherits (currently) the arm flash's 2 second cooldown between uses

# Wiki Documentation

revolutionary heads now have their roundstart flash placed in their ARM as an implant

# Changelog

:cl:  
tweak: revheads now get a flash implant rather than an actual flash to convert people with
rscdel: revheads can NO LONGER USE NORMAL FLASHES TO CONVERT
/:cl:
