### PR TITLE
fixes runtime in forceMove if you're forcedMoved to a place that doesn't have a turf yet

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -493,7 +493,7 @@
 	. = FALSE
 	if(destination)
 		var/turf/new_turf = get_turf(destination)
-		if(ismob(src))
+		if(new_turf && ismob(src))
 			var/mob/M = src
 			if(is_secret_level(new_turf.z) && !M.client?.holder)
 				return


### PR DESCRIPTION
# Document the changes in your pull request

Closes https://github.com/yogstation13/Yogstation/issues/14199

Sometimes things get spawned in nullspace with no location, then stuff happens to them, then they are moved to wherever the action is. With https://github.com/yogstation13/Yogstation/pull/13967, you can't forceMove to things in nullspace because of a runtime since there's no turf for the item so you just.. don't

# Changelog

:cl:  
bugfix: fixes runtime in forceMove if you move to some place without a turf
/:cl:
