### PR TITLE
Ports TG geysers (the correct way)

### DIFF
--- a/code/datums/mapgen/CaveGenerator.dm
+++ b/code/datums/mapgen/CaveGenerator.dm
@@ -43,7 +43,7 @@
 	if(!flora_spawn_list)
 		flora_spawn_list = list(/obj/structure/flora/ash/leaf_shroom = 2 , /obj/structure/flora/ash/cap_shroom = 2 , /obj/structure/flora/ash/stem_shroom = 2 , /obj/structure/flora/ash/cacti = 1, /obj/structure/flora/ash/tall_shroom = 2)
 	if(!feature_spawn_list)
-		feature_spawn_list = list(/obj/structure/geyser/random = 1)
+		feature_spawn_list = list() //yogs no geysers in asteroid caves
 
 /datum/map_generator/cave_generator/generate_terrain(list/turfs)
 	. = ..()

--- a/code/datums/mapgen/Cavegens/LavalandGenerator.dm
+++ b/code/datums/mapgen/Cavegens/LavalandGenerator.dm
@@ -10,8 +10,7 @@
 	)
 	flora_spawn_list = list(/obj/structure/flora/ash/leaf_shroom = 2 , /obj/structure/flora/ash/cap_shroom = 2 , /obj/structure/flora/ash/stem_shroom = 2 , /obj/structure/flora/ash/cacti = 1, /obj/structure/flora/ash/tall_shroom = 2)
 	///Note that this spawn list is also in the icemoon generator
-	//feature_spawn_list = list(/obj/structure/geyser/wittel = 6, /obj/structure/geyser/random = 2, /obj/structure/geyser/plasma_oxide = 10, /obj/structure/geyser/protozine = 10, /obj/structure/geyser/hollowwater = 10)
-	feature_spawn_list = list(/obj/structure/geyser/random = 1)
+	feature_spawn_list = list(/obj/structure/geyser/ash = 10, /obj/structure/geyser/random = 2, /obj/structure/geyser/stable_plasma = 6, /obj/structure/geyser/oil = 8,/obj/structure/geyser/protozine = 10,/obj/structure/geyser/holywater = 2) //yogs, yes geysers
 
 	initial_closed_chance = 45
 	smoothing_iterations = 50

--- a/code/game/objects/structures/lavaland/geyser.dm
+++ b/code/game/objects/structures/lavaland/geyser.dm
@@ -7,12 +7,34 @@
 	icon_state = "geyser"
 	anchored = TRUE
 
-	var/erupting_state = null //set to null to get it greyscaled from "[icon_state]_soup". Not very usable with the whole random thing, but more types can be added if you change the spawn prob
-	var/activated = FALSE //whether we are active and generating chems
+	///set to null to get it greyscaled from "[icon_state]_soup". Not very usable with the whole random thing, but more types can be added if you change the spawn prob
+	var/erupting_state = null
+	//whether we are active and generating chems
+	var/activated = FALSE
+	///what chem do we produce?
 	var/reagent_id = /datum/reagent/oil
-	var/potency = 2 //how much reagents we add every process (2 seconds)
+	///how much reagents we add every process (2 seconds)
+	var/potency = 2
+	///maximum volume
 	var/max_volume = 500
+	///how much we start with after getting activated
 	var/start_volume = 50
+
+	///Have we been discovered with a mining scanner?
+	var/discovered = FALSE
+	///How many points we grant to whoever discovers us
+	var/point_value = 100
+	///what's our real name that will show upon discovery? null to do nothing
+	var/true_name
+	///the message given when you discover this geyser.
+	var/discovery_message = null
+	///The internal GPS once this is discovered
+	var/obj/item/gps/internal
+
+/obj/structure/geyser/Destroy()
+	QDEL_NULL(internal)
+	. = ..()
+	
 
 /obj/structure/geyser/proc/start_chemming()
 	activated = TRUE
@@ -42,13 +64,72 @@
 	if(do_after(user, 5 SECONDS*P.plunge_mod, src) && !activated)
 		start_chemming()
 
+/obj/structure/geyser/attackby(obj/item/item, mob/user, params)
+	if(!istype(item, /obj/item/mining_scanner) && !istype(item, /obj/item/t_scanner/adv_mining_scanner))
+		return ..() //this runs the plunger code
+
+	if(discovered)
+		to_chat(user, span_warning("This geyser has already been discovered!"))
+		return
+
+	to_chat(user, span_notice("You discovered the geyser and mark it on the GPS system!"))
+	if(discovery_message)
+		to_chat(user, discovery_message)
+
+	discovered = TRUE
+	if(true_name)
+		name = true_name
+
+	internal = new /obj/item/gps/internal/geyser(src) //put it on the gps so miners can mark it and chemists can profit off of it //Yogs - LOL NO!
+	internal.gpstag = true_name
+
+	if(isliving(user))
+		var/mob/living/living = user
+
+		var/obj/item/card/id/card = living.get_idcard()
+		if(card)
+			to_chat(user, span_notice("[point_value] mining points have been paid out!"))
+			card.mining_points += point_value
+			playsound(src, 'sound/machines/ping.ogg', 15, TRUE)
+
+/obj/structure/geyser/ash
+	reagent_id = /datum/reagent/ash
+	true_name = "ash geyser"
+
+/obj/structure/geyser/stable_plasma
+	reagent_id = /datum/reagent/stable_plasma
+	true_name = "plasma geyser"
+
+/obj/structure/geyser/oil
+	reagent_id = /datum/reagent/oil
+	true_name = "oil geyser"
+
+/obj/structure/geyser/protozine
+	reagent_id = /datum/reagent/medicine/omnizine/protozine
+	true_name = "protozine geyser"
+
+/obj/structure/geyser/holywater
+	point_value = 250
+	reagent_id = /datum/reagent/water/holywater
+	true_name = "holy water geyser"
+	start_volume = 5
+	max_volume = 50
+	potency = 0.5
+
 /obj/structure/geyser/random
-	erupting_state = null
-	var/list/options = list(/datum/reagent/oil = 2, /datum/reagent/clf3 = 1) //fucking add more
+	point_value = 500
+	true_name = "strange geyser"
+	discovery_message = "It's a strange geyser! How does any of this even work?" //it doesnt
 
 /obj/structure/geyser/random/Initialize()
 	. = ..()
-	reagent_id = pickweight(options)
+	reagent_id = get_random_reagent_id()
+
+/obj/item/gps/internal/geyser
+	icon_state = null
+	gpstag = "Geyser"
+	desc = "Chemicals come from deep below."
+	invisibility = 100
 
 /obj/item/plunger
 	name = "plunger"
@@ -57,16 +138,16 @@
 	icon_state = "plunger"
 
 	var/plunge_mod = 1 //time*plunge_mod = total time we take to plunge an object
-	var/reinforced = FALSE //whether we do heavy duty stuff like geysers
+	var/reinforced = TRUE //whether we do heavy duty stuff like geysers / TG made all plungers reinforced
 
 /obj/item/plunger/attack_obj(obj/O, mob/living/user)
 	if(!O.plunger_act(src, user, reinforced))
 		return ..()
 
+//UNUSED, NORMAL PLUNGERS ARE REINFORCED TOO NOW.
 /obj/item/plunger/reinforced
 	name = "reinforced plunger"
 	desc = " It's an M. 7 Reinforced Plunger© for heavy duty plunging."
 	icon_state = "reinforced_plunger"
 
-	reinforced = TRUE
 	plunge_mod = 0.8

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -141,6 +141,15 @@
 	category = list("initial","Tools","Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
+/datum/design/plunger
+	name = "Plunger"
+	id = "plunger"
+	build_type = AUTOLATHE | PROTOLATHE
+	materials = list(/datum/material/iron = 150)
+	build_path = /obj/item/plunger
+	category = list("initial","Tools","Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_CARGO | DEPARTMENTAL_FLAG_MEDICAL //yogs, no plumbing so only cargo (miners) and medical
+
 /datum/design/welding_helmet
 	name = "Welding Helmet"
 	id = "welding_helmet"


### PR DESCRIPTION
# Document the changes in your pull request

Ports the geyser changes TG has had since we've implemented ours.
Adds a autolathe/protolathe design datum for cargo (miners) and medical.
Switches normal plungers to be reinforced.
Gives points when you discover them and marks them on the GPS.

SuperSlayer's brings us further away from parity with TG while doing nothing new or interesting and creates more code bloat. I have however taken the idea of getting plasma from them.

Reagents available:
Ash
Stable Plasma
Oil
Protozine
Holy Water
small chance for OOOO RANDOM!!!

Closes https://github.com/yogstation13/Yogstation/pull/14779

# Wiki Documentation

Geyser section for Shaft Miners

# Changelog

:cl:  
rscadd: ports tg's geyser changes to bring us up to parity
/:cl:
