### PR TITLE
[Meta] Removes the random loot drop from the contraband locker

### DIFF
--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -71216,6 +71216,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison/hallway)
+"lcz" = (
+/obj/structure/closet/secure_closet{
+	name = "contraband locker";
+	req_access_txt = "3"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "ldn" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -79380,24 +79397,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"twX" = (
-/obj/structure/closet/secure_closet{
-	name = "contraband locker";
-	req_access_txt = "3"
-	},
-/obj/effect/spawner/lootdrop/armory_contraband/metastation,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "twY" = (
 /obj/machinery/meter{
 	target_layer = 2
@@ -111772,7 +111771,7 @@ aaa
 aaf
 aaa
 aeq
-twX
+lcz
 agc
 afj
 aeU


### PR DESCRIPTION

# Document the changes in your pull request

who the fuck thought this was a good idea

removes the random loot spawn in meta's contraband locker, no more free desert eagles for sec

# Spriting


# Wiki Documentation

if the armory page has a loot drop, remove it
# Changelog


:cl:  
tweak: removed the loot drop from meta's contraband locker
/:cl:
