### PR TITLE
Disables plague rat, because plague rat bad

### DIFF
--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -1,5 +1,5 @@
 #define REGAL_RAT_CHANCE 2
-#define PLAGUE_RAT_CHANCE 5
+#define PLAGUE_RAT_CHANCE 0
 SUBSYSTEM_DEF(minor_mapping)
 	name = "Minor Mapping"
 	init_order = INIT_ORDER_MINOR_MAPPING


### PR DESCRIPTION
# Document the changes in your pull request

Someone can fix it if they want, but currently having 4 rats running around on lowpop with a 100% chance to infect with a plague that medbay can't cure while hiding under tables and shit so they can't be killed is bad.

# Changelog

:cl:  
rscdel: Plague rats can no longer spawn
/:cl:
