### PR TITLE
Fixes the glowy mutation always being blood red instead of your mutation color

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -190,6 +190,7 @@
 	var/obj/effect/dummy/luminescent_glow/glowth //shamelessly copied from luminescents
 	var/glow = 2.5
 	var/range = 2.5
+	var/color 
 	power_coeff = 1
 	conflicts = list(/datum/mutation/human/glow/anti)
 
@@ -204,7 +205,15 @@
 	if(!glowth)
 		return
 	var/power = GET_MUTATION_POWER(src)
-	glowth.set_light(range * power, glow * power, dna.features["mcolor"])
+	if(owner.dna.features["mcolor"][1] != "#")
+		//if it doesn't start with a pound, it needs that for the color
+		color += "#"
+	if(length(owner.dna.features["mcolor"]) < 6)
+		//this atrocity converts shorthand hex rgb back into full hex that's required for light to be given a functional value
+		color += owner.dna.features["mcolor"][1] + owner.dna.features["mcolor"][1] + owner.dna.features["mcolor"][2] + owner.dna.features["mcolor"][2] + owner.dna.features["mcolor"][3] + owner.dna.features["mcolor"][3]
+	else
+		color += owner.dna.features["mcolor"]
+	glowth.set_light(range * power, glow * power, color)
 
 /datum/mutation/human/glow/on_losing(mob/living/carbon/human/owner)
 	. = ..()


### PR DESCRIPTION
It was breaking because we use shorthand hexadecimal colors and the set_light proc requires a full hex color with leading #.
![image](https://user-images.githubusercontent.com/46236974/169637254-af7b2ec1-489c-4dfb-a0bb-a3b694d6a501.png)

this is pictured with the power chromosome, so it's a bit exaggerated. Humans get a random color because despite being human you have mutant color in your dna that you're unaware of.

# Changelog

:cl:  
bugfix: glowy mutation is no longer always red
/:cl:
