### PR TITLE
Gives the level 7 biohazard some teeth

### DIFF
--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -70,6 +70,7 @@
 					adv.AddSymptom(new /datum/symptom/alkali)
 				if (3)
 					adv.AddSymptom(new /datum/symptom/flesh_death)
+			adv.properties["transmittable"] += 4
 		D.carrier = TRUE
 		H.ForceContractDisease(D, FALSE, TRUE)
 

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -23,11 +23,11 @@
 /datum/round_event/disease_outbreak/start()
 	var/advanced_virus = FALSE
 	max_severity = 3 + max(FLOOR((world.time - control.earliest_start)/6000, 1),0) //3 symptoms at 20 minutes, plus 1 per 10 minutes
-	if(prob(20 + (10 * max_severity)))
+	if(prob(10 * max_severity))
 		advanced_virus = TRUE
 
 	if(!virus_type && !advanced_virus)
-		virus_type = pick(/datum/disease/dnaspread, /datum/disease/advance/flu, /datum/disease/advance/cold, /datum/disease/sleepy, /datum/disease/brainrot, /datum/disease/magnitis, /datum/disease/jitters)
+		virus_type = pick(/datum/disease/dnaspread, /datum/disease/sleepy, /datum/disease/brainrot, /datum/disease/magnitis, /datum/disease/transformation/robot, /datum/disease/rhumba_beat, /datum/disease/gbs)
 
 	for(var/mob/living/carbon/human/H in shuffle(GLOB.alive_mob_list))
 		var/turf/T = get_turf(H)
@@ -62,6 +62,14 @@
 				D = new virus_type()
 		else
 			D = new /datum/disease/advance/random(max_severity, max_severity)
+			var/datum/disease/advance/adv = D 
+			switch (rand(1, 3))
+				if (1)
+					adv.AddSymptom(new /datum/symptom/asphyxiation)
+				if (2)
+					adv.AddSymptom(new /datum/symptom/alkali)
+				if (3)
+					adv.AddSymptom(new /datum/symptom/flesh_death)
 		D.carrier = TRUE
 		H.ForceContractDisease(D, FALSE, TRUE)
 


### PR DESCRIPTION
The level 7 biohazard event kinda sucks. Whenever it happens nobody really notices except for that one guy who got the carrier infection but never gave it to anyone because the stats suck and it's only transmissible by blood. I added some simple diseases that actually have impacts on the round as well as making the random advanced disease more powerful. Simple diseases are more likely to roll as well.

:cl:  
tweak: Buffed the level 7 biohazard
/:cl:
