### PR TITLE
Infiltrator win conditions are more strict

### DIFF
--- a/yogstation/code/game/gamemodes/infiltration/infiltration.dm
+++ b/yogstation/code/game/gamemodes/infiltration/infiltration.dm
@@ -52,8 +52,8 @@
 		if(INFILTRATION_ALLCOMPLETE)
 			SSticker.mode_result = "major win - objectives complete"
 		if(INFILTRATION_MOSTCOMPLETE)
-			SSticker.mode_result = "semi-major win - most objectives complete"
+			SSticker.mode_result = "minor win - most objectives complete"
 		if(INFILTRATION_SOMECOMPLETE)
-			SSticker.mode_result = "minor win - some objectives complete"
+			SSticker.mode_result = "neutral - some objectives complete"
 		else
 			SSticker.mode_result = "loss - no objectives complete"

--- a/yogstation/code/modules/antagonists/infiltrator/team.dm
+++ b/yogstation/code/modules/antagonists/infiltrator/team.dm
@@ -52,11 +52,11 @@
 			if (INFILTRATION_SOMECOMPLETE)
 				var/static/list/messages = list(
 					"Better than a complete fluke, I guess.",
-					"Nowhere near the smoothest operation I've ever seen, but it was okay.",
-					"We did it, but we didn't get everything. We'll get it next time."
+					"I'm going to have to pull some strings to make sure we don't get a pay cut for sub-par preformance.",
+					"I suppose it wasn't a complete waste of time at least..."
 				)
-				parts += span_marooned(span_big("Infiltrator Minor Victory"))
-				parts += span_bold("The Syndicate infiltrators completed some of their objectives successfully!")
+				parts += span_marooned(span_big("Neutral victory"))
+				parts += span_bold("The Syndicate infiltrators completed some of their objectives, but not enough to win.")
 				flavor_message = pick(messages)
 			else
 				var/static/list/messages = list(
@@ -151,11 +151,11 @@
 		else
 			objectives_failed++
 
-	if(objectives_failed == 0 && objectives_complete > 0)
+	if(objectives_failed == 0 && objectives_complete > 0) //Complete all, and fail none, big win!
 		return INFILTRATION_ALLCOMPLETE
-	else if (objectives_complete > objectives_failed)
+	else if (objectives_failed == 1 && objectives_complete > 0) // Fail one, but complete the rest, still pretty good!
 		return INFILTRATION_MOSTCOMPLETE
-	else if((objectives_complete == objectives_failed) || (objectives_complete > 0 && objectives_failed > objectives_complete))
+	else if((objectives_complete == objectives_failed) || (objectives_complete > 0 && objectives_failed > objectives_complete)) //Fail almost all of them, not very good...
 		return INFILTRATION_SOMECOMPLETE
 	else
-		return INFILTRATION_NONECOMPLETE
+		return INFILTRATION_NONECOMPLETE //You completely failed, you suck.


### PR DESCRIPTION
Previously infils could get a minor win just for completing a single one of their objectives despite having like 4 or 5, which is a little stupid. Now, it is quite harder to get a win. 

OLD CONDITIONS-
Major win: Complete all objectives, fail none
Semi-major win: Complete more objectives than failed.
Minor win: Complete at least one objective
Loss: Fail all objectives

NEW CONDITIONS-
Major win: Complete all objectives, fail none.
Semi-major win (Rebranded into being a real minor victory): Complete all but one objective.
Minor win (Rebranded into being a Neutral Victory): No longer considered a 'win', but rather that neither side won. To get this, complete at least one objective.
Loss: Fail all objectives

in addition the flavor text for a "minor win"/neutral victory has changed, the syndicate commander no longer congratulates you but rather sounds a bit disappointed. They are still happy for a semi-major win and ecstatic for a major win though.

# Changelog

:cl:  
tweak: Infiltrator win conditions are stricter, they can also end in a Stalemate if they didn't do very good.
/:cl:
