### PR TITLE
Make hellgun single-packs come in small items crates

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -520,6 +520,7 @@
 	name = "Hellgun Single-Pack"
 	desc = "Contains one hellgun, an old pattern of laser gun infamous for its ability to horribly disfigure targets with burns. Technically violates the Space Geneva Convention when used on humanoids."
 	cost = 1500
+	small_item = TRUE
 	contains = list(/obj/item/gun/energy/laser/hellgun)
 
 /datum/supply_pack/security/armory/energy


### PR DESCRIPTION
makes hellfire laser guns single-packs come in small items crates like every other single pack

# Wiki Documentation

none needed

# Changelog

hellfire laser guns now come in small items crates

:cl:  
bugfix: hellgun single packs now come in small item packs like every other single weapon  
/:cl:
