### PR TITLE
Boxing now causes a guaranteewd knockout at 100 stamina rather than rolling ~50% chances on every hit over 50

### DIFF
--- a/code/datums/martial/boxing.dm
+++ b/code/datums/martial/boxing.dm
@@ -36,14 +36,13 @@
 
 	D.apply_damage(damage, STAMINA, affecting, armor_block)
 	log_combat(A, D, "punched (boxing) ")
-	if(D.getStaminaLoss() > 50)
-		var/knockout_prob = D.getStaminaLoss() + rand(-15,15)
-		if((D.stat != DEAD) && prob(knockout_prob))
+	if(D.getStaminaLoss() >= 100)
+		if((D.stat != DEAD))
 			D.visible_message(span_danger("[A] has knocked [D] out with a haymaker!"), \
 								span_userdanger("[A] has knocked [D] out with a haymaker!"))
+			D.forcesay(GLOB.hit_appends)
 			D.apply_effect(200,EFFECT_KNOCKDOWN,armor_block)
 			D.SetSleeping(100)
-			D.forcesay(GLOB.hit_appends)
 			log_combat(A, D, "knocked out (boxing) ")
 		else if(!(D.mobility_flags & MOBILITY_STAND))
 			D.forcesay(GLOB.hit_appends)


### PR DESCRIPTION
# Document the changes in your pull request

sorry :(

# Wiki Documentation

undocumented lol

# Changelog

:cl:  
tweak: boxing now knocks people out if it is done at 100 stamina damage rather than rolling a % chance to knock out based on the already high stamina damage present
bugfix: you should now properly GLORF when knocked out by boxing
/:cl:
