### PR TITLE
Update item_attack.dm

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -44,9 +44,9 @@
 	return ..() || ((obj_flags & CAN_BE_HIT) && I.attack_obj(src, user))
 
 /mob/living/attackby(obj/item/I, mob/living/user, params)
+	var/dist = get_dist(src,user)
 	if(..())
 		return TRUE
-	var/dist = get_dist(src,user)
 	user.changeNext_move(CLICK_CD_MELEE * I.weapon_stats[SWING_SPEED] * (I.range_cooldown_mod ? (dist > 0 ? min(dist, I.weapon_stats[REACH]) * I.range_cooldown_mod : I.range_cooldown_mod) : 1)) //range increases attack cooldown by swing speed
 	user.weapon_slow(I)
 	if(user.a_intent == INTENT_HARM && stat == DEAD && (butcher_results || guaranteed_butcher_results)) //can we butcher it?


### PR DESCRIPTION
# Document the changes in your pull request
I move the distance check up to before anything gets stabbed so it's actually accurate
I don't know why i didn't think of this earlier


# Changelog
:cl:  
bugfix: melee weapons that theoretically have range will not theoretically always use their maximum range cooldown when attacking qdel on death mobs
/:cl:
