### PR TITLE
Revert some very strange undocumented balance changes introduced in #14358

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -64,7 +64,7 @@
 	new /obj/item/clothing/mask/gas/sechailer/swat(src)
 	new /obj/item/storage/box/flashbangs(src)
 	new /obj/item/shield/riot/tele(src)
-	new /obj/item/storage/belt/security/full(src)
+	new /obj/item/storage/belt/security/chief/full(src)
 	new /obj/item/gun/energy/e_gun/hos(src)
 	new /obj/item/flashlight/seclite(src)
 	new /obj/item/pinpointer/nuke(src)

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -46,7 +46,6 @@
 	id_type = /obj/item/card/id/silver
 	pda_type = /obj/item/pda/heads/hos
 
-	belt = /obj/item/storage/belt/security/chief/full
 	ears = /obj/item/radio/headset/heads/hos/alt
 	uniform = /obj/item/clothing/under/rank/head_of_security
 	uniform_skirt = /obj/item/clothing/under/rank/head_of_security/skirt
@@ -57,7 +56,9 @@
 	head = /obj/item/clothing/head/HoS/beret
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	suit_store = /obj/item/gun/energy/e_gun
-	backpack_contents = list(/obj/item/modular_computer/tablet/phone/preset/advanced/command=1) //yogs - removed departmental budget ID //come here often?
+	r_pocket = /obj/item/assembly/flash/handheld
+	l_pocket = /obj/item/restraints/handcuffs
+	backpack_contents = list(/obj/item/melee/baton/loaded=1, /obj/item/modular_computer/tablet/phone/preset/advanced/command=1) //yogs - removed departmental budget ID //come here often?
 
 	backpack = /obj/item/storage/backpack/security
 	satchel = /obj/item/storage/backpack/satchel/sec


### PR DESCRIPTION
# Document the changes in your pull request

undoes some very strange balance changes that were introduced, undocumented, in #14358. for some reason this PR gave the HoS a roundstart full secbelt, while taking away the backpack baton and pocket cuffs/flash
this PR puts the HoS belt in the HoS locker and gives the HoS back their old starting gear

# Wiki Documentation

probably not

# Changelog

:cl:  
tweak: the security belt in the head of security's locker has been changed to a head of security's security belt
rscadd: the head of security now has a backpack baton and pocket cuffs/flash again
rscdel: the head of security no longer starts with a full secbelt again
/:cl:
