### PR TITLE
makes tape recursively check contents to make sure theres no grenades or explosives in the taped item

### DIFF
--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -46,9 +46,11 @@
 	if(I.w_class > maximum_weight_class)
 		to_chat(user, span_warning("[I] is too big!"))
 		return
-	if(is_type_in_typecache(I,tape_blacklist))
-		to_chat(user, span_warning("The [src] doesn't seem to stick to [I]!"))
-		return
+	var/list/item_contents = GetAllContents(I)
+	for(var/C in item_contents)
+		if(is_type_in_typecache(C,tape_blacklist))
+			to_chat(user, span_warning("The [src] doesn't seem to stick to [I]!"))
+			return
 	to_chat(user, span_info("You wrap [I] with [src]."))
 	use(1)
 	I.embedding = I.embedding.setRating(100, 10, 0, 0, 0, 0, 0, 0, TRUE)


### PR DESCRIPTION
# Document the changes in your pull request

![Discord_kAaeMaLpjn](https://user-images.githubusercontent.com/5091394/168453278-20ece8ae-56e4-447d-bce5-0f5054e8d886.png)

# Changelog

:cl:  
tweak: makes tape recursively check contents to make sure theres no grenades or explosives in the taped item
/:cl:
