### PR TITLE
Makes WT mags not be invisible

### DIFF
--- a/code/modules/projectiles/boxes_magazines/external/smg.dm
+++ b/code/modules/projectiles/boxes_magazines/external/smg.dm
@@ -7,7 +7,19 @@
 
 /obj/item/ammo_box/magazine/wt550m9/update_icon()
 	..()
-	icon_state = "46x30mmt-[round(ammo_count(),4)]"
+	switch(ammo_count())
+		if(19 to 22)
+			icon_state = "46x30mmt-20"
+		if(15 to 18)
+			icon_state = "46x30mmt-16"
+		if(11 to 14)
+			icon_state = "46x30mmt-12"
+		if(7 to 10)
+			icon_state = "46x30mmt-8"
+		if(3 to 6)
+			icon_state = "46x30mmt-4"
+		else
+			icon_state = "46x30mmt-0"
 
 /obj/item/ammo_box/magazine/wt550m9/wtap
 	name = "\improper WT-550 magazine (Armour Piercing 4.6x30mm)"
@@ -16,7 +28,19 @@
 
 /obj/item/ammo_box/magazine/wt550m9/wtap/update_icon()
 	..()
-	icon_state = "46x30mmtA-[round(ammo_count(),4)]"
+	switch(ammo_count())
+		if(19 to 22)
+			icon_state = "46x30mmtA-20"
+		if(15 to 18)
+			icon_state = "46x30mmtA-16"
+		if(11 to 14)
+			icon_state = "46x30mmtA-12"
+		if(7 to 10)
+			icon_state = "46x30mmtA-8"
+		if(3 to 6)
+			icon_state = "46x30mmtA-4"
+		else
+			icon_state = "46x30mmtA-0"
 
 /obj/item/ammo_box/magazine/wt550m9/wtic
 	name = "\improper WT-550 magazine (Incendiary 4.6x30mm)"
@@ -25,7 +49,19 @@
 
 /obj/item/ammo_box/magazine/wt550m9/wtic/update_icon()
 	..()
-	icon_state = "46x30mmtI-[round(ammo_count(),4)]"
+	switch(ammo_count())
+		if(19 to 22)
+			icon_state = "46x30mmtI-20"
+		if(15 to 18)
+			icon_state = "46x30mmtI-16"
+		if(11 to 14)
+			icon_state = "46x30mmtI-12"
+		if(7 to 10)
+			icon_state = "46x30mmtI-8"
+		if(3 to 6)
+			icon_state = "46x30mmtI-4"
+		else
+			icon_state = "46x30mmtI-0"
 
 /obj/item/ammo_box/magazine/wt550m9/wtr
 	name = "\improper WT-550 magazine(Rubber Rounds 4.6x30mm)"
@@ -34,7 +70,19 @@
 
 /obj/item/ammo_box/magazine/wt550m9/wtr/update_icon()
 	..()
-	icon_state = "46x30mmtR-[round(ammo_count(),4)]"
+	switch(ammo_count())
+		if(19 to 22)
+			icon_state = "46x30mmtR-20"
+		if(15 to 18)
+			icon_state = "46x30mmtR-16"
+		if(11 to 14)
+			icon_state = "46x30mmtR-12"
+		if(7 to 10)
+			icon_state = "46x30mmtR-8"
+		if(3 to 6)
+			icon_state = "46x30mmtR-4"
+		else
+			icon_state = "46x30mmtR-0"
 
 /obj/item/ammo_box/magazine/uzim9mm
 	name = "uzi magazine (9mm)"


### PR DESCRIPTION
# Document the changes in your pull request

Fixes the missing sprite issue because mags have more ammo than before.

# Changelog

:cl:    
bugfix: WT mags are now visible again
/:cl:
