### PR TITLE
The Golden Age of Piracy

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_cugganscove.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_cugganscove.dmm
@@ -380,8 +380,8 @@
 /obj/item/clothing/shoes/jackboots,
 /obj/item/clothing/glasses/eyepatch,
 /obj/item/clothing/glasses/eyepatch,
-/obj/item/clothing/head/bandana,
-/obj/item/clothing/head/bandana,
+/obj/item/clothing/head/pirate/bandana,
+/obj/item/clothing/head/pirate/bandana,
 /turf/open/floor/wood,
 /area/ruin/unpowered)
 "bC" = (
@@ -407,8 +407,8 @@
 /obj/item/clothing/shoes/jackboots,
 /obj/item/clothing/glasses/eyepatch,
 /obj/item/clothing/glasses/eyepatch,
-/obj/item/clothing/head/bandana,
-/obj/item/clothing/head/bandana,
+/obj/item/clothing/head/pirate/bandana,
+/obj/item/clothing/head/pirate/bandana,
 /obj/item/toy/katana,
 /turf/open/floor/wood,
 /area/ruin/unpowered)

--- a/_maps/shuttles/ruin_pirate_cutter.dmm
+++ b/_maps/shuttles/ruin_pirate_cutter.dmm
@@ -171,7 +171,7 @@
 /obj/item/clothing/suit/pirate,
 /obj/item/clothing/under/pirate,
 /obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/head/bandana,
+/obj/item/clothing/head/pirate/bandana,
 /turf/open/floor/plasteel/dark/side{
 	dir = 5
 	},
@@ -458,7 +458,7 @@
 /obj/item/clothing/suit/pirate,
 /obj/item/clothing/under/pirate,
 /obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/head/bandana,
+/obj/item/clothing/head/pirate/bandana,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -224,7 +224,7 @@
 	name = "pirate hat or bandana spawner"
 	loot = list(
 		/obj/item/clothing/head/pirate = 1,
-		/obj/item/clothing/head/bandana = 1)
+		/obj/item/clothing/head/pirate/bandana = 1)
 
 /obj/effect/spawner/lootdrop/minor/twentyfive_percent_cyborg_mask
 	name = "25% cyborg mask spawner"

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -638,6 +638,7 @@
 
 /obj/effect/mob_spawn/human/pirate/gunner
 	rank = "Gunner"
+	outfit = /datum/outfit/pirate/space/gunner
 
 //The Innkeeper, a iceplanet ghostrole for peacefully operating a rest stop complete with food and drinks.
 /obj/effect/mob_spawn/human/innkeeper

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -135,7 +135,7 @@
 
 /obj/item/clothing/head/pirate
 	name = "pirate hat"
-	desc = "Yarr."
+	desc = "Ahoy! This hat inspires you to take arms to scourge the several seas."
 	icon_state = "pirate"
 	item_state = "pirate"
 	dog_fashion = /datum/dog_fashion/head/pirate
@@ -161,13 +161,14 @@
 		to_chat(user, "You can no longer speak like a pirate.")
 
 /obj/item/clothing/head/pirate/captain
-	name = "pirate captain"
+	name = "pirate captain hat"
+	desc = "Ahoy! A hat befit only for the greatest pirates. May your exploits be legendary and your treasure hoard safe!"
 	icon_state = "hgpiratecap"
 	item_state = "hgpiratecap"
 
-/obj/item/clothing/head/bandana
+/obj/item/clothing/head/pirate/bandana
 	name = "pirate bandana"
-	desc = "Yarr."
+	desc = "Ahoy! A colorful wrap to collect and wipe up sweat after long days at sea."
 	icon_state = "bandana"
 	item_state = "bandana"
 	dynamic_hair_suffix = ""

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -83,10 +83,11 @@
 	uniform = /obj/item/clothing/under/pirate
 	shoes = /obj/item/clothing/shoes/sneakers/brown
 	suit = /obj/item/clothing/suit/pirate
-	head = /obj/item/clothing/head/bandana
+	head = /obj/item/clothing/head/pirate/bandana
 	glasses = /obj/item/clothing/glasses/eyepatch
 
 /datum/outfit/pirate/space
+	uniform = /obj/item/clothing/under/pirate/space
 	suit = /obj/item/clothing/suit/space/pirate
 	head = /obj/item/clothing/head/helmet/space/pirate/bandana
 	mask = /obj/item/clothing/mask/breath
@@ -94,8 +95,12 @@
 	ears = /obj/item/radio/headset/syndicate
 	id = /obj/item/card/id
 
-/datum/outfit/pirate/space/captain
+/datum/outfit/pirate/space/gunner
 	head = /obj/item/clothing/head/helmet/space/pirate
+
+/datum/outfit/pirate/space/captain
+	suit = /obj/item/clothing/suit/space/pirate/captain
+	head = /obj/item/clothing/head/helmet/space/pirate/captain
 
 /datum/outfit/pirate/post_equip(mob/living/carbon/human/H)
 	H.faction |= "pirate"

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -107,33 +107,50 @@ Contains:
 
 	//Space pirate outfit
 /obj/item/clothing/head/helmet/space/pirate
-	name = "pirate hat"
-	desc = "Yarr."
+	name = "syndicate pirate hat"
+	desc = "Ahoy! A reinforced hat worn by space privateers who thrill in stealing fine booty."
 	icon_state = "pirate"
 	item_state = "pirate"
-	armor = list(MELEE = 30, BULLET = 50, LASER = 30,ENERGY = 15, BOMB = 30, BIO = 30, RAD = 30, FIRE = 60, ACID = 75)
+	armor = list(MELEE = 30, BULLET = 50, LASER = 30, ENERGY = 25, BOMB = 30, BIO = 30, RAD = 30, FIRE = 60, ACID = 75)
 	flags_inv = HIDEHAIR
 	strip_delay = 40
 	equip_delay_other = 20
 	flags_cover = HEADCOVERSEYES
 
 /obj/item/clothing/head/helmet/space/pirate/bandana
-	name = "pirate bandana"
+	name = "syndicate pirate bandana"
+	desc = "Ahoy! Worn by typical maties who sail out to terrorize ships and stations alike. The bandana is reinforced."
 	icon_state = "bandana"
 	item_state = "bandana"
 
+/obj/item/clothing/head/helmet/space/pirate/captain
+	name = "syndicate pirate captain hat"
+	desc = "Ahoy! The pinnacle of terror of hardened Syndicate captains who lead violent crews to plunder and glory. Reinforced to keep your skull on your skeleton."
+	armor = list(MELEE = 40, BULLET = 60, LASER = 40, ENERGY = 25, BOMB = 50, BIO = 30, RAD = 30, FIRE = 100, ACID = 100, WOUND = 10)
+	resistance_flags = FIRE_PROOF | ACID_PROOF
+	icon_state = "hgpiratecap"
+	item_state = "hgpiratecap"
+
 /obj/item/clothing/suit/space/pirate
-	name = "pirate coat"
-	desc = "Yarr."
+	name = "syndicate pirate coat"
+	desc = "Argh! The standard armor of freelance forces contracted by the Syndicate to terrorize and disrupt commercial operations."
 	icon_state = "pirate"
 	item_state = "pirate"
 	w_class = WEIGHT_CLASS_NORMAL
 	flags_inv = 0
-	allowed = list(/obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/tank/internals, /obj/item/melee/transforming/energy/sword/pirate, /obj/item/clothing/glasses/eyepatch, /obj/item/reagent_containers/food/drinks/bottle/rum)
+	allowed = list(/obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/tank/internals, /obj/item/melee/transforming/energy/sword/pirate, /obj/item/melee/cutlass, /obj/item/reagent_containers/food/drinks/bottle/rum)
 	slowdown = 0
-	armor = list(MELEE = 30, BULLET = 50, LASER = 30,ENERGY = 15, BOMB = 30, BIO = 30, RAD = 30, FIRE = 60, ACID = 75)
+	armor = list(MELEE = 30, BULLET = 50, LASER = 30, ENERGY = 15, BOMB = 30, BIO = 30, RAD = 30, FIRE = 60, ACID = 75)
 	strip_delay = 40
 	equip_delay_other = 20
+
+/obj/item/clothing/suit/space/pirate/captain
+	name = "syndicate pirate captain coat"
+	desc = "Argh! Adorned with immeasurable protection, this coat serves the most fearsome Syndicate pirates in their neverending quest of loot."
+	armor = list(MELEE = 40, BULLET = 60, LASER = 40, ENERGY = 25, BOMB = 50, BIO = 30, RAD = 30, FIRE = 100, ACID = 100, WOUND = 10)
+	resistance_flags = FIRE_PROOF | ACID_PROOF
+	icon_state = "hgpirate"
+	item_state = "hgpirate"
 
 /obj/item/clothing/suit/space/paramedic
 	name = "medical space suit"

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -51,14 +51,14 @@
 
 /obj/item/clothing/suit/pirate
 	name = "pirate coat"
-	desc = "Yarr."
+	desc = "Arrrgh! A bulky coat worn by the terrors of the seas."
 	icon_state = "pirate"
 	item_state = "pirate"
-	allowed = list(/obj/item/melee/transforming/energy/sword/pirate, /obj/item/clothing/glasses/eyepatch, /obj/item/reagent_containers/food/drinks/bottle/rum)
+	allowed = list(/obj/item/melee/transforming/energy/sword/pirate, /obj/item/melee/cutlass, /obj/item/reagent_containers/food/drinks/bottle/rum, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman)
 
 /obj/item/clothing/suit/pirate/captain
 	name = "pirate captain coat"
-	desc = "Yarr."
+	desc = "Arrrgh! This treacherous garb of a seaworthy captain instills great fear in those who gaze upon it."
 	icon_state = "hgpirate"
 	item_state = "hgpirate"
 

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -439,12 +439,18 @@
 
 /obj/item/clothing/under/pirate
 	name = "pirate outfit"
-	desc = "Yarr."
+	desc = "Yarr! A fine shirt and pants for the enterprising corsair."
 	icon_state = "pirate"
 	item_state = "pirate"
 	item_color = "pirate"
 	can_adjust = FALSE
 	mutantrace_variation = MUTANTRACE_VARIATION
+
+/obj/item/clothing/under/pirate/space
+	name = "syndicate pirate outfit"
+	desc = "Yarr! A set of reinforced pirate clothing worn by boney Syndicate privateers."
+	has_sensor = NO_SENSORS
+	armor = list(MELEE = 10, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 40)
 
 /obj/item/clothing/under/soviet
 	name = "soviet uniform"

--- a/code/modules/mob/living/simple_animal/corpse.dm
+++ b/code/modules/mob/living/simple_animal/corpse.dm
@@ -85,7 +85,7 @@
 	uniform = /obj/item/clothing/under/pirate
 	shoes = /obj/item/clothing/shoes/jackboots
 	glasses = /obj/item/clothing/glasses/eyepatch
-	head = /obj/item/clothing/head/bandana
+	head = /obj/item/clothing/head/pirate/bandana
 
 
 /obj/effect/mob_spawn/human/corpse/pirate/ranged

--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -61,7 +61,7 @@
 					/obj/item/clothing/under/pirate = 1,
 					/obj/item/clothing/suit/pirate = 1,
 					/obj/item/clothing/head/pirate = 1,
-					/obj/item/clothing/head/bandana = 1,
+					/obj/item/clothing/head/pirate/bandana = 1,
 					/obj/item/clothing/under/soviet = 1,
 					/obj/item/clothing/head/ushanka = 1,
 					/obj/item/clothing/suit/imperium_monk = 1,


### PR DESCRIPTION
# Document the changes in your pull request

Adjusts and revamps a lot of the pirate clothing.

Before, the Syndicate pirate gear (to which I will now refer to it as) did not have any visual or description-based differences to the player's eye. This PR first and foremost updates and expands the descriptions on all pirate clothing to differentiate them from simply "Yarr!".

It then renames and gives additional unique descriptions to the Syndicate pirate garb that space pirates spawn with, which better clarifies their existence of armor. The sprites should all remain the same.

The Syndicate Pirate Captain now spawns with the captain's coat and hat to better differentiate them from the rest of the pirate crew. Their armor is also more robust because they're the captain. The specific numbers themselves could likely use tweaks but the purpose is to make the captain stand out even more.

The Gunner (which I had no idea existed before this) now also spawns with a normal pirate hat (which the Captain had before) to differentiate them, despite their rank difference being the only thing of note.

All pirate exosuits can now hold the normal cutlass because it is ten times more pirate-y than the ecutlass, and the normal one can now also hold emergency tanks (including plasmamen ones) because it didn't allow it before despite being a crew-based suit.

The pirate bandana also permits the speaking of pirate now.

# Wiki Documentation

Space pirates now spawn with a unique uniform that has armor stats identical to the tactical turtleneck.
The Gunner now spawns with a Syndicate pirate hat.
The Captain now spawns with a Syndicate captain's coat and hat which have improved armors: MELEE = 40, BULLET = 60, LASER = 40, ENERGY = 25, BOMB = 50, BIO = 30, RAD = 30, FIRE = 100, ACID = 100, WOUND = 10, also gained FIRE_PROOF and ACID_PROOF tags
For comparison, normal pirate armor is MELEE = 30, BULLET = 50, LASER = 30, ENERGY = 25, BOMB = 30, BIO = 30, RAD = 30, FIRE = 60, ACID = 75

All space pirate gear has been given updated names and descriptions to differentiate between Syndicate and non-Syndicate pirate gear, the former possessing armor values as well as their exosuits permitting a wider range of gear.
The pirate bandana also gives the ability to speak pirate now.

# Changelog

:cl:  
rscadd: Space Pirates now have a unique uniform which has armor stats equal to the tactical turtleneck as well as no sensors.
rscadd: Space Pirate captain now spawns with a Syndicate captain's coat and hat, which has more robust armor than the standard space pirate gear.
rscadd: Space Pirate gunner now spawns with a Syndicate pirate hat, having their own unique uniform.
rscadd: The pirate bandana now gives the ability to speak pirate, similar to the pirate and pirate captain's hat.
tweak: All pirate exosuits can now hold the normal cutlass in addition to the energy one. Normal exosuits can hold emergency tanks now.
tweak: The normal and space pirate garb have all been given updated descriptions. The Syndicate ones have also received new names and different descriptions.
/:cl:
