### PR TITLE
Pine tree mobs don't have their plant faction overwritten by a 2nd faction setting

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/tree.dm
+++ b/code/modules/mob/living/simple_animal/hostile/tree.dm
@@ -34,7 +34,6 @@
 	minbodytemp = 0
 	maxbodytemp = 1200
 
-	faction = list("hostile")
 	deathmessage = "is hacked into pieces!"
 	loot = list(/obj/item/stack/sheet/mineral/wood)
 	gold_core_spawnable = HOSTILE_SPAWN


### PR DESCRIPTION
Their faction was getting overwritten by a second faction define. now they match other plant enemies like man eaters and killer tomatoes

# Changelog

:cl:  
bugfix: pine trees don't have a 2nd faction define that erases their original plants faction 
/:cl:
