### PR TITLE
Adds a user warning when someone tries to fry a brain with a deepfryer.

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -115,7 +115,7 @@ God bless America.
 			return
 	if(istype(I, /obj/item/organ/brain))
 		var/safety = alert(user, "Warning! This brain might still contain a life in it.", "Proceed anyways?" ,"No.", "FRY THIS BITCH ! ! !")
-		if(safety != "FRY THIS BITCH")
+		if(safety != "FRY ANYWAY")
 			to_chat(user, span_warning("You decided not to fry this brain..."))
 			return
 	if(default_unfasten_wrench(user, I))

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -113,6 +113,11 @@ God bless America.
 			var/turf/T = get_turf(src)
 			new /obj/item/syndicate_basket(T)
 			return
+	if(istype(I, /obj/item/organ/brain))
+		var/safety = alert(user, "Warning! This brain might still contain a life in it.", "Proceed anyways?" ,"No", "FRY THIS BITCH")
+		if(safety != "FRY THIS BITCH")
+			to_chat(user, span_warning("You decided not to fry this brain..."))
+			return
 	if(default_unfasten_wrench(user, I))
 		return
 	else if(default_deconstruction_screwdriver(user, "fryer_off", "fryer_off" ,I))	//where's the open maint panel icon?!

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -114,7 +114,7 @@ God bless America.
 			new /obj/item/syndicate_basket(T)
 			return
 	if(istype(I, /obj/item/organ/brain))
-		var/safety = alert(user, "Warning! This brain might still contain a life in it.", "Proceed anyways?" ,"No", "FRY THIS BITCH")
+		var/safety = alert(user, "Warning! This brain might still contain a life in it.", "Proceed anyways?" ,"No.", "FRY THIS BITCH ! ! !")
 		if(safety != "FRY THIS BITCH")
 			to_chat(user, span_warning("You decided not to fry this brain..."))
 			return

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -114,7 +114,7 @@ God bless America.
 			new /obj/item/syndicate_basket(T)
 			return
 	if(istype(I, /obj/item/organ/brain))
-		var/safety = alert(user, "Warning! This brain might still contain a life in it.", "Proceed anyways?" ,"No.", "FRY THIS BITCH ! ! !")
+		var/safety = alert(user, "Warning! This brain might still contain a life in it.", "Proceed anyways?" ,"No.", "FRY ANYWAY")
 		if(safety != "FRY ANYWAY")
 			to_chat(user, span_warning("You decided not to fry this brain..."))
 			return


### PR DESCRIPTION


# Document the changes in your pull request
Adds a warning 
![image](https://user-images.githubusercontent.com/81328245/173508616-42379156-2261-4a7a-8ccc-fd2885747399.png)

Just incase if someone accidentally clicks the deep fryer with someone elses' brain and take them out of the round permanently

# Changelog

:cl:  
tweak: tweaked deepfryer code
/:cl:
