### PR TITLE
Shredding Emag with a shredder will now cause an explosion

### DIFF
--- a/code/modules/paperwork/papershredder.dm
+++ b/code/modules/paperwork/papershredder.dm
@@ -50,6 +50,10 @@
 		shred_amount = 3
 	else if(istype(W, /obj/item/station_charter))
 		shred_amount = 3
+	else if(istype(W, /obj/item/card/emag))
+		qdel(W)
+		explosion(src, -1, 0, 1,)
+		visible_message(("<span class='danger'>The [src] short-circuits and explodes! </span>"))
 	else if(istype(W, /obj/item/paper_bundle))
 		shred_amount = 3
 	else if(istype(W, /obj/item/book))


### PR DESCRIPTION
Emag will explode and be removed if shredded with a paper shredder

blame @slicerv  for this idea

# Wiki Documentation
Idek, add a note that emagging a shredder will make it explode?

# Changelog

:cl:  
rscadd: explosion
/:cl:
