### PR TITLE
Makes traitor/malf AI obvious antags

### DIFF
--- a/code/game/gamemodes/malfunction/malf.dm
+++ b/code/game/gamemodes/malfunction/malf.dm
@@ -10,7 +10,6 @@
 	reroll_friendly = FALSE
 	title_icon = "ss13"
 	time_required = 600
-	show_to_ghosts = TRUE
 
 	announce_span = "danger"
 	announce_text = "The station's Artificial Intelligence is rogue!\n\

--- a/code/game/gamemodes/malfunction/malf.dm
+++ b/code/game/gamemodes/malfunction/malf.dm
@@ -10,6 +10,7 @@
 	reroll_friendly = FALSE
 	title_icon = "ss13"
 	time_required = 600
+	show_to_ghosts = TRUE
 
 	announce_span = "danger"
 	announce_text = "The station's Artificial Intelligence is rogue!\n\

--- a/code/modules/antagonists/malf/malf.dm
+++ b/code/modules/antagonists/malf/malf.dm
@@ -2,6 +2,7 @@
 	malf = TRUE
 	roundend_category = "malfunctioning AIs"
 	name = "Malf"
+	show_to_ghosts = TRUE
 
 /datum/antagonist/traitor/malf/forge_ai_objectives()
 	var/datum/objective/block/block_objective = new


### PR DESCRIPTION
# Document the changes in your pull request

You can see their laws and tell if their malf within seconds.

# Changelog

:cl:  
rscadd: Orbit menu now shows malf/traitor AIs as antags
/:cl:
