### PR TITLE
Modular PC downloading alerts and borg tablet sound tweak

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -92,6 +92,13 @@
 		return 
 	return ..()
 
+/**
+ * Plays a sound through the computer's speakers.
+ */
+/obj/item/modular_computer/proc/play_computer_sound(soundin, vol, vary)
+	if(isobserver(usr))
+		return
+	playsound(loc, soundin, vol, vary, -1)
 
 /**
  * Plays a ping sound.
@@ -99,13 +106,13 @@
  * Timers runtime if you try to make them call playsound. Yep.
  */
 /obj/item/modular_computer/proc/play_ping()
-	playsound(loc, 'sound/machines/ping.ogg', get_clamped_volume(), FALSE, -1)
+	play_computer_sound('sound/machines/ping.ogg', get_clamped_volume(), FALSE)
 
 // Plays a random interaction sound, which is by default a bunch of keboard clacking
 /obj/item/modular_computer/proc/play_interact_sound()
 	if(isobserver(usr))
 		return
-	playsound(loc, pick(interact_sounds), get_clamped_volume(), FALSE, -1)
+	play_computer_sound(pick(interact_sounds), get_clamped_volume(), FALSE, -1)
 
 
 /obj/item/modular_computer/AltClick(mob/user)
@@ -295,7 +302,7 @@
 			to_chat(user, span_notice("You press the power button and start up \the [src]."))
 		enabled = TRUE
 		update_icon()
-		playsound(loc, startup_sound, get_clamped_volume(), FALSE, -1)
+		play_computer_sound(startup_sound, get_clamped_volume(), FALSE)
 		ui_interact(user)
 	else // Unpowered
 		if(issynth)
@@ -355,11 +362,11 @@
 /obj/item/modular_computer/proc/alert_call(datum/computer_file/program/caller, alerttext, sound = 'sound/machines/twobeep_high.ogg')
 	if(!caller || !caller.alert_able || caller.alert_silenced || !alerttext) //Yeah, we're checking alert_able. No, you don't get to make alerts that the user can't silence.
 		return
-	playsound(src, sound, 50, TRUE)
-	visible_message("<span class='notice'>The [src] displays a [caller.filedesc] notification: [alerttext]</span>")
+	play_computer_sound(sound, 50, TRUE)
+	visible_message(span_notice("\The [src] displays a [caller.filedesc] notification: [alerttext]</span>"))
 	var/mob/living/holder = loc
 	if(istype(holder))
-		to_chat(holder, "[icon2html(src)] <span class='notice'>The [src] displays a [caller.filedesc] notification: [alerttext]</span>")
+		to_chat(holder, span_notice("\The [src] displays a [caller.filedesc] notification: [alerttext]"))
 
 // Function used by NanoUI's to obtain data for header. All relevant entries begin with "PC_"
 /obj/item/modular_computer/proc/get_header_data()
@@ -454,7 +461,7 @@
 		physical.visible_message(span_notice("\The [src] shuts down."))
 	enabled = FALSE
 	update_icon()
-	playsound(loc, shutdown_sound, get_clamped_volume(), FALSE, -1)
+	play_computer_sound(shutdown_sound, get_clamped_volume(), FALSE)
 
 /obj/item/modular_computer/screwdriver_act(mob/user, obj/item/tool)
 	if(!all_components.len)

--- a/code/modules/modular_computers/computers/item/integrated_tablet.dm
+++ b/code/modules/modular_computers/computers/item/integrated_tablet.dm
@@ -33,6 +33,11 @@
 		return ..()
 	return FALSE
 
+/obj/item/modular_computer/tablet/integrated/play_computer_sound(soundin, vol, vary)
+	if(isobserver(usr) || !borgo)
+		return
+	borgo.playsound_local(loc, soundin, vol, vary, -1)
+
 /**
   * Returns a ref to the RoboTact app, creating the app if need be.
   *

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -91,10 +91,11 @@
 	if(!computer || !hard_drive || !hard_drive.store_file(downloaded_file))
 		// The download failed
 		downloaderror = "I/O ERROR - Unable to save file. Check whether you have enough free space on your hard drive and whether your hard drive is properly connected. If the issue persists contact your system administrator for assistance."
-		if(computer.active_program != src)
-			computer.alert_call(src, "Aborted download of file [downloaded_file.filename].[downloaded_file.filetype].")
-	else if(computer.active_program != src)
+		computer.alert_call(src, "Aborted download of file [downloaded_file.filename].[downloaded_file.filetype].")
+	else 
 		computer.alert_call(src, "Completed download of file [downloaded_file.filename].[downloaded_file.filetype].")
+	
+	if(computer.active_program != src)
 		alert_pending = TRUE
 	downloaded_file = null
 	download_completion = 0

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -12,6 +12,7 @@
 	ui_header = "downloader_finished.gif"
 	tgui_id = "NtosNetDownloader"
 	program_icon = "download"
+	alert_able = TRUE
 
 	var/datum/computer_file/program/downloaded_file = null
 	var/hacked_download = FALSE
@@ -90,6 +91,11 @@
 	if(!computer || !hard_drive || !hard_drive.store_file(downloaded_file))
 		// The download failed
 		downloaderror = "I/O ERROR - Unable to save file. Check whether you have enough free space on your hard drive and whether your hard drive is properly connected. If the issue persists contact your system administrator for assistance."
+		if(computer.active_program != src)
+			computer.alert_call(src, "Aborted download of file [downloaded_file.filename].[downloaded_file.filetype].")
+	else if(computer.active_program != src)
+		computer.alert_call(src, "Completed download of file [downloaded_file.filename].[downloaded_file.filetype].")
+		alert_pending = TRUE
 	downloaded_file = null
 	download_completion = 0
 	ui_header = "downloader_finished.gif"


### PR DESCRIPTION
# Document the changes in your pull request

Some mod PC tweaks for QoL. Modular PCs make an alert when a program finish downloading, and borg PCs only make noises for the borg. Tested, does work.

# Wiki Documentation

No changes needed. 

# Changelog

:cl:  
rscadd: Added alerts when the NTOS downloader finishes downloading a program
tweak: Borg integrated tablet sounds can only be heard by the borg
/:cl:
