### PR TITLE
Security is no longer granted 1000 credits a minute if the self destruct nuke core hasn't been stolen

### DIFF
--- a/code/modules/goals/department_goals/security.dm
+++ b/code/modules/goals/department_goals/security.dm
@@ -6,7 +6,6 @@
 /datum/department_goal/sec/nukecore
 	name = "Protect the nuke"
 	desc = "Protect the nuclear core of the station's self-destruct device, by keeping it in the device"
-	continuous = 1200 // Check every 2 minutes
 	reward = 2000 // Corresponds to 50k in 50mins
 	fail_if_failed = TRUE // Set this to false if we ever bother making it so you can stuff the core back into the self-destruct device
 


### PR DESCRIPTION
# Document the changes in your pull request

who thought this was a good idea??

# Wiki Documentation


# Changelog


:cl:  
rscdel: Security no longer gets a free 1000 credits a minute
/:cl:
