### PR TITLE
Fix test merged icons in replays

### DIFF
--- a/code/controllers/subsystem/demo.dm
+++ b/code/controllers/subsystem/demo.dm
@@ -66,7 +66,7 @@ SUBSYSTEM_DEF(demo)
 /datum/controller/subsystem/demo/Initialize()
 	WRITE_LOG_NO_FORMAT(GLOB.demo_log, "demo version 1\n") // increment this if you change the format
 	if(GLOB.revdata)
-		WRITE_LOG_NO_FORMAT(GLOB.demo_log, "commit [GLOB.revdata.originmastercommit || GLOB.revdata.commit]\n")
+		WRITE_LOG_NO_FORMAT(GLOB.demo_log, "commit [GLOB.revdata.commit || GLOB.revdata.originmastercommit]\n")
 
 	// write a "snapshot" of the world at this point.
 	// start with turfs


### PR DESCRIPTION
# Document the changes in your pull request

Replays now use tm commits rather than the master commit a tm was based on, allowing tm icons to appear

# Changelog

:cl:  
bugfix: fixed replays not showing test merged icons
/:cl:
