### PR TITLE
[Fix] You can now actually print plates from service lathe and the RSF

### DIFF
--- a/code/game/objects/items/RSF.dm
+++ b/code/game/objects/items/RSF.dm
@@ -29,6 +29,7 @@ RSF
 								/obj/item/storage/pill_bottle/dice = 200,
 								/obj/item/pen = 50,
 								/obj/item/clothing/mask/cigarette = 10,
+								/obj/item/plate = 25,
 								)
 	var/list/allowed_surfaces = list(/obj/structure/table) 	///A list of surfaces that we are allowed to place things on.
 	var/action_type = "Dispensing" 	///The verb that describes what we're doing, for use in text

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -364,7 +364,7 @@
 	id = "plate"
 	build_type = AUTOLATHE | PROTOLATHE
 	materials = list(/datum/material/iron = 1500)
-	build_path = /obj/item/storage/bag/tray
+	build_path = /obj/item/plate
 	category = list("initial","Dinnerware","Service")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
 


### PR DESCRIPTION
Title.
Turns out there was an error on build pathes for both tray and plates
Also you can print out plates from the RSF, just like glasses

# Wiki Documentation
uhh im not sure

:cl:  
bugfix: fixed duplicate build path for plate and trays  
tweak: RSF can now print plates    
/:cl:
