### PR TITLE
saves yogstation from tape logging

### DIFF
--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -44,7 +44,6 @@
 		return
 	var/list/item_contents = I.GetAllContents()
 	for(var/obj/item/C in item_contents)
-		world.log << C.type
 		if(is_type_in_typecache(C,tape_blacklist))
 			to_chat(user, span_warning("The [src] doesn't seem to stick to [I]!"))
 			return


### PR DESCRIPTION
this shouldn't be here

![image](https://user-images.githubusercontent.com/71668564/170592354-c8c2ccd3-fe42-49ab-9fb0-5ae0c19da553.png)

:cl:  
bugfix: taped items no longer send themselves and contents to world.log
/:cl:
