### PR TITLE
the *lick emote command for lizards is now an audible emote 

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -223,6 +223,7 @@
 	key_third_person = "licks"
 	message = "licks their eyes!"
 	cooldown = 10 SECONDS
+	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/carbon/human/lick/run_emote(mob/user, params)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -218,4 +218,12 @@
 		var/turf/T = loc
 		T.Entered(src)
 
+/datum/emote/living/carbon/human/lick
+	key = "lick"
+	key_third_person = "licks"
+	message = "licks their eyes!"
+
+/datum/emote/living/carbon/lick/can_run_emote(mob/living/user, status_check = TRUE, intentional)
+	return islizard(user)
+
 //Ayy lmao

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -222,8 +222,15 @@
 	key = "lick"
 	key_third_person = "licks"
 	message = "licks their eyes!"
+	cooldown = 10 SECONDS
 
-/datum/emote/living/carbon/lick/can_run_emote(mob/living/user, status_check = TRUE, intentional)
+/datum/emote/living/carbon/human/lick/run_emote(mob/user, params)
+	. = ..()
+	if(. && ishuman(user))
+		var/mob/living/carbon/human/H = user
+		H.adjustOrganLoss(ORGAN_SLOT_EYES, -0.15)
+
+/datum/emote/living/carbon/human/lick/can_run_emote(mob/living/user, status_check = TRUE, intentional)
 	return islizard(user)
 
 //Ayy lmao


### PR DESCRIPTION
Edited the emote so that it's an AUDIBLE EMOTE to make sure that it check for muzzles and all that.

# Wiki Documentation
Change lizard emote to audible.
:cl:  
tweak: what do you mean I can't lick with a mouth restraint on
/:cl:
