### PR TITLE
adds support for "spawn at one" station landmarks

### DIFF
--- a/yogstation/code/game/objects/effects/landmarks.dm
+++ b/yogstation/code/game/objects/effects/landmarks.dm
@@ -86,10 +86,13 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 			template_names = current_templates
 	var/chosen_template = pickweight(template_names)
 	if(unique && chosen_template == EMPTY_SPAWN)
-		template_names -= EMPTY_SPAWN
-		if(!template_names.len)
-			stack_trace("Station room spawner (type: [type]) has run out of ruins from an EMPTY_SPAWN, unique will be ignored")
-			template_names = current_templates
+		for(var/obj/effect/landmark/L in stationroom_landmarks)
+			if(L.type != src.type)
+				continue
+			L.template_names -= EMPTY_SPAWN
+			if(!L.template_names.len)
+				stack_trace("Station room spawner (type: [type]) has run out of ruins from an EMPTY_SPAWN, unique will be ignored")
+				L.template_names = current_templates
 	return chosen_template
 
 /obj/effect/landmark/stationroom/box/bar

--- a/yogstation/code/game/objects/effects/landmarks.dm
+++ b/yogstation/code/game/objects/effects/landmarks.dm
@@ -86,7 +86,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 			template_names = current_templates
 	var/chosen_template = pickweight(template_names)
 	if(unique && chosen_template == EMPTY_SPAWN)
-		for(var/obj/effect/landmark/L in stationroom_landmarks)
+		for(var/obj/effect/landmark/stationroom/L in GLOB.stationroom_landmarks)
 			if(L.type != src.type)
 				continue
 			L.template_names -= EMPTY_SPAWN


### PR DESCRIPTION
# Document the changes in your pull request

If you have multiple landmarks with EMPTY_SPAWN they'll correctly make the others less likely to pick an empty one

# Wiki Documentation

# Changelog


:cl:  
rscadd: Gax AI whale will now spawn
/:cl:
