### PR TITLE
cuffed does not count as escaped out of custody

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -71,7 +71,7 @@ GLOBAL_LIST_EMPTY(objectives)
 	var/turf/location = get_turf(M.current)
 	if(!location || istype(location, /turf/open/floor/plasteel/shuttle/red) || istype(location, /turf/open/floor/mineral/plastitanium/red/brig)) // Fails if they are in the shuttle brig
 		return FALSE
-	if(istype(M.current, /mob/living/carbon))
+	if(iscarbon(M.current))
 		var/mob/living/carbon/C = M.current
 		if(C.handcuffed && (C.buckled || C.pulledby)) // If handcuffed and being pulled/buckled
 			return FALSE

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -71,6 +71,10 @@ GLOBAL_LIST_EMPTY(objectives)
 	var/turf/location = get_turf(M.current)
 	if(!location || istype(location, /turf/open/floor/plasteel/shuttle/red) || istype(location, /turf/open/floor/mineral/plastitanium/red/brig)) // Fails if they are in the shuttle brig
 		return FALSE
+	if(istype(M.current, /mob/living/carbon))
+		var/mob/living/carbon/C = M.current
+		if(C.handcuffed)
+			return FALSE
 	return location.onCentCom() || location.onSyndieBase()
 
 /datum/objective/proc/check_completion()

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -73,7 +73,7 @@ GLOBAL_LIST_EMPTY(objectives)
 		return FALSE
 	if(istype(M.current, /mob/living/carbon))
 		var/mob/living/carbon/C = M.current
-		if(C.handcuffed)
+		if(C.handcuffed && (C.buckled || C.pulledby)) // If handcuffed and being pulled/buckled
 			return FALSE
 	return location.onCentCom() || location.onSyndieBase()
 


### PR DESCRIPTION
# Document the changes in your pull request

Not every shuttle has red brig area and sometimes the funny red brig tiles get crowbarred and then you're fucked

I.E. BYOS (Build Your Own Shuttle)

`if(C.handcuffed && (C.buckled || C.pulledby)) // If handcuffed and being pulled/buckled`

# Changelog

:cl:  
tweak: Being in handcuffs no longer counts as out of custody
/:cl:
