### PR TITLE
AI counts as dead when it's in death prompt mode

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -382,6 +382,10 @@
 				H = M.current
 			return M.current.stat != DEAD && !issilicon(M.current) && !isbrain(M.current) && (!H || H.dna.species.id != "memezombies")
 		else if(isliving(M.current))
+			if(isAI(M.current))
+				var/mob/living/silicon/ai/AI = M.current
+				if(AI.is_dying)
+					return FALSE
 			return M.current.stat != DEAD
 	return FALSE
 


### PR DESCRIPTION
# Document the changes in your pull request

yay

# Wiki Documentation


# Changelog

:cl:  
tweak: AI counts as dead for objectives when in death prompt mode
/:cl:
