### PR TITLE
Removes geysers from lavaland

### DIFF
--- a/code/datums/mapgen/CaveGenerator.dm
+++ b/code/datums/mapgen/CaveGenerator.dm
@@ -43,7 +43,7 @@
 	if(!flora_spawn_list)
 		flora_spawn_list = list(/obj/structure/flora/ash/leaf_shroom = 2 , /obj/structure/flora/ash/cap_shroom = 2 , /obj/structure/flora/ash/stem_shroom = 2 , /obj/structure/flora/ash/cacti = 1, /obj/structure/flora/ash/tall_shroom = 2)
 	if(!feature_spawn_list)
-		feature_spawn_list = list(/obj/structure/geyser/random = 1)
+		feature_spawn_list = list() //yogs, no geysers
 
 /datum/map_generator/cave_generator/generate_terrain(list/turfs)
 	. = ..()

--- a/code/datums/mapgen/Cavegens/LavalandGenerator.dm
+++ b/code/datums/mapgen/Cavegens/LavalandGenerator.dm
@@ -11,7 +11,7 @@
 	flora_spawn_list = list(/obj/structure/flora/ash/leaf_shroom = 2 , /obj/structure/flora/ash/cap_shroom = 2 , /obj/structure/flora/ash/stem_shroom = 2 , /obj/structure/flora/ash/cacti = 1, /obj/structure/flora/ash/tall_shroom = 2)
 	///Note that this spawn list is also in the icemoon generator
 	//feature_spawn_list = list(/obj/structure/geyser/wittel = 6, /obj/structure/geyser/random = 2, /obj/structure/geyser/plasma_oxide = 10, /obj/structure/geyser/protozine = 10, /obj/structure/geyser/hollowwater = 10)
-	feature_spawn_list = list(/obj/structure/geyser/random = 1)
+	feature_spawn_list = list() //yogs, no geysers
 
 	initial_closed_chance = 45
 	smoothing_iterations = 50


### PR DESCRIPTION
# Document the changes in your pull request

We don't have plumbing, have no way to get a plunger, and any questions I had about putting chemicals in them were met with an "i dunno", so now we don't have them again.

# Changelog

:cl:  
rscdel: No more useless geysers
/:cl:
