### PR TITLE
Removes deepfrying non-food items without the syndicate fryer

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -113,18 +113,16 @@ God bless America.
 			var/turf/T = get_turf(src)
 			new /obj/item/syndicate_basket(T)
 			return
-	if(istype(I, /obj/item/organ/brain))
-		var/safety = alert(user, "Warning! This brain might still contain a life in it.", "Proceed anyways?" ,"No.", "FRY ANYWAY")
-		if(safety != "FRY ANYWAY")
-			to_chat(user, span_warning("You decided not to fry this brain..."))
-			return
 	if(default_unfasten_wrench(user, I))
 		return
 	else if(default_deconstruction_screwdriver(user, "fryer_off", "fryer_off" ,I))	//where's the open maint panel icon?!
 		return
 	else
-		if(is_type_in_typecache(I, deepfry_blacklisted_items) || HAS_TRAIT(I, TRAIT_NODROP) || (I.item_flags & (ABSTRACT | DROPDEL)))
+		if(user.a_intent != INTENT_HELP)
 			return ..()
+		if((!superfry && !istype(I, /obj/item/reagent_containers/food)) || HAS_TRAIT(I, TRAIT_NODROP) || (I.item_flags & (ABSTRACT | DROPDEL)))
+			to_chat(user, span_warning("Your cooking skills do not allow you to fry [I]..."))
+			return
 		else if(!frying && user.transferItemToLoc(I, src))
 			to_chat(user, span_notice("You put [I] into [src]."))
 			var/item_reags = I.grind_results

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -118,7 +118,7 @@
 
 /datum/reagent/consumable/cooking_oil/reaction_obj(obj/O, reac_volume)
 	if(holder && holder.chem_temp >= fry_temperature)
-		if(isitem(O) && !istype(O, /obj/item/reagent_containers/food/snacks/deepfryholder))
+		if(istype(O, /obj/item/reagent_containers/food) && !istype(O, /obj/item/reagent_containers/food/snacks/deepfryholder))
 			O.loc.visible_message(span_warning("[O] rapidly fries as it's splashed with hot oil! Somehow."))
 			var/obj/item/reagent_containers/food/snacks/deepfryholder/F = new(O.drop_location(), O)
 			F.fry(volume)


### PR DESCRIPTION
# Document the changes in your pull request
### This is probably going to be ungodly controversial
 
As it stands currently you can deepfry nearly everything, which isnt great as someone can grief away the armory, a brain, important objects, or anything not covered here.

This ends up leading to poor gameplay where someone can permanently remove someone from the round by placing their brain into the frying oil for 0.1s

While I originally did want to fully remove it I decided to restrict it to the syndicate fryer just for chef traitorbus

And while yes this is an _Admin Issue_ admins are not always on, cannot always catch, or people dont ahelp the issue.

# Wiki Documentation

No more frying random objects

# Changelog

:cl:  
experimental: Removes frying non-food objects from regular fryer
/:cl:
