### PR TITLE
Capitalizes "Syndicate" in skillcape descriptions

### DIFF
--- a/code/modules/clothing/neck/skillcapes/skillcapes.dm
+++ b/code/modules/clothing/neck/skillcapes/skillcapes.dm
@@ -86,13 +86,13 @@
 
 /obj/item/clothing/neck/skillcape/hos
 	name = "cape of the head of security"
-	desc = "A slick, blue cape. The owner must have executed many syndicate personnel."
+	desc = "A slick, blue cape. The owner must have executed many Syndicate personnel."
 	icon_state = "hos-skillcape"
 	item_state = "hos-skillcape"
 
 /obj/item/clothing/neck/skillcape/trimmed/hos
 	name = "cape of the grand executor"
-	desc = "A shiny, blue cape. The owner is the bane of the syndicate."
+	desc = "A shiny, blue cape. The owner is the bane of the Syndicate."
 	icon_state = "hos-trimmed"
 	item_state = "hos-trimmed"
 


### PR DESCRIPTION
Read the title

If you can that is, I'm not sure all of you know how to read

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
tweak: The word "Syndicate" has been capitalized in skillcape descriptions
/:cl:
