### PR TITLE
Buffs explorer webbing + sinew belt

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -317,9 +317,9 @@
 /obj/item/storage/belt/mining/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = 6
+	STR.max_items = 8
 	STR.max_w_class = WEIGHT_CLASS_BULKY
-	STR.max_combined_w_class = 20
+	STR.max_combined_w_class = 24
 	STR.set_holdable(list(
 		/obj/item/crowbar,
 		/obj/item/screwdriver,
@@ -346,12 +346,14 @@
 		/obj/item/stack/medical,
 		/obj/item/kitchen/knife,
 		/obj/item/reagent_containers/hypospray,
+		/obj/item/lazarus_injector,
 		/obj/item/gps,
 		/obj/item/storage/bag/ore,
 		/obj/item/survivalcapsule,
 		/obj/item/t_scanner/adv_mining_scanner,
 		/obj/item/reagent_containers/pill,
 		/obj/item/storage/pill_bottle,
+		/obj/item/reagent_containers/food/drinks/bottle/whiskey,
 		/obj/item/stack/ore,
 		/obj/item/reagent_containers/food/drinks,
 		/obj/item/hivelordstabilizer,
@@ -361,8 +363,7 @@
 		/obj/item/stack/marker_beacon,
 		/obj/item/handdrill,
 		/obj/item/jawsoflife,
-		/obj/item/restraints/legcuffs/bola/watcher,
-		/obj/item/claymore/bone
+		/obj/item/restraints/legcuffs/bola/watcher
 		))
 
 
@@ -382,7 +383,7 @@
 /obj/item/storage/belt/mining/primitive/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = 5
+	STR.max_items = 6
 
 /obj/item/storage/belt/soulstone
 	name = "soul stone belt"


### PR DESCRIPTION
# Document the changes in your pull request

Explorer webbing gets two more slots and sinew belt gets one more slot so former's not just actively a worse box and makes it maybe worthwhile taking roundstart

Also makes it so lazarus injectors and whiskey can be held by the explorer webbing because I noticed the former could be held by medibelts despite being a mining item and the latter is a true miner's beverage

Also also removes bone sword from mining webbing in conjunction with its weight nerf in #14530

# Wiki Documentation

Explorer webbing storage increased to 8 from 6
Sinew belt storage increased to 6 from 5
Explorer webbing can hold lazarus injectors and whiskey bottles now
Explorer webbing can no longer hold bone swords

# Changelog

:cl:  
tweak: Mining belts can now hold lazarus injectors and bottles of whiskey
tweak: Mining belts can no longer hold bone swords
tweak: Storage on mining webbing and sinewbelt increased
/:cl:
