### PR TITLE
Fixes mining medic belt showing overlays

### DIFF
--- a/yogstation/code/game/objects/items/storage/belt.dm
+++ b/yogstation/code/game/objects/items/storage/belt.dm
@@ -3,3 +3,4 @@
 	item_state = "explorer2"
 	name = "medical webbing"
 	desc = "A combat belt cherished by emergency medics in every corner of the galaxy."
+	content_overlays = FALSE


### PR DESCRIPTION
# Document the changes in your pull request

Mining medic belt doesn't have working overlays, and I forgot to disable it.

# Wiki Documentation

No changes needed. 

# Changelog

:cl:  
bugfix: fixed a mining medic belt showing overlays
/:cl:
