### PR TITLE
Lightbulbs have a small chance to burn out

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -417,7 +417,7 @@
 /obj/machinery/light/process()
 	if (!cell)
 		return
-	// 0.04% Chance to burn out each tick
+	// 0.02% Chance to burn out each tick
 	if(on && prob(0.02))
 		burn_out()
 	if(has_power())

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -292,7 +292,6 @@
 // create a new lighting fixture
 /obj/machinery/light/Initialize(mapload)
 	. = ..()
-
 	if(!mapload) //sync up nightshift lighting for player made lights
 		var/area/A = get_area(src)
 		var/obj/machinery/power/apc/temp_apc = A.get_apc()
@@ -352,6 +351,9 @@
 	switch(status)
 		if(LIGHT_BROKEN,LIGHT_BURNED,LIGHT_EMPTY)
 			on = FALSE
+			STOP_PROCESSING(SSmachines, src)
+		else
+			START_PROCESSING(SSmachines, src)
 	emergency_mode = FALSE
 	if(on)
 		var/BR = brightness
@@ -385,7 +387,6 @@
 	else if(has_emergency_power(LIGHT_EMERGENCY_POWER_USE) && !turned_off())
 		use_power = IDLE_POWER_USE
 		emergency_mode = TRUE
-		START_PROCESSING(SSmachines, src)
 	else
 		use_power = IDLE_POWER_USE
 		set_light(0)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -418,7 +418,7 @@
 	if (!cell)
 		return
 	// 0.04% Chance to burn out each tick
-	if(on && prob(0.04))
+	if(on && prob(0.02))
 		burn_out()
 	if(has_power())
 		if (cell.charge == cell.maxcharge)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -415,10 +415,13 @@
 
 /obj/machinery/light/process()
 	if (!cell)
-		return PROCESS_KILL
+		return
+	// 0.04% Chance to burn out each tick
+	if(on && prob(0.04))
+		burn_out()
 	if(has_power())
 		if (cell.charge == cell.maxcharge)
-			return PROCESS_KILL
+			return
 		cell.charge = min(cell.maxcharge, cell.charge + LIGHT_EMERGENCY_POWER_USE) //Recharge emergency power automatically while not using it
 	if(emergency_mode && !use_emergency_power(LIGHT_EMERGENCY_POWER_USE))
 		update(FALSE) //Disables emergency mode and sets the color to normal


### PR DESCRIPTION
# Document the changes in your pull request

Makes lightbulbs have a rare chance to burn out ~~Janitor Nerf~~
On average they last about ~80 minutes
(about 1.1 whole station replacement in a round)

# Wiki Documentation

Lights can burn out now

# Changelog

:cl:  
rscadd: Lights now have a small chance to burn out randomly
/:cl:
