### PR TITLE
Gives ghosts a way to quickly unobserve someone

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -207,6 +207,7 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 			show_hud(hud_version, M)
 	else if (viewmob.hud_used)
 		viewmob.hud_used.plane_masters_update()
+		viewmob.client.screen -= hide_actions_toggle // Hide this from the observer
 
 	return TRUE
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -867,7 +867,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /datum/action/unobserve/Trigger()
 	owner.reset_perspective(null)
-	Remove(owner)
+	qdel(src)
 
 /datum/action/unobserve/IsAvailable()
 	return TRUE

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -856,6 +856,22 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			mob_eye.observers |= src
 			mob_eye.hud_used.show_hud(mob_eye.hud_used.hud_version, src)
 			observetarget = mob_eye
+			var/datum/action/unobserve/UO = new // Convinent way to unobserve
+			UO.Grant(src)
+
+/datum/action/unobserve
+	name = "Stop Observing"
+	desc = "Stops observing the person."
+	icon_icon = 'icons/mob/mob.dmi'
+	button_icon_state = "ghost_nodir"
+
+/datum/action/unobserve/Trigger()
+	owner.reset_perspective(null)
+	Remove(owner)
+
+/datum/action/unobserve/IsAvailable()
+	return TRUE
+
 
 /mob/dead/observer/proc/on_observing_z_changed(datum/source, turf/old_turf, turf/new_turf)
 	SHOULD_NOT_SLEEP(TRUE)


### PR DESCRIPTION
# Document the changes in your pull request
![image](https://user-images.githubusercontent.com/20369082/178122086-40707b41-7061-4d20-89d7-72ebcb7eeab6.png)

Allows you to quickly stop observing
Also removes the hide action button that will sometimes show up

# Changelog

:cl:  
rscadd: Gives ghost a unobserve button
/:cl:
