### PR TITLE
craftable epi and atropine medipens

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -10,7 +10,7 @@
 	var/chem_catalysts[] = list() //like tools but for reagents
 	var/category = CAT_NONE //where it shows up in the crafting UI
 	var/subcategory = CAT_NONE
-	var/always_availible = TRUE //Set to FALSE if it needs to be learned first.
+	var/always_availible = TRUE //Set to FALSE if it needs to be learned first. // lmao availible
 
 /datum/crafting_recipe/New()
 	if(!(result in reqs))
@@ -551,7 +551,7 @@
 /datum/crafting_recipe/bone_spade
 	name = "Bone Spade"
 	result = /obj/item/shovel/spade/bone
-	time = 80
+	time = 8 SECONDS
 	reqs = list(/obj/item/stack/sheet/bone = 1,
 				 /obj/item/stack/sheet/sinew = 1)
 	category = CAT_TOOLS
@@ -559,7 +559,7 @@
 /datum/crafting_recipe/bone_hatchet
 	name = "Bone Hatchet"
 	result = /obj/item/hatchet/bone
-	time = 80
+	time = 8 SECONDS
 	reqs = list(/obj/item/stack/sheet/bone = 1,
 				 /obj/item/stack/sheet/sinew = 1)
 	category = CAT_TOOLS
@@ -567,7 +567,27 @@
 /datum/crafting_recipe/bone_cultivator
 	name = "Bone Cultivator"
 	result = /obj/item/cultivator/bone
-	time = 80
+	time = 8 SECONDS
 	reqs = list(/obj/item/stack/sheet/bone = 2,
 				 /obj/item/stack/sheet/sinew = 1)
+	category = CAT_TOOLS
+
+/datum/crafting_recipe/medipen
+	name = "Epinephrine Medipen"
+	result = /obj/item/reagent_containers/hypospray/medipen
+	tools = list(TOOL_SCREWDRIVER)
+	time = 2 SECONDS
+	reqs = list(/obj/item/pen = 1, // You feel a tiny prick!
+				/obj/item/reagent_containers/syringe = 1,
+				/datum/reagent/medicine/epinephrine = 10) // Sanguirite is unobtainable
+	category = CAT_TOOLS
+
+/datum/crafting_recipe/medipen
+	name = "Atropine Autoinjector"
+	result = /obj/item/reagent_containers/hypospray/medipen/atropine
+	tools = list(TOOL_SCREWDRIVER)
+	time = 4 SECONDS
+	reqs = list(/obj/item/pen = 1, // You feel a tiny prick!
+				/obj/item/reagent_containers/syringe = 1,
+				/datum/reagent/medicine/atropine = 10)
 	category = CAT_TOOLS

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -10,7 +10,7 @@
 	var/chem_catalysts[] = list() //like tools but for reagents
 	var/category = CAT_NONE //where it shows up in the crafting UI
 	var/subcategory = CAT_NONE
-	var/always_availible = TRUE //Set to FALSE if it needs to be learned first. // lmao availible
+	var/always_availible = TRUE //Set to FALSE if it needs to be learned first.
 
 /datum/crafting_recipe/New()
 	if(!(result in reqs))

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -572,7 +572,7 @@
 				 /obj/item/stack/sheet/sinew = 1)
 	category = CAT_TOOLS
 
-/datum/crafting_recipe/medipen
+/datum/crafting_recipe/epinephrine_medipen
 	name = "Epinephrine Medipen"
 	result = /obj/item/reagent_containers/hypospray/medipen
 	tools = list(TOOL_SCREWDRIVER)
@@ -582,7 +582,7 @@
 				/datum/reagent/medicine/epinephrine = 10) // Sanguirite is unobtainable
 	category = CAT_TOOLS
 
-/datum/crafting_recipe/medipen
+/datum/crafting_recipe/atropine_medipen
 	name = "Atropine Autoinjector"
 	result = /obj/item/reagent_containers/hypospray/medipen/atropine
 	tools = list(TOOL_SCREWDRIVER)


### PR DESCRIPTION
# Document the changes in your pull request

Kind of pissed that the only way to get atropine medipens is to purchase a 600 credit (economy amirite?) medpack that has a bunch of synthflesh and other crap I don't really care about

Also makes epipens more renewable, obviously

More attractive to medical staff than a bottle that sits idle in a fridge, so it's healthy for player interaction!

Also fixed some missing time defines in the same file

# Wiki Documentation

Epinephrine Medipen
Tools category
Requires screwdriver
Takes 2 seconds
Recipe:
1 Pen
1 Syringe
10u Epinephrine

Atropine Autoinjector
Tools category
Requires screwdriver
Takes 4 seconds
Recipe:
1 Pen
1 Syringe
10u Atropine

# Changelog

:cl:  
rscadd: Added crafting recipes for epinephrine and atropine medipens
/:cl:
