### PR TITLE
removes sleepy pens from all uplinks except infiltrators 

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -660,6 +660,17 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cant_discount = TRUE
 	exclude_modes = list(/datum/game_mode/infiltration) // yogs: infiltration
 
+/datum/uplink_item/stealthy_weapons/sleepy_pen
+	name = "Sleepy Pen"
+	desc = "A syringe disguised as a functional pen, filled with a potent mix of drugs, including a \
+			strong anesthetic and a chemical that prevents the target from speaking. \
+			The pen holds one dose of the mixture. Note that before the target \
+			falls asleep, they will be able to move and act."
+	item = /obj/item/pen/sleepy
+	cost = 4
+	manufacturer = /datum/corporation/traitor/waffleco
+	include_modes = list(/datum/game_mode/infiltration)
+
 /datum/uplink_item/stealthy_weapons/suppressor
 	name = "Suppressor"
 	desc = "This suppressor will silence the shots of the weapon it is attached to for increased stealth and superior ambushing capability. It is compatible with many small ballistic guns including the Stechkin and C-20r, but not revolvers or energy guns."

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -660,17 +660,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cant_discount = TRUE
 	exclude_modes = list(/datum/game_mode/infiltration) // yogs: infiltration
 
-/datum/uplink_item/stealthy_weapons/sleepy_pen
-	name = "Sleepy Pen"
-	desc = "A syringe disguised as a functional pen, filled with a potent mix of drugs, including a \
-			strong anesthetic and a chemical that prevents the target from speaking. \
-			The pen holds one dose of the mixture. Note that before the target \
-			falls asleep, they will be able to move and act."
-	item = /obj/item/pen/sleepy
-	cost = 4
-	manufacturer = /datum/corporation/traitor/waffleco
-	exclude_modes = list(/datum/game_mode/nuclear)
-
 /datum/uplink_item/stealthy_weapons/suppressor
 	name = "Suppressor"
 	desc = "This suppressor will silence the shots of the weapon it is attached to for increased stealth and superior ambushing capability. It is compatible with many small ballistic guns including the Stechkin and C-20r, but not revolvers or energy guns."


### PR DESCRIPTION
improves RP by removing the 1-click kill weapon from everyone except infiltrators because its not fun for anyone to left click someone once for a free win only reduced by nanites/drinking the shit out of charcoal. surplus crates, the special ops crate from cargo and null crates still get sleepy pens

# Document the changes in your pull request

removes the sleepy pen from traitor (and clownop) uplinks

# Wiki Documentation

uplink item wiki page

# Changelog

:cl:  
tweak: the sleepy pen is no longer capable of being purchased in uplink by normal traitors
/:cl:
