### PR TITLE
Fixes Sleepers Not Checking If Occupants Are Silicons

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -185,8 +185,10 @@
 /obj/machinery/sleeper/process()
 	..()
 	check_nap_violations()
+	if(issilicon(occupant))
+		return
 	var/mob/living/carbon/C = occupant
-	if(!issilicon(occupant))
+	if(C)
 		if(stasis && (C.stat == DEAD || C.health < 0))
 			C.apply_status_effect(STATUS_EFFECT_STASIS, null, TRUE)
 		else

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -186,7 +186,7 @@
 	..()
 	check_nap_violations()
 	var/mob/living/carbon/C = occupant
-	if(iscarbon(occupant))
+	if(!issilicon(occupant))
 		if(stasis && (C.stat == DEAD || C.health < 0))
 			C.apply_status_effect(STATUS_EFFECT_STASIS, null, TRUE)
 		else

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -186,7 +186,7 @@
 	..()
 	check_nap_violations()
 	var/mob/living/carbon/C = occupant
-	if(C)
+	if(iscarbon(occupant))
 		if(stasis && (C.stat == DEAD || C.health < 0))
 			C.apply_status_effect(STATUS_EFFECT_STASIS, null, TRUE)
 		else


### PR DESCRIPTION
No more free silicon repairs

# Document the changes in your pull request

Originally they simply set all people inside the machine to Occupant, without checking at all if they were a carbon, despite that being the intention. This let you heal silicons if an iscarbon would fail. This change fixes this.

# Changelog

:cl:  VaelophisNyx, @Chubbygummibear 
bugfix: You may no longer repair silicons in a sleeper
/:cl:
