### PR TITLE
fixes jamie indirectly breaking AIs being able to turn on their own APC

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -75,7 +75,7 @@
 	var/turf/waypoint //Holds the turf of the currently selected waypoint.
 	var/waypoint_mode = FALSE		//Waypoint mode is for selecting a turf via clicking.
 	var/call_bot_cooldown = 0		//time of next call bot command
-	var/apc_override = FALSE		//hack for letting the AI use its APC even when visionless
+	var/obj/machinery/power/apc/apc_override		//Ref of the AI's APC, used when the AI has no power in order to access their APC.
 	var/nuking = FALSE
 	var/obj/machinery/doomsday_device/doomsday_device
 
@@ -232,7 +232,7 @@
 	SSshuttle.autoEvac()
 	qdel(eyeobj) // No AI, no Eye
 	malfhack = null
-
+	apc_override = null
 	GLOB.ai_os.remove_ai(src)
 
 	. = ..()
@@ -451,9 +451,20 @@
 	. = 0
 
 /mob/living/silicon/ai/Topic(href, href_list)
-	if(usr != src || incapacitated())
-		return
 	..()
+	if(usr != src)
+		return
+	
+	if(href_list["emergencyAPC"]) //This check comes before incapacitated() because the only time it would be useful is when we have no power.
+		if(!apc_override)
+			to_chat(src, "<span class='notice'>APC backdoor is no longer available.</span>")
+			return
+		apc_override.ui_interact(src)
+		return
+
+	if(incapacitated())
+		return	
+	
 	if (href_list["mach_close"])
 		if (href_list["mach_close"] == "aialerts")
 			viewalerts = 0
@@ -933,7 +944,7 @@
 	if(isturf(loc) || istype(loc, /obj/machinery/ai/data_core)) //AI in core, check if on cameras
 		//get_turf_pixel() is because APCs in maint aren't actually in view of the inner camera
 		//apc_override is needed here because AIs use their own APC when depowered
-		return (GLOB.cameranet && GLOB.cameranet.checkTurfVis(get_turf_pixel(A))) || apc_override
+		return ((GLOB.cameranet && GLOB.cameranet.checkTurfVis(get_turf_pixel(A))) || (A == apc_override))
 	//AI is carded/shunted
 	//view(src) returns nothing for carded/shunted AIs and they have X-ray vision so just use get_dist
 	var/list/viewscale = getviewsize(client.view)

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -179,9 +179,9 @@
 				sleep(5 SECONDS)
 				to_chat(src, "Receiving control information from APC.")
 				sleep(0.2 SECONDS)
-				apc_override = 1
-				theAPC.ui_interact(src)
-				apc_override = 0
+				to_chat(src, "<A HREF=?src=[REF(src)];emergencyAPC=[TRUE]>APC ready for connection.</A>")
+				apc_override = theAPC
+				apc_override.ui_interact(src)
 				aiRestorePowerRoutine = POWER_RESTORATION_APC_FOUND
 		sleep(5 SECONDS)
 		theAPC = null
@@ -190,10 +190,13 @@
 	if(aiRestorePowerRoutine)
 		if(aiRestorePowerRoutine == POWER_RESTORATION_APC_FOUND)
 			to_chat(src, "Alert cancelled. Power has been restored.")
+			if(apc_override)
+				to_chat(src, "<span class='notice'>APC backdoor has been closed.</span>") //Fluff for why we have to hack every time.
 		else
 			to_chat(src, "Alert cancelled. Power has been restored without our assistance.")
 		aiRestorePowerRoutine = POWER_RESTORATION_OFF
 		set_blindness(0)
+		apc_override = null
 		update_sight()
 
 /mob/living/silicon/ai/proc/ai_lose_power()

--- a/code/modules/mob/living/silicon/ai/login.dm
+++ b/code/modules/mob/living/silicon/ai/login.dm
@@ -6,6 +6,8 @@
 			O.mode = 1
 			O.emotion = "Neutral"
 			O.update()
+		if(lacks_power() && apc_override) //Placing this in Login() in case the AI doesn't have this link for whatever reason.
+			to_chat(usr, "<span class='warning'>Main power is unavailable, backup power in use. Diagnostics scan complete.</span> <A HREF='?src=[REF(src)];emergencyAPC=[TRUE]'>Local APC ready for connection.</A>")
 	set_eyeobj_visible(TRUE)
 	if(multicam_on)
 		end_multicam()

--- a/code/modules/tgui/states.dm
+++ b/code/modules/tgui/states.dm
@@ -78,6 +78,8 @@
 
 /mob/living/silicon/ai/shared_ui_interaction(src_object)
 	// Disable UIs if the AI is unpowered.
+	if(apc_override == src_object) //allows AI to (eventually) use the interface for their own APC even when out of power
+		return UI_INTERACTIVE
 	if(lacks_power())
 		return UI_DISABLED
 	return ..()


### PR DESCRIPTION
Ports https://github.com/tgstation/tgstation/pull/55977

# Document the changes in your pull request

When an AI runs out of power, they get a short fluff text story about hacking into their own APC through the powernet or whatever, before having the APC's interface open. The intention is that an AI can re-enable their own breaker after a bit if something flipped it off. However, one of the many checks in TGUI will fail if the AI has no power (specifically, if incapacitated() returns TRUE), making this whole feature not work. In fact, it's probably been broken since TGUI APCs were done. I have fixed it by adding a check in the very same proc to return UI_INTERACTIVE if the UI's source object is the same object referenced in the AIs apc_override variable. Closes https://github.com/tgstation/tgstation/issues/52548
The apc_override variable is now an APC object reference rather than a boolean. It is set to the AI's local APC when the hack flufftext completes, and is null'd when power is restored. This reference is used by the above, so that the AI only gets access to this one APC rather than any APC in general.
AIs now also get a hyperlink in their chatbox, allowing them to open the APC interface should they have closed it. If they have had power restored, the apc_override reference var will be null, and using the hyperlink will simply result in text stating the backdoor to the APC is closed.
If the AI reconnects into a state where it has no power and apc_override is set, it will get a hyperlink to the APC, in case the AI player had been reconnecting when the window would have popped up or otherwise does not have the link for whatever reason.

# Wiki Documentation

# Changelog


:cl:  zxaber
bugfix: AIs that lose power can access their APC once more (after the same short hacking delay is complete).
/:cl:
