### PR TITLE
fake death 3.5 to 4.5 UR

### DIFF
--- a/code/modules/research/nanites/nanite_programs/suppression.dm
+++ b/code/modules/research/nanites/nanite_programs/suppression.dm
@@ -108,7 +108,7 @@
 /datum/nanite_program/fake_death
 	name = "Death Simulation"
 	desc = "The nanites induce a death-like coma into the host, able to fool most medical scans."
-	use_rate = 3.5
+	use_rate = 4.5
 	rogue_types = list(/datum/nanite_program/nerve_decay, /datum/nanite_program/necrotic, /datum/nanite_program/brain_decay)
 	harmful = TRUE
 


### PR DESCRIPTION
# Document the changes in your pull request

it is much more potent as a instant sleep than a paralyze(3)+mute(0.75) and yet costs less than that combo?

# Wiki Documentation

fake death 3.5 to 4.5 Use Rate

# Changelog

:cl:  
tweak: Nanite fake death now has a 4.5 use rate from 3.5
/:cl:
