### PR TITLE
SHARPENS YE PIRATE BLADE

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -73,7 +73,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	force = 18
 	throwforce = 10
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_HUGE
 	block_chance = 30
 	sharpness = SHARP_EDGED
 	attack_verb = list("slashed", "cut")

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -64,7 +64,7 @@
 
 /obj/item/melee/cutlass
 	name = "cutlass"
-	desc = "YAAAAAR! A fine weapon for a pirate, fit for slicing land-lubber." //All pirate weapons must have pirate quips from now on it is non-negotiable
+	desc = "YAAAAAR! A fine weapon for a pirate, fit for slicing land-lubbers." //All pirate weapons must have pirate quips from now on it is non-negotiable
 	icon = 'icons/obj/weapons/swords.dmi'
 	icon_state = "metalcutlass"
 	item_state = "metalcutlass"

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -64,15 +64,18 @@
 
 /obj/item/melee/cutlass
 	name = "cutlass"
-	desc = "A true pirates weapon, seems somewhat dull though"
+	desc = "YAAAAAR! A fine weapon for a pirate, fit for slicing land-lubber." //All pirate weapons must have pirate quips from now on it is non-negotiable
 	icon = 'icons/obj/weapons/swords.dmi'
 	icon_state = "metalcutlass"
 	item_state = "metalcutlass"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
-	force = 16
-	throwforce = 5
+	slot_flags = ITEM_SLOT_BELT
+	force = 18
+	throwforce = 10
 	w_class = WEIGHT_CLASS_BULKY
+	block_chance = 30
+	sharpness = SHARP_EDGED
 	attack_verb = list("slashed", "cut")
 	hitsound = 'sound/weapons/rapierhit.ogg'
 	materials = list(/datum/material/iron = 1000)


### PR DESCRIPTION
# Document the changes in your pull request

ARRRRRRGH

THE SOLID PIRATE CUTLASS NOW CAN BE ATTACHED TO A BELT AND HAS HAD ITS NUMBERS MORE TWEAKED TO OTHER LAVALAND MELEE WEAPONS

NOTE THAT IN ACCORDANCE WITH YE SCURVY CLAYMORES, THIS DOES THREE LESS DAMAGE, CAN'T BE PUT ON THE BACK, WHICH MEANS IT'S ESSENTIALLY A NULLROD WITHOUT ANTIMAGIC

ARRRRRRRRRRRRRRRRRRRRRRRRRRRGH

THIS CUTLASS IS NOW ALSO HUGE INSTEAD OF BULKY SO IT CAN GO ON EXOSUITS IN CONJUNCTION WITH #14583

# Wiki Documentation

PIRATE CUTLASS CAN NOW BE ATTACHED TO THE BELT
DAMAGE TO 18 FROM 15
THROW FORCE TO 10 FROM 5
BLOCK CHANCE TO 30 FROM 0
HAS GAINED THE SHARP TRAIT
NOW HUGE INSTEAD OF BULKY

# Changelog

:cl:  
tweak: FEAR THE (LAVA) SEAS LAND LUBBERS, OUR BLADES HUNGER FOR WHELPLING BLOOD
/:cl:
