### PR TITLE
Reverts #14164 because it broke genetics

### DIFF
--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -89,7 +89,6 @@
 		O.setOrganLoss(ORGAN_SLOT_BRAIN, getOrganLoss(ORGAN_SLOT_BRAIN))
 		O.updatehealth()
 		O.radiation = radiation
-		O.blood_volume = blood_volume
 
 	//re-add implants to new mob
 	if (tr_flags & TR_KEEPIMPLANTS)
@@ -266,7 +265,6 @@
 		O.adjustOrganLoss(ORGAN_SLOT_BRAIN, getOrganLoss(ORGAN_SLOT_BRAIN))
 		O.updatehealth()
 		O.radiation = radiation
-		O.blood_volume = blood_volume
 
 	//re-add implants to new mob
 	if (tr_flags & TR_KEEPIMPLANTS)


### PR DESCRIPTION
# Document the changes in your pull request
Reverts #14164

Keeping current blood volume from a monkey (a monkey's max blood volume is 60% of a human's) as it turns into a human causes the monkey to become a human with 60% blood volume and, as such, perish

+1 exploit
-1 job that requires most of the medbay's blood supply every round
Find another way

# Changelog

:cl:  
bugfix: Monkeys now do not die of exsanguination when made into humans
/:cl: