### PR TITLE
TRADERS: NPC ships who dock with the station and offer you discounted items/crates and quests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+e
 ## Yogstation codebase
 
 [![Build Status](https://github.com/yogstation13/Yogstation/workflows/Turdis/badge.svg?branch=master)](https://github.com/yogstation13/Yogstation/actions?query=workflow%3ATurdis+branch%3Amaster)


### PR DESCRIPTION
# Document the changes in your pull request

Different types of flavorful ships:
NT Loyalists, Secretive """Traders""" (syndicates), Free Miners (not the actual free miner ruin though), Lizard ship, slaver ship (you get to beat these guys up)
Depending on the flavor of ship they'll offer you different crates at discounts, and special items you normally can't get through cargo. TBD

If we do quests they can either be fetch-me-this-item quests or clear-this-part-of-our-ship quests, or maybe they even take you to a mini awaymission, who knows!

Persistent reputation system based on the last 10-20 rounds change which ships attempt to dock.

# Wiki Documentation


# Changelog

:cl:  
rscadd: NPC ships may request docking permissions to the station
rscadd: Aboard NPC ships you'll be able to purchase discounted crates and rare items
rscadd: Some ships may have quests available
/:cl:
