### PR TITLE
New RCD upgrade: Conveyor upgrade

### DIFF
--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -112,11 +112,13 @@
 #define RCD_MACHINE (1<<4)
 #define RCD_COMPUTER (1<<5)
 #define RCD_FURNISHING (1<<6)
+#define RCD_CONVEYOR (1<<7)
 
 #define RCD_UPGRADE_FRAMES (1<<0)
 #define RCD_UPGRADE_SIMPLE_CIRCUITS	(1<<1)
 #define RCD_UPGRADE_SILO_LINK (1<<2)
 #define RCD_UPGRADE_FURNISHING (1<<3)
+#define RCD_UPGRADE_CONVEYORS (1<<4)
 
 #define RCD_WINDOW_FULLTILE "full tile"
 #define RCD_WINDOW_DIRECTIONAL "directional"

--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -113,6 +113,7 @@
 #define RCD_COMPUTER (1<<5)
 #define RCD_FURNISHING (1<<6)
 #define RCD_CONVEYOR (1<<7)
+#define RCD_SWITCH (1<<8)
 
 #define RCD_UPGRADE_FRAMES (1<<0)
 #define RCD_UPGRADE_SIMPLE_CIRCUITS	(1<<1)

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -38,6 +38,9 @@ RLD
 	var/banned_upgrades = NONE
 	var/datum/component/remote_materials/silo_mats //remote connection to the silo
 	var/silo_link = FALSE //switch to use internal or remote storage
+	var/linked_switch_id = null	//integer variable, the id for the assigned conveyor switch
+	var/obj/machinery/conveyor/last_placed
+	var/color_choice = null
 
 /obj/item/construction/Initialize(mapload)
 	. = ..()
@@ -549,6 +552,27 @@ RLD
 					playsound(src.loc, 'sound/machines/click.ogg', 50, TRUE)
 					return TRUE
 	qdel(rcd_effect)
+	return FALSE
+
+/obj/item/construction/rcd/proc/rcd_conveyor(atom/A, mob/user)
+	var/delay = 5
+	var/cost = 12
+	var/obj/effect/constructing_effect/rcd_effect = new(get_turf(A), delay, src.mode)
+	if(checkResource(cost, user))
+		if(do_after(user, delay, target = A))
+			if(checkResource(cost, user))
+				rcd_effect.end_animation()
+				useResource(cost, user)
+				activate()
+				playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
+				var/cdir = get_dir(A, user)
+				if (last_placed)
+					cdir = get_dir(A, last_placed)
+					if(cdir in GLOB.cardinals)
+						last_placed.setDir(get_dir(last_placed, A))
+				last_placed = new/obj/machinery/conveyor(A, cdir, linked_switch_id)
+				return
+	qdel(rcd_effect)
 
 /obj/item/construction/rcd/Initialize()
 	. = ..()
@@ -596,6 +620,10 @@ RLD
 		choices += list(
 		"Change Furnishing Type" = image(icon = 'icons/mob/radial.dmi', icon_state = "chair")
 		)
+	if(upgrade & RCD_UPGRADE_CONVEYORS)
+		choices += list(
+		"Conveyor" = image(icon = 'icons/obj/recycling.dmi', icon_state = "conveyor_construct")
+		)
 	var/choice = show_radial_menu(user, src, choices, custom_check = CALLBACK(src, .proc/check_menu, user), require_near = TRUE, tooltips = TRUE)
 	if(!check_menu(user))
 		return
@@ -634,6 +662,10 @@ RLD
 		if("Silo Link")
 			toggle_silo_link(user)
 			return
+		if("Conveyor")
+			mode = RCD_CONVEYOR
+			linked_switch_id = null
+			last_placed = null
 		else
 			return
 	playsound(src, 'sound/effects/pop.ogg', 50, FALSE)
@@ -647,9 +679,22 @@ RLD
 
 /obj/item/construction/rcd/afterattack(atom/A, mob/user, proximity)
 	. = ..()
-	if(!prox_check(proximity))
-		return
-	rcd_create(A, user)
+	if (mode == RCD_CONVEYOR)	
+		if(!range_check(A, user) || !target_check(A,user)  || istype(A, /obj/machinery/conveyor) || !isopenturf(A) || istype(A, /area/shuttle))
+			to_chat(user, "<span class='warning'>Error! Invalid tile!</span>")
+			return
+		if (!linked_switch_id)
+			to_chat(user, "<span class='warning'>Error! [src] is not linked!</span>")
+			return
+		if (get_turf(A) == get_turf(user))
+			to_chat(user, "<span class='notice'>Cannot place conveyor below your feet!</span>")
+			return
+
+		rcd_conveyor(A, user)
+	else
+		if(!prox_check(proximity))
+			return
+		rcd_create(A, user)
 
 /obj/item/construction/rcd/proc/detonate_pulse()
 	audible_message("<span class='danger'><b>[src] begins to vibrate and \
@@ -758,7 +803,7 @@ RLD
 	has_ammobar = FALSE
 
 /obj/item/construction/rcd/arcd/afterattack(atom/A, mob/user)
-	. = ..()
+	..()
 	if(!range_check(A,user))
 		return
 	if(target_check(A,user))
@@ -794,9 +839,6 @@ RLD
 	var/floordelay = 10
 	var/decondelay = 15
 
-	var/color_choice = null
-
-
 /obj/item/construction/rld/ui_action_click(mob/user, datum/action/A)
 	if(istype(A, /datum/action/item_action/pick_color))
 		color_choice = input(user,"","Choose Color",color_choice) as color
@@ -821,6 +863,12 @@ RLD
 			mode = REMOVE_MODE
 			to_chat(user, span_notice("You change RLD's mode to 'Deconstruct'."))
 
+/obj/item/construction/rcd/attackby(obj/item/I, mob/user, params)
+	..()
+	if(upgrade & RCD_UPGRADE_CONVEYORS && istype(I, /obj/item/conveyor_switch_construct))
+		to_chat(user, "<span class='notice'>You link the switch to the [src].</span>")
+		var/obj/item/conveyor_switch_construct/C = I
+		linked_switch_id = C.id
 
 /obj/item/construction/rld/proc/checkdupes(var/target)
 	. = list()
@@ -831,7 +879,7 @@ RLD
 
 
 /obj/item/construction/rld/afterattack(atom/A, mob/user)
-	. = ..()
+	..()
 	if(!range_check(A,user))
 		return
 	var/turf/start = get_turf(src)
@@ -950,7 +998,10 @@ RLD
 /obj/item/rcd_upgrade/furnishing
 	desc = "It contains the design for chairs, stools, tables, and glass tables."
 	upgrade = RCD_UPGRADE_FURNISHING
-
+/obj/item/rcd_upgrade/conveyor
+	desc = "The disk warns against building an endless conveyor trap, but we know what you're gonna do."
+	upgrade = RCD_UPGRADE_CONVEYORS
+	
 #undef GLOW_MODE
 #undef LIGHT_MODE
 #undef REMOVE_MODE

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -559,7 +559,7 @@ RLD
 	var/delay = 1
 	var/obj/effect/constructing_effect/rcd_effect = new(get_turf(A), delay, src.mode)
 	if(checkResource(cost, user))
-		if(do_after(user, delay, target = A))
+		if(do_after(user, delay, A))
 			if(checkResource(cost, user))
 				rcd_effect.end_animation()
 				useResource(cost, user)

--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -73,6 +73,16 @@
 	category = list("Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
+/datum/design/rcd_upgrade/conveyor
+	name = "RCD Conveyor upgrade"
+	desc = "Adds the ability to dispense conveyors and switches using the RCD."
+	id = "rcd_upgrade_conveyor"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 5000, /datum/material/glass = 2500)
+	build_path = /obj/item/rcd_upgrade/conveyor
+	category = list("Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
+
 /datum/design/rcd_upgrade/silo_link
 	name = "Advanced RCD silo link upgrade"
 	desc = "Adds the silo direct link to the RCD."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -649,7 +649,7 @@
 	id = "rcd_upgrade"
 	display_name = "RCD designs upgrade"
 	description = "Unlocks new RCD designs."
-	design_ids = list("rcd_upgrade_frames", "rcd_upgrade_simple_circuits", "rcd_upgrade_furnishing")
+	design_ids = list("rcd_upgrade_frames", "rcd_upgrade_simple_circuits", "rcd_upgrade_furnishing", "rcd_upgrade_conveyor")
 	prereq_ids = list("adv_engi")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000


### PR DESCRIPTION
# About PR
[Original PR for conveyor](https://github.com/BeeStation/BeeStation-Hornet/pull/2973)
I added switch for it with the help of SapphicOverload fixing some bugs
Featuring new upgrade: spawn conveyor and switch via RCD, really convenient, just load mat in and shoot out conveyors and switches!
# Wiki Documentation
RCD can now dispense conveyor and switch

# Changelog

:cl:  Warface1234455, eeSPee, SapphicOverload
rscadd: Added Conveyor Upgrade
/:cl:
