### PR TITLE
frenzy now provides reduced damage slowdown since it also provides a constant source of damage

### DIFF
--- a/code/modules/antagonists/bloodsuckers/bloodsucker_frenzy.dm
+++ b/code/modules/antagonists/bloodsuckers/bloodsucker_frenzy.dm
@@ -59,6 +59,7 @@
 	// Give the other Frenzy effects
 	ADD_TRAIT(owner, TRAIT_MUTE, FRENZY_TRAIT)
 	ADD_TRAIT(owner, TRAIT_DEAF, FRENZY_TRAIT)
+	ADD_TRAIT(owner, TRAIT_REDUCED_DAMAGE_SLOWDOWN, FRENZY_TRAIT)
 	if(user.IsAdvancedToolUser())
 		was_tooluser = TRUE
 		ADD_TRAIT(owner, TRAIT_MONKEYLIKE, SPECIES_TRAIT)
@@ -80,6 +81,7 @@
 	to_chat(owner, span_warning("You come back to your senses."))
 	REMOVE_TRAIT(owner, TRAIT_MUTE, FRENZY_TRAIT)
 	REMOVE_TRAIT(owner, TRAIT_DEAF, FRENZY_TRAIT)
+	REMOVE_TRAIT(owner, TRAIT_REDUCED_DAMAGE_SLOWDOWN, FRENZY_TRAIT)
 	if(was_tooluser)
 		REMOVE_TRAIT(owner, TRAIT_MONKEYLIKE, SPECIES_TRAIT)
 		was_tooluser = FALSE


### PR DESCRIPTION
# Document the changes in your pull request

idk but becoming incapable of fighting rather quickly after entering the "fight or die" mode is kind of counter intuitive to me

# Wiki Documentation

bloodsucker frenzy now provides reduced damage slowdown for its duration

# Changelog


:cl:  
tweak: bloodsucker frenzy now provides reduced damage slowdown for its duration
/:cl:
