### PR TITLE
adds ventriloquist dummy to autodrobe

### DIFF
--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -76,6 +76,7 @@
 					/obj/item/clothing/suit/wizrobe/fake = 1,
 					/obj/item/clothing/head/wizard/fake = 1,
 					/obj/item/staff = 3,
+					/obj/item/toy/dummy = 2,
 					/obj/item/clothing/mask/gas/sexyclown = 1,
 					/obj/item/clothing/under/rank/clown/sexy = 1,
 					/obj/item/clothing/mask/gas/sexymime = 1,


### PR DESCRIPTION
# Document the changes in your pull request

This is a cool item that doesn't show up literally anywhere outside maints

# Wiki Documentation

ventriloquist dummies are now sold in autodrobes, these can be spoken into via prefix .l and .r depending on the hand (.l for left .r for right) to talk as the dummy (name set by using it in hand). 2 in stock per autodrobe

# Changelog

:cl:  
rscadd: 2 ventriloquist dummies are now stocked in autodrobes
/:cl:
