### PR TITLE
makes the box biogen public like on other maps

### DIFF
--- a/_maps/RandomRuins/StationRuins/BoxStation/hydro1.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/hydro1.dmm
@@ -129,10 +129,6 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
 /area/template_noop)
-"w" = (
-/obj/machinery/biogenerator,
-/turf/open/floor/plasteel,
-/area/template_noop)
 "y" = (
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/plasteel,
@@ -401,7 +397,7 @@ W
 Z
 E
 f
-w
+T
 H
 a
 m

--- a/_maps/RandomRuins/StationRuins/BoxStation/hydro2.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/hydro2.dmm
@@ -249,7 +249,6 @@
 /turf/open/floor/plasteel,
 /area/template_noop)
 "R" = (
-/obj/machinery/biogenerator,
 /obj/machinery/light{
 	dir = 4
 	},

--- a/_maps/RandomRuins/StationRuins/BoxStation/hydro3.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/hydro3.dmm
@@ -200,11 +200,13 @@
 /turf/open/floor/plasteel,
 /area/template_noop)
 "D" = (
-/obj/machinery/biogenerator,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green,
+/obj/machinery/vending/hydroseeds{
+	slogan_delay = 700
+	},
 /turf/open/floor/plasteel,
 /area/template_noop)
 "E" = (
@@ -279,12 +281,6 @@
 	dir = 4
 	},
 /obj/machinery/holopad,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"O" = (
-/obj/machinery/vending/hydroseeds{
-	slogan_delay = 700
-	},
 /turf/open/floor/plasteel,
 /area/template_noop)
 "R" = (
@@ -393,7 +389,7 @@ K
 K
 N
 E
-O
+E
 p
 "}
 (6,1,1) = {"

--- a/_maps/RandomRuins/StationRuins/BoxStation/hydro4.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/hydro4.dmm
@@ -64,19 +64,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/template_noop)
-"m" = (
+"n" = (
+/obj/machinery/light{
+	dir = 4
+	},
 /obj/structure/table/glass,
 /obj/item/storage/box/syringes,
 /obj/item/storage/box/beakers{
 	pixel_x = 2;
 	pixel_y = 2
-	},
-/turf/open/floor/plasteel,
-/area/template_noop)
-"n" = (
-/obj/machinery/biogenerator,
-/obj/machinery/light{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/template_noop)
@@ -352,7 +348,7 @@ s
 s
 s
 x
-m
+P
 Q
 "}
 (6,1,1) = {"

--- a/_maps/RandomRuins/StationRuins/BoxStation/hydro5.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/hydro5.dmm
@@ -159,10 +159,6 @@
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/plasteel,
 /area/template_noop)
-"w" = (
-/obj/machinery/biogenerator,
-/turf/open/floor/plasteel,
-/area/template_noop)
 "x" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -390,7 +386,7 @@ G
 d
 X
 C
-w
+Q
 m
 "}
 (5,1,1) = {"
@@ -401,7 +397,7 @@ G
 d
 c
 C
-Q
+C
 m
 "}
 (6,1,1) = {"

--- a/_maps/RandomRuins/StationRuins/BoxStation/hydro6.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/hydro6.dmm
@@ -281,7 +281,6 @@
 /turf/open/floor/plasteel,
 /area/template_noop)
 "V" = (
-/obj/machinery/biogenerator,
 /obj/machinery/light{
 	dir = 4
 	},

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -4077,7 +4077,7 @@
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/smoke_machine,
 /obj/item/reagent_containers/glass/beaker/large/silver_sulfadiazine{
-	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin = 100);
+	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin=100);
 	name = "liquid pepper spray"
 	},
 /turf/open/floor/plasteel/dark,
@@ -7518,7 +7518,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass{
 	icon_state = "cognacglass";
-	list_reagents = list(/datum/reagent/consumable/ethanol/cognac = 20);
+	list_reagents = list(/datum/reagent/consumable/ethanol/cognac=20);
 	pixel_x = -5;
 	pixel_y = -3
 	},
@@ -20158,7 +20158,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 4;
-	sensors = list("air_sensor" = "Tank")
+	sensors = list("air_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
@@ -28387,7 +28387,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/carbon_tank{
 	dir = 8;
-	sensors = list("co2_sensor" = "Tank")
+	sensors = list("co2_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -30779,7 +30779,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/toxin_tank{
 	dir = 8;
-	sensors = list("tox_sensor" = "Tank")
+	sensors = list("tox_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
@@ -35414,6 +35414,9 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "iaB" = (
@@ -39305,7 +39308,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/mix_tank{
 	dir = 4;
-	sensors = list("mix_sensor" = "Tank")
+	sensors = list("mix_sensor"="Tank")
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -49848,7 +49851,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
 	dir = 4;
-	sensors = list("o2_sensor" = "Tank")
+	sensors = list("o2_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -50647,6 +50650,14 @@
 "pAL" = (
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"pAW" = (
+/obj/machinery/biogenerator,
+/obj/machinery/door/window/southright{
+	req_access_txt = "35";
+	name = "Biogenerator Window"
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "pBG" = (
 /turf/closed/wall,
 /area/maintenance/department/medical/morgue)
@@ -56950,7 +56961,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/nitrous_tank{
 	dir = 8;
-	sensors = list("n2o_sensor" = "Tank")
+	sensors = list("n2o_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -57360,7 +57371,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
 	dir = 4;
-	sensors = list("n2_sensor" = "Tank")
+	sensors = list("n2_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
@@ -109519,7 +109530,7 @@ nia
 nia
 nia
 nia
-wBr
+pAW
 aYV
 aYV
 aYV


### PR DESCRIPTION
# Document the changes in your pull request

biogen is now in the window of hydroponics, blockaded by a patented anti-shitter windoor that starts closed

![](https://i.imgur.com/pLKIfdL.png)

## Why
the biogenerator has several cosmetic buttons like "cardboard" and "leather" and "cloth" that seemingly do nothing because no one ever asks for shit, sometimes as botanist i literally just throw toolbelts on the floor and hope people take/appreciate them, now if someone wants something they can use it themselves

# Changelog

:cl:  
tweak: the hydroponics biogenerator is now public-facing
/:cl:
