### PR TITLE
fixes the window in metastation courtroom to be a proper spawner

### DIFF
--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -12704,11 +12704,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"aDU" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/tinted/fulltile,
-/turf/open/floor/plating,
-/area/security/courtroom)
 "aDV" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/dark,
@@ -112066,7 +112061,7 @@ aHD
 aHD
 aHD
 aHD
-aDU
+aTk
 aRX
 aTk
 aUF


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/5091394/173712102-1626d50e-40f1-4bb1-951a-64731a7cadf1.png)
![image](https://user-images.githubusercontent.com/5091394/173712114-8fc1fe84-5084-496d-a183-af00fc486fd2.png)

before:
![image](https://user-images.githubusercontent.com/5091394/173712090-cb25b2e5-534f-4309-9ecb-1d337ba0f1d6.png)

after:
![image](https://user-images.githubusercontent.com/5091394/173712082-7afa20c0-8bf1-476b-a9c9-b1b693c6fa24.png)

# Changelog

:cl:   
bugfix: tinted window in metastation courtroom is now a proper window spawner
/:cl:
