### PR TITLE
Adds Clownshot

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -64,6 +64,14 @@
 	pellets = 6
 	variance = 25
 
+/obj/item/ammo_casing/shotgun/clownshot
+	name = "buckshot shell..?"
+	desc = "This feels a little light for a buckshot shell."
+	icon_state = "gshell"
+	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_clownshot
+	pellets = 6
+	variance = 25
+
 /obj/item/ammo_casing/shotgun/rubbershot
 	name = "rubber shot"
 	desc = "A shotgun casing filled with densely-packed rubber balls, used to incapacitate crowds from a distance."

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -129,14 +129,6 @@
 	icon_state = "cshell"
 	projectile_type = null
 	
-/obj/item/ammo_casing/shotgun/techshell(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/stamp/clown) && !istype(loc, /obj/item/storage))
-		var/atom/droploc = drop_location()
-		if(use(1))
-			playsound(I, 'sound/items/bikehorn.ogg', 50, 1, -1)
-			to_chat(user, span_notice("You create a Clownshot shell."))
-			/obj/item/ammo_casing/shotgun/clownshot
-
 /obj/item/ammo_casing/shotgun/dart
 	name = "shotgun dart"
 	desc = "A dart for use in shotguns. Can be injected with up to 30 units of any chemical."

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -69,8 +69,8 @@
 	desc = "This feels a little light for a buckshot shell."
 	icon_state = "gshell"
 	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_clownshot
-	pellets = 6
-	variance = 25
+	pellets = 20
+	variance = 40
 
 /obj/item/ammo_casing/shotgun/rubbershot
 	name = "rubber shot"

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -128,6 +128,14 @@
 	desc = "A high-tech shotgun shell which can be loaded with materials to produce unique effects."
 	icon_state = "cshell"
 	projectile_type = null
+	
+/obj/item/ammo_casing/shotgun/techshell(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/stamp/clown) && !istype(loc, /obj/item/storage))
+		var/atom/droploc = drop_location()
+		if(use(1))
+			playsound(I, 'sound/items/bikehorn.ogg', 50, 1, -1)
+			to_chat(user, span_notice("You create a Clownshot shell."))
+			/obj/item/ammo_casing/shotgun/clownshot
 
 /obj/item/ammo_casing/shotgun/dart
 	name = "shotgun dart"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -71,6 +71,11 @@
 	wound_bonus = 5
 	bare_wound_bonus = 5
 	wound_falloff_tile = -2.5 // low damage + additional dropoff will already curb wounding potential anything past point blank
+	
+/obj/item/projectile/bullet/pellet/shotgun_clownshot
+	name = "clownshot pellet"
+	damage = 0
+	hitsound = 'sound/items/bikehorn.ogg'
 
 /obj/item/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubbershot pellet"

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -136,6 +136,16 @@
 	build_path = /obj/item/bikehorn/airhorn
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_ALL			//HONK!
+	
+/datum/design/clownshot
+	name = "Clownshot Shell"
+	desc = "A tactical round used by the clown planet's finest soldiers."
+	id = "clownshot"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 4000, /datum/material/bananium = 1000)
+	build_path = /obj/item/ammo_casing/shotgun/clownshot
+	category = list("Equipment")
+	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
 
 /datum/design/mesons
 	name = "Optical Meson Scanners"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -416,7 +416,7 @@
 	description = "Honk?!"
 	prereq_ids = list("base")
 	design_ids = list("air_horn", "honker_main", "honker_peri", "honker_targ", "honk_chassis", "honk_head", "honk_torso", "honk_left_arm", "honk_right_arm",
-	"honk_left_leg", "honk_right_leg", "mech_banana_mortar", "mech_mousetrap_mortar", "mech_honker", "mech_punching_face", "implant_trombone", "borg_transform_clown", "clown_mine")
+	"honk_left_leg", "honk_right_leg", "mech_banana_mortar", "mech_mousetrap_mortar", "mech_honker", "mech_punching_face", "implant_trombone", "borg_transform_clown", "clown_mine", "clownshot")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 


### PR DESCRIPTION
_honk!_

Clownshot is a harmless ammo type made from Bananium and Iron, capable of being printed once clown technology is researched. Clownshot does zero damage and fires twenty pellets. Getting shot will play a honk sound.

# Wiki Documentation

Combat page. RND item page too probably

# Changelog

:cl:  
rscadd: Adds Clownshot, a harmless honking ammo type!
/:cl:
