### PR TITLE
[ADMIN] setting nuke code via request now sets beer nuke code aswell

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1982,6 +1982,8 @@
 		var/code = random_nukecode()
 		for(var/obj/machinery/nuclearbomb/selfdestruct/SD in GLOB.nuke_list)
 			SD.r_code = code
+		for(var/obj/machinery/nuclearbomb/beer/BN in GLOB.nuke_list)
+			BN.r_code = code
 		message_admins("[key_name_admin(usr)] has set the self-destruct \
 			code to \"[code]\".")
 


### PR DESCRIPTION
# Document the changes in your pull request

as god intended

closes #14527

# Changelog

:cl:  
tweak: When admins give you the nuke codes, those codes now also work for the beer nuke
/:cl:
