### PR TITLE
WT Tweak/Buff

### DIFF
--- a/code/modules/projectiles/boxes_magazines/external/smg.dm
+++ b/code/modules/projectiles/boxes_magazines/external/smg.dm
@@ -3,7 +3,7 @@
 	icon_state = "46x30mmt-20"
 	ammo_type = /obj/item/ammo_casing/c46x30mm
 	caliber = "4.6x30mm"
-	max_ammo = 26
+	max_ammo = 22
 
 /obj/item/ammo_box/magazine/wt550m9/update_icon()
 	..()

--- a/code/modules/projectiles/boxes_magazines/external/smg.dm
+++ b/code/modules/projectiles/boxes_magazines/external/smg.dm
@@ -3,7 +3,7 @@
 	icon_state = "46x30mmt-20"
 	ammo_type = /obj/item/ammo_casing/c46x30mm
 	caliber = "4.6x30mm"
-	max_ammo = 20
+	max_ammo = 26
 
 /obj/item/ammo_box/magazine/wt550m9/update_icon()
 	..()

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -83,12 +83,12 @@
 
 /obj/item/gun/ballistic/automatic/wt550
 	name = "security auto rifle"
-	desc = "An outdated personal defence weapon. Uses 4.6x30mm rounds and is designated the WT-550 Automatic Rifle. Has a single fire burst mode, but you still can't figure out what advantage that has over semi automatic."
+	desc = "An outdated personal defence weapon. Uses 4.6x30mm rounds and is designated the WT-550 Automatic Rifle. Has a two-round burst or a semi-automatic firing mode."
 	icon_state = "wt550"
 	item_state = "arg"
 	mag_type = /obj/item/ammo_box/magazine/wt550m9
 	fire_delay = 2
-	burst_size = 1
+	burst_size = 2
 	can_suppress = FALSE
 	can_bayonet = TRUE
 	knife_x_offset = 25

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -89,6 +89,7 @@
 	mag_type = /obj/item/ammo_box/magazine/wt550m9
 	fire_delay = 2
 	burst_size = 2
+	weapon_weight = WEAPON_MEDIUM
 	can_suppress = FALSE
 	can_bayonet = TRUE
 	knife_x_offset = 25

--- a/code/modules/projectiles/projectile/bullets/smg.dm
+++ b/code/modules/projectiles/projectile/bullets/smg.dm
@@ -10,22 +10,22 @@
 
 /obj/item/projectile/bullet/c46x30mm
 	name = "4.6x30mm bullet"
-	damage = 20
+	damage = 13
 	wound_bonus = -5
 	bare_wound_bonus = 5
 	armour_penetration = 20
 
 /obj/item/projectile/bullet/c46x30mm_ap
 	name = "4.6x30mm armor-piercing bullet"
-	damage = 15
+	damage = 10
 	armour_penetration = 50
 
 /obj/item/projectile/bullet/incendiary/c46x30mm
 	name = "4.6x30mm incendiary bullet"
-	damage = 10
+	damage = 7
 	fire_stacks = 1
 
 /obj/item/projectile/bullet/c46x30mm_rubber
 	name = "4.6x30mm rubber bullet"
-	damage = 5
-	stamina = 20 //slightly more effective than the detective's revolver when fired in bursts
+	damage = 4
+	stamina = 21 //slightly more effective than the detective's revolver when fired in bursts

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -310,7 +310,7 @@
 
 /datum/design/mag_oldsmg
 	name = "WT-550 Auto Gun Magazine (4.6x30mm)"
-	desc = "A 26 round magazine for the out of date security WT-550 Auto Rifle."
+	desc = "A 22 round magazine for the out of date security WT-550 Auto Rifle."
 	id = "mag_oldsmg"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 4000)
@@ -320,7 +320,7 @@
 
 /datum/design/mag_oldsmg/ap_mag
 	name = "WT-550 Auto Gun Armour Piercing Magazine (4.6x30mm AP)"
-	desc = "A 26 round armour piercing magazine for the out of date security WT-550 Auto Rifle."
+	desc = "A 22 round armour piercing magazine for the out of date security WT-550 Auto Rifle."
 	id = "mag_oldsmg_ap"
 	materials = list(/datum/material/iron = 6000, /datum/material/silver = 600)
 	build_path = /obj/item/ammo_box/magazine/wt550m9/wtap
@@ -328,7 +328,7 @@
 
 /datum/design/mag_oldsmg/ic_mag
 	name = "WT-550 Auto Gun Incendiary Magazine (4.6x30mm IC)"
-	desc = "A 26 round armour piercing magazine for the out of date security WT-550 Auto Rifle."
+	desc = "A 22 round armour piercing magazine for the out of date security WT-550 Auto Rifle."
 	id = "mag_oldsmg_ic"
 	materials = list(/datum/material/iron = 6000, /datum/material/silver = 600, /datum/material/glass = 1000)
 	build_path = /obj/item/ammo_box/magazine/wt550m9/wtic
@@ -336,7 +336,7 @@
 
 /datum/design/mag_oldsmg/rubber_mag
 	name = "WT-550 Auto Gun Rubber Bullet Magazine (4.6x30mm Rubber)"
-	desc = "A 26 round rubber bullet magazine for the out of date security WT-550 Auto Rifle."
+	desc = "A 22 round rubber bullet magazine for the out of date security WT-550 Auto Rifle."
 	id = "mag_oldsmg_rubber"
 	materials = list(/datum/material/iron = 4000)
 	build_path = /obj/item/ammo_box/magazine/wt550m9/wtr

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -310,7 +310,7 @@
 
 /datum/design/mag_oldsmg
 	name = "WT-550 Auto Gun Magazine (4.6x30mm)"
-	desc = "A 20 round magazine for the out of date security WT-550 Auto Rifle."
+	desc = "A 26 round magazine for the out of date security WT-550 Auto Rifle."
 	id = "mag_oldsmg"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 4000)
@@ -320,7 +320,7 @@
 
 /datum/design/mag_oldsmg/ap_mag
 	name = "WT-550 Auto Gun Armour Piercing Magazine (4.6x30mm AP)"
-	desc = "A 20 round armour piercing magazine for the out of date security WT-550 Auto Rifle."
+	desc = "A 26 round armour piercing magazine for the out of date security WT-550 Auto Rifle."
 	id = "mag_oldsmg_ap"
 	materials = list(/datum/material/iron = 6000, /datum/material/silver = 600)
 	build_path = /obj/item/ammo_box/magazine/wt550m9/wtap
@@ -328,7 +328,7 @@
 
 /datum/design/mag_oldsmg/ic_mag
 	name = "WT-550 Auto Gun Incendiary Magazine (4.6x30mm IC)"
-	desc = "A 20 round armour piercing magazine for the out of date security WT-550 Auto Rifle."
+	desc = "A 26 round armour piercing magazine for the out of date security WT-550 Auto Rifle."
 	id = "mag_oldsmg_ic"
 	materials = list(/datum/material/iron = 6000, /datum/material/silver = 600, /datum/material/glass = 1000)
 	build_path = /obj/item/ammo_box/magazine/wt550m9/wtic
@@ -336,7 +336,7 @@
 
 /datum/design/mag_oldsmg/rubber_mag
 	name = "WT-550 Auto Gun Rubber Bullet Magazine (4.6x30mm Rubber)"
-	desc = "A 20 round rubber bullet magazine for the out of date security WT-550 Auto Rifle."
+	desc = "A 26 round rubber bullet magazine for the out of date security WT-550 Auto Rifle."
 	id = "mag_oldsmg_rubber"
 	materials = list(/datum/material/iron = 4000)
 	build_path = /obj/item/ammo_box/magazine/wt550m9/wtr


### PR DESCRIPTION
# Document the changes in your pull request

Buffs the WT in an effort to bring it closer to the power of the mosin, another notable weapon that's orderable from cargo.

The advantages of the WT over the Mosin:
 - Normal-sized
 - Higher magazine size + quicker reload
 - Inherent AP
 - Faster RoF
 - Ammo variants

Weaknesses:
 - Non rubber/lethal shot can only be printed at an armory techfab after appropriate research
 - Much easier to hack an autolathe to print mosin ammo
 - Mosin does 60 mf'ing brute versus a measly 20 on the base WT bullet
 - Rubber shot was not considered at all with the 2-rnd burst removal, it's currently terrible

Buffs are targeted to make the WT more fun to use (with the 2-rnd burst back) but also tweak its numbers to make it more of a competitive choice for something that has to be ordered from Cargo.

# Wiki Documentation

WT has 2-rnd burst again
WT magazines now hold 22 bullets instead of 20
Standard bullet damage down to 13 from 20
AP bullet damage down to 10 from 15
Incendiary bullet damage down to 7 from 10
Rubber shot damage down to 4 from 5, stamina damage up to 21 from 20

# Changelog

:cl:  
tweak: WT has 2-rnd burst back, bullets do less individual damage, magazine size increased
/:cl:
