### PR TITLE
Stops Admins Lagging the Game

### DIFF
--- a/yogstation/code/modules/admin/sql_message_system.dm
+++ b/yogstation/code/modules/admin/sql_message_system.dm
@@ -274,7 +274,7 @@
 		return
 	var/list/output = list()
 	var/ruler = "<hr style='background:#000000; border:0; height:3px'>"
-	var/list/navbar = list("<a href='?_src_=holder;[HrefToken()];nonalpha=1'>\[All\]</a>|<a href='?_src_=holder;[HrefToken()];nonalpha=2'>\[#\]</a>")
+	var/list/navbar = list("<a href='?_src_=holder;[HrefToken()];nonalpha=2'>\[#\]</a>")
 	for(var/letter in GLOB.alphabet)
 		navbar += "|<a href='?_src_=holder;[HrefToken()];showmessages=[letter]'>\[[letter]\]</a>"
 	navbar += "|<a href='?_src_=holder;[HrefToken()];showmemo=1'>\[Memos\]</a>|<a href='?_src_=holder;[HrefToken()];showwatch=1'>\[Watchlist\]</a>"


### PR DESCRIPTION
Removes a button which lags the entire server and crashes the client which clicked it. Well done Admins.
Removes ALL button from investigate.

:cl:  
rscdel: Removes ALL button from investigate.
/:cl:
