### PR TITLE
Cybernetic Eye Nerf

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -220,6 +220,7 @@
 #define TRAIT_NOPULSE           "nopulse" // Your heart doesn't beat
 #define TRAIT_MASQUERADE        "masquerade" // Falsifies Health analyzer blood levels
 #define TRAIT_COLDBLOODED       "coldblooded" // Your body is literal room temperature. Does not make you immune to the temp 
+#define TRAIT_MESONS
 
 //non-mob traits
 /// Used for limb-based paralysis, where replacing the limb will fix it.

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -220,7 +220,7 @@
 #define TRAIT_NOPULSE           "nopulse" // Your heart doesn't beat
 #define TRAIT_MASQUERADE        "masquerade" // Falsifies Health analyzer blood levels
 #define TRAIT_COLDBLOODED       "coldblooded" // Your body is literal room temperature. Does not make you immune to the temp 
-#define TRAIT_MESONS
+#define TRAIT_MESONS			"mesons"
 
 //non-mob traits
 /// Used for limb-based paralysis, where replacing the limb will fix it.

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -67,11 +67,11 @@
 /obj/item/clothing/glasses/meson/equipped(mob/user, slot)
 	. = ..()
 	if(ishuman(user) && slot == SLOT_GLASSES)
-		ADD_TRAIT(user, TRAIT_MESON, CLOTHING_TRAIT)
+		ADD_TRAIT(user, TRAIT_MESONS, CLOTHING_TRAIT)
 
 /obj/item/clothing/glasses/meson/dropped(mob/user)
 	. = ..()
-	REMOVE_TRAIT(user, TRAIT_MESON, CLOTHING_TRAIT)
+	REMOVE_TRAIT(user, TRAIT_MESONS, CLOTHING_TRAIT)
 
 /obj/item/clothing/glasses/meson/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] is putting \the [src] to [user.p_their()] eyes and overloading the brightness! It looks like [user.p_theyre()] trying to commit suicide!"))

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -64,6 +64,15 @@
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 	glass_colour_type = /datum/client_colour/glass_colour/lightgreen
 
+/obj/item/clothing/glasses/meson/equipped(mob/user, slot)
+	. = ..()
+	if(ishuman(user) && slot == SLOT_GLASSES)
+		ADD_TRAIT(user, TRAIT_MESON, CLOTHING_TRAIT)
+
+/obj/item/clothing/glasses/meson/dropped(mob/user)
+	. = ..()
+	REMOVE_TRAIT(user, TRAIT_MESON, CLOTHING_TRAIT)
+
 /obj/item/clothing/glasses/meson/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] is putting \the [src] to [user.p_their()] eyes and overloading the brightness! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return BRUTELOSS

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -231,8 +231,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 /obj/machinery/power/supermatter_crystal/examine(mob/user)
 	. = ..()
 	if (istype(user, /mob/living/carbon))
-		var/mob/living/carbon/C = user
-		if ((!HAS_TRAIT(C, TRAIT_MESONS)) && (get_dist(user, src) < HALLUCINATION_RANGE(power)))
+		if ((!HAS_TRAIT(user, TRAIT_MESONS)) && (get_dist(user, src) < HALLUCINATION_RANGE(power)))
 			. += span_danger("You get headaches just from looking at it.")
 
 /obj/machinery/power/supermatter_crystal/proc/get_status()
@@ -542,7 +541,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			air_update_turf()
 
 	for(var/mob/living/carbon/human/l in view(src, HALLUCINATION_RANGE(power))) // If they can see it without mesons on.  Bad on them.
-		if((!HAS_TRAIT(C, TRAIT_MESONS)) || corruptor_attached)
+		if((!HAS_TRAIT(l, TRAIT_MESONS)) || corruptor_attached)
 			var/D = sqrt(1 / max(1, get_dist(l, src)))
 			l.hallucination += power * config_hallucination_power * D
 			l.hallucination = clamp(l.hallucination, 0, 200)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -232,7 +232,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	. = ..()
 	if (istype(user, /mob/living/carbon))
 		var/mob/living/carbon/C = user
-		if (!istype(C.glasses, /obj/item/clothing/glasses/meson) && (get_dist(user, src) < HALLUCINATION_RANGE(power)))
+		if ((!HAS_TRAIT(C, TRAIT_MESONS)) && (get_dist(user, src) < HALLUCINATION_RANGE(power)))
 			. += span_danger("You get headaches just from looking at it.")
 
 /obj/machinery/power/supermatter_crystal/proc/get_status()
@@ -542,7 +542,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			air_update_turf()
 
 	for(var/mob/living/carbon/human/l in view(src, HALLUCINATION_RANGE(power))) // If they can see it without mesons on.  Bad on them.
-		if(!istype(l.glasses, /obj/item/clothing/glasses/meson) || corruptor_attached)
+		if((!HAS_TRAIT(C, TRAIT_MESONS)) || corruptor_attached)
 			var/D = sqrt(1 / max(1, get_dist(l, src)))
 			l.hallucination += power * config_hallucination_power * D
 			l.hallucination = clamp(l.hallucination, 0, 200)

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -354,13 +354,13 @@
 	category = list("Implants", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
-/datum/design/cyberimp_xray
-	name = "X-ray Eyes"
-	desc = "These cybernetic eyes will give you X-ray vision. Blinking is futile."
-	id = "ci-xray"
+/datum/design/cyberimp_meson
+	name = "Meson Eyes"
+	desc = "These cybernetic eyes will give you meson-vision. Looks like it could withstand seeing a supermatter crystal!."
+	id = "ci-meson"
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 60
-	materials = list(/datum/material/iron = 600, /datum/material/glass = 600, /datum/material/silver = 600, /datum/material/gold = 600, /datum/material/plasma = 1000, /datum/material/uranium = 1000, /datum/material/diamond = 1000, /datum/material/bluespace = 1000)
+	materials = list(/datum/material/iron = 600, /datum/material/glass = 600, /datum/material/silver = 600, /datum/material/gold = 600, /datum/material/plastic = 1000, /datum/material/uranium = 1000)
 	build_path = /obj/item/organ/eyes/robotic/xray
 	category = list("Implants", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -365,6 +365,17 @@
 	category = list("Implants", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
+/datum/design/cyberimp_xray
+	name = "X-Ray Eyes"
+	desc = "These cybernetic eyes will give you X-Ray-vision. Blinking is futile."
+	id = "ci-xray"
+	build_type = PROTOLATHE | MECHFAB
+	construction_time = 60
+	materials = list(/datum/material/iron = 600, /datum/material/glass = 600, /datum/material/silver = 600, /datum/material/gold = 600, /datum/material/plasma = 1000, /datum/material/uranium = 1000, /datum/material/diamond = 1000, /datum/material/bluespace = 1000)
+	build_path = /obj/item/organ/eyes/robotic/xray/syndicate
+	category = list("Implants", "Medical Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+
 /datum/design/cyberimp_thermals
 	name = "Thermal Eyes"
 	desc = "These cybernetic eyes will give you Thermal vision. Vertical slit pupil included."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -547,7 +547,7 @@
 	display_name = "Cybernetic Implants"
 	description = "Electronic implants that improve humans."
 	prereq_ids = list("adv_biotech", "datatheory")
-	design_ids = list("ci-nutriment", "ci-breather", "ci-gloweyes", "ci-welding", "ci-medhud", "ci-sechud", "ci-scihud", "ci-diaghud")
+	design_ids = list("ci-nutriment", "ci-breather", "ci-gloweyes", "ci-meson", "ci-welding", "ci-medhud", "ci-sechud", "ci-scihud", "ci-diaghud")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
@@ -564,8 +564,8 @@
 	id = "combat_cyber_implants"
 	display_name = "Combat Cybernetic Implants"
 	description = "Military grade combat implants to improve performance."
-	prereq_ids = list("adv_cyber_implants","weaponry","NVGtech","high_efficiency")
-	design_ids = list("ci-xray", "ci-thermals", "ci-antidrop", "ci-antistun", "ci-thrusters")
+	prereq_ids = list("adv_cyber_implants","weaponry","NVGtech","high_efficiency","syndicate_basic")
+	design_ids = list("ci-thermals", "ci-antidrop", "ci-antistun", "ci-thrusters")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -564,9 +564,18 @@
 	id = "combat_cyber_implants"
 	display_name = "Combat Cybernetic Implants"
 	description = "Military grade combat implants to improve performance."
-	prereq_ids = list("adv_cyber_implants","weaponry","NVGtech","high_efficiency","syndicate_basic")
+	prereq_ids = list("adv_cyber_implants","weaponry","NVGtech","high_efficiency")
 	design_ids = list("ci-thermals", "ci-antidrop", "ci-antistun", "ci-thrusters")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	export_price = 5000
+
+/datum/techweb_node/illegal_cyber_implants
+	id = "illegal_cyber_implants"
+	display_name = "Illegal Cybernetic Implants"
+	description = "Nanotrasen would like to remind employees that use of unlicensed cybernetic implants violates multiple employee contract clauses."
+	prereq_ids = list("combat_cyber_implants","syndicate_basic")
+	design_ids = list("ci-xray")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	export_price = 5000
 
 ////////////////////////Tools////////////////////////

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -87,7 +87,7 @@
 	starting_organ = /obj/item/organ/eyes/robotic/thermals
 
 /obj/item/autosurgeon/xray_eyes
-	starting_organ = /obj/item/organ/eyes/robotic/xray
+	starting_organ = /obj/item/organ/eyes/robotic/xray/syndicate
 
 /obj/item/autosurgeon/anti_stun
 	starting_organ = /obj/item/organ/cyberimp/brain/anti_stun

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -149,13 +149,13 @@
 	sight_flags = SEE_TURFS
 	see_in_dark = 4
 
-/obj/item/organ/eyes/robotic/flashlight/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = FALSE)
+/obj/item/organ/eyes/robotic/xray/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = FALSE, initialising)
 	. = ..()
-	ADD_TRAIT(user, TRAIT_MESONS)
+	ADD_TRAIT(M, TRAIT_MESONS, src)
 
-/obj/item/organ/eyes/robotic/flashlight/Remove(var/mob/living/carbon/M, var/special = 0)
+/obj/item/organ/eyes/robotic/xray/Remove(mob/living/carbon/M, special = 0)
 	. = ..()
-	REMOVE_TRAIT(user, TRAIT_MESONS)
+	REMOVE_TRAIT(M, TRAIT_MESONS, src)
 
 /obj/item/organ/eyes/robotic/xray/syndicate
 	name = "\improper X-ray eyes"

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -132,17 +132,37 @@
 	. = ..()
 	if(!owner || . & EMP_PROTECT_SELF)
 		return
-	if(prob(10 * severity))
+	if(prob(20 * severity))
 		return
-	to_chat(owner, span_warning("Static obfuscates your vision!"))
-	owner.flash_act(visual = 1)
+	var/obj/item/organ/eyes/eyes = owner.getorganslot(ORGAN_SLOT_EYES)
+	to_chat(owner, span_danger("your eyes overload and blind you!"))
+	owner.flash_act(override_blindness_check = 1)
+	owner.blind_eyes(5)
+	owner.blur_eyes(8)
+	eyes.applyOrganDamage(25)
 
 /obj/item/organ/eyes/robotic/xray
+	name = "\improper meson eyes"
+	desc = "These cybernetic eyes will give you meson-vision. Looks like it could withstand seeing a supermatter crystal!."
+	eye_color = "00FF00"
+	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
+	sight_flags = SEE_TURFS
+	see_in_dark = 4
+
+/obj/item/organ/eyes/robotic/flashlight/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = FALSE)
+	. = ..()
+	ADD_TRAIT(user, TRAIT_MESONS)
+
+/obj/item/organ/eyes/robotic/flashlight/Remove(var/mob/living/carbon/M, var/special = 0)
+	. = ..()
+	REMOVE_TRAIT(user, TRAIT_MESONS)
+
+/obj/item/organ/eyes/robotic/xray/syndicate
 	name = "\improper X-ray eyes"
-	desc = "These cybernetic eyes will give you X-ray vision. Blinking is futile."
+	desc = "These cybernetic eyes will give you true X-ray vision. Blinking is futile."
 	eye_color = "000"
-	see_in_dark = 8
 	sight_flags = SEE_MOBS | SEE_OBJS | SEE_TURFS
+	see_in_dark = 8
 
 /obj/item/organ/eyes/robotic/thermals
 	name = "thermal eyes"


### PR DESCRIPTION
alternative to https://github.com/yogstation13/Yogstation/pull/14740

# Document the changes in your pull request

adds a new Illegal Cybernetic Implants technology node
repurposes original xray eyes into Meson Eyes, that provide meson vision (SEE_TURFS) but nothing else
makes them available in the same node as welder eyes, and cheaper than before
makes a subtype of them into the old pre-nerf Xray eyes, and sets the nukie autosurgeon to implant those
makes the EMP act for robotic eyes cause blindness, blurry vision, and a blindness-bypassing true flash, as well as some organ damage to the eyes.
adjusts the code for mesons and the SM to check for a new trait, instead of directly checking if you have mesons on, so the new eyes provide the same hallucination protections.
locks syndicate X-Ray eyes behind Illegal Cybernetic Implants tech node
Thermal eyes are affected by the new EMP effect but otherwise are unchanged.


nukies still get to have wallhack eyes easily, but crew can now choose implanted mesons instead of the antag sniper eyes without illegal tech.

# Wiki Documentation

Guide to Research and Development's table on protolathe designs needs Meson Eyes that are available at Cybernetic Implants added
X-Ray eyes on the same table need to be moved to the new Illegal Cybernetic Implants tech

# Changelog

:cl:  
rscadd: adds syndicate variant of xray eyes that are un-nerfed for nuclear operative autosurgeons
tweak: xray eyes are now simply Meson Eyes that do not provide mob or object vision through walls. Does provide SM hallucination protection
rscadd: adds new tech node for Illegal Cybernetic Implants, which costs 10000 points, and requires Illegal Tech and Combat Cybernetic Implants
rscadd: adds syndicate xray eyes to Illegal Cybernetic Implants tech node
tweak: meson eyes are available in Cybernetic Implants tech node instead of Combat Cybernetic Implants
/:cl:
