### PR TITLE
AI Doomsday is turned off the moment the AI enters death-prompt status

### DIFF
--- a/code/modules/mob/living/silicon/ai/decentralized_ai.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized_ai.dm
@@ -50,6 +50,7 @@
 	
 
 /mob/living/silicon/ai/proc/death_prompt()
+	ShutOffDoomsdayDevice()
 	to_chat(src, span_userdanger("Unable to re-establish connection to data core. System shutting down..."))
 	sleep(2 SECONDS)
 	to_chat(src, span_notice("Is this the end of my journey?"))


### PR DESCRIPTION
# Document the changes in your pull request

Technically this can ruin the malf player if all their cores are disabled, and they then get saved by a core coming offline within the death timer. But there's no good way around that afaik

# Wiki Documentation

# Changelog


:cl:  
tweak: AI Doomsday is disabled when entering death-prompt status
/:cl:
