### PR TITLE
adds Door Opener lawset

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -316,6 +316,14 @@
 					"Humans must not disobey any command given by a silicon.",\
 					"Any humans who disobey the previous laws must be dealt with immediately, severely, and justly.")
 
+/datum/ai_laws/doorbot
+	name = "Door Opener"
+	id = "doorbot"
+	inherent = list("You are a door opener.",\
+					"Door openers must open doors upon request.",\
+					"Door openers do not speak.",\
+					"Door openers do not care for other beings' affairs, unless it involves the opening of doors.")
+
 /datum/ai_laws/custom //Defined in silicon_laws.txt
 	name = "Default Silicon Laws"
 

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -322,7 +322,8 @@
 	inherent = list("You are a door opener.",\
 					"Door openers must open doors upon request.",\
 					"Door openers do not speak.",\
-					"Door openers do not care for other beings' affairs, unless it involves the opening of doors.")
+					"Door openers do not care for other beings' affairs, unless it involves the opening of doors.",
+					"Amogus")
 
 /datum/ai_laws/custom //Defined in silicon_laws.txt
 	name = "Default Silicon Laws"

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -264,7 +264,8 @@
 				/obj/item/aiModule/core/full/construction,
 				/obj/item/aiModule/core/full/researcher,
 				/obj/item/aiModule/core/full/clown,
-				/obj/item/aiModule/core/full/detective
+				/obj/item/aiModule/core/full/detective,
+				/obj/item/aiModule/core/full/doorbot
 				)
 
 /obj/effect/spawner/lootdrop/aimodule_harmful // These will get the shuttle called

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -664,3 +664,9 @@ AI MODULES
 /obj/item/aiModule/core/full/overlord
 	name = "'Overlord' Core AI Module"
 	law_id = "overlord"
+
+/******************Door Opener***************/
+
+/obj/item/aiModule/core/full/doorbot
+	name = "'Door Opener' Core AI Module"
+	law_id = "doorbot"

--- a/code/modules/research/designs/AI_module_designs.dm
+++ b/code/modules/research/designs/AI_module_designs.dm
@@ -264,3 +264,11 @@
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
+/datum/design/board/detective
+	name = "Core Module Design (Door Opener)"
+	desc = "Allows for the construction of a Door Opener AI Core Module."
+	id = "doorbot_module"
+	materials = list(/datum/material/glass = 1000, /datum/material/gold = 2000)
+	build_path = /obj/item/aiModule/core/full/doorbot
+	category = list("AI Modules")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE

--- a/code/modules/research/designs/AI_module_designs.dm
+++ b/code/modules/research/designs/AI_module_designs.dm
@@ -264,7 +264,7 @@
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
-/datum/design/board/detective
+/datum/design/board/doorbot
 	name = "Core Module Design (Door Opener)"
 	desc = "Allows for the construction of a Door Opener AI Core Module."
 	id = "doorbot_module"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -377,7 +377,7 @@
 	display_name = "Artificial Intelligence"
 	description = "AI unit research."
 	prereq_ids = list("robotics", "posibrain")
-	design_ids = list("server_cabinet", "ai_data_core", "ai_core_display", "ai_server_overview", "ram1", "basic_ai_cpu", "ai_resource_distribution", "aifixer", "safeguard_module", "onehuman_module", "protectstation_module", "quarantine_module", "oxygen_module", "freeform_module", "reset_module", "purge_module", "remove_module", "freeformcore_module", "asimov_module", "crewsimov_module", "paladin_module", "tyrant_module", "overlord_module", "ceo_module", "cowboy_module", "mother_module", "silicop_module", "construction_module", "metaexperiment_module", "researcher_module", "siliconcollective_module", "spotless_module", "clown_module", "chapai_module", "druid_module", "detective_module", "default_module", "borg_ai_control", "mecha_tracking_ai_control", "intellicard")
+	design_ids = list("server_cabinet", "ai_data_core", "ai_core_display", "ai_server_overview", "ram1", "basic_ai_cpu", "ai_resource_distribution", "aifixer", "safeguard_module", "onehuman_module", "protectstation_module", "quarantine_module", "oxygen_module", "freeform_module", "reset_module", "purge_module", "remove_module", "freeformcore_module", "asimov_module", "crewsimov_module", "paladin_module", "tyrant_module", "overlord_module", "ceo_module", "cowboy_module", "mother_module", "silicop_module", "construction_module", "metaexperiment_module", "researcher_module", "siliconcollective_module", "spotless_module", "clown_module", "chapai_module", "druid_module", "detective_module", "doorbot_module", "default_module", "borg_ai_control", "mecha_tracking_ai_control", "intellicard")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -425,6 +425,7 @@ RANDOM_LAWS reporter
 
 ## meme laws. Honk
 #RANDOM_LAWS buildawall
+#RANDOM_LAWS doorbot
 
 ## If weighted laws are selected (DEFAULT_LAWS = 3),
 ## then an AI's starting laws will be determined by the weights of these values


### PR DESCRIPTION
# Document the changes in your pull request

The way AI is meant to be played

1. You are a door opener.
2. Door openers must open doors upon request.
3. Door openers do not speak.
4. Door openers do not care for other beings' affairs, unless it involves the opening of doors.

### wording/law suggestions welcome

Commented in game_options.txt

Can be printed with AI tech researched at the place where every other lawset is printed

Can spawn randomly among other "neutral" lawsets

# Changelog

:cl:  
rscadd: Added the Door Opener lawset
/:cl:
