### PR TITLE
st credit is now fair to all

### DIFF
--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -190,6 +190,8 @@
 					  /datum/religion_rites/looks)
 
 /datum/religion_sect/capitalists/sect_bless(mob/living/L, mob/living/user)
+	if(!ishuman(L))
+		return
 	if(world.time < last_dono) // immersion broken
 		user.visible_message(span_notice("You are getting too greedy! You can recieve another donation in [(last_dono - world.time)/10] seconds!"))
 		return

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -190,8 +190,6 @@
 					  /datum/religion_rites/looks)
 
 /datum/religion_sect/capitalists/sect_bless(mob/living/L, mob/living/user)
-	if(!ishuman(L))
-		return
 	if(world.time < last_dono) // immersion broken
 		user.visible_message(span_notice("You are getting too greedy! You can recieve another donation in [(last_dono - world.time)/10] seconds!"))
 		return

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -185,21 +185,26 @@
 	alignment = ALIGNMENT_EVIL
 	desired_items = list(/obj/item/holochip)
 	max_favor = 100000
+	var/last_dono = 0 // world.time
 	rites_list = list(/datum/religion_rites/toppercent,
 					  /datum/religion_rites/looks)
 
 /datum/religion_sect/capitalists/sect_bless(mob/living/L, mob/living/user)
 	if(!ishuman(L))
 		return
+	if(world.time < last_dono) // immersion broken
+		user.visible_message(span_notice("You are getting too greedy! You can recieve another donation in [(last_dono - world.time)/10] seconds!"))
+		return
 	var/mob/living/carbon/human/H = L
 	var/obj/item/card/id/id_card = H.get_idcard()
 	var/obj/item/card/id/id_cardu = user.get_idcard()
-	var/money_check = 500
+	var/money_to_donate = round(id_card.registered_account.account_balance * 0.1) // takes 10% of their money and rounds it down
 
-	if(!id_card.registered_account.account_balance > money_check)
+	if(money_to_donate <= 0)
 		user.visible_message(span_notice("[H] is too poor to recieve [GLOB.deity]'s blessing!"))
 	else
-		var/heal_amt = 10
+		last_dono = world.time + 15 SECONDS // healing CD is 15 seconds but your healing strength is 2.5x stronger
+		var/heal_amt = 30
 		var/list/hurt_limbs = H.get_damaged_bodyparts(TRUE, TRUE, null, BODYPART_ORGANIC)
 
 		if(hurt_limbs.len)
@@ -207,26 +212,13 @@
 				var/obj/item/bodypart/affecting = X
 				if(affecting.heal_damage(heal_amt, heal_amt, null, BODYPART_ORGANIC))
 					H.update_damage_overlays()
-		id_card.registered_account.adjust_money(-10)
-		id_cardu.registered_account.adjust_money(10)
+		id_card.registered_account.adjust_money(-money_to_donate)
+		id_cardu.registered_account.adjust_money(money_to_donate)
 		SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "blessing", /datum/mood_event/blessing)
 		playsound(user, 'sound/misc/capitialism-short.ogg', 25, TRUE, -1)
 		H.visible_message(span_notice("[user] blesses [H] with the power of capitalism!"))
 		to_chat(H, span_boldnotice("You feel spiritually enriched, and donate to the cause of [GLOB.deity]!"))
-		H.visible_message(span_notice("[H] donated 10 credits!"))
-
-	var/heal_amt = 10
-	var/list/hurt_limbs = H.get_damaged_bodyparts(1, 1, null, BODYPART_ORGANIC)
-
-	if(hurt_limbs.len)
-		for(var/X in hurt_limbs)
-			var/obj/item/bodypart/affecting = X
-			if(affecting.heal_damage(heal_amt, heal_amt, null, BODYPART_ORGANIC))
-				H.update_damage_overlays()
-		H.visible_message(span_notice("[user] heals [H] with the power of [GLOB.deity]!"))
-		to_chat(H, span_boldnotice("May the power of [GLOB.deity] compel you to be healed!"))
-		playsound(user, "punch", 25, TRUE, -1)
-		SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "blessing", /datum/mood_event/blessing)
+		H.visible_message(span_notice("[H] donated [money_to_donate] credits!"))
 	return TRUE
 
 /datum/religion_sect/capitalists/on_sacrifice(obj/item/I, mob/living/L)

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -201,7 +201,7 @@
 	if(money_to_donate <= 0)
 		user.visible_message(span_notice("[H] is too poor to recieve [GLOB.deity]'s blessing!"))
 	else
-		last_dono = world.time + 15 SECONDS // healing CD is 15 seconds but your healing strength is 2.5x stronger
+		last_dono = world.time + 15 SECONDS // healing CD is 15 seconds but your healing strength is 3x stronger
 		var/heal_amt = 30
 		var/list/hurt_limbs = H.get_damaged_bodyparts(TRUE, TRUE, null, BODYPART_ORGANIC)
 


### PR DESCRIPTION
# Document the changes in your pull request

St. Credit bible now takes 10% of your cash instead of 10 credits, which means the chaplain can strategize around ~~taking~~ receiving donations from richer patrons and no longer robs the poor ones blind in comparison.

It used to heal 10 to those that could not donate and 10+10 to those that could, strangely.

Now, with a 15 second cooldown introduced (to make sure chaplains can't drain bank accounts instantly), healing is set to 30 and now only heals those that can donate (anyone with more than 10 credits in their account).

P.S. to anyone that thinks 10% is too much, you have to have more than 100 credits for it to even take more than it did previously, which is more money than you will ever need, so shut up top one percenter!!!


Should make the impossibly high goal of 10k credits a little more achievable

BTW economy rework when? @TheGamerdk 

# Changelog

:cl:  
tweak: St. Credit's bible now takes 10% of your money but has a cooldown
/:cl:
