### PR TITLE
Fixes limbgrower synthetic limbs having corrupted text

### DIFF
--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -267,7 +267,7 @@
 		limb.icon = 'icons/mob/human_parts.dmi'
 	// Set this limb up using the specias name and body zone
 	limb.icon_state = "[selected_category]_[limb.body_zone]"
-	limb.name = "\improper synthetic [selected_category] [parse_zone(limb.body_zone)]"
+	limb.name = "synthetic [selected_category] [parse_zone(limb.body_zone)]"
 	limb.desc = "A synthetic [selected_category] limb that will morph on its first use in surgery. This one is for the [parse_zone(limb.body_zone)]."
 	limb.species_id = selected_category
 	limb.update_icon_dropped()


### PR DESCRIPTION
i can only assume \improper doesn't like having data references in the string? every other use of \improper that i saw was for static strings.
was this
![image](https://user-images.githubusercontent.com/46236974/172026709-44ae5d54-96a9-4b6d-b5f2-a4f4c904901a.png)

now this
![image](https://user-images.githubusercontent.com/46236974/172026720-8a2abff7-fb8d-4546-b477-bea0975ef66e.png)

capitalization probably isn't technically correct but unless the wiki team can fix the code i'm not too concerned by a big s

# Changelog

:cl:  
bugfix: limbgrower synthetic limb text no longer shows up scrambled on analyzers (hopefully)
/:cl:
