### PR TITLE
Gives miners a GPS on shift start.

### DIFF
--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -23,7 +23,7 @@ GLOBAL_LIST_EMPTY(GPS_list)
 	name = "global positioning system ([gpstag])"
 	if(tracking) //Some roundstart GPS are off.
 		add_overlay("working")
-		
+
 /obj/item/gps/Destroy()
 	GLOB.GPS_list -= src
 	return ..()

--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -23,7 +23,7 @@ GLOBAL_LIST_EMPTY(GPS_list)
     name = "global positioning system ([gpstag])"
     if(tracking) //Some roundstart GPS are off.
         add_overlay("working")
-    addtimer(CALLBACK(src, .proc/InitMob), 1 SECONDS)
+    addtimer(CALLBACK(src, .proc/InitMob), 2 SECONDS)
 
 /obj/item/gps/proc/InitMob()
     var/mob/living/carbon/human/potential = src.loc.loc

--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -18,18 +18,12 @@ GLOBAL_LIST_EMPTY(GPS_list)
 	. += span_notice("Alt-click to switch it [tracking ? "off":"on"].")
 
 /obj/item/gps/Initialize()
-    . = ..()
-    GLOB.GPS_list += src
-    name = "global positioning system ([gpstag])"
-    if(tracking) //Some roundstart GPS are off.
-        add_overlay("working")
-    addtimer(CALLBACK(src, .proc/InitMob), 2 SECONDS)
-
-/obj/item/gps/proc/InitMob()
-    var/mob/living/carbon/human/potential = src.loc.loc
-    if(istype(potential, /mob/living/carbon/human))
-        gpstag = potential.name
-
+	. = ..()
+	GLOB.GPS_list += src
+	name = "global positioning system ([gpstag])"
+	if(tracking) //Some roundstart GPS are off.
+		add_overlay("working")
+		
 /obj/item/gps/Destroy()
 	GLOB.GPS_list -= src
 	return ..()

--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -18,11 +18,17 @@ GLOBAL_LIST_EMPTY(GPS_list)
 	. += span_notice("Alt-click to switch it [tracking ? "off":"on"].")
 
 /obj/item/gps/Initialize()
-	. = ..()
-	GLOB.GPS_list += src
-	name = "global positioning system ([gpstag])"
-	if(tracking) //Some roundstart GPS are off.
-		add_overlay("working")
+    . = ..()
+    GLOB.GPS_list += src
+    name = "global positioning system ([gpstag])"
+    if(tracking) //Some roundstart GPS are off.
+        add_overlay("working")
+    addtimer(CALLBACK(src, .proc/InitMob), 1 SECONDS)
+
+/obj/item/gps/proc/InitMob()
+    var/mob/living/carbon/human/potential = src.loc.loc
+    if(istype(potential, /mob/living/carbon/human))
+        gpstag = potential.name
 
 /obj/item/gps/Destroy()
 	GLOB.GPS_list -= src

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -141,8 +141,7 @@
 	new /obj/item/clothing/mask/gas/explorer(src)
 	new /obj/item/tank/internals/emergency_oxygen(src)
 	new /obj/item/crowbar/red(src)
-	var/obj/item/gps/mining/snowflake = new /obj/item/gps/mining(src)
-	snowflake.gpstag = src.loc.loc.name
+	new /obj/item/gps/mining(src)
 	new /obj/item/reagent_containers/hypospray/medipen(src)
 
 // Engineer survival box

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -142,7 +142,7 @@
 	new /obj/item/tank/internals/emergency_oxygen(src)
 	new /obj/item/crowbar/red(src)
 	var/obj/item/gps/mining/snowflake = new /obj/item/gps/mining(src)
-  		snowflake.gpstag = src.loc.loc.name
+	snowflake.gpstag = src.loc.loc.name
 	new /obj/item/reagent_containers/hypospray/medipen(src)
 
 // Engineer survival box

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -141,10 +141,8 @@
 	new /obj/item/clothing/mask/gas/explorer(src)
 	new /obj/item/tank/internals/emergency_oxygen(src)
 	new /obj/item/crowbar/red(src)
-
 	var/obj/item/gps/mining/snowflake = new /obj/item/gps/mining(src)
-  	snowflake.gpstag = src.loc.loc.name
-
+  		snowflake.gpstag = src.loc.loc.name
 	new /obj/item/reagent_containers/hypospray/medipen(src)
 
 // Engineer survival box

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -141,6 +141,7 @@
 	new /obj/item/clothing/mask/gas/explorer(src)
 	new /obj/item/tank/internals/emergency_oxygen(src)
 	new /obj/item/crowbar/red(src)
+	new /obj/item/gps/mining(src)
 	new /obj/item/reagent_containers/hypospray/medipen(src)
 
 // Engineer survival box

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -141,8 +141,10 @@
 	new /obj/item/clothing/mask/gas/explorer(src)
 	new /obj/item/tank/internals/emergency_oxygen(src)
 	new /obj/item/crowbar/red(src)
+
 	var/obj/item/gps/mining/snowflake = new /obj/item/gps/mining(src)
-  	snowflake.location = src.loc.loc.name
+  	snowflake.gpstag = src.loc.loc.name
+
 	new /obj/item/reagent_containers/hypospray/medipen(src)
 
 // Engineer survival box

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -141,7 +141,8 @@
 	new /obj/item/clothing/mask/gas/explorer(src)
 	new /obj/item/tank/internals/emergency_oxygen(src)
 	new /obj/item/crowbar/red(src)
-	new /obj/item/gps/mining(src)
+	var/obj/item/gps/mining/snowflake = new /obj/item/gps/mining(src)
+  	snowflake.location = src.loc.loc.name
 	new /obj/item/reagent_containers/hypospray/medipen(src)
 
 // Engineer survival box


### PR DESCRIPTION
# Document the changes in your pull request

Adds a GPS to the shaft miner survival box.

No more will you have to suffer to try and find a dead miner! 

# Changelog

:cl:  
rscadd: Puts a GPS in the shaft miner survival box.
/:cl:
