### PR TITLE
Tape now gives a "harmless" embed

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -760,6 +760,8 @@ GLOBAL_LIST_INIT(can_embed_types, typecacheof(list(
 	if(is_type_in_typecache(W, GLOB.can_embed_types))
 		return TRUE
 
+	if(W.taped)
+		return TRUE
 
 /*
 Checks if that loc and dir has an item on the wall

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -120,6 +120,9 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/list/grind_results //A reagent list containing the reagents this item produces when ground up in a grinder - this can be an empty list to allow for reagent transferring only
 	var/list/juice_results //A reagent list containing blah blah... but when JUICED in a grinder!
 
+	//Tape vars
+	var/taped = FALSE
+
 /obj/item/Initialize()
 
 	materials =	typelist("materials", materials)

--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -24,3 +24,14 @@
 			to_chat(user, span_warning("You fail tape [M]'s mouth shut!"))
 			return
 		amount -= 1
+
+/obj/item/stack/tape/afterattack(atom/target, mob/user, proximity)
+	if(!proximity || !istype(target, /obj/item))
+		return
+	var/obj/item/I = target
+	if(I.is_sharp())
+		to_chat(user, span_warning("[I] would cut the tape if you tried to wrap it!"))
+		return
+	to_chat(user, span_info("You wrap [I] with [src]."))
+	I.embedding = I.embedding.setRating(100, 10, 0, 0, 0, 0, 0, 0, TRUE)
+	I.taped = TRUE

--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -23,7 +23,7 @@
 		if(!M.equip_to_slot_or_del(tape_muzzle, SLOT_WEAR_MASK, user))
 			to_chat(user, span_warning("You fail tape [M]'s mouth shut!"))
 			return
-		amount -= 1
+		use(1)
 
 /obj/item/stack/tape/afterattack(atom/target, mob/user, proximity)
 	if(!proximity || !istype(target, /obj/item))
@@ -33,5 +33,6 @@
 		to_chat(user, span_warning("[I] would cut the tape if you tried to wrap it!"))
 		return
 	to_chat(user, span_info("You wrap [I] with [src]."))
+	use(1)
 	I.embedding = I.embedding.setRating(100, 10, 0, 0, 0, 0, 0, 0, TRUE)
 	I.taped = TRUE

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -907,7 +907,8 @@
 	//We want an accurate reading of .len
 	listclearnulls(embedded_objects)
 	for(var/obj/item/embeddies in embedded_objects)
-		bleed_rate += 0.5
+		if(!embeddies.taped)
+			bleed_rate += 0.5
 
 	for(var/thing in wounds)
 		var/datum/wound/W = thing


### PR DESCRIPTION
# Document the changes in your pull request

now you can use tape in items to give them a 100% embed chance that has 0 damage and extreamly low time to be removed, this embed will not trigger bleading adding to that
![2022-05-08 00_12_36-Space station 13_ Mother's Airstrip Fifteen](https://user-images.githubusercontent.com/68789204/167281636-f52e876c-313e-4c16-88df-cadeff640bad.png)
![2022-05-08 00_12_24-Space station 13_ Mother's Airstrip Fifteen](https://user-images.githubusercontent.com/68789204/167281639-7ef8df79-b25e-4389-855e-2614f23f7626.png)


being that tape is only obtainable from botany as of now situations like this shouldnt be to common to be an issue

![image](https://user-images.githubusercontent.com/68789204/167281655-628195e4-35d2-4796-a800-ead5359b50b9.png)

also thanks theos for basicaly writing all the code for me
# Changelog
:cl:  
rscadd: Added new harmless embed with tape
/:cl:
