### PR TITLE
Stechkin Ammo Buffs

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -480,6 +480,20 @@
 	new /obj/item/reagent_containers/glass/bottle/amanitin(src)
 	new /obj/item/reagent_containers/syringe(src)
 
+/obj/item/storage/box/syndie_kit/pistolammo
+	name = "10mm magazine box"
+
+/obj/item/storage/box/syndie_kit/pistolammo/PopulateContents()
+	for(var/i in 1 to 2)
+		new /obj/item/ammo_box/magazine/m10mm(src)
+
+/obj/item/storage/box/syndie_kit/pistolsleepyammo
+	name = "10mm soporific magazine box"
+
+/obj/item/storage/box/syndie_kit/pistolsleepyammo/PopulateContents()
+	for(var/i in 1 to 2)
+		new /obj/item/ammo_box/magazine/m10mm/sp(src)
+
 /obj/item/storage/box/syndie_kit/nuke
 	name = "box"
 

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -27,8 +27,8 @@
 
 /obj/item/projectile/bullet/c10mm_hp
 	name = "10mm hollow-point bullet"
-	damage = 40
-	armour_penetration = -50
+	damage = 45
+	armour_penetration = -45
 
 /obj/item/projectile/bullet/c10mm_sp
 	name = "10mm soporific bullet"
@@ -45,5 +45,5 @@
 
 /obj/item/projectile/bullet/incendiary/c10mm
 	name = "10mm incendiary bullet"
-	damage = 15
+	damage = 20
 	fire_stacks = 2

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -726,7 +726,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/ammo/pistolfire
 	name = "10mm Incendiary Magazine"
 	desc = "An additional 8-round 10mm magazine; compatible with the Stechkin Pistol. \
-			Loaded with incendiary rounds which inflict little damage, but ignite the target."
+			Loaded with incendiary rounds which inflict reduced damage, but ignite the target."
 	item = /obj/item/ammo_box/magazine/m10mm/fire
 	cost = 1
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -693,9 +693,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	surplus = 40
 
 /datum/uplink_item/ammo/pistol
-	name = "10mm Handgun Magazine"
-	desc = "An additional 8-round 10mm magazine; compatible with the Stechkin Pistol."
-	item = /obj/item/ammo_box/magazine/m10mm
+	name = "Pair of 10mm Handgun Magazines"
+	desc = "A box that contains two additional 8-round 10mm magazines; compatible with the Stechkin Pistol."
+	item = /obj/item/storage/box/syndie_kit/pistolammo
 	cost = 1
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 
@@ -704,7 +704,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "An additional 8-round 10mm magazine; compatible with the Stechkin Pistol. \
 			These rounds are less effective at injuring the target but penetrate protective gear."
 	item = /obj/item/ammo_box/magazine/m10mm/ap
-	cost = 2
+	cost = 1
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 
 /datum/uplink_item/ammo/pistolhp
@@ -712,14 +712,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "An additional 8-round 10mm magazine; compatible with the Stechkin Pistol. \
 			These rounds are more damaging but ineffective against armour."
 	item = /obj/item/ammo_box/magazine/m10mm/hp
-	cost = 3
+	cost = 1
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 
 /datum/uplink_item/ammo/pistolsleepy
-	name = "10mm Soporific Magazine"
-	desc = "An additional 8-round 10mm magazine; compatible with the Stechkin Pistol. \
+	name = "Pair of 10mm Soporific Magazines"
+	desc = "A box that contains 2 additional 8-round 10mm magazines; compatible with the Stechkin Pistol. \
 			These rounds will deliver small doses of tranqulizers on hit, knocking the target out after a few successive hits."
-	item = /obj/item/ammo_box/magazine/m10mm/sp
+	item = /obj/item/storage/box/syndie_kit/pistolsleepyammo
 	cost = 1
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 
@@ -728,7 +728,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "An additional 8-round 10mm magazine; compatible with the Stechkin Pistol. \
 			Loaded with incendiary rounds which inflict little damage, but ignite the target."
 	item = /obj/item/ammo_box/magazine/m10mm/fire
-	cost = 2
+	cost = 1
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 
 /datum/uplink_item/ammo/shotgun


### PR DESCRIPTION
# Document the changes in your pull request

Attempts to make purchasing additional stechkin magazines less of a TC dump and also buffs HP and incind to be much more usable relative to their costs.

A bit drastic of a change but more than willing to see adjustments and suggestions

# Wiki Documentation

In the uplink:
10mm magazine replaced with Pair of 10mm magazines which contains two 10mm magazines.
AP 10mm magazine TC cost reduced to 1 from 2.
HP 10mm magazine TC cost reduced to 1 from 3.
Soporific 10mm magazine replaced with Pair of Soporific 10mm magazines which contains two soporific 10mm magazines.
Incendiary 10mm magazine TC cost reduced to 1 from 2.

Values themselves:
HP damage and AP to 45 and -45 from 40 and -50 respectively
Incendiary damage up to 20 from 15

# Changelog

:cl:  
tweak: The cost of AP, HP, and incind 10mm magazines have all been reduced to 1 TC each
tweak: Normal and soporific 10mm magazines are now bought in pairs, they come in a box
tweak: HP 10mm now does 45 damage with only -45 AP, up from 40/-50
tweak: Incind 10mm now does 20 damage, up from 15
/:cl:
