### PR TITLE
replaces the loose beans in the bean locker with bean boxes

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -171,5 +171,5 @@
 
 /obj/structure/closet/ammunitionlocker/PopulateContents()
 	..()
-	for(var/i in 1 to 8)
-		new /obj/item/ammo_casing/shotgun/beanbag(src)
+	for(var/i in 1 to 3)
+		new /obj/item/storage/box/beanbag(src)


### PR DESCRIPTION
the beanbag locker in the armory is super useless and is mostly just used as a place for security to dump all the nonlethal rounds out of their shotguns in before loading up on snails/anti-darkspawn shot. it also only contains 8 loose shells, for context the lethal shotgun locker contains three boxes of buckshot, AKA 21 lethal rounds vs the non-lethal locket's eight

the non-lethal ammo locker now contains three boxes of beanbag shells instead of the eight loose ones it currently has

# Wiki Documentation

the armory page doesn't actually mention the beanbag locker at all, so none

# Changelog

:cl:  
tweak: the loose beans in the armory have been placed in boxes. there are also more of them now.
/:cl:
