### PR TITLE
fixes health doll being on top of stop pulling button for simplemob

### DIFF
--- a/code/_onclick/hud/_defines.dm
+++ b/code/_onclick/hud/_defines.dm
@@ -106,9 +106,9 @@
 #define ui_mood "EAST-1:28,CENTER-3:10"
 
 //living
-#define ui_living_pull "EAST-1:28,CENTER-2:15"
+#define ui_living_pull "EAST-1:28,CENTER-3"
 #define ui_living_health "EAST-1:28,CENTER:15"
-#define ui_living_healthdoll "EAST-1:28,CENTER-2:13"
+#define ui_living_healthdoll "EAST-1:28,CENTER-1:15"
 
 //borgs
 #define ui_borg_health "EAST-1:28,CENTER-1:15"		//borgs have the health display where humans have the pressure damage indicator.

--- a/code/_onclick/hud/_defines.dm
+++ b/code/_onclick/hud/_defines.dm
@@ -106,7 +106,7 @@
 #define ui_mood "EAST-1:28,CENTER-3:10"
 
 //living
-#define ui_living_pull "EAST-1:28,CENTER-3"
+#define ui_living_pull "EAST-1:28,CENTER-3:15"
 #define ui_living_health "EAST-1:28,CENTER:15"
 #define ui_living_healthdoll "EAST-1:28,CENTER-1:15"
 


### PR DESCRIPTION

# Document the changes in your pull request
makes the icons on simple mob health doll not on top of eachother

![image](https://user-images.githubusercontent.com/84217619/174470095-42cfdd0f-e268-4d1e-95c8-983ea8d65869.png)

:cl:  
bugfix: made simplemob health doll not spawn on top of the stop pulling button  
/:cl:
