### PR TITLE
nerf DU slugs, but make them cheaper

### DIFF
--- a/code/datums/components/crafting/weapons.dm
+++ b/code/datums/components/crafting/weapons.dm
@@ -420,7 +420,7 @@
 	name = "Depleted Uranium Slug Shell"
 	result = /obj/item/ammo_casing/shotgun/uraniumpenetrator
 	reqs = list(/obj/item/ammo_casing/shotgun/techshell = 1,
-				/obj/item/stack/sheet/mineral/uranium = 1,
+				/obj/item/stack/sheet/mineral/uranium = 2,
 				/obj/item/stack/rods = 2,
 				/datum/reagent/thermite = 5)
 	tools = list(TOOL_SCREWDRIVER)

--- a/code/datums/components/crafting/weapons.dm
+++ b/code/datums/components/crafting/weapons.dm
@@ -420,7 +420,7 @@
 	name = "Depleted Uranium Slug Shell"
 	result = /obj/item/ammo_casing/shotgun/uraniumpenetrator
 	reqs = list(/obj/item/ammo_casing/shotgun/techshell = 1,
-				/obj/item/stack/sheet/mineral/uranium = 3,
+				/obj/item/stack/sheet/mineral/uranium = 1,
 				/obj/item/stack/rods = 2,
 				/datum/reagent/thermite = 5)
 	tools = list(TOOL_SCREWDRIVER)

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -98,9 +98,9 @@
 /obj/item/projectile/bullet/shotgun_uraniumslug
 	name = "depleted uranium slug"
 	icon_state = "ubullet"
-	damage = 35
-	armour_penetration = 200 // he he funny round go through armor
-	wound_bonus = -30
+	damage = 20
+	armour_penetration = 85 // he he funny round go through armor
+	wound_bonus = -35
 
 /obj/item/projectile/bullet/shotgun_uraniumslug/on_hit(atom/target)
 	. = ..()

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -99,8 +99,8 @@
 	name = "depleted uranium slug"
 	icon_state = "ubullet"
 	damage = 30
-	armour_penetration = 85 // he he funny round go through armor
-	wound_bonus = -35	
+	armour_penetration = 60 // he he funny round go through armor
+	wound_bonus = -45
 
 /obj/item/projectile/bullet/shotgun_uraniumslug/on_hit(atom/target)
 	. = ..()

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -98,7 +98,7 @@
 /obj/item/projectile/bullet/shotgun_uraniumslug
 	name = "depleted uranium slug"
 	icon_state = "ubullet"
-	damage = 20
+	damage = 33
 	armour_penetration = 85 // he he funny round go through armor
 	wound_bonus = -35
 

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -98,9 +98,9 @@
 /obj/item/projectile/bullet/shotgun_uraniumslug
 	name = "depleted uranium slug"
 	icon_state = "ubullet"
-	damage = 33
+	damage = 30
 	armour_penetration = 85 // he he funny round go through armor
-	wound_bonus = -35
+	wound_bonus = -35	
 
 /obj/item/projectile/bullet/shotgun_uraniumslug/on_hit(atom/target)
 	. = ..()


### PR DESCRIPTION
1 less uranium sheets each, AP under 100 but still absurdly high, lower damage to go with them being slightly less expensive

# Document the changes in your pull request

Makes Depleted Uranium Slugs for shotguns 1 uranium sheet cheaper (2 from 3), drops their damage by 5 (30 from 35), and
reels in their LUDICROUS 200AP, down to 60, and changes their wound mod to -45 from -30

Changes untested, but should work.

# Wiki Documentation

wiki info about DU slugs would require a small adjustment to match

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
tweak: Depleted Uranium Slugs cost 1 less uranium sheet each
tweak: Depleted Uranium Slugs have 60 ap (down from 200)
tweak: Depleted Uranium Slugs do 30 damage (down from 35)
tweak: Depleted Uranium Slugs have a -45 wound mod (down from -30)
/:cl:
