### PR TITLE
Makes shadowling glare not un-ready if you miss

### DIFF
--- a/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
@@ -33,13 +33,11 @@
 /obj/effect/proc_holder/spell/targeted/sling/InterceptClickOn(mob/living/caller, params, atom/t)
 	if(!isliving(t))
 		to_chat(caller, span_warning("You may only use this ability on living things!"))
-		revert_cast()
-		return
+		return FALSE
 	user = caller
 	target = t
 	if(!shadowling_check(user))
-		revert_cast()
-		return
+		return FALSE
 
 /obj/effect/proc_holder/spell/targeted/sling/revert_cast()
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request
Using glare as a shadowling will no longer require you to re-cast it if you miss and click on the floor or something, because clicking someone first try while moving at meth speed is hard sometimes. Vampiric gaze, cult/heretic stun hand, etc. don't have this issue like glare does.

Tested and didnt see any issues

# Changelog

:cl:  
tweak: shadowling glare does not unready if you miss
/:cl:
