### PR TITLE
Elites now drop their special loot on kill + nerf to herald cloak

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -235,8 +235,8 @@ obj/structure/elite_tumor/proc/onEliteLoss()
 	visible_message(span_boldwarning("[src] begins to convulse violently before beginning to dissipate."))
 	visible_message(span_boldwarning("As [src] closes, something is forced up from down below."))
 	new /obj/structure/closet/crate/necropolis/tendril(loc)
-	/*if(mychild.loot_drop) //holding this to check if the herald's loot needs to be nerfed/reworked
-		new mychild.loot_drop(lootbox)*/
+	if(mychild.loot_drop) //holding this to check if the herald's loot needs to be nerfed/reworked
+		new mychild.loot_drop(lootbox)
 	mychild = null
 	activator = null
 	qdel(src)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -234,7 +234,7 @@ obj/structure/elite_tumor/proc/onEliteLoss()
 	playsound(loc,'sound/effects/tendril_destroyed.ogg', 200, 0, 50, TRUE, TRUE)
 	visible_message(span_boldwarning("[src] begins to convulse violently before beginning to dissipate."))
 	visible_message(span_boldwarning("As [src] closes, something is forced up from down below."))
-	new /obj/structure/closet/crate/necropolis/tendril(loc)
+	var/obj/structure/closet/crate/necropolis/tendril/lootbox = new /obj/structure/closet/crate/necropolis/tendril(loc)
 	if(mychild.loot_drop) //holding this to check if the herald's loot needs to be nerfed/reworked
 		new mychild.loot_drop(lootbox)
 	mychild = null

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
@@ -266,10 +266,9 @@
 	H.fire(set_angle)
 
 /obj/item/clothing/neck/cloak/herald_cloak/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!prob(hit_reaction_chance))
-		return FALSE
-	owner.visible_message(span_danger("[owner]'s [src] emits a loud noise as [owner] is struck!"))
-	var/static/list/directional_shot_angles = list(0, 45, 90, 135, 180, 225, 270, 315)
-	playsound(get_turf(owner), 'sound/magic/clockwork/invoke_general.ogg', 20, TRUE)
-	addtimer(CALLBACK(src, .proc/reactionshot, owner), 10)
-	return TRUE
+	. = FALSE
+	if(prob(hit_reaction_chance))
+		owner.visible_message(span_danger("[owner]'s [src] emits a loud noise as [owner] is struck!"))
+		var/static/list/directional_shot_angles = list(0, 45, 90, 135, 180, 225, 270, 315)
+		playsound(get_turf(owner), 'sound/magic/clockwork/invoke_general.ogg', 20, TRUE)
+		addtimer(CALLBACK(src, .proc/reactionshot, owner), 10)


### PR DESCRIPTION
# Document the changes in your pull request

Herald cloak no longer actually blocks bullets it just reacts to being shot

Elites now drop their specific loot on being killed

# Wiki Documentation

Herald cloak no longer actually blocks bullets it just reacts to being shot

Elites now drop their specific loot on being killed (without boosting)

# Changelog

:cl:  
tweak: prophet cloak from herald no longer actually BLOCKS bullets, it just reacts to them
tweak: elites now drop their specific loot
/:cl:
