### PR TITLE
Recommend anturk.dmi-editor for vscode and lets yogs actually use it

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
 		"platymuus.dm-langclient",
 		"EditorConfig.EditorConfig",
 		"arcanis.vscode-zipfs",
-		"dbaeumer.vscode-eslint"
+		"dbaeumer.vscode-eslint",
+		"anturk.dmi-editor"
 	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,9 +7,8 @@
 		"tgui/.yarn": true,
 		"tgui/.pnp.*": true
 	},
-	"workbench.editorAssociations": {
-		"*.dmi": "imagePreview.previewEditor"
-	},
 	"files.eol": "\n",
-	"gitlens.advanced.blame.customArguments": ["-w"]
+	"gitlens.advanced.blame.customArguments": [
+		"-w"
+	]
 }


### PR DESCRIPTION
# Document the changes in your pull request

https://marketplace.visualstudio.com/items?itemName=AnturK.dmi-editor

We have a setting that makes it so you open .dmis in an image preview instead of the very very nicve DMI Editor that you can get for vscode. Now recommends it and removes the setting to open them in the image preview so it should automatically use thee DMI editor (tested)

while not a full editor definitely helps with tweaking things and previewing icons more gracefully without loading up dream maker to see states and the like.

![image](https://user-images.githubusercontent.com/5091394/173261743-8d21cd0f-4554-407f-9dca-1d4a526292c9.png)

![image](https://user-images.githubusercontent.com/5091394/173261760-0df1f6a4-b214-4131-87da-af843941c2b9.png)

No changelog since this isn't player facing
