### PR TITLE
Cleaving Saw + Basalt Katana easier to store

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -282,6 +282,9 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	user.visible_message(span_suicide("[user] is slitting [user.p_their()] stomach open with [src]! It looks like [user.p_theyre()] trying to commit seppuku!"))
 	return(BRUTELOSS)
 
+/obj/item/katana/cursed
+	slot_flags = null
+
 /obj/item/wirerod
 	name = "wired rod"
 	desc = "A rod with some wire wrapped around the top. It'd be easy to attach something to the top bit."

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -226,10 +226,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 50)
 	resistance_flags = FIRE_PROOF
 
-/obj/item/katana/cursed
-	slot_flags = null
-
-/obj/item/katana/cursed/basalt
+/obj/item/katana/basalt
 	name = "basalt katana"
 	desc = "a katana made out of hardened basalt. Particularly damaging to lavaland fauna. (Activate this item in hand to dodge roll in the direction you're facing)"
 	icon_state = "basalt_katana"
@@ -242,7 +239,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	var/next_roll
 	var/roll_dist = 3
 
-/obj/item/katana/cursed/basalt/afterattack(atom/target, mob/user, proximity)
+/obj/item/katana/basalt/afterattack(atom/target, mob/user, proximity)
 	. = ..()
 	if(!proximity)
 		return
@@ -252,7 +249,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 			L.apply_damage(fauna_damage_bonus,fauna_damage_type)
 			playsound(L, 'sound/weapons/sear.ogg', 100, 1)
 
-/obj/item/katana/cursed/basalt/attack_self(mob/living/user)
+/obj/item/katana/basalt/attack_self(mob/living/user)
 	if(world.time > next_roll)
 		var/stam_cost = 15
 		var/turf/T = get_turf(user)

--- a/code/game/objects/structures/lavaland/katana_grave.dm
+++ b/code/game/objects/structures/lavaland/katana_grave.dm
@@ -23,5 +23,5 @@
 	qdel(src)
 
 /obj/structure/katana_grave/basalt
-	dropping_item = /obj/item/katana/cursed/basalt
+	dropping_item = /obj/item/katana/basalt
 	icon_state = "grave_katana_basalt"

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -789,7 +789,8 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 	attack_verb_on = list("cleaved", "swiped", "slashed", "chopped")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	hitsound_on = 'sound/weapons/bladeslice.ogg'
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
+	w_class_on = WEIGHT_CLASS_BULKY
 	sharpness = SHARP_EDGED
 	faction_bonus_force = 30
 	nemesis_factions = list("mining", "boss")


### PR DESCRIPTION
# Document the changes in your pull request

The basalt katana is no longer cursed (???) and can properly fit on a belt or back as god intended.

The cleaving saw is now normal-sized when shrinked so it can actually be lugged around. While it does fit on the belt still, it can go in the bag now, just as long as it's not extended.

Cursed tag removed because basalt katana is no longer a valid man's tool and cleaving saw made normal-sized to throw it something for how pathetically poor it is as megafauna loot.

# Wiki Documentation

Cleaving saw now normal instead of huge while closed
Basalt katana can now fit on belt and back
Not sure if this is even documented on wiki?

# Changelog

:cl:  
tweak: Basalt katana now has the capability of being worn on the waist or back
tweak: Cleaving saw had its blade made backpack-safe
/:cl:
