### PR TITLE
Oven now plays a "ding" sound when something finishes baking

### DIFF
--- a/code/datums/components/bakeable.dm
+++ b/code/datums/components/bakeable.dm
@@ -80,6 +80,7 @@
 
 	if(positive_result)
 		used_oven.visible_message(span_warning("You smell something great coming from [used_oven]"))
+		playsound(parent, 'sound/machines/microwave/microwave-end.ogg', 50, 1)
 	else
 		used_oven.visible_message(span_warning("You smell a burnt smell coming from [used_oven]"))
 	SEND_SIGNAL(parent, COMSIG_BAKE_COMPLETED, baked_result)


### PR DESCRIPTION


# Document the changes in your pull request
Instead of just having a small red text, a chef can also have an audible cue for when something in the oven has finished baking

# Changelog

:cl:  
rscadd: Ding  
/:cl:
