### PR TITLE
Preternis.... buff?? Preternis eyes no longer delete themselves in non-Preternis and instead take damage (lose power) and recharge (heal) in Preternis

### DIFF
--- a/_maps/RandomRuins/StationRuins/maint/3x5/3x5_dissection.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/3x5/3x5_dissection.dmm
@@ -79,7 +79,7 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/organ/eyes,
 /obj/item/organ/eyes/moth,
-/obj/item/organ/eyes/preternis,
+/obj/item/organ/eyes/robotic/preternis,
 /obj/item/organ/eyes/snail,
 /turf/open/floor/plasteel/white,
 /area/template_noop)

--- a/code/modules/antagonists/changeling/powers/augmented_eyesight.dm
+++ b/code/modules/antagonists/changeling/powers/augmented_eyesight.dm
@@ -15,7 +15,7 @@
 	var/obj/item/organ/eyes/E = user.getorganslot(ORGAN_SLOT_EYES)
 	if (E)
 		E.flash_protect = 2 //Adjust the user's eyes' flash protection
-		if(istype(E, /obj/item/organ/eyes/preternis))
+		if(istype(E, /obj/item/organ/eyes/robotic/preternis))
 			E.Remove(user, 1)
 			var/obj/item/organ/eyes/neweyes = new(user)
 			neweyes.Insert(user, 1)

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
@@ -1,6 +1,6 @@
 /obj/item/organ/eyes/robotic/preternis
 	name = "preternis eyes"
-	desc = "An experimental upgraded version of eyes that can see in the dark.They are designed to fit preternis"
+	desc = "An experimental upgraded version of eyes that can see in the dark. They are designed to fit preternis"
 	see_in_dark = PRETERNIS_NV_ON
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 	//preternis eyes need to be powered by a preternis to function, in a non preternis they slowly power down to blindness
@@ -63,6 +63,17 @@
 			lighting_alpha = LIGHTING_PLANE_ALPHA_VISIBLE
 			sight_flags &= ~SEE_BLACKNESS
 			owner.update_sight()
+
+/obj/item/organ/eyes/robotic/preternis/examine(mob/user)
+	. = ..()
+	if(status == ORGAN_ROBOTIC && (organ_flags & ORGAN_FAILING))
+		. += span_warning("[src] appears to be completely out of charge. However, that's nothing popping them back in a Preternis wouldn't fix.")
+
+	else if(organ_flags & ORGAN_FAILING)
+		. += span_warning("[src] appears to be completely out of charge. If they were put back in a Preternis they would surely recharge in time.")
+
+	else if(damage > high_threshold)
+		. += span_warning("[src] seem to flicker on and off. They must be pretty low on charge without being in a Preternis")
 
 /obj/item/organ/lungs/preternis
 	name = "preternis lungs"

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
@@ -6,19 +6,19 @@
 	//preternis eyes need to be powered by a preternis to function, in a non preternis they slowly power down to blindness
 	organ_flags = ORGAN_SYNTHETIC
 
-	low_threshold_passed = span_info("Your Preternis Eyes switch to battery saver mode.")
-	high_threshold_passed = span_info("Your Preternis Eyes only show a sliver of battery life left!")
+	low_threshold_passed = span_info("Your Preternis eyes switch to battery saver mode.")
+	high_threshold_passed = span_info("Your Preternis eyes only show a sliver of battery life left!")
 	now_failing = span_warning("An empty battery icon is all you can see as your eyes shut off!")
 	now_fixed = span_info("Lines of text scroll in your vision as your eyes begin rebooting.")
-	high_threshold_cleared = span_info("Your Preternis Eyes have recharged enough to re-enable most functionality.")
-	low_threshold_cleared = span_info("Your Preternis Eyes have almost fully recharged.")
+	high_threshold_cleared = span_info("Your Preternis eyes have recharged enough to re-enable most functionality.")
+	low_threshold_cleared = span_info("Your Preternis eyes have almost fully recharged.")
 	var/powered = TRUE 
 	actions_types = list(/datum/action/item_action/organ_action/use)
 	var/night_vision = TRUE
 
 /obj/item/organ/eyes/robotic/preternis/ui_action_click()
-//	var/datum/species/preternis/S = owner.dna.species
 	if(damage > low_threshold)
+		//no nightvision if your eyes are hurt
 		return
 	sight_flags = initial(sight_flags)
 	switch(lighting_alpha)
@@ -50,12 +50,12 @@
 		//to simulate running out of power, they take damage
 		owner.adjustOrganLoss(ORGAN_SLOT_EYES,0.5)
 	
-	//var/datum/species/preternis/S = owner.dna.species
 	if(damage < low_threshold)
 		if(see_in_dark == PRETERNIS_NV_OFF)
 			see_in_dark = PRETERNIS_NV_ON
 			owner.update_sight()
 	else
+		//if your eyes start getting hurt no more nightvision
 		if(see_in_dark == PRETERNIS_NV_ON)
 			see_in_dark = PRETERNIS_NV_OFF
 			owner.update_sight()

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -25,7 +25,7 @@ adjust_charge - take a positive or negative value to adjust the charge level
 	siemens_coeff = 1.75 //Computers REALLY don't like being shorted out
 	payday_modifier = 0.8 //Useful to NT for engineering + very close to Human
 	yogs_draw_robot_hair = TRUE
-	mutanteyes = /obj/item/organ/eyes/preternis
+	mutanteyes = /obj/item/organ/eyes/robotic/preternis
 	mutantlungs = /obj/item/organ/lungs/preternis
 	yogs_virus_infect_chance = 20
 	virus_resistance_boost = 10 //YEOUTCH,good luck getting it out


### PR DESCRIPTION
# Document the changes in your pull request

So right now Preternis eyes are hardcoded to delete themselves if they exist in any non-preternis host. While this is an incredibly rare event, it's bound to happen because of the nature of this game. so to remedy this, I Preyes to not delete themselves and instead give you a warning that your eyes have lose their external power source if you suddenly find yourself meatier than you should be. From that point on you start taking eye damage and after roughly a minute and a half, you'll go blind. During this time you'll go from full vision to fuzzy outer ring, to hard nearsighted, and finally blind. You get popups too warning you about your depleting eye charge. As soon as the eyes are back in a preternis, they will begin to recharge at the same rate they recharge. As a result of this, Preternis eyes naturally heal themselves pretty quickly from any and all eye damage. I considered making emps damage the eyes more, but like... if you're a preternis and you get emp'd... i don't think your eyes are gonna be a concern

The exact damage rate on the eyes in a non preternis host is 0.5 damage per tick out of the eye's 50 health. The recovery rate is just .5 healing per tick for "recharging"

Preternis eyes are now actually cybernetic instead of organic (rip in more emp suffering), but your eyes also heal quicker from eye damage. so. give and take, weld without goggles because the damage won't last. The eyes' night vision ability is now based on them being healthy rather than the preternis charged

(please ignore the fact that i decided to eat my old eyes during this)
![image](https://user-images.githubusercontent.com/46236974/173955002-72870a8a-87e7-4694-a55b-465f51caa3d3.png)
![image](https://user-images.githubusercontent.com/46236974/173955012-80a8cea4-bcae-4574-af39-4080d7573c6d.png)

Technically you can put preternis eyes in a person and they can drink oculine to have cybernetic eyes with night vision that are constantly trying to die.

# Why is this good for the game
I know it's a needlessly complex fix for "The eyes probably shouldn't delete themselves in a non preternis", but i was having a lot of fun making a dynamic eye charge system with some flavor. Additionally i still felt immediate blinding was harsh so i wanted a way to give people time to get to medbay for different eyes if this weird case ever happened. The speed of recharging might be a bit strong, but i also felt like preternis didn't have a lot going for them in terms of power.

Open to suggestions for number changes, these are shots in the dark at giving people time to get to safety before their world goes dark

# Spriting
changed preternis eyes using organic eye sprite to cybernetic eye sprite. nothing new

# Wiki Documentation

Preternis eyes are naturally cybernetic. Take gradual damage from being in a non Preternis host, and recharge (heal) quickly in a Preternis

# Changelog

:cl:   
tweak: Preternis eyes no longer delete themselves when in a non preternis host
tweak: Preternis eyes use their organ health as a charge meter. They drain (take damage at .5 eye damage per tick) in a non-preternis and recharge quickly (.5 eye healing per tick) in an actual preternis.
tweak: Preternis eyes depend on being high organ health to use their night vision rather than preternis charge meter.
tweak: Preternis eyes are naturally cybernetic, so they don't decay outside of a body and you get flashed if emp'd. although your eyes are probably the least of your worries if emp'd as a preternis
/:cl:
