### PR TITLE
Add a space carp crate for cargo

### DIFF
--- a/yogstation/code/modules/cargo/cargo_packs.dm
+++ b/yogstation/code/modules/cargo/cargo_packs.dm
@@ -167,3 +167,16 @@
 	contains = list(/obj/item/clothing/head/milliondollarhat)
 	crate_name = "million dollar hat crate"
 	crate_type = /obj/structure/closet/crate/large
+
+/datum/supply_pack/critter/carp
+	name = "Exotic Fish Crate"
+	desc = "°@$#|TIRED OF THOSE BORING SEAFARING FISHES? WANT TO SEE REAL FAUNA FROM SPACE? WELL WE GOT 3 OF ITS FINEST SPECIMENS IN A BOX JUST FOR YOU! WE COULDN'T FIND DECENT FOOD FOR THEM SO THEY MIGHT BE VERY HUNGRY, GET SOME FOOD READY FOR THEM!(@/!&"
+	hidden = TRUE
+	cost = 5000
+	contains = list(/mob/living/simple_animal/hostile/carp)
+	crate name = "fish crate"
+
+/datum/supply_pack/critter/carp/generate()
+	. = ..()
+	for(var/i in 1 to 2)
+		new /mob/living/simple_animal/hostile/carp(.)

--- a/yogstation/code/modules/cargo/cargo_packs.dm
+++ b/yogstation/code/modules/cargo/cargo_packs.dm
@@ -172,7 +172,7 @@
 	name = "Exotic Fish Crate"
 	desc = "°@$#|TIRED OF THOSE BORING SEAFARING FISHES? WANT TO SEE REAL FAUNA FROM SPACE? WELL WE GOT 3 OF ITS FINEST SPECIMENS IN A BOX JUST FOR YOU! WE COULDN'T FIND DECENT FOOD FOR THEM SO THEY MIGHT BE VERY HUNGRY, GET SOME FOOD READY FOR THEM!(@/!&"
 	hidden = TRUE
-	cost = 5000
+	cost = 2000
 	contains = list(/mob/living/simple_animal/hostile/carp)
 	crate name = "fish crate"
 


### PR DESCRIPTION
# Document the changes in your pull request

Add a new crate available through emagging for traitorous cargonnians. Contains 3 space carps for 2000 credits.
This can be used for murder (open the box in someone's workplace and watch them get mauled) or to obtain carpotoxin in an overly complicated and dangerous way (aka the fun way).

# Changelog

New Exotic Fish Crate, contains 3 space carps, cost 2000 credits and require emagging to order.
:cl:  
rscadd: Added new space carp crate available through emagging 
/:cl:
