### PR TITLE
Slight disabler nerf

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -83,7 +83,7 @@
 /obj/item/projectile/beam/disabler
 	name = "disabler beam"
 	icon_state = "omnilaser"
-	damage = 30
+	damage = 25
 	damage_type = STAMINA
 	flag = ENERGY
 	hitsound = 'sound/weapons/tap.ogg'


### PR DESCRIPTION
# Document the changes in your pull request

The disabler beam now does 25 stamina damage instead of 30.

There's about a million arguments for both sides of this but I'll simply say:
1) Makes it so energy armor is actually potentially viable as most sources of it won't make the disabler 4-shot crit because it's just not enough armor (you would need 20 or more, never mind the slowdown coming in just as quick)
2) The disabler has 20 shots and is easily one of the best anti-organic weapons on the station for any poor chap that isn't simply immune to stuns or stamina or knockdown. Does this encourage lethals more often? Yes. However baton buff coming in means that sec still has perfectly capable non-lethal intent.

Having a ranged option is very good and typically the pinnacle strength of security. I intend to make a separate PR to buff less-lethals such as rubber shot and WT rubber shot because, uh, they suck ass and right now there's only "never do damage no no no just stun spam them" or "kill someone as fast as you can with little regard for excessive bodily harm"

If anything else this PR will spawn discussion on what the disabler should be so I'm prepared to eat a ratio for it

# Wiki Documentation

Disabler stamina damage to 25 from 30

# Changelog

:cl:  
tweak: Makes accuracy more of a requirement for disabler use
/:cl:
