### PR TITLE
NO PUTTING GLASS ON SUPERMATTERS

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -396,6 +396,9 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	if(!istype(T)) 	//We are in a crate or somewhere that isn't turf, if we return to turf resume processing but for now.
 		return  //Yeah just stop.
 
+	for(var/obj/structure/window/struct in T.contents) //no fulltile window exploit
+		Consume(struct)
+
 	if(power)
 		soundloop.volume = clamp((50 + (power / 50)), 50, 100)
 	if(damage >= 300)


### PR DESCRIPTION
# Document the changes in your pull request

putting a piece of glass on the SM makes it never have atmos updates but also never delam so you get 1 billion power for no reason

# Changelog

:cl: ToasterBiome, CookPet, TWarface1234455
bugfix: no more fulltile SM exploit
/:cl:
