### PR TITLE
grille defibs now heal oxygen and toxin damage when successful

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -368,6 +368,8 @@
 	if(stat == DEAD && can_defib()) //yogs: ZZAPP
 		if(!illusion && (shock_damage * siemens_coeff >= 1) && prob(80))
 			set_heartattack(FALSE)
+			adjustOxyLoss(-50)
+			adjustToxLoss(-50)
 			revive()
 			INVOKE_ASYNC(src, .proc/emote, "gasp")
 			Jitter(100)


### PR DESCRIPTION
# Document the changes in your pull request

Prevents damage that can't be healed on corpses from preventing a shock from reviving people


# Changelog

:cl:  
tweak: defibbing someone via uncontrolled shock will now heal them of oxygen and toxin damage before actually trying to revive them
/:cl:
