### PR TITLE
[s] permadeath

### DIFF
--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -1,3 +1,5 @@
+GLOBAL_VAR_INIT(permadeath, FALSE)
+
 /mob/living/gib(no_brain, no_organs, no_bodyparts)
 	var/prev_lying = lying
 	if(stat != DEAD)
@@ -88,5 +90,8 @@
 	for(var/s in sharedSoullinks)
 		var/datum/soullink/S = s
 		S.sharerDies(gibbed)
+	
+	if(GLOB.permadeath)
+		ghostize(FALSE)
 
 	return TRUE


### PR DESCRIPTION
calls `ghostize(FALSE)` on death which force ghosts and doesn't allow body re-entry