### PR TITLE
Throwing a body at the wall is no longer silent

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -114,8 +114,8 @@
 		if(hurt)
 			Paralyze(20)
 			take_bodypart_damage(10 + 5 * extra_speed, check_armor = TRUE, wound_bonus = extra_speed * 5)
-			visible_message(span_danger("[src] crashes into [hit_atom][extra_speed ? "really hard" : ""]!"),\
-				span_userdanger("You violently crash into [hit_atom][extra_speed ? "extra hard" : ""]!"))
+			visible_message(span_danger("[src] crashes into [hit_atom][extra_speed ? " really hard" : ""]!"),\
+				span_userdanger("You violently crash into [hit_atom][extra_speed ? " extra hard" : ""]!"))
 			playsound(src,'sound/weapons/punch2.ogg',50,1)
 	if(iscarbon(hit_atom) && hit_atom != src)
 		var/mob/living/carbon/victim = hit_atom

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -114,6 +114,9 @@
 		if(hurt)
 			Paralyze(20)
 			take_bodypart_damage(10 + 5 * extra_speed, check_armor = TRUE, wound_bonus = extra_speed * 5)
+			visible_message(span_danger("[src] crashes into [hit_atom][extra_speed ? "really hard" : ""]!"),\
+				span_userdanger("You violently crash into [hit_atom][extra_speed ? "extra hard" : ""]!"))
+			playsound(src,'sound/weapons/punch2.ogg',50,1)
 	if(iscarbon(hit_atom) && hit_atom != src)
 		var/mob/living/carbon/victim = hit_atom
 		if(victim.movement_type & FLYING)


### PR DESCRIPTION
# Document the changes in your pull request

plays sound & vis message when you hit wall

feels strange to me that something that paralyzes you and hurts you doesn't make any noise

```
visible_message(span_danger("[src] crashes into [hit_atom][extra_speed ? "really hard" : ""]!"),\
  span_userdanger("You violently crash into [hit_atom][extra_speed ? "extra hard" : ""]!"))
playsound(src,'sound/weapons/punch2.ogg',50,1)
```

# Changelog

:cl:  
tweak: Throwing a body at the wall is no longer silent
/:cl:
