### PR TITLE
Fixes improper secbelt/bandolier item storage

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -235,6 +235,7 @@
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 6
+	STR.max_combined_w_class = 18
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
 	STR.set_holdable(list(
 		/obj/item/melee/baton,
@@ -281,6 +282,7 @@
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 7
+	STR.max_combined_w_class = 21
 
 /obj/item/storage/belt/security/chief/full/PopulateContents()
 	new /obj/item/reagent_containers/spray/pepper(src)
@@ -304,6 +306,7 @@
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 7
+	STR.max_combined_w_class = 21
 
 /obj/item/storage/belt/mining
 	name = "explorer's webbing"
@@ -664,6 +667,7 @@
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 24
+	STR.max_combined_w_class = 72
 	STR.display_numerical_stacking = TRUE
 	STR.set_holdable(list(
 		/obj/item/ammo_casing/shotgun

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -667,7 +667,7 @@
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 24
-	STR.max_combined_w_class = 72
+	STR.max_combined_w_class = 24
 	STR.display_numerical_stacking = TRUE
 	STR.set_holdable(list(
 		/obj/item/ammo_casing/shotgun


### PR DESCRIPTION
# Document the changes in your pull request

Fixes #14508

Indirect buff to the baton thrower subclass of secoff but we should begin to actually see them now ig

# Wiki Documentation

No

# Changelog

:cl:  
bugfix: Secbelts and bandoliers can now hold proper number of items
/:cl:
