### PR TITLE
Plasmaman armor/clothing buffs

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -265,6 +265,14 @@
 	if(istype(H))
 		H.toggle_welding_screen(owner)
 
+/datum/action/item_action/toggle_welding_shield
+	name = "Toggle Welding Shield"
+
+/datum/action/item_action/toggle_welding_shield/Trigger()
+	var/obj/item/clothing/head/helmet/space/plasmamen/P = target
+	if(istype(P))
+		G.toggle_welding_shield(owner)
+
 /datum/action/item_action/toggle_headphones
 	name = "Toggle Headphones"
 	desc = "UNTZ UNTZ UNTZ"

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -265,14 +265,6 @@
 	if(istype(H))
 		H.toggle_welding_screen(owner)
 
-/datum/action/item_action/toggle_welding_shield
-	name = "Toggle Welding Shield"
-
-/datum/action/item_action/toggle_welding_shield/Trigger()
-	var/obj/item/clothing/head/helmet/space/plasmaman/H = target
-	if(istype(H))
-		H.toggle_welding_shield(owner)
-
 /datum/action/item_action/toggle_headphones
 	name = "Toggle Headphones"
 	desc = "UNTZ UNTZ UNTZ"

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -265,14 +265,12 @@
 	if(istype(H))
 		H.toggle_welding_screen(owner)
 
+<<<<<<< HEAD
 /datum/action/item_action/toggle_welding_shield
 	name = "Toggle Welding Shield"
 
-/datum/action/item_action/toggle_welding_shield/Trigger()
-	var/obj/item/clothing/head/helmet/space/plasmamen/P = target
-	if(istype(P))
-		G.toggle_welding_shield(owner)
-
+=======
+>>>>>>> parent of 38403e0e38d (bullshit fix?)
 /datum/action/item_action/toggle_headphones
 	name = "Toggle Headphones"
 	desc = "UNTZ UNTZ UNTZ"

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -265,12 +265,6 @@
 	if(istype(H))
 		H.toggle_welding_screen(owner)
 
-<<<<<<< HEAD
-/datum/action/item_action/toggle_welding_shield
-	name = "Toggle Welding Shield"
-
-=======
->>>>>>> parent of 38403e0e38d (bullshit fix?)
 /datum/action/item_action/toggle_headphones
 	name = "Toggle Headphones"
 	desc = "UNTZ UNTZ UNTZ"

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -265,6 +265,14 @@
 	if(istype(H))
 		H.toggle_welding_screen(owner)
 
+/datum/action/item_action/toggle_welding_shield
+	name = "Toggle Welding Shield"
+
+/datum/action/item_action/toggle_welding_shield/Trigger()
+	var/obj/item/clothing/head/helmet/space/plasmaman/H = target
+	if(istype(H))
+		H.toggle_welding_shield(owner)
+
 /datum/action/item_action/toggle_headphones
 	name = "Toggle Headphones"
 	desc = "UNTZ UNTZ UNTZ"

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -46,7 +46,7 @@
 	resistance_flags = FIRE_PROOF
 	var/brightness_on = 4 //luminosity when the light is on
 	var/on = FALSE
-	actions_types = list(/datum/action/item_action/toggle_helmet_light, /datum/action/item_action/toggle_welding_screen)
+	actions_types = list(/datum/action/item_action/toggle_helmet_light, /datum/action/item_action/toggle_welding_shield)
 	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT
 	flash_protect = 2
 	tint = 2
@@ -67,11 +67,11 @@
 		A.UpdateButtonIcon()
 
 /obj/item/clothing/head/helmet/space/plasmaman/AltClick(mob/user)
-	toggle_welding_screen(user)
+	toggle_welding_shield(user)
 
-/obj/item/clothing/head/helmet/space/plasmaman/proc/toggle_welding_screen(mob/living/user)
+/obj/item/clothing/head/helmet/space/plasmaman/proc/toggle_welding_shield(mob/living/user)
 	if(weldingvisortoggle(user))
-		playsound(src, 'sound/mecha/mechmove03.ogg', 50, TRUE) //Sound of the welding screen sliding down, maybe
+		playsound(src, 'sound/mecha/mechmove03.ogg', 50, TRUE) //Delicious welding shield
 
 /obj/item/clothing/head/helmet/space/plasmaman/security
 	name = "security envirosuit helmet"

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -69,15 +69,9 @@
 /obj/item/clothing/head/helmet/space/plasmaman/AltClick(mob/user)
 	toggle_welding_screen(user)
 
-<<<<<<< HEAD
-/obj/item/clothing/head/helmet/space/plasmaman/proc/toggle_welding_shield(mob/living/user)
-	weldingvisortoggle(user)
-	playsound(src, 'sound/mecha/mechmove03.ogg', 50, TRUE) //Delicious welding shield
-=======
 /obj/item/clothing/head/helmet/space/plasmaman/proc/toggle_welding_screen(mob/living/user)
 	if(weldingvisortoggle(user))
 		playsound(src, 'sound/mecha/mechmove03.ogg', 50, TRUE) //Sound of the welding screen sliding down, maybe
->>>>>>> parent of 38403e0e38d (bullshit fix?)
 
 /obj/item/clothing/head/helmet/space/plasmaman/security
 	name = "security envirosuit helmet"

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -73,6 +73,8 @@
 /obj/item/clothing/head/helmet/space/plasmaman/proc/toggle_welding_shield(mob/living/user)
 	if(weldingvisortoggle(user))
 		playsound(src, 'sound/mecha/mechmove03.ogg', 50, TRUE)
+	icon_state = "[initial(icon_state)][on ? "-light":""]"
+	item_state = icon_state
 
 /obj/item/clothing/head/helmet/space/plasmaman/security
 	name = "security envirosuit helmet"

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -38,7 +38,7 @@
 //I just want the light feature of the hardsuit helmet
 /obj/item/clothing/head/helmet/space/plasmaman
 	name = "purple envirosuit helmet"
-	desc = "A generic purple envirohelm of Nanotrasen design. This updated model comes with an activatable welding shield."
+	desc = "A generic purple envirohelm of Nanotrasen design. This updated model comes with a built-in lamp."
 	icon_state = "purple_envirohelm"
 	item_state = "purple_envirohelm"
 	strip_delay = 80
@@ -46,23 +46,12 @@
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	var/brightness_on = 4 //luminosity when the light is on
 	var/on = FALSE
-	actions_types = list(/datum/action/item_action/toggle_helmet_light, /datum/action/item_action/toggle_welding_shield)
-	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT
-	flash_protect = 2
-	tint = 2
-
-/obj/item/clothing/head/helmet/space/plasmaman/Initialize()
-	. = ..()
-	visor_toggling() //So the shield starts up
+	actions_types = list(/datum/action/item_action/toggle_helmet_light)
 
 /obj/item/clothing/head/helmet/space/plasmaman/attack_self(mob/user)
 	toggle_helmet_light(user)
 
 /obj/item/clothing/head/helmet/space/plasmaman/proc/toggle_helmet_light(mob/user)
-	if(!on && !up) //Easier to have it in the start if I want to go back and add sprites
-		to_chat(user, span_warning("Your shield raises as your toggle on your lights."))
-		toggle_welding_shield(user)
-
 	on = !on
 	if(on)
 		set_light(brightness_on)
@@ -75,28 +64,6 @@
 	for(var/X in actions)
 		var/datum/action/A=X
 		A.UpdateButtonIcon()
-
-/obj/item/clothing/head/helmet/space/plasmaman/AltClick(mob/user)
-	if(user.canUseTopic(src, BE_CLOSE))
-		toggle_welding_shield(user)
-
-/obj/item/clothing/head/helmet/space/plasmaman/proc/toggle_welding_shield(mob/user)
-	if(on && up) //Easier to have it in the start if I want to go back and add sprites
-		to_chat(user, span_warning("Your lights turn off as you toggle on the shield."))
-		toggle_helmet_light(user)
-
-	if(weldingvisortoggle(user))
-		playsound(src, 'sound/mecha/mechmove03.ogg', 50, TRUE)
-
-/obj/item/clothing/head/helmet/space/plasmaman/visor_toggling() //So the icon_state doesn't get altered
-    up = !up
-    clothing_flags ^= visor_flags
-    flags_inv ^= visor_flags_inv
-    flags_cover ^= initial(flags_cover)
-    if(visor_vars_to_toggle & VISOR_FLASHPROTECT)
-        flash_protect ^= initial(flash_protect)
-    if(visor_vars_to_toggle & VISOR_TINT)
-        tint ^= initial(tint)
 
 /obj/item/clothing/head/helmet/space/plasmaman/security
 	name = "security envirosuit helmet"

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -46,7 +46,7 @@
 	resistance_flags = FIRE_PROOF
 	var/brightness_on = 4 //luminosity when the light is on
 	var/on = FALSE
-	actions_types = list(/datum/action/item_action/toggle_helmet_light, /datum/action/item_action/toggle_welding_shield)
+	actions_types = list(/datum/action/item_action/toggle_helmet_light, /datum/action/item_action/toggle_welding_screen)
 	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT
 	flash_protect = 2
 	tint = 2
@@ -67,11 +67,17 @@
 		A.UpdateButtonIcon()
 
 /obj/item/clothing/head/helmet/space/plasmaman/AltClick(mob/user)
-	toggle_welding_shield(user)
+	toggle_welding_screen(user)
 
+<<<<<<< HEAD
 /obj/item/clothing/head/helmet/space/plasmaman/proc/toggle_welding_shield(mob/living/user)
+	weldingvisortoggle(user)
+	playsound(src, 'sound/mecha/mechmove03.ogg', 50, TRUE) //Delicious welding shield
+=======
+/obj/item/clothing/head/helmet/space/plasmaman/proc/toggle_welding_screen(mob/living/user)
 	if(weldingvisortoggle(user))
-		playsound(src, 'sound/mecha/mechmove03.ogg', 50, TRUE) //Delicious welding shield
+		playsound(src, 'sound/mecha/mechmove03.ogg', 50, TRUE) //Sound of the welding screen sliding down, maybe
+>>>>>>> parent of 38403e0e38d (bullshit fix?)
 
 /obj/item/clothing/head/helmet/space/plasmaman/security
 	name = "security envirosuit helmet"

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -46,7 +46,7 @@
 	resistance_flags = FIRE_PROOF
 	var/brightness_on = 4 //luminosity when the light is on
 	var/on = FALSE
-	actions_types = list(/datum/action/item_action/toggle_helmet_light, /datum/action/item_action/toggle_welding_screen)
+	actions_types = list(/datum/action/item_action/toggle_helmet_light, /datum/action/item_action/toggle_welding_shield)
 	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT
 	flash_protect = 2
 	tint = 2
@@ -67,11 +67,12 @@
 		A.UpdateButtonIcon()
 
 /obj/item/clothing/head/helmet/space/plasmaman/AltClick(mob/user)
-	toggle_welding_screen(user)
+	if(user.canUseTopic(src, BE_CLOSE))
+		toggle_welding_shield(user)
 
-/obj/item/clothing/head/helmet/space/plasmaman/proc/toggle_welding_screen(mob/living/user)
+/obj/item/clothing/head/helmet/space/plasmaman/proc/toggle_welding_shield(mob/living/user)
 	if(weldingvisortoggle(user))
-		playsound(src, 'sound/mecha/mechmove03.ogg', 50, TRUE) //Sound of the welding screen sliding down, maybe
+		playsound(src, 'sound/mecha/mechmove03.ogg', 50, TRUE)
 
 /obj/item/clothing/head/helmet/space/plasmaman/security
 	name = "security envirosuit helmet"

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -38,12 +38,12 @@
 //I just want the light feature of the hardsuit helmet
 /obj/item/clothing/head/helmet/space/plasmaman
 	name = "purple envirosuit helmet"
-	desc = "A generic purple envirohelm."
+	desc = "A generic purple envirohelm of Nanotrasen design. This updated model comes with an activatable welding shield."
 	icon_state = "purple_envirohelm"
 	item_state = "purple_envirohelm"
 	strip_delay = 80
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 0, FIRE = 100, ACID = 75)
-	resistance_flags = FIRE_PROOF
+	resistance_flags = FIRE_PROOF | ACID_PROOF
 	var/brightness_on = 4 //luminosity when the light is on
 	var/on = FALSE
 	actions_types = list(/datum/action/item_action/toggle_helmet_light, /datum/action/item_action/toggle_welding_shield)
@@ -100,7 +100,7 @@
 
 /obj/item/clothing/head/helmet/space/plasmaman/security
 	name = "security envirosuit helmet"
-	desc = "A plasma containment helmet designed for security, protecting them from being bludgeoned and burning alive, along-side other undesirables."
+	desc = "A reinforced envirohelm designed for security personnel, reducing most traditional forms of injury."
 	icon_state = "deathcurity_envirohelm"
 	item_state = "deathcurity_envirohelm"
 	armor = list(MELEE = 35, BULLET = 30, LASER = 30, ENERGY = 10, BOMB = 25, BIO = 100, RAD = 0, FIRE = 100, ACID = 75, WOUND = 10)
@@ -113,20 +113,20 @@
 	
 /obj/item/clothing/head/helmet/space/plasmaman/viro
 	name = "virology envirosuit helmet"
-	desc = "A helmet specially designated for virologist plasmamen."
+	desc = "An envirohelm specially designated for virologists."
 	icon_state = "virologist_envirohelm"
 	item_state = "virologist_envirohelm"
 
 /obj/item/clothing/head/helmet/space/plasmaman/engineering
 	name = "engineering envirosuit helmet"
-	desc = "A space-worthy helmet specifically designed for engineer plasmamen."
+	desc = "A tougher, space-worthy envirohelm designed for engineering personnel."
 	icon_state = "engineer_envirohelm"
 	item_state = "engineer_envirohelm"
 	armor = list(MELEE = 15, BULLET = 5, LASER = 20, ENERGY = 10, BOMB = 20, BIO = 100, RAD = 20, FIRE = 100, ACID = 75, WOUND = 10)
 
 /obj/item/clothing/head/helmet/space/plasmaman/curator
 	name = "prototype envirosuit helmet"
-	desc = "An ancient helmet from the second generation of Nanotrasen-plasmaman related equipment. Clunky, but still sees use due to its reliability."
+	desc = "An ancient envirohelm from the second generation of Nanotrasen-plasmaman related equipment. Clunky, but still sees use due to its reliability."
 	icon_state = "curator_envirohelm"
 	item_state = "curator_envirohelm"
 	

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -5,7 +5,7 @@
 	name = "EVA plasma envirosuit"
 	desc = "A special plasma containment suit designed to be space-worthy, as well as worn over other clothing. Like its smaller counterpart, it can automatically extinguish the wearer in a crisis, and holds twice as many charges."
 	allowed = list(/obj/item/gun, /obj/item/ammo_casing, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/melee/transforming/energy/sword, /obj/item/restraints/handcuffs, /obj/item/tank)
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 0, FIRE = 100, ACID = 75)
+	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 50, FIRE = 100, ACID = 75)
 	resistance_flags = FIRE_PROOF
 	icon_state = "plasmaman_suit"
 	item_state = "plasmaman_suit"
@@ -46,8 +46,9 @@
 	resistance_flags = FIRE_PROOF
 	var/brightness_on = 4 //luminosity when the light is on
 	var/on = FALSE
-	actions_types = list(/datum/action/item_action/toggle_helmet_light)
-	flash_protect = 0
+	actions_types = list(/datum/action/item_action/toggle_helmet_light, /datum/action/item_action/toggle_welding_screen)
+	flash_protect = 2
+	tint = 2
 
 /obj/item/clothing/head/helmet/space/plasmaman/attack_self(mob/user)
 	on = !on
@@ -64,12 +65,19 @@
 		var/datum/action/A=X
 		A.UpdateButtonIcon()
 
+/obj/item/clothing/head/helmet/space/plasmaman/AltClick(mob/user)
+	weldingvisortoggle(user)
+
+/obj/item/clothing/head/helmet/space/plasmaman/proc/toggle_welding_screen(mob/living/user)
+	if(weldingvisortoggle(user))
+		playsound(src, 'sound/mecha/mechmove03.ogg', 50, 1) //Sound of the welding screen sliding down, maybe
+
 /obj/item/clothing/head/helmet/space/plasmaman/security
 	name = "security envirosuit helmet"
-	desc = "A plasma containment helmet designed for security, protecting them from being flashed and burning alive, along-side other undesirables."
+	desc = "A plasma containment helmet designed for security, protecting them from being bludgeoned and burning alive, along-side other undesirables."
 	icon_state = "deathcurity_envirohelm"
 	item_state = "deathcurity_envirohelm"
-	armor = list(MELEE = 10, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 0, FIRE = 100, ACID = 75)
+	armor = list(MELEE = 35, BULLET = 30, LASER = 30, ENERGY = 10, BOMB = 25, BIO = 100, RAD = 0, FIRE = 100, ACID = 75, WOUND = 10)
 
 /obj/item/clothing/head/helmet/space/plasmaman/blue
 	name = "blue envirosuit helmet"
@@ -88,7 +96,7 @@
 	desc = "A space-worthy helmet specially designed for engineer plasmamen, the usual purple stripes being replaced by engineering's orange."
 	icon_state = "engineer_envirohelm"
 	item_state = "engineer_envirohelm"
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 10, FIRE = 100, ACID = 75)
+	armor = list(MELEE = 15, BULLET = 5, LASER = 20, ENERGY = 10, BOMB = 20, BIO = 100, RAD = 20, FIRE = 100, ACID = 75, WOUND = 10)
 
 /obj/item/clothing/head/helmet/space/plasmaman/curator
 	name = "prototype envirosuit helmet"

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -47,6 +47,7 @@
 	var/brightness_on = 4 //luminosity when the light is on
 	var/on = FALSE
 	actions_types = list(/datum/action/item_action/toggle_helmet_light, /datum/action/item_action/toggle_welding_screen)
+	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT
 	flash_protect = 2
 	tint = 2
 

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -73,8 +73,6 @@
 /obj/item/clothing/head/helmet/space/plasmaman/proc/toggle_welding_shield(mob/living/user)
 	if(weldingvisortoggle(user))
 		playsound(src, 'sound/mecha/mechmove03.ogg', 50, TRUE)
-	icon_state = "[initial(icon_state)][on ? "-light":""]"
-	item_state = icon_state
 
 /obj/item/clothing/head/helmet/space/plasmaman/security
 	name = "security envirosuit helmet"

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -51,17 +51,27 @@
 	flash_protect = 2
 	tint = 2
 
-/obj/item/clothing/head/helmet/space/plasmaman/attack_self(mob/user)
-	on = !on
-	icon_state = "[initial(icon_state)][on ? "-light":""]"
-	item_state = icon_state
-	user.update_inv_head() //So the mob overlay updates
+/obj/item/clothing/head/helmet/space/plasmaman/Initialize()
+	. = ..()
+	visor_toggling() //So the shield starts up
 
+/obj/item/clothing/head/helmet/space/plasmaman/attack_self(mob/user)
+	toggle_helmet_light(user)
+
+/obj/item/clothing/head/helmet/space/plasmaman/proc/toggle_helmet_light(mob/user)
+	if(!on && !up) //Easier to have it in the start if I want to go back and add sprites
+		to_chat(user, span_warning("Your shield raises as your toggle on your lights."))
+		toggle_welding_shield(user)
+
+	on = !on
 	if(on)
 		set_light(brightness_on)
 	else
 		set_light(0)
 
+	icon_state = "[initial(icon_state)][on ? "-light":""]"
+	item_state = icon_state
+	user.update_inv_head()
 	for(var/X in actions)
 		var/datum/action/A=X
 		A.UpdateButtonIcon()
@@ -70,9 +80,23 @@
 	if(user.canUseTopic(src, BE_CLOSE))
 		toggle_welding_shield(user)
 
-/obj/item/clothing/head/helmet/space/plasmaman/proc/toggle_welding_shield(mob/living/user)
+/obj/item/clothing/head/helmet/space/plasmaman/proc/toggle_welding_shield(mob/user)
+	if(on && up) //Easier to have it in the start if I want to go back and add sprites
+		to_chat(user, span_warning("Your lights turn off as you toggle on the shield."))
+		toggle_helmet_light(user)
+
 	if(weldingvisortoggle(user))
 		playsound(src, 'sound/mecha/mechmove03.ogg', 50, TRUE)
+
+/obj/item/clothing/head/helmet/space/plasmaman/visor_toggling() //So the icon_state doesn't get altered
+    up = !up
+    clothing_flags ^= visor_flags
+    flags_inv ^= visor_flags_inv
+    flags_cover ^= initial(flags_cover)
+    if(visor_vars_to_toggle & VISOR_FLASHPROTECT)
+        flash_protect ^= initial(flash_protect)
+    if(visor_vars_to_toggle & VISOR_TINT)
+        tint ^= initial(tint)
 
 /obj/item/clothing/head/helmet/space/plasmaman/security
 	name = "security envirosuit helmet"
@@ -86,34 +110,35 @@
 	desc = "A generic blue envirohelm."
 	icon_state = "blue_envirohelm"
 	item_state = "blue_envirohelm"
-
+	
 /obj/item/clothing/head/helmet/space/plasmaman/viro
 	name = "virology envirosuit helmet"
-	desc = "The helmet worn by the safest people on the station, those who are completely immune to the monstrosities they create."
+	desc = "A helmet specially designated for virologist plasmamen."
 	icon_state = "virologist_envirohelm"
 	item_state = "virologist_envirohelm"
 
 /obj/item/clothing/head/helmet/space/plasmaman/engineering
 	name = "engineering envirosuit helmet"
-	desc = "A space-worthy helmet specially designed for engineer plasmamen, the usual purple stripes being replaced by engineering's orange."
+	desc = "A space-worthy helmet specifically designed for engineer plasmamen."
 	icon_state = "engineer_envirohelm"
 	item_state = "engineer_envirohelm"
 	armor = list(MELEE = 15, BULLET = 5, LASER = 20, ENERGY = 10, BOMB = 20, BIO = 100, RAD = 20, FIRE = 100, ACID = 75, WOUND = 10)
 
 /obj/item/clothing/head/helmet/space/plasmaman/curator
 	name = "prototype envirosuit helmet"
-	desc = "A slight modification on a tradiational voidsuit helmet, this helmet was Nano-Trasen's first solution to the *logistical problems* that come with employing plasmamen. Despite their limitations, these helmets still see use by historian and old-styled plasmamen alike."
+	desc = "An ancient helmet from the second generation of Nanotrasen-plasmaman related equipment. Clunky, but still sees use due to its reliability."
 	icon_state = "curator_envirohelm"
 	item_state = "curator_envirohelm"
-
+	
 /obj/item/clothing/head/helmet/space/plasmaman/mime
 	name = "mime envirosuit helmet"
-	desc = "The make-up is painted on, it's a miracle it doesn't chip. It's not very colourful."
+	desc = "The make-up is painted on. It's a miracle it doesn't chip. It's not very colourful."
 	icon_state = "mime_envirohelm"
 	item_state = "mime_envirohelm"
-
+	
 /obj/item/clothing/head/helmet/space/plasmaman/clown
 	name = "clown envirosuit helmet"
-	desc = "The make-up is painted on, it's a miracle it doesn't chip. <i>'HONK!'</i>"
+	desc = "The make-up is painted on. It's a miracle it doesn't chip. <i>'HONK!'</i>"
 	icon_state = "clown_envirohelm"
 	item_state = "clown_envirohelm"
+	

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -71,7 +71,7 @@
 
 /obj/item/clothing/head/helmet/space/plasmaman/proc/toggle_welding_screen(mob/living/user)
 	if(weldingvisortoggle(user))
-		playsound(src, 'sound/mecha/mechmove03.ogg', 50, 1) //Sound of the welding screen sliding down, maybe
+		playsound(src, 'sound/mecha/mechmove03.ogg', 50, TRUE) //Sound of the welding screen sliding down, maybe
 
 /obj/item/clothing/head/helmet/space/plasmaman/security
 	name = "security envirosuit helmet"

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -67,7 +67,7 @@
 		A.UpdateButtonIcon()
 
 /obj/item/clothing/head/helmet/space/plasmaman/AltClick(mob/user)
-	weldingvisortoggle(user)
+	toggle_welding_screen(user)
 
 /obj/item/clothing/head/helmet/space/plasmaman/proc/toggle_welding_screen(mob/living/user)
 	if(weldingvisortoggle(user))

--- a/code/modules/clothing/under/jobs/Plasmaman/civilian_service.dm
+++ b/code/modules/clothing/under/jobs/Plasmaman/civilian_service.dm
@@ -37,7 +37,7 @@
 
 /obj/item/clothing/under/plasmaman/curator
 	name = "prototype envirosuit"
-	desc = "Made out of a modified voidsuit, this suit was Nano-Trasen's first solution to the *logistical problems* that come with employing plasmamen. Due to the modifications, the suit is no longer space-worthy. Despite their limitations, these suits are still in used by historian and old-styled plasmamen alike."
+	desc = "The far lighter, second-generation variant of the plasmaman uniforms designed by Nanotrasen. Unlike the first-generation variants, this uniform is made of fire-resistant fabrics, rather than clunky hardsuit plating. The latest extinguishers have also been installed."
 	icon_state = "plasmaman_OLD"
 	item_state = "plasmaman_OLD"
 
@@ -49,7 +49,7 @@
 
 /obj/item/clothing/under/plasmaman/botany
 	name = "botanical envirosuit"
-	desc = "A green envirosuit designed to protect plasmamen from minor plant-related injuries."
+	desc = "A green-blue envirosuit designed to protect plasmamen from minor plant-related injuries."
 	icon_state = "botany_envirosuit"
 	item_state = "botany_envirosuit"
 

--- a/code/modules/clothing/under/jobs/Plasmaman/engineering.dm
+++ b/code/modules/clothing/under/jobs/Plasmaman/engineering.dm
@@ -1,20 +1,20 @@
 /obj/item/clothing/under/plasmaman/chief_engineer
 	name = "chief engineer's envirosuit"
-	desc = "An air-tight suit given to plasmamen insane enough to achieve the rank of \"Chief Engineer\". It protects the user from fire and acid damage."
+	desc = "A comfortable envirosuit with engineering insignia designated for plasmamen with the rank of \"Chief Engineer\". Offers better protection from fire and acid."
 	icon_state = "ce_envirosuit"
 	item_state = "ce_envirosuit"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 10, FIRE = 95, ACID = 95)
 
 /obj/item/clothing/under/plasmaman/engineering
 	name = "engineering envirosuit"
-	desc = "An air-tight suit designed to be used by plasmamen employed as engineers, the usual purple stripes being replaced by engineer's orange. It protects the user from fire and acid damage."
+	desc = "An envirosuit with orange and yellow stripes decoring its exterior, designed for station engineers. Offers better protection from fire and acid."
 	icon_state = "engineer_envirosuit"
 	item_state = "engineer_envirosuit"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 10, FIRE = 95, ACID = 95)
 
 /obj/item/clothing/under/plasmaman/atmospherics
 	name = "atmospheric envirosuit"
-	desc = "An air-tight suit designed to be used by plasmamen exployed as atmos technicians, the usual purple stripes being replaced by atmos's blue."
+	desc = "An envirosuit with blue and yellow stripes decoring its exterior, designed for atmospheric technicians. Offers better protection from fire and acid."
 	icon_state = "atmos_envirosuit"
 	item_state = "atmos_envirosuit"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 10, FIRE = 95, ACID = 95)

--- a/code/modules/clothing/under/jobs/Plasmaman/engineering.dm
+++ b/code/modules/clothing/under/jobs/Plasmaman/engineering.dm
@@ -3,7 +3,7 @@
 	desc = "An air-tight suit given to plasmamen insane enough to achieve the rank of \"Chief Engineer\". It protects the user from fire and acid damage."
 	icon_state = "ce_envirosuit"
 	item_state = "ce_envirosuit"
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 10, "fire" = 95, "acid" = 95)
+	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 10, FIRE = 95, ACID = 95)
 
 /obj/item/clothing/under/plasmaman/engineering
 	name = "engineering envirosuit"
@@ -17,4 +17,4 @@
 	desc = "An air-tight suit designed to be used by plasmamen exployed as atmos technicians, the usual purple stripes being replaced by atmos's blue."
 	icon_state = "atmos_envirosuit"
 	item_state = "atmos_envirosuit"
-
+	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 10, FIRE = 95, ACID = 95)

--- a/code/modules/clothing/under/jobs/Plasmaman/engineering.dm
+++ b/code/modules/clothing/under/jobs/Plasmaman/engineering.dm
@@ -18,3 +18,4 @@
 	icon_state = "atmos_envirosuit"
 	item_state = "atmos_envirosuit"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 10, FIRE = 95, ACID = 95)
+	

--- a/code/modules/clothing/under/jobs/Plasmaman/medsci.dm
+++ b/code/modules/clothing/under/jobs/Plasmaman/medsci.dm
@@ -3,7 +3,7 @@
 	desc = "A plasmaman envirosuit worn by those with the know-how to achieve the position of \"Research Director\"."
 	icon_state = "rd_envirosuit"
 	item_state = "rd_envirosuit"
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 10, "bio" = 10, "rad" = 0, "fire" = 0, "acid" = 35)
+	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 10, BIO = 100, RAD = 0, FIRE = 95, ACID = 95)
 
 /obj/item/clothing/under/plasmaman/medical
 	name = "medical envirosuit"

--- a/code/modules/clothing/under/jobs/Plasmaman/medsci.dm
+++ b/code/modules/clothing/under/jobs/Plasmaman/medsci.dm
@@ -1,42 +1,42 @@
 /obj/item/clothing/under/plasmaman/research_director
 	name = "scientific envirosuit"
-	desc = "A plasmaman envirosuit worn by those with the know-how to achieve the position of \"Research Director\"."
+	desc = "A formal envirosuit with comfortable, shrapnel-resistant fibers, designed for a \"Research Director\" plasmaman."
 	icon_state = "rd_envirosuit"
 	item_state = "rd_envirosuit"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 10, BIO = 100, RAD = 0, FIRE = 95, ACID = 95)
 
 /obj/item/clothing/under/plasmaman/medical
 	name = "medical envirosuit"
-	desc = "A suit designed for the station's more plasma-based doctors."
+	desc = "A blue envirosuit designed for medically-capable plasmamen."
 	icon_state = "doctor_envirosuit"
 	item_state = "doctor_envirosuit"
 
 /obj/item/clothing/under/plasmaman/science
 	name = "scientific envirosuit"
-	desc = "A plasmaman envirosuit designed for scientists."
+	desc = "An envirosuit with purple and white stripes decorating its exterior, designed for scientists."
 	icon_state = "scientist_envirosuit"
 	item_state = "scientist_envirosuit"
 
 /obj/item/clothing/under/plasmaman/robotics
 	name = "robotics envirosuit"
-	desc = "A plasmaman envirosuit designed for roboticists."
+	desc = "An envirosuit with red and white stripes decorating its exterior, designed for roboticists."
 	icon_state = "roboticist_envirosuit"
 	item_state = "roboticist_envirosuit"
 
 /obj/item/clothing/under/plasmaman/viro
 	name = "virology envirosuit"
-	desc = "The suit worn by the safest people on the station, those who are almost completely immune to the monstrosities they create."
+	desc = "An envirosuit with green and white stripes decorating its exterior, designed for virologists."
 	icon_state = "virologist_envirosuit"
 	item_state = "virologist_envirosuit"
 
 /obj/item/clothing/under/plasmaman/genetics
 	name = "genetics envirosuit"
-	desc = "A plasmaman envirosuit designed for geneticists."
+	desc = "An envirosuit with blue and white stripes decorating its exterior, designed for geneticists."
 	icon_state = "geneticist_envirosuit"
 	item_state = "geneticist_envirosuit"
 
 /obj/item/clothing/under/plasmaman/chemist
 	name = "chemistry envirosuit"
-	desc = "A plasmaman envirosuit designed for chemists."
+	desc = "An envirosuit with orange and white stripes decorating its exterior, designed for chemists."
 	icon_state = "chemist_envirosuit"
 	item_state = "chemist_envirosuit"

--- a/code/modules/clothing/under/jobs/Plasmaman/security.dm
+++ b/code/modules/clothing/under/jobs/Plasmaman/security.dm
@@ -1,12 +1,12 @@
 /obj/item/clothing/under/plasmaman/security
 	name = "security envirosuit"
-	desc = "A plasmaman containment suit designed for security officers, offering a limited amount of protection."
+	desc = "A toughened envirosuit designed for security personnel. It offers a limited amount of protection."
 	icon_state = "deathcurity_envirosuit"
 	item_state = "deathcurity_envirosuit"
 	armor = list(MELEE = 10, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 0, FIRE = 95, ACID = 95, WOUND = 10)
 
 /obj/item/clothing/under/plasmaman/security/warden
 	name = "warden's envirosuit"
-	desc = "A plasmaman containment suit designed for the warden, white stripes being added to differeciate them from other members of security."
+	desc = "A unique security envirosuit with white markings to indicate a warden or lieutenant-level security staff."
 	icon_state = "warden_envirosuit"
 	item_state = "warden_envirosuit"

--- a/code/modules/clothing/under/jobs/Plasmaman/security.dm
+++ b/code/modules/clothing/under/jobs/Plasmaman/security.dm
@@ -3,7 +3,7 @@
 	desc = "A plasmaman containment suit designed for security officers, offering a limited amount of protection."
 	icon_state = "deathcurity_envirosuit"
 	item_state = "deathcurity_envirosuit"
-	armor = list(MELEE = 10, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 0, FIRE = 95, ACID = 95)
+	armor = list(MELEE = 10, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 0, FIRE = 95, ACID = 95, WOUND = 10)
 
 /obj/item/clothing/under/plasmaman/security/warden
 	name = "warden's envirosuit"

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -655,6 +655,7 @@
 	icon_state = "plasmaman"
 	item_state = "plasmaman"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 0, FIRE = 95, ACID = 95)
+	resistance_flags = FIRE_PROOF
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	can_adjust = FALSE
 	strip_delay = 80

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -651,11 +651,11 @@
 
 /obj/item/clothing/under/plasmaman
 	name = "envirosuit"
-	desc = "A special containment suit that allows plasma-based lifeforms to exist safely in an oxygenated environment, and automatically extinguishes them in a crisis. Despite being airtight, it's not spaceworthy."
+	desc = "The latest generation of Nanotrasen-designed plasmamen envirosuits. This new version has an extinguisher built into the uniform's workings. While airtight, the suit is not EVA-rated."
 	icon_state = "plasmaman"
 	item_state = "plasmaman"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 0, FIRE = 95, ACID = 95)
-	resistance_flags = FIRE_PROOF
+	resistance_flags = FIRE_PROOF | ACID_PROOF
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	can_adjust = FALSE
 	strip_delay = 80


### PR DESCRIPTION
# Document the changes in your pull request

Was meant to add a welding screen to plasmamen, no more.

While traveling through clothing code I also noticed that several armor values were inconsistent or otherwise undertweaked, so most of those have been moped up.

Plasmaman envirosuits now also have the FIRE_PROOF tag so they don't spontaneously burn off, though you should be able to burn still, but it makes zero sense for a suit with inherent extinguishing properties to be able to burn to a crisp.

Both plasmamen envirohelms and envirosuits have ACID_PROOF because design oversights and being stripped from a piece of gear that is essential for your participation in the round when there are very limited extra is just shitty to a species that has so little.

Also buffs certain plasmaman helmet armor designs with the idea that they would *probably* be better reinforced and capable for their position. Effectively, it just means that their increased damage from all sources might be tweaked down a little. Most importantly is the helmet armor for security envirohelmets, because being able to negate any form of armor a security plasmaman might have by just targeting the head is a nasty blow to anyone trying to be a plasmaman. They'll still take increased damage relative to other officers, but it shouldn't be AS notable now.

# Wiki Documentation

The EVA plasma envirosuit now also gives 50 rad armor
The engineering plasmaman helmet now has armor values akin to the hard hat: MELEE = 15, BULLET = 5, LASER = 20, ENERGY = 10, BOMB = 20, BIO = 100, RAD = 20, FIRE = 100, ACID = 75, WOUND = 10
The security plasmaman helmet now has armor values akin to the helmet: MELEE = 35, BULLET = 30, LASER = 30, ENERGY = 10, BOMB = 25, BIO = 100, RAD = 0, FIRE = 100, ACID = 75, WOUND = 10
All engineering plasmaman jumpsuits have properly been given the +10 rad armor of engineering jumpsuits
The RD plasmaman jumpsuit has had its weird undertweaked values fixed to be a normal plasmaman jump with +10 bomb armor
The security/warden plasmaman jumpsuits now also give 10 wound armor

# Changelog

:cl:  
bugfix: Fixes RD plasmaman jumpsuit having unintentionally undertweaked values
bugfix: Fixes atmos plasmaman jumpsuit not sharing rad armor of other jumpsuits
tweak: All envirosuits now have fire proof and acid proof tags. Envirohelms gained acid proof tag.
tweak: Gives the EVA-proof plasmaman exosuit rad armor to be in line with the normal space suit
tweak: The engineering plasmaman helmet has had its armor buffed to hard hat levels
tweak: The security plasmaman helmet has had its armor buffed to standard helmet levels
tweak: All plasmamen envirosuits and envirohelms have received new descriptions (except Mime and Clown)
/:cl:
