### PR TITLE
fixes inspecting the twisted construction spell having an incorrect description as well

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -600,8 +600,6 @@
 	. += {"<u>A sinister spell used to convert:</u>\n
 	Plasteel into runed metal\n
 	[METAL_TO_CONSTRUCT_SHELL_CONVERSION] metal into a construct shell\n
-	Living cyborgs into constructs after a delay\n
-	Cyborg shells into construct shells\n
 	Airlocks into brittle runed airlocks after a delay (harm intent)"}
 
 /obj/item/melee/blood_magic/construction/afterattack(atom/target, mob/user, proximity_flag, click_parameters)


### PR DESCRIPTION
i forgot to do this but thats okay its not like anyone looks at the spell descriptions

# Wiki Documentation

none lol

# Changelog

:cl:  
spellcheck: inspecting the twisted construction spell AKA the hand that appears after casting the spell will also no longer incorrectly state that it can convert cyborgs
/:cl:
