### PR TITLE
[s] Fix server_hop not requiring the comms key

### DIFF
--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -125,6 +125,7 @@
 
 /datum/world_topic/server_hop
 	keyword = "server_hop"
+	require_comms_key = TRUE
 
 /datum/world_topic/server_hop/Run(list/input)
 	var/expected_key = input[keyword]


### PR DESCRIPTION
# Document the changes in your pull request

This is bad, pls fix

# Changelog

:cl:  
bugfix: Fixed anyone being able to load the title splash screen onto any observer
/:cl:
