### PR TITLE
Fixes vend machines ignoring ignores_capitalism flag, so centcom dudes can use them

### DIFF
--- a/tgui/packages/tgui/interfaces/Vending.js
+++ b/tgui/packages/tgui/interfaces/Vending.js
@@ -20,6 +20,9 @@ const VendingRow = (props, context) => {
       && data.user
       && data.department === data.user.department
     )
+    // yogs start -- patch to make ignores_capitalism work again
+    || data.ignores_capitalism
+    // yogs end
   );
   return (
     <Table.Row>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/29939414/172035554-14dc8dbf-8733-4976-90f9-4d9fc08b704e.png)


This is a redux of https://github.com/yogstation13/Yogstation/pull/4622, making it work again three years later now that vending machines use TGUI.

## Changelog
:cl: Altoids
bugfix: Central Command personnel are now capable of operating the vending machines aboard the station.
/:cl: