### PR TITLE
Adds Brain Damage Quirk

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -768,3 +768,20 @@
 	gain_text = span_danger("You feel like your blood is thin.")
 	lose_text = span_notice("You feel like your blood is of normal thickness once more.")
 	medical_record_text = "Patient appears unable to naturally form blood clots."
+
+/datum/quirk/brain_damage
+	name = "Brain Damage"
+	desc = "The shuttle ride was a bit bumpty to the station."
+	value = -1
+	gain_text = span_danger("Oww....")
+	lose_text = span_notice("Your head feels good again.")
+	medical_record_text = "Patient appears to have brain damage."
+
+/datum/quirk/brain_damage/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/datum/brain_trauma/badtimes = list(BRAIN_TRAUMA_MILD, BRAIN_TRAUMA_SEVERE)
+	var/amount = 0 // Pray you dont get fucked
+	amount = rand(1, 4)
+
+	for(var/i = 0 to amount)
+		H.gain_trauma_type(pick(badtimes), TRAUMA_RESILIENCE_ABSOLUTE) // Mr bones wild rides takes no breaks

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -772,7 +772,7 @@
 /datum/quirk/brain_damage
 	name = "Brain Damage"
 	desc = "The shuttle ride was a bit bumpty to the station."
-	value = -1
+	value = -2
 	gain_text = span_danger("Oww....")
 	lose_text = span_notice("Your head feels good again.")
 	medical_record_text = "Patient appears to have brain damage."

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -771,8 +771,8 @@
 
 /datum/quirk/brain_damage
 	name = "Brain Damage"
-	desc = "The shuttle ride was a bit bumpty to the station."
-	value = -2
+	desc = "The shuttle ride was a bit bumpy to the station."
+	value = -7
 	gain_text = span_danger("Your head hurts.")
 	lose_text = span_notice("Your head feels good again.")
 	medical_record_text = "Patient appears to have brain damage."

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -773,7 +773,7 @@
 	name = "Brain Damage"
 	desc = "The shuttle ride was a bit bumpty to the station."
 	value = -2
-	gain_text = span_danger("Oww....")
+	gain_text = span_danger("Your head hurts.")
 	lose_text = span_notice("Your head feels good again.")
 	medical_record_text = "Patient appears to have brain damage."
 


### PR DESCRIPTION
# Document the changes in your pull request

You start with 1-4 brain traumas that are uncurable(because otherwise the quirk would be kinda pointless)
Picks from both the severe and mild pools.
Gives you 7 quirk points. open to changes


# Wiki Documentation

New quirk that gives 1-4 severe/mild brain traumas
Gives you 7 quirk points to use

# Changelog

:cl:  
rscadd: Brain damage quirk
/:cl:
