### PR TITLE
Blinking with bluespace crystals is 233% more unpleasant

### DIFF
--- a/code/game/objects/items/stacks/bscrystal.dm
+++ b/code/game/objects/items/stacks/bscrystal.dm
@@ -31,10 +31,10 @@
 	new /obj/effect/particle_effect/sparks(loc)
 	playsound(loc, "sparks", 50, 1)
 	blink_mob(user)
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		H.adjust_disgust(30)	//Won't immediately make you vomit, just dont use more than one or two at a time
-		H.confused += 7
+	if(iscarbon(user))
+		var/mob/living/carbon/C = user
+		C.adjust_disgust(30)	//Won't immediately make you vomit, just dont use more than one or two at a time
+		C.confused += 7
 	use(1)
 
 /obj/item/stack/ore/bluespace_crystal/proc/blink_mob(mob/living/L)

--- a/code/game/objects/items/stacks/bscrystal.dm
+++ b/code/game/objects/items/stacks/bscrystal.dm
@@ -31,6 +31,10 @@
 	new /obj/effect/particle_effect/sparks(loc)
 	playsound(loc, "sparks", 50, 1)
 	blink_mob(user)
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		H.adjust_disgust(30)	//Won't immediately make you vomit, just dont use more than one or two at a time
+		H.confused += 7
 	use(1)
 
 /obj/item/stack/ore/bluespace_crystal/proc/blink_mob(mob/living/L)


### PR DESCRIPTION

This should cull the bluespace crystal smashing spam that is really annoying to deal with, at least partially because antags will drain ALL the crystals from the silo. Use them sparingly, or pay the price!

One crystal won't be an issue, but two consecutive will put you in the danger zone. Waiting about 20 seconds will make you mostly safe from vomiting after smashing one, but using a third will really make your tummy frowny face :((((


# Wiki Documentation

Smashing a bluespace crystal makes you nauseous.

# Changelog


:cl:  

tweak: Smashing a bluespace crystal now makes you nauseous and slightly confused

/:cl:
