### PR TITLE
does sa thing that makes probably the miner gpses spawn with numbersand not spawn on lavaland corpses

### DIFF
--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -64,7 +64,7 @@
 	..()
 	if(visualsOnly)
 		return
-	if(!is_station_level(H.z) && !is_centcom_level(H.z))
+	if(H.stat == DEAD)
 		return
 	for(var/obj/item/gps in H.contents)
 		gps.gpstag = "MINE[gps_number]"

--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -35,6 +35,7 @@
 
 /datum/outfit/job/miner
 	name = "Shaft Miner"
+	var/static/gps_number = 1
 	jobtype = /datum/job/mining
 
 	pda_type = /obj/item/pda/shaftminer
@@ -58,6 +59,16 @@
 	box = /obj/item/storage/box/survival_mining
 
 	chameleon_extras = /obj/item/gun/energy/kinetic_accelerator
+
+/datum/outfit/job/miner/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	if(visualsOnly)
+		return
+	if(!is_station_level(H.z) && !is_centcom_level(H.z))
+		return
+	for(var/obj/item/gps in H.contents)
+		gps.gpstag = "MINE[gps_number]"
+		gps_number ++
 
 /datum/outfit/job/miner/equipped
 	name = "Shaft Miner (Equipment)"

--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -66,8 +66,8 @@
 		return
 	if(H.stat == DEAD)
 		return
-	for(var/obj/item/gps in H.contents)
-		gps.gpstag = "MINE[gps_number]"
+	for(var/obj/item/gps/G in H.contents)
+		G.gpstag = "MINE[gps_number]"
 		gps_number ++
 
 /datum/outfit/job/miner/equipped

--- a/yogstation/code/modules/jobs/job_types/mining_medic.dm
+++ b/yogstation/code/modules/jobs/job_types/mining_medic.dm
@@ -34,8 +34,7 @@
 	pda_type = /obj/item/pda/miningmed
 
 	backpack_contents = list(/obj/item/roller = 1,\
-		/obj/item/kitchen/knife/combat/survival = 1,\
-		/obj/item/gps/mining = 1)
+		/obj/item/kitchen/knife/combat/survival = 1)
 	belt = /obj/item/storage/belt/medical/mining
 	ears = /obj/item/radio/headset/headset_medcargo
 	glasses = /obj/item/clothing/glasses/hud/health/meson


### PR DESCRIPTION
# Document the changes in your pull request

adds a static variable to name gpses with which increments by 1 per miner
prevents gpses from spawning on corpses by making them only spawn if the person being equipped is alive

# Changelog

:cl:  
bugfix: no more ruin spawned corpses with gpses because people with gpses dont get not recovered (this is canon shut up)
tweak: gpses on miners now properly iterate numbers i.e. MINE1 2 3 4 rather than just all being MINE0. The mining medic isn't included because they suck
tweak: mining medic no longer gets 2 gpses
/:cl:
