### PR TITLE
fixes a something where ghosts could always see themselves even when invisible

### DIFF
--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -3,7 +3,7 @@
 INITIALIZE_IMMEDIATE(/mob/dead)
 
 /mob/dead
-	sight = SEE_TURFS | SEE_MOBS | SEE_OBJS | SEE_SELF
+	sight = SEE_TURFS | SEE_MOBS | SEE_OBJS
 	move_resist = INFINITY
 	throwforce = 0
 


### PR DESCRIPTION
# Document the changes in your pull request

Did you know that when given the choice between a silent refrigerator and a loud refrigerator people would prefer the loud refrigerator because even though it was more irritating to have a loud noise every once and a while it was a steady reassurance that your food was in fact actually safe and not being turned into mush

# Changelog

:cl:  
bugfix: invisible ghosts can no longer see themselves
/:cl:
