### PR TITLE
fixes doodoo tzimisce code, makes it so only 2 midround bloodsuckers can spawn, and makes non-bloodsucker round tzimisce need 25 players

### DIFF
--- a/code/modules/events/tzimisce.dm
+++ b/code/modules/events/tzimisce.dm
@@ -3,9 +3,10 @@
 	max_occurrences = 1
 	weight = 5
 	typepath = /datum/round_event/ghost_role/tzimisce/bloodsucker
+	max_occurrences = 2
 	min_players = 25
 	earliest_start = 30 MINUTES
-	gamemode_whitelist = list("bloodsucker","traitorsucker","dynamic")
+	gamemode_whitelist = list("bloodsucker","traitorsucker")
 
 /datum/round_event/ghost_role/tzimisce/bloodsucker
 	fakeable = FALSE
@@ -25,7 +26,7 @@
 	name = "Spawn Tzimisce"
 	typepath = /datum/round_event/ghost_role/tzimisce
 	max_occurrences = 1
-	min_players = 15
+	min_players = 25
 	earliest_start = 45 MINUTES
 
 /datum/round_event/ghost_role/tzimisce
@@ -80,7 +81,7 @@
 	return SUCCESSFUL_SPAWN
 
 
-/proc/spawn_event_tzimisce()
+/datum/round_event/ghost_role/tzimisce/proc/spawn_event_tzimisce()
 	var/mob/living/carbon/human/new_tzimisce = new()
 	SSjob.SendToLateJoin(new_tzimisce)
 	var/datum/preferences/A = new() //Randomize appearance.
@@ -88,7 +89,7 @@
 	new_tzimisce.dna.update_dna_identity()
 	return new_tzimisce
 
-/proc/create_tzimisce_mind(key)
+/datum/round_event/ghost_role/tzimisce/proc/create_tzimisce_mind(key)
 	var/datum/mind/Mind = new /datum/mind(key)
 	Mind.special_role = ROLE_BLOODSUCKER
 	return Mind


### PR DESCRIPTION
# Document the changes in your pull request

- having a round antag spawn on a non-dynamic non-bloodsucker round is weird, especially 15 player lowpop (Bad wizard has 20 minimum)
- Having 3 morbillion bloodsuckers being added because there's no cap (get lucky) is weird
- also tatax made some global procs so i fixed those
- oh also he whitelisted dynamic but we dont do dynamic antag spawning through these

# Changelog

:cl:  
tweak: make Spawn Tzimisce - Bloodsucker occur only twice per round (down from infinite)
tweak: make Spawn Tzimisce require 25 minimum pop (up from 15)
/:cl:
