### PR TITLE
remove one space that might be the reason why polys can't be CE

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -20,7 +20,7 @@ REVIVAL_BRAIN_LIFE -1
 JOB_SPECIES_WHITELIST /datum/job/captain human
 JOB_SPECIES_WHITELIST /datum/job/hop human
 JOB_SPECIES_WHITELIST /datum/job/hos human,lizard
-JOB_SPECIES_WHITELIST /datum/job/chief_engineer human,plasmaman,moth,ethereal,preternis, polysmorph
+JOB_SPECIES_WHITELIST /datum/job/chief_engineer human,plasmaman,moth,ethereal,preternis,polysmorph
 JOB_SPECIES_WHITELIST /datum/job/rd human,pod,plasmaman,ethereal,preternis,polysmorph
 JOB_SPECIES_WHITELIST /datum/job/cmo human,lizard,pod,moth
 


### PR DESCRIPTION
# Changelog
remove one space

:cl:  
rscdel: Removed a space in the species whitelisting
bugfix: maybe fixed polys not being able to be CE (I hope it's not actually something as stupid as a singular space that broke everything though it would be nice because it would mean that it's easy to fix)
/:cl:
