### PR TITLE
stunprod now does 9 more stamina damage per hit

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -362,7 +362,7 @@
 	force = 3
 	throwforce = 5
 	stunforce = 100
-	stamina_damage = 45
+	stamina_damage = 55
 	hitcost = 2000
 	throw_hit_chance = 10
 	slot_flags = ITEM_SLOT_BACK

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -362,7 +362,7 @@
 	force = 3
 	throwforce = 5
 	stunforce = 100
-	stamina_damage = 55
+	stamina_damage = 54
 	hitcost = 2000
 	throw_hit_chance = 10
 	slot_flags = ITEM_SLOT_BACK


### PR DESCRIPTION
# Document the changes in your pull request

Stunprods now do 54 stamina damage, up from 45. 54 is enough damage to two hit stun people if they have no energy armor. Security vest and firesuit will let you take an extra hit without getting stunned.

For context, stun batons do 140 stamina damage per hit and 70 when un-upgraded, plus stunprods are size bulky, if they're not concealable they deserve to at least be useful. Flashes, another easy to get stun weapon fit in pockets and instantly stun for comparison, even an improvised shotgun loaded with beanbags stuns in less hits than the stunprod, and that fits in backpacks when sawn-off.

# Spriting
Nope

# Wiki Documentation

Guide to Combat

# Changelog

:cl:  
tweak: stunprods now do 54 stamina damage, up from 45
/:cl:
