### PR TITLE
Makes power failure never affect areas that contain AI data cores

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -729,11 +729,20 @@
 	return pick(possible_loc)
 
 /proc/power_fail(duration_min, duration_max)
+	var/list/data_core_areas = list()
+	for(var/obj/machinery/ai/data_core/core as anything in GLOB.data_cores)
+		if(!isarea(core.loc))
+			continue
+		var/area/A = core.loc
+		data_core_areas[A.type] = TRUE
+
 	for(var/P in GLOB.apcs_list)
 		var/obj/machinery/power/apc/C = P
 		if(C.cell && SSmapping.level_trait(C.z, ZTRAIT_STATION))
 			var/area/A = C.area
 			if(GLOB.typecache_powerfailure_safe_areas[A.type])
+				continue
+			if(data_core_areas[A.type])
 				continue
 
 			C.energy_fail(rand(duration_min,duration_max))

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -731,6 +731,8 @@
 /proc/power_fail(duration_min, duration_max)
 	var/list/data_core_areas = list()
 	for(var/obj/machinery/ai/data_core/core as anything in GLOB.data_cores)
+		if(!core.valid_data_core())
+			continue
 		if(!isarea(core.loc))
 			continue
 		var/area/A = core.loc


### PR DESCRIPTION
# Document the changes in your pull request
see title, only applies to functional AI cores, aka no spamming non-functional ones in areas you don't want depowered

# Wiki Documentation


# Changelog


:cl:  
tweak: An area with an AI data core can no longer experience power failure from random events
/:cl:
