### PR TITLE
Mentors will now be told if an MHelp is from admins

### DIFF
--- a/yogstation/code/modules/admin/verbs/adminhelp.dm
+++ b/yogstation/code/modules/admin/verbs/adminhelp.dm
@@ -472,7 +472,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 	if(initiator)
 		to_chat(initiator, msg, confidential=TRUE)
-		initiator.mentorhelp(name)
+		initiator.mentorhelp(name, 1)
 
 	SSblackbox.record_feedback("tally", "ahelp_stats", 1, "MHelp")
 	msg = "Ticket [TicketHref("#[id]")] marked as MHelp by [key_name]"

--- a/yogstation/code/modules/mentor/mentorhelp.dm
+++ b/yogstation/code/modules/mentor/mentorhelp.dm
@@ -1,4 +1,4 @@
-/client/verb/mentorhelp(msg as text)
+/client/verb/mentorhelp(msg as text, fromadmins as null|num)
 	set category = "Mentor"
 	set name = "Mentorhelp"
 
@@ -23,9 +23,12 @@
 	if(!msg)	return
 	if(!mob)	return						//this doesn't happen
 
+	var/admininfo = "MENTORHELP:"
+	if(fromadmins == 1)
+		admininfo = "MENTORHELP(From Admins):"
 	var/show_char = CONFIG_GET(flag/mentors_mobname_only)
-	var/mentor_msg = "<span class='mentornotice purple'><b>MENTORHELP:</b> <b>[key_name_mentor(src, 1, 0, 1, show_char)]</b>: [msg]</span>"
-	log_mentor("MENTORHELP: [key_name_mentor(src, 0, 0, 0, 0)]: [msg]")
+	var/mentor_msg = "<span class='mentornotice purple'><b>[admininfo]</b> <b>[key_name_mentor(src, 1, 0, 1, show_char)]</b>: [msg]</span>"
+	log_mentor("[admininfo] [key_name_mentor(src, 0, 0, 0, 0)]: [msg]")
 
 	for(var/client/X in GLOB.mentors | GLOB.admins)
 		if(X.prefs.toggles & SOUND_ADMINHELP)

--- a/yogstation/code/modules/mentor/mentorhelp.dm
+++ b/yogstation/code/modules/mentor/mentorhelp.dm
@@ -24,7 +24,7 @@
 	if(!mob)	return						//this doesn't happen
 
 	var/admininfo = "MENTORHELP:"
-	if(fromadmins == 1)
+	if(fromadmins)
 		admininfo = "MENTORHELP(From Admins):"
 	var/show_char = CONFIG_GET(flag/mentors_mobname_only)
 	var/mentor_msg = "<span class='mentornotice purple'><b>[admininfo]</b> <b>[key_name_mentor(src, 1, 0, 1, show_char)]</b>: [msg]</span>"


### PR DESCRIPTION
Mentors will now be told if an MHelp is from Admins

When an AHELP is marked as MHelp there is no way for a mentor to know if the mhelp was from admins, this sometimes gave situations where mentors would tell the person who got mhelped to ahelp which makes this loop.
This makes it more clear when an Mhelp is sent from the admins AHELP.

MENTORHELP(From Admins):

# Changelog

:cl:  
rscadd: Mentors will now be told if an MHelp is from Admins
/:cl:
