### PR TITLE
Makes vomit crawling function more like everyone thought it should

### DIFF
--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -117,6 +117,14 @@
 	icon_state = "vomit_1"
 	random_icon_states = list("vomit_1", "vomit_2", "vomit_3", "vomit_4")
 
+/obj/effect/decal/cleanable/vomit/Initialize(mapload, list/datum/disease/diseases)
+	. = ..()
+	GLOB.vomit_spots += src
+
+/obj/effect/decal/cleanable/vomit/Destroy(force)
+	. = ..()
+	GLOB.vomit_spots -= src
+
 /obj/effect/decal/cleanable/vomit/attack_hand(mob/user)
 	. = ..()
 	if(.)
@@ -200,3 +208,11 @@
 	icon = 'icons/effects/blood.dmi'
 	icon_state = "xfloor1"
 	random_icon_states = list("xfloor1", "xfloor2", "xfloor3", "xfloor4", "xfloor5", "xfloor6", "xfloor7")
+
+/obj/effect/decal/cleanable/insectguts/Initialize(mapload, list/datum/disease/diseases)
+	. = ..()
+	GLOB.vomit_spots += src
+
+/obj/effect/decal/cleanable/insectguts/Destroy(force)
+	. = ..()
+	GLOB.vomit_spots -= src

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -122,8 +122,8 @@
 	GLOB.vomit_spots += src
 
 /obj/effect/decal/cleanable/vomit/Destroy(force)
-	. = ..()
 	GLOB.vomit_spots -= src
+	. = ..()
 
 /obj/effect/decal/cleanable/vomit/attack_hand(mob/user)
 	. = ..()
@@ -214,5 +214,5 @@
 	GLOB.vomit_spots += src
 
 /obj/effect/decal/cleanable/insectguts/Destroy(force)
-	. = ..()
 	GLOB.vomit_spots -= src
+	. = ..()

--- a/yogstation/code/datums/components/crawl.dm
+++ b/yogstation/code/datums/components/crawl.dm
@@ -8,7 +8,7 @@
 	invisibility = 60
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
-/obj/effect/dummy/crawling/vomit/relaymove(mob/user, direction)
+/obj/effect/dummy/crawling/relaymove(mob/user, direction)
 	forceMove(get_step(src,direction))
 	
 /obj/effect/dummy/crawling/ex_act()

--- a/yogstation/code/datums/components/crawl.dm
+++ b/yogstation/code/datums/components/crawl.dm
@@ -1,16 +1,18 @@
+GLOBAL_LIST_EMPTY(puke)
+
 /obj/effect/dummy/crawling
 	name = "THESE WOUNDS, THEY WILL NOT HEAL"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "nothing"
-	var/canmove = 1
+	var/canmove = TRUE
 	density = FALSE
 	anchored = TRUE
 	invisibility = 60
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
-/obj/effect/dummy/crawling/relaymove(mob/user, direction)
+/obj/effect/dummy/crawling/vomit/relaymove(mob/user, direction)
 	forceMove(get_step(src,direction))
-
+	
 /obj/effect/dummy/crawling/ex_act()
 	return
 /obj/effect/dummy/crawling/bullet_act()
@@ -328,7 +330,9 @@
 	thing = "silicons"
 	crawl_name = "siliconcrawl"
 	crawling_types = list(/mob/living/silicon)
-	
+
+GLOBAL_LIST_EMPTY(vomit_spots)
+
 ////////////VOMITCRAWL
 /datum/component/crawl/vomit //ABSOLUTELY DISGUSIN
 	var/obj/effect/decal/cleanable/enteredvomit
@@ -360,7 +364,10 @@
 	RegisterSignal(target, COMSIG_PARENT_PREQDELETED, .proc/throw_out)
 	user.visible_message(span_warning("[user] sinks into the pool of vomit!?"))
 	playsound(get_turf(target), 'sound/magic/mutate.ogg', 50, 1, -1)
-	..()
+	holder = new /obj/effect/dummy/crawling/vomit(get_turf(user))
+	user.forceMove(holder)
+	var/obj/effect/dummy/crawling/vomit/vomitholder = holder
+	vomitholder.currentvomit = target
 
 /datum/component/crawl/vomit/proc/exit_vomit_effect(atom/target, mob/living/user)
 	playsound(get_turf(target), 'sound/misc/splort.ogg', 100, 1, -1)
@@ -413,3 +420,33 @@
 /obj/item/vomitcrawl/Initialize()
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, ABSTRACT_ITEM_TRAIT)
+
+/obj/effect/dummy/crawling/vomit
+	canmove = FALSE
+	//this is for crawling to work more like a sentient disease movement, where it moves to various targets instead of noclipping through everything
+	var/last_move_tick = 0
+	var/move_delay = 1
+	var/obj/effect/decal/cleanable/currentvomit
+
+/obj/effect/dummy/crawling/vomit/relaymove(mob/user, direction)
+	if(canmove)
+		forceMove(get_step(src,direction))
+	else
+		if(world.time > (last_move_tick + move_delay))
+			follow_next(direction & NORTHWEST)
+			last_move_tick = world.time
+
+/obj/effect/dummy/crawling/vomit/proc/follow_next(reverse = FALSE)
+	var/index = GLOB.vomit_spots.Find(currentvomit)
+	if(index)
+		if(reverse)
+			index = index == 1 ? GLOB.vomit_spots.len : index - 1
+		else
+			index = index == GLOB.vomit_spots.len ? 1 : index + 1
+		currentvomit = GLOB.vomit_spots[index]
+		follow_vomit()
+
+/obj/effect/dummy/crawling/vomit/proc/follow_vomit()
+	var/turf/T = get_turf(currentvomit)
+	if(T)
+		forceMove(T)

--- a/yogstation/code/datums/components/crawl.dm
+++ b/yogstation/code/datums/components/crawl.dm
@@ -1,5 +1,3 @@
-GLOBAL_LIST_EMPTY(puke)
-
 /obj/effect/dummy/crawling
 	name = "THESE WOUNDS, THEY WILL NOT HEAL"
 	icon = 'icons/effects/effects.dmi'


### PR DESCRIPTION
# Document the changes in your pull request

- can't noclip everywhere (no find antag)
- can only move to vomit tiles
- moving off the edge of a vomit tile will teleport you to the next vomit tile, so you can still "jaunt" to other vomit piles
- can't snoop the vampire in SE maints killing someone if you don't have one there
- works pretty similarly to how sentient disease camera works

https://user-images.githubusercontent.com/5091394/169718207-e4103287-e37b-4853-a337-fdd8d0a37dfa.mp4

# Wiki Documentation

I'm not even sure if the wiki explains how these work

# Changelog

:cl:  
tweak: changes the way that vomit crawling movement works (no more noclip through the entire station)
/:cl:
