### PR TITLE
Bumped energy harvester budget cap up a bit

### DIFF
--- a/code/modules/power/energyharvester.dm
+++ b/code/modules/power/energyharvester.dm
@@ -1,6 +1,6 @@
 #define MAXIMUM_POWER_LIMIT 1000000000000000.0 //1 Petawatt, same as PTL
 #define POWER_SOFTCAP_1 300000000.0 //300MJ, or 1MW/s for 300s, which is the cycle time of SSeconomy, power below this threshold gets treated differently.
-#define POWER_SOFTCAP_2 6000000000.0 //6GJ or 20MW/s for 300s
+#define POWER_SOFTCAP_2 12000000000.0 //12GJ or 40MW/s for 300s
 #define SOFTCAP_BUDGET_1 5000 //reward for reaching the first softcap
 #define SOFTCAP_BUDGET_2 10000 //extra money added on top of the first softcap for going beyond it, until softcap 2
 #define HARDCAP_BUDGET 20000 //last tranche of money for going above and beyond the call of duty until hitting the hardcap

--- a/code/modules/power/energyharvester.dm
+++ b/code/modules/power/energyharvester.dm
@@ -1,6 +1,6 @@
 #define MAXIMUM_POWER_LIMIT 1000000000000000.0 //1 Petawatt, same as PTL
-#define POWER_SOFTCAP_1 75000000.0 //75MJ, or 250KW/s for 300s, which is the cycle time of SSeconomy, power below this threshold gets treated differently.
-#define POWER_SOFTCAP_2 3000000000.0 //3GJ or 10MW/s for 300s
+#define POWER_SOFTCAP_1 100000000.0 //100MJ, or 250KW/s for 400s, which is the cycle time of SSeconomy, power below this threshold gets treated differently.
+#define POWER_SOFTCAP_2 4000000000.0 //4GJ or 10MW/s for 400s
 #define SOFTCAP_BUDGET_1 5000 //reward for reaching the first softcap
 #define SOFTCAP_BUDGET_2 10000 //extra money added on top of the first softcap for going beyond it, until softcap 2
 #define HARDCAP_BUDGET 20000 //last tranche of money for going above and beyond the call of duty until hitting the hardcap

--- a/code/modules/power/energyharvester.dm
+++ b/code/modules/power/energyharvester.dm
@@ -1,5 +1,5 @@
 #define MAXIMUM_POWER_LIMIT 1000000000000000.0 //1 Petawatt, same as PTL
-#define POWER_SOFTCAP_1 120000000.0 //120MJ, or 400KW/s for 300s, which is the cycle time of SSeconomy, power below this threshold gets treated differently.
+#define POWER_SOFTCAP_1 300000000.0 //300MJ, or 1MW/s for 300s, which is the cycle time of SSeconomy, power below this threshold gets treated differently.
 #define POWER_SOFTCAP_2 6000000000.0 //6GJ or 20MW/s for 300s
 #define SOFTCAP_BUDGET_1 5000 //reward for reaching the first softcap
 #define SOFTCAP_BUDGET_2 10000 //extra money added on top of the first softcap for going beyond it, until softcap 2

--- a/code/modules/power/energyharvester.dm
+++ b/code/modules/power/energyharvester.dm
@@ -3,7 +3,7 @@
 #define POWER_SOFTCAP_2 3000000000.0 //3GJ or 10MW/s for 300s
 #define SOFTCAP_BUDGET_1 3000 //reward for reaching the first softcap
 #define SOFTCAP_BUDGET_2 5000 //extra money added on top of the first softcap for going beyond it, until softcap 2
-#define HARDCAP_BUDGET 10000 //last tranche of money for going above and beyond the call of duty until hitting the hardcap
+#define HARDCAP_BUDGET 12000 //last tranche of money for going above and beyond the call of duty until hitting the hardcap
 
 /obj/item/energy_harvester
 	desc = "A Device which upon connection to a node, will harvest the energy and send it to engineerless stations in return for credits, derived from a syndicate powersink model."

--- a/code/modules/power/energyharvester.dm
+++ b/code/modules/power/energyharvester.dm
@@ -1,9 +1,9 @@
 #define MAXIMUM_POWER_LIMIT 1000000000000000.0 //1 Petawatt, same as PTL
 #define POWER_SOFTCAP_1 75000000.0 //75MJ, or 250KW/s for 300s, which is the cycle time of SSeconomy, power below this threshold gets treated differently.
 #define POWER_SOFTCAP_2 3000000000.0 //3GJ or 10MW/s for 300s
-#define SOFTCAP_BUDGET_1 4000 //reward for reaching the first softcap
-#define SOFTCAP_BUDGET_2 6000 //extra money added on top of the first softcap for going beyond it, until softcap 2
-#define HARDCAP_BUDGET 15000 //last tranche of money for going above and beyond the call of duty until hitting the hardcap
+#define SOFTCAP_BUDGET_1 5000 //reward for reaching the first softcap
+#define SOFTCAP_BUDGET_2 10000 //extra money added on top of the first softcap for going beyond it, until softcap 2
+#define HARDCAP_BUDGET 20000 //last tranche of money for going above and beyond the call of duty until hitting the hardcap
 
 /obj/item/energy_harvester
 	desc = "A Device which upon connection to a node, will harvest the energy and send it to engineerless stations in return for credits, derived from a syndicate powersink model."

--- a/code/modules/power/energyharvester.dm
+++ b/code/modules/power/energyharvester.dm
@@ -1,6 +1,6 @@
 #define MAXIMUM_POWER_LIMIT 1000000000000000.0 //1 Petawatt, same as PTL
 #define POWER_SOFTCAP_1 300000000.0 //300MJ, or 1MW/s for 300s, which is the cycle time of SSeconomy, power below this threshold gets treated differently.
-#define POWER_SOFTCAP_2 12000000000.0 //12GJ or 40MW/s for 300s
+#define POWER_SOFTCAP_2 9000000000.0 //9GJ or 30MW/s for 300s
 #define SOFTCAP_BUDGET_1 5000 //reward for reaching the first softcap
 #define SOFTCAP_BUDGET_2 10000 //extra money added on top of the first softcap for going beyond it, until softcap 2
 #define HARDCAP_BUDGET 20000 //last tranche of money for going above and beyond the call of duty until hitting the hardcap

--- a/code/modules/power/energyharvester.dm
+++ b/code/modules/power/energyharvester.dm
@@ -1,6 +1,6 @@
 #define MAXIMUM_POWER_LIMIT 1000000000000000.0 //1 Petawatt, same as PTL
-#define POWER_SOFTCAP_1 100000000.0 //100MJ, or 250KW/s for 400s, which is the cycle time of SSeconomy, power below this threshold gets treated differently.
-#define POWER_SOFTCAP_2 4000000000.0 //4GJ or 10MW/s for 400s
+#define POWER_SOFTCAP_1 120000000.0 //120MJ, or 400KW/s for 300s, which is the cycle time of SSeconomy, power below this threshold gets treated differently.
+#define POWER_SOFTCAP_2 6000000000.0 //6GJ or 20MW/s for 300s
 #define SOFTCAP_BUDGET_1 5000 //reward for reaching the first softcap
 #define SOFTCAP_BUDGET_2 10000 //extra money added on top of the first softcap for going beyond it, until softcap 2
 #define HARDCAP_BUDGET 20000 //last tranche of money for going above and beyond the call of duty until hitting the hardcap

--- a/code/modules/power/energyharvester.dm
+++ b/code/modules/power/energyharvester.dm
@@ -1,9 +1,9 @@
 #define MAXIMUM_POWER_LIMIT 1000000000000000.0 //1 Petawatt, same as PTL
 #define POWER_SOFTCAP_1 75000000.0 //75MJ, or 250KW/s for 300s, which is the cycle time of SSeconomy, power below this threshold gets treated differently.
 #define POWER_SOFTCAP_2 3000000000.0 //3GJ or 10MW/s for 300s
-#define SOFTCAP_BUDGET_1 3000 //reward for reaching the first softcap
-#define SOFTCAP_BUDGET_2 5000 //extra money added on top of the first softcap for going beyond it, until softcap 2
-#define HARDCAP_BUDGET 12000 //last tranche of money for going above and beyond the call of duty until hitting the hardcap
+#define SOFTCAP_BUDGET_1 4000 //reward for reaching the first softcap
+#define SOFTCAP_BUDGET_2 6000 //extra money added on top of the first softcap for going beyond it, until softcap 2
+#define HARDCAP_BUDGET 15000 //last tranche of money for going above and beyond the call of duty until hitting the hardcap
 
 /obj/item/energy_harvester
 	desc = "A Device which upon connection to a node, will harvest the energy and send it to engineerless stations in return for credits, derived from a syndicate powersink model."

--- a/code/modules/power/energyharvester.dm
+++ b/code/modules/power/energyharvester.dm
@@ -1,9 +1,9 @@
 #define MAXIMUM_POWER_LIMIT 1000000000000000.0 //1 Petawatt, same as PTL
 #define POWER_SOFTCAP_1 75000000.0 //75MJ, or 250KW/s for 300s, which is the cycle time of SSeconomy, power below this threshold gets treated differently.
 #define POWER_SOFTCAP_2 3000000000.0 //3GJ or 10MW/s for 300s
-#define SOFTCAP_BUDGET_1 2000 //reward for reaching the first softcap
-#define SOFTCAP_BUDGET_2 3000 //extra money added on top of the first softcap for going beyond it, until softcap 2
-#define HARDCAP_BUDGET 5000 //last tranche of money for going above and beyond the call of duty until hitting the hardcap
+#define SOFTCAP_BUDGET_1 3000 //reward for reaching the first softcap
+#define SOFTCAP_BUDGET_2 5000 //extra money added on top of the first softcap for going beyond it, until softcap 2
+#define HARDCAP_BUDGET 10000 //last tranche of money for going above and beyond the call of duty until hitting the hardcap
 
 /obj/item/energy_harvester
 	desc = "A Device which upon connection to a node, will harvest the energy and send it to engineerless stations in return for credits, derived from a syndicate powersink model."


### PR DESCRIPTION
# About PR
I find the energy harvester budget payout is kinda low and isn't worth the effort, so i buffed it a bit higher
You gonna need an engine that produce above 7-15(Minimum) MW to get near 8000-10000cr per payout, higher payout will require fusion engine

# Wiki Documentation
Soft cap 1 buffed from 2000cr to 5000cr when reached 300MJ (was 75MJ)
Soft cap 2 buffed from 3000cr to 10000cr when reached 9GJ (was 3GJ)
Hard cap buffed from 5000cr to 20000cr when going beyond 9GJ 
Now cap at 25000cr (Was 8000cr before)
![image](https://user-images.githubusercontent.com/89688125/177323199-6c90651e-5c45-4d01-9e36-be71b0375b04.png)


# Changelog

:cl:  
tweak: Buffed energy harvester cap
/:cl:
