### PR TITLE
BibbyBank | Persistent Savings Account and Medical Insurance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+e
 ## Yogstation codebase
 
 [![Build Status](https://github.com/yogstation13/Yogstation/workflows/Turdis/badge.svg?branch=master)](https://github.com/yogstation13/Yogstation/actions?query=workflow%3ATurdis+branch%3Amaster)


### PR DESCRIPTION
# Document the changes in your pull request

Depending on your job you get a paycheck after every shift you survive (On the escape shuttle or not)
This gets added to a persistent account. You can subscribe to different plans for *health insurance!*
Medbay can create bills for you (They don't have to) and you can pay them! 

Apart from that you can use your persistent account for showing how cool at playing the game you are! (Leaderboard basically)

Other things maybe too idk.

See what everyone is saying:

> I don't think this is a good idea
> -the discord

> this isn't a good idea
> -me

> can i get funny powergame loot???
> -the donators

# Wiki Documentation


# Changelog

:cl:  
rscadd: Every player is granted a persistent savings account, every shift you survive gets you a paycheck that gets put into this
rscadd: Adds medical insurance. Spend your persistent savings on differing tiers of medical insurance! WHOO!!!
rscadd: Invest your savings in either the NanoTrasen or Syndicate retirement funds! Investing in the Syndicate may potentially help fund their operations..
rscadd: Medical gets a new machine to print out bills! Bills are paid in-shift using actual normal money. 
rscadd: Gift other people medical insurance! WOW!
rscadd: Donators get free shifts of medical insurance????? WHAt???
experimental: This is experimental, like... all of it
/:cl:
