### PR TITLE
removes monster hunter event from dynamic

### DIFF
--- a/code/modules/events/monsterhunter.dm
+++ b/code/modules/events/monsterhunter.dm
@@ -17,7 +17,7 @@
 	weight = 2000
 	min_players = 10
 	earliest_start = 35 MINUTES
-	gamemode_whitelist = list("bloodsucker","traitorsucker","dynamic")
+	gamemode_whitelist = list("bloodsucker","traitorsucker")
 
 /datum/round_event/bloodsucker_hunters
 	fakeable = FALSE
@@ -62,7 +62,7 @@
 	weight = 7
 	min_players = 10
 	earliest_start = 25 MINUTES
-	gamemode_whitelist = list("traitorchan","changeling","heresy","cult","clockwork_cult","dynamic")
+	gamemode_whitelist = list("traitorchan","changeling","heresy","cult","clockwork_cult")
 
 /datum/round_event/monster_hunters
 	fakeable = FALSE


### PR DESCRIPTION
# Document the changes in your pull request

dynamic spawns midrounds using rulesets instead of events on normal rounds, so these shouldn't ever trigger on dynamic

# Changelog

:cl:  
tweak: removes monster hunter event from being whitelisted on dynamic
/:cl:
