### PR TITLE
Make temp gun's beams go through glass and grille

### DIFF
--- a/code/modules/projectiles/projectile/special/temperature.dm
+++ b/code/modules/projectiles/projectile/special/temperature.dm
@@ -1,6 +1,7 @@
 /obj/item/projectile/temp
 	name = "freeze beam"
 	icon_state = "ice_2"
+	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
 	damage = 0
 	damage_type = BURN
 	nodamage = FALSE


### PR DESCRIPTION
# Document the changes in your pull request

All beams can go through glass and grilles, it's counterintuitive that the beams of the temp gun don't act the same. Iceblox ammo do damage and cryoshot shell with the multiple pellets do more effect so temperature beams could have the niche of freezing targets from a safer spot.

# Wiki Documentation

Nothing on the wiki spoke about the fact that it couldn't go through glass and most people would probably assume it did considering that's how beams work so nothing to change on the wiki.

# Changelog
Temperature beams can now go through glass and grilles like every other beam weapons.
:cl:  
tweak: Temperature beams go through windows and grilles.
/:cl:
