### PR TITLE
Bone sword should properly go on exosuit

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -64,7 +64,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
 	force = 40
 	throwforce = 10
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_HUGE
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	block_chance = 50
 	sharpness = SHARP_EDGED
@@ -232,7 +232,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	force = 15
 	throwforce = 10
 	armour_penetration = 15
-	w_class = WEIGHT_CLASS_HUGE
+	w_class = WEIGHT_CLASS_BULKY
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "tore", "ripped", "diced", "cut")
 	block_chance = 30


### PR DESCRIPTION
# Document the changes in your pull request

I'm a dumbass and mixed up bulky and huge weights

Claymore is properly huge like katana and the holy claymore and the bone sword is now bulky so it can fit on exosuits as intended.

Technically not a bug fix I'm just a dumbass

Oopsie

# Wiki Documentation

Claymores now huge
Bone sword now bulky

# Changelog

:cl:  
tweak: Bone sword bulky now so it can go on exosuit
tweak: Claymore huge now because uh consistency
/:cl:
