### PR TITLE
Makes contract kit's randomized gear more consistently useful

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -327,19 +327,19 @@
 		/obj/item/pen/edagger,
 		/obj/item/pen/sleepy,
 		/obj/item/flashlight/emp,
-		/obj/item/reagent_containers/syringe/mulligan,
+		/obj/item/book/granter/crafting_recipe/weapons,
 		/obj/item/clothing/shoes/chameleon/noslip/syndicate,
 		/obj/item/storage/firstaid/tactical,
-		/obj/item/encryptionkey/syndicate,
+		/obj/item/clothing/shoes/airshoes,
 		/obj/item/clothing/glasses/thermal/syndi,
-		/obj/item/slimepotion/slime/sentience/nuclear,
+		/obj/item/camera_bug,
 		/obj/item/storage/box/syndie_kit/imp_radio,
 		/obj/item/storage/box/syndie_kit/imp_uplink,
 		/obj/item/clothing/gloves/krav_maga/combatglovesplus,
 		/obj/item/gun/ballistic/automatic/c20r/toy/unrestricted/riot,
 		/obj/item/reagent_containers/syringe/stimulants,
 		/obj/item/storage/box/syndie_kit/imp_freedom,
-		/obj/item/toy/eightball/haunted
+		/obj/item/storage/belt/chameleon/syndicate
 	)
 
 	var/obj/item1 = pick_n_take(item_list)


### PR DESCRIPTION
# Document the changes in your pull request

Removes the following items in the contract kit's list of possible bonus gear:
-Haunted Eightball (why would you want this?)
-Mulligan Syringe (you already get a chameleon suit and mask for disguising)
-Sentience Potion (you are unlikely to have anything to use this on, especially since you got it randomly)
-Syndicate Encryption Key (syndicate radio implant is already in the list of possible gear)

And replaces them with:
-Makeshift Weapons 101
-Air Shoes
-Camera Bug
-Chameleon Chest Rig

These are all 4 or less TC, keeping in line with most other contractor items.

# Changelog
:cl:  
rscadd: Adds makeshift weapons 101, air shoes, camera bug, and chameleon chest rig to contractor gear
rscdel: Removes haunted eightball, mulligan, sentience potion, and encryption key from contractor gear
/:cl:
