### PR TITLE
Adds stored research and makes toxins bombs apply it instead of directly producing points

### DIFF
--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -76,7 +76,7 @@ SUBSYSTEM_DEF(research)
 		if(science_tech.stored_research_points[i])
 			var/boost_amt = clamp(0, bitcoins[i], science_tech.stored_research_points[i]) //up to 2x research speed when burning stored research
 			bitcoins[i] += boost_amt
-			science_tech.stored_research_points.remove_stored_point_type(i, boost_amt)
+			science_tech.remove_stored_point_type(i, boost_amt)
 	science_tech.add_point_list(bitcoins)
 	last_income = world.time
 

--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -73,6 +73,10 @@ SUBSYSTEM_DEF(research)
 	science_tech.last_bitcoins = bitcoins  // Doesn't take tick drift into account
 	for(var/i in bitcoins)
 		bitcoins[i] *= income_time_difference / 10
+		if(science_tech.stored_research_points[i])
+			var/boost_amt = clamp(0, bitcoins[i], science_tech.stored_research_points[i]) //up to 2x research speed when burning stored research
+			bitcoins[i] += boost_amt
+			science_tech.stored_research_points.remove_stored_point_type(i, boost_amt)
 	science_tech.add_point_list(bitcoins)
 	last_income = world.time
 

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -126,8 +126,8 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 		if(D)
 			D.adjust_money(point_gain)
-			linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, point_gain)
-			say("Explosion details and mixture analyzed and sold to the highest bidder for $[point_gain], with a reward of [point_gain] points.")
+			linked_techweb.add_stored_point_type(TECHWEB_POINT_TYPE_DEFAULT, point_gain)
+			say("Explosion details and mixture analyzed and sold to the highest bidder for $[point_gain], with a reward of [point_gain] points to be processed by research servers.")
 
 	else //you've made smaller bombs
 		say("Data already captured. Aborting.")

--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -14,6 +14,7 @@
 	var/list/hidden_nodes = list()			//Hidden nodes. id = TRUE. Used for unhiding nodes when requirements are met by removing the entry of the node.
 	var/list/deconstructed_items = list()						//items already deconstructed for a generic point boost. path = list(point_type = points)
 	var/list/research_points = list()										//Available research points. type = number
+	var/list/stored_research_points = list()	//Stored research, up to doubles server mining when present. type = number
 	var/list/obj/machinery/computer/rdconsole/consoles_accessing = list()
 	var/id = "generic"
 	var/list/research_logs = list()								//IC logs.
@@ -142,6 +143,7 @@
 /datum/techweb/proc/get_researched_nodes()
 	return researched_nodes - hidden_nodes
 
+/// procs for modifying a specific point type amount
 /datum/techweb/proc/add_point_type(type, amount)
 	if(!SSresearch.point_types[type] || (amount <= 0))
 		return FALSE
@@ -158,6 +160,25 @@
 	if(!SSresearch.point_types[type] || (amount <= 0))
 		return FALSE
 	research_points[type] = max(0, research_points[type] - amount)
+	return TRUE
+
+/// procs for modifying a specific point type's stored research amount
+/datum/techweb/proc/add_stored_point_type(type, amount)
+	if(!SSresearch.point_types[type] || (amount <= 0))
+		return FALSE
+	stored_research_points[type] = max(0, research_points[type] + amount)
+	return TRUE
+
+/datum/techweb/proc/modify_stored_point_type(type, amount)
+	if(!SSresearch.point_types[type])
+		return FALSE
+	stored_research_points[type] = max(0, research_points[type] + amount)
+	return TRUE
+
+/datum/techweb/proc/remove_stored_point_type(type, amount)
+	if(!SSresearch.point_types[type] || (amount <= 0))
+		return FALSE
+	stored_research_points[type] = max(0, research_points[type] - amount)
 	return TRUE
 
 /datum/techweb/proc/add_design_by_id(id, custom = FALSE)

--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -166,19 +166,19 @@
 /datum/techweb/proc/add_stored_point_type(type, amount)
 	if(!SSresearch.point_types[type] || (amount <= 0))
 		return FALSE
-	stored_research_points[type] = max(0, research_points[type] + amount)
+	stored_research_points[type] = max(0, stored_research_points[type] + amount)
 	return TRUE
 
 /datum/techweb/proc/modify_stored_point_type(type, amount)
 	if(!SSresearch.point_types[type])
 		return FALSE
-	stored_research_points[type] = max(0, research_points[type] + amount)
+	stored_research_points[type] = max(0, stored_research_points[type] + amount)
 	return TRUE
 
 /datum/techweb/proc/remove_stored_point_type(type, amount)
 	if(!SSresearch.point_types[type] || (amount <= 0))
 		return FALSE
-	stored_research_points[type] = max(0, research_points[type] - amount)
+	stored_research_points[type] = max(0, stored_research_points[type] - amount)
 	return TRUE
 
 /datum/techweb/proc/add_design_by_id(id, custom = FALSE)


### PR DESCRIPTION
# Document the changes in your pull request

Adds stored researhc to slow the science speedrun techweb 100% run by making toxins bombs give stored research instead of actual research points
stored research works in the vein of rested experience where it is applied when servers produce research, doubling research speed
i.e. normal research speed gives 3000 points per minute, if you have stored research it will be expended at 3000 points per minute to increase normal research speed to 6000 points per minute until it runs out

# Wiki Documentation

toxins bombs no longer give direct research, instead doubling research speed for the amount of points they are worth

# Changelog

:cl:  
tweak: toxins bombs no longer give direct research, instead doubling research speed for the amount of points they are worth
/:cl:
