### PR TITLE
Destroying the spare id/fireaxe cabinet now drops the items

### DIFF
--- a/yogstation/code/game/objects/structures/fireaxe.dm
+++ b/yogstation/code/game/objects/structures/fireaxe.dm
@@ -16,7 +16,9 @@
 
 /obj/structure/fireaxecabinet/Destroy()//<-- mirrored/overwritten proc
 	if(fireaxe)
-		QDEL_NULL(fireaxe)
+		fireaxe.forceMove(get_turf(src))
+	if(spareid)
+		spareid.forceMove(get_turf(src))
 	QDEL_NULL(spark_system)
 	return ..()
 


### PR DESCRIPTION
# Document the changes in your pull request

fixes https://github.com/yogstation13/Yogstation/issues/14197

punching the cabinets with something like a durand can get you into a situation where your punch goes past the threshold to break the glass (letting you grab it out of there) but also goes past the threshhold where you destroy the entire object (and have no chance to grab it) and destroying doesn't drop the items, just deletes them (fuck you) so now it does

# Changelog

:cl:   
tweak: punching the spare id/fireaxe cabinets to destruction will drop the things inside them
/:cl:
