### PR TITLE
Ports TG's eye contact: social anxiety harder, get caught staring at your obsession target, and new quirk Shifty Eyes

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -199,10 +199,8 @@
 #define COMSIG_MOB_THROW "mob_throw"							//from base of /mob/throw_item(): (atom/target)
 #define COMSIG_MOB_TABLING "mob_tabling"						//form base of /obj/structure/table_place() and table_push(): (mob/living/user, mob/living/pushed_mob)
 #define COMSIG_MOB_EXAMINATE "mob_examinate"					//from base of /mob/verb/examinate(): (atom/target)
-///from /mob/living/handle_eye_contact(): (mob/living/other_mob)
-#define COMSIG_MOB_EYECONTACT "mob_eyecontact"
-	/// return this if you want to block printing this message to this person, if you want to print your own (does not affect the other person's message)
-	#define COMSIG_BLOCK_EYECONTACT (1<<0)
+#define COMSIG_MOB_EYECONTACT "mob_eyecontact"					///from /mob/living/handle_eye_contact(): (mob/living/other_mob)
+#define COMSIG_BLOCK_EYECONTACT (1<<0)							/// return this if you want to block printing this message to this person, if you want to print your own (does not affect the other person's message)
 #define COMSIG_MOB_UPDATE_SIGHT "mob_update_sight"				//from base of /mob/update_sight(): ()
 #define COMSIG_MOB_SAY "mob_say" // from /mob/living/say(): ()
 #define COMPONENT_UPPERCASE_SPEECH 1

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -199,6 +199,10 @@
 #define COMSIG_MOB_THROW "mob_throw"							//from base of /mob/throw_item(): (atom/target)
 #define COMSIG_MOB_TABLING "mob_tabling"						//form base of /obj/structure/table_place() and table_push(): (mob/living/user, mob/living/pushed_mob)
 #define COMSIG_MOB_EXAMINATE "mob_examinate"					//from base of /mob/verb/examinate(): (atom/target)
+///from /mob/living/handle_eye_contact(): (mob/living/other_mob)
+#define COMSIG_MOB_EYECONTACT "mob_eyecontact"
+	/// return this if you want to block printing this message to this person, if you want to print your own (does not affect the other person's message)
+	#define COMSIG_BLOCK_EYECONTACT (1<<0)
 #define COMSIG_MOB_UPDATE_SIGHT "mob_update_sight"				//from base of /mob/update_sight(): ()
 #define COMSIG_MOB_SAY "mob_say" // from /mob/living/say(): ()
 #define COMPONENT_UPPERCASE_SPEECH 1

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -338,8 +338,23 @@
 #define WABBAJACK     (1<<6)
 
 #define SLEEP_CHECK_DEATH(X) sleep(X); if(QDELETED(src) || stat == DEAD) return;
+
+// recent examine defines
+/// How long it takes for an examined atom to be removed from recent_examines. Should be the max of the below time windows
+#define RECENT_EXAMINE_MAX_WINDOW 2 SECONDS
 /// If you examine the same atom twice in this timeframe, we call examine_more() instead of examine()
-#define EXAMINE_MORE_TIME	1 SECONDS
+#define EXAMINE_MORE_WINDOW 1 SECONDS
+/// If you examine another mob who's successfully examined you during this duration of time, you two try to make eye contact. Cute!
+#define EYE_CONTACT_WINDOW 2 SECONDS
+/// If you yawn while someone nearby has examined you within this time frame, it will force them to yawn as well. Tradecraft!
+#define YAWN_PROPAGATION_EXAMINE_WINDOW 2 SECONDS
+
+/// How far away you can be to make eye contact with someone while examining
+#define EYE_CONTACT_RANGE 5
+
+//this should be in the ai defines, but out ai defines are actual ai, not simplemob ai
+#define IS_DEAD_OR_INCAP(source) (source.incapacitated() || source.stat)
+
 #define INTERACTING_WITH(X, Y) (Y in X.do_afters)
 
 

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -257,6 +257,8 @@
 #define TRAIT_EAT_LESS			"eat_less"
 #define TRAIT_CRAFTY			"crafty"
 #define TRAIT_ANOREXIC			"anorexic"
+#define TRAIT_SHIFTY_EYES		"shifty_eyes"
+#define TRAIT_ANXIOUS			"anxious"
 
 // common trait sources
 #define TRAIT_GENERIC "generic"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -440,23 +440,104 @@
 	lose_text = span_notice("You feel easier about talking again.") //if only it were that easy!
 	medical_record_text = "Patient is usually anxious in social encounters and prefers to avoid them."
 	var/dumb_thing = TRUE
+	mob_trait = TRAIT_ANXIOUS
 
-/datum/quirk/social_anxiety/on_process()
+/datum/quirk/social_anxiety/add()
+	RegisterSignal(quirk_holder, COMSIG_MOB_EYECONTACT, .proc/eye_contact)
+	RegisterSignal(quirk_holder, COMSIG_MOB_EXAMINATE, .proc/looks_at_floor)
+	RegisterSignal(quirk_holder, COMSIG_MOB_SAY, .proc/handle_speech)
+
+/datum/quirk/social_anxiety/remove()
+	UnregisterSignal(quirk_holder, list(COMSIG_MOB_EYECONTACT, COMSIG_MOB_EXAMINATE, COMSIG_MOB_SAY))
+
+/datum/quirk/social_anxiety/proc/handle_speech(datum/source, list/speech_args)
+	if(HAS_TRAIT(quirk_holder, TRAIT_FEARLESS))
+		return
+
+	var/datum/component/mood/mood = quirk_holder.GetComponent(/datum/component/mood)
+	var/moodmod
+	if(mood)
+		moodmod = (1+0.02*(50-(max(50, mood.mood_level*(7-mood.sanity_level))))) //low sanity levels are better, they max at 6
+	else
+		moodmod = (1+0.02*(50-(max(50, 0.1*quirk_holder.nutrition))))
 	var/nearby_people = 0
 	for(var/mob/living/carbon/human/H in oview(3, quirk_holder))
 		if(H.client)
 			nearby_people++
-	var/mob/living/carbon/human/H = quirk_holder
-	if(prob(2 + nearby_people))
-		H.stuttering = max(3, H.stuttering)
-	else if(prob(min(3, nearby_people)) && !H.silent)
-		to_chat(H, span_danger("You retreat into yourself. You <i>really</i> don't feel up to talking."))
-		H.silent = max(10, H.silent)
-	else if(prob(0.5) && dumb_thing)
-		to_chat(H, span_userdanger("You think of a dumb thing you said a long time ago and scream internally."))
-		dumb_thing = FALSE //only once per life
-		if(prob(1))
-			new/obj/item/reagent_containers/food/snacks/spaghetti/pastatomato(get_turf(H)) //now that's what I call spaghetti code
+	var/message = speech_args[SPEECH_MESSAGE]
+	if(message)
+		var/list/message_split = splittext(message, " ")
+		var/list/new_message = list()
+		var/mob/living/carbon/human/quirker = quirk_holder
+		for(var/word in message_split)
+			if(prob(max(5,(nearby_people*12.5*moodmod))) && word != message_split[1]) //Minimum 1/20 chance of filler
+				new_message += pick("uh,","erm,","um,")
+				if(prob(min(5,(0.05*(nearby_people*12.5)*moodmod)))) //Max 1 in 20 chance of cutoff after a succesful filler roll, for 50% odds in a 15 word sentence
+					quirker.silent = max(3, quirker.silent)
+					to_chat(quirker, span_danger("You feel self-conscious and stop talking. You need a moment to recover!"))
+					break
+			if(prob(max(5,(nearby_people*12.5*moodmod)))) //Minimum 1/20 chance of stutter
+				// Add a short stutter, THEN treat our word
+				quirker.stuttering += max(3, quirker.stuttering)
+				new_message += quirker.treat_message(word)
+
+			else
+				new_message += word
+
+		message = jointext(new_message, " ")
+	var/mob/living/carbon/human/quirker = quirk_holder
+	if(prob(min(50,(0.50*(nearby_people*12.5)*moodmod)))) //Max 50% chance of not talking
+		if(dumb_thing)
+			to_chat(quirker, span_userdanger("You think of a dumb thing you said a long time ago and scream internally."))
+			dumb_thing = FALSE //only once per life
+			if(prob(1))
+				new/obj/item/reagent_containers/food/snacks/spaghetti/pastatomato(get_turf(quirker)) //now that's what I call spaghetti code
+		else
+			to_chat(quirk_holder, span_warning("You think that wouldn't add much to the conversation and decide not to say it."))
+			if(prob(min(25,(0.25*(nearby_people*12.75)*moodmod)))) //Max 25% chance of silence stacks after succesful not talking roll
+				to_chat(quirker, span_danger("You retreat into yourself. You <i>really</i> don't feel up to talking."))
+				quirker.silent = max(5, quirker.silent)
+		speech_args[SPEECH_MESSAGE] = pick("Uh.","Erm.","Um.")
+	else
+		speech_args[SPEECH_MESSAGE] = message
+
+// small chance to make eye contact with inanimate objects/mindless mobs because of nerves
+/datum/quirk/social_anxiety/proc/looks_at_floor(datum/source, atom/A)
+	var/mob/living/mind_check = A
+	if(prob(85) || (istype(mind_check) && mind_check.mind))
+		return
+
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat, quirk_holder, span_smallnotice("You make eye contact with [A].")), 3)
+
+/datum/quirk/social_anxiety/proc/eye_contact(datum/source, mob/living/other_mob, triggering_examiner)
+	var/mob/living/carbon/human/quirker = quirk_holder
+	if(prob(75))
+		return
+	var/msg
+	if(triggering_examiner)
+		msg = "You make eye contact with [other_mob], "
+	else
+		msg = "[other_mob] makes eye contact with you, "
+
+	switch(rand(1,3))
+		if(1)
+			quirker.Jitter(5)
+			msg += "causing you to start fidgeting!"
+		if(2)
+			quirker.stuttering = max(3, quirker.stuttering)
+			msg += "causing you to start stuttering!"
+		if(3)
+			quirker.Stun(2 SECONDS)
+			msg += "causing you to freeze up!"
+
+	SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "anxiety_eyecontact", /datum/mood_event/anxiety_eyecontact)
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat, quirk_holder, span_userdanger("[msg]")), 3) // so the examine signal has time to fire and this will print after
+	return COMSIG_BLOCK_EYECONTACT
+
+/datum/mood_event/anxiety_eyecontact
+	description = "Sometimes eye contact makes me so nervous..."
+	mood_change = -5
+	timeout = 3 MINUTES
 
 //If you want to make some kind of junkie variant, just extend this quirk.
 /datum/quirk/junkie

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -102,6 +102,13 @@
 	if(quirk_holder)
 		quirk_holder.remove_client_colour(/datum/client_colour/monochrome)
 
+/datum/quirk/shifty_eyes
+	name = "Shifty Eyes"
+	desc = "Your eyes tend to wander all over the place, whether you mean to or not, causing people to sometimes think you're looking directly at them when you aren't."
+	value = 0
+	medical_record_text = "Fucking creep kept staring at me the whole damn checkup. I'm only diagnosing this because it's less awkward than thinking it was on purpose."
+	mob_trait = TRAIT_SHIFTY_EYES
+
 /datum/quirk/random_accent
 	name = "Randomized Accent"
 	desc = "You have developed a random accent."

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -498,7 +498,7 @@
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user, .)
 
 /**
-  * Called when a mob examines (shift click or verb) this atom twice (or more) within EXAMINE_MORE_TIME (default 1.5 seconds)
+  * Called when a mob examines (shift click or verb) this atom twice (or more) within EXAMINE_MORE_WINDOW (default 1.5 seconds)
   *
   * This is where you can put extra information on something that may be superfluous or not important in critical gameplay
   * moments, while allowing people to manually double-examine to take a closer look

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -129,7 +129,7 @@
 
 	var/datum/viewData/view_size
 
-///A lazy list of atoms we've examined in the last EXAMINE_MORE_TIME (default 1.5) seconds, so that we will call [atom/proc/examine_more()] instead of [atom/proc/examine()] on them when examining
+	///A lazy list of atoms we've examined in the last RECENT_EXAMINE_MAX_WINDOW (default 2) seconds, so that we will call [atom/proc/examine_more()] instead of [atom/proc/examine()] on them when examining
 	var/list/recent_examines
 
 	/// our current tab

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1236,6 +1236,9 @@
 		scaries.fake = TRUE
 		QDEL_NULL(phantom_wound)
 
+/mob/living/carbon/is_face_visible()
+	return !(wear_mask?.flags_inv & HIDEFACE) && !(head?.flags_inv & HIDEFACE)
+
 /**
   * get_biological_state is a helper used to see what kind of wounds we roll for. By default we just assume carbons (read:monkeys) are flesh and bone, but humans rely on their species datums
   *

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1456,3 +1456,6 @@
             return TRUE
     return FALSE
 
+/// Only defined for carbons who can wear masks and helmets, we just assume other mobs have visible faces
+/mob/living/proc/is_face_visible()
+	return TRUE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -447,9 +447,10 @@
 				var/extra_info = A.examine_more(src)
 				result = extra_info
 			if(!result)
-				client.recent_examines[A] = world.time + EXAMINE_MORE_TIME
+				client.recent_examines[A] = world.time + EXAMINE_MORE_WINDOW
 				result = A.examine(src)
-				addtimer(CALLBACK(src, .proc/clear_from_recent_examines, A), EXAMINE_MORE_TIME)		
+				addtimer(CALLBACK(src, .proc/clear_from_recent_examines, A), RECENT_EXAMINE_MAX_WINDOW)
+				handle_eye_contact(A)		
 	else
 		result = A.examine(src) // if a tree is examined but no client is there to see it, did the tree ever really exist?
 
@@ -509,6 +510,40 @@
 	a_intent = previous_intent
 
 	return TRUE
+
+/**
+ * handle_eye_contact() is called when we examine() something. If we examine an alive mob with a mind who has examined us in the last 2 seconds within 5 tiles, we make eye contact!
+ *
+ * Note that if either party has their face obscured, the other won't get the notice about the eye contact
+ * Also note that examine_more() doesn't proc this or extend the timer, just because it's simpler this way and doesn't lose much.
+ * The nice part about relying on examining is that we don't bother checking visibility, because we already know they were both visible to each other within the last second, and the one who triggers it is currently seeing them
+ */
+/mob/proc/handle_eye_contact(mob/living/examined_mob)
+	return
+
+/mob/living/handle_eye_contact(mob/living/examined_mob)
+	if(!istype(examined_mob) || src == examined_mob || examined_mob.stat >= UNCONSCIOUS || !client)
+		return
+
+	var/imagined_eye_contact = FALSE
+	if(!LAZYACCESS(examined_mob.client?.recent_examines, src))
+		// even if you haven't looked at them recently, if you have the shift eyes trait, they may still imagine the eye contact
+		if(HAS_TRAIT(examined_mob, TRAIT_SHIFTY_EYES) && prob(10 - get_dist(src, examined_mob)))
+			imagined_eye_contact = TRUE
+		else
+			return
+
+	if(get_dist(src, examined_mob) > EYE_CONTACT_RANGE)
+		return
+
+	// check to see if their face is blocked or, if not, a signal blocks it
+	if(examined_mob.is_face_visible() && SEND_SIGNAL(src, COMSIG_MOB_EYECONTACT, examined_mob, TRUE) != COMSIG_BLOCK_EYECONTACT)
+		var/msg = span_smallnotice("You make eye contact with [examined_mob].")
+		addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat, src, msg), 3) // so the examine signal has time to fire and this will print after
+
+	if(!imagined_eye_contact && is_face_visible() && SEND_SIGNAL(examined_mob, COMSIG_MOB_EYECONTACT, src, FALSE) != COMSIG_BLOCK_EYECONTACT)
+		var/msg = span_smallnotice("[src] makes eye contact with you.")
+		addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat, examined_mob, msg), 3)
 
 /**
   * Point at an atom


### PR DESCRIPTION
# Document the changes in your pull request

First and foremost this adds eye contact when two spesspeople examine each other in a brief window of time from less than 5 tiles apart. You'll know you both examined each other when you see
![image](https://user-images.githubusercontent.com/46236974/170806279-41f163b7-9b72-4c98-a58e-2f9d7fa2fa56.png)
indicating you both just examined one another.

However, if one person is wearing a mask and both parties examine each other, only the person wearing the mask knows they made eye contact, the unmasked will see nothing.

# Impact this has on other things
Anyone who takes social anxiety has a chance to suffer greatly from making eye contact in the form of increased stuttering, jitters, and even potentially a brief stun. So watch where you point your peepers
![image](https://user-images.githubusercontent.com/46236974/170806425-0d9b04cb-8897-4450-a12f-066318632119.png)
![image](https://user-images.githubusercontent.com/46236974/170806602-c325e010-a240-4531-b79f-a9d17ad8740a.png)


Those who become obsessed need to be weary of examining their target, as making eye contact has a chance to warn your target without you knowing in the form of a subtle message
![image](https://user-images.githubusercontent.com/46236974/170806459-6fc6d57c-9a3d-4014-aa36-6865c3a2bd3e.png)
so either don't examine too much, or wear a mask before spilling your spaghetti because you got too close to your obsession

# New quirk: Shifty Eyes

A 0 cost quirk that makes it so if someone examines you, there's a small chance they see a reciprocated eye contact message when you didn't actually look at them. Get called a weirdo because you're constantly making eye contact when you're really not, have sec show up and beat you for being suspicious.

# Wiki Documentation

Eye contact on examining one another. masks make it so that only the masked person knows eye contact was made. double mask means neither know if they made eye contact.
Social anxiety users suffer from eye contact
Obsessed can give away their status to their obsession through eye contact

# Changelog

:cl:  
rscadd: Eye contact: when two people examine each other and have unobscured faces, you'll each see that you made eye contact. Look deeply into one another's eyes while you're actually just assessing wounds.
rscadd: Those with the social anxiety quirk have a chance to suffer negative effects from making eye contact
rscadd: Obsessed can potentially give themselves away through eye contact
rscadd: New quirk Shifty Eyes: 0 cost quirk that gives a small chance for people examining them to see a that they made eye contact when they actually didn't
/:cl:
