### PR TITLE
Makes bloodbrothers start with the makeshift weapons book learned. (Jamie Edition)

### DIFF
--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -23,8 +23,18 @@
 	owner.special_role = special_role
 	if(owner.current)
 		give_pinpointer()
+		equip_brother()
 	finalize_brother()
 	return ..()
+
+/datum/antagonist/brother/proc/equip_brother()
+	var/list/crafting_recipe_types = list(/datum/crafting_recipe/baseball_bat, /datum/crafting_recipe/lance, /datum/crafting_recipe/knifeboxing, /datum/crafting_recipe/flamethrower, /datum/crafting_recipe/pipebomb, /datum/crafting_recipe/makeshiftpistol, /datum/crafting_recipe/makeshiftmagazine, /datum/crafting_recipe/makeshiftsuppressor, /datum/crafting_recipe/makeshiftcrowbar, /datum/crafting_recipe/makeshiftwrench, /datum/crafting_recipe/makeshiftwirecutters, /datum/crafting_recipe/makeshiftweldingtool, /datum/crafting_recipe/makeshiftmultitool, /datum/crafting_recipe/makeshiftscrewdriver, /datum/crafting_recipe/makeshiftknife, /datum/crafting_recipe/makeshiftpickaxe, /datum/crafting_recipe/makeshiftradio)
+	
+	for(var/crafting_recipe_type in crafting_recipe_types)
+		var/datum/crafting_recipe/R = crafting_recipe_type
+		owner.teach_crafting_recipe(crafting_recipe_type)
+		to_chat(user,span_notice("You learned how to make [initial(R.name)]."))
+	span_userdanger("You know how to craft makeshift weapons due to your training.")
 
 /datum/antagonist/brother/on_removal()
 	SSticker.mode.brothers -= owner

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -28,12 +28,10 @@
 	return ..()
 
 /datum/antagonist/brother/proc/equip_brother()
-	var/list/crafting_recipe_types = list(/datum/crafting_recipe/baseball_bat, /datum/crafting_recipe/lance, /datum/crafting_recipe/knifeboxing, /datum/crafting_recipe/flamethrower, /datum/crafting_recipe/pipebomb, /datum/crafting_recipe/makeshiftpistol, /datum/crafting_recipe/makeshiftmagazine, /datum/crafting_recipe/makeshiftsuppressor, /datum/crafting_recipe/makeshiftcrowbar, /datum/crafting_recipe/makeshiftwrench, /datum/crafting_recipe/makeshiftwirecutters, /datum/crafting_recipe/makeshiftweldingtool, /datum/crafting_recipe/makeshiftmultitool, /datum/crafting_recipe/makeshiftscrewdriver, /datum/crafting_recipe/makeshiftknife, /datum/crafting_recipe/makeshiftpickaxe, /datum/crafting_recipe/makeshiftradio)
-	
-	for(var/crafting_recipe_type in crafting_recipe_types)
-		var/datum/crafting_recipe/R = crafting_recipe_type
-		owner.teach_crafting_recipe(crafting_recipe_type)
-		to_chat(owner,span_notice("You learned how to make [initial(R.name)]."))
+	/datum/antagonist/brother/proc/equip_brother()
+    var/obj/item/book/granter/crafting_recipe/weapons/W = new
+    W.on_reading_finished(owner.current)
+	qdel(W)
 
 /datum/antagonist/brother/on_removal()
 	SSticker.mode.brothers -= owner

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -28,8 +28,8 @@
 	return ..()
 
 /datum/antagonist/brother/proc/equip_brother()
-    var/obj/item/book/granter/crafting_recipe/weapons/W = new
-    W.on_reading_finished(owner.current)
+	var/obj/item/book/granter/crafting_recipe/weapons/W = new
+	W.on_reading_finished(owner.current)
 	qdel(W)
 
 /datum/antagonist/brother/on_removal()

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -33,8 +33,7 @@
 	for(var/crafting_recipe_type in crafting_recipe_types)
 		var/datum/crafting_recipe/R = crafting_recipe_type
 		owner.teach_crafting_recipe(crafting_recipe_type)
-		to_chat(user,span_notice("You learned how to make [initial(R.name)]."))
-	span_userdanger("You know how to craft makeshift weapons due to your training.")
+		to_chat(owner,span_notice("You learned how to make [initial(R.name)]."))
 
 /datum/antagonist/brother/on_removal()
 	SSticker.mode.brothers -= owner

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -28,7 +28,6 @@
 	return ..()
 
 /datum/antagonist/brother/proc/equip_brother()
-	/datum/antagonist/brother/proc/equip_brother()
     var/obj/item/book/granter/crafting_recipe/weapons/W = new
     W.on_reading_finished(owner.current)
 	qdel(W)


### PR DESCRIPTION
# Document the changes in your pull request

Bloodbrothers are one of the weakest antagonists. They're also the only syndicate antagonist to have NO syndicate equipment. By giving them access to the items from 'makeshift weapons' they can have more room to improvise, which is what they're meant to do anyways.

# Wiki Documentation

Probably put a blurb about them having the makeshift weapons recipes on the bloodbrother page.

# Changelog

:cl:  
rscadd: Blood brothers will now start with all of the makeshift weapons recipes learned.
/:cl:

Closes:#13954