### PR TITLE
Inducer can charge Preternis at the cost of burning them

### DIFF
--- a/code/game/objects/items/inducer.dm
+++ b/code/game/objects/items/inducer.dm
@@ -128,7 +128,6 @@
 					done_any = TRUE
 					cell.use(totransfer*coefficient)
 					preternis.charge = clamp(preternis.charge + (powertransfer*coefficient), PRETERNIS_LEVEL_NONE, PRETERNIS_LEVEL_FULL)
-					//H.adjustFireLoss(totransfer*coefficient)
 					H.apply_damage(totransfer*coefficient, BURN, BODY_ZONE_CHEST, wound_bonus = CANT_WOUND)
 					user.visible_message("Smoke rises off of [A]'s body!",span_notice("You smell something burning as [A] is charged by the [src]!"))
 					do_sparks(1, FALSE, A)

--- a/code/game/objects/items/inducer.dm
+++ b/code/game/objects/items/inducer.dm
@@ -107,6 +107,39 @@
 	if(istype(A, /obj/item/gun/energy))
 		to_chat(user,"Error unable to interface with device")
 		return FALSE
+	if(ishuman(A))
+		var/mob/living/carbon/human/H = A
+		if(ispreternis(H)) //let's charge some dumb robot players
+			if(user.zone_selected != BODY_ZONE_CHEST)
+				to_chat(user, span_warning("You need to target [A]'s chest with [src] to recharge [H.p_them()]!"))
+				recharging = FALSE
+				return TRUE
+			coefficient = 0.1
+			var/totransfer = min(cell.charge,(powertransfer * coefficient))
+			var/datum/species/preternis/preternis = H.dna.species
+			var/done_any = FALSE
+			if(preternis.charge >= PRETERNIS_LEVEL_FULL - 25)
+				to_chat(user, span_notice("[A] is fully charged!"))
+				recharging = FALSE
+				return TRUE
+			user.visible_message("[user] starts recharging [A] with [src].",span_notice("You start recharging [A] with [src]."))
+			while(preternis.charge < PRETERNIS_LEVEL_FULL - 25)
+				if(do_after(user, 1 SECONDS, target = user) && cell.charge)
+					done_any = TRUE
+					cell.use(totransfer*coefficient)
+					preternis.charge = clamp(preternis.charge + (powertransfer*coefficient), PRETERNIS_LEVEL_NONE, PRETERNIS_LEVEL_FULL)
+					//H.adjustFireLoss(totransfer*coefficient)
+					H.apply_damage(totransfer*coefficient, BURN, BODY_ZONE_CHEST, wound_bonus = CANT_WOUND)
+					user.visible_message("Smoke rises off of [A]'s body!",span_notice("You smell something burning as [A] is charged by the [src]!"))
+					do_sparks(1, FALSE, A)
+					if(O)
+						O.update_icon()
+				else
+					break
+			if(done_any) // Only show a message if we succeeded at least once
+				user.visible_message("[user] recharged [A]!",span_notice("You recharged [A]!"))
+			recharging = FALSE
+			return TRUE
 	if(istype(A, /obj))
 		O = A
 	if(C)


### PR DESCRIPTION
i know the obvious solution is to shove pizza in their mouth to charge them a bit and then revive so they can suck an apc but this just makes it so you can give them a real charge before picking them up. (i hate afk robots)

This does burn them based on how much you charge them because you probably shouldn't be pressing an industrial charger to a robot person's chest

# Wiki Documentation

maybe a little blurb added to the guide to medicine about this as an option to charge them.

# Changelog

:cl:  
rscadd: Inducers can be used to charge Preternis but this process burns them  
/:cl:
