### PR TITLE
Makes sleepy pens 2tc more expensive and locks them to 35+ pop

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -667,7 +667,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			The pen holds one dose of the mixture. Note that before the target \
 			falls asleep, they will be able to move and act."
 	item = /obj/item/pen/sleepy
-	player_minimum = 38
+	player_minimum = 35
 	cost = 6
 	manufacturer = /datum/corporation/traitor/waffleco
 	exclude_modes = list(/datum/game_mode/nuclear)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -667,7 +667,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			The pen holds one dose of the mixture. Note that before the target \
 			falls asleep, they will be able to move and act."
 	item = /obj/item/pen/sleepy
-	cost = 4
+	player_minimum = 38
+	cost = 6
 	manufacturer = /datum/corporation/traitor/waffleco
 	exclude_modes = list(/datum/game_mode/nuclear)
 


### PR DESCRIPTION
sleepy pens are awful, they're just a 1-click win and rarely used for their intended use of kidnapping people. it's usually just combat penning someone to murder them because they're a win button that silences your target and gets a free 5+ minute stun in about 10 seconds

# Document the changes in your pull request

sleepy pens are now 2tc more expensive and can only be purchased with 35+ players

# Wiki Documentation

update the traitor items page

# Changelog

:cl:  
tweak: sleepy pens are 6tc
tweak: sleepy pens are now locked to 35 or more players
/:cl:
