### PR TITLE
Buffs advanced stack healing items

### DIFF
--- a/code/datums/wounds/pierce.dm
+++ b/code/datums/wounds/pierce.dm
@@ -101,7 +101,7 @@
 /datum/wound/pierce/proc/suture(obj/item/stack/medical/suture/I, mob/user)
 	var/self_penalty_mult = (user == victim ? 1.4 : 1)
 	user.visible_message(span_notice("[user] begins stitching [victim]'s [limb.name] with [I]..."), span_notice("You begin stitching [user == victim ? "your" : "[victim]'s"] [limb.name] with [I]..."))
-	if(!do_after(user, base_treat_time * self_penalty_mult, target=victim, extra_checks = CALLBACK(src, .proc/still_exists)))
+	if(!do_after(user, base_treat_time * self_penalty_mult * I.treatment_speed, target=victim, extra_checks = CALLBACK(src, .proc/still_exists)))
 		return
 	user.visible_message(span_green("[user] stitches up some of the bleeding on [victim]."), span_green("You stitch up some of the bleeding on [user == victim ? "yourself" : "[victim]"]."))
 	var/blood_sutured = I.stop_bleeding / self_penalty_mult

--- a/code/datums/wounds/slash.dm
+++ b/code/datums/wounds/slash.dm
@@ -233,7 +233,7 @@
 	var/self_penalty_mult = (user == victim ? 1.4 : 1)
 	user.visible_message(span_notice("[user] begins stitching [victim]'s [limb.name] with [I]..."), span_notice("You begin stitching [user == victim ? "your" : "[victim]'s"] [limb.name] with [I]..."))
 
-	if(!do_after(user, base_treat_time * self_penalty_mult, target=victim, extra_checks = CALLBACK(src, .proc/still_exists)))
+	if(!do_after(user, base_treat_time * self_penalty_mult * I.treatment_speed, target=victim, extra_checks = CALLBACK(src, .proc/still_exists)))
 		return
 	user.visible_message(span_green("[user] stitches up some of the bleeding on [victim]."), span_green("You stitch up some of the bleeding on [user == victim ? "yourself" : "[victim]"]."))
 	var/blood_sutured = I.stop_bleeding / self_penalty_mult

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -33,6 +33,8 @@
 	var/absorption_capacity
 	/// How quickly we lower the blood flow on a cut wound we're bandaging. Expected lifetime of this bandage in ticks is thus absorption_capacity/absorption_rate, or until the cut heals, whichever comes first
 	var/absorption_rate
+	/// Coefficient for applying this stack to a wound
+	var/treatment_speed = 1
 
 /obj/item/stack/medical/attack(mob/living/M, mob/user)
 	. = ..()
@@ -232,8 +234,11 @@
 	name = "medicated suture"
 	icon_state = "suture_purp"
 	desc = "A suture infused with drugs that speed up wound healing of the treated laceration."
+	amount = 20
+	max_amount = 20
 	heal_brute = 15
 	stop_bleeding = 0.75
+	treatment_speed = 0.5
 	grind_results = list(/datum/reagent/medicine/polypyr = 2)
 
 /obj/item/stack/medical/suture/heal(mob/living/M, mob/user)
@@ -270,7 +275,6 @@
 	max_amount = 8
 	self_delay = 40
 	other_delay = 20
-
 	heal_burn = 5
 	flesh_regeneration = 2.5
 	sanitization = 0.25
@@ -297,8 +301,8 @@
 	self_delay = 30
 	other_delay = 10
 	amount = 15
-	heal_burn = 10
 	max_amount = 15
+	heal_burn = 10
 	repeating = TRUE
 	sanitization = 0.75
 	flesh_regeneration = 3
@@ -357,10 +361,11 @@
 /obj/item/stack/medical/mesh/advanced
 	name = "advanced regenerative mesh"
 	desc = "An advanced mesh made with aloe extracts and sterilizing chemicals, used to treat burns."
-
 	gender = PLURAL
 	singular_name = "advanced regenerative mesh"
 	icon_state = "aloe_mesh"
+	amount = 30
+	max_amount = 30
 	heal_burn = 15
 	sanitization = 1.25
 	flesh_regeneration = 3.5
@@ -374,7 +379,6 @@
 /obj/item/stack/medical/aloe
 	name = "aloe cream"
 	desc = "A healing paste you can apply on wounds."
-
 	icon_state = "aloe_paste"
 	apply_sounds = list('sound/effects/ointment.ogg')
 	self_delay = 20

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -216,8 +216,8 @@
 	icon_state = "suture"
 	self_delay = 30
 	other_delay = 10
-	amount = 10
-	max_amount = 10
+	amount = 15
+	max_amount = 15
 	repeating = TRUE
 	heal_brute = 10
 	stop_bleeding = 0.6
@@ -234,8 +234,8 @@
 	name = "medicated suture"
 	icon_state = "suture_purp"
 	desc = "A suture infused with drugs that speed up wound healing of the treated laceration."
-	amount = 20
-	max_amount = 20
+	amount = 25
+	max_amount = 25
 	heal_brute = 15
 	stop_bleeding = 0.75
 	treatment_speed = 0.5

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -364,8 +364,8 @@
 	gender = PLURAL
 	singular_name = "advanced regenerative mesh"
 	icon_state = "aloe_mesh"
-	amount = 30
-	max_amount = 30
+	amount = 25
+	max_amount = 25
 	heal_burn = 15
 	sanitization = 1.25
 	flesh_regeneration = 3.5


### PR DESCRIPTION
# Document the changes in your pull request

Both advanced stack healing items have had their stack size increased by 10
Advanced sutures are applied to wounds twice as fast as normal sutures

# Wiki Documentation

Both advanced stack healing items (adv mesh + medicated suture) have had their stack size increased by 10
Advanced sutures are applied to wounds twice as fast as normal sutures

# Changelog

:cl:  
tweak: Both advanced stack healing items (adv mesh + medicated suture) have had their stack size increased by 10
tweak: Advanced sutures are applied to wounds twice as fast as normal sutures
tweak: sutures now have 15 items in each stack isntead of 10 because why 10 when mesh has 15
/:cl:
