### PR TITLE
Adds New 10x10 Maintenance Fishing Ruin

### DIFF
--- a/_maps/RandomRuins/StationRuins/maint/10x10/10x10_fishinghole.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/10x10/10x10_fishinghole.dmm
@@ -5,6 +5,41 @@
 /obj/structure/chair/stool/bamboo,
 /turf/open/floor/plasteel/cafeteria,
 /area/template_noop)
+"ak" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/trashbin,
+/obj/effect/turf_decal/pool,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"bv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/pool{
+	dir = 1
+	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"eW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/pool{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/template_noop)
 "hn" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/stool/bamboo,
@@ -15,6 +50,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel/white,
+/area/template_noop)
+"lf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/pool{
+	dir = 8
+	},
+/obj/structure/railing/corner,
+/turf/open/floor/wood,
 /area/template_noop)
 "li" = (
 /turf/open/water/safe,
@@ -37,18 +80,6 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/open/floor/wood,
-/area/template_noop)
-"pe" = (
-/obj/item/reagent_containers/food/snacks/fish/goldfish{
-	bitecount = 0;
-	length = 1;
-	weight = 2
-	},
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/template_noop)
 "pj" = (
@@ -97,11 +128,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/blackwhite,
 /area/template_noop)
-"tN" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/wood,
-/area/template_noop)
 "tO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/glass,
@@ -131,11 +157,42 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/template_noop)
+"xi" = (
+/obj/item/reagent_containers/food/snacks/fish/goldfish{
+	bitecount = 0;
+	length = 1;
+	weight = 2
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/pool{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/template_noop)
 "xG" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/grill,
 /turf/open/floor/plasteel/blackwhite,
+/area/template_noop)
+"yw" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/pool{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/template_noop)
 "zC" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -147,12 +204,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/blackwhite,
-/area/template_noop)
-"BB" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/blood/gibs/old,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
 /area/template_noop)
 "BO" = (
 /obj/machinery/smartfridge/food,
@@ -174,6 +225,15 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/checker,
+/area/template_noop)
+"ED" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/pool/corner,
+/obj/structure/railing/corner,
+/turf/open/floor/wood,
 /area/template_noop)
 "EH" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -203,6 +263,16 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/checker,
 /area/template_noop)
+"GJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/pool/corner{
+	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/template_noop)
 "GL" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 4
@@ -217,8 +287,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/template_noop)
-"Ix" = (
+"Ig" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/pool{
+	dir = 1
+	},
+/obj/structure/railing/corner,
+/obj/structure/railing/corner{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/template_noop)
 "JM" = (
@@ -247,6 +324,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/template_noop)
+"Mq" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/pool/corner{
+	dir = 1
+	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/template_noop)
 "Mw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -254,6 +343,16 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
+/area/template_noop)
+"MA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/turf_decal/pool,
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/structure/railing/corner,
+/turf/open/floor/wood,
 /area/template_noop)
 "MI" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -293,6 +392,19 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/checker,
 /area/template_noop)
+"OV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/pool{
+	dir = 8
+	},
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/template_noop)
 "Pj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/railing,
@@ -310,6 +422,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/template_noop)
+"RS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing,
+/obj/effect/turf_decal/pool,
+/turf/open/floor/wood,
+/area/template_noop)
 "SA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/stool/bamboo,
@@ -320,6 +438,16 @@
 /obj/effect/spawner/lootdrop/trashbin,
 /obj/structure/railing{
 	dir = 1
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"Tw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/pool{
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/template_noop)
@@ -343,16 +471,30 @@
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/cafeteria,
 /area/template_noop)
-"Wm" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/trashbin,
-/turf/open/floor/wood,
-/area/template_noop)
-"YL" = (
+"Xp" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/pool{
+	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"YR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/pool/corner{
+	dir = 8
+	},
+/obj/structure/railing/corner{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/template_noop)
 "Ze" = (
@@ -362,6 +504,20 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
+/area/template_noop)
+"ZB" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/pool{
+	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/structure/railing/corner,
+/turf/open/floor/wood,
 /area/template_noop)
 "ZO" = (
 /obj/effect/decal/cleanable/vomit/old,
@@ -397,72 +553,72 @@ tw
 (3,1,1) = {"
 Cj
 rS
-YL
-YL
-YL
-YL
-pe
-BB
+ED
+yw
+Xp
+ZB
+xi
+Mq
 AR
 zC
 "}
 (4,1,1) = {"
 Rc
 GL
-Ix
+RS
 qR
 li
 li
 li
-Ix
+eW
 AR
 nH
 "}
 (5,1,1) = {"
 oW
 oW
-Wm
+ak
 li
 Qj
 li
 li
-Ix
+bv
 oW
 oW
 "}
 (6,1,1) = {"
 Og
 Og
-tN
+MA
 li
 li
 KU
 li
-Ix
+Ig
 Og
 Og
 "}
 (7,1,1) = {"
 Ei
 Ou
-Ix
+RS
 li
 li
 li
 qR
-Ix
+eW
 Mw
 Ze
 "}
 (8,1,1) = {"
 EH
 Ou
-Ix
-Ix
-Ix
-Ix
-Ix
-Ix
+GJ
+Tw
+OV
+lf
+Tw
+YR
 vX
 kF
 "}

--- a/_maps/RandomRuins/StationRuins/maint/10x10/10x10_fishinghole.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/10x10/10x10_fishinghole.dmm
@@ -1,0 +1,492 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ag" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/stool/bamboo,
+/turf/open/floor/plasteel/cafeteria,
+/area/template_noop)
+"hn" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/stool/bamboo,
+/obj/structure/chair/stool/bamboo,
+/turf/open/floor/plasteel/cafeteria,
+/area/template_noop)
+"kF" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/green/filled/line,
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"li" = (
+/turf/open/water/safe,
+/area/template_noop)
+"nH" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/broken,
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel/blackwhite,
+/area/template_noop)
+"of" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/trashbin,
+/turf/open/floor/plasteel/blackwhite,
+/area/template_noop)
+"oW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"pe" = (
+/obj/item/reagent_containers/food/snacks/fish/goldfish{
+	bitecount = 0;
+	length = 1;
+	weight = 2
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/template_noop)
+"pj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"qR" = (
+/obj/effect/spawner/lootdrop/trashbin,
+/turf/open/water/safe,
+/area/template_noop)
+"rS" = (
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/cafeteria,
+/area/template_noop)
+"sb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/railing,
+/turf/open/floor/wood,
+/area/template_noop)
+"tg" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/twohanded/fishingrod,
+/obj/structure/rack,
+/obj/item/poster/random_contraband,
+/obj/item/picket_sign,
+/obj/item/picket_sign,
+/obj/item/picket_sign,
+/obj/item/picket_sign,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/checker,
+/area/template_noop)
+"tw" = (
+/obj/machinery/griddle,
+/obj/item/reagent_containers/food/snacks/deadmouse,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/blackwhite,
+/area/template_noop)
+"tN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/wood,
+/area/template_noop)
+"tO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/cafeteria,
+/area/template_noop)
+"uj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/cafeteria,
+/area/template_noop)
+"vX" = (
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"wk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/coffee,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"xG" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/grill,
+/turf/open/floor/plasteel/blackwhite,
+/area/template_noop)
+"zC" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/turf/open/floor/plasteel/blackwhite,
+/area/template_noop)
+"AR" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/blackwhite,
+/area/template_noop)
+"BB" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/template_noop)
+"BO" = (
+/obj/machinery/smartfridge/food,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/food/snacks/carpmeat/fish,
+/obj/item/reagent_containers/food/snacks/carpmeat/fish,
+/obj/item/reagent_containers/food/snacks/carpmeat/fish,
+/obj/item/reagent_containers/food/snacks/carpmeat/fish,
+/turf/open/floor/plasteel/blackwhite,
+/area/template_noop)
+"Cj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/cafeteria,
+/area/template_noop)
+"Ei" = (
+/obj/machinery/vending/fishing,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/checker,
+/area/template_noop)
+"EH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/smartfridge/drying_rack,
+/turf/open/floor/plasteel/checker,
+/area/template_noop)
+"EQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/cola/random{
+	tilted = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"FV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"GH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/turf/open/floor/plasteel/checker,
+/area/template_noop)
+"GL" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/cafeteria,
+/area/template_noop)
+"He" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"Ix" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/template_noop)
+"JM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/blackwhite,
+/area/template_noop)
+"Ke" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"KU" = (
+/obj/effect/landmark/blobstart,
+/turf/open/water/safe,
+/area/template_noop)
+"LT" = (
+/obj/structure/rack,
+/obj/item/radio,
+/obj/item/relic,
+/obj/item/twohanded/fishingrod,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"Mw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"MI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/twohanded/fishingrod,
+/obj/structure/rack,
+/obj/item/pet_carrier,
+/turf/open/floor/plasteel/checker,
+/area/template_noop)
+"Ng" = (
+/obj/machinery/smartfridge/drinks,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/reagent_containers/food/drinks/beer/stout,
+/obj/item/reagent_containers/food/drinks/beer/light,
+/obj/item/reagent_containers/food/drinks/beer/light,
+/obj/item/reagent_containers/food/drinks/beer/light,
+/obj/item/reagent_containers/food/drinks/beer/light,
+/obj/item/reagent_containers/food/drinks/beer/light,
+/obj/item/reagent_containers/food/drinks/beer/light,
+/obj/item/reagent_containers/food/drinks/beer/light,
+/obj/item/reagent_containers/food/drinks/beer/light,
+/obj/item/reagent_containers/food/drinks/beer/light,
+/obj/item/reagent_containers/food/drinks/beer/light,
+/obj/item/reagent_containers/food/drinks/beer/stout,
+/turf/open/floor/plasteel/blackwhite,
+/area/template_noop)
+"Og" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"Ou" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/checker,
+/area/template_noop)
+"Pj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing,
+/turf/open/floor/wood,
+/area/template_noop)
+"Qj" = (
+/obj/effect/landmark/xeno_spawn,
+/turf/open/water/safe,
+/area/template_noop)
+"Rc" = (
+/obj/machinery/vending/fishing,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/template_noop)
+"SA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/stool/bamboo,
+/turf/open/floor/plasteel/cafeteria,
+/area/template_noop)
+"SM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/trashbin,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"Uj" = (
+/obj/structure/rack,
+/obj/item/soap/homemade,
+/obj/item/soap/homemade,
+/obj/item/twohanded/fishingrod,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"Wi" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/cafeteria,
+/area/template_noop)
+"Wm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/trashbin,
+/turf/open/floor/wood,
+/area/template_noop)
+"YL" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/template_noop)
+"Ze" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/broken,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"ZO" = (
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/mouse,
+/turf/open/floor/plasteel/checker,
+/area/template_noop)
+
+(1,1,1) = {"
+Wi
+tO
+tO
+uj
+FV
+Pj
+Ng
+BO
+of
+xG
+"}
+(2,1,1) = {"
+SA
+SA
+ag
+hn
+FV
+sb
+JM
+of
+of
+tw
+"}
+(3,1,1) = {"
+Cj
+rS
+YL
+YL
+YL
+YL
+pe
+BB
+AR
+zC
+"}
+(4,1,1) = {"
+Rc
+GL
+Ix
+qR
+li
+li
+li
+Ix
+AR
+nH
+"}
+(5,1,1) = {"
+oW
+oW
+Wm
+li
+Qj
+li
+li
+Ix
+oW
+oW
+"}
+(6,1,1) = {"
+Og
+Og
+tN
+li
+li
+KU
+li
+Ix
+Og
+Og
+"}
+(7,1,1) = {"
+Ei
+Ou
+Ix
+li
+li
+li
+qR
+Ix
+Mw
+Ze
+"}
+(8,1,1) = {"
+EH
+Ou
+Ix
+Ix
+Ix
+Ix
+Ix
+Ix
+vX
+kF
+"}
+(9,1,1) = {"
+EH
+Ou
+ZO
+Ou
+FV
+Pj
+He
+Ke
+pj
+kF
+"}
+(10,1,1) = {"
+GH
+Ou
+MI
+tg
+SM
+Pj
+Uj
+LT
+wk
+EQ
+"}

--- a/yogstation/code/datums/ruins/station.dm
+++ b/yogstation/code/datums/ruins/station.dm
@@ -1248,3 +1248,9 @@
 	id= "fourshops"
 	suffix = "10x10_fourshops.dmm"
 	name = "Maint fourshops"
+
+///Author: Vaelophis
+/datum/map_template/ruin/station/maint/tenxten/fishinghole
+	id= "fishinghole"
+	suffix = "10x10_fishinghole.dmm"
+	name = "Maint fishinghole"


### PR DESCRIPTION
A maint fishing ruin! set up with a partial kitchen, vendors, and some goodies for mainteneers to find.

with spawners and landmarks hidden:
![ss (2022-06-16 at 03 11 55)](https://user-images.githubusercontent.com/1534478/174155911-9c9b92d1-f3bc-4037-ad4c-cc81c28f7df2.png)

spawners and landmarks shown:

![ss (2022-06-16 at 03 11 39)](https://user-images.githubusercontent.com/1534478/174155905-85fa323a-9176-43d0-be85-dd47ea658fd8.png)

Spawners are 7 trash spawners, and 3 maint loot spawners

Reason for addition:
Allows for occasional use of the new fishing mechanics, and adds a new item to the limited pool of 10x10 maint ruins.

# Changelog

:cl:  
rscadd: Adds new Fishing themed 10x10 maint ruin. 
tweak: Adds new ruin to station.dmm
/:cl:
