### PR TITLE
Adds nitrous oxide decomposition

### DIFF
--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -15,8 +15,10 @@
 #define FREON_BURN_RATE_DELTA				4
 #define FIRE_FREON_ENERGY_RELEASED			-300000 //amount of heat absorbed per mole of burnt freon in the tile
 
-#define N2O_DECOMPOSITION_MIN_ENERGY		1400
-#define N2O_DECOMPOSITION_ENERGY_RELEASED	200000
+#define N2O_DECOMPOSITION_MIN_HEAT			800+T0C	//minimum heat for n2o to decompose
+#define N2O_DECOMPOSITION_MAX_HEAT			100000	//maximum heat n2o can decompose at, completely arbitrary
+#define N2O_DECOMPOSITION_ENERGY			82050	//energy released for each mole of n2o decomposed
+#define N2O_DECOMPOSITION_RATE				0.5		//maximum percentage of n2o that can decompose in one tick
 
 #define NITRYL_DECOMPOSITION_ENERGY			30000
 #define NITRYL_FORMATION_ENERGY				100000

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -236,6 +236,34 @@ nobliumformation = 1001
 
 	return cached_results["fire"] ? REACTING : NO_REACTION
 
+/datum/gas_reaction/n2odecomp
+	priority = 0
+	name = "Nitrous Oxide Decomposition"
+	id = "n2odecomp"
+
+/datum/gas_reaction/n2odecomp/init_reqs()
+	min_requirements = list(
+		"TEMP" = N2O_DECOMPOSITION_MIN_HEAT,
+		/datum/gas/nitrous_oxide = MINIMUM_MOLE_COUNT*2
+	)
+
+/datum/gas_reaction/n2odecomp/react(datum/gas_mixture/air, datum/holder)
+	var/old_heat_capacity = air.heat_capacity()
+	var/temperature = air.return_temperature()
+	var/nitrous = air.get_moles(/datum/gas/nitrous_oxide)
+
+	var/burned_fuel = min(N2O_DECOMPOSITION_RATE*nitrous*temperature*(temperature-N2O_DECOMPOSITION_MAX_HEAT)/((-1/4)*(N2O_DECOMPOSITION_MAX_HEAT**2)), nitrous)
+	if(burned_fuel>0)
+		air.set_moles(/datum/gas/nitrous_oxide, QUANTIZE(nitrous - burned_fuel))
+		air.set_moles(/datum/gas/nitrogen, QUANTIZE(air.get_moles(/datum/gas/nitrogen) + burned_fuel))
+		air.set_moles(/datum/gas/oxygen, QUANTIZE(air.get_moles(/datum/gas/oxygen) + burned_fuel/2))
+		var/new_heat_capacity = air.heat_capacity()
+		if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)
+			air.set_temperature((temperature*old_heat_capacity + burned_fuel*N2O_DECOMPOSITION_ENERGY)/new_heat_capacity)
+		return REACTING
+
+	return NO_REACTION
+
 //fusion: a terrible idea that was fun but broken. Now reworked to be less broken and more interesting. Again (and again, and again). Again!
 //Fusion Rework Counter: Please increment this if you make a major overhaul to this system again.
 //6 reworks


### PR DESCRIPTION
# Document the changes in your pull request

Makes nitrous oxide decompose into nitrogen and oxygen in an exothermic reaction when heated above 1073 Kelvin. Reaction stops at 100,000 Kelvin. Has been tested.

# Wiki Documentation

Write about this on the guides to atmospherics and the supermatter engine.

# Changelog

:cl:  
rscadd: adds nitrous oxide decomposition
/:cl:
