### PR TITLE
More safe cooldown overlays and makes it so being forced out of shadowling void jaunt starts the cooldown properly

### DIFF
--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -301,6 +301,8 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	return TRUE
 
 /obj/effect/proc_holder/spell/proc/start_recharge()
+	if(cooldown_overlay)
+		QDEL_NULL(cooldown_overlay)
 	cooldown_overlay = start_cooldown(action.button, world.time + charge_max)
 	recharging = TRUE
 
@@ -380,6 +382,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 			charge_counter++
 		if("holdervar")
 			adjust_var(user, holder_var_type, -holder_var_amount)
+	QDEL_NULL(cooldown_overlay)
 	if(action)
 		action.UpdateButtonIcon()
 

--- a/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
@@ -774,6 +774,9 @@
 		user.forceMove(S2)
 		S2.jaunter = user
 		charge_counter = charge_max //Don't have to wait for cooldown to exit
+		QDEL_NULL(cooldown_overlay) //since we're giving them a free cooldown, no more cooldown_overlay
+		S2.jaunt_spell = src
+
 
 //Both have to be high to cancel out natural regeneration
 #define VOIDJAUNT_STAM_PENALTY_DARK 10
@@ -793,6 +796,8 @@
 	var/apply_damage = TRUE
 	var/move_delay = 0			//Time until next move allowed
 	var/move_speed = 2			//Deciseconds per move
+
+	var/obj/effect/proc_holder/spell/targeted/void_jaunt/jaunt_spell //what spell we actually came from (for forced cooldown)
 
 /obj/effect/dummy/phased_mob/shadowling/relaymove(mob/user, direction)
 	if(move_delay > world.time && apply_damage)	//Ascendants get no slowdown
@@ -821,6 +826,8 @@
 															span_shadowling("You exit the void."))
 
 		playsound(get_turf(jaunter), 'sound/magic/ethereal_exit.ogg', 50, 1, -1)
+		jaunt_spell?.charge_counter = 0
+		jaunt_spell?.start_recharge()
 		jaunter = null
 	qdel(src)
 


### PR DESCRIPTION
# Document the changes in your pull request

Sometimes cooldown overlays stack on top of each other which should hopefully be fixed in spells that function in ways that are different than normal (such as void jaunt)

This also makes it so shadowlings that are forced out of void jaunt by stamina crit actually have it go on cooldown since you can cast an 80 second cooldown ability every 20 seconds by simply waiting until you're forced out in which it will never actually start the cooldown since it's refunded when you cast it so you can uncast it. I believe this was a bug but some more robust (exploiter) players can make it seem like shadowlings are impossible to fight because they can get out of every situation for free forever.

# Changelog

:cl:  
bugfix: safer cooldown overlay checking
bugfix: makes shadowling void jaunt start cooldown if you're forced out of it
/:cl:
