### PR TITLE
Remove lizard from HoS whitelist

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -19,7 +19,7 @@ REVIVAL_BRAIN_LIFE -1
 
 JOB_SPECIES_WHITELIST /datum/job/captain human
 JOB_SPECIES_WHITELIST /datum/job/hop human
-JOB_SPECIES_WHITELIST /datum/job/hos human,lizard
+JOB_SPECIES_WHITELIST /datum/job/hos human
 JOB_SPECIES_WHITELIST /datum/job/chief_engineer human,plasmaman,moth,ethereal,preternis, polysmorph
 JOB_SPECIES_WHITELIST /datum/job/rd human,pod,plasmaman,ethereal,preternis,polysmorph
 JOB_SPECIES_WHITELIST /datum/job/cmo human,lizard,pod,moth


### PR DESCRIPTION

# Document the changes in your pull request

Causes too much conflict with Asimov AI, and in many cases ends in the HOS detonating all the borgs and or trying to kill the AI because they were harming a human. Too much power for being unprotected by AI.

# Wiki Documentation

HOS can't be played by a lizard anymore.

# Changelog

:cl:  
tweak: Lizards can't be the head of security anymore.
/:cl:
