### PR TITLE
buffs the bulldog shotgun because it kind of stinks

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -8,6 +8,11 @@
 	projectile_type = /obj/item/projectile/bullet/shotgun_slug
 	materials = list(/datum/material/iron=4000)
 
+/obj/item/ammo_casing/shotgun/syndie
+	name = "syndicate shotgun slug"
+	desc = "An illegal type of ammunition used by the syndicate for their bulldog shotguns. Hopefully you're not the one on the receiving end."
+	projectile_type = /obj/item/projectile/bullet/shotgun_slug/syndie
+
 /obj/item/ammo_casing/shotgun/beanbag
 	name = "beanbag slug"
 	desc = "A weak beanbag slug for riot control."

--- a/code/modules/projectiles/boxes_magazines/external/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/external/shotgun.dm
@@ -16,9 +16,9 @@
 	ammo_type = /obj/item/ammo_casing/shotgun/stunslug
 
 /obj/item/ammo_box/magazine/m12g/slug
-	name = "shotgun magazine (12g slugs)"
+	name = "shotgun magazine (12g syndicate slugs)"
 	icon_state = "m12gb"    //this may need an unique sprite
-	ammo_type = /obj/item/ammo_casing/shotgun
+	ammo_type = /obj/item/ammo_casing/shotgun/syndie
 
 /obj/item/ammo_box/magazine/m12g/dragon
 	name = "shotgun magazine (12g dragon's breath)"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -4,6 +4,10 @@
 	sharpness = SHARP_POINTY
 	wound_bonus = -30
 
+/obj/item/projectile/bullet/shotgun_slug/syndie
+	name = "12g syndicate shotgun slug"
+	damage = 60
+
 /obj/item/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"
 	damage = 5


### PR DESCRIPTION
# Document the changes in your pull request
the shotgun slugs nuclear operatives are capable of purchasing has been changed to 'Syndie Slugs' which do 60 damage, like old shotgun slugs, instead of the 42 that normal slugs do. bulldog got hit hard by the slug nerf, and hopefully this will make it more viable to buy a bulldog shotgun instead of getting a syndie revolver, which already does 60 brute per shot

# Wiki Documentation

combat page, syndicate items page

# Changelog

:cl:  
rscadd: the shotgun slug drums purchasable by nuclear operative have had their ammo type replaced with syndicate slugs, which do more damage.
rscadd: syndicate slugs, shotgun slugs that do 60 brute instead of 42. only purchasable by nuclear operatives
/:cl:
