### PR TITLE
Fixes a very old exploit

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -570,21 +570,22 @@
 //movement_dir == 0 when stopping or any dir when trying to move
 /atom/movable/proc/Process_Spacemove(movement_dir = 0)
 	if(has_gravity(src))
-		return 1
+		return TRUE
 
 	if(pulledby)
-		return 1
+		pulledby.stop_pulling()
+		return TRUE
 
 	if(throwing)
-		return 1
+		return TRUE
 
 	if(!isturf(loc))
-		return 1
+		return TRUE
 
 	if(locate(/obj/structure/lattice) in range(1, get_turf(src))) //Not realistic but makes pushing things in space easier
-		return 1
+		return TRUE
 
-	return 0
+	return FALSE
 
 
 /atom/movable/proc/newtonian_move(direction) //Only moves the object if it's under no gravity


### PR DESCRIPTION
# Document the changes in your pull request
This has been in the game for at least _**8**_ years.

Now instead of being able to walk in space by pulling each other the person that moves is forced to let go

# Changelog

:cl:  
bugfix: You can no longer walk infinitely in space by grabbing each other
/:cl:
