### PR TITLE
Reduces the amount of things that you can tape

### DIFF
--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -9,6 +9,12 @@
 	max_amount = 5
 	resistance_flags = FLAMMABLE
 	grind_results = list(/datum/reagent/cellulose = 5)
+	var/maximum_weight_class = WEIGHT_CLASS_SMALL
+	var/list/tape_blacklist = list() //stuff you can't take that may or may not be max_weight_class
+
+/obj/item/stack/tape/Initialize(mapload, new_amount, merge)
+	. = ..()
+	tape_blacklist = typecacheof(list(/obj/item/grenade))
 
 /obj/item/stack/tape/attack(mob/living/M, mob/user)
 	. = ..()
@@ -18,12 +24,17 @@
 			to_chat(user, span_warning("You can't tape [M]'s mouth shut!"))
 			return
 		playsound(user, 'sound/effects/tape.ogg', 25)
-		if(!do_after(user, 20, target = M))
+		M.visible_message(span_danger("[user] is trying to put [tape_muzzle.name] on [M]!"), span_userdanger("[user] is trying to put [tape_muzzle.name] on [M]!"))
+		if(!do_after(user, 2 SECONDS, target = M))
+			qdel(tape_muzzle)
 			return
 		if(!M.equip_to_slot_or_del(tape_muzzle, SLOT_WEAR_MASK, user))
 			to_chat(user, span_warning("You fail tape [M]'s mouth shut!"))
+			qdel(tape_muzzle)
 			return
 		use(1)
+	else
+		to_chat(user,span_warning("You must be targetting the mouth to tape [M.p_their()] mouth!"))
 
 /obj/item/stack/tape/afterattack(atom/target, mob/user, proximity)
 	if(!proximity || !istype(target, /obj/item))
@@ -31,6 +42,12 @@
 	var/obj/item/I = target
 	if(I.is_sharp())
 		to_chat(user, span_warning("[I] would cut the tape if you tried to wrap it!"))
+		return
+	if(I.w_class > maximum_weight_class)
+		to_chat(user, span_warning("[I] is too big!"))
+		return
+	if(is_type_in_typecache(I,tape_blacklist))
+		to_chat(user, span_warning("The [src] doesn't seem to stick to [I]!"))
 		return
 	to_chat(user, span_info("You wrap [I] with [src]."))
 	use(1)


### PR DESCRIPTION
# Document the changes in your pull request

Holy fuck this shit is comically broken and will make it so you instantly win any fight if you have 1) an explosive and 2) a tape and 3) a throw arm 1% the accuracy of Ark Shaffer's throws.

You see the spinning item for like 3 frames, and then you get an alert that something is stuck in you (it is embedded and invisible in you now), and then you blow up.

Things you can do with tape:

- Stick anybody with an invisible maxcap (bad)
- Stick anybody with an invisible clf grenade (bad)
- Stick anybody with an invisible combustible lemon (bad)
- Stick anybody with an invisible flashbang (also you count as standing on it!)
- Stick anybody with an invisible piece of anything with an invisible C4 attached to it (bad)
- Stick anybody with an invisible tracking beacon (ok you can jaunt now vampire see you in 3 seconds)

This makes it so you can't tape grenades, and you can't tape anything over small weight class (it is simply too big!) Also cleans up the code a little and gives more response to "huh why cant i tape this person" (you are not selecting the mouth you idiot!)

oh also adds a visible message to it when you try to tape someone's mouth

# Changelog

:cl:  ToasterBiome, Tbanner
rscadd: Adds weight requirement to taping things
rscadd: Blacklists grenades from being taped
rscadd: Adds visible messaging for when your mouth is getting taped
/:cl:
