### PR TITLE
Reduce Thruster Implant Speed & Apply An EMP Effect

### DIFF
--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -213,8 +213,8 @@
 	switch(severity)
 		if(EMP_HEAVY)
 			owner.adjustFireLoss(35)
-			to_chat(owner, span_warning("Your thruster implant malfunctions and mildly burns you!"))
+			to_chat(owner, span_warning("Your thruster implant malfunctions and severely burns you!"))
 		if(EMP_LIGHT)
 			owner.adjustFireLoss(10)
-			to_chat(owner, span_danger("Your thruster implant malfunctions and severely burns you!"))
+			to_chat(owner, span_danger("Your thruster implant malfunctions and mildly burns you!"))
 

--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -152,7 +152,7 @@
 		if(allow_thrust(0.01))
 			ion_trail.start()
 			RegisterSignal(owner, COMSIG_MOVABLE_MOVED, .proc/move_react)
-			owner.add_movespeed_modifier(MOVESPEED_ID_CYBER_THRUSTER, priority=100, multiplicative_slowdown=-2, movetypes=FLOATING, conflict=MOVE_CONFLICT_JETPACK)
+			owner.add_movespeed_modifier(MOVESPEED_ID_CYBER_THRUSTER, priority=100, multiplicative_slowdown=-0.3, movetypes=FLOATING, conflict=MOVE_CONFLICT_JETPACK)
 			if(!silent)
 				to_chat(owner, span_notice("You turn your thrusters set on."))
 	else
@@ -207,3 +207,12 @@
 
 	toggle(silent = TRUE)
 	return 0
+
+/obj/item/organ/cyberimp/chest/thrusters/emp_act(severity)
+	. = ..()
+	switch(severity)
+		if(EMP_HEAVY)
+			owner.adjustFireLoss(35)
+		if(EMP_LIGHT)
+			owner.adjustFireLoss(10)
+

--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -213,6 +213,8 @@
 	switch(severity)
 		if(EMP_HEAVY)
 			owner.adjustFireLoss(35)
+			to_chat(owner, span_warning("Your thruster implant malfunctions and mildly burns you!"))
 		if(EMP_LIGHT)
 			owner.adjustFireLoss(10)
+			to_chat(owner, span_danger("Your thruster implant malfunctions and severely burns you!"))
 


### PR DESCRIPTION
no more free methspeed :)

# Document the changes in your pull request

makes thruster implants give you -0.3 movespeed modifier instead of -2, so equal to a regular jetpack
EMPing a thruster implant applies burn damage to the owner; currently couldn't figure out how to make it randomly throw the owner.

# Changelog

:cl:  
rscadd: thruster implants can now be EMPed
tweak: thruster implants now only as fast as a jetpack
/:cl:
