### PR TITLE
removes miming drill mining ruin for being free syndicate gear for miners

### DIFF
--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -257,13 +257,13 @@
 	cost = 10
 	allow_duplicates = FALSE
 
-/datum/map_template/ruin/lavaland/mimingdrill
+/*/datum/map_template/ruin/lavaland/mimingdrill
 	name = "Miming Drill"
 	id = "mimingdrill"
 	description = "A silent mining operation, its workers died as they lived."
 	suffix = "lavaland_surface_mimingdrill.dmm"
 	cost = 5
-	allow_duplicates = FALSE
+	allow_duplicates = FALSE*/
 
 /datum/map_template/ruin/lavaland/cugganscove
 	name = "Cuggans Cove"


### PR DESCRIPTION
# Document the changes in your pull request

Also the ruin somehow has higher atmos inside than outside

Miners don't need to get 
trade request
you recieve: gun and 3x1 barrier
you give: being able to talk

They dont talk anyway they just kill people like everyone else

# Wiki Documentation

miming drill is gONE

# Changelog

:cl:  
rscdel: miming drill ruin is gone
/:cl:
