### PR TITLE
Ports TG's stomach pumping surgery. A way to remove the 400u misc narcotics from someone who's dead

### DIFF
--- a/code/modules/antagonists/changeling/powers/panacea.dm
+++ b/code/modules/antagonists/changeling/powers/panacea.dm
@@ -15,7 +15,7 @@
 		H.leave_victim()
 		if(iscarbon(user))
 			var/mob/living/carbon/C = user
-			C.vomit(0, toxic = TRUE)
+			C.vomit(0)
 			to_chat(user, span_notice("A parasite exits our form."))
 	..()
 	var/list/bad_organs = list(
@@ -30,7 +30,7 @@
 		O.Remove(user)
 		if(iscarbon(user))
 			var/mob/living/carbon/C = user
-			C.vomit(0, toxic = TRUE)
+			C.vomit(0)
 		O.forceMove(get_turf(user))
 
 	user.reagents.add_reagent(/datum/reagent/medicine/mutadone, 10)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -497,8 +497,8 @@
 		return 0
 	return ..()
 
-/mob/living/carbon/proc/vomit(lost_nutrition = 10, blood = FALSE, stun = TRUE, distance = 1, message = TRUE, toxic = FALSE)
-	if(HAS_TRAIT(src, TRAIT_NOHUNGER))
+/mob/living/carbon/proc/vomit(lost_nutrition = 10, blood = FALSE, stun = TRUE, distance = 1, message = TRUE, vomit_type = VOMIT_TOXIC, harm = TRUE, force = FALSE, purge_ratio = 0.1)
+	if((HAS_TRAIT(src, TRAIT_NOHUNGER) || HAS_TRAIT(src, TRAIT_TOXINLOVER)) && !force)
 		return TRUE
 
 	if(istype(src.loc, /obj/effect/dummy))  //cannot vomit while phasing/vomitcrawling
@@ -538,12 +538,9 @@
 				add_splatter_floor(T)
 			if(stun)
 				adjustBruteLoss(3)
-		else if(src.reagents.has_reagent(/datum/reagent/consumable/ethanol/blazaam, needs_metabolizing = TRUE))
-			if(T)
-				T.add_vomit_floor(src, VOMIT_PURPLE)
 		else
 			if(T)
-				T.add_vomit_floor(src, VOMIT_TOXIC)//toxic barf looks different
+				T.add_vomit_floor(src, vomit_type, purge_ratio) //toxic barf looks different || call purge when doing detoxicfication to pump more chems out of the stomach.
 		T = get_step(T, dir)
 		if (is_blocked_turf(T))
 			break

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -869,8 +869,8 @@
 		override = dna.species.override_float
 	..()
 
-/mob/living/carbon/human/vomit(lost_nutrition = 10, blood = 0, stun = 1, distance = 0, message = 1, toxic = 0)
-	if(blood && (NOBLOOD in dna.species.species_traits))
+/mob/living/carbon/human/vomit(lost_nutrition = 10, blood = FALSE, stun = TRUE, distance = 1, message = TRUE, vomit_type = VOMIT_TOXIC, harm = TRUE, force = FALSE, purge_ratio = 0.1)
+	if(blood && (NOBLOOD in dna.species.species_traits) && !HAS_TRAIT(src, TRAIT_TOXINLOVER))
 		if(message)
 			visible_message(span_warning("[src] dry heaves!"), \
 							span_userdanger("You try to throw up, but there's nothing in your stomach!"))

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -286,7 +286,7 @@
 		if(getToxLoss() >= 45 && nutrition > 20)
 			lastpuke += prob(50)
 			if(lastpuke >= 50) // about 25 second delay I guess
-				vomit(20, toxic = TRUE)
+				vomit(20)
 				lastpuke = 0
 
 

--- a/code/modules/surgery/stomachpump.dm
+++ b/code/modules/surgery/stomachpump.dm
@@ -49,5 +49,5 @@
 		display_results(user, target, span_warning("You screw up, brusing [target_human]'s chest!"),
 			span_warning("[user] screws up, brusing [target_human]'s abdomen!"),
 			span_warning("[user] screws up!"))
-		target_human.adjustOrganLoss(ORGAN_SLOT_STOMACH, 5)
+		target_human.adjustOrganLoss(ORGAN_SLOT_STOMACH, 10)
 		target_human.adjustBruteLoss(5)

--- a/code/modules/surgery/stomachpump.dm
+++ b/code/modules/surgery/stomachpump.dm
@@ -1,0 +1,53 @@
+/datum/surgery/stomach_pump
+	name = "Stomach Pump"
+	steps = list(
+		/datum/surgery_step/incise,
+		/datum/surgery_step/retract_skin,
+		/datum/surgery_step/incise,
+		/datum/surgery_step/clamp_bleeders,
+		/datum/surgery_step/stomach_pump,
+		/datum/surgery_step/close)
+
+	target_mobtypes = list(/mob/living/carbon/human)
+	possible_locs = list(BODY_ZONE_CHEST)
+	requires_bodypart_type = TRUE
+	ignore_clothes = FALSE
+
+/datum/surgery/stomach_pump/can_start(mob/user, mob/living/carbon/target)
+	var/obj/item/organ/stomach/target_stomach = target.getorganslot(ORGAN_SLOT_STOMACH)
+	if(HAS_TRAIT(target, TRAIT_HUSK))
+		return FALSE
+	if(!target_stomach)
+		return FALSE
+	return ..()
+
+//Working the stomach by hand in such a way that you induce vomiting.
+/datum/surgery_step/stomach_pump
+	name = "Pump Stomach"
+	accept_hand = TRUE
+	repeatable = TRUE
+	time = 2 SECONDS
+
+/datum/surgery_step/stomach_pump/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	display_results(user, target, span_notice("You begin pumping [target]'s stomach..."),
+		span_notice("[user] begins to pump [target]'s stomach."),
+		span_notice("[user] begins to press on [target]'s chest."))
+	display_pain(target, "You feel a horrible sloshing feeling in your gut! You're going to be sick!")
+
+/datum/surgery_step/stomach_pump/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
+	if(ishuman(target))
+		var/mob/living/carbon/human/target_human = target
+		display_results(user, target, span_notice("[user] forces [target_human] to vomit, cleansing their stomach of some chemicals!"),
+				span_notice("[user] forces [target_human] to vomit, cleansing their stomach of some chemicals!"),
+				"[user] forces [target_human] to vomit!")
+		target_human.vomit(20, FALSE, TRUE, 1, TRUE, FALSE, purge_ratio = 0.67) //higher purge ratio than regular vomiting
+	return ..()
+
+/datum/surgery_step/stomach_pump/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	if(ishuman(target))
+		var/mob/living/carbon/human/target_human = target
+		display_results(user, target, span_warning("You screw up, brusing [target_human]'s chest!"),
+			span_warning("[user] screws up, brusing [target_human]'s chest!"),
+			span_warning("[user] screws up!"))
+		target_human.adjustOrganLoss(ORGAN_SLOT_STOMACH, 5)
+		target_human.adjustBruteLoss(5)

--- a/code/modules/surgery/stomachpump.dm
+++ b/code/modules/surgery/stomachpump.dm
@@ -47,7 +47,7 @@
 	if(ishuman(target))
 		var/mob/living/carbon/human/target_human = target
 		display_results(user, target, span_warning("You screw up, brusing [target_human]'s chest!"),
-			span_warning("[user] screws up, brusing [target_human]'s chest!"),
+			span_warning("[user] screws up, brusing [target_human]'s abdomen!"),
 			span_warning("[user] screws up!"))
 		target_human.adjustOrganLoss(ORGAN_SLOT_STOMACH, 5)
 		target_human.adjustBruteLoss(5)

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -203,7 +203,7 @@
  * * mechanical_surgery - Boolean flag that represents if a surgery step is done on a mechanical limb (therefore does not force scream)
  */
 /datum/surgery_step/proc/display_pain(mob/living/target, pain_message, mechanical_surgery = FALSE)
-	if(target.stat < UNCONSCIOUS)
+	if(!HAS_TRAIT(target, TRAIT_SURGERY_PREPARED))
 		to_chat(target, span_userdanger(pain_message))
 		if(prob(30) && !mechanical_surgery)
 			target.emote("scream")

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -193,3 +193,17 @@
 	//if(ishuman(target) &&fuckup_damage_type == BRUTE && prob(final_ouchie_chance/2))
 		//var/mob/living/carbon/human/H = target
 		//H.bleed_rate += min(fuckup_damage/4, 10)
+
+/**
+ * Sends a pain message to the target, including a chance of screaming.
+ *
+ * Arguments:
+ * * target - Who the message will be sent to
+ * * pain_message - The message to be displayed
+ * * mechanical_surgery - Boolean flag that represents if a surgery step is done on a mechanical limb (therefore does not force scream)
+ */
+/datum/surgery_step/proc/display_pain(mob/living/target, pain_message, mechanical_surgery = FALSE)
+	if(target.stat < UNCONSCIOUS)
+		to_chat(target, span_userdanger(pain_message))
+		if(prob(30) && !mechanical_surgery)
+			target.emote("scream")

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3153,6 +3153,7 @@
 #include "code\modules\surgery\prosthetic_replacement.dm"
 #include "code\modules\surgery\remove_embedded_object.dm"
 #include "code\modules\surgery\repair_puncture.dm"
+#include "code\modules\surgery\stomachpump.dm"
 #include "code\modules\surgery\surgery.dm"
 #include "code\modules\surgery\surgery_step.dm"
 #include "code\modules\surgery\tools.dm"


### PR DESCRIPTION
# Document the changes in your pull request
Stomach pumping is a procedure dedicated to draining the reagents from a person, living or dead. Much faster than calomel at the cost of a bit of time, nutrition from the person getting pumped, and vomit on the floor 🤢 

Initiate the surgery by targeting the chest and choosing the "Stomach Pump" procedure. Then the steps are:

- Scalpel
- Retractor
- Scalpel
- Hemostat
- Empty hand help intent (this step is repeatable and purges 67% reagent volume total each time. the only limit being running out of nutrition because then they can't vomit anymore)
- Cautery to finish

This procedure also uses a more powerful vomit effect that purges 67% of the person's entire reagent content on each stomach squeeze. (This required me to brush up our vomit code to match tg's, but for everything except this specific procedure there's no difference.

Be sure to be ready to feed the person after, as multiple pumps is going to drain their nutrition by a substantial amount.

# Wiki Documentation

New surgery dropped, use cases and steps listed in the documentation

# Changelog

:cl:  
rscadd: Stomach Pumping surgery. A quick way to deal with someone, living or dead who has way too many reagents in their system.
tweak: I updated our vomit code and i don't want to talk about it. players won't notice a difference
/:cl:
