### PR TITLE
I love horrors I love horrors I love horrors

### DIFF
--- a/code/modules/antagonists/horror/horror.dm
+++ b/code/modules/antagonists/horror/horror.dm
@@ -488,7 +488,8 @@
 		if(has_upgrade("paralysis"))
 			playsound(loc, "sound/effects/sparks4.ogg", 30, 1, -1)
 			M.Stun(50)
-			M.SetSleeping(70)  //knocked out cold
+			M.SetSleeping(50)  //knocked out cold
+			M.Knockdown(70)
 			M.electrocute_act(15, src, 1, FALSE, FALSE, FALSE, 1, FALSE)
 		else
 			to_chat(M, span_userdanger("You feel something wrapping around your leg, pulling you down!"))

--- a/code/modules/antagonists/horror/horror.dm
+++ b/code/modules/antagonists/horror/horror.dm
@@ -394,6 +394,7 @@
 	Update_Invisibility_Button()
 
 	victim = C
+	victim.visible_message(span_warning("[src] enters [victim]'s head!"), span_notice("Something enters your head!"))
 	forceMove(victim)
 	RefreshAbilities()
 	log_game("[src]/([src.ckey]) has infested [victim]/([victim.ckey]")
@@ -484,6 +485,11 @@
 	for (var/mob/living/carbon/M in range(1, src))
 		if(!M || !Adjacent(M))
 			return
+		if(has_upgrade("paralysis"))
+			playsound(loc, "sound/effects/sparks4.ogg", 30, 1, -1)
+			M.Stun(50)
+			M.SetSleeping(70)  //knocked out cold
+			M.electrocute_act(15, src, 1, FALSE, FALSE, FALSE, 1, FALSE)
 		else
 			to_chat(M, span_userdanger("You feel something wrapping around your leg, pulling you down!"))
 			playsound(loc, "sound/weapons/whipgrab.ogg", 30, 1, -1)
@@ -507,13 +513,13 @@
 		to_chat(src, span_danger("You decide against leaving your host."))
 		return
 
-	to_chat(src, span_danger("You begin disconnecting from [victim]'s synapses and prodding at [victim.p_their()] internal ear canal.")) //Yogs -- pronouns
+	to_chat(src, span_danger("You begin disconnecting from [victim]'s synapses and prodding at [victim.p_their()] internal ear canal.")) //Yogs -- pronouns ~~holy shit dude this is yogs exclusive antag already, why #Chester
 
 	if(victim.stat != DEAD && !has_upgrade("invisible_exit"))
 		to_chat(victim, span_userdanger("An odd, uncomfortable pressure begins to build inside your skull, behind your ear..."))
 
 	leaving = TRUE
-	if(do_after(src, 30 SECONDS, victim, extra_checks = CALLBACK(src, .proc/is_leaving), stayStill = FALSE)) //Enough time to do quick surgery
+	if(do_after(src, 10 SECONDS, victim, extra_checks = CALLBACK(src, .proc/is_leaving), stayStill = FALSE))
 		release_host()
 
 /mob/living/simple_animal/horror/proc/release_host()

--- a/code/modules/antagonists/horror/horror_abilities_and_upgrades.dm
+++ b/code/modules/antagonists/horror/horror_abilities_and_upgrades.dm
@@ -366,6 +366,21 @@
 /datum/horror_upgrade/proc/apply_effects()
 	return
 
+//Upgrades the knockdown ability
+/datum/horror_upgrade/paralysis
+	name = "Electrocharged tentacle"
+	id = "paralysis"
+	desc = "Empowers your tentacle knockdown ability by giving it extra charge, knocking your victim down unconcious."
+	soul_price = 3
+
+/datum/horror_upgrade/paralysis/apply_effects()
+	var/datum/action/innate/horror/A = B.has_ability(/datum/action/innate/horror/freeze_victim)
+	if(A)
+		A.name = "Paralyze Victim"
+		A.desc = "Shock a victim with an electrically charged tentacle."
+		A.button_icon_state = "paralyze"
+		B.update_action_buttons()
+
 //Increases chemical regeneration rate by 2
 /datum/horror_upgrade/chemical_regen
 	name = "Efficient chemical glands"
@@ -374,7 +389,7 @@
 	soul_price = 2
 
 /datum/horror_upgrade/chemical_regen/apply_effects()
-	B.chem_regen_rate += 2
+	B.chem_regen_rate += 3
 
 //Lets horror regenerate chemicals outside of a host
 /datum/horror_upgrade/nohost_regen


### PR DESCRIPTION
# Document the changes in your pull request
After having horror set down for quite some time, i've decided to bring some balance changes.

First of all, i'm buffing the chemical regeneration upgrade from 2 extra chemicals per tick to 3, hopefully this will justify it's moderate cost of 2 souls.

Next up, i'm bringing back the knockdown upgrade. 3 soul points, so pretty expensive, makes your aoe tentacle whip paralyze targets and knock them down unconcious for 5 seconds. It's important, because without it, any horror can be simply pushed away even by the person just you whipped. This costly upgrade also comes important to the another part:
Horrors now leave a visible message when infecting someone. - This should take away the confusion whether a horror entered a vent or a person. Obviously, people knocked unconcious don't see this message, so stealth is still viable.

Finally, leaving a person no longer takes 30 freaking seconds, now it takes 10. Consuming someone's soul still takes half of minute, but this change should encourage infecting non-target people.

# Wiki Documentation
idk probably should be included, at least the "new" upgrade part.

# Changelog
:cl:  
tweak: slightly buffs horror to make it more fun
/:cl:
