### PR TITLE
[ADMIN] Adds ability to set beer nuke with a button

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -57,6 +57,7 @@
 #define ADMIN_LOOKUP(user) "[key_name_admin(user)][ADMIN_QUE(user)]"
 #define ADMIN_LOOKUPFLW(user) "[key_name_admin(user)][ADMIN_QUE(user)] [ADMIN_FLW(user)]"
 #define ADMIN_SET_SD_CODE "(<a href='?_src_=holder;[HrefToken(TRUE)];set_selfdestruct_code=1'>SETCODE</a>)"
+#define ADMIN_SET_BC_CODE "(<a href='?_src_=holder;[HrefToken(TRUE)];set_beer_code=1'>SETBEER</a>)"
 #define ADMIN_FULLMONTY_NONAME(user) "[ADMIN_QUE(user)] [ADMIN_PP(user)] [ADMIN_VV(user)] [ADMIN_SM(user)] [ADMIN_FLW(user)] [ADMIN_TP(user)] [ADMIN_INDIVIDUALLOG(user)] [ADMIN_SMITE(user)]"
 #define ADMIN_FULLMONTY(user) "[key_name_admin(user)] [ADMIN_FULLMONTY_NONAME(user)]"
 #define ADMIN_JMP(src) "(<a href='?_src_=holder;[HrefToken(TRUE)];adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1984,7 +1984,14 @@
 			SD.r_code = code
 		message_admins("[key_name_admin(usr)] has set the self-destruct \
 			code to \"[code]\".")
-
+	else if(href_list["set_beer_code"])
+		if(!check_rights(R_ADMIN))
+			return
+		var/code = random_nukecode()
+		for(var/obj/machinery/nuclearbomb/beer/BN in GLOB.nuke_list)
+			BN.r_code = code
+		message_admins("[key_name_admin(usr)] has set the beer nuke \
+			code to \"[code]\".")
 	else if(href_list["add_station_goal"])
 		if(!check_rights(R_ADMIN))
 			return

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -72,7 +72,7 @@
 /// Used by communications consoles to request the nuclear launch codes
 /proc/nuke_request(text, mob/sender)
 	var/msg = copytext_char(sanitize(text), 1, MAX_MESSAGE_LEN)
-	msg = span_adminnotice("<b><font color=orange>NUKE CODE REQUEST:</font>[ADMIN_FULLMONTY(sender)] [ADMIN_CENTCOM_REPLY(sender)] [ADMIN_SET_SD_CODE]:</b> [msg]")
+	msg = span_adminnotice("<b><font color=orange>NUKE CODE REQUEST:</font>[ADMIN_FULLMONTY(sender)] [ADMIN_CENTCOM_REPLY(sender)] [ADMIN_SET_SD_CODE] [ADMIN_SET_BC_CODE]:</b> [msg]")
 	to_chat(GLOB.admins, msg, confidential = TRUE)
 	for(var/obj/machinery/computer/communications/console in GLOB.machines)
 		console.override_cooldown()


### PR DESCRIPTION
# Document the changes in your pull request
Closes #14523
#14523 but more sensible

Adds a button to set the beer nuke **separate** of the real one.

### Why this is better than #14523.
  Admin could stop paying attention and someone could have nuke the station (Very Unlikely but possible)
  Someone will try to do the above regardless but admin is paying attention and prevents anything bad (Slightly probable)
  Better code sanity wise

# Changelog

:cl:  
rscadd: Admins now have a button to set the beer nuke code
/:cl:
