### PR TITLE
Anyone with Brig Access Can Download Secureye + Brig Phys Laptop!

### DIFF
--- a/code/modules/modular_computers/computers/item/laptop_presets.dm
+++ b/code/modules/modular_computers/computers/item/laptop_presets.dm
@@ -7,3 +7,7 @@
 /obj/item/modular_computer/laptop/preset/civillian
 	desc = "A low-end laptop often used for personal recreation."
 	starting_files = list(new /datum/computer_file/program/chatclient)
+
+/obj/item/modular_computer/laptop/preset/brig_physician
+	desc = "A low-end laptop often used by brig physicians."
+	starting_files = list(new /datum/computer_file/program/SecurEye)

--- a/code/modules/modular_computers/computers/item/laptop_presets.dm
+++ b/code/modules/modular_computers/computers/item/laptop_presets.dm
@@ -10,4 +10,4 @@
 
 /obj/item/modular_computer/laptop/preset/brig_physician
 	desc = "A low-end laptop often used by brig physicians."
-	starting_files = list(new /datum/computer_file/program/SecurEye)
+	starting_files = list(new /datum/computer_file/program/secureye)

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -7,7 +7,7 @@
 	program_icon_state = "generic"
 	extended_desc = "This program allows access to standard security camera networks."
 	requires_ntnet = TRUE
-	transfer_access = ACCESS_SECURITY, ACCESS_BRIG_PHYS
+	transfer_access = ACCESS_BRIG
 	usage_flags = PROGRAM_CONSOLE | PROGRAM_LAPTOP | PROGRAM_INTEGRATED // Probably not a good idea to let borgs use this, though im curious how it will pan out
 	size = 10
 	tgui_id = "NtosSecurEye"

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -7,7 +7,7 @@
 	program_icon_state = "generic"
 	extended_desc = "This program allows access to standard security camera networks."
 	requires_ntnet = TRUE
-	transfer_access = (ACCESS_SECURITY, ACCESS_BRIG_PHYS)
+	transfer_access = ACCESS_SECURITY, ACCESS_BRIG_PHYS
 	usage_flags = PROGRAM_CONSOLE | PROGRAM_LAPTOP | PROGRAM_INTEGRATED // Probably not a good idea to let borgs use this, though im curious how it will pan out
 	size = 10
 	tgui_id = "NtosSecurEye"

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -7,7 +7,7 @@
 	program_icon_state = "generic"
 	extended_desc = "This program allows access to standard security camera networks."
 	requires_ntnet = TRUE
-	transfer_access = ACCESS_SECURITY
+	transfer_access = (ACCESS_SECURITY, ACCESS_BRIG_PHYS)
 	usage_flags = PROGRAM_CONSOLE | PROGRAM_LAPTOP | PROGRAM_INTEGRATED // Probably not a good idea to let borgs use this, though im curious how it will pan out
 	size = 10
 	tgui_id = "NtosSecurEye"

--- a/yogstation/code/modules/jobs/job_types/brig_physician.dm
+++ b/yogstation/code/modules/jobs/job_types/brig_physician.dm
@@ -50,6 +50,6 @@
 	satchel = /obj/item/storage/backpack/satchel/med
 	duffelbag = /obj/item/storage/backpack/duffelbag/med
 	box = /obj/item/storage/box/survival
-	backpack_contents = list(/obj/item/modular_computer/laptop/preset/civillian=1)
+	backpack_contents = list(/obj/item/modular_computer/laptop/preset/preset=1)
 
 	implants = list(/obj/item/implant/mindshield)

--- a/yogstation/code/modules/jobs/job_types/brig_physician.dm
+++ b/yogstation/code/modules/jobs/job_types/brig_physician.dm
@@ -50,6 +50,6 @@
 	satchel = /obj/item/storage/backpack/satchel/med
 	duffelbag = /obj/item/storage/backpack/duffelbag/med
 	box = /obj/item/storage/box/survival
-	backpack_contents = list(/obj/item/modular_computer/tablet/phone/preset/cheap=1)
+	backpack_contents = list(/obj/item/modular_computer/laptop/preset/brig_physician=1)
 
 	implants = list(/obj/item/implant/mindshield)

--- a/yogstation/code/modules/jobs/job_types/brig_physician.dm
+++ b/yogstation/code/modules/jobs/job_types/brig_physician.dm
@@ -44,7 +44,7 @@
 	uniform = /obj/item/clothing/under/yogs/rank/miner/medic
 	suit = /obj/item/clothing/suit/toggle/labcoat/emt/physician
 	l_hand = /obj/item/storage/firstaid/regular
-	r_hand = list(/obj/item/modular_computer/laptop/preset/brig_physician=1)
+	r_hand = /obj/item/modular_computer/laptop/preset/brig_physician=1
 	gloves = /obj/item/clothing/gloves/color/latex
 	head = /obj/item/clothing/head/soft/emt/phys
 	backpack = /obj/item/storage/backpack/medic

--- a/yogstation/code/modules/jobs/job_types/brig_physician.dm
+++ b/yogstation/code/modules/jobs/job_types/brig_physician.dm
@@ -50,6 +50,6 @@
 	satchel = /obj/item/storage/backpack/satchel/med
 	duffelbag = /obj/item/storage/backpack/duffelbag/med
 	box = /obj/item/storage/box/survival
-	backpack_contents = list(/obj/item/modular_computer/laptop/preset)
+	backpack_contents = list(/obj/item/modular_computer/laptop/preset/civillian=1)
 
 	implants = list(/obj/item/implant/mindshield)

--- a/yogstation/code/modules/jobs/job_types/brig_physician.dm
+++ b/yogstation/code/modules/jobs/job_types/brig_physician.dm
@@ -50,6 +50,6 @@
 	satchel = /obj/item/storage/backpack/satchel/med
 	duffelbag = /obj/item/storage/backpack/duffelbag/med
 	box = /obj/item/storage/box/survival
-	backpack_contents = list(/obj/item/modular_computer/laptop/preset=1)
+	backpack_contents = list(/obj/item/modular_computer/tablet/phone/preset/cheap=1)
 
 	implants = list(/obj/item/implant/mindshield)

--- a/yogstation/code/modules/jobs/job_types/brig_physician.dm
+++ b/yogstation/code/modules/jobs/job_types/brig_physician.dm
@@ -44,12 +44,12 @@
 	uniform = /obj/item/clothing/under/yogs/rank/miner/medic
 	suit = /obj/item/clothing/suit/toggle/labcoat/emt/physician
 	l_hand = /obj/item/storage/firstaid/regular
+	r_hand = list(/obj/item/modular_computer/laptop/preset/brig_physician=1)
 	gloves = /obj/item/clothing/gloves/color/latex
 	head = /obj/item/clothing/head/soft/emt/phys
 	backpack = /obj/item/storage/backpack/medic
 	satchel = /obj/item/storage/backpack/satchel/med
 	duffelbag = /obj/item/storage/backpack/duffelbag/med
 	box = /obj/item/storage/box/survival
-	backpack_contents = list(/obj/item/modular_computer/laptop/preset/brig_physician=1)
 
 	implants = list(/obj/item/implant/mindshield)

--- a/yogstation/code/modules/jobs/job_types/brig_physician.dm
+++ b/yogstation/code/modules/jobs/job_types/brig_physician.dm
@@ -50,5 +50,6 @@
 	satchel = /obj/item/storage/backpack/satchel/med
 	duffelbag = /obj/item/storage/backpack/duffelbag/med
 	box = /obj/item/storage/box/survival
+	backpack_contents = list(/obj/item/modular_computer/tablet/pda/preset/basic=1)
 
 	implants = list(/obj/item/implant/mindshield)

--- a/yogstation/code/modules/jobs/job_types/brig_physician.dm
+++ b/yogstation/code/modules/jobs/job_types/brig_physician.dm
@@ -50,6 +50,6 @@
 	satchel = /obj/item/storage/backpack/satchel/med
 	duffelbag = /obj/item/storage/backpack/duffelbag/med
 	box = /obj/item/storage/box/survival
-	backpack_contents = list(/obj/item/modular_computer/laptop/preset/basic=1)
+	backpack_contents = list(/obj/item/modular_computer/laptop)
 
 	implants = list(/obj/item/implant/mindshield)

--- a/yogstation/code/modules/jobs/job_types/brig_physician.dm
+++ b/yogstation/code/modules/jobs/job_types/brig_physician.dm
@@ -50,6 +50,6 @@
 	satchel = /obj/item/storage/backpack/satchel/med
 	duffelbag = /obj/item/storage/backpack/duffelbag/med
 	box = /obj/item/storage/box/survival
-	backpack_contents = list(/obj/item/modular_computer/tablet/pda/preset/basic=1)
+	backpack_contents = list(/obj/item/modular_computer/laptop/preset/basic=1)
 
 	implants = list(/obj/item/implant/mindshield)

--- a/yogstation/code/modules/jobs/job_types/brig_physician.dm
+++ b/yogstation/code/modules/jobs/job_types/brig_physician.dm
@@ -44,7 +44,7 @@
 	uniform = /obj/item/clothing/under/yogs/rank/miner/medic
 	suit = /obj/item/clothing/suit/toggle/labcoat/emt/physician
 	l_hand = /obj/item/storage/firstaid/regular
-	r_hand = /obj/item/modular_computer/laptop/preset/brig_physician=1
+	r_hand = /obj/item/modular_computer/laptop/preset/brig_physician
 	gloves = /obj/item/clothing/gloves/color/latex
 	head = /obj/item/clothing/head/soft/emt/phys
 	backpack = /obj/item/storage/backpack/medic

--- a/yogstation/code/modules/jobs/job_types/brig_physician.dm
+++ b/yogstation/code/modules/jobs/job_types/brig_physician.dm
@@ -50,6 +50,6 @@
 	satchel = /obj/item/storage/backpack/satchel/med
 	duffelbag = /obj/item/storage/backpack/duffelbag/med
 	box = /obj/item/storage/box/survival
-	backpack_contents = list(/obj/item/modular_computer/laptop/preset/preset=1)
+	backpack_contents = list(/obj/item/modular_computer/laptop/preset=1)
 
 	implants = list(/obj/item/implant/mindshield)

--- a/yogstation/code/modules/jobs/job_types/brig_physician.dm
+++ b/yogstation/code/modules/jobs/job_types/brig_physician.dm
@@ -50,6 +50,6 @@
 	satchel = /obj/item/storage/backpack/satchel/med
 	duffelbag = /obj/item/storage/backpack/duffelbag/med
 	box = /obj/item/storage/box/survival
-	backpack_contents = list(/obj/item/modular_computer/laptop)
+	backpack_contents = list(/obj/item/modular_computer/laptop/preset)
 
 	implants = list(/obj/item/implant/mindshield)


### PR DESCRIPTION

# Document the changes in your pull request

Allows anyone with brig access can now download secureye on a laptop (So pretty much adding heads + brig phys), and Brig Phys gets its own laptop that they spawn in with in their right hand.

# Changelog
:cl:  
rscadd: Brig Phys Laptop
tweak: Secureye Access from security to brig.
/:cl:
