### PR TITLE
Teleporting onto the CC level is always 100% accurate

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -187,6 +187,8 @@
 		return F
 
 /proc/get_teleport_turfs(turf/center, precision = 0)
+	if(is_centcom_level(center))
+		precision = 0
 	if(!precision)
 		return list(center)
 	var/list/posturfs = list()


### PR DESCRIPTION
# Document the changes in your pull request

smh goredem

# Wiki Documentation

# Changelog


:cl:  
bugfix: You are now 100% accurate when teleporting onto the CC level
/:cl:
