### PR TITLE
Rollerbeds now do not cost plastic

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -217,7 +217,7 @@
 	id = "rollerbed"
 	build_path = /obj/item/roller
 	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 8000, /datum/material/plastic = 2000) // balancing is a bitch, what does this even mean? i don't really know.
+	materials = list(/datum/material/iron = 8000)
 	category = list("Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
 


### PR DESCRIPTION
# Document the changes in your pull request

Rollerbeds no longer need an entire sheet of plastic to build, or any plastic at all
Much less of them spawn with the map now and I don't know what that comment is talking about when it says "balance" because body bags exist and are basically better

# Changelog

:cl:  
tweak: Rollerbeds no longer require plastic
/:cl: