### PR TITLE
Revert "Sterilizes the codebase - Pt.7 Removes Catsip"

### DIFF
--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -809,6 +809,12 @@
 	results = list(/datum/reagent/consumable/red_queen = 10)
 	required_reagents = list(/datum/reagent/consumable/tea = 6, /datum/reagent/mercury = 2, /datum/reagent/consumable/blackpepper = 1, /datum/reagent/growthserum = 1)
 
+/datum/chemical_reaction/catsip
+	name = "Catsip"
+	id = /datum/reagent/consumable/ethanol/catsip
+	results = list(/datum/reagent/consumable/ethanol/catsip = 4)
+	required_reagents = list(/datum/reagent/consumable/ethanol/sake = 2, /datum/reagent/consumable/soymilk = 2, /datum/reagent/consumable/corn_syrup = 1, /datum/reagent/consumable/grenadine = 1)
+
 /datum/chemical_reaction/flaming_moe
 	name = "Flaming Moe"
 	required_temp = 500

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -159,11 +159,6 @@
 
 	H.set_species(/datum/species/human)
 
-/datum/species/human/felinid/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
-	. = ..()
-	if(H.reagents.has_reagent(/datum/reagent/consumable/ethanol/catsip))
-		H.adjustBruteLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER,FALSE,FALSE, BODYPART_ANY)
-
 /datum/species/human/felinid/get_scream_sound(mob/living/carbon/human/H)
 	return pick(screamsound)
 

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -161,6 +161,8 @@
 
 /datum/species/human/felinid/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
 	. = ..()
+	if(H.reagents.has_reagent(/datum/reagent/consumable/ethanol/catsip))
+		H.adjustBruteLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER,FALSE,FALSE, BODYPART_ANY)
 
 /datum/species/human/felinid/get_scream_sound(mob/living/carbon/human/H)
 	return pick(screamsound)

--- a/yogstation/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/yogstation/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1,3 +1,24 @@
+/datum/reagent/consumable/ethanol/catsip
+	name = "Catsip"
+	description = "A kawaii drink from space-Japan."
+	color ="#ff99ac"
+	boozepwr = 50
+	quality = DRINK_NICE
+	taste_description = "degeneracy"
+	glass_icon_state = "catsip"
+	glass_name = "Catsip"
+	glass_desc = "Unfortunately has a tendency to induce the peculiar vocal tics of a wapanese mutant in the imbiber."
+
+/datum/reagent/consumable/ethanol/catsip/on_mob_life(mob/living/M)
+	if(prob(8))
+		M.say(pick("Nya.", "N-nya!", "NYA!"), forced = "catsip")
+	return ..()
+
+/datum/reagent/consumable/ethanol/catsip/on_mob_add(mob/living/carbon/human/M)
+	if(!M.dna.species.is_wagging_tail())
+		M.emote("wag")
+	return ..()
+
 /datum/reagent/consumable/ethanol/whiskey/kong
 	name = "Kong"
 	description = "Makes You Go Ape!&#174;"

--- a/yogstation/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/yogstation/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1,5 +1,3 @@
-#define CATSIP_MEOW_MAX 2
-
 /datum/reagent/consumable/ethanol/catsip
 	name = "Catsip"
 	description = "A kawaii drink from space-Japan."
@@ -11,7 +9,7 @@
 	glass_name = "Catsip"
 	glass_desc = "Unfortunately has a tendency to induce the peculiar vocal tics of a wapanese mutant in the imbiber."
 	/// Number of times the chemical is allowed to cause forced speech
-	var/meowcount = CATSIP_MEOW_MAX
+	var/meowcount = 2
 
 /datum/reagent/consumable/ethanol/catsip/on_mob_life(mob/living/M)
 	if(prob(8) && meowcount)
@@ -73,4 +71,3 @@
 	if(prob(10))
 		M.hallucination += hal_amt //conscious dreamers can be treasurers to their own currency
 	..()
-#undef CATSIP_MEOW_MAX

--- a/yogstation/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/yogstation/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1,3 +1,5 @@
+#define CATSIP_MEOW_MAX 2
+
 /datum/reagent/consumable/ethanol/catsip
 	name = "Catsip"
 	description = "A kawaii drink from space-Japan."
@@ -8,10 +10,13 @@
 	glass_icon_state = "catsip"
 	glass_name = "Catsip"
 	glass_desc = "Unfortunately has a tendency to induce the peculiar vocal tics of a wapanese mutant in the imbiber."
+	/// Number of times the chemical is allowed to cause forced speech
+	var/meowcount = CATSIP_MEOW_MAX
 
 /datum/reagent/consumable/ethanol/catsip/on_mob_life(mob/living/M)
-	if(prob(8))
+	if(prob(8) && meowcount)
 		M.say(pick("Nya.", "N-nya!", "NYA!"), forced = "catsip")
+		meowcount--
 	return ..()
 
 /datum/reagent/consumable/ethanol/catsip/on_mob_add(mob/living/carbon/human/M)
@@ -68,3 +73,4 @@
 	if(prob(10))
 		M.hallucination += hal_amt //conscious dreamers can be treasurers to their own currency
 	..()
+#undef CATSIP_MEOW_MAX


### PR DESCRIPTION
Reverts yogstation13/Yogstation#14720

Does literally nothing that can't be accomplished by other sources also forcing people to say "nya" is funny and can't be construed as fetishy bullshit

If you stupid fucks are going to add forced speech references to a stupid dwarf game I see no reason for this to be considered differently plus unlike game references that are extremely forced and will not be funny after a month at least the catsip nyaing can be used to an actual comedic effect

:cl:
rscadd: catsip is back
tweak: catsip no longer heals felinids
/:cl: