### PR TITLE
Makes Radiation Storm Event more dangerous

### DIFF
--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -3,7 +3,7 @@
 	name = "radiation storm"
 	desc = "A cloud of intense radiation passes through the area dealing rad damage to those who are unprotected."
 
-	telegraph_duration = 20 SECONDS
+	telegraph_duration = 25 SECONDS
 	telegraph_message = span_danger("The air begins to grow warm.")
 
 	weather_message = span_userdanger("<i>You feel waves of heat wash over you! Find shelter!</i>")

--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -3,7 +3,7 @@
 	name = "radiation storm"
 	desc = "A cloud of intense radiation passes through the area dealing rad damage to those who are unprotected."
 
-	telegraph_duration = 400
+	telegraph_duration = 20 SECONDS
 	telegraph_message = span_danger("The air begins to grow warm.")
 
 	weather_message = span_userdanger("<i>You feel waves of heat wash over you! Find shelter!</i>")

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -1,15 +1,7 @@
 /datum/round_event_control/radiation_storm
 	name = "Radiation Storm"
 	typepath = /datum/round_event/radiation_storm
-	max_occurrences = 1
-
-/datum/round_event/radiation_storm
-
-
-/datum/round_event/radiation_storm/setup()
-	startWhen = 3
-	endWhen = startWhen + 1
-	announceWhen	= 1
+	max_occurrences = 2
 
 /datum/round_event/radiation_storm/announce(fake)
 	priority_announce("High levels of radiation detected near the station. Maintenance is best shielded from radiation.", "Anomaly Alert", ANNOUNCER_RADIATION)


### PR DESCRIPTION
# Document the changes in your pull request

Currently as it is a radstorm will warn you for about 40 seconds plus a few unknown seconds(Event code)

This makes it so you only have 25 seconds to run into maint making the event atleast *somewhat* dangerous
Also gives it the ability to happen another time

# Wiki Documentation
Above

# Changelog

:cl:  
tweak: Radiation storm is more dangerous
/:cl:
