### PR TITLE
removes all the stupid murderbone bubblegum loot

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1037,7 +1037,12 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 /obj/structure/closet/crate/necropolis/bubblegum/PopulateContents()
 	new /obj/item/clothing/suit/space/hostile_environment(src)
 	new /obj/item/clothing/head/helmet/space/hostile_environment(src)
-	new /obj/item/melee/knuckles(src)
+	var/loot = rand(1,2)
+	switch(loot)
+		if(1)
+			new /obj/item/organ/stomach/cursed(src)
+		if(2)
+			new /obj/item/melee/knuckles(src)
 
 /obj/structure/closet/crate/necropolis/bubblegum/crusher
 	name = "bloody bubblegum chest"

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1037,16 +1037,7 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 /obj/structure/closet/crate/necropolis/bubblegum/PopulateContents()
 	new /obj/item/clothing/suit/space/hostile_environment(src)
 	new /obj/item/clothing/head/helmet/space/hostile_environment(src)
-	var/loot = rand(1,4)
-	switch(loot)
-		if(1)
-			new /obj/item/mayhem(src)
-		if(2)
-			new /obj/item/blood_contract(src)
-		if(3)
-			new /obj/item/melee/knuckles(src)
-		if(4)
-			new /obj/item/organ/stomach/cursed(src)
+	new /obj/item/melee/knuckles(src)
 
 /obj/structure/closet/crate/necropolis/bubblegum/crusher
 	name = "bloody bubblegum chest"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -18,11 +18,7 @@ It may summon clones charging from all sides, one of these charges being bubbleg
 It can charge at its target, and also heavily damaging anything directly hit in the charge.
 If at half health it will start to charge from all sides with clones.
 
-When Bubblegum dies, it leaves behind a H.E.C.K. mining suit as well as a chest that can contain three things:
- 1. A bottle that, when activated, drives everyone nearby into a frenzy
- 2. A contract that marks for death the chosen target
- 3. A set of knuckles that can trap victims where they stand
- 4. A cursed stomach allowing the user to travel via puddles of vomit
+When Bubblegum dies, it leaves behind a H.E.C.K. mining suit as well as a set of knuckles that can trap victims where they stand
 
 Difficulty: Hard
 


### PR DESCRIPTION
# Document the changes in your pull request

goodbye

# Wiki Documentation

bubblegum only drops heck suit and knuckles

# Changelog

:cl:  
rscdel: bubblegum only drops heck suit and knuckles
/:cl:
