### PR TITLE
Gives shuttle arena a mood bonus

### DIFF
--- a/code/modules/admin/fun_balloon.dm
+++ b/code/modules/admin/fun_balloon.dm
@@ -166,3 +166,6 @@
 	name = "The Arena"
 	has_gravity = STANDARD_GRAVITY
 	requires_power = FALSE
+	hidden = TRUE
+	mood_bonus = 25
+	mood_message = span_nicegreen("NO TIME TO THINK, JUST RIP AND TEAR!!/n")


### PR DESCRIPTION
# Document the changes in your pull request
ripping and tearing is pretty nice :))
may counteract the mood debuff of seeing like 20 corpses

also makes the area hidden


# Changelog
:cl:  
tweak: arena shuttle now has a mood bonus
/:cl:
