### PR TITLE
Round Time, Map, Alert Level in Hub Entry, Removes Banner Image

### DIFF
--- a/yogstation/code/game/world.dm
+++ b/yogstation/code/game/world.dm
@@ -42,7 +42,10 @@ GLOBAL_LIST_EMPTY(donators)
 	var/server_name = CONFIG_GET(string/servername)
 	if (server_name)
 		s += "<br><b>[server_name]</b> &#8212; New Player Friendly &#8212; 99% Lag Free!!"
-	s += "<br>(<a href=\"https://tinyurl.com/yogsfo\">Forums</a>|<a href=\"https://tinyurl.com/yogsdis\">Discord</a>)<br>" // The Forum & Discord links line
+	s += "<br>(<a href=\"https://tinyurl.com/yogsfo\">Forums</a>|<a href=\"https://tinyurl.com/yogsdis\">Discord</a>)" // The Forum & Discord links line
+	s += "<br>Round time: <b>[gameTimestamp("hh:mm")]</b>"
+	s += "<br>Map: <b>[SSmapping.config.map_name]</b>"
+	s += "<br>Alert level: <b>[capitalize(get_security_level())]</b>"
 	s += "<br><i>[pick(world.file2list("yogstation/strings/taglines.txt"))]</i><br>"
 
 

--- a/yogstation/code/game/world.dm
+++ b/yogstation/code/game/world.dm
@@ -42,9 +42,9 @@ GLOBAL_LIST_EMPTY(donators)
 	if (server_name)
 		s += "<br><b>[server_name]</b> &#8212; New Player Friendly &#8212; 99% Lag Free!!"
 	s += "<br>(<a href=\"https://tinyurl.com/yogsfo\">Forums</a>|<a href=\"https://tinyurl.com/yogsdis\">Discord</a>)" // The Forum & Discord links line
-	s += "<br>Round time: <b>[gameTimestamp("hh:mm")]</b>"
+	s += "<br>Time: <b>[gameTimestamp("hh:mm")]</b>"
 	s += "<br>Map: <b>[SSmapping.config.map_name]</b>"
-	s += "<br>Alert level: <b>[capitalize(get_security_level())]</b>"
+	s += "<br>Alert: <b>[capitalize(get_security_level())]</b>"
 	s += "<br><i>[pick(world.file2list("yogstation/strings/taglines.txt"))]</i><br>"
 
 

--- a/yogstation/code/game/world.dm
+++ b/yogstation/code/game/world.dm
@@ -38,7 +38,6 @@ GLOBAL_LIST_EMPTY(donators)
 
 	//BASIC SHIT
 	var/s = ""
-	s += "<img src=\"https://i.imgur.com/gNgarRJ.gif\">" //Banner image
 	var/server_name = CONFIG_GET(string/servername)
 	if (server_name)
 		s += "<br><b>[server_name]</b> &#8212; New Player Friendly &#8212; 99% Lag Free!!"


### PR DESCRIPTION
Adds round time, current map, alert level to the hub entry, it shows below the discord and forum links

removed the banner image, because it took of tons of space and you can't even see it in the byond launcher

new players all use the byond launcher not the byond ss13 webpage, so the banner image is pretty much pointless

## Why?

It's useful being able to see this information it helps players make informed decisions when joining the server

Another thing is that these are dynamic elements of the hub entry, they'll never always be the same, which makes the server feel more alive, same spirit as the "We have Ice Box!" taglines

:cl:
add: The round time, current map, and alert level now show in the hub entry
/:cl: