### PR TITLE
Replaces welding helmets in Engineering Gear Crate with welding goggles

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -748,7 +748,7 @@
 
 /datum/supply_pack/engineering/engiequipment
 	name = "Engineering Gear Crate"
-	desc = "Gear up with three toolbelts, high-visibility vests, welding helmets, hardhats, and two pairs of meson goggles!"
+	desc = "Gear up with three toolbelts, high-visibility vests, welding goggles, hardhats, and two pairs of meson goggles!"
 	cost = 1300
 	contains = list(/obj/item/storage/belt/utility,
 					/obj/item/storage/belt/utility,
@@ -756,9 +756,9 @@
 					/obj/item/clothing/suit/hazardvest,
 					/obj/item/clothing/suit/hazardvest,
 					/obj/item/clothing/suit/hazardvest,
-					/obj/item/clothing/head/welding,
-					/obj/item/clothing/head/welding,
-					/obj/item/clothing/head/welding,
+					/obj/item/clothing/glasses/welding,
+					/obj/item/clothing/glasses/welding,
+					/obj/item/clothing/glasses/welding,
 					/obj/item/clothing/head/hardhat,
 					/obj/item/clothing/head/hardhat,
 					/obj/item/clothing/head/hardhat,


### PR DESCRIPTION
# Document the changes in your pull request

Simple as title.

Considering welding helmets can be printed at the autolathe and there is currently no way to create more it would be a really nice Cargo buff if they could get them huh

# Wiki Documentation

The three welding helmets in the Engineering Gear Crate under the Engineering tab have been replaced with three welding goggles. Description for the crate updated appropriately.

# Changelog

:cl:  
rscadd: Adds three welding goggles to engineering gear crate
rscdel: Removes three welding helmets from engineering gear crate
/:cl:
