### PR TITLE
Non-dwarves no longer have a chance to say dwarf related lines while mining

### DIFF
--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -84,9 +84,10 @@
 	playsound(src, 'sound/effects/break_stone.ogg', 50, 1) //beautiful destruction
 	if(iscarbon(user)) 	//yogs - rock and stone
 		var/mob/living/carbon/C = user
-		if(prob(0.5) || (prob(1.5) && C.dna?.check_mutation(DWARFISM)))
+		if(prob(2) && C.dna?.check_mutation(DWARFISM))
 			var/picked_phrase = pick(list("Rock and stone!","Rock and rollin' stone!","For rock and stone!","Rock solid!"))
 			C.say(picked_phrase)
+
 /turf/closed/mineral/proc/attempt_drill(mob/user,triggered_by_explosion = FALSE, power = 1)
 	hardness -= power
 	if(hardness <= 0)

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -84,7 +84,7 @@
 	playsound(src, 'sound/effects/break_stone.ogg', 50, 1) //beautiful destruction
 	if(iscarbon(user)) 	//yogs - rock and stone
 		var/mob/living/carbon/C = user
-		if(prob(2) && C.dna?.check_mutation(DWARFISM))
+		if(prob(1.5) && C.dna?.check_mutation(DWARFISM))
 			var/picked_phrase = pick(list("Rock and stone!","Rock and rollin' stone!","For rock and stone!","Rock solid!"))
 			C.say(picked_phrase)
 

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -84,7 +84,7 @@
 	playsound(src, 'sound/effects/break_stone.ogg', 50, 1) //beautiful destruction
 	if(iscarbon(user)) 	//yogs - rock and stone
 		var/mob/living/carbon/C = user
-		if(prob(1.5) && C.dna?.check_mutation(DWARFISM))
+		if(prob(1) && C.dna?.check_mutation(DWARFISM))
 			var/picked_phrase = pick(list("Rock and stone!","Rock and rollin' stone!","For rock and stone!","Rock solid!"))
 			C.say(picked_phrase)
 


### PR DESCRIPTION
# Document the changes in your pull request

hey guys let's shoehorn in a reference in the most obtrusive way possible

# Changelog

:cl:  
tweak: Non-dwarves no longer have a chance to say dwarf related lines while mining
/:cl:
