### PR TITLE
Novaflower damage type changed to burn

### DIFF
--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -211,7 +211,7 @@
 	icon_state = "novaflower"
 	lefthand_file = 'icons/mob/inhands/weapons/plants_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/plants_righthand.dmi'
-	damtype = FIRE
+	damtype = BURN
 	force = 0
 	slot_flags = ITEM_SLOT_HEAD
 	throwforce = 0


### PR DESCRIPTION
I think this is the only damtype that got missed in #14187. or at least that I noticed. Fire damage type does nothing

# Changelog

:cl:  
bugfix: novaflower damage type switched to burn so it actually deals damage like it's supposed to
/:cl:
