### PR TITLE
x-ray eyes can no longer be printed with the combat cybernetics technology

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -565,7 +565,7 @@
 	display_name = "Combat Cybernetic Implants"
 	description = "Military grade combat implants to improve performance."
 	prereq_ids = list("adv_cyber_implants","weaponry","NVGtech","high_efficiency")
-	design_ids = list("ci-xray", "ci-thermals", "ci-antidrop", "ci-antistun", "ci-thrusters")
+	design_ids = list("ci-thermals", "ci-antidrop", "ci-antistun", "ci-thrusters")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 


### PR DESCRIPTION
# Document the changes in your pull request

x-ray implants can't be printed anymore. ops can still get them of course.

why remove x-ray eyes?
x-ray eyes have zero downsides except for being harder to see for a second if you get EMPed. you gain unlimited vision, and unlike thermal eyes, which have a downside (-1 flash protection, sunglasses won't shield your eyes from flashes) x-ray is completely risk-free. x-ray completely bones antagonists like bloodsuckers since maintenance dwelling security officers will always see them with no way for the bloodsucker to conceal their base. the only things bloodsuckers can do is destroy ore silo or the RnD servers, but that's not very realistic and can't be done forever. thermals remain since they're situational and have a downside.

# Wiki Documentation

techwebs page

# Changelog

:cl:  
rscdel: x-ray eyes can no longer be printed  
/:cl:
