### PR TITLE
Adds support for map spawned holochips

### DIFF
--- a/code/game/objects/items/credit_holochip.dm
+++ b/code/game/objects/items/credit_holochip.dm
@@ -10,7 +10,8 @@
 
 /obj/item/holochip/Initialize(mapload, amount)
 	. = ..()
-	credits = amount
+	if(amount)
+		credits = amount
 	update_icon()
 
 /obj/item/holochip/examine(mob/user)


### PR DESCRIPTION
# Document the changes in your pull request

Required for https://github.com/yogstation13/Yogstation/pull/14406

simply change the credits amount and it will work sort itself out on initialize, instead of it automatically setting to 0

# Changelog

:cl:  
rscadd: Adds support for map spawned holochips
/:cl:
