### PR TITLE
lesser form can't activate while stunned or cuffed, price reduced to pre-nerf

### DIFF
--- a/code/modules/antagonists/changeling/powers/lesserform.dm
+++ b/code/modules/antagonists/changeling/powers/lesserform.dm
@@ -1,11 +1,12 @@
 /datum/action/changeling/lesserform
 	name = "Lesser Form"
-	desc = "We debase ourselves and become lesser. We become a monkey. Costs 30 chemicals."
-	helptext = "The transformation greatly reduces our size, allowing us to slip out of cuffs and climb through vents."
+	desc = "We debase ourselves and become lesser. We become a monkey. Cannot be used while cuffed or stunned. Costs 5 chemicals."
+	helptext = "The transformation greatly reduces our size, allowing us to climb through vents."
 	button_icon_state = "lesser_form"
-	chemical_cost = 30
-	dna_cost = 3 //effectively a straight upgrade from biodegrade
+	chemical_cost = 5
+	dna_cost = 1 //effectively a straight upgrade from biodegrade
 	req_human = 1
+	check_flags = AB_CHECK_RESTRAINED | AB_CHECK_STUN
 
 //Transform into a monkey.
 /datum/action/changeling/lesserform/sting_action(mob/living/carbon/human/user)

--- a/code/modules/antagonists/changeling/powers/lesserform.dm
+++ b/code/modules/antagonists/changeling/powers/lesserform.dm
@@ -4,7 +4,7 @@
 	helptext = "The transformation greatly reduces our size, allowing us to climb through vents."
 	button_icon_state = "lesser_form"
 	chemical_cost = 5
-	dna_cost = 1 //effectively a straight upgrade from biodegrade
+	dna_cost = 1
 	req_human = 1
 	check_flags = AB_CHECK_RESTRAINED | AB_CHECK_STUN
 


### PR DESCRIPTION
# Document the changes in your pull request

People want this apparently and it's better than having a second biodegrade

# Wiki Documentation

Lesser form cannot be used while stunned or cuffed, prices are 1 dna and 5 chemicals as if anyone would actually update the changeling page lmao


:cl:  
tweak: lesser form now costs 1 dna and 5 chemicals, cannot be used if stunned or cuffed
/:cl:
