### PR TITLE
Blob buff: double blob passive point gen

### DIFF
--- a/code/modules/antagonists/blob/blob.dm
+++ b/code/modules/antagonists/blob/blob.dm
@@ -7,7 +7,7 @@
 
 	var/datum/action/innate/blobpop/pop_action
 	var/starting_points_human_blob = 60
-	var/point_rate_human_blob = 2
+	var/point_rate_human_blob = 4
 
 /datum/antagonist/blob/roundend_report()
 	var/basic_report = ..()


### PR DESCRIPTION
blobs struggle to keep up with crew attacking on all sides with late-late game weapons like Particle accelerators and Phazons. This buff should help with that a little.

# Document the changes in your pull request

Blob default passive resource generation (ie: not from resource blobs) increased from 2 to 4

Changes UNTESTED. Requires testing that is practically impossible in a local-host environment.

this change is made to help blobs counter 6-10 crew members/borgs, emitters, heavily armed combat mechs, particle accelerators, all hammering away at it from many directions at once. When a blob is spotted, you have mere moments before you will be engaged in the passive resource drain of being forced to replace blob tiles faster than you generate points, even with resource blobs.

This does not make any changes to blob resource cap, nor the speed at which resource-blobs generate resources, nor the slowdown from placing more resource blobs

# Wiki Documentation

Blob wiki might need a tweak to match? Unsure if resource rate is mentioned there.

# Changelog

:cl:  
tweak: blob base resource generation up to 4, from 2
/:cl:
