### PR TITLE
Alert & delay when swarmer dismantling ore silo

### DIFF
--- a/code/modules/mining/machine_silo.dm
+++ b/code/modules/mining/machine_silo.dm
@@ -186,6 +186,10 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 	. = ..()
 	. += span_notice("[src] can be linked to techfabs, circuit printers and protolathes with a multitool.")
 
+/obj/machinery/ore_silo/swarmer_act(mob/living/simple_animal/hostile/swarmer/actor)
+	actor.dismantle_machine(src, TRUE)
+	return TRUE
+
 /datum/ore_silo_log
 	var/name  // for VV
 	var/formatted  // for display

--- a/code/modules/swarmers/swarmer.dm
+++ b/code/modules/swarmers/swarmer.dm
@@ -260,7 +260,7 @@
   */
 /mob/living/simple_animal/hostile/swarmer/proc/dismantle_machine(obj/machinery/target, alert = FALSE)
 	do_attack_animation(target)
-	to_chat(src, span_info("We begin to dismantle this machine. We will need to be uninterrupted."))
+	to_chat(src, span_info("We begin to dismantle this machine. We will need to be uninterrupted for some time."))
 	var/obj/effect/temp_visual/swarmer/dismantle/dismantle_effect = new /obj/effect/temp_visual/swarmer/dismantle(get_turf(target))
 	dismantle_effect.pixel_x = target.pixel_x
 	dismantle_effect.pixel_y = target.pixel_y

--- a/code/modules/swarmers/swarmer.dm
+++ b/code/modules/swarmers/swarmer.dm
@@ -67,6 +67,8 @@
 	var/max_resources = 100
 	///List used for player swarmers to keep track of their drones
 	var/list/mob/living/simple_animal/hostile/swarmer/melee/dronelist
+	///Prevents alert spam
+	var/last_alert = 0
 
 /mob/living/simple_animal/hostile/swarmer/Initialize()
 	. = ..()
@@ -256,14 +258,20 @@
   * Arguments:
   * * target - The machine the swarmer is attempting to disassemble
   */
-/mob/living/simple_animal/hostile/swarmer/proc/dismantle_machine(obj/machinery/target)
+/mob/living/simple_animal/hostile/swarmer/proc/dismantle_machine(obj/machinery/target, alert = FALSE)
 	do_attack_animation(target)
 	to_chat(src, span_info("We begin to dismantle this machine. We will need to be uninterrupted."))
 	var/obj/effect/temp_visual/swarmer/dismantle/dismantle_effect = new /obj/effect/temp_visual/swarmer/dismantle(get_turf(target))
 	dismantle_effect.pixel_x = target.pixel_x
 	dismantle_effect.pixel_y = target.pixel_y
 	dismantle_effect.pixel_z = target.pixel_z
-	if(do_mob(src, target, 100))
+	var/dismantle_time = 10 SECONDS
+	if(alert)
+		dismantle_time = 30 SECONDS
+		if(last_alert < world.time)
+			last_alert = world.time + 5 SECONDS
+			priority_announce("Connection encryption violation in machine: [target]. Deconstruction ETA: 30 SECONDS")
+	if(do_mob(src, target, dismantle_time))
 		to_chat(src, span_info("Dismantling complete."))
 		var/atom/target_loc = target.drop_location()
 		new /obj/item/stack/sheet/metal(target_loc, 5)

--- a/code/modules/swarmers/swarmer.dm
+++ b/code/modules/swarmers/swarmer.dm
@@ -270,7 +270,7 @@
 		dismantle_time = 30 SECONDS
 		if(last_alert < world.time)
 			last_alert = world.time + 5 SECONDS
-			priority_announce("Connection encryption violation in machine: [target]. Deconstruction ETA: 30 SECONDS")
+			priority_announce("Connection encryption violation in machine: [target]! Deconstruction projected to complete in: 30 SECONDS")
 	if(do_mob(src, target, dismantle_time))
 		to_chat(src, span_info("Dismantling complete."))
 		var/atom/target_loc = target.drop_location()


### PR DESCRIPTION
# Document the changes in your pull request

Dismantling the ore silo can cripple the entire round and should not be as easy as popping into the vault vent and dismantling it as you would any other machine

Makes prio announcement & takes 30 seconds as opposed to 10 seconds

30 seconds seems reasonable, crew by then will either respond with proper access or they won't at all

# Changelog

:cl:  
tweak: Swarmers dismantling the ore silo now alerts the station and takes 30 seconds
/:cl:
