### PR TITLE
Buffs rubber shot

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -63,7 +63,7 @@
 
 /obj/item/projectile/bullet/pellet
 	var/tile_dropoff = 0.45
-	var/tile_dropoff_s = 0.5
+	var/tile_dropoff_s = 0.35
 
 /obj/item/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"
@@ -80,7 +80,7 @@
 /obj/item/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubbershot pellet"
 	damage = 3
-	stamina = 11
+	stamina = 13
 	sharpness = SHARP_NONE
 
 /obj/item/projectile/bullet/pellet/shotgun_cryoshot


### PR DESCRIPTION
# Document the changes in your pull request

Rubber shot:beanbag ratios now more akin to buckshot:slugs, plus rubber pellets have less stamina damage falloff.

Hopefully promotes less-lethal usage, even though beanbag slugs having 55 stamina is absurd and somehow not used more often by security

# Wiki Documentation

Stamina damage falloff for pellets reduced to 0.35 from 0.5
Stamina damage per pellet of rubber shot increased to 13 from 11 (effective 78 stamina damage, 15 brute for PBS)

# Changelog

:cl:  
tweak: Rubber shot more damage and less damage falloff
/:cl:
