### PR TITLE
autorifles can be dual wielded again

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -96,7 +96,6 @@
 	mag_display = TRUE
 	mag_display_ammo = TRUE
 	empty_indicator = TRUE
-	weapon_weight = WEAPON_MEDIUM
 
 /obj/item/gun/ballistic/automatic/wt550/occupying
 	name = "surplus security auto rifle"


### PR DESCRIPTION
autorifles can be dual wielded again because when they were changed to be incapable of akimbo they had two round burst and were therefore capable of 80 damage bursts. right now they're basically just reloadable laserguns that fire slower anyways and those can be dual wielded

# Wiki Documentation
none i think, maybe combat page
# Changelog

:cl:  
tweak: autorifles can be dual-wielded again
/:cl:
