### PR TITLE
Nerfs claymores

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_cultritual.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_cultritual.dmm
@@ -187,9 +187,9 @@
 /area/lavaland/surface/outdoors)
 "O" = (
 /obj/item/claymore{
-	name = "Excalibur";
-	desc = "A legendary sword passed down through the ages, though it seems to have lost its magic.";
-	force = 21;
+	name = "Excalibur"
+	desc = "A legendary sword passed down through the ages, though it seems to have lost its magic."
+	force = 21
 	block_chance = 30
 	},
 /obj/item/clothing/shoes/plate,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_cultritual.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_cultritual.dmm
@@ -186,7 +186,7 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "O" = (
-/obj/item/claymore/excalibur,
+/obj/item/claymore/ruin/excalibur,
 /obj/item/clothing/shoes/plate,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/ash/large,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_cultritual.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_cultritual.dmm
@@ -186,12 +186,7 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "O" = (
-/obj/item/claymore{
-	name = "Excalibur"
-	desc = "A legendary sword passed down through the ages, though it seems to have lost its magic."
-	force = 21
-	block_chance = 30
-	},
+/obj/item/claymore/excalibur,
 /obj/item/clothing/shoes/plate,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/ash/large,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_cultritual.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_cultritual.dmm
@@ -187,7 +187,10 @@
 /area/lavaland/surface/outdoors)
 "O" = (
 /obj/item/claymore{
-	name = "Excalibur"
+	name = "Excalibur";
+	desc = "A legendary sword passed down through the ages, though it seems to have lost its magic.";
+	force = 21;
+	block_chance = 30
 	},
 /obj/item/clothing/shoes/plate,
 /obj/effect/decal/cleanable/blood/old,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_legionbarracks.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_legionbarracks.dmm
@@ -84,7 +84,7 @@
 /obj/structure/rack,
 /obj/item/claymore{
 	name = "Ancient Sword";
-	desc = "It's cracked and blunted";
+	desc = "A cracked and blunted sword, clearly weathered over the ages.";
 	force = 21;
 	block_chance = 30
 	},

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_legionbarracks.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_legionbarracks.dmm
@@ -83,9 +83,10 @@
 "S" = (
 /obj/structure/rack,
 /obj/item/claymore{
+	name = "Ancient Sword";
 	desc = "It's cracked and blunted";
 	force = 21;
-	name = "Ancient Sword"
+	block_chance = 30
 	},
 /obj/item/shield/riot/roman{
 	block_chance = 25;

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_legionbarracks.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_legionbarracks.dmm
@@ -82,12 +82,7 @@
 /area/ruin/unpowered)
 "S" = (
 /obj/structure/rack,
-/obj/item/claymore{
-	name = "Ancient Sword";
-	desc = "A cracked and blunted sword, clearly weathered over the ages.";
-	force = 21;
-	block_chance = 30
-	},
+/obj/item/claymore/ruin,
 /obj/item/shield/riot/roman{
 	block_chance = 25;
 	desc = "Bears an inscription on the inside: <i>\"Necropolis venio domus\"</i>.";

--- a/_maps/RandomRuins/SpaceRuins/Academy.dmm
+++ b/_maps/RandomRuins/SpaceRuins/Academy.dmm
@@ -1171,7 +1171,12 @@
 /area/awaymission/academy/academycellar)
 "mn" = (
 /obj/structure/rack,
-/obj/item/claymore,
+/obj/item/claymore[
+	name = "Lapis-Adorned Blade";
+	desc = "A sword made of enchanted lapis. Though, it seems to have lost its magic.";
+	force = 21;
+	block_chance = 30
+],
 /obj/item/toy/figure/wizard,
 /turf/open/floor/vault,
 /area/awaymission/academy/academycellar)

--- a/_maps/RandomRuins/SpaceRuins/Academy.dmm
+++ b/_maps/RandomRuins/SpaceRuins/Academy.dmm
@@ -1171,12 +1171,7 @@
 /area/awaymission/academy/academycellar)
 "mn" = (
 /obj/structure/rack,
-/obj/item/claymore[
-	name = "Lapis-Adorned Blade";
-	desc = "A sword made of enchanted lapis. Though, it seems to have lost its magic.";
-	force = 21;
-	block_chance = 30
-],
+/obj/item/claymore,
 /obj/item/toy/figure/wizard,
 /turf/open/floor/vault,
 /area/awaymission/academy/academycellar)

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -79,6 +79,18 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 /obj/item/claymore/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] is falling on [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return(BRUTELOSS)
+	
+/obj/item/claymore/excalibur
+	name = "Excalibur"
+	desc = "A legendary sword passed down through the ages, though it seems to have lost its magic."
+	force = 21
+	block_chance = 30
+	
+/obj/item/claymore/ruin
+	name = "Ancient Sword"
+	desc = "A cracked and blunted sword, clearly weathered over the ages."
+	force = 21
+	block_chance = 30
 
 /obj/item/claymore/highlander //ALL COMMENTS MADE REGARDING THIS SWORD MUST BE MADE IN ALL CAPS
 	desc = "<b><i>THERE CAN BE ONLY ONE, AND IT WILL BE YOU!!!</i></b>\nActivate it in your hand to point to the nearest victim."

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -75,6 +75,11 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 /obj/item/claymore/Initialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 40, 105)
+	
+/obj/item/claymore/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+	if(attack_type == PROJECTILE_ATTACK)
+		final_block_chance = 0 //Don't bring a sword to a gunfight
+	return ..()
 
 /obj/item/claymore/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] is falling on [src]! It looks like [user.p_theyre()] trying to commit suicide!"))

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -219,7 +219,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 
 /obj/item/claymore/bone
 	name = "Bone Sword"
-	desc = "Jagged pieces of bone are tied to what looks like a goliaths femur."
+	desc = "Jagged pieces of bone are tied to what looks like a goliath's femur."
 	icon = 'icons/obj/weapons/swords.dmi'
 	icon_state = "bone_sword"
 	item_state = "bone_sword"

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -64,7 +64,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
 	force = 40
 	throwforce = 10
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	block_chance = 50
 	sharpness = SHARP_EDGED
@@ -204,6 +204,24 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 
 	name = new_name
 	playsound(user, 'sound/items/screwdriver2.ogg', 50, 1)
+
+/obj/item/claymore/bone
+	name = "Bone Sword"
+	desc = "Jagged pieces of bone are tied to what looks like a goliaths femur."
+	icon = 'icons/obj/weapons/swords.dmi'
+	icon_state = "bone_sword"
+	item_state = "bone_sword"
+	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
+	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
+	force = 15
+	throwforce = 10
+	armour_penetration = 15
+	w_class = WEIGHT_CLASS_HUGE
+	hitsound = 'sound/weapons/bladeslice.ogg'
+	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "tore", "ripped", "diced", "cut")
+	block_chance = 30
+	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 50)
 
 /obj/item/katana
 	name = "katana"
@@ -801,20 +819,3 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		to_chat(user, span_warning("[M] is too close to use [src] on."))
 		return
 	M.attack_hand(user)
-
-/obj/item/claymore/bone
-	name = "Bone Sword"
-	desc = "Jagged pieces of bone are tied to what looks like a goliaths femur."
-	icon = 'icons/obj/weapons/swords.dmi'
-	icon_state = "bone_sword"
-	item_state = "bone_sword"
-	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
-	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
-	force = 15
-	throwforce = 10
-	armour_penetration = 15
-	w_class = WEIGHT_CLASS_NORMAL
-	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "tore", "ripped", "diced", "cut")
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 50)

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -80,17 +80,15 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	user.visible_message(span_suicide("[user] is falling on [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return(BRUTELOSS)
 	
-/obj/item/claymore/excalibur
-	name = "Excalibur"
-	desc = "A legendary sword passed down through the ages, though it seems to have lost its magic."
-	force = 21
-	block_chance = 30
-	
 /obj/item/claymore/ruin
-	name = "Ancient Sword"
+	name = "ancient sword"
 	desc = "A cracked and blunted sword, clearly weathered over the ages."
 	force = 21
 	block_chance = 30
+	
+/obj/item/claymore/ruin/excalibur
+	name = "Excalibur"
+	desc = "A legendary sword passed down through the ages, though it seems to have lost its magic."
 
 /obj/item/claymore/highlander //ALL COMMENTS MADE REGARDING THIS SWORD MUST BE MADE IN ALL CAPS
 	desc = "<b><i>THERE CAN BE ONLY ONE, AND IT WILL BE YOU!!!</i></b>\nActivate it in your hand to point to the nearest victim."


### PR DESCRIPTION
# Document the changes in your pull request

Claymores are now baseline bulky because they're huge-ass swords??

Also nerfs any claymore variants that can be found in ruins because their numbers were overtweaked for standards of miner loot.

Also also bone sword had its block chance looked at because as it turns out an easily-craftable 50 block chance normal-sized weapon is a bit absurd. As a little funky trade-off it's only huge (also so it can fit on certain exosuits).

Also also also claymores shouldn't be able to block projectiles anymore (I stole the code from captain's sabre)

# Wiki Documentation

Claymores are now baseline bulky, can't block projectiles
Bone sword block chance to 30, item is also now huge
All ruin claymores have had a pass over their flavor text and deal 21 damage with 30 block chance, rather than the baseline 40/50 of normal claymores. Also new items now; Excalibur and Ancient Sword, as before.

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
tweak: Claymores are now baseline bulky, cannot block projectiles
tweak: Bone sword now huge, less block chance
tweak: All claymores in ruins are now unique items in code, have updated description, also damage/blockchance nerfed
/:cl:
