### PR TITLE
extinguishers deal 33% less damage to blazing oil blob strain

### DIFF
--- a/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
+++ b/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
@@ -14,7 +14,7 @@
 	reagent = /datum/reagent/blob/blazing_oil
 
 /datum/blobstrain/reagent/blazing_oil/extinguish_reaction(obj/structure/blob/B)
-	B.take_damage(1.5, BURN, ENERGY)
+	B.take_damage(1, BURN, ENERGY)
 
 /datum/blobstrain/reagent/blazing_oil/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag)
 	if(damage_type == BURN && damage_flag != ENERGY)


### PR DESCRIPTION
title

blazing oil has the potential to be good but it's really bad because a single person with a fire extinguisher can delete your whole setup in seconds. They probably can still do massive amounts of damage in a short amount of time, but now it may actually be worth going blazing oil. 

# Changelog

:cl:  
tweak: extinguishers deal 33% less damage to blazing oil blob strain
/:cl:
