### PR TITLE
Prevents Consecutive Traitors/Changeling/Brother/Bloodsucker/Vampire players from rolling - Double for Low pop

### DIFF
--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -1,12 +1,23 @@
 Any time you make a change to the schema files, remember to increment the database schema version. Generally increment the minor number, major should be reserved for significant changes to the schema. Both values go up to 255.
 
-The latest database version is 5.6; The query to update the schema revision table is:
+The latest database version is 5.11; The query to update the schema revision table is:
 
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 9);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 11);
 or
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 9);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 11);
 
 In any query remember to add a prefix to the table names if you use one.
+
+
+
+version 5.11 19 May 2022, by JamieD12
+
+Adds the antagrounds column to the player table
+
+ALTER TABLE ss13_player
+    ADD COLUMN `antagrounds` TINYINT NULL DEFAULT 0 AFTER `mfa_backup`;
+
+-----------------------------------------------------------------
 
 version 5.9 23 November 2021, by adamsogm
 

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -12,10 +12,11 @@ In any query remember to add a prefix to the table names if you use one.
 
 version 5.11 19 May 2022, by JamieD12
 
-Adds the antagrounds column to the player table
+Adds the antag_rounds column to the player table
 
 ALTER TABLE ss13_player
     ADD COLUMN `antagrounds` TINYINT NOTNULL DEFAULT 0 AFTER `mfa_backup`;
+
 
 -----------------------------------------------------------------
 

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -15,7 +15,7 @@ version 5.11 19 May 2022, by JamieD12
 Adds the antagrounds column to the player table
 
 ALTER TABLE ss13_player
-    ADD COLUMN `antagrounds` TINYINT NULL DEFAULT 0 AFTER `mfa_backup`;
+    ADD COLUMN `antagrounds` TINYINT NOTNULL DEFAULT 0 AFTER `mfa_backup`;
 
 -----------------------------------------------------------------
 

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -355,7 +355,7 @@ CREATE TABLE IF NOT EXISTS `player` (
   `job_whitelisted` tinyint(3) unsigned NOT NULL DEFAULT 0,
   `totp_seed` varchar(20),
   `mfa_backup` varchar(128),
-  `antagrounds` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  `antag_rounds` tinyint(3) unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`ckey`),
   KEY `idx_player_cid_ckey` (`computerid`,`ckey`),
   KEY `idx_player_ip_ckey` (`ip`,`ckey`)

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -338,7 +338,7 @@ CREATE TABLE IF NOT EXISTS `misc` (
 DROP TABLE IF EXISTS `player`;
 CREATE TABLE IF NOT EXISTS `player` (
   `ckey` varchar(32) NOT NULL,
-`byond_key` varchar(32) DEFAULT NULL,
+  `byond_key` varchar(32) DEFAULT NULL,
   `firstseen` datetime NOT NULL,
   `firstseen_round_id` int(10) unsigned NOT NULL,
   `lastseen` datetime NOT NULL,

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -338,7 +338,7 @@ CREATE TABLE IF NOT EXISTS `misc` (
 DROP TABLE IF EXISTS `player`;
 CREATE TABLE IF NOT EXISTS `player` (
   `ckey` varchar(32) NOT NULL,
-  `byond_key` varchar(32) DEFAULT NULL,
+`byond_key` varchar(32) DEFAULT NULL,
   `firstseen` datetime NOT NULL,
   `firstseen_round_id` int(10) unsigned NOT NULL,
   `lastseen` datetime NOT NULL,
@@ -355,6 +355,7 @@ CREATE TABLE IF NOT EXISTS `player` (
   `job_whitelisted` tinyint(3) unsigned NOT NULL DEFAULT 0,
   `totp_seed` varchar(20),
   `mfa_backup` varchar(128),
+  `antagrounds` tinyint(3) unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`ckey`),
   KEY `idx_player_cid_ckey` (`computerid`,`ckey`),
   KEY `idx_player_ip_ckey` (`ip`,`ckey`)

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -356,7 +356,7 @@ CREATE TABLE IF NOT EXISTS `SS13_player` (
   `job_whitelisted` tinyint(3) unsigned NOT NULL DEFAULT 0,
   `totp_seed` varchar(20),
   `mfa_backup` varchar(128),
-  `antagrounds` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  `antag_rounds` tinyint(3) unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`ckey`),
   KEY `idx_player_cid_ckey` (`computerid`,`ckey`),
   KEY `idx_player_ip_ckey` (`ip`,`ckey`)

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -356,6 +356,7 @@ CREATE TABLE IF NOT EXISTS `SS13_player` (
   `job_whitelisted` tinyint(3) unsigned NOT NULL DEFAULT 0,
   `totp_seed` varchar(20),
   `mfa_backup` varchar(128),
+  `antagrounds` tinyint(3) unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`ckey`),
   KEY `idx_player_cid_ckey` (`computerid`,`ckey`),
   KEY `idx_player_ip_ckey` (`ip`,`ckey`)

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -21,7 +21,7 @@
   * make sure you add an update to the schema_version stable in the db changelog
   */
 
-#define DB_MINOR_VERSION 9
+#define DB_MINOR_VERSION 11
 
 //! ## Timing subsystem
 /**

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -725,7 +725,7 @@
 			if(antagdatums)
 				if(!antagdatum.owner)
 					continue
-				if(!antagdatum.restrictmultiplerounds)
+				if(!antagdatum.restrict_multiple_rounds)
 					continue
 				antagckeys += antagdatum.owner.key
 			nonantagckeys += antagdatum.owner.key
@@ -739,6 +739,6 @@
 		numberofrounds = numberofrounds + 1
 	if(numberofrounds > 2)
 		numberofrounds = 2
-	var/datum/DBQuery/Q2 = SSdbcore.New("UPDATE [format_table_name("player")] SET `antag_rounds` = LEAST('antag_rounds' + `[numberofrounds], 2) WHERE `key` IN ([nonantagckeys])")
+	var/datum/DBQuery/Q2 = SSdbcore.New("UPDATE [format_table_name("player")] SET `antag_rounds` = LEAST('antag_rounds' + [numberofrounds], 2) WHERE `key` IN ([nonantagckeys])")
 	Q2.Execute()
 	qdel(Q2)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -228,6 +228,9 @@
 	if(mode.allow_persistence_save)
 		SSpersistence.CollectData()
 
+	///Collect Antag data
+	antagrounds()
+
 	//stop collecting feedback during grifftime
 	SSblackbox.Seal()
 
@@ -711,3 +714,23 @@
 		Q.Execute()
 		qdel(Q)
 
+/datum/controller/subsystem/ticker/proc/antagrounds()
+	var/list/viableminds = list()
+	var/numberofrounds = 1
+	for(var/datum/antagonist/A in GLOB.antagonists)
+		if(!A.restrictmultiplerounds)
+			continue
+		if(!A.owner)
+			continue
+		viableminds += A.owner
+	
+	if(GLOB.startingminds < CONFIG_GET(number/minimal_access_threshold)) /// Low pop check
+		numberofrounds = numberofrounds + 1
+
+	if(numberofrounds > 2)
+		numberofrounds = 2
+
+	for(var/datum/mind/antagmind in viableminds)
+		var/datum/DBQuery/Q = SSdbcore.New("UPDATE [format_table_name("player")] SET `antagrounds` = '[numberofrounds]' WHERE `key` = '[antagmind.key]'")
+		Q.Execute()
+		qdel(Q)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1372,7 +1372,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	return temp
 
 //same as do_mob except for movables and it allows both to drift and doesn't draw progressbar
-/proc/do_atom(atom/movable/user , atom/movable/target, time = 30, uninterruptible = 0,datum/callback/extra_checks = null)
+/proc/do_atom(atom/movable/user, atom/movable/target, time = 30, uninterruptible = 0,datum/callback/extra_checks = null)
 	if(!user || !target)
 		return TRUE
 	var/user_loc = user.loc

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1372,7 +1372,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	return temp
 
 //same as do_mob except for movables and it allows both to drift and doesn't draw progressbar
-/proc/do_atom(atom/movable/user, atom/movable/target, time = 30, uninterruptible = 0,datum/callback/extra_checks = null)
+/proc/do_atom(atom/movable/user, atom/movable/target, time = 30, uninterruptible = 0, datum/callback/extra_checks = null)
 	if(!user || !target)
 		return TRUE
 	var/user_loc = user.loc

--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -2,6 +2,7 @@ GLOBAL_LIST_EMPTY(clients)							//all clients
 GLOBAL_LIST_EMPTY(admins)							//all clients whom are admins
 GLOBAL_PROTECT(admins)
 GLOBAL_LIST_EMPTY(deadmins)							//all ckeys who have used the de-admin verb.
+GLOBAL_LIST_EMPTY(startingminds)
 
 GLOBAL_LIST_EMPTY(directory)							//all ckeys with associated client
 GLOBAL_LIST_EMPTY(stealthminID)						//reference list with IDs that store ckeys, for stealthmins

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -364,22 +364,22 @@
 
 	
 	for(var/datum/mind/mind in candidates)
-		var/antagrounds = 0
+		var/antag_rounds = 0
 		var/antagckey = mind.key
 		if(!SSdbcore.Connect())
 			log_world("Failed to connect to database in load_antaground().")
 			WRITE_FILE(GLOB.world_game_log, "Failed to connect to database in load_antaground().")
 			continue
 
-		var/datum/DBQuery/query_load_antagrounds = SSdbcore.NewQuery("SELECT antagrounds FROM [format_table_name("player")] WHERE ckey = :antagckey", list("antagckey" = antagckey))
+		var/datum/DBQuery/query_load_antagrounds = SSdbcore.NewQuery("SELECT antag_rounds FROM [format_table_name("player")] WHERE ckey = :antagckey", list("antagckey" = antagckey))
 		if(!query_load_antagrounds.Execute())
 			qdel(query_load_antagrounds)
 			continue
 
 		while(query_load_antagrounds.NextRow())
-			antagrounds = query_load_antagrounds.item[1]
+			antag_rounds = query_load_antagrounds.item[1]
 		
-		if(antagrounds > 0)
+		if(antag_rounds > 0)
 			candidates -= mind
 
 		qdel(query_load_antagrounds)

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -25,7 +25,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 	var/show_to_ghosts = FALSE // Should this antagonist be shown as antag to ghosts? Shouldn't be used for stealthy antagonists like traitors
 	/// The corporation employing us
 	var/datum/corporation/company
-	var/restrictmultiplerounds = FALSE
+	var/restrict_multiple_rounds = FALSE
 
 
 /datum/antagonist/New()

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -25,6 +25,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 	var/show_to_ghosts = FALSE // Should this antagonist be shown as antag to ghosts? Shouldn't be used for stealthy antagonists like traitors
 	/// The corporation employing us
 	var/datum/corporation/company
+	var/restrictmultiplerounds = FALSE
 
 
 /datum/antagonist/New()

--- a/code/modules/antagonists/bloodsuckers/bloodsuckers.dm
+++ b/code/modules/antagonists/bloodsuckers/bloodsuckers.dm
@@ -6,6 +6,7 @@
 	job_rank = ROLE_BLOODSUCKER
 	show_name_in_check_antagonists = TRUE
 	can_coexist_with_others = FALSE
+	restrictmultiplerounds = TRUE
 
 	// TIMERS //
 	///Timer between alerts for Burn messages

--- a/code/modules/antagonists/bloodsuckers/bloodsuckers.dm
+++ b/code/modules/antagonists/bloodsuckers/bloodsuckers.dm
@@ -6,7 +6,7 @@
 	job_rank = ROLE_BLOODSUCKER
 	show_name_in_check_antagonists = TRUE
 	can_coexist_with_others = FALSE
-	restrictmultiplerounds = TRUE
+	restrict_multiple_rounds = TRUE
 
 	// TIMERS //
 	///Timer between alerts for Burn messages

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -6,7 +6,7 @@
 	var/datum/team/brother_team/team
 	antag_moodlet = /datum/mood_event/focused
 	can_hijack = HIJACK_HIJACKER
-	restrictmultiplerounds = TRUE
+	restrict_multiple_rounds = TRUE
 
 /datum/antagonist/brother/create_team(datum/team/brother_team/new_team)
 	if(!new_team)

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -6,6 +6,7 @@
 	var/datum/team/brother_team/team
 	antag_moodlet = /datum/mood_event/focused
 	can_hijack = HIJACK_HIJACKER
+	restrictmultiplerounds = TRUE
 
 /datum/antagonist/brother/create_team(datum/team/brother_team/new_team)
 	if(!new_team)

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -43,6 +43,7 @@
 
 	var/static/list/all_powers = typecacheof(/datum/action/changeling,TRUE)
 	var/list/stored_snapshots = list() //list of stored snapshots
+	restrictmultiplerounds = TRUE
 
 /datum/antagonist/changeling/New()
 	. = ..()

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -43,7 +43,7 @@
 
 	var/static/list/all_powers = typecacheof(/datum/action/changeling,TRUE)
 	var/list/stored_snapshots = list() //list of stored snapshots
-	restrictmultiplerounds = TRUE
+	restrict_multiple_rounds = TRUE
 
 /datum/antagonist/changeling/New()
 	. = ..()

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -16,7 +16,7 @@
 	var/malf = FALSE //whether or not the AI is malf (in case it's a traitor)
 	var/datum/contractor_hub/contractor_hub
 	can_hijack = HIJACK_HIJACKER
-	restrictmultiplerounds = TRUE
+	restrict_multiple_rounds = TRUE
 
 /datum/antagonist/traitor/on_gain()
 	if(owner.current && iscyborg(owner.current))

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -16,6 +16,7 @@
 	var/malf = FALSE //whether or not the AI is malf (in case it's a traitor)
 	var/datum/contractor_hub/contractor_hub
 	can_hijack = HIJACK_HIJACKER
+	restrictmultiplerounds = TRUE
 
 /datum/antagonist/traitor/on_gain()
 	if(owner.current && iscyborg(owner.current))

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -352,7 +352,7 @@ CONFIG_GATEWAY_CHANCE 0
 ## If the number of players ready at round starts exceeds this threshold, JOBS_HAVE_MINIMAL_ACCESS will automatically be enabled. Otherwise, it will be disabled.
 ## This is useful for accomodating both low and high population rounds on the same server.
 ## Comment this out or set to 0 to disable this automatic toggle.
-MINIMAL_ACCESS_THRESHOLD 18
+MINIMAL_ACCESS_THRESHOLD 20
 
 ## Comment this out this if you wish to use the setup where jobs have more access.
 ## This is intended for servers with low populations - where there are not enough

--- a/yogstation/code/datums/antagonists/vampire.dm
+++ b/yogstation/code/datums/antagonists/vampire.dm
@@ -7,7 +7,7 @@
 	antagpanel_category = "Vampire"
 	roundend_category = "vampires"
 	job_rank = ROLE_VAMPIRE
-	restrictmultiplerounds = TRUE
+	restrict_multiple_rounds = TRUE
 
 	var/usable_blood = 0
 	var/total_blood = 0

--- a/yogstation/code/datums/antagonists/vampire.dm
+++ b/yogstation/code/datums/antagonists/vampire.dm
@@ -7,6 +7,7 @@
 	antagpanel_category = "Vampire"
 	roundend_category = "vampires"
 	job_rank = ROLE_VAMPIRE
+	restrictmultiplerounds = TRUE
 
 	var/usable_blood = 0
 	var/total_blood = 0


### PR DESCRIPTION
Prevents Consecutive Traitors/Changeling/Brother/Bloodsucker/Vampire rounds - Double for Low pop

This also means more then the same person will get antag every shift.

:cl:  
rscadd: Prevents Consecutive Traitors/Changeling/Brother/Bloodsucker/Vampire rounds - Double for Low pop
/:cl:
