### PR TITLE
Lizards can no longer lick their eyes when they have a mouth restraint

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -223,6 +223,7 @@
 	key_third_person = "licks"
 	message = "licks their eyes!"
 	cooldown = 10 SECONDS
+	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/carbon/human/lick/run_emote(mob/user, params)
 	. = ..()


### PR DESCRIPTION

Adds emote_type = EMOTE_AUDIBLE to the lizard lick emote
# Wiki Documentation
Update emotes wiki page thanks tessa 
# Changelog

:cl:  
tweak: I CANT LICK MY EYES WITH THIS MUZZLE ON
/:cl:
