### PR TITLE
Update ghost_role_spawners.dm

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -179,7 +179,7 @@
 		notify_ghosts("\A [initial(species.prefix)] golem shell has been completed in \the [A.name].", source = src, action=NOTIFY_ATTACKORBIT, flashwindow = FALSE, ignore_key = POLL_IGNORE_GOLEM)
 	if(has_owner && creator)
 		short_desc = "You are a Golem."
-		flavour_text = "You move slowly, but are highly resistant to heat and cold as well as blunt trauma. You are unable to wear clothes, but can still use most tools. \
+		flavour_text = "You move slowly and are unable to wear clothes, but can still use most tools. Depending on the material you were made of, you will have different strengths and weaknesses \
 		Serve [creator], and assist [creator.p_them()] in completing [creator.p_their()] goals at any cost."
 		owner = creator
 


### PR DESCRIPTION
# Document the changes in your pull request

fixes #8573
golem text now says "you are simply built different" rather than "you are strong against x and y" because you may not in fact be strong against x and y because golems are BUILT DIFFERENT


# Wiki Documentation

golem greet text if documented is now
"You move slowly and are unable to wear clothes, but can still use most tools. Depending on the material you were made of, you will have different strengths and weaknesses 
Serve [creator], and assist [creator.p_them()] in completing [creator.p_their()] goals at any cost."

# Changelog


:cl:  
tweak: golem greet text no longer gives conflicting information with certain golem types by assuming your material
/:cl:
