### PR TITLE
Makes Dead Mice contain Protein instead of Nutriment

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -306,7 +306,7 @@ GLOBAL_VAR_INIT(mouse_killed, 0)
 	icon_state = "mouse_gray_dead"
 	bitesize = 3
 	eatverb = "devour"
-	list_reagents = list(/datum/reagent/consumable/protein = 3, /datum/reagent/consumable/nutriment/vitamin = 2)
+	list_reagents = list(/datum/reagent/consumable/nutriment/protein = 3, /datum/reagent/consumable/nutriment/vitamin = 2)
 	foodtype = MICE
 	grind_results = list(/datum/reagent/blood = 20, /datum/reagent/liquidgibs = 5)
 

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -306,7 +306,7 @@ GLOBAL_VAR_INIT(mouse_killed, 0)
 	icon_state = "mouse_gray_dead"
 	bitesize = 3
 	eatverb = "devour"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 2)
+	list_reagents = list(/datum/reagent/consumable/protein = 3, /datum/reagent/consumable/nutriment/vitamin = 2)
 	foodtype = MICE
 	grind_results = list(/datum/reagent/blood = 20, /datum/reagent/liquidgibs = 5)
 


### PR DESCRIPTION

# Document the changes in your pull request

Makes Dead Mice contain Protein instead of Nutriment. They're...literally a whole mouse, not a fucking potato. Why were they not protein??
works best with https://github.com/yogstation13/Yogstation/pull/14823

# Changelog

:cl:  
tweak: Mice now contain Protein instead of Nutriment
/:cl:
