### PR TITLE
Harmbatoning assistants adds 1 credit to the security budget, harmbatoning clowns adds 5

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -243,9 +243,12 @@
 		var/mob/living/carbon/human/H = L
 		var/datum/mind/M = H.mind
 		if(M?.assigned_role == "Assistant" && user.a_intent == INTENT_HARM)
+			var/amount_given = 1
+			if(M.assigned_role == "Clown")
+				amount_given = 5
 			var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_SEC)
 			if(D)
-				D.adjust_money(1)
+				D.adjust_money(amount_given)
 		H.forcesay(GLOB.hit_appends)
 
 	cooldown_check = world.time + cooldown

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -242,7 +242,7 @@
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
 		var/datum/mind/M = H.mind
-		if(M?.assigned_role == "Assistant" && user.a_intent == INTENT_HARM)
+		if(M && (M.assigned_role == "Assistant" || M.assigned_role == "Clown") && user.a_intent == INTENT_HARM)
 			var/amount_given = 1
 			if(M.assigned_role == "Clown")
 				amount_given = 5
@@ -252,7 +252,6 @@
 		H.forcesay(GLOB.hit_appends)
 
 	cooldown_check = world.time + cooldown
-	
 
 	return TRUE
 

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -241,9 +241,14 @@
 
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
+		if(H.assigned_role == "Assistant" && user.a_intent == INTENT_HARM)
+			var/datum/bank_account/D = get_dep_account(ACCOUNT_SEC)
+			if(D)
+				D.adjust_money(1)
 		H.forcesay(GLOB.hit_appends)
 
 	cooldown_check = world.time + cooldown
+	
 
 	return TRUE
 

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -241,8 +241,9 @@
 
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
-		if(H.assigned_role == "Assistant" && user.a_intent == INTENT_HARM)
-			var/datum/bank_account/D = get_dep_account(ACCOUNT_SEC)
+		var/datum/mind/M = H.mind
+		if(M?.assigned_role == "Assistant" && user.a_intent == INTENT_HARM)
+			var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_SEC)
 			if(D)
 				D.adjust_money(1)
 		H.forcesay(GLOB.hit_appends)


### PR DESCRIPTION
# Document the changes in your pull request

See title

# Wiki Documentation

# Changelog

:cl:  
rscadd: Using a baton with harm intent on an assistant will give the security budget 1 credit. Clowns give 5
/:cl:
