### PR TITLE
Monster hunters are no longer a guaranteed spawn on all bloodsucker rounds what

### DIFF
--- a/code/modules/events/monsterhunter.dm
+++ b/code/modules/events/monsterhunter.dm
@@ -14,7 +14,7 @@
 	name = "Spawn Monster Hunter - Bloodsucker"
 	typepath = /datum/round_event/bloodsucker_hunters
 	max_occurrences = 1 // We have to see how Bloodsuckers are in game to decide if having more than 1 is beneficial.
-	weight = 7
+	weight = 20
 	min_players = 10
 	earliest_start = 35 MINUTES
 	gamemode_whitelist = list("bloodsucker","traitorsucker")

--- a/code/modules/events/monsterhunter.dm
+++ b/code/modules/events/monsterhunter.dm
@@ -14,7 +14,7 @@
 	name = "Spawn Monster Hunter - Bloodsucker"
 	typepath = /datum/round_event/bloodsucker_hunters
 	max_occurrences = 1 // We have to see how Bloodsuckers are in game to decide if having more than 1 is beneficial.
-	weight = 2000
+	weight = 0
 	min_players = 10
 	earliest_start = 35 MINUTES
 	gamemode_whitelist = list("bloodsucker","traitorsucker","dynamic")
@@ -62,7 +62,7 @@
 	weight = 7
 	min_players = 10
 	earliest_start = 25 MINUTES
-	gamemode_whitelist = list("traitorchan","changeling","heresy","cult","clockwork_cult","dynamic")
+	gamemode_whitelist = list("traitorchan","changeling","heresy","cult","clockwork_cult","dynamic","bloodsucker","traitorsucker")
 
 /datum/round_event/monster_hunters
 	fakeable = FALSE

--- a/code/modules/events/monsterhunter.dm
+++ b/code/modules/events/monsterhunter.dm
@@ -14,10 +14,10 @@
 	name = "Spawn Monster Hunter - Bloodsucker"
 	typepath = /datum/round_event/bloodsucker_hunters
 	max_occurrences = 1 // We have to see how Bloodsuckers are in game to decide if having more than 1 is beneficial.
-	weight = 0
+	weight = 7
 	min_players = 10
 	earliest_start = 35 MINUTES
-	gamemode_whitelist = list("bloodsucker","traitorsucker","dynamic")
+	gamemode_whitelist = list("bloodsucker","traitorsucker")
 
 /datum/round_event/bloodsucker_hunters
 	fakeable = FALSE
@@ -62,7 +62,7 @@
 	weight = 7
 	min_players = 10
 	earliest_start = 25 MINUTES
-	gamemode_whitelist = list("traitorchan","changeling","heresy","cult","clockwork_cult","dynamic","bloodsucker","traitorsucker")
+	gamemode_whitelist = list("traitorchan","changeling","heresy","cult","clockwork_cult","dynamic")
 
 /datum/round_event/monster_hunters
 	fakeable = FALSE


### PR DESCRIPTION
# Document the changes in your pull request

Zeroes out the weight of "Monster Hunter - Bloodsucker," an event that currently has 2000 weight so that one will spawn every bloodsucker round
Leaves in the regular monster hunter event and makes it able to trigger on bloodsucker rounds

# Why am I doing this

Look at the branch name if you're curious

anyway
You never see bloodsuckers win, right? I haven't. The closest I've seen was me, kicking off with the help of a metafriend, vassalizing a bunch of medbay, and losing by FAR because these objectives are SO DEMANDING
They never get off the ground with all of security on high alert because they need a place to hide that will remain safe (there are about five reliable lairs on all of boxstation and none of them are as simple as going for maint), and all of security is always on high alert because one of the bloodsuckers always goes loud and gives the whole game away as they get obliterated with half a laser gun magazine. And random crewmembers make stakes and camp coffins because lol why wouldn't they.

Usually they don't even survive the full shift. The only bloodsucker I've ever seen survive the full shift was me. That one time.
So...
What's the last thing a bloodsucker needs when everyone is validhunting them?
A guy who redtexts if he doesn't validhunt them and has the ability to ignore their precious stealth, mesmerize, and all other abilities, punch them through the heart repeatedly with literally "harm harm" to kill them in 10 hits with their bare fists, and shows no indication whatsoever that he is in fact an unkillable monster instead of an easy mesmerize target until he starts slugging.
"oh just immortal haste him" no I can't because he didn't turn on Flow because he doesn't need it.
And he also has a shotgun from sec because he went up and said "I'm a hunter help me"

I'm not removing monster hunters even though it sounds like it. It's just the 7-weight event now.

# Wiki Documentation

There isn't any

# Changelog

:cl:  
rscdel: Monster Hunters are no longer a guaranteed spawn on all bloodsucker rounds
/:cl: