### PR TITLE
Foolproofs vending machine being spawned tipped by mappers

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -171,6 +171,8 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
   * * TRUE - all other cases
   */
 /obj/machinery/vending/Initialize(mapload)
+	if(tilted)
+		src.tilt() // We don't need to set tilted to false before tilt because it will handle it.
 	var/build_inv = FALSE
 	if(!refill_canister)
 		circuit = null

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -479,7 +479,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 	if(forcecrit)
 		crit_case = forcecrit
 
-	if(in_range(fatty, src) || no_tipper)
+	if(in_range(fatty, src))
 		for(var/mob/living/L in get_turf(fatty))
 			var/mob/living/carbon/C = L
 

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -547,7 +547,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 	M.Turn(pick(90, 270))
 	transform = M
 
-	if(get_turf(fatty) != get_turf(src))
+	if(fatty && get_turf(fatty) != get_turf(src))
 		throw_at(get_turf(fatty), 1, 1, spin=FALSE)
 
 /obj/machinery/vending/proc/untilt(mob/user)

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -465,9 +465,6 @@ GLOBAL_LIST_EMPTY(vending_products)
 			break
 
 /obj/machinery/vending/proc/tilt(mob/fatty, crit=FALSE)
-	var/no_tipper = FALSE
-	if(!fatty)
-		no_tipper = TRUE
 	visible_message("<span class='danger'>[src] tips over!</span>")
 	tilted = TRUE
 	layer = ABOVE_MOB_LAYER

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -479,7 +479,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 	if(forcecrit)
 		crit_case = forcecrit
 
-	if(in_range(fatty, src))
+	if(fatty && in_range(fatty, src))
 		for(var/mob/living/L in get_turf(fatty))
 			var/mob/living/carbon/C = L
 

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -465,6 +465,9 @@ GLOBAL_LIST_EMPTY(vending_products)
 			break
 
 /obj/machinery/vending/proc/tilt(mob/fatty, crit=FALSE)
+	var/no_tipper = FALSE
+	if(!fatty)
+		no_tipper = TRUE
 	visible_message("<span class='danger'>[src] tips over!</span>")
 	tilted = TRUE
 	layer = ABOVE_MOB_LAYER
@@ -476,7 +479,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 	if(forcecrit)
 		crit_case = forcecrit
 
-	if(fatty && in_range(fatty, src))
+	if(no_tipper || in_range(fatty, src))
 		for(var/mob/living/L in get_turf(fatty))
 			var/mob/living/carbon/C = L
 

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -465,6 +465,9 @@ GLOBAL_LIST_EMPTY(vending_products)
 			break
 
 /obj/machinery/vending/proc/tilt(mob/fatty, crit=FALSE)
+	var/no_tipper = FALSE
+	if(!fatty)
+		no_tipper = TRUE
 	visible_message("<span class='danger'>[src] tips over!</span>")
 	tilted = TRUE
 	layer = ABOVE_MOB_LAYER
@@ -476,7 +479,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 	if(forcecrit)
 		crit_case = forcecrit
 
-	if(in_range(fatty, src))
+	if(in_range(fatty, src) || no_tipper)
 		for(var/mob/living/L in get_turf(fatty))
 			var/mob/living/carbon/C = L
 


### PR DESCRIPTION
part 2 of #14414

Ensures no runtimes happen and that tipping can handle being tipped without a fatty per:
![image](https://user-images.githubusercontent.com/24533979/173503229-2bf006d0-3786-4dc9-a3d3-4258bf09f7e7.png)
