### PR TITLE
Radstorms will trigger emergency maintaince with no living heads or AIs

### DIFF
--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -50,6 +50,8 @@
 		return
 	priority_announce("The radiation threat has passed. Please return to your workplaces.", "Anomaly Alert")
 	status_alarm(FALSE)
+	sleep(1 MINUTES) // Want to give them time to get out of maintenance.
+	revoke_maint_all_access()
 
 /datum/weather/rad_storm/proc/status_alarm(active)	//Makes the status displays show the radiation warning for those who missed the announcement.
 	var/datum/radio_frequency/frequency = SSradio.return_frequency(FREQ_STATUS_DISPLAYS)

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -13,7 +13,7 @@
 
 /datum/round_event/radiation_storm/announce(fake)
 	priority_announce("High levels of radiation detected near the station. Maintenance is best shielded from radiation.", "Anomaly Alert", ANNOUNCER_RADIATION)
-	if((!SSjob.get_all_heads()) && (!active_ais())) // No heads or AIs
+	if((!SSjob.GetJob("Captain")) && (!active_ais())) // No captains or AIs
 		make_maint_all_access()
 	//sound not longer matches the text, but an audible warning is probably good
 

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -13,6 +13,8 @@
 
 /datum/round_event/radiation_storm/announce(fake)
 	priority_announce("High levels of radiation detected near the station. Maintenance is best shielded from radiation.", "Anomaly Alert", ANNOUNCER_RADIATION)
+	if((get_living_heads().len == 0) && (active_ais().len == 0)) // No heads or AIs
+		make_maint_all_access()
 	//sound not longer matches the text, but an audible warning is probably good
 
 /datum/round_event/radiation_storm/start()

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -13,7 +13,7 @@
 
 /datum/round_event/radiation_storm/announce(fake)
 	priority_announce("High levels of radiation detected near the station. Maintenance is best shielded from radiation.", "Anomaly Alert", ANNOUNCER_RADIATION)
-	if((!get_living_heads()) && (!active_ais())) // No heads or AIs
+	if((!SSjob.get_all_heads()) && (!active_ais())) // No heads or AIs
 		make_maint_all_access()
 	//sound not longer matches the text, but an audible warning is probably good
 

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -13,7 +13,7 @@
 
 /datum/round_event/radiation_storm/announce(fake)
 	priority_announce("High levels of radiation detected near the station. Maintenance is best shielded from radiation.", "Anomaly Alert", ANNOUNCER_RADIATION)
-	if((get_living_heads().len == 0) && (active_ais().len == 0)) // No heads or AIs
+	if((!get_living_heads()) && (!active_ais())) // No heads or AIs
 		make_maint_all_access()
 	//sound not longer matches the text, but an audible warning is probably good
 


### PR DESCRIPTION
# Document the changes in your pull request

please help jamie is turning me into his C*der slave

# Wiki Documentation

Automaint for no heads and AIs during radstorms

# Changelog

:cl:  
rscadd: If there is no heads and AIs are dead radiation storms will trigger emergency maintenance
/:cl:
