### PR TITLE
Removes Syndicate Card Pack From Contraband Crates

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2212,7 +2212,6 @@
 					/obj/item/storage/pill_bottle/lsd,
 					/obj/item/storage/pill_bottle/aranesp,
 					/obj/item/storage/pill_bottle/stimulant,
-					/obj/item/toy/cards/deck/syndicate,
 					/obj/item/reagent_containers/food/drinks/bottle/absinthe,
 					/obj/item/clothing/under/syndicate/tacticool,
 					/obj/item/storage/box/fancy/cigarettes/cigpack_syndicate,


### PR DESCRIPTION
# Document the changes in your pull request

Removes the ability to get syndicate throwing cards from contraband crates, thus closing an illegal-tech farming loophole where cargo dumps money on dozens of crates to get illegal tech in record time

# Wiki Documentation

Contraband page would need a modification to indicate that, while still illegal to have, syndicate playing cards cant come from the contraband crate.

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl: 
rscdel: Removes syndicate playing cards from the contraband crate
/:cl:
