### PR TITLE
Rune Scimmy rework: Now with 100% more grinding and bonus loot

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -580,12 +580,86 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 	righthand_file = 'yogstation/icons/mob/inhands/weapons/scimmy_righthand.dmi'
 	icon = 'yogstation/icons/obj/lavaland/artefacts.dmi'
 	icon_state = "rune_scimmy"
-	force = 28
+	force = 20
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
 	damtype = BRUTE
 	sharpness = SHARP_EDGED
 	hitsound = 'yogstation/sound/weapons/rs_slash.ogg'
 	attack_verb = list("slashed","pk'd","atk'd")
+	var/mobs_grinded = 0
+	var/max_grind = 20
+
+/obj/item/rune_scimmy/examine(mob/living/user)
+	. = ..()
+	. += span_notice("This blade fills you with a need to 'grind'. Slay hostile fauna to increase the Scimmy's power and earn loot.")
+	. += span_notice("The blade has grinded [mobs_grinded] out of [max_grind] to reach maximum power, and will deal [mobs_grinded * 5] bonus damage to fauna.")
+
+/obj/item/rune_scimmy/afterattack(atom/target, mob/user, proximity, click_parameters)
+	. = ..()
+	if(!proximity)
+		return
+	if(isliving(target))
+		var/mob/living/L = target
+		if(ismegafauna(L) || istype(L, /mob/living/simple_animal/hostile/asteroid)) //no loot allowed from the little skulls
+			if(!istype(L, /mob/living/simple_animal/hostile/asteroid/hivelordbrood))
+				RegisterSignal(target,COMSIG_MOB_DEATH,.proc/roll_loot, TRUE)
+			//after quite a bit of grinding, you'll be doing a total of 120 damage to fauna per hit. A lot, but i feel like the grind justifies the payoff. also this doesn't effect crew. so. go nuts.
+			L.apply_damage(mobs_grinded*5,BRUTE)
+
+///This proc handles rolling the loot on the loot table and "drops" the loot where the hostile fauna died
+/obj/item/rune_scimmy/proc/roll_loot(mob/living/target)
+	UnregisterSignal(target, COMSIG_MOB_DEATH)
+	if(mobs_grinded<max_grind)
+		mobs_grinded++
+	var/spot = get_turf(target)
+	var/loot = rand(1,100)
+	switch(loot)
+		if(1 to 20)//20% chance at 3 gold coins, the most basic rs drop
+			for(var/i in 1 to 3) 
+				new /obj/item/coin/gold(spot)
+		if(21 to 30)//10% chance for 5 gold coins
+			for(var/i in 1 to 5)
+				new /obj/item/coin/gold(spot)
+		if(31 to 40)//10% chance for 2 GOLD (banana) DOUBLOONS 
+			for(var/i in 1 to 2)
+				new /obj/item/coin/bananium(spot)
+		if(41 to 50) //10% chance to spawn 10 gold, diamond, or bluespace crystal ores, because runescape ore drops and gem drops
+			for(var/i in 1 to 5)
+				switch(rand(1,5))
+					if(1 to 2)
+						new /obj/item/stack/ore/gold(spot)
+					if(3 to 4)
+						new /obj/item/stack/ore/diamond(spot)
+					if(5)
+						new /obj/item/stack/sheet/bluespace_crystal(spot)
+		if(51 to 60)//10% for bow and bronze tipped arrows, bronze are supposed to be the worst in runescape but they kinda slap in here, hopefully limited by the 5 arrows
+			new /obj/item/gun/ballistic/bow(spot)
+			for(var/i in 1 to 5)
+				new /obj/item/ammo_casing/caseless/arrow/bronze(spot)
+		if(61 to 70)//10% chance at a seed drop, runescape drops seeds somewhat frequently for players to plant and harvest later
+			switch(rand(1,5))
+				if(1)
+					new /obj/item/seeds/lavaland/cactus(spot)
+				if(2)
+					new /obj/item/seeds/lavaland/ember(spot)
+				if(3)
+					new /obj/item/seeds/lavaland/inocybe(spot) 
+				if(4)
+					new /obj/item/seeds/lavaland/polypore(spot) 
+				if(5)
+					new /obj/item/seeds/lavaland/porcini(spot) 
+			if(prob(25)) //25% chance to get strange seeds, should they feel like cooperating with botanists. this would also be interesting to see ash walkers get lmao
+				new /obj/item/seeds/random(spot)
+		if(71 to 80) //magmite is cool and somewhat rare i think?
+			new /obj/item/magmite(spot)
+		if(81 to 90) //i could make it drop foods for healing items like rs dropping fish, but i think the rewards should be a bit more immediate
+			new /obj/item/reagent_containers/hypospray/medipen/survival(spot)
+		if(91 to 95) //5% PET DROP LET'S GO
+			new /mob/living/simple_animal/hostile/mining_drone(spot)
+		if(96 to 99) //4% DHIDE ARMOR
+			new /obj/item/stack/sheet/animalhide/ashdrake(spot)
+		if(100)
+			new /obj/structure/closet/crate/necropolis(spot)
 
 //Potion of Flight
 /obj/item/reagent_containers/glass/bottle/potion

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -592,7 +592,7 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 /obj/item/rune_scimmy/examine(mob/living/user)
 	. = ..()
 	. += span_notice("This blade fills you with a need to 'grind'. Slay hostile fauna to increase the Scimmy's power and earn loot.")
-	. += span_notice("The blade has grinded [mobs_grinded] out of [max_grind] to reach maximum power, and will deal [mobs_grinded * 5] bonus damage to fauna.")
+	. += span_notice("The blade has grinded [mobs_grinded] out of [max_grind] fauna to reach maximum power, and will deal [mobs_grinded * 5] bonus damage to fauna.")
 
 /obj/item/rune_scimmy/afterattack(atom/target, mob/user, proximity, click_parameters)
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request
Reworks the Rune Scimmy from a click stick into a grinding mining minigame. 
First off the base force is dropped to 20, which is still strong considering this is a normal sized weapon that fits in belt slots and backpacks.
You can increase the damage dealt to fauna by grinding (killing) mobs. this tracks up to 20 kills and gives you 5 * mobs killed bonus damage, meaning you can smack lavaland fauna for 120 damage when you finished the grind.
![image](https://user-images.githubusercontent.com/46236974/174909883-4fa34900-6a2f-408f-b76b-5dfc370faf29.png)
![image](https://user-images.githubusercontent.com/46236974/174908241-6cf172be-55b7-4901-a153-24fdf0939422.png)
![image](https://user-images.githubusercontent.com/46236974/174909945-09867b1b-6357-4a3c-95e2-50cafac89ab8.png)

Open to suggestions for loot table modifications in terms of the probabilities and what should drop. I didn't really want to make it drop other weapons besides the bow because i feel like that's counterintuitive to using the scimmy, and there's not really good armor that it could drop that wouldn't be too strong or a waste of a drop slot. Bow and bronze arrows are also keeping within the runescape theme.

# Spriting
nothing. this time

# Wiki Documentation
base force down to 20
you can grind up to 20 lavaland fauna kills for 5 * mobs killed bonus damage against fauna, up to 120 total damage.
Each fauna you kill drops items from a custom loot table here:
![image](https://user-images.githubusercontent.com/46236974/174907609-b8aa6b45-dd54-4942-bd12-74233e0336fd.png)
(this is from my sandbox page so it'll be easy to copy and paste in later)

# Why is this good for the game
Currently the Rune Scimitar is a 28 force click people good weapon with a minor runescape theme. I wanted to cut down its ability to click people good while bolstering its flavor and a bit of a rewarding gimmick. Even at 120 damage it's probably not the best for killing megafauna due to the danger you put yourself in at melee range, but being able to grind lesser fauna for loot and power best encapsulates the old school runescape theme, I think.

# Changelog

:cl:  
rscadd: Rune Scimitar causes mobs to drop bonus loot from a loot table on kill  
rscadd: Rune Scimitar gains bonus damage against fauna with each lavaland fauna slain up to 20, for a total of 100 bonus damage. get out there and grind
tweak: Rune Scimitar's base force down to 20
/:cl:
