### PR TITLE
Alerts security over the radio if you try to launder money

### DIFF
--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -85,7 +85,7 @@
 		if(istype(X,/obj/item/stack/spacecash) && !moneylaundering && launderer) 
 			moneylaundering = TRUE
 			alertradio.set_frequency(FREQ_SECURITY)
-			alertradio.talk_into(src, "SECURITY ALERT: Crewmember [launderer] recorded attempting to launder space cash in [get_area(src)]. Please watch for embezzlement.", FREQ_SECURITY)
+			alertradio.talk_into(src, "SECURITY ALERT: Crewmember [launderer] recorded attempting to launder space cash in [get_area(src)]. Please watch for misuse.", FREQ_SECURITY)
 	moneylaundering = FALSE
 	busy = FALSE
 	if(color_source)


### PR DESCRIPTION
# Document the changes in your pull request

If you try to launder money using something like space cash, security will be auto notified through their radio your location and name.

# Changelog

:cl:  
rscadd: Alerts security over the radio if you try to launder money now
/:cl:
