### PR TITLE
[Box] Adjusts Janitor Closet, Part of Atmos, And Janitorial/Atmos Maint

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -28166,21 +28166,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"evS" = (
-/obj/machinery/power/apc{
-	areastring = "/area/janitor";
-	name = "Custodial Closet APC";
-	pixel_y = -23
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/filled/line,
-/turf/open/floor/plasteel,
-/area/janitor)
 "evX" = (
 /obj/machinery/door/window/eastright{
 	base_state = "left";
@@ -56839,6 +56824,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"sFz" = (
+/obj/machinery/power/apc{
+	areastring = "/area/janitor";
+	name = "Custodial Closet APC";
+	pixel_y = -23
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/line,
+/obj/machinery/portable_atmospherics/canister/water_vapor,
+/turf/open/floor/plasteel,
+/area/janitor)
 "sFG" = (
 /obj/machinery/porta_turret/ai{
 	scan_range = 5
@@ -99283,7 +99284,7 @@ bCv
 tLK
 qtq
 kgG
-evS
+sFz
 bCv
 eEO
 bAw

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -6457,6 +6457,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"aBE" = (
+/obj/machinery/computer/atmos_control{
+	dir = 4;
+	name = "Tank Monitor"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "aBF" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -10423,13 +10430,6 @@
 /obj/machinery/photocopier,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"aQl" = (
-/obj/machinery/pipedispenser,
-/obj/machinery/camera{
-	c_tag = "Atmospherics Corridor North"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "aQn" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
@@ -11745,16 +11745,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"aXf" = (
-/obj/structure/sign/departments/minsky/supply/janitorial{
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aXh" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -11879,25 +11869,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"aXW" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	department = "Janitorial";
-	departmentType = 1;
-	pixel_y = -32
-	},
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/lizard{
-	name = "Wags-His-Tail";
-	real_name = "Wags-His-Tail"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "aXX" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -12545,20 +12516,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
-"bbp" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "bbq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -13777,6 +13734,23 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/robotics/lab)
+"bgo" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/machinery/door/window/westleft{
+	name = "Atmospherics Delivery";
+	req_access_txt = "24"
+	},
+/obj/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "bgp" = (
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -15097,13 +15071,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"bmG" = (
-/obj/machinery/pipedispenser/disposal,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "bmH" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -20066,20 +20033,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"bKD" = (
-/obj/structure/rack,
-/obj/item/storage/box/lights/mixed,
-/obj/item/storage/box/lights/mixed,
-/obj/item/restraints/legcuffs/beartrap,
-/obj/item/restraints/legcuffs/beartrap,
-/obj/item/storage/box/mousetraps,
-/obj/item/toy/figure/janitor,
-/obj/item/storage/box/mousetraps,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "bKG" = (
 /obj/machinery/requests_console{
 	department = "EVA";
@@ -21063,13 +21016,6 @@
 /obj/effect/landmark/stationroom/maint/threexfive,
 /turf/template_noop,
 /area/maintenance/starboard/fore)
-"bQg" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 8
-	},
-/obj/effect/landmark/start/janitor,
-/turf/open/floor/plasteel,
-/area/janitor)
 "bQn" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/power/apc/highcap/five_k{
@@ -21224,13 +21170,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"bQQ" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/janitor)
 "bQS" = (
 /turf/open/floor/plasteel/dark,
 /area/security/interrogation)
@@ -21368,14 +21307,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"bSA" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel/dark,
-/area/janitor)
 "bSC" = (
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /obj/structure/window/reinforced{
@@ -24202,14 +24133,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"cyS" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/start/janitor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "cyT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -24534,6 +24457,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"cCk" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "cCt" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -24645,12 +24580,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"cDV" = (
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "cDZ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -25930,6 +25859,17 @@
 /obj/machinery/smartfridge/drying_rack,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
+"dff" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "dfz" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Dormitories Maintenance";
@@ -27095,12 +27035,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/aft)
-"dNs" = (
-/obj/structure/sink{
-	pixel_y = 27
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "dNI" = (
 /obj/machinery/space_heater,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -27372,17 +27306,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"dVi" = (
-/obj/effect/landmark/event_spawn,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "dVM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -28243,6 +28166,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"evS" = (
+/obj/machinery/power/apc{
+	areastring = "/area/janitor";
+	name = "Custodial Closet APC";
+	pixel_y = -23
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/line,
+/turf/open/floor/plasteel,
+/area/janitor)
 "evX" = (
 /obj/machinery/door/window/eastright{
 	base_state = "left";
@@ -29217,6 +29155,16 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/crew_quarters/locker)
+"eVx" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "eVD" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -29412,6 +29360,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"eZf" = (
+/obj/structure/sink{
+	pixel_y = 27
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "eZD" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -29585,6 +29542,12 @@
 "fgc" = (
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
+"fge" = (
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "fgv" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -29656,6 +29619,16 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"fix" = (
+/obj/machinery/vending/wardrobe/jani_wardrobe,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "fiP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -31327,19 +31300,6 @@
 	},
 /turf/open/space,
 /area/solar/port/aft)
-"ggi" = (
-/obj/structure/closet/l3closet/janitor,
-/obj/machinery/camera{
-	c_tag = "Custodial Closet";
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "ggN" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -31693,14 +31653,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"gpp" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/chair/office/dark,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "gpq" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -32562,20 +32514,6 @@
 "gLo" = (
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
-"gNS" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/obj/machinery/door/window/westleft{
-	name = "Atmospherics Delivery";
-	req_access_txt = "24"
-	},
-/obj/structure/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "gOa" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -32942,6 +32880,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
+"gVF" = (
+/obj/machinery/requests_console{
+	department = "Janitorial";
+	departmentType = 1;
+	pixel_y = -32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "gVL" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -33215,6 +33170,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"hdl" = (
+/obj/structure/sign/departments/minsky/supply/janitorial{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/white/filled/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hdx" = (
 /obj/machinery/light,
 /obj/structure/reagent_dispensers/peppertank{
@@ -33690,13 +33656,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"hmA" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "hmO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -33826,6 +33785,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"hpt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hpx" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/red,
@@ -36930,14 +36899,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"iLi" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/westleft{
-	name = "Janitorial Delivery";
-	req_access_txt = "26"
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "iLA" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/sign/warning/nosmoking{
@@ -37945,6 +37906,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"jiG" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "jiL" = (
 /obj/structure/sign/departments/minsky/medical/virology/virology2{
 	pixel_y = -32
@@ -38079,19 +38049,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"jlP" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=8";
-	dir = 1;
-	freq = 1400;
-	location = "Janitor"
-	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plating,
-/area/janitor)
 "jmA" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/gun/syringe,
@@ -38321,12 +38278,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port)
-"jrd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "jrf" = (
 /obj/machinery/advanced_airlock_controller{
 	pixel_y = 24
@@ -38588,6 +38539,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"jwf" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/westleft{
+	name = "Janitorial Delivery";
+	req_access_txt = "26"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/aft)
 "jwH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -38670,17 +38629,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"jAt" = (
-/obj/machinery/power/apc{
-	areastring = "/area/janitor";
-	name = "Custodial Closet APC";
-	pixel_y = -23
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "jAv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -39503,16 +39451,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
-"kbT" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "kcl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -39707,6 +39645,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"kgG" = (
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/janitor,
+/turf/open/floor/plasteel,
+/area/janitor)
 "kgP" = (
 /obj/machinery/shower{
 	dir = 4
@@ -40242,16 +40185,6 @@
 	dir = 4
 	},
 /area/engine/atmos_distro)
-"ksi" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 25
-	},
-/obj/machinery/computer/station_alert{
-	dir = 1;
-	name = "Station Alert Console"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "kso" = (
 /obj/structure/chair/sofa/right{
 	dir = 4
@@ -41790,15 +41723,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"lgq" = (
-/obj/structure/closet/l3closet/janitor,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/janitor)
 "lgK" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/sign/departments/minsky/engineering/atmospherics{
@@ -41914,6 +41838,43 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"liZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/grenade/chem_grenade/cleaner{
+	pixel_x = -7;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -9;
+	pixel_y = 4
+	},
+/obj/item/grenade/chem_grenade/cleaner{
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/obj/item/pen{
+	pixel_x = 4;
+	pixel_y = -5
+	},
+/obj/item/paper_bin{
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/obj/item/grenade/chem_grenade/cleaner{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/line,
+/turf/open/floor/plasteel,
+/area/janitor)
 "lja" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
@@ -42644,6 +42605,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"lCu" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "lCS" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/turf_decal/stripes/line{
@@ -42733,6 +42700,22 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"lDB" = (
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/item/flashlight/lamp,
+/obj/structure/table,
+/obj/item/stack/packageWrap{
+	pixel_x = -1;
+	pixel_y = -1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/item/hand_labeler,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "lDX" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/white,
@@ -42849,6 +42832,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"lHv" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/janitorialcart,
+/obj/item/mop,
+/turf/open/floor/plasteel/dark,
+/area/janitor)
 "lHz" = (
 /obj/structure/chair/sofa/right,
 /turf/open/floor/wood,
@@ -43144,6 +43133,16 @@
 	},
 /turf/open/floor/plating,
 /area/science/misc_lab)
+"lTb" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "lTC" = (
 /obj/machinery/light,
 /obj/machinery/disposal/bin,
@@ -44567,6 +44566,17 @@
 /obj/structure/chair/office/dark,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"mzo" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -30
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "mzz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -45051,6 +45061,22 @@
 "mMW" = (
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"mMY" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "mNd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -45604,6 +45630,20 @@
 /obj/structure/window/reinforced/tinted,
 /turf/open/floor/wood,
 /area/medical/psych)
+"nai" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/lizard{
+	name = "Wags-His-Tail";
+	real_name = "Wags-His-Tail"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "nam" = (
 /obj/structure/cable/orange{
 	icon_state = "2-8"
@@ -46096,13 +46136,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"njN" = (
-/obj/machinery/computer/atmos_control{
-	dir = 1;
-	name = "Tank Monitor"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "nka" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable/yellow,
@@ -46501,6 +46534,22 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"nvF" = (
+/obj/structure/closet/l3closet/janitor,
+/obj/machinery/camera{
+	c_tag = "Custodial Closet";
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "nvM" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -46866,6 +46915,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"nDu" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/janitor)
 "nDx" = (
 /obj/machinery/door/poddoor{
 	id = "Secure Storage";
@@ -47132,6 +47189,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"nKE" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=8";
+	dir = 1;
+	freq = 1400;
+	location = "Janitor"
+	},
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "nKM" = (
 /obj/effect/landmark/start/station_engineer,
 /obj/effect/turf_decal/stripes/corner{
@@ -47286,6 +47356,35 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"nQW" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "atmos";
+	name = "Atmospherics Lockdown";
+	pixel_x = -24;
+	pixel_y = -7;
+	req_access_txt = "24"
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26;
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "nQZ" = (
 /obj/structure/rack,
 /obj/item/lighter,
@@ -47515,6 +47614,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"nUM" = (
+/obj/machinery/camera{
+	c_tag = "Atmospherics Corridor North"
+	},
+/obj/machinery/lapvend,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "nUQ" = (
 /obj/effect/decal/cleanable/oil,
 /obj/item/cigbutt,
@@ -50395,6 +50501,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
+"pvR" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "pvX" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/blue{
@@ -51217,6 +51336,19 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"pUt" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/effect/landmark/start/janitor,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "pUH" = (
 /obj/structure/table,
 /obj/item/hand_tele,
@@ -51356,20 +51488,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"pYt" = (
-/obj/machinery/light,
-/obj/machinery/computer/atmos_alert{
-	dir = 1;
-	name = "Atmospheric Alert Console"
-	},
-/obj/machinery/requests_console{
-	department = "Atmospherics";
-	departmentType = 4;
-	name = "Atmos RC";
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "pYv" = (
 /obj/machinery/camera{
 	c_tag = "Secondary AI Core";
@@ -52144,6 +52262,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
+"qtq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "qts" = (
 /obj/structure/window/reinforced,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -52669,15 +52794,6 @@
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
-"qJq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "qJt" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -53069,6 +53185,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"qSY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qTf" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -53411,6 +53539,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"rbZ" = (
+/obj/effect/landmark/event_spawn,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/janitor)
 "rcg" = (
 /obj/structure/chair{
 	dir = 8
@@ -53805,21 +53945,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
-"rmg" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "rnf" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
@@ -54045,6 +54170,16 @@
 "ruc" = (
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"ruf" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning,
+/turf/open/floor/plasteel,
+/area/janitor)
 "rur" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -56200,12 +56335,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"sqA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "sqE" = (
 /obj/structure/sign/warning/fire{
 	pixel_y = -32
@@ -56520,30 +56649,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"sxH" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/button/door{
-	id = "atmos";
-	name = "Atmospherics Lockdown";
-	pixel_x = -24;
-	pixel_y = -7;
-	req_access_txt = "24"
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "syc" = (
 /obj/machinery/light{
 	dir = 1
@@ -57714,16 +57819,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"tcL" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/janitor)
 "tcO" = (
 /obj/machinery/camera{
 	c_tag = "Surgery Operating";
@@ -58283,6 +58378,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"trj" = (
+/obj/machinery/light,
+/obj/machinery/requests_console{
+	department = "Atmospherics";
+	departmentType = 4;
+	name = "Atmos RC";
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "trn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -58348,6 +58453,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"tut" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 25
+	},
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "tuI" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -59021,11 +59135,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"tKM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/janitor)
 "tKP" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Four";
@@ -59064,6 +59173,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"tLK" = (
+/obj/machinery/light_switch{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "tLS" = (
 /obj/machinery/light{
 	dir = 1
@@ -59098,6 +59216,23 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"tMI" = (
+/obj/machinery/camera{
+	c_tag = "Central Primary Hallway South";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "tMO" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
@@ -59160,18 +59295,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"tOe" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "tOu" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -59931,6 +60054,14 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"ued" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "uej" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -59961,6 +60092,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"ueF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/storage/box/mousetraps,
+/obj/item/toy/figure/janitor,
+/obj/item/storage/box/mousetraps,
+/obj/item/restraints/legcuffs/beartrap,
+/obj/item/restraints/legcuffs/beartrap,
+/obj/item/storage/box/lights/mixed,
+/obj/item/storage/box/lights/mixed,
+/obj/effect/turf_decal/trimline/white/filled/line,
+/turf/open/floor/plasteel,
+/area/janitor)
 "ueG" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -60214,18 +60360,6 @@
 "ulL" = (
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"umh" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"umC" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "umE" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -60534,15 +60668,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
-"uvU" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "uvW" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -61430,38 +61555,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
-"uVO" = (
-/obj/structure/table,
-/obj/item/grenade/chem_grenade/cleaner{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/item/grenade/chem_grenade/cleaner{
-	pixel_x = -1;
-	pixel_y = 7
-	},
-/obj/item/grenade/chem_grenade/cleaner{
-	pixel_x = -7;
-	pixel_y = -1
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -9;
-	pixel_y = 4
-	},
-/obj/item/paper_bin{
-	pixel_x = 5;
-	pixel_y = -2
-	},
-/obj/item/pen{
-	pixel_x = 4;
-	pixel_y = -5
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "uWH" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -61722,6 +61815,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"vcQ" = (
+/obj/structure/closet/l3closet/janitor,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "vcU" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/cable{
@@ -62241,13 +62346,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"vsZ" = (
-/obj/machinery/portable_atmospherics/canister/water_vapor,
-/obj/effect/turf_decal/trimline/blue,
-/obj/effect/turf_decal/trimline/white,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/janitor)
 "vth" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -62403,13 +62501,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"vwz" = (
-/obj/machinery/vending/wardrobe/jani_wardrobe,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "vwN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -63650,6 +63741,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"wfS" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/janitor)
 "wfZ" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -65772,6 +65867,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"xrG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "xrN" = (
 /obj/effect/landmark/start/scientist,
 /obj/structure/chair/comfy/black,
@@ -66712,17 +66813,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"xQk" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -30
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "xQl" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4
@@ -66847,25 +66937,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"xSW" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/item/flashlight/lamp,
-/obj/structure/table,
-/obj/item/stack/packageWrap{
-	pixel_x = -1;
-	pixel_y = -1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/item/hand_labeler,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "xTe" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -66930,16 +67001,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"xTS" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "xTZ" = (
 /obj/structure/cloth_curtain{
 	color = "#99ccff"
@@ -67246,22 +67307,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"ybg" = (
-/obj/machinery/camera{
-	c_tag = "Central Primary Hallway South";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "ycf" = (
 /obj/machinery/meter{
 	pixel_x = -5;
@@ -97178,8 +97223,8 @@ aJw
 syX
 sXZ
 kFe
-rmg
-xTS
+mMY
+xKF
 iCO
 xKF
 iCO
@@ -97435,8 +97480,8 @@ cyZ
 sBi
 sYk
 urN
-kbT
-umh
+dff
+nzd
 nzd
 nzd
 xqf
@@ -97692,8 +97737,8 @@ aJw
 sCB
 sYv
 ggN
-tOe
-umC
+pvR
+jdW
 uDS
 uVm
 wMs
@@ -97954,9 +97999,9 @@ bCv
 bCv
 bCv
 bCv
-bzs
+bCv
 siG
-qtP
+bzs
 xrc
 xPt
 yfl
@@ -98209,11 +98254,11 @@ bBf
 bCv
 bAO
 vCX
-bSA
+lHv
+nDu
 bCv
-rkM
 eEO
-bLK
+bzs
 bLK
 bLK
 taW
@@ -98462,24 +98507,24 @@ aaa
 msD
 rWx
 rWx
-ybg
+tMI
 bCv
-bQQ
-bQg
-aXW
+lTb
+pUt
+nai
+gVF
 bCv
-vYi
 eEO
+rkM
 bLK
-bbp
-xQk
-gNS
+mzo
+bgo
 seF
 caN
 xIf
 mmf
 rnf
-sxH
+nQW
 mXy
 bLK
 eoU
@@ -98719,18 +98764,18 @@ gXs
 wjT
 aJq
 gus
-aXf
+hdl
 bCv
+fge
+xrG
 bDG
-sqA
-bKD
-bCv
+ueF
 bCv
 eEO
+vYi
 bLK
-bmG
-qtN
-bOd
+jiG
+lCu
 rqh
 acF
 bOd
@@ -98976,17 +99021,17 @@ bqH
 bqH
 aJq
 aJq
-uvU
+eVx
 eTP
-tKM
-dVi
-uVO
-vsZ
+ued
+rbZ
+wfS
+liZ
 bCv
 eEO
+bAw
 bLK
-aQl
-qtN
+nUM
 bOd
 wRZ
 acF
@@ -99233,17 +99278,17 @@ rGe
 bqH
 srF
 aJq
-vDS
+hpt
 bCv
-cDV
-qJq
-cyS
-jAt
+tLK
+qtq
+kgG
+evS
 bCv
 eEO
+bAw
 bLK
-bLK
-xSW
+lDB
 bOd
 kDr
 ejY
@@ -99490,12 +99535,12 @@ rGt
 bqH
 sCv
 aJq
-vDS
+qSY
 bCv
-dNs
+eZf
 vMu
-jrd
-hmA
+bDG
+ruf
 vZn
 moC
 wUc
@@ -99749,10 +99794,10 @@ sCB
 aJq
 qkv
 bCv
-tcL
-ggi
-lgq
-vwz
+cCk
+nvF
+vcQ
+fix
 bCv
 eEO
 wUw
@@ -100005,8 +100050,8 @@ bqH
 sDl
 aJq
 vDS
-bCv
-iLi
+aJw
+jwf
 bCv
 bCv
 bCv
@@ -100262,9 +100307,9 @@ bqH
 aNz
 aNz
 txj
-bCv
-jlP
-bCv
+aJw
+nKE
+bzs
 bAw
 bHX
 xgI
@@ -100532,7 +100577,7 @@ qtN
 bOd
 tya
 nrO
-njN
+aBE
 bLK
 bvA
 bvA
@@ -100788,8 +100833,8 @@ xwU
 qtN
 bOd
 fbJ
-gpp
-pYt
+nrO
+trj
 bLK
 bvA
 rHf
@@ -101046,7 +101091,7 @@ qtN
 yfZ
 eEc
 nrO
-ksi
+tut
 bLK
 bvA
 rHf

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -24600,6 +24600,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
+"cEj" = (
+/obj/structure/table,
+/obj/item/radio/off,
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/obj/item/clothing/glasses/meson,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "cEm" = (
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff";
@@ -42701,6 +42710,12 @@
 /obj/item/hand_labeler,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"lDN" = (
+/obj/machinery/camera{
+	c_tag = "Atmospherics Corridor North"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "lDX" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/white,
@@ -47599,13 +47614,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"nUM" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics Corridor North"
-	},
-/obj/machinery/lapvend,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "nUQ" = (
 /obj/effect/decal/cleanable/oil,
 /obj/item/cigbutt,
@@ -56665,6 +56673,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"szv" = (
+/obj/machinery/light_switch{
+	pixel_x = -23
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/lapvend,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "szB" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = -32
@@ -60917,6 +60935,15 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/wood,
 /area/medical/psych)
+"uBq" = (
+/obj/structure/table,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/cell_charger,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "uBx" = (
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -63252,17 +63279,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"vTD" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/machinery/light_switch{
-	pixel_x = -23
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "vTG" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -67199,15 +67215,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
-"xYW" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/meson,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "xZb" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
@@ -67728,14 +67735,6 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"yln" = (
-/obj/structure/table,
-/obj/item/radio/off,
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "yly" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -98272,9 +98271,9 @@ qmg
 nNC
 nVj
 vKp
-vTD
-xYW
-yln
+szv
+uBq
+cEj
 vKp
 bWJ
 xne
@@ -99032,7 +99031,7 @@ bCv
 eEO
 bAw
 bLK
-nUM
+lDN
 bOd
 wRZ
 acF


### PR DESCRIPTION
# Document the changes in your pull request

Before:
![ss (2022-07-13 at 01 48 21)](https://user-images.githubusercontent.com/1534478/178674216-7fa7b497-a86e-4cee-b75c-2b094b091ebf.png)

After
![ss (2022-07-13 at 01 47 52)](https://user-images.githubusercontent.com/1534478/178674199-6bdec3be-3b96-4617-812d-afc9d5415cc0.png)

Adjusts the janitorial closet to account for there being, shocker, more than one janitor!
Adds a second janicart, and space cleaner bottle
swaps the water tank for a high capacity water tank
shifts the disposal and table/rack combo down a tile
moves atmos' disposal down a tile and deletes the two pipe dispensers because...RPDs exist and atmos is swimming in them? If you need a pipe dispenser you can just...go build one.
adjusts the firelocks in the engineering hallway entrance because they were spaced out 1 tile for seemingly no reason
adds white trim to the janitorial closet
adds a modular PC vendor to engineering because why not

# Changelog

:cl:  
rscadd: adds trims to the janitorial closet
rscadd: Adds a second janicart, and space cleaner bottle to the janitor closet
rscadd: adds a modular PC vendor to the engineering foyer
rscdel: deletes the two pipe dispensers in atmos
tweak: changes the water tank in the janitorial closet into a high capacity variant
tweak: moves engineering hallway northern firelocks
tweak: shifts janitorial/atmos maint hallway so nothing is too far from where it was, to make room for the janitorial closet changes
tweak: moves atmos' disposal down a tile
tweak: shifts the janitor closet disposal and table/rack combo down a tile
/:cl:
