### PR TITLE
Removes tumor boosting

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -153,7 +153,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 				activity = TUMOR_ACTIVE
 				visible_message(span_boldwarning("[src] begins to convulse.  Your instincts tell you to step back."))
 				activator = user
-				addtimer(CALLBACK(src, .proc/spawn_elite), 30)
+				addtimer(CALLBACK(src, .proc/spawn_elite), 3 SECONDS)
 
 obj/structure/elite_tumor/proc/spawn_elite()
 	var/selectedspawn = pick(potentialspawns)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -151,12 +151,11 @@ While using this makes the system rely on OnFire, it still gives options for tim
 				INVOKE_ASYNC(src, .proc/arena_checks)
 			if(TUMOR_INACTIVE)
 				activity = TUMOR_ACTIVE
-				var/mob/dead/observer/elitemind = null
 				visible_message(span_boldwarning("[src] begins to convulse.  Your instincts tell you to step back."))
 				activator = user
 				addtimer(CALLBACK(src, .proc/spawn_elite), 30)
 
-obj/structure/elite_tumor/proc/spawn_elite(var/mob/dead/observer/elitemind)
+obj/structure/elite_tumor/proc/spawn_elite()
 	var/selectedspawn = pick(potentialspawns)
 	mychild = new selectedspawn(loc)
 	visible_message(span_boldwarning("[mychild] emerges from [src]!"))
@@ -235,7 +234,7 @@ obj/structure/elite_tumor/proc/onEliteLoss()
 	playsound(loc,'sound/effects/tendril_destroyed.ogg', 200, 0, 50, TRUE, TRUE)
 	visible_message(span_boldwarning("[src] begins to convulse violently before beginning to dissipate."))
 	visible_message(span_boldwarning("As [src] closes, something is forced up from down below."))
-	var/obj/structure/closet/crate/necropolis/tendril/lootbox = new /obj/structure/closet/crate/necropolis/tendril(loc)
+	new /obj/structure/closet/crate/necropolis/tendril(loc)
 	/*if(mychild.loot_drop) //holding this to check if the herald's loot needs to be nerfed/reworked
 		new mychild.loot_drop(lootbox)*/
 	mychild = null

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -123,7 +123,6 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	armor = list(MELEE = 100, BULLET = 100, LASER = 100, ENERGY = 100, BOMB = 100, BIO = 100, RAD = 100, FIRE = 100, ACID = 100)
 	resistance_flags = INDESTRUCTIBLE
 	var/activity = TUMOR_INACTIVE
-	var/boosted = FALSE
 	var/times_won = 0
 	var/mob/living/carbon/human/activator = null
 	var/mob/living/simple_animal/hostile/asteroid/elite/mychild = null
@@ -148,9 +147,6 @@ While using this makes the system rely on OnFire, it still gives options for tim
 				activity = TUMOR_ACTIVE
 				visible_message(span_boldwarning("[src] convulses as your arm enters its radius.  Your instincts tell you to step back."))
 				activator = user
-				if(boosted)
-					mychild.playsound_local(get_turf(mychild), 'sound/effects/magic.ogg', 40, 0)
-					to_chat(mychild, "<b>Someone has activated your tumor.  You will be returned to fight shortly, get ready!</b>")
 				addtimer(CALLBACK(src, .proc/return_elite), 30)
 				INVOKE_ASYNC(src, .proc/arena_checks)
 			if(TUMOR_INACTIVE)
@@ -158,31 +154,13 @@ While using this makes the system rely on OnFire, it still gives options for tim
 				var/mob/dead/observer/elitemind = null
 				visible_message(span_boldwarning("[src] begins to convulse.  Your instincts tell you to step back."))
 				activator = user
-				if(!boosted)
-					addtimer(CALLBACK(src, .proc/spawn_elite), 30)
-					return
-				visible_message(span_boldwarning("Something within [src] stirs..."))
-				var/list/candidates = pollCandidatesForMob("Do you want to play as a lavaland elite?", ROLE_SENTIENCE, null, ROLE_SENTIENCE, 50, src, POLL_IGNORE_SENTIENCE_POTION)
-				if(candidates.len)
-					audible_message(span_boldwarning("The stirring sounds increase in volume!"))
-					elitemind = pick(candidates)
-					elitemind.playsound_local(get_turf(elitemind), 'sound/effects/magic.ogg', 40, 0)
-					to_chat(elitemind, "<b>You have been chosen to play as a Lavaland Elite.\nIn a few seconds, you will be summoned on Lavaland as a monster to fight your activator, in a fight to the death.\nYour attacks can be switched using the buttons on the top left of the HUD, and used by clicking on targets or tiles similar to a gun.\nWhile the opponent might have an upper hand with  powerful mining equipment and tools, you have great power normally limited by AI mobs.\nIf you want to win, you'll have to use your powers in creative ways to ensure the kill.  It's suggested you try using them all as soon as possible.\nShould you win, you'll receive extra information regarding what to do after.  Good luck!</b>")
-					addtimer(CALLBACK(src, .proc/spawn_elite, elitemind), 100)
-				else
-					visible_message(span_boldwarning("The stirring stops, and nothing emerges.  Perhaps try again later."))
-					activity = TUMOR_INACTIVE
-					activator = null
-
+				addtimer(CALLBACK(src, .proc/spawn_elite), 30)
 
 obj/structure/elite_tumor/proc/spawn_elite(var/mob/dead/observer/elitemind)
 	var/selectedspawn = pick(potentialspawns)
 	mychild = new selectedspawn(loc)
 	visible_message(span_boldwarning("[mychild] emerges from [src]!"))
 	playsound(loc,'sound/effects/phasein.ogg', 200, 0, 50, TRUE, TRUE)
-	if(boosted)
-		mychild.key = elitemind.key
-		mychild.sentience_act()
 	icon_state = "tumor_popped"
 	INVOKE_ASYNC(src, .proc/arena_checks)
 
@@ -191,9 +169,6 @@ obj/structure/elite_tumor/proc/return_elite()
 	visible_message(span_boldwarning("[mychild] emerges from [src]!"))
 	playsound(loc,'sound/effects/phasein.ogg', 200, 0, 50, TRUE, TRUE)
 	mychild.revive(full_heal = TRUE, admin_revive = TRUE)
-	if(boosted)
-		mychild.maxHealth = mychild.maxHealth * 2
-		mychild.health = mychild.maxHealth
 
 /obj/structure/elite_tumor/Initialize(mapload)
 	. = ..()
@@ -220,20 +195,6 @@ obj/structure/elite_tumor/proc/return_elite()
 				mychild.adjustHealth(-mychild.maxHealth*0.05)
 				var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal(get_turf(mychild))
 				H.color = "#FF0000"
-
-/obj/structure/elite_tumor/attackby(obj/item/I, mob/user, params)
-	. = ..()
-	if(istype(I, /obj/item/organ/regenerative_core) && activity == TUMOR_INACTIVE && !boosted)
-		var/obj/item/organ/regenerative_core/core = I
-		if(!core.preserved)
-			return
-		visible_message(span_boldwarning("As [user] drops the core into [src], [src] appears to swell."))
-		icon_state = "advanced_tumor"
-		boosted = TRUE
-		light_range = 6
-		desc = "[desc]  This one seems to glow with a strong intensity."
-		qdel(core)
-		return TRUE
 
 /obj/structure/elite_tumor/proc/arena_checks()
 	if(activity != TUMOR_ACTIVE || QDELETED(src))
@@ -275,16 +236,8 @@ obj/structure/elite_tumor/proc/onEliteLoss()
 	visible_message(span_boldwarning("[src] begins to convulse violently before beginning to dissipate."))
 	visible_message(span_boldwarning("As [src] closes, something is forced up from down below."))
 	var/obj/structure/closet/crate/necropolis/tendril/lootbox = new /obj/structure/closet/crate/necropolis/tendril(loc)
-	if(!boosted)
-		mychild = null
-		activator = null
-		qdel(src)
-		return
-	var/lootpick = rand(1, 2)
-	if(lootpick == 1 && mychild.loot_drop != null)
-		new mychild.loot_drop(lootbox)
-	else
-		new /obj/item/tumor_shard(lootbox)
+	/*if(mychild.loot_drop) //holding this to check if the herald's loot needs to be nerfed/reworked
+		new mychild.loot_drop(lootbox)*/
 	mychild = null
 	activator = null
 	qdel(src)
@@ -293,15 +246,6 @@ obj/structure/elite_tumor/proc/onEliteWon()
 	activity = TUMOR_PASSIVE
 	activator = null
 	mychild.revive(full_heal = TRUE, admin_revive = TRUE)
-	if(boosted)
-		times_won++
-		mychild.maxHealth = mychild.maxHealth * 0.5
-		mychild.health = mychild.maxHealth
-	if(times_won == 1)
-		mychild.playsound_local(get_turf(mychild), 'sound/effects/magic.ogg', 40, 0)
-		to_chat(mychild, span_boldwarning("As the life in the activator's eyes fade, the forcefield around you dies out and you feel your power subside.\nDespite this inferno being your home, you feel as if you aren't welcome here anymore.\nWithout any guidance, your purpose is now for you to decide."))
-		to_chat(mychild, "<b>Your max health has been halved, but can now heal by standing on your tumor.  Note, it's your only way to heal.\nBear in mind, if anyone interacts with your tumor, you'll be resummoned here to carry out another fight.  In such a case, you will regain your full max health.\nAlso, be weary of your fellow inhabitants, they likely won't be happy to see you!</b>")
-		to_chat(mychild, "<span class='big bold'>Note that you are a lavaland monster, and thus not allied to the station.  You should not cooperate or act friendly with any station crew unless under extreme circumstances!</span>")
 
 /obj/item/tumor_shard
 	name = "tumor shard"


### PR DESCRIPTION
# Document the changes in your pull request

When boosting a tumor 1 of 3 things happens
1: you die like a moron and let a sentient mob get to kill anyone it comes across
2: you kill a sentient mob and get to revive it as an ally which doesn't really do much, has faction checks on its abilities (usually) and generally can't talk
3: you kill a sentient mob and get flavor loot that is generally garbage

Also some of these bosses (pandora) are excessively capable of mass murder due to their abilities and aren't particularly built to be player controlled

# Wiki Documentation

lavaland tumors can no longer create sentient bosses

# Changelog


:cl:  
rscdel: you can no longer boost lavaland tumors to make their boss spawn sentient
/:cl:
