### PR TITLE
Prevents #41133 happening again

### DIFF
--- a/strings/abductee_objectives.txt
+++ b/strings/abductee_objectives.txt
@@ -32,7 +32,6 @@ Flood the station's powernet with as much electricity as you can.
 Replace all the floor tiles with wood, carpeting, grass or bling.
 You must escape the station! Get the shuttle called!
 Don't allow anyone to be cloned.
-The oxygen is killing them all and they don't even know it. Make sure no oxygen is on the station.
 Your body must be improved. Ingest as many drugs as you can.
 You are hungry. Eat as much food as you can find.
 You see you see what they cannot you see the open door you seeE you SEeEe you SEe yOU seEee SHOW THEM ALL


### PR DESCRIPTION
Way too strong of an objective to give via abductors, especially if you have access to the AI and give it oxygen is toxic...

:cl:  
rscdel: Removes Oxygen is bad from abductors objectives
/:cl:
