### PR TITLE
Allows mappers to spawn tilted vending machines

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -171,6 +171,8 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
   * * TRUE - all other cases
   */
 /obj/machinery/vending/Initialize(mapload)
+	if(tilted)
+		src.tilt() // We don't need to set tilted to false before tilt because it will handle it.
 	var/build_inv = FALSE
 	if(!refill_canister)
 		circuit = null


### PR DESCRIPTION
Compliments #14406

Adds this functionality:
![image](https://user-images.githubusercontent.com/24533979/173499064-b58e2384-f1df-4ed8-8f08-fe6e18599506.png)

:cl:  Hopek
rscadd: Mappers can now created round-start tilted vending machines 
/:cl:
