### PR TITLE
Allows WT rifles to be made from the armory laithe. With research!

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -411,3 +411,13 @@
 	build_path = /obj/item/gun/ballistic/bow/energy
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/wtrifle
+	name = "WT-550 Automatic Rifle"
+	desc = "An outdated personal defence weapon. Uses 4.6x30mm rounds and is designated the WT-550 Automatic Rifle."
+	id = "wtrifle"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 7500, /datum/material/glass = 1500, /datum/material/silver = 2500)
+	build_path = /obj/item/gun/ballistic/automatic/wt550
+	category = list("Weapons")
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -791,6 +791,15 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
+/datum/techweb_node/ballistic_production
+	id = "ballistic_production"
+	display_name = "Ballistic Weapons Production"
+	description = "The first step to making your own militia."
+	prereq_ids = list("adv_weaponry")
+	design_ids = list("wtrifle")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
+	export_price = 5000	
+
 ////////////////////////mech technology////////////////////////
 /datum/techweb_node/adv_mecha
 	id = "adv_mecha"

--- a/code/modules/research/techweb/layout.dm
+++ b/code/modules/research/techweb/layout.dm
@@ -534,3 +534,7 @@
 /datum/techweb_node/mech_xray
 	ui_x = -640
 	ui_y = -896
+
+/datum/techweb_node/ballistic_production
+	ui_x = -740
+	ui_y = -750


### PR DESCRIPTION
# Document the changes in your pull request

Adds a new tech node behind advanced weapons research, called "Ballistic Weapons Production". Costs 7500 points and allows security to print WT Rifles from the armory laithe.


If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob.

# Wiki Documentation

Add rifle to list of things able to be made from the laithe

# Changelog

:cl:  
rscadd: New research for WT production. Adds to armory laithe.
/:cl:
