### PR TITLE
Fixes some YogsBox Issues.

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -16392,6 +16392,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/science/storage)
 "bsg" = (
@@ -16402,6 +16405,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
@@ -16451,6 +16457,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/science/storage)
 "bsn" = (
@@ -16471,6 +16480,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/science/storage)
 "bsq" = (
@@ -16479,6 +16491,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 5
@@ -18613,6 +18628,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bBH" = (
@@ -18944,6 +18962,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bDn" = (
@@ -19028,6 +19049,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/science/storage)
 "bEg" = (
@@ -19085,6 +19109,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bEs" = (
@@ -19506,6 +19533,9 @@
 	network = list("ss13","rd")
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plasteel,
 /area/science/storage)
 "bHi" = (
@@ -39564,14 +39594,6 @@
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
-"kcy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "kcH" = (
 /obj/machinery/disposal/bin,
 /obj/structure/window/reinforced,
@@ -59685,11 +59707,6 @@
 	pixel_x = -23;
 	pixel_y = -7
 	},
-/obj/machinery/camera{
-	c_tag = "Genetics Research";
-	dir = 4;
-	network = list("ss13","medbay")
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "tZp" = (
@@ -66101,6 +66118,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "xBl" = (
@@ -84561,7 +84579,7 @@ aSf
 aSf
 xBb
 aSf
-kcy
+pxE
 cOY
 fLr
 bjg


### PR DESCRIPTION
Some fixes to YogBox (or Yogstation) for mapping issues that have popped up recently.

Fixes missing disposal pipes in maint.
<img width="94" alt="Screenshot 2022-05-30 145546" src="https://user-images.githubusercontent.com/64857565/170997552-de52ee8a-5ecb-404e-bc05-8991777c7d29.png">

Fixes unwired toxin storage apc.
<img width="338" alt="Screenshot 2022-05-30 145622" src="https://user-images.githubusercontent.com/64857565/170998340-2941b371-2595-4280-80d1-a76234518b1e.png">


Fixes the extra camera in genetics lab. (that one's my bad)
<img width="302" alt="Screenshot 2022-05-30 145607" src="https://user-images.githubusercontent.com/64857565/170998328-d5322fae-bbb8-40b8-adaa-4279c8adefc9.png">


# Document the changes in your pull request

See above.

# Wiki Documentation

None needed.
Toxin storage seems to be listed under toxin lab on the wiki, it seems fine but now that its its own area we may need to add something.

# Changelog

:cl:  
rscdel: Removed the extra camera in genetics on Yogstation.
bugfix: Fixes the disposals loop on Yogstation.
bugfix: Fixes toxin storage apc on Yogstation.
/:cl:
