### PR TITLE
Fixes a bug in the Holodeck

### DIFF
--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -108,7 +108,7 @@
 			var/valid = FALSE
 			var/list/checked = program_cache
 			if(obj_flags & EMAGGED)
-				checked |= emag_programs
+				checked = checked + emag_programs
 			for(var/prog in checked)
 				var/list/P = prog
 				if(P["type"] == program_to_load)


### PR DESCRIPTION
# Document the changes in your pull request

the var `checked` is a variable pointing to the `program_cache` list and doing |= will add to the `program_cache` causing an unintended behavior where emag programs are added to the normal programs. Doing `checked = checked + emag_programs` creates a new list.

# Changelog

:cl:  
bugfix: Emagging the holodeck and using a emag program doesnt add to emag programs the normal list now
/:cl:
