### PR TITLE
spoectral blade and landmine have icons again

### DIFF
--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -1,6 +1,7 @@
 /obj/item/deployablemine
 	name = "deployable mine"
 	desc = "An unarmed landmine. It can be planted to arm it."
+	icon = 'icons/obj/misc.dmi'
 	icon_state = "uglymine"
 	var/mine_type = /obj/effect/mine
 	var/arming_time = 3 SECONDS

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -792,6 +792,7 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 /obj/item/melee/ghost_sword
 	name = "\improper spectral blade"
 	desc = "A rusted and dulled blade. It doesn't look like it'd do much damage. It glows weakly."
+	icon = 'icons/obj/weapons/swords.dmi'
 	icon_state = "spectral"
 	item_state = "spectral"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'


### PR DESCRIPTION
# Document the changes in your pull request

fixes #14069
fixes #13930

# Changelog

:cl:  
bugfix: spectral blade and landmines now have icons again
/:cl:
