### PR TITLE
Allows lizards to be round start RD and CE

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -20,8 +20,8 @@ REVIVAL_BRAIN_LIFE -1
 JOB_SPECIES_WHITELIST /datum/job/captain human
 JOB_SPECIES_WHITELIST /datum/job/hop human
 JOB_SPECIES_WHITELIST /datum/job/hos human,lizard
-JOB_SPECIES_WHITELIST /datum/job/chief_engineer human,plasmaman,moth,ethereal,preternis, polysmorph
-JOB_SPECIES_WHITELIST /datum/job/rd human,pod,plasmaman,ethereal,preternis,polysmorph
+JOB_SPECIES_WHITELIST /datum/job/chief_engineer human,plasmaman,moth,ethereal,preternis, polysmorph,lizard
+JOB_SPECIES_WHITELIST /datum/job/rd human,pod,plasmaman,ethereal,preternis,polysmorph,lizard
 JOB_SPECIES_WHITELIST /datum/job/cmo human,lizard,pod,moth
 
 


### PR DESCRIPTION
# Document the changes in your pull request

Allows lizards to be round start CE and RD. I guess late join too. point is they can be the job now when they spawn in.

"But WHY" I hear you asking, allow me to explain.

We have lizards as HoS, so there is already no issue with them working as crucial roles. 
Why wouldn't you want someone who is willing to work just as hard, but for 0.6 the pay?
Someone just as qualified but far more expendable should something go wrong.

And yes I hear you saying "Lizard RD? How will they deal with Asimov ai?"
we call this a "perk of the job"
also, every race (except moths) can be the RD already, so how is this any different?


# Wiki Documentation

I'm sure it needs something but frankly, I don't know

# Changelog

:cl:  
rscadd: Allows lizards to be CE and RD. It's (Current year) guys.
/:cl:
