### PR TITLE
Tea plants, coffee plants, and Novaflower get a small amount of nutriment because their grind results would return nothing

### DIFF
--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -201,7 +201,7 @@
 	icon_dead = "sunflower-dead"
 	product = /obj/item/grown/novaflower
 	mutatelist = list()
-	reagents_add = list(/datum/reagent/consumable/condensedcapsaicin = 0.25, /datum/reagent/consumable/capsaicin = 0.3, /datum/reagent/consumable/nutriment = 0)
+	reagents_add = list(/datum/reagent/consumable/condensedcapsaicin = 0.25, /datum/reagent/consumable/capsaicin = 0.3, /datum/reagent/consumable/nutriment = 0.03)
 	rarity = 20
 
 /obj/item/grown/novaflower

--- a/code/modules/hydroponics/grown/tea_coffee.dm
+++ b/code/modules/hydroponics/grown/tea_coffee.dm
@@ -14,6 +14,7 @@
 	icon_dead = "tea-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/tea/astra)
+	reagents_add = list(/datum/reagent/consumable/nutriment = 0.05)
 
 /obj/item/reagent_containers/food/snacks/grown/tea
 	seed = /obj/item/seeds/tea
@@ -33,7 +34,7 @@
 	plantname = "Tea Astra Plant"
 	product = /obj/item/reagent_containers/food/snacks/grown/tea/astra
 	mutatelist = list()
-	reagents_add = list(/datum/reagent/medicine/synaptizine = 0.1, /datum/reagent/toxin/teapowder = 0.1)
+	reagents_add = list(/datum/reagent/medicine/synaptizine = 0.1, /datum/reagent/toxin/teapowder = 0.1, /datum/reagent/consumable/nutriment = 0.05)
 	rarity = 20
 
 /obj/item/reagent_containers/food/snacks/grown/tea/astra
@@ -61,7 +62,7 @@
 	icon_dead = "coffee-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/coffee/robusta)
-	reagents_add = list(/datum/reagent/toxin/coffeepowder = 0.1)
+	reagents_add = list(/datum/reagent/toxin/coffeepowder = 0.1, /datum/reagent/consumable/nutriment = 0.05)
 
 /obj/item/reagent_containers/food/snacks/grown/coffee
 	seed = /obj/item/seeds/coffee
@@ -83,7 +84,7 @@
 	plantname = "Coffee Robusta Bush"
 	product = /obj/item/reagent_containers/food/snacks/grown/coffee/robusta
 	mutatelist = list()
-	reagents_add = list(/datum/reagent/medicine/ephedrine = 0.1, /datum/reagent/toxin/coffeepowder = 0.1)
+	reagents_add = list(/datum/reagent/medicine/ephedrine = 0.1, /datum/reagent/toxin/coffeepowder = 0.1, /datum/reagent/consumable/nutriment = 0.05)
 	rarity = 20
 
 /obj/item/reagent_containers/food/snacks/grown/coffee/robusta


### PR DESCRIPTION
So both coffee and tea have a few interesting grind results after you dry and grind them out, but the issue is that plant grind results are based on the nutriment value in the plant. I thought it was bugged when i ground up tea and got literally nothing out of it, but this is technically working as intended. you _could_ take nutriment out of another plant and modify the tea and coffee seeds to have nutriment values so that when you grind them you actually get something, but i feel like you should intrinsically get something. 

Novaflower naturally has capsaicin and condensed capsaicin in it, and no nutriment value, so if you grind it, you still get your capsaicins and don't even notice, so i'm just adding a tiny nutriment value so the grind process still works, and you get a bit more of each capsaicin

# Wiki Documentation

plant chart will need an update

# Changelog

:cl:  
rscadd: Tea plants, Coffee plants, and Novaflower have a small amount of nutriment in them so their grind results component works
/:cl:
