### PR TITLE
makes cultists obvious to ghosts

### DIFF
--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -13,6 +13,7 @@
 	var/give_equipment = FALSE
 	var/datum/team/cult/cult_team
 	var/original_eye_color = "000" //this will store the eye color of the cultist so it can be returned if they get deconverted
+	show_to_ghosts = TRUE
 
 
 /datum/antagonist/cult/get_team()


### PR DESCRIPTION
# Document the changes in your pull request

Its comedically easy to figure out who they are;
Changes it so ghosts can see them

~~im also not opposed to just turning it on for every antag~~
# Changelog
:cl:  
tweak: Cults are obvious antags to ghost now
/:cl:
