### PR TITLE
Revert "Stun batons cannot be turned on for 8 Seconds after being dropped"

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -155,7 +155,6 @@
 #define COMSIG_MOVABLE_IMPACT_ZONE "item_impact_zone"			//from base of mob/living/hitby(): (mob/living/target, hit_zone)
 #define COMSIG_MOVABLE_BUCKLE "buckle"							//from base of atom/movable/buckle_mob(): (mob, force)
 #define COMSIG_MOVABLE_UNBUCKLE "unbuckle"						//from base of atom/movable/unbuckle_mob(): (mob, force)
-#define COMSIG_MOVABLE_PRE_DROPTHROW "movable_pre_dropthrow"	//from base of atom/movable/throw_at(): Triggers when throwing, before the item is dropped and before COMSIG_MOVABLE_PRE_THROW 
 #define COMSIG_MOVABLE_PRE_THROW "movable_pre_throw"			//from base of atom/movable/throw_at(): (list/args)
 #define COMPONENT_CANCEL_THROW 1
 #define COMSIG_MOVABLE_POST_THROW "movable_post_throw"			//from base of atom/movable/throw_at(): (datum/thrownthing, spin)

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -15,8 +15,7 @@
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 50, BIO = 0, RAD = 0, FIRE = 80, ACID = 80)
 
 	var/cooldown_check = 0
-	/// if the baton is on cooldown from being  dropped
-	var/dropcheck = FALSE
+
 	///how long we can't use this baton for after slapping someone with it. Does not account for melee attack cooldown (default of 0.8 seconds).
 	var/cooldown = 1.2 SECONDS
 	///how long a clown stuns themself for, or someone is stunned for if they are hit to >90 stamina damage
@@ -35,7 +34,6 @@
 	var/preload_cell_type
 	///used for passive discharge
 	var/cell_last_used = 0
-	var/thrown = FALSE
 
 /obj/item/melee/baton/get_cell()
 	return cell
@@ -46,13 +44,11 @@
 
 /obj/item/melee/baton/Initialize()
 	. = ..()
-	status = FALSE
 	if(preload_cell_type)
 		if(!ispath(preload_cell_type,/obj/item/stock_parts/cell))
 			log_mapping("[src] at [AREACOORD(src)] had an invalid preload_cell_type: [preload_cell_type].")
 		else
 			cell = new preload_cell_type(src)
-	RegisterSignal(src, COMSIG_MOVABLE_PRE_DROPTHROW, .proc/throwbaton)
 	update_icon()
 
 /obj/item/melee/baton/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
@@ -61,22 +57,6 @@
 	//Only mob/living types have stun handling
 	if(status && prob(throw_hit_chance) && iscarbon(hit_atom))
 		baton_stun(hit_atom)
-
-/obj/item/melee/baton/proc/throwbaton()
-	thrown = TRUE
-
-/obj/item/melee/baton/dropped(mob/user, silent)
-	if(loc != user.loc)
-		return
-	. = ..()
-	if(!thrown)
-		dropcheck = TRUE
-		status = FALSE
-		visible_message(span_warning("The safety strap on [src] is pulled as it is dropped, triggering its emergency shutoff!"))
-		addtimer(VARSET_CALLBACK(src, dropcheck, FALSE), 8 SECONDS)
-		update_icon()
-	else
-		thrown = FALSE
 
 /obj/item/melee/baton/loaded //this one starts with a cell pre-installed.
 	preload_cell_type = /obj/item/stock_parts/cell/high
@@ -144,9 +124,6 @@
 		return ..()
 
 /obj/item/melee/baton/attack_self(mob/user)
-	if(dropcheck)
-		to_chat(user, "[src]'s emergency shutoff is still active!")
-		return
 	if(cell && cell.charge > hitcost)
 		status = !status
 		to_chat(user, span_notice("[src] is now [status ? "on" : "off"]."))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -187,7 +187,6 @@
 
 	else if(!CHECK_BITFIELD(I.item_flags, ABSTRACT) && !HAS_TRAIT(I, TRAIT_NODROP))
 		thrown_thing = I
-		SEND_SIGNAL(thrown_thing, COMSIG_MOVABLE_PRE_DROPTHROW, src)
 		dropItemToGround(I, silent = TRUE)
 
 		if(HAS_TRAIT(src, TRAIT_PACIFISM) && I.throwforce)


### PR DESCRIPTION
Reverts yogstation13/Yogstation#14322
![SjEgeBY](https://user-images.githubusercontent.com/23666142/173661035-85ff1f62-d6d1-4ca2-90a2-c6cc2076e5cf.png)

also this was made contingent on one-hit batons being merged, and they were not merged (and hopefully will not be merged)
ergo, this really has no purpose besides being a really weird and specific sec buff (you are unrobust)

my point here is that this "buff" only applies to a very specific situation that can be easily avoided by anyone with more then 3 braincells playing security. Security shouldn't hugbox their players, because then the experience turns from "damn I got caught by a good sec member" to "damn I got caught by a bad sec member carried by game mechanics" and that isn't fun. 

Literally just use the disabler, flashbangs, or the flash. If your first choice is "rush anteg with batong" you gonna learn today
