### PR TITLE
Fixes being able to make eye contact with traitorous cigarette butts

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1237,7 +1237,7 @@
 		QDEL_NULL(phantom_wound)
 
 /mob/living/carbon/is_face_visible()
-	return !(wear_mask?.flags_inv & HIDEFACE) && !(head?.flags_inv & HIDEFACE)
+	return ..() && !(wear_mask?.flags_inv & HIDEFACE) && !(head?.flags_inv & HIDEFACE) // Yogs -- you can no longer make eye contact with a cigarette butt that contains a tator
 
 /**
   * get_biological_state is a helper used to see what kind of wounds we roll for. By default we just assume carbons (read:monkeys) are flesh and bone, but humans rely on their species datums

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1461,4 +1461,4 @@
 
 /// Only defined for carbons who can wear masks and helmets, we just assume other mobs have visible faces
 /mob/living/proc/is_face_visible()
-	return TRUE
+	return isturf(loc) // Yogs -- forbids making eye contact with things hidden within objects


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/172019623-003f3dc7-c992-4c08-8dd9-423498105291.png)

Fixes #14323 by just making it so that you can't make eye contact with mobs whose location isn't a turf. This gets around issues like eye-contact with traitors using chameleon projectors (since that's coded as the traitor being stuffed into an `/obj/effect`'s contents)

## Changelog
:cl: Altoids
bugfix: You can no longer make eye contact with cigarette butts or people otherwise hiding in objects.
/:cl:
