### PR TITLE
Ports TG's uplink implant traitor preference. For the low price of 4TC, spawn with your uplink in your guts.

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -44,6 +44,16 @@
 /// Selects a random location for the blob to be placed.
 #define BLOB_RANDOM_PLACEMENT 1
 
+
+/// How many telecrystals a normal traitor starts with
+#define TELECRYSTALS_DEFAULT 20
+/// How many telecrystals mapper/admin only "precharged" uplink implant
+#define TELECRYSTALS_PRELOADED_IMPLANT 10
+/// The normal cost of an uplink implant; used for calcuating how many
+/// TC to charge someone if they get a free implant through choice or
+/// because they have nothing else that supports an implant.
+#define UPLINK_IMPLANT_TELECRYSTAL_COST 4
+
 //ERT Types
 #define ERT_BLUE "Blue"
 #define ERT_RED  "Red"

--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -130,7 +130,8 @@ GLOBAL_LIST_INIT(jumpsuitlist, list(PREF_SUIT, PREF_SKIRT))
 #define UPLINK_PDA		"PDA"
 #define UPLINK_RADIO	"Radio"
 #define UPLINK_PEN		"Pen" //like a real spy!
-GLOBAL_LIST_INIT(uplink_spawn_loc_list, list(UPLINK_PDA, UPLINK_RADIO, UPLINK_PEN))
+#define UPLINK_IMPLANT  "Implant"
+GLOBAL_LIST_INIT(uplink_spawn_loc_list, list(UPLINK_PDA, UPLINK_RADIO, UPLINK_PEN, UPLINK_IMPLANT))
 
 	//Female Uniforms
 GLOBAL_LIST_EMPTY(female_clothing_icons)

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -28,10 +28,11 @@ GLOBAL_LIST_EMPTY(uplinks)
 	var/failsafe_code
 	var/debug = FALSE
 	var/compact_mode = FALSE
-
+	///Instructions on how to access the uplink based on location
+	var/unlock_text
 	var/list/previous_attempts
 
-/datum/component/uplink/Initialize(_owner, _lockable = TRUE, _enabled = FALSE, datum/game_mode/_gamemode, starting_tc = 20)
+/datum/component/uplink/Initialize(_owner, _lockable = TRUE, _enabled = FALSE, datum/game_mode/_gamemode, starting_tc = TELECRYSTALS_DEFAULT)
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -318,6 +318,7 @@
 			P = inowhaveapen
 
 	var/obj/item/uplink_loc
+	var/implant = FALSE
 
 	if(traitor_mob.client && traitor_mob.client.prefs)
 		switch(traitor_mob.client.prefs.uplink_spawn_loc)
@@ -339,12 +340,13 @@
 					uplink_loc = PDA
 				if(!uplink_loc)
 					uplink_loc = R
+			if(UPLINK_IMPLANT)
+				implant = TRUE
 
-	if (!uplink_loc)
-		if(!silent)
-			to_chat(traitor_mob, "Unfortunately, [employer] wasn't able to get you an Uplink.")
-		. = 0
-	else
+	if(!uplink_loc) // We've looked everywhere, let's just implant you
+		implant = TRUE
+	
+	if(!implant)
 		. = uplink_loc
 		var/datum/component/uplink/U = uplink_loc.AddComponent(/datum/component/uplink, traitor_mob.key)
 		if(!U)
@@ -357,11 +359,18 @@
 				to_chat(traitor_mob, "[employer] has cunningly disguised a Syndicate Uplink as your [PDA.name]. Simply enter the code \"[U.unlock_code]\" into the ringtone select to unlock its hidden features.")
 			else if(uplink_loc == P)
 				to_chat(traitor_mob, "[employer] has cunningly disguised a Syndicate Uplink as your [P.name]. Simply twist the top of the pen [english_list(U.unlock_code)] from its starting position to unlock its hidden features.")
-
 		if(uplink_owner)
 			uplink_owner.antag_memory += U.unlock_note + "<br>"
 		else
 			traitor_mob.mind.store_memory(U.unlock_note)
+	else
+		var/obj/item/implant/uplink/starting/I = new(traitor_mob)
+		I.implant(traitor_mob, null, silent = TRUE)
+		if(!silent)
+			to_chat(traitor_mob, "<span class='boldnotice'>[employer] has cunningly implanted you with a Syndicate Uplink (although uplink implants cost valuable TC, so you will have slightly less). Simply trigger the uplink to access it.</span>")
+		return I
+
+
 
 //Link a new mobs mind to the creator of said mob. They will join any team they are currently on, and will only switch teams when their creator does.
 
@@ -572,7 +581,7 @@
 		switch(href_list["common"])
 			if("undress")
 				for(var/obj/item/W in current)
-					current.dropItemToGround(W, TRUE) //The 1 forces all items to drop, since this is an admin undress.
+					current.dropItemToGround(W, TRUE) //The TRUE forces all items to drop, since this is an admin undress.
 			if("takeuplink")
 				take_uplink()
 				memory = null//Remove any memory they may have had.

--- a/code/game/objects/items/implants/implantuplink.dm
+++ b/code/game/objects/items/implants/implantuplink.dm
@@ -10,6 +10,18 @@
 /obj/item/implant/uplink/Initialize(mapload, _owner)
 	. = ..()
 	AddComponent(/datum/component/uplink, _owner, TRUE, FALSE, null, starting_tc)
+	RegisterSignal(src, COMSIG_COMPONENT_REMOVING, .proc/_component_removal)
+
+/**
+ * Proc called when component is removed; ie. uplink component
+ *
+ * Callback catching if the underlying uplink component has been removed,
+ * generally by admin verbs or var editing. Implant does nothing without
+ * the component, so delete itself.
+ */
+/obj/item/implant/uplink/proc/_component_removal(datum/source, datum/component/component)
+	if(istype(component, /datum/component/uplink))
+		qdel(src)
 
 /obj/item/implanter/uplink
 	name = "implanter (uplink)"
@@ -20,4 +32,7 @@
 	imp_type = /obj/item/implant/uplink/precharged
 
 /obj/item/implant/uplink/precharged
-	starting_tc = 10
+	starting_tc = TELECRYSTALS_PRELOADED_IMPLANT
+
+/obj/item/implant/uplink/starting
+	starting_tc = TELECRYSTALS_DEFAULT - UPLINK_IMPLANT_TELECRYSTAL_COST

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1758,7 +1758,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "An implant injected into the body, and later activated at the user's will. Has no telecrystals and must be charged by the use of physical telecrystals. \
 			Undetectable (except via surgery), and excellent for escaping confinement."
 	item = /obj/item/storage/box/syndie_kit/imp_uplink
-	cost = 4
+	cost = UPLINK_IMPLANT_TELECRYSTAL_COST
 	// An empty uplink is kinda useless.
 	surplus = 0
 	restricted = TRUE


### PR DESCRIPTION
# Document the changes

Ports [#51828](https://github.com/tgstation/tgstation/pull/51828)

![image](https://user-images.githubusercontent.com/46236974/171789421-c62bfd71-ca87-48d1-903e-5823268fa03e.png)

![image](https://user-images.githubusercontent.com/46236974/171789512-ab909e85-6462-4a5c-acfb-b66b8a03c6df.png)

![image](https://user-images.githubusercontent.com/46236974/171789552-18ca0d7f-f2a3-4a60-9d02-14ebc321933c.png)


In your player preference page you can choose an implant as your uplink spawn preference. Be warned this does cost 4 tc, but your uplink can be triggered anytime from your actions buttons.

(also want this because i need us to have this code so i can work on other things i want)

# Wiki Documentation

Traitors can get their guts stuffed with uplink on spawn

# Changelog

:cl:  
rscadd: Uplink Implant preference on player panel which lets you spawn with your uplink as an implant, but this costs 4TC. Access your uplink with an action button
/:cl:
