### PR TITLE
Role Restricts brainwash surgery to Doctors and Roboticists and pop locks it to 30+

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1945,7 +1945,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A disk containing the procedure to perform a brainwashing surgery, allowing you to implant an objective onto a target. \
 	Insert into an Operating Console to enable the procedure."
 	item = /obj/item/disk/surgery/brainwashing
-	restricted_roles = list("Medical Doctor", "Chief Medical Officer", "Paramedic", "Roboticist") //yogs
+	restricted_roles = list("Medical Doctor", "Chief Medical Officer", "Roboticist") //yogs
 	player_minimum = 30
 	cost = 5
 	manufacturer = /datum/corporation/traitor/cybersun

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1945,7 +1945,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A disk containing the procedure to perform a brainwashing surgery, allowing you to implant an objective onto a target. \
 	Insert into an Operating Console to enable the procedure."
 	item = /obj/item/disk/surgery/brainwashing
-	restricted_roles = list("Medical Doctor", "Chief Medical Officer", "Roboticist") //yogs
+	restricted_roles = list("Medical Doctor", "Chief Medical Officer", "Roboticist", "Research Director") //yogs
 	player_minimum = 30
 	cost = 5
 	manufacturer = /datum/corporation/traitor/cybersun

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1940,7 +1940,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 8
 	manufacturer = /datum/corporation/traitor/cybersun
 
-/datum/uplink_item/device_tools/brainwash_disk
+/datum/uplink_item/role_restricted/brainwash_disk
 	name = "Brainwashing Surgery Program"
 	desc = "A disk containing the procedure to perform a brainwashing surgery, allowing you to implant an objective onto a target. \
 	Insert into an Operating Console to enable the procedure."

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1946,7 +1946,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	Insert into an Operating Console to enable the procedure."
 	item = /obj/item/disk/surgery/brainwashing
 	restricted_roles = list("Medical Doctor", "Chief Medical Officer", "Roboticist", "Research Director") //yogs
-	player_minimum = 30
+	player_minimum = 28
 	cost = 5
 	manufacturer = /datum/corporation/traitor/cybersun
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1493,14 +1493,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	manufacturer = /datum/corporation/traitor/cybersun
 	exclude_modes = list(/datum/game_mode/infiltration)
 
-/datum/uplink_item/device_tools/brainwash_disk
-	name = "Brainwashing Surgery Program"
-	desc = "A disk containing the procedure to perform a brainwashing surgery, allowing you to implant an objective onto a target. \
-	Insert into an Operating Console to enable the procedure."
-	item = /obj/item/disk/surgery/brainwashing
-	cost = 5
-	manufacturer = /datum/corporation/traitor/cybersun
-
 /datum/uplink_item/device_tools/hypnotic_flash
 	name = "Hypnotic Flash"
 	desc = "A modified flash able to hypnotize targets. If the target is not in a mentally vulnerable state, it will only confuse and pacify them temporarily."
@@ -1946,6 +1938,16 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/autosurgeon/medibeam
 	restricted_roles = list("Medical Doctor", "Chief Medical Officer", "Paramedic", "Mining Medic") //yogs
 	cost = 8
+	manufacturer = /datum/corporation/traitor/cybersun
+
+/datum/uplink_item/device_tools/brainwash_disk
+	name = "Brainwashing Surgery Program"
+	desc = "A disk containing the procedure to perform a brainwashing surgery, allowing you to implant an objective onto a target. \
+	Insert into an Operating Console to enable the procedure."
+	item = /obj/item/disk/surgery/brainwashing
+	restricted_roles = list("Medical Doctor", "Chief Medical Officer", "Paramedic", "Roboticist") //yogs
+	player_minimum = 30
+	cost = 5
 	manufacturer = /datum/corporation/traitor/cybersun
 
 /datum/uplink_item/role_restricted/cat_grenade


### PR DESCRIPTION
In the past week it's become painfully apparent how easy it is for either a lowpop doctor to brainwash the entire medbay team of 3 people, or a mining medic or miner to get alone time with someone else to turn them into a minion. Miners especially when they can stun someone and use heiro beacon to teleport a morbillion miles away in 3 seconds. This is made more an issue with the fact that advanced analyzers can download the surgery, so if you manage to nab and brainwash someone, you can send them on their way with the ability to also brainwash people. So it's potentially self perpetuating.

The reason behind role restricting it is also to give doctors an item that's "their thing" because currently they can purchase a state of the art, augmented healing beam arm... to... heal... their target? with illegal technology? what.
Roboticists get it too because they're surgery capable as well.

so yeah ided imad ishit

# Wiki Documentation

pop lock (and drop it) surgery disk to 30+ and it's now a doctor/roboticist item.

# Changelog

:cl:  
tweak: brainwash surgery disk is now doctors and roboticists only and locked to 30+ pop
/:cl:
