### PR TITLE
Sec Webbing cheaper

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -300,7 +300,7 @@
 	icon_state = "securitywebbing"
 	item_state = "securitywebbing"
 	w_class = WEIGHT_CLASS_BULKY
-	custom_premium_price = 800
+	custom_premium_price = 200
 
 /obj/item/storage/belt/security/webbing/ComponentInitialize()
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request

Makes sec webbing cost 200 instead of 800 so sec offs can slot one more insta-win baton into their belt slot to huck at the antagonist

Realistically anyone in sec could get these anyway but wardens have no brain cells to not just use the budget card to give out money for these because the money's going to come out of the budget anyway

# Wiki Documentation

Security webbing now costs 200 rather than 800 at the vending machine

# Changelog

:cl:  
tweak: Warden webbing powergaming has been destroyed by secoff financial independence
/:cl:
