### PR TITLE
fixes bloody knuckles not splashing when used by undead races and also marking the user with one of the abilities

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1171,16 +1171,16 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 				return
 			next_knuckle = world.time + COOLDOWN_ANIMAL
 
-/obj/item/melee/knuckles/attack_self(mob/living/user)
+/obj/item/melee/knuckles/attack_self(mob/user)
 	var/turf/T = get_turf(user)
 	if(next_splash > world.time)
 		to_chat(user, span_warning("You can't do that yet!"))
 		return
-	user.visible_message(span_warning("[user] splashes blood from their knuckles!"))
+	user.visible_message(span_warning("[user] splashes blood from the knuckles!"))
 	playsound(T, 'sound/effects/splat.ogg', 80, 5, -1)
 	for(var/i = 0 to splash_range)
 		if(T)
-			user.add_splatter_floor(T)
+			new /obj/effect/decal/cleanable/blood(T)
 		T = get_step(T,user.dir)
 	next_splash = world.time + COOLDOWN
 
@@ -1196,6 +1196,7 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 				if(istype(B, /obj/effect/decal/cleanable/blood )|| istype(B, /obj/effect/decal/cleanable/trail_holder))
 					valid_reaching = TRUE
 					L.apply_status_effect(STATUS_EFFECT_KNUCKLED)
+					U.remove_status_effect(STATUS_EFFECT_KNUCKLED)
 		if(!valid_reaching)
 			to_chat(U, span_warning("There's nobody to use this on!"))
 			return

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1192,11 +1192,12 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 			return
 		var/valid_reaching = FALSE
 		for(var/mob/living/L in view(7, U))
+			if(L == U)
+				continue
 			for(var/obj/effect/decal/cleanable/B in range(0,L))
 				if(istype(B, /obj/effect/decal/cleanable/blood )|| istype(B, /obj/effect/decal/cleanable/trail_holder))
 					valid_reaching = TRUE
 					L.apply_status_effect(STATUS_EFFECT_KNUCKLED)
-					U.remove_status_effect(STATUS_EFFECT_KNUCKLED)
 		if(!valid_reaching)
 			to_chat(U, span_warning("There's nobody to use this on!"))
 			return


### PR DESCRIPTION
# Document the changes in your pull request

skeletons and zombies and shit can now use the splash part of the knuckles and one of the abilities no longer marks the user.

:cl:  
bugfix: fixes knuckles not working right 
/:cl:
