### PR TITLE
de nettle nerf

### DIFF
--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -72,7 +72,10 @@
 	if(!proximity)
 		return
 	if(force > 0)
-		force -= rand(1, (force / 3) + 1) // When you whack someone with it, leaves fall off
+		if(istype(src, /obj/item/reagent_containers/food/snacks/grown/nettle/death)) // istype instead of new proc because . = ..() is scary
+			force -= rand(1, (force / 10) + 1) // rand of 1 to (10% + 1) as opposed to (33% + 1)
+		else
+			force -= rand(1, (force / 3) + 1) // When you whack someone with it, leaves fall off
 	else
 		to_chat(usr, "All the leaves have fallen off the nettle from violent whacking.")
 		qdel(src)
@@ -94,7 +97,7 @@
 
 /obj/item/reagent_containers/food/snacks/grown/nettle/death/add_juice()
 	..()
-	force = round((5 + seed.potency / 2.5), 1)
+	force = round((5 + seed.potency / 4), 1) // Max 30 dmg, esword level, with max potency and buffed force reduction, should down unarmored in 3-4 hits
 
 /obj/item/reagent_containers/food/snacks/grown/nettle/death/pickup(mob/living/carbon/user)
 	if(..())


### PR DESCRIPTION
# Document the changes in your pull request

## TL;DR

Death Nettles have had their force reduced to max 30 but increased durability to increase combat effectiveness (-4 per hit instead of -16)

This is supposed to encourage/ease use of fewer dnettles instead of botanist main pulling out 45 damage dnettles and tossing them for new ones to no downside

-
-
-

The main goal of this is to reduce the cringe combat strategy of holding several pocket deswords that you can use once and toss, completely removing the downside this weapon has

Instead of having 45 damage at your disposal every new nettle, you will only have 30

As a compromise to this, it is more forgiving in terms of using only one (or a couple) death nettles in a given encounter. 

(In the worst case,) a death nettle after 3 uses previously would be as effective as a kitchen knife, whereas with these changes, after 5 uses you are still looking at force comparable to a toolbox, with extremely diminishing punishment as force is reduced (At 16 force, the damage reduction on a hit is between 1 and 2.6).

## Details

### Force/Damage

Old
`force = round((5 + seed.potency / 2.5), 1)` Max 45 damage at 100 potency
New
`force = round((5 + seed.potency / 4), 1)` Max 30 damage at 100 potency

-

### Durability (Force reduction on hit)

Old
`force -= rand(1, (force / 3) + 1)` Hits reduce up to `33% + 1` force (At 45 force, reduces max 16 force; at 30, max 11)
New
`force -= rand(1, (force / 10) + 1)` Hits reduce up to `10% + 1` force (At 30 force, reduces max 4 force)

-

### Combat simulation

If RNG is dealing its absolute worst hand against you, a max potency death nettle would look like this

Old hits

0. 45 force (45 total)
1. 29 force (74 total)
2. 18.333 force (92.333 total)
3. 7.111 force (99.444 total)
4. 3.37 force (102.814 total)

New hits

0. 30 force (30 total)
1. 26 force (56 total)
2. 22.4 force (78.4 total)
3. 19.16 force (97.56 total)
4. 16.244 force (113.804 total)

With both old and new dnettles, they both would 100dmg at worst RNG in 5 hits

As a side note, best case RNG would be reducing force by 1 every hit (old:133 in 3, new:117 in 4)

# Changelog

:cl:  
wip: Death nettles have reduced force and increased durability
/:cl:

# Scroll to top for TL;DR
