### PR TITLE
Adds craftable armor that can be created with on-station resources.

### DIFF
--- a/code/datums/components/crafting/tailoring.dm
+++ b/code/datums/components/crafting/tailoring.dm
@@ -12,7 +12,7 @@
 /datum/crafting_recipe/improvarmor
 	name = "Improvised Armor Vest"
 	result = /obj/item/clothing/suit/armor/vest/improvised
-	reqs = list(/obj/item/stack/cable_coil = 10
+	reqs = list(/obj/item/stack/cable_coil = 10,
 				/obj/item/stack/sheet/metal = 8)
 	tools = list(TOOL_WELDER, TOOL_WIRECUTTER)
 	time = 15 SECONDS

--- a/code/datums/components/crafting/tailoring.dm
+++ b/code/datums/components/crafting/tailoring.dm
@@ -9,12 +9,32 @@
 	category = CAT_APPAREL
 	subcategory = CAT_ARMOR
 
+/datum/crafting_recipe/improvarmor
+	name = "Improvised Armor Vest"
+	result = /obj/item/clothing/suit/armor/vest/improvised
+	reqs = list(/obj/item/stack/cable_coil = 10
+				/obj/item/stack/sheet/metal = 8)
+	tools = list(TOOL_WELDER, TOOL_WIRECUTTER)
+	time = 15 SECONDS
+	category = CAT_APPAREL
+	subcategory = CAT_ARMOR
+
 /datum/crafting_recipe/durathread_helmet
 	name = "Durathread Helmet"
 	result = /obj/item/clothing/head/helmet/durathread
 	reqs = list(/obj/item/stack/sheet/cloth/durathread = 4,
 				/obj/item/stack/sheet/leather = 5)
 	time = 4 SECONDS
+	category = CAT_APPAREL
+	subcategory = CAT_ARMOR
+
+/datum/crafting_recipe/improvhelmet
+	name = "Improvised Helmet"
+	result = /obj/item/clothing/head/helmet/old/improvised
+	reqs = list(/obj/item/stack/sheet/metal = 4,
+				/obj/item/stack/sheet/glass = 1)
+	tools = list(TOOL_WELDER, TOOL_SCREWDRIVER)
+	time = 10 SECONDS
 	category = CAT_APPAREL
 	subcategory = CAT_ARMOR
 

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -95,6 +95,10 @@
 	desc = "Standard issue security helmet. Due to degradation the helmet's visor obstructs the users ability to see long distances."
 	tint = 2
 
+/obj/item/clothing/head/helmet/old/improvised
+	name = "improvised helmet"
+	desc = "Sheets of metal bent into a cylinder. Protects your head, at the cost of visibility."
+
 /obj/item/clothing/head/helmet/blueshirt
 	name = "blue helmet"
 	desc = "A reliable, blue tinted helmet reminding you that you <i>still</i> owe that engineer a beer."

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -35,6 +35,16 @@
 	icon_state = "armor"
 	item_state = "armor"
 	slowdown = 1
+	
+/obj/item/clothing/suit/armor/vest/improvised
+	name = "improvised armor"
+	desc = "Metal sheets welded together, connected with cable. It will protect your chest, but it looks difficult to move in."
+	icon_state = "armor"
+	item_state = "armor"
+	slowdown = 0.65
+	cold_protection = CHEST
+	heat_protection = CHEST
+	body_parts_covered = CHEST
 
 /obj/item/clothing/suit/armor/vest/blueshirt
 	name = "large armor vest"


### PR DESCRIPTION
# Document the changes in your pull request

Makeshift/improvised stuff is a lot of fun, But there's no improvised armor for people on station, which is pretty saddening. This pull request adds makeshift armor and a helmet. They both have the same stats as their non-improvised counterparts, but with notable downsides. The vest has a slowdown and doesn't protect your groin, and the helmet adds the tint effect from the welding helmet, but it doesn't give you flash protection. The vest is crafted from 6 metal sheets and 10 cablecoil, and the helmet is created from 4 metal sheets and a sheet of glass. If these items turn out to be too strong, I'm willing to turn down the stats or lock them to syndicate crafting. This pull request is not ready, because I do not have sprites for the helmet or armor.

# Spriting
Sprites are the last thing I have to do, but I don't have them yet.

# Wiki Documentation

Combat page, in the armor section.

# Changelog

:cl:  
rscadd: added makeshift armor and helmets, craftable from the crafting menu. 
/:cl:
