### PR TITLE
Adds Fullupgrade Borg Charger Variant & Adds it to Nukie/Infil related maps and shuttles

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -23139,21 +23139,6 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/evac)
-"aUj" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/mineral/plastitanium,
-/area/yogs/infiltrator_base)
 "aUk" = (
 /obj/structure/flora/tree/pine,
 /turf/open/floor/holofloor/snow,
@@ -24313,21 +24298,6 @@
 	icon_state = "darkfull"
 	},
 /area/holodeck/rec_center/gym)
-"aWF" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	pixel_y = 24;
-	req_access = 150
-	},
-/obj/structure/table,
-/obj/item/storage/toolbox/syndicate,
-/obj/item/flashlight,
-/turf/open/floor/mineral/plastitanium,
-/area/yogs/infiltrator_base)
 "aWG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -26074,6 +26044,22 @@
 "dbb" = (
 /turf/open/indestructible/wiki/greenscreen,
 /area/centcom/testchamber)
+"dgz" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm{
+	pixel_y = 24;
+	req_access = 150
+	},
+/obj/structure/table,
+/obj/item/storage/toolbox/syndicate,
+/obj/item/flashlight,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/mineral/plastitanium,
+/area/yogs/infiltrator_base)
 "dgH" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info25"
@@ -26247,6 +26233,20 @@
 	icon_state = "title2"
 	},
 /area/centcom/testchamber)
+"nfW" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/obj/machinery/recharge_station/fullupgrade,
+/turf/open/floor/mineral/plastitanium,
+/area/yogs/infiltrator_base)
 "nIM" = (
 /turf/open/indestructible/wiki/title{
 	icon_state = "title8"
@@ -26284,6 +26284,10 @@
 	icon_state = "info11"
 	},
 /area/centcom/testchamber)
+"ria" = (
+/obj/machinery/recharge_station/fullupgrade,
+/turf/open/floor/plasteel/dark,
+/area/syndicate_mothership/control)
 "rib" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info7"
@@ -42493,7 +42497,7 @@ aSh
 aVw
 afo
 aSA
-aWF
+dgz
 aPX
 aLw
 aBm
@@ -43521,7 +43525,7 @@ adu
 aUR
 abs
 aSA
-aUj
+nfW
 ayS
 aLw
 aLD
@@ -45646,7 +45650,7 @@ aVf
 apZ
 awp
 aku
-axG
+ria
 axG
 axG
 azx

--- a/_maps/map_files/generic/City_of_Cogs.dmm
+++ b/_maps/map_files/generic/City_of_Cogs.dmm
@@ -279,6 +279,10 @@
 "Ct" = (
 /turf/closed/indestructible/riveted,
 /area/reebe)
+"Us" = (
+/obj/machinery/recharge_station/fullupgrade,
+/turf/open/floor/clockwork/reebe,
+/area/reebe/city_of_cogs)
 "Vl" = (
 /obj/structure/table/reinforced/brass,
 /obj/effect/landmark/servant_of_ratvar/scarab,
@@ -4602,7 +4606,7 @@ ai
 am
 aj
 aj
-aj
+Us
 as
 ah
 ah

--- a/_maps/map_files/generic/City_of_Cogs.dmm
+++ b/_maps/map_files/generic/City_of_Cogs.dmm
@@ -279,10 +279,6 @@
 "Ct" = (
 /turf/closed/indestructible/riveted,
 /area/reebe)
-"Us" = (
-/obj/machinery/recharge_station/fullupgrade,
-/turf/open/floor/clockwork/reebe,
-/area/reebe/city_of_cogs)
 "Vl" = (
 /obj/structure/table/reinforced/brass,
 /obj/effect/landmark/servant_of_ratvar/scarab,
@@ -4606,7 +4602,7 @@ ai
 am
 aj
 aj
-Us
+aj
 as
 ah
 ah

--- a/_maps/shuttles/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator_basic.dmm
@@ -1166,10 +1166,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/shuttle/syndicate/hallway)
-"cs" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/circuit/red,
-/area/shuttle/syndicate/armory)
 "ct" = (
 /obj/machinery/telecomms/allinone{
 	intercept = 1
@@ -1285,6 +1281,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/syndicate/airlock)
+"sI" = (
+/obj/machinery/recharge_station/fullupgrade,
+/turf/open/floor/circuit/red,
+/area/shuttle/syndicate/armory)
 "tZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -1730,7 +1730,7 @@ bO
 bW
 cg
 bP
-cs
+sI
 cy
 cE
 "}
@@ -1780,7 +1780,7 @@ bQ
 bX
 ci
 cn
-cs
+sI
 cy
 cG
 "}

--- a/_maps/shuttles/infiltrator_cutter.dmm
+++ b/_maps/shuttles/infiltrator_cutter.dmm
@@ -336,19 +336,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/yogs/stealthcruiser)
-"aQ" = (
-/obj/machinery/sleeper{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24;
-	req_access = null;
-	req_access_txt = "150"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/yogs/stealthcruiser)
 "aR" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate/freezer/blood,
@@ -866,26 +853,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/yogs/stealthcruiser)
-"pF" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Syndicate Cutter APC";
-	pixel_x = -25;
-	req_access = 150
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24;
-	req_access = 150
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/shuttle/yogs/stealthcruiser)
 "rY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm{
@@ -1030,9 +997,33 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/yogs/stealthcruiser)
+"No" = (
+/obj/machinery/recharge_station/fullupgrade,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Syndicate Cutter APC";
+	pixel_x = -25;
+	req_access = 150
+	},
+/turf/open/floor/plating,
+/area/shuttle/yogs/stealthcruiser)
 "Pz" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
+/area/shuttle/yogs/stealthcruiser)
+"QS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24;
+	req_access = 150
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
 /area/shuttle/yogs/stealthcruiser)
 "Re" = (
 /obj/machinery/button/door{
@@ -1046,6 +1037,19 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
+/area/shuttle/yogs/stealthcruiser)
+"Vb" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24;
+	req_access = null;
+	req_access_txt = "150"
+	},
+/obj/machinery/sleeper/syndie/fullupgrade{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/shuttle/yogs/stealthcruiser)
 "Ys" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1118,7 +1122,7 @@ ad
 am
 az
 aL
-ad
+No
 Dr
 Ey
 cP
@@ -1133,7 +1137,7 @@ ag
 an
 aA
 aM
-pF
+QS
 Ys
 aA
 bH
@@ -1207,7 +1211,7 @@ ad
 ad
 as
 aD
-aQ
+Vb
 ad
 bp
 aD

--- a/_maps/shuttles/infiltrator_cutter.dmm
+++ b/_maps/shuttles/infiltrator_cutter.dmm
@@ -853,6 +853,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/yogs/stealthcruiser)
+"qo" = (
+/obj/machinery/power/smes/fullycharged,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/shuttle/yogs/stealthcruiser)
 "rY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm{
@@ -916,16 +926,8 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/yogs/stealthcruiser)
-"Dr" = (
-/obj/machinery/power/smes/fullycharged,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
+"Bd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/yogs/stealthcruiser)
 "Ey" = (
@@ -981,6 +983,19 @@
 /obj/machinery/computer/crew/syndie,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/yogs/stealthcruiser)
+"JT" = (
+/obj/machinery/recharge_station/fullupgrade,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Syndicate Cutter APC";
+	pixel_x = -25;
+	req_access = 150
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/shuttle/yogs/stealthcruiser)
 "Lb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -997,33 +1012,9 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/yogs/stealthcruiser)
-"No" = (
-/obj/machinery/recharge_station/fullupgrade,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Syndicate Cutter APC";
-	pixel_x = -25;
-	req_access = 150
-	},
-/turf/open/floor/plating,
-/area/shuttle/yogs/stealthcruiser)
 "Pz" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
-/area/shuttle/yogs/stealthcruiser)
-"QS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24;
-	req_access = 150
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
 /area/shuttle/yogs/stealthcruiser)
 "Re" = (
 /obj/machinery/button/door{
@@ -1038,6 +1029,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/yogs/stealthcruiser)
+"SN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24;
+	req_access = 150
+	},
+/turf/open/floor/plating,
+/area/shuttle/yogs/stealthcruiser)
 "Vb" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/airalarm{
@@ -1050,13 +1052,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/yogs/stealthcruiser)
-"Ys" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
 /area/shuttle/yogs/stealthcruiser)
 "YI" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -1122,8 +1117,8 @@ ad
 am
 az
 aL
-No
-Dr
+JT
+qo
 Ey
 cP
 ad
@@ -1137,8 +1132,8 @@ ag
 an
 aA
 aM
-QS
-Ys
+SN
+Bd
 aA
 bH
 bQ

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -101,3 +101,17 @@
 	if(!occupant)
 		return
 	SEND_SIGNAL(occupant, COMSIG_PROCESS_BORGCHARGER_OCCUPANT, recharge_speed, repairs)
+
+/obj/machinery/recharge_station/fullupgrade
+	flags_1 = NODECONSTRUCT_1
+
+/obj/machinery/recharge_station/fullupgrade/Initialize()
+	. = ..()
+	update_icon()
+	component_parts = list()
+	component_parts += new /obj/item/circuitboard/machine/cyborgrecharger(null)
+	component_parts += new /obj/item/stock_parts/capacitor/quadratic(null)
+	component_parts += new /obj/item/stock_parts/capacitor/quadratic(null)
+	component_parts += new /obj/item/stock_parts/manipulator/femto(null)
+	component_parts += new /obj/item/stock_parts/cell/bluespace(null)
+	RefreshParts()


### PR DESCRIPTION
Replaces normal variant where any existed for addition to nukie/infil ship/base
compensation for https://github.com/yogstation13/Yogstation/pull/14792 removing fast borg healing from nukies

# Document the changes in your pull request

Adds a "fullupgrade" subtype for cyborg recharger stations, spawning them with t4 parts and NODECONSTRUCT so you cant use them to get free T4 parts.
Adds the new fullupgrade subtype chargers to nukie and infil related ships and bases. Also swaps the infil cutter sleeper with the syndie variant. had to remove a wall in the engineering area to fit the new charger, and shuffled the APC backward one tile to the wall again to fit.

# Changelog

:cl:  
rscadd: Added fullupgrade subtype of recharger_station for mappers
tweak: replaces borg chargers  in the nuke ops ship with fullupgrade borg chargers
rscadd: adds fullupgrad borg chargers to the nuclear ops base
rscadd: adds fullupgrad borg chargers to the infiltrator ship
rscadd: adds fullupgrad borg chargers to the infiltrator base
tweak: swapped the infiltrator ship's sleeper with a syndicate variant
/:cl:
