### PR TITLE
IAA Cyanide implant replaced with dusting implant

### DIFF
--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -32,13 +32,9 @@
 	START_PROCESSING(SSprocessing, src)
 
 	if(ishuman(owner.current))
-		//Gives Cyanide/death pill dental implant
-		var/obj/item/reagent_containers/pill/iaa/death = new
-		owner.current.transferItemToLoc(death, owner, TRUE)
-		var/datum/action/item_action/hands_free/activate_pill/P = new(death)
-		P.button.name = "Activate [death.name]"
-		P.target = death
-		P.Grant(owner.current)//The pill never actually goes in an inventory slot, so the owner doesn't inherit actions from it
+		var/mob/living/carbon/human/H = owner.current
+		var/obj/item/implant/dusting/E = new/obj/item/implant/dusting(H)
+		E.implant(H)
 
 	company = /datum/corporation/mi13
 


### PR DESCRIPTION
# Document the changes in your pull request

no more (sec) keeping caught IAA alive

no more reviving killed IAA

no more having to kill cloned IAA or destroy cloning and destroy medical/staff in the process

# 

also lessens the infiltrators meta!!

https://user-images.githubusercontent.com/28408322/173261705-e21104cf-9a55-4770-bcbe-69f693824dc2.mp4



# Changelog

:cl:  
tweak: Internal Affairs Agents are now equipped with dusting implants instead of cyanide capsules
/:cl:
