### PR TITLE
Adds auto tail wagging when happy

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -86,6 +86,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	//Quirk list
 	var/list/all_quirks = list()
 
+	var/mood_tail_wagging = TRUE
+
 	//Job preferences 2.0 - indexed by job title , no key or value implies never
 	var/list/job_preferences = list()
 
@@ -753,6 +755,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			//yogs start -- Mood preference toggling
 			if(CONFIG_GET(flag/disable_human_mood))
 				dat += "<b>Mood:</b> <a href='?_src_=prefs;preference=mood'>[yogtoggles & PREF_MOOD ? "Enabled" : "Disabled"]</a><br>"
+				dat += "<b>Mood Tail Wagging:</b> <a href='?_src_=prefs;preference=moodtailwagging'>[mood_tail_wagging  ? "Enabled" : "Disabled"] </a><br>"
 			//yogs end
 
 			dat += "</td><td width='300px' height='300px' valign='top'>"
@@ -2084,6 +2087,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 				if("mood")
 					yogtoggles ^= PREF_MOOD
+
+				if("moodtailwagging")
+					mood_tail_wagging = !mood_tail_wagging
 				// yogs end
 
 	ShowChoices(user)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -232,6 +232,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	READ_FILE(S["yogtoggles"], yogtoggles)
 
 	READ_FILE(S["accent"], accent) // Accents, too!
+
+	READ_FILE(S["mood_tail_wagging"], mood_tail_wagging)
 	// yogs end
 
 	//try to fix any outdated data if necessary
@@ -368,6 +370,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["purrbation"], purrbation)
 
 	WRITE_FILE(S["accent"], accent) // Accents, too!
+	
+	WRITE_FILE(S["mood_tail_wagging"], mood_tail_wagging)
 	// yogs end
 
 	save_keybindings(S) // yogs - Custom keybindings

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1235,6 +1235,9 @@
 /mob/living/carbon/human/species/lizard/ashwalker
 	race = /datum/species/lizard/ashwalker
 
+/mob/living/carbon/human/species/lizard/draconid
+	race = /datum/species/lizard/draconid
+
 /mob/living/carbon/human/species/moth
 	race = /datum/species/moth
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1219,7 +1219,7 @@ GLOBAL_LIST_EMPTY(mentor_races)
 /datum/species/proc/check_species_weakness(obj/item, mob/living/attacker)
 	return 0 //This is not a boolean, it's the multiplier for the damage that the user takes from the item.It is added onto the check_weakness value of the mob, and then the force of the item is multiplied by this value
 
-////////
+	////////
 	//LIFE//
 	////////
 

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -166,3 +166,20 @@
 
 /datum/species/human/felinid/get_scream_sound(mob/living/carbon/human/H)
 	return pick(screamsound)
+
+/datum/species/human/felinid/spec_life(mob/living/carbon/human/H)
+	. = ..()
+	if(!is_wagging_tail() && H.mood_enabled)
+		var/datum/component/mood/mood = H.GetComponent(/datum/component/mood)
+		if(!istype(mood) || !(mood.shown_mood >= MOOD_LEVEL_HAPPY2)) 
+			return
+		var/chance = 0
+		switch(mood.shown_mood)
+			if(MOOD_LEVEL_HAPPY2 to MOOD_LEVEL_HAPPY3)
+				chance = 0.001
+			if(MOOD_LEVEL_HAPPY3 to MOOD_LEVEL_HAPPY4)
+				chance = 0.1
+			if(MOOD_LEVEL_HAPPY4 to INFINITY)
+				chance = 1
+		if(prob(chance))
+			H.emote("wag")

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -169,17 +169,25 @@
 
 /datum/species/human/felinid/spec_life(mob/living/carbon/human/H)
 	. = ..()
-	if(!is_wagging_tail() && H.mood_enabled)
+	if((H.client && H.client.prefs.mood_tail_wagging) && !is_wagging_tail() && H.mood_enabled)
 		var/datum/component/mood/mood = H.GetComponent(/datum/component/mood)
 		if(!istype(mood) || !(mood.shown_mood >= MOOD_LEVEL_HAPPY2)) 
 			return
 		var/chance = 0
 		switch(mood.shown_mood)
+			if(0 to MOOD_LEVEL_SAD4)
+				chance = -0.1
+			if(MOOD_LEVEL_SAD4 to MOOD_LEVEL_SAD3)
+				chance = -0.01
 			if(MOOD_LEVEL_HAPPY2 to MOOD_LEVEL_HAPPY3)
 				chance = 0.001
 			if(MOOD_LEVEL_HAPPY3 to MOOD_LEVEL_HAPPY4)
 				chance = 0.1
 			if(MOOD_LEVEL_HAPPY4 to INFINITY)
 				chance = 1
-		if(prob(chance))
-			H.emote("wag")
+		if(prob(abs(chance)))
+			switch(SIGN(chance))
+				if(1)
+					H.emote("wag")
+				if(-1)
+					stop_wagging_tail(H)

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -64,20 +64,28 @@
 
 /datum/species/lizard/spec_life(mob/living/carbon/human/H)
 	. = ..()
-	if(!is_wagging_tail() && H.mood_enabled)
+	if((H.client && H.client.prefs.mood_tail_wagging) && !is_wagging_tail() && H.mood_enabled)
 		var/datum/component/mood/mood = H.GetComponent(/datum/component/mood)
 		if(!istype(mood) || !(mood.shown_mood >= MOOD_LEVEL_HAPPY2)) 
 			return
 		var/chance = 0
 		switch(mood.shown_mood)
+			if(0 to MOOD_LEVEL_SAD4)
+				chance = -0.1
+			if(MOOD_LEVEL_SAD4 to MOOD_LEVEL_SAD3)
+				chance = -0.01
 			if(MOOD_LEVEL_HAPPY2 to MOOD_LEVEL_HAPPY3)
 				chance = 0.001
 			if(MOOD_LEVEL_HAPPY3 to MOOD_LEVEL_HAPPY4)
 				chance = 0.1
 			if(MOOD_LEVEL_HAPPY4 to INFINITY)
 				chance = 1
-		if(prob(chance))
-			H.emote("wag")
+		if(prob(abs(chance)))
+			switch(SIGN(chance))
+				if(1)
+					H.emote("wag")
+				if(-1)
+					stop_wagging_tail(H)
 	
 
 /*

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -62,6 +62,24 @@
 		stunmod *= heat_stun_mult 	//however many times, and if it goes down we multiply by 1.1
 						//This gets us an effective stunmod of 0.91, 1, 1.1, 1.21, 1.33, based on temp
 
+/datum/species/lizard/spec_life(mob/living/carbon/human/H)
+	. = ..()
+	if(!is_wagging_tail() && H.mood_enabled)
+		var/datum/component/mood/mood = H.GetComponent(/datum/component/mood)
+		if(!istype(mood) || !(mood.shown_mood >= MOOD_LEVEL_HAPPY2)) 
+			return
+		var/chance = 0
+		switch(mood.shown_mood)
+			if(MOOD_LEVEL_HAPPY2 to MOOD_LEVEL_HAPPY3)
+				chance = 0.001
+			if(MOOD_LEVEL_HAPPY3 to MOOD_LEVEL_HAPPY4)
+				chance = 0.1
+			if(MOOD_LEVEL_HAPPY4 to INFINITY)
+				chance = 1
+		if(prob(chance))
+			H.emote("wag")
+	
+
 /*
  Lizard subspecies: ASHWALKERS
 */

--- a/yogstation/code/modules/mob/living/carbon/human/human.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/human.dm
@@ -4,6 +4,15 @@
 /mob/living/carbon/human/species/egg
 	race = /datum/species/egg
 
+/mob/living/carbon/human/species/preternis
+	race = /datum/species/preternis
+
+/mob/living/carbon/human/species/lizard/ashwalker/cosmic
+	race = /datum/species/lizard/ashwalker/cosmic
+
+/mob/living/carbon/human/species/szlachta
+	race = /datum/species/szlachta
+
 /mob/living/carbon/human/get_blood_state()
 	if(NOBLOOD in dna.species.species_traits) //Can't have blood problems if your species doesn't have any blood, innit?
 		return BLOOD_SAFE


### PR DESCRIPTION
# Document the changes in your pull request

Adds a small chance for felinids/liznerd to wag their tail when they are happy and if they aren't doing so already. It uses visable_mood, so its wont cause antags to wag because of their mood buff. Also adds human subtypes to a few species because I can.

# Wiki Documentation

Maybe add it to the mood wiki page. 

# Changelog

:cl:  
rscadd: Added chance for felinids and lizards to wag their tail when they are happy and if they aren't doing so already
rscadd: Added human subtypes for some species that were missing them, making it posable to spawn them in with spawn
/:cl:
