### PR TITLE
Bluespace Locker Nerf Proposal [1 of 2]

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/bluespace_locker.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bluespace_locker.dm
@@ -151,7 +151,7 @@
 
 /obj/structure/closet/bluespace/external/Destroy()
 	SSbluespace_locker.external_locker = null
-	SSbluespace_locker.bluespaceify_random_locker()
+	SSbluespace_locker.wipe_locker()
 	return ..()
 
 /obj/structure/closet/bluespace/external/can_open()

--- a/yogstation/code/controllers/subsystem/bluespace_locker.dm
+++ b/yogstation/code/controllers/subsystem/bluespace_locker.dm
@@ -67,3 +67,11 @@ SUBSYSTEM_DEF(bluespace_locker)
 		internal_locker.dump_contents()
 	internal_locker.update_icon()
 	external_locker.update_icon()
+
+/datum/controller/subsystem/bluespace_locker/proc/wipe_locker()
+	if(!internal_locker)
+		return
+	var/area/A = get_area(internal_locker)
+	for(var/atom/movable/M in A)
+		qdel(M)
+	internal_locker = null


### PR DESCRIPTION
# Document the changes in your pull request

Closes #14288

My personal favorite of the two

Upon bluespace locker destruction, all things inside are deleted and a new locker is not chosen.

Tested with no runtimes or errors

# Changelog

:cl:  
tweak: Destroying the bluespace locker now destroys everything inside
/:cl:
