### PR TITLE
replaces ghostrole/vr dispensers with fullupgrade

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_chemistry.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_chemistry.dmm
@@ -350,7 +350,7 @@
 /turf/open/floor/plating,
 /area/ruin/powered)
 "Q" = (
-/obj/machinery/chem_dispenser,
+/obj/machinery/chem_dispenser/fullupgrade,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_medical.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_medical.dmm
@@ -148,7 +148,7 @@
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "aw" = (
-/obj/machinery/chem_dispenser,
+/obj/machinery/chem_dispenser/fullupgrade,
 /turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "ax" = (

--- a/_maps/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacebar.dmm
@@ -95,7 +95,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/chem_dispenser,
+/obj/machinery/chem_dispenser/fullupgrade,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
 "eC" = (

--- a/_maps/RandomZLevels/VR/syndicate_trainer.dmm
+++ b/_maps/RandomZLevels/VR/syndicate_trainer.dmm
@@ -2060,7 +2060,7 @@
 /turf/open/indestructible,
 /area/awaymission/centcomAway/thunderdome)
 "lX" = (
-/obj/machinery/chem_dispenser,
+/obj/machinery/chem_dispenser/fullupgrade,
 /obj/item/storage/box/beakers,
 /turf/open/indestructible,
 /area/awaymission/centcomAway/cafe)

--- a/_maps/RandomZLevels/VR/vrhub.dmm
+++ b/_maps/RandomZLevels/VR/vrhub.dmm
@@ -642,7 +642,7 @@
 /turf/open/indestructible,
 /area/awaymission/vr/syndicate)
 "eI" = (
-/obj/machinery/chem_dispenser,
+/obj/machinery/chem_dispenser/fullupgrade,
 /obj/item/storage/box/beakers,
 /turf/open/indestructible,
 /area/awaymission/vr/syndicate)


### PR DESCRIPTION
# Document the changes in your pull request

https://forums.yogstation.net/threads/make-the-chem-dispensers-on-the-lavaland-medical-site-be-able-to-dispense-water-welding-fuel.25327/

# Changelog

:cl:  
tweak: ghost role chemical dispensers are now fully upgraded
tweak: VR chemical dispensers are now fully upgraded
/:cl:
