### PR TITLE
Adds the horror's host to check antags

### DIFF
--- a/code/modules/antagonists/horror/horror_datums.dm
+++ b/code/modules/antagonists/horror/horror_datums.dm
@@ -14,6 +14,15 @@
 		var/mob/living/simple_animal/horror/H = owner.current
 		H.update_horror_hud()
 
+/datum/antagonist/horror/antag_listing_name()
+	. = ..()
+	var/mob/living/simple_animal/horror/H = owner.current
+	if(!istype(H) || !H.victim)
+		return
+	if(H.host_brain)
+		return ..() + ", controlling [H.host_brain.real_name]"
+	return ..() + ", inside [H.victim.real_name]"
+
 /datum/antagonist/horror/proc/give_objectives()
 	if(summoner)
 		var/datum/objective/newobjective = new


### PR DESCRIPTION
# Document the changes in your pull request

Makes it easier to tell who the horror is possessing, and if they are in charge, so admins don't assume the host is a greifer

# Changelog

:cl:  
rscadd: Added horror's host to check antags
/:cl:
