### PR TITLE
People without +BAN are notified if there are unclaimed tickets, but are not notified for each

### DIFF
--- a/yogstation/code/modules/admin/verbs/adminhelp.dm
+++ b/yogstation/code/modules/admin/verbs/adminhelp.dm
@@ -239,7 +239,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 					confidential = TRUE)
 			else
 				if(world.time > last_unclaimed_notification)
-					last_unlcaimed_notification = world.time + 1 SECONDS
+					last_unclaimed_notification = world.time + 1 SECONDS
 					msg = "<span class=\"prefix\">ADMIN LOG:</span> <span class=\"message linkify\"><font color='blue'>Unclaimed Tickets!</font></span>"
 					to_chat(X,
 						type = MESSAGE_TYPE_ADMINLOG,

--- a/yogstation/code/modules/admin/verbs/adminhelp.dm
+++ b/yogstation/code/modules/admin/verbs/adminhelp.dm
@@ -134,6 +134,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	var/list/_interactions	//use AddInteraction() or, preferably, admin_ticket_log()
 	var/static/ticket_counter = 0
 	var/static/last_bwoinking = 0
+	var/static/last_unclaimed_notification = 0
 
 //call this on its own to create a ticket, don't manually assign current_ticket
 //msg is the title of the ticket: usually the ahelp text
@@ -229,7 +230,26 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 /datum/admin_help/proc/check_owner() // Handles unclaimed tickets; returns TRUE if no longer unclaimed
 	if(!handling_admin && state == AHELP_ACTIVE)
-		message_admins("<font color='blue'>Ticket [TicketHref("#[id]")] Unclaimed!</font>")
+		var/msg = span_admin("<span class=\"prefix\">ADMIN LOG:</span> <span class=\"message linkify\"><font color='blue'>Ticket [TicketHref("#[id]")] Unclaimed!</font></span>")
+		to_chat(GLOB.admins,
+			type = MESSAGE_TYPE_ADMINLOG,
+			html = msg,
+			confidential = TRUE)
+		for(var/client/X in GLOB.admins)
+			if(check_rights_for(X,R_BAN))
+				to_chat(X,
+					type = MESSAGE_TYPE_ADMINLOG,
+					html = msg,
+					confidential = TRUE)
+			else
+				if(world.time > last_unclaimed_notification)
+					last_unlcaimed_notification = world.time + 1 SECONDS
+					msg = <span class=\"prefix\">ADMIN LOG:</span> <span class=\"message linkify\"><font color='blue'>Unclaimed Tickets!</font></span>
+					to_chat(X,
+						type = MESSAGE_TYPE_ADMINLOG,
+						html = msg,
+						confidential = TRUE)
+				
 		if(world.time > last_bwoinking)
 			last_bwoinking = world.time + 1 SECONDS
 			for(var/client/X in GLOB.admins)

--- a/yogstation/code/modules/admin/verbs/adminhelp.dm
+++ b/yogstation/code/modules/admin/verbs/adminhelp.dm
@@ -231,10 +231,6 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 /datum/admin_help/proc/check_owner() // Handles unclaimed tickets; returns TRUE if no longer unclaimed
 	if(!handling_admin && state == AHELP_ACTIVE)
 		var/msg = span_admin("<span class=\"prefix\">ADMIN LOG:</span> <span class=\"message linkify\"><font color='blue'>Ticket [TicketHref("#[id]")] Unclaimed!</font></span>")
-		to_chat(GLOB.admins,
-			type = MESSAGE_TYPE_ADMINLOG,
-			html = msg,
-			confidential = TRUE)
 		for(var/client/X in GLOB.admins)
 			if(check_rights_for(X,R_BAN))
 				to_chat(X,

--- a/yogstation/code/modules/admin/verbs/adminhelp.dm
+++ b/yogstation/code/modules/admin/verbs/adminhelp.dm
@@ -244,7 +244,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			else
 				if(world.time > last_unclaimed_notification)
 					last_unlcaimed_notification = world.time + 1 SECONDS
-					msg = <span class=\"prefix\">ADMIN LOG:</span> <span class=\"message linkify\"><font color='blue'>Unclaimed Tickets!</font></span>
+					msg = “<span class=\"prefix\">ADMIN LOG:</span> <span class=\"message linkify\"><font color='blue'>Unclaimed Tickets!</font></span>“
 					to_chat(X,
 						type = MESSAGE_TYPE_ADMINLOG,
 						html = msg,

--- a/yogstation/code/modules/admin/verbs/adminhelp.dm
+++ b/yogstation/code/modules/admin/verbs/adminhelp.dm
@@ -244,7 +244,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			else
 				if(world.time > last_unclaimed_notification)
 					last_unlcaimed_notification = world.time + 1 SECONDS
-					msg = “<span class=\"prefix\">ADMIN LOG:</span> <span class=\"message linkify\"><font color='blue'>Unclaimed Tickets!</font></span>“
+					msg = "<span class=\"prefix\">ADMIN LOG:</span> <span class=\"message linkify\"><font color='blue'>Unclaimed Tickets!</font></span>"
 					to_chat(X,
 						type = MESSAGE_TYPE_ADMINLOG,
 						html = msg,


### PR DESCRIPTION
# Document the changes in your pull request

Replaces this
![image](https://user-images.githubusercontent.com/5618080/170312225-4c1da493-df2d-4c6b-a38e-4b5d19e6d95c.png)
with a singular message if you don't have +BAN

# Wiki Documentation

# Changelog

:cl:  
tweak: People without +BAN only see a singular unclaimed ticket notification
/:cl:
