### PR TITLE
Bluespace Locker Nerf Proposal [2 of 2]

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/bluespace_locker.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bluespace_locker.dm
@@ -151,7 +151,7 @@
 
 /obj/structure/closet/bluespace/external/Destroy()
 	SSbluespace_locker.external_locker = null
-	SSbluespace_locker.bluespaceify_random_locker()
+	SSbluespace_locker.redistribute_locker()
 	return ..()
 
 /obj/structure/closet/bluespace/external/can_open()

--- a/yogstation/code/controllers/subsystem/bluespace_locker.dm
+++ b/yogstation/code/controllers/subsystem/bluespace_locker.dm
@@ -67,3 +67,12 @@ SUBSYSTEM_DEF(bluespace_locker)
 		internal_locker.dump_contents()
 	internal_locker.update_icon()
 	external_locker.update_icon()
+
+/datum/controller/subsystem/bluespace_locker/proc/redistribute_locker()
+	if(!internal_locker)
+		return
+	var/area/A = get_area(internal_locker)
+	for(var/atom/movable/M in A)
+		M.forceMove(find_safe_turf())
+	qdel(internal_locker)
+	internal_locker = null

--- a/yogstation/code/controllers/subsystem/bluespace_locker.dm
+++ b/yogstation/code/controllers/subsystem/bluespace_locker.dm
@@ -78,3 +78,4 @@ SUBSYSTEM_DEF(bluespace_locker)
 		if(istype(M, /obj/machinery/light))
 			continue
 		M.forceMove(find_safe_turf())
+	bluespaceify_random_locker()

--- a/yogstation/code/controllers/subsystem/bluespace_locker.dm
+++ b/yogstation/code/controllers/subsystem/bluespace_locker.dm
@@ -73,6 +73,8 @@ SUBSYSTEM_DEF(bluespace_locker)
 		return
 	var/area/A = get_area(internal_locker)
 	for(var/atom/movable/M in A)
+		if(M == internal_locker)
+			continue
+		if(istype(M, /obj/machinery/light))
+			continue
 		M.forceMove(find_safe_turf())
-	qdel(internal_locker)
-	internal_locker = null


### PR DESCRIPTION
# Document the changes in your pull request

Closes #14287

Upon bluespace locker destruction, all things inside are teleported to a safe station turf and a new locker is not chosen.

Tested with no runtimes or errors

# Changelog

:cl:  
tweak: Destroying the bluespace locker now teleports everything inside to the station
/:cl:
