### PR TITLE
Fixes Track Monster (and more future) cooldowns, adds Vampire to Track Monster, fixes Track Monster (it now works)

### DIFF
--- a/code/modules/antagonists/bloodsuckers/powers/_powers.dm
+++ b/code/modules/antagonists/bloodsuckers/powers/_powers.dm
@@ -163,8 +163,6 @@
 
 	// Wait for cooldown
 	COOLDOWN_START(src, bloodsucker_power_cooldown, this_cooldown)
-	//if(cooldown_overlay)
-		//QDEL_NULL(cooldown_overlay)
 	cooldown_overlay = start_cooldown(button,world.time + this_cooldown)
 	addtimer(CALLBACK(src, .proc/alpha_in), this_cooldown)
 

--- a/code/modules/antagonists/bloodsuckers/powers/_powers.dm
+++ b/code/modules/antagonists/bloodsuckers/powers/_powers.dm
@@ -99,9 +99,6 @@
 	ActivatePower()
 	if(power_flags & BP_AM_SINGLEUSE)
 		RemoveAfterUse()
-		return TRUE
-	if(!(power_flags & BP_AM_TOGGLE) || !active)
-		StartCooldown() // Must come AFTER UpdateButtonIcon(), otherwise icon will revert!
 	return TRUE
 
 /datum/action/bloodsucker/proc/CheckCanPayCost()
@@ -166,6 +163,8 @@
 
 	// Wait for cooldown
 	COOLDOWN_START(src, bloodsucker_power_cooldown, this_cooldown)
+	//if(cooldown_overlay)
+		//QDEL_NULL(cooldown_overlay)
 	cooldown_overlay = start_cooldown(button,world.time + this_cooldown)
 	addtimer(CALLBACK(src, .proc/alpha_in), this_cooldown)
 

--- a/code/modules/antagonists/monsterhunter/monstertrack.dm
+++ b/code/modules/antagonists/monsterhunter/monstertrack.dm
@@ -6,7 +6,7 @@
 	icon_icon = 'icons/mob/actions/actions_bloodsucker.dmi'
 	background_icon_state = "vamp_power_off"
 	button_icon_state = "power_hunter"
-	power_flags = NONE
+	power_flags = BP_AM_STATIC_COOLDOWN
 	check_flags = BP_CANT_USE_WHILE_INCAPACITATED|BP_CANT_USE_WHILE_UNCONSCIOUS
 	purchase_flags = NONE
 	cooldown = 30 SECONDS
@@ -17,23 +17,28 @@
 /datum/action/bloodsucker/trackvamp/ActivatePower()
 	. = ..()
 	/// Return text indicating direction
-	to_chat(owner, span_notice("You look around, scanning your environment and discerning signs of any filthy, wretched affronts to the natural order."))
-	if(!do_after(owner, 6 SECONDS, owner))
+	to_chat(owner, span_notice("You look around, scanning your environment and discerning signs of any filthy, wretched affronts to the natural order..."))
+	if(!do_mob(owner, owner, 6 SECONDS))
+		to_chat(owner,span_warning("You were interrupted and lost the tracks!"))
+		DeactivatePower()
 		return
 	if(give_pinpointer)
 		var/mob/living/user = owner
 		user.apply_status_effect(/datum/status_effect/agent_pinpointer/hunter_edition)
 	display_proximity()
+	DeactivatePower()
 
 /datum/action/bloodsucker/trackvamp/proc/display_proximity()
 	/// Pick target
 	var/turf/my_loc = get_turf(owner)
-	var/best_dist = 9999
-	var/mob/living/best_vamp
+	var/closest_dist = 9999
+	var/mob/living/closest_monster
 
 	/// Track ALL living Monsters.
 	var/list/datum/mind/monsters = list()
 	for(var/mob/living/carbon/all_carbons in GLOB.alive_mob_list)
+		if(all_carbons == owner) //don't track ourselves!
+			continue
 		if(!all_carbons.mind)
 			continue
 		var/datum/mind/carbon_minds = all_carbons.mind
@@ -43,7 +48,7 @@
 			monsters += carbon_minds
 		if(carbon_minds.has_antag_datum(/datum/antagonist/ashwalker))
 			monsters += carbon_minds
-		if(carbon_minds.has_antag_datum(/datum/antagonist/wizard/apprentice))
+		if(carbon_minds.has_antag_datum(/datum/antagonist/vampire)) //yogs, still supporting vampires!
 			monsters += carbon_minds
 
 	for(var/datum/mind/monster_minds in monsters)
@@ -56,15 +61,15 @@
 			var/their_loc = get_turf(monster_minds.current)
 			var/distance = get_dist_euclidian(my_loc, their_loc)
 			/// Found One: Closer than previous/max distance
-			if(distance < best_dist && distance <= HUNTER_SCAN_MAX_DISTANCE)
-				best_dist = distance
-				best_vamp = monster_minds.current
+			if(distance < closest_dist && distance <= HUNTER_SCAN_MAX_DISTANCE)
+				closest_dist = distance
+				closest_monster = monster_minds.current
 				/// Stop searching through my antag datums and go to the next guy
 				break
 
 	/// Found one!
-	if(best_vamp)
-		var/distString = best_dist <= HUNTER_SCAN_MAX_DISTANCE / 2 ? "<b>somewhere closeby!</b>" : "somewhere in the distance."
+	if(closest_monster)
+		var/distString = closest_dist <= HUNTER_SCAN_MAX_DISTANCE / 2 ? "<b>somewhere nearby!</b>" : "somewhere in the distance."
 		to_chat(owner, span_warning("You detect signs of monsters [distString]"))
 
 	/// Will yield a "?"


### PR DESCRIPTION
# Document the changes in your pull request

It will now work correctly btw and how you think a track monster would work.

1) Due to the do_after (now do_mob) of Track Monster, Cooldown would start twice, and make the cooldown overlay bug out. This fixes it.
2) The start cooldown for sanity on bloodsuckers is never used. All normal powers handle it in DeactivatePower and targetted powers handle it in their own proc. This removes it (fixes 1)
3) Track Monster tracks more than vamps, so the variables for scanning were changed
4) Yogs still supports vampires, and until there's a council vote removing them, Track Monster also tracks Vampires. They are monsters.
5) Track Monster has a forever level of 0, and not having a static cooldown makes it so it's 2~ seconds longer than it should be from cooldown math, so that's fixed (it is 30 seconds)
6) has_antag_datum checks subtypes if you don't set check_subtypes to false, so we don't need to check for new bloods or wizard apprentices as they are subtypes of vampire and wizard respectively.

# Changelog

:cl:  ToasterBiome, tatax
tweak: Add Vampire to Track Monster
bugfix: Stops double cooldown overlay bug on Track Monster
bugfix: Fixes incorrect Track Monster cooldown
/:cl:
