### PR TITLE
Nerfs experimental .38 and adjusts TRAC rounds

### DIFF
--- a/code/game/objects/items/implants/implant_track.dm
+++ b/code/game/objects/items/implants/implant_track.dm
@@ -9,7 +9,7 @@
 	name = "TRAC implant"
 	desc = "A smaller tracking implant that supplies power for only a few minutes."
 	var/lifespan = 15 MINUTES //how long does the implant last?
-	allow_teleport = FALSE
+	allow_teleport = TRUE
 
 /obj/item/implant/tracking/c38/Initialize()
 	. = ..()

--- a/code/game/objects/items/implants/implant_track.dm
+++ b/code/game/objects/items/implants/implant_track.dm
@@ -9,7 +9,6 @@
 	name = "TRAC implant"
 	desc = "A smaller tracking implant that supplies power for only a few minutes."
 	var/lifespan = 15 MINUTES //how long does the implant last?
-	allow_teleport = TRUE
 
 /obj/item/implant/tracking/c38/Initialize()
 	. = ..()

--- a/code/game/objects/items/implants/implant_track.dm
+++ b/code/game/objects/items/implants/implant_track.dm
@@ -8,7 +8,7 @@
 /obj/item/implant/tracking/c38
 	name = "TRAC implant"
 	desc = "A smaller tracking implant that supplies power for only a few minutes."
-	var/lifespan = 15 MINUTES //how long does the implant last?
+	var/lifespan = 5 MINUTES //how long does the implant last?
 
 /obj/item/implant/tracking/c38/Initialize()
 	. = ..()

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -18,7 +18,7 @@
 /obj/item/ammo_box/c38/trac
 	name = "speed loader (.38 TRAC)"
 	desc = "A six-shot speed loader designed for .38 revolvers. \
-			These rounds deal lessened damage and stopping power, but inject a tracking implant upon burrowing into a target's body. Implant lifespan is fifteen minutes."
+			These rounds deal lessened damage and stopping power, but inject a tracking implant upon burrowing into a target's body. Implant lifespan is five minutes."
 	ammo_type = /obj/item/ammo_casing/c38/trac
 
 /obj/item/ammo_box/c38/hotshot

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -1,6 +1,6 @@
 /obj/item/ammo_box/a357
 	name = "speed loader (.357)"
-	desc = "Designed to quickly reload revolvers."
+	desc = "A seven-shot speed loader designed for .357 revolvers."
 	icon_state = "357"
 	ammo_type = /obj/item/ammo_casing/a357
 	max_ammo = 7
@@ -8,7 +8,7 @@
 
 /obj/item/ammo_box/c38
 	name = "speed loader (.38)"
-	desc = "Designed to quickly reload revolvers."
+	desc = "A six-shot speed loader designed for .38 revolvers."
 	icon_state = "38"
 	ammo_type = /obj/item/ammo_casing/c38
 	max_ammo = 6
@@ -17,17 +17,20 @@
 
 /obj/item/ammo_box/c38/trac
 	name = "speed loader (.38 TRAC)"
-	desc = "Designed to quickly reload revolvers. TRAC bullets embed a tracking implant within the target's body."
+	desc = "A six-shot speed loader designed for .38 revolvers. \
+			These rounds deal lessened damage and stopping power, but inject a tracking implant upon burrowing into a target's body. Implant lifespan is fifteen minutes."
 	ammo_type = /obj/item/ammo_casing/c38/trac
 
 /obj/item/ammo_box/c38/hotshot
 	name = "speed loader (.38 Hot Shot)"
-	desc = "Designed to quickly reload revolvers. Hot Shot bullets contain an incendiary payload."
+	desc = "A six-shot speed loader designed for .38 revolvers. \
+			These rounds trade exhaustive properties for an incendiary payload which sets targets ablaze."
 	ammo_type = /obj/item/ammo_casing/c38/hotshot
 
 /obj/item/ammo_box/c38/iceblox
 	name = "speed loader (.38 Iceblox)"
-	desc = "Designed to quickly reload revolvers. Iceblox bullets contain a cryogenic payload."
+	desc = "A six-shot speed loader designed for .38 revolvers. \
+			These rounds trade exhaustive properties for a cryogenic payload which significantly reduces the body temperature of targets hit."
 	ammo_type = /obj/item/ammo_casing/c38/iceblox
 
 /obj/item/ammo_box/c9mm

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -22,7 +22,8 @@
 
 /obj/item/projectile/bullet/c38/trac
 	name = ".38 TRAC bullet"
-	damage = 10
+	damage = 8
+	stamina = 25
 
 /obj/item/projectile/bullet/c38/trac/on_hit(atom/target, blocked = FALSE)
 	. = ..()
@@ -37,18 +38,20 @@
 
 /obj/item/projectile/bullet/c38/hotshot //similar to incendiary bullets, but do not leave a flaming trail
 	name = ".38 Hot Shot bullet"
-	damage = 20
+	damage = 15
+	stamina = 0
 
 /obj/item/projectile/bullet/c38/hotshot/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
-		M.adjust_fire_stacks(6)
+		M.adjust_fire_stacks(2)
 		M.IgniteMob()
 
 /obj/item/projectile/bullet/c38/iceblox //see /obj/item/projectile/temp for the original code
 	name = ".38 Iceblox bullet"
-	damage = 20
+	damage = 15
+	stamina = 0
 	var/temperature = 100
 
 /obj/item/projectile/bullet/c38/iceblox/on_hit(atom/target, blocked = FALSE)


### PR DESCRIPTION
# Document the changes in your pull request

Primarily makes .38 experimental rounds less of a direct upgrade and instead more of a "I am going to give up stamina damage to absolutely destroy someone's life"

Also makes it so TRAC rounds can be teleported to again, for some clarification on all the yoggers out there they last **5 minutes NOW** and can only be removed early by shocking yourself or undergoing the knife.

Also also TRAC does less damage but should still be usable in self-defense, relatively speaking. Numbers could probably get pumped up again.

Also also also updates the descriptions for all .357 and .38 speed loaders to actually have differences rather than being C+P'd laziness.

# Wiki Documentation

TRAC rounds now deal 8 damage and 25 stamina rather than 10 damage and inheriting 35 stamina damage
TRAC rounds can be teleported to again but only last 5 minutes
Hotshot rounds do 15 damage and 0 stamina damage down from 20/35
Hotshot rounds only apply 2 firestacks rather than 6
Iceblax rounds do 15 damage and 0 stamina damage down from 20/35

# Changelog

:cl:  
tweak: TRAC does less damage but can be teleported to again, implant lasts 5 minutes
tweak: Hotshot and iceblax both do 15 damage and no stamina damage down from 20 and 35 respectively
tweak: Hotshot only applies 2 firestacks now instead of 6
/:cl:
