### PR TITLE
Fixes uplink getting common channel

### DIFF
--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -316,7 +316,7 @@ GLOBAL_LIST_EMPTY(uplinks)
 	if(istype(parent,/obj/item/pda))
 		return "[rand(100,999)] [pick(GLOB.phonetic_alphabet)]"
 	else if(istype(parent,/obj/item/radio))
-		return sanitize_frequency(rand(MIN_FREQ, MAX_FREQ))
+		return sanitize_frequency(rand(FREQ_COMMON+1, MAX_FREQ))
 	else if(istype(parent,/obj/item/pen))
 		var/list/L = list()
 		for(var/i in 1 to PEN_ROTATIONS)


### PR DESCRIPTION
# Document the changes in your pull request

Fixes: #14753 

Makes the frequency generate above the common channel preventing any issues
generates from 146.0 - 148.9 so 29 possible codes vs 48 so not a terrible loss.

# Changelog

:cl:  
bugfix: Radio uplinks no longer choose commons channel
/:cl:
