### PR TITLE
Revert "Fleeing the station is now Crew Minor Victory instead of Major"

### DIFF
--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -341,8 +341,8 @@
 			parts += "<span class='redtext big'>Crew Major Victory!</span>"
 			parts += "<B>The Research Staff has saved the disk and killed the [syndicate_name] Operatives</B>"
 		if(NUKE_RESULT_CREW_WIN)
-			parts += "<span class='redtext big'>Crew Minor Victory</span>"
-			parts += "<B>The Research Staff has saved the disk and fled the station!</B>"
+			parts += "<span class='redtext big'>Crew Major Victory</span>"
+			parts += "<B>The Research Staff has saved the disk and stopped the [syndicate_name] Operatives!</B>"
 		if(NUKE_RESULT_DISK_LOST)
 			parts += "<span class='neutraltext big'>Neutral Victory!</span>"
 			parts += "<B>The Research Staff failed to secure the authentication disk but did manage to kill most of the [syndicate_name] Operatives!</B>"


### PR DESCRIPTION
Reverts yogstation13/Yogstation#12581

In theory - Crew kills the nukies, crew gets major,
In practice - Crew kills the nukies, the round ends immediately, and because the logic only counts a major when the station has been evacuated, it's counted as a minor.

Now while I guess I could omit the station evacuated check, I geninuely do not know what that might break (nor do I know how to test the end conditions). And on the principle of the orignal PR attempting to fix something that wasn't broken (in my opnion), I'd rather just revert the whole thing instead. 

# Changelog
:cl:  
tweak: Escaping with the disk  on nuclear emergency is now a crew major again, instead of a minor
/:cl:
