### PR TITLE
Adds new 5x3 maint ruin theme'd around fishing

### DIFF
--- a/_maps/RandomRuins/StationRuins/maint/5x3/5x3_smallfish.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/5x3/5x3_smallfish.dmm
@@ -1,0 +1,124 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"b" = (
+/turf/open/floor/wood,
+/area/template_noop)
+"d" = (
+/turf/open/water/safe,
+/area/template_noop)
+"e" = (
+/obj/machinery/vending/fishing,
+/turf/open/floor/wood,
+/area/template_noop)
+"g" = (
+/obj/effect/turf_decal/pool/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/template_noop)
+"h" = (
+/obj/effect/turf_decal/pool,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/template_noop)
+"k" = (
+/obj/effect/turf_decal/pool/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"l" = (
+/obj/effect/turf_decal/pool{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"p" = (
+/obj/effect/turf_decal/pool,
+/turf/open/floor/wood,
+/area/template_noop)
+"q" = (
+/obj/effect/turf_decal/pool/corner,
+/obj/effect/spawner/lootdrop/trashbin{
+	pixel_x = -2;
+	pixel_y = -7
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"I" = (
+/obj/effect/turf_decal/pool{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"J" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/wood,
+/area/template_noop)
+"N" = (
+/obj/effect/turf_decal/pool{
+	dir = 8
+	},
+/obj/structure/chair/stool/bamboo,
+/obj/item/twohanded/fishingrod{
+	pixel_x = -6;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/snacks/fish/goldfish{
+	bitecount = 0;
+	length = 1;
+	pixel_x = 7;
+	pixel_y = 9;
+	weight = 2
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"R" = (
+/obj/effect/turf_decal/pool{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/maintenance{
+	pixel_x = -7;
+	pixel_y = -7
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"Y" = (
+/obj/effect/turf_decal/pool/corner{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+
+(1,1,1) = {"
+q
+l
+g
+"}
+(2,1,1) = {"
+h
+d
+I
+"}
+(3,1,1) = {"
+p
+d
+R
+"}
+(4,1,1) = {"
+Y
+N
+k
+"}
+(5,1,1) = {"
+e
+J
+b
+"}

--- a/yogstation/code/datums/ruins/station.dm
+++ b/yogstation/code/datums/ruins/station.dm
@@ -781,6 +781,12 @@
 	suffix = "5x3_yogsmaintrpg.dmm"
 	name = "Maint yogsmaintrpg"
 
+///Author: Vaelophis
+/datum/map_template/ruin/station/maint/fivexthree/smallfish
+	id = "smallfish"
+	suffix = "5x3_smallfish.dmm"
+	name = "Maint smallfish"
+
 ///Author: Veeblefetzer
 /datum/map_template/ruin/station/maint/fivexthree/podmin
 	id = "podmin"


### PR DESCRIPTION
as per request from Biome.

# Document the changes in your pull request

Adds a new 5x3 maint ruin for fishing
Adds this new ruin to the station.dm file so it can spawn.

![ss (2022-07-04 at 04 33 33)](https://user-images.githubusercontent.com/1534478/177218375-cc26137e-2e87-43fd-8473-b19c37e89c65.png)
left spawner is trash, right spawner is maint-loot

# Changelog

:cl:  
rscadd: Added a new 5x3 maint ruin theme'd around fishing
/:cl:
