### PR TITLE
Adds admin and ghost capes to the selection list

### DIFF
--- a/code/modules/clothing/neck/skillcapes/skillcape_datums.dm
+++ b/code/modules/clothing/neck/skillcapes/skillcape_datums.dm
@@ -476,6 +476,13 @@
 	id = "admin_trimmed"
 	special = TRUE
 
+/datum/skillcape/mentor
+	name = "cape of the sage"
+	job = "Mentor"
+	path = /obj/item/clothing/neck/skillcape/mentor
+	id = "mentor"
+	special = TRUE
+
 /datum/skillcape/ghost
 	name = "cape of invisible skill"
 	job = "Ghost"

--- a/code/modules/clothing/neck/skillcapes/skillcape_datums.dm
+++ b/code/modules/clothing/neck/skillcapes/skillcape_datums.dm
@@ -2,7 +2,7 @@
 	var/name = ""
 	var/minutes = 18000
 	var/job
-	var/special = FALSE //If its TRUE it wont have a related job, it's for the switch statement in preferences.dm
+	var/special = FALSE // If true, exempt from the max cape
 	var/capetype = "" // goes along with special, for the switch statement.
 	var/path = /obj/item/clothing/neck/skillcape
 	var/id
@@ -462,4 +462,22 @@
 	path = /obj/item/clothing/neck/skillcape/trimmed/botany
 	id = "botany_trimmed"
 
+/datum/skillcape/admin
+	name = "cape of mighty judgement"
+	job = "Admin"
+	path = /obj/item/clothing/neck/skillcape/admin
+	id = "admin"
+	special = TRUE
 
+/datum/skillcape/trimmed/admin
+	name = "cape of the supreme judge"
+	job = "Admin"
+	path = /obj/item/clothing/neck/skillcape/trimmed/admin
+	id = "admin_trimmed"
+	special = TRUE
+
+/datum/skillcape/ghost
+	name = "cape of invisible skill"
+	job = "Ghost"
+	path = /obj/item/clothing/neck/skillcape
+	id = "ghost"

--- a/config/secret.txt
+++ b/config/secret.txt
@@ -27,8 +27,8 @@ $include private_default.txt
 # IPINTEL_EMAIL ch@nge.me
 
 ##Used to send round data to a webhook. Can now use HTTPS thanks to rust_g
-#WEBHOOK_ADDRESS https://example.com
-#WEBHOOK_KEY webkey
+WEBHOOK_ADDRESS http://127.0.0.1:8443/byond
+WEBHOOK_KEY webkey
 
 ## The XF API key for forum verification
 #XENFORO_KEY xenforokey

--- a/config/secret.txt
+++ b/config/secret.txt
@@ -27,8 +27,8 @@ $include private_default.txt
 # IPINTEL_EMAIL ch@nge.me
 
 ##Used to send round data to a webhook. Can now use HTTPS thanks to rust_g
-WEBHOOK_ADDRESS http://127.0.0.1:8443/byond
-WEBHOOK_KEY webkey
+#WEBHOOK_ADDRESS https://example.com
+#WEBHOOK_KEY webkey
 
 ## The XF API key for forum verification
 #XENFORO_KEY xenforokey


### PR DESCRIPTION
# Document the changes in your pull request

Adds admin and trimmed admin capes as selectable capes. Anyone who has adminned for the required hours can get it, even ex-staff. 
Adds mentor cape as a selectable cape. Anyone who has mentored for the required hours can get it, even ex-mentors
Adds ghost cape as a selectable cape.

All of these capes are still in the autodrobe

# Changelog

:cl:  
tweak: Made admin capes unlockable
tweak: Made mentor cape unlockable
tweak: Made ghost cape unlockable
/:cl:
