### PR TITLE
Kilo roboticists get anesthesia

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -29646,27 +29646,6 @@
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
-"aZU" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/item/surgical_drapes,
-/obj/item/retractor,
-/obj/item/cautery,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/robotics/lab)
 "aZV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -29866,28 +29845,6 @@
 "bai" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/science/robotics/lab)
-"baj" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/item/circular_saw,
-/obj/item/scalpel{
-	pixel_y = 16
-	},
-/obj/item/hemostat,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bak" = (
 /obj/machinery/computer/operating{
@@ -95909,6 +95866,25 @@
 	icon_state = "panelscorched"
 	},
 /area/security/prison)
+"pmX" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/plasteel/dark,
+/area/science/robotics/lab)
 "pnQ" = (
 /obj/structure/lattice,
 /obj/structure/girder/reinforced,
@@ -98541,6 +98517,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/chemistry)
+"saU" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/item/tank/internals/anesthetic,
+/obj/item/clothing/mask/breath/medical,
+/turf/open/floor/plasteel/dark,
+/area/science/robotics/lab)
 "sbr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -139712,7 +139707,7 @@ cHi
 waG
 bhC
 aCK
-baj
+saU
 bak
 aZS
 bOL
@@ -140226,7 +140221,7 @@ azN
 aAo
 aBw
 aHM
-aZU
+pmX
 bgB
 bez
 aJV


### PR DESCRIPTION
# Document the changes in your pull request

Allows Kilo roboticists to decide whether they want to put their patient to sleep to conduct brain removal, augmentation, or whatever surgery they want to, or they could just go back to using medbots again.

![image](https://user-images.githubusercontent.com/107460718/174611303-aa4b8147-08dc-4631-b9e5-bb6af422f137.png)


This map change has also been tested and was made using FastDMM2's Commit Maps. 
![image](https://user-images.githubusercontent.com/107460718/174610639-09c699fd-73f4-4d50-b388-f7051a80ea2f.png)
Edit: Went back to check if the duffle had actual surgery tools.
![image](https://user-images.githubusercontent.com/107460718/174615690-337e4b15-dd9a-4baa-bf30-ce424f3702e9.png)
# Changelog

:cl:  
tweak: Adds in Surgery Duffel and a Medical mask with an Anesthetic tank while removing the surgery tools on the table, this also means they get a sterilizer a razor, and an extra surgery mask now
/:cl:
