### PR TITLE
Adds new Chemical Analyzer implant (Science Goggle implant)

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -259,6 +259,7 @@
 #define TRAIT_ANOREXIC			"anorexic"
 #define TRAIT_SHIFTY_EYES		"shifty_eyes"
 #define TRAIT_ANXIOUS			"anxious"
+#define TRAIT_SEE_REAGENTS		"see_reagents"
 
 // common trait sources
 #define TRAIT_GENERIC "generic"

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -178,6 +178,8 @@
 		return TRUE
 	if(isclothing(wear_mask) && (wear_mask.clothing_flags & SCAN_REAGENTS))
 		return TRUE
+	if(HAS_TRAIT(src, TRAIT_SEE_REAGENTS))
+		return TRUE
 
 /// When we're joining the game in [/mob/dead/new_player/proc/create_character], we increment our scar slot then store the slot in our mind datum.
 /mob/living/carbon/human/proc/increment_scar_slot()

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -344,7 +344,7 @@
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
 /datum/design/cyberimp_science_analyzer
-	name = "Scientific Analyzer Implant"
+	name = "Chemical Analyzer Implant"
 	desc = "These cybernetic eye implants will allow rapid identification of reagents. Wiggle eyes to control."
 	id = "ci-scihud"
 	build_type = PROTOLATHE | MECHFAB

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -343,6 +343,17 @@
 	category = list("Implants", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
+/datum/design/cyberimp_science_analyzer
+	name = "Scientific Analyzer Implant"
+	desc = "These cybernetic eye implants will allow rapid identification of reagents. Wiggle eyes to control."
+	id = "ci-scihud"
+	build_type = PROTOLATHE | MECHFAB
+	construction_time = 50
+	materials = list(/datum/material/iron = 600, /datum/material/glass = 600, /datum/material/silver = 600, /datum/material/gold = 600, /datum/material/plastic = 150)
+	build_path = /obj/item/organ/cyberimp/eyes/hud/science
+	category = list("Implants", "Medical Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+
 /datum/design/cyberimp_xray
 	name = "X-ray Eyes"
 	desc = "These cybernetic eyes will give you X-ray vision. Blinking is futile."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -547,7 +547,7 @@
 	display_name = "Cybernetic Implants"
 	description = "Electronic implants that improve humans."
 	prereq_ids = list("adv_biotech", "datatheory")
-	design_ids = list("ci-nutriment", "ci-breather", "ci-gloweyes", "ci-welding", "ci-medhud", "ci-sechud", "ci-diaghud")
+	design_ids = list("ci-nutriment", "ci-breather", "ci-gloweyes", "ci-welding", "ci-medhud", "ci-sechud", "ci-scihud", "ci-diaghud")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 

--- a/code/modules/surgery/organs/augments_eyes.dm
+++ b/code/modules/surgery/organs/augments_eyes.dm
@@ -49,5 +49,3 @@
 /obj/item/organ/cyberimp/eyes/hud/science
 	name = "Scientific Analyzer implant"
 	desc = "These cybernetic eye implants will allow rapid identification of reagents, and also allow scanning items for research value."
-	clothing_flags = SCAN_REAGENTS //You can see reagents while wearing science goggles
-	

--- a/code/modules/surgery/organs/augments_eyes.dm
+++ b/code/modules/surgery/organs/augments_eyes.dm
@@ -45,3 +45,9 @@
 	name = "Contraband Security HUD Implant"
 	desc = "A Cybersun Industries brand Security HUD Implant. These illicit cybernetic eye implants will display a security HUD over everything you see."
 	syndicate_implant = TRUE
+
+/obj/item/organ/cyberimp/eyes/hud/science
+	name = "Scientific Analyzer implant"
+	desc = "These cybernetic eye implants will allow rapid identification of reagents, and also allow scanning items for research value."
+	clothing_flags = SCAN_REAGENTS //You can see reagents while wearing science goggles
+	

--- a/code/modules/surgery/organs/augments_eyes.dm
+++ b/code/modules/surgery/organs/augments_eyes.dm
@@ -48,4 +48,12 @@
 
 /obj/item/organ/cyberimp/eyes/hud/science
 	name = "Scientific Analyzer implant"
-	desc = "These cybernetic eye implants will allow rapid identification of reagents, and also allow scanning items for research value."
+	desc = "These cybernetic eye implants will allow rapid identification of reagents."
+
+/obj/item/organ/cyberimp/eyes/hud/science/Insert(var/mob/living/carbon/M, var/special = 0, drop_if_replaced = FALSE)
+	..()
+	ADD_TRAIT(owner, TRAIT_SEE_REAGENTS, src)
+
+/obj/item/organ/cyberimp/eyes/hud/science/Remove(var/mob/living/carbon/M, var/special = 0)
+	REMOVE_TRAIT(owner, TRAIT_SEE_REAGENTS, src)
+	..()

--- a/code/modules/surgery/organs/augments_eyes.dm
+++ b/code/modules/surgery/organs/augments_eyes.dm
@@ -47,7 +47,7 @@
 	syndicate_implant = TRUE
 
 /obj/item/organ/cyberimp/eyes/hud/science
-	name = "Scientific Analyzer implant"
+	name = "Chemical Analyzer implant"
 	desc = "These cybernetic eye implants will allow rapid identification of reagents."
 
 /obj/item/organ/cyberimp/eyes/hud/science/Insert(var/mob/living/carbon/M, var/special = 0, drop_if_replaced = FALSE)


### PR DESCRIPTION
Adds a new eye implant that allows you to have the reagent scanning ability without wearing goggles and not being a silicon, or dead.

# Document the changes in your pull request
 
Adds new implant, adds that implant as a design unlocked with the other HUD implants
makes tweaks to the traits file to add a new trait that gives you the SCAN_REAGENTS clothing flag, but at the trait level. Properly removed when the implant is removed. Does not allow you to scan items for research value, like the goggles. Name pending possible change to reflect this.

also had to adjust the Human helper file, to include a second check for if you have the Trait, if both the dead or silicon checks return false.

Changes tested, works flawlessly. Only the lathe design was untested. Can test tomorrow.

I would like to ask if anyone would prefer this function would rather be rolled into the MedHUD implant, instead of an individual implant.

# Wiki Documentation

Would have to be added to all locations that HUD implants are mentioned.

# Changelog

:cl:  Galacticruler, @Chubbygummibear, @Hopekz 
rscadd: Added new eye implant for reagent scanning, the chemical analyzer implant
tweak: added new implant to the tech node with the other HUD implants
tweak: added third mob-level check to allow for the new implant to work
/:cl:
