### PR TITLE
kills random goat king plushies 

### DIFF
--- a/code/game/objects/items/gift.dm
+++ b/code/game/objects/items/gift.dm
@@ -87,7 +87,7 @@ GLOBAL_LIST_EMPTY(possible_gifts)
 		/obj/item/stack/sheet/mineral/coal)
 
 	gift_type_list += subtypesof(/obj/item/clothing/head/collectable)
-	gift_type_list += subtypesof(/obj/item/toy) - (((typesof(/obj/item/toy/cards) - /obj/item/toy/cards/deck) + /obj/item/toy/figure + /obj/item/toy/ammo)) //All toys, except for abstract types and syndicate cards.
+	gift_type_list += subtypesof(/obj/item/toy) - (((typesof(/obj/item/toy/cards) - /obj/item/toy/cards/deck) + /obj/item/toy/figure + /obj/item/toy/ammo + typesof(/obj/item/toy/plush/goatplushie/angry/kinggoat))) //All toys, except for abstract types and syndicate cards and the stupid fuckign goat.
 
 	var/gift_type = pick(gift_type_list)
 

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2377,7 +2377,7 @@
 		if(prob(50))
 			the_toy = pickweight(GLOB.arcade_prize_pool)
 		else
-			the_toy = pick(subtypesof(/obj/item/toy/plush))
+			the_toy = pick(subtypesof(/obj/item/toy/plush) - typesof(/obj/item/toy/plush/goatplushie/angry/kinggoat))
 			if(istype(the_toy, /obj/item/toy/plush/lizard/azeel/snowflake))
 				the_toy = /obj/item/toy/plush/lizard/azeel
 		new the_toy(.)


### PR DESCRIPTION
# Document the changes in your pull request

goat king plushes should no longer spawn in random drops

# Changelog

:cl:  
rscdel: king goat plushes no longer randomly show up in lootboxes
/:cl:
