### PR TITLE
should stop resonator blasts from stacking during replication

### DIFF
--- a/code/modules/mining/equipment/resonator.dm
+++ b/code/modules/mining/equipment/resonator.dm
@@ -121,5 +121,5 @@
 	if(!istype(M) || !M.mineralType) // so we don't end up in the ultimate chain reaction
 		return
 	for(var/turf/closed/mineral/T in orange(1, M))
-		if(istype(T) && M.mineralType == T.mineralType)
+		if(istype(T) && !locate(/obj/effect/temp_visual/resonance) in T && M.mineralType == T.mineralType)
 			new /obj/effect/temp_visual/resonance(T, creator, null, duration)	//yogs end


### PR DESCRIPTION
# Document the changes in your pull request

OH BOY I CANT WAIT TO PICK UP THIS ROCK 
CRUNCH

# Changelog

:cl:  
bugfix: resonator blasts will no longer stack on top of eachother creating a tile you cannot step on without breaking your bones that has collectable rocks on it  
/:cl:
