### PR TITLE
nerfs grub juice

### DIFF
--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -129,7 +129,7 @@ GLOBAL_LIST_INIT(xeno_recipes, list ( \
 	desc = "Gross, slimy, and green intestines retrieved from a Gold Grub. Legends say it is valuable in traditional medicines."
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "goldgrubguts"
-	grind_results = list(/datum/reagent/medicine/grubjuice = 5)
+	grind_results = list(/datum/reagent/medicine/grubjuice = 10)
 
 /obj/item/stack/sheet/hairlesshide
 	name = "hairless hide"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1158,7 +1158,7 @@
 	can_synth = FALSE
 
 /datum/reagent/medicine/grubjuice/on_mob_life(mob/living/carbon/M)
-	M.heal_bodypart_damage(7,7)
+	M.heal_bodypart_damage(5,5)
 	M.adjustOrganLoss(ORGAN_SLOT_LIVER, 2*REM)
 	..()
 	return TRUE

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1154,12 +1154,12 @@
 	reagent_state = LIQUID
 	color = "#43bf1d"
 	taste_description = "bug intestines"
-	overdose_threshold = 10
+	overdose_threshold = 20
 	can_synth = FALSE
 
 /datum/reagent/medicine/grubjuice/on_mob_life(mob/living/carbon/M)
-	M.heal_bodypart_damage(5,5)
-	M.adjustOrganLoss(ORGAN_SLOT_LIVER, 2*REM)
+	M.heal_bodypart_damage(3,3)
+	M.adjustOrganLoss(ORGAN_SLOT_LIVER, 1*REM)
 	..()
 	return TRUE
 


### PR DESCRIPTION
Been a long time since I meant to do this.

If you didnt know, gold grub guts can be harvested from gold grubs and turned into a really potent medicine product that also damages your liver. 

Previously healed 7,7 brute and burn while dealing 2 liver damage. Overdose limit of 10 and you got 5 units from one guts. Now heals 3,3 brute and burn while dealing 1 liver damage. Overdose limit of 20 and you get 10 units from one guts. Overall, it lasts twice as long but about half the effects (though slightly less healing), mostly because previously it gave too much healing power to miners who used it to it's full capacity.

# Changelog

:cl:  
tweak: grub juice healing nerfed.
/:cl:
