### PR TITLE
Saboteur/Medical Syndicate Borg Tweaks

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -678,7 +678,6 @@
 		/obj/item/crowbar/cyborg,
 		/obj/item/wirecutters/cyborg,
 		/obj/item/multitool/cyborg,
-		/obj/item/card/emag,
 		/obj/item/stack/sheet/metal/cyborg,
 		/obj/item/stack/sheet/glass/cyborg,
 		/obj/item/stack/sheet/rglass/cyborg,

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -648,8 +648,7 @@
 		/obj/item/bonesetter,
 		/obj/item/melee/transforming/energy/sword/cyborg/saw,
 		/obj/item/roller/robo,
-		/obj/item/card/emag,
-		/obj/item/crowbar/cyborg,
+		/obj/item/restraints/handcuffs/cable/zipties,
 		/obj/item/extinguisher/mini,
 		/obj/item/pinpointer/syndicate_cyborg,
 		/obj/item/stack/medical/gauze/cyborg,
@@ -668,6 +667,7 @@
 	name = "Syndicate Saboteur"
 	basic_modules = list(
 		/obj/item/assembly/flash/cyborg,
+		/obj/item/kitchen/knife/combat/cyborg,
 		/obj/item/borg/sight/thermal,
 		/obj/item/construction/rcd/borg/syndicate,
 		/obj/item/pipe_dispenser,
@@ -678,6 +678,7 @@
 		/obj/item/crowbar/cyborg,
 		/obj/item/wirecutters/cyborg,
 		/obj/item/multitool/cyborg,
+		/obj/item/card/emag,
 		/obj/item/stack/sheet/metal/cyborg,
 		/obj/item/stack/sheet/glass/cyborg,
 		/obj/item/stack/sheet/rglass/cyborg,


### PR DESCRIPTION
# Document the changes in your pull request

Syndicate medical cyborg loses EMAG now because why does it have it as a support unit and not a saboteur?

Originally gave EMAG to sabo borg as a tradeoff before the comments graciously pointed out that a camouflaged EMAG user that can subvert borgs was maybe a bad idea.

Also removes the crowbar from the medical syndicate borg because it's strictly meant to be a support unit, instead giving it cuffs in the rare case that it or an operative incapacitates an individual and wishes to bring them back to the shuttle to be brainwashed.

Gives saboteur borg a combat knife for some effectiveness in melee combat outside of the welder, though the weapon isn't as effective as the esword or the esaw that the other two Syndicate borgs get.

# Wiki Documentation

Medical Syndicate borg has lost EMAG and crowbar. Gained zipties identical to those the secborg has.
Saboteur Syndicate borg has gained combat knife (identical to the one that is gained from EMAG'ing toolset implants).

# Changelog

:cl:  
tweak: Syndie mediborg loses emag and crowbar, gains zipties
tweak: Syndie saboborg gains combat knife
/:cl:
