### PR TITLE
Changes laser slug to laser buckshot

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -345,12 +345,12 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 
-/datum/crafting_recipe/laserslug
-	name = "Laser Slug Shell"
-	result = /obj/item/ammo_casing/shotgun/laserslug
+/datum/crafting_recipe/laserbuckshot
+	name = "Laser Buckshot Shell"
+	result = /obj/item/ammo_casing/shotgun/laserbuckshot
 	reqs = list(/obj/item/ammo_casing/shotgun/techshell = 1,
 				/obj/item/stock_parts/capacitor/adv = 1,
-				/obj/item/stock_parts/micro_laser/high = 1)
+				/obj/item/stock_parts/micro_laser/high = 2)
 	tools = list(TOOL_SCREWDRIVER)
 	time = 0.5 SECONDS
 	category = CAT_WEAPONRY

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -95,8 +95,8 @@
 	name = "laser buckshot"
 	desc = "An advanced shotgun shell that uses  micro lasers to replicate the effects of a laser weapon in a ballistic package."
 	icon_state = "lshell"
-	projectile_type = /obj/item/projectile/beam/laser
-	pellets = 4
+	projectile_type = /obj/item/projectile/beam/laser/buckshot
+	pellets = 5
 	variance = 35
 
 /obj/item/ammo_casing/shotgun/techshell

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -91,11 +91,13 @@
 	pellets = 4
 	variance = 35
 
-/obj/item/ammo_casing/shotgun/laserslug
-	name = "laser slug"
-	desc = "An advanced shotgun shell that uses a micro laser to replicate the effects of a laser weapon in a ballistic package."
+/obj/item/ammo_casing/shotgun/laserbuckshot
+	name = "laser buckshot"
+	desc = "An advanced shotgun shell that uses  micro lasers to replicate the effects of a laser weapon in a ballistic package."
 	icon_state = "lshell"
 	projectile_type = /obj/item/projectile/beam/laser
+	pellets = 4
+	variance = 35
 
 /obj/item/ammo_casing/shotgun/techshell
 	name = "unloaded technological shell"

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -183,4 +183,4 @@
 	damage = 5
 
 /obj/item/projectile/beam/laser/buckshot
-	damage = 12
+	damage = 10

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -181,3 +181,6 @@
 /obj/item/projectile/beam/laser/makeshiftlasrifle/weak
 	name = "weak laser"
 	damage = 5
+
+/obj/item/projectile/beam/laser/buckshot
+	damage = 12


### PR DESCRIPTION
# Document the changes in your pull request

Let's be honest, most people don't know you can make laser slugs to begin with, and those that do just make pulse slugs because why would you go out of your way to make a WORSE version of something?

Because of that, I have decided to make the laser slug into laser buckshot. Therefore it isn't useless.

# Wiki Documentation

Edit the special ammo section to reflect these changes

# Changelog

:cl:  
rscadd: Adds laser buckshot, a much cooler ammo type.
rscdel: Removes laser slug, nobody used it anyway.
/:cl:
