### PR TITLE
refillable medipen recipes

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -591,3 +591,19 @@
 				/obj/item/reagent_containers/syringe = 1,
 				/datum/reagent/medicine/atropine = 10)
 	category = CAT_TOOLS
+
+/datum/crafting_recipe/refill_epinephrine_medipen
+	name = "Refill Epinephrine Medipen"
+	result = /obj/item/reagent_containers/hypospray/medipen
+	time = 2 SECONDS
+	reqs = list(/obj/item/reagent_containers/hypospray/medipen = 1,
+				/datum/reagent/medicine/epinephrine = 10)
+	category = CAT_TOOLS
+
+/datum/crafting_recipe/refill_atropine_medipen
+	name = "Refill Atropine Autoinjector"
+	result = /obj/item/reagent_containers/hypospray/medipen/atropine
+	time = 4 SECONDS
+	reqs = list(/obj/item/reagent_containers/hypospray/medipen/atropine,
+				/datum/reagent/medicine/atropine = 10)
+	category = CAT_TOOLS


### PR DESCRIPTION
# Document the changes in your pull request

continuation of #14710

more abusable for Sanguirite but it's not exactly an amazing chem anyways and would take like a straight minute of farming for one bottle that no one will use anyways

# Wiki Documentation

Refill Epinephrine Medipen
Tools category
Takes 2 seconds
Recipe:
1 Epinephrine Medipen
10u Epinephrine

Refill Atropine Autoinjector
Tools category
Takes 4 seconds
Recipe:
1 Atropine Autoinjector
10u Atropine

# Changelog

:cl:  
rscadd: Added refilling recipes for atropine and epinephrine medipens
/:cl:
