### PR TITLE
Adds new Blood, Bone, and Brain Mutations

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -54,7 +54,7 @@
 #define EXTRASTUN	/datum/mutation/human/extrastun
 #define GELADIKINESIS		/datum/mutation/human/geladikinesis
 #define CRYOKINESIS /datum/mutation/human/cryokinesis
-
+#define CEREBRAL	/datum/mutation/human/cerebral
 
 
 #define UI_CHANGED "ui changed"

--- a/code/datums/mutations/_combined.dm
+++ b/code/datums/mutations/_combined.dm
@@ -28,3 +28,7 @@
 /datum/generecipe/antiglow
 	required = "/datum/mutation/human/glow; /datum/mutation/human/void"
 	result = ANTIGLOWY
+
+/datum/generecipe/cerebral
+	required = "/datum/mutation/human/insulated; /datum/mutation/human/mindreader"
+	result = CEREBRAL

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -430,3 +430,65 @@
 			owner.SetStun(owner.AmountStun()*2)
 			owner.visible_message(span_danger("[owner] tries to stand up, but trips!"), span_userdanger("You trip over your own feet!"))
 			stun_cooldown = world.time + 300
+
+/datum/mutation/human/hypermarrow
+	name = "Hyperactive Bone Marrow"
+	desc = "A mutation that stimulates the subject's bone marrow causes it to work three times faster than usual."
+	quality = POSITIVE
+	text_gain_indication = span_notice("You feel your bones ache for a moment.")
+	text_lose_indication = span_notice("You feel something in your bones calm down.")
+	difficulty = 12
+	instability = 20
+	power_coeff = 1
+
+/datum/mutation/human/hypermarrow/on_life()
+	if(owner.blood_volume < BLOOD_VOLUME_NORMAL(owner))
+		owner.blood_volume += GET_MUTATION_POWER(src) * 2 - 1
+		owner.physiology.hunger_mod *= GET_MUTATION_POWER(src) * 2 - 0.8
+
+/datum/mutation/human/densebones
+	name = "Bone Densification"
+	desc = "A mutation that gives the subject a rare form of increased bone density, making their entire body slightly more resilient to low kinetic blows."
+	quality = POSITIVE
+	text_gain_indication = span_notice("You feel your bones get denser.")
+	text_lose_indication = span_notice("You feel your bones get lighter.")
+	difficulty = 16
+	instability = 25
+	power_coeff = 1
+
+/datum/mutation/human/densebones/on_acquiring(mob/living/carbon/human/owner)
+	. = ..()
+	if(owner.physiology)
+		owner.physiology.armor.melee += 5
+		owner.physiology.armor.wound += 10
+		if(GET_MUTATION_POWER(src) > 1)
+			ADD_TRAIT(owner, TRAIT_HARDLY_WOUNDED, "genetics")
+
+/datum/mutation/human/densebones/on_losing(mob/living/carbon/human/owner)
+	. = ..()
+	if(owner.physiology)
+		owner.physiology.armor.melee += 5
+		owner.physiology.armor.wound += 10
+		if(GET_MUTATION_POWER(src) > 1)
+			REMOVE_TRAIT(owner, TRAIT_HARDLY_WOUNDED, "genetics")
+
+/datum/mutation/human/cerebral
+	name = "Cerebral Neuroplasticity"
+	desc = "A mutation that reorganizes the subject's brain, giving them more stamina while allowing for a slightly quicker recovery speed if exhausted."
+	quality = POSITIVE
+	locked = TRUE
+	text_gain_indication = span_notice("You feel your brain get sturdier.")
+	text_lose_indication = span_notice("You feel your brain getting weaker. ")
+	instability = 70
+
+/datum/mutation/human/cerebral/on_acquiring(mob/living/carbon/human/owner)
+	. = ..()
+	if(owner.physiology)
+		owner.physiology.stamina_mod *= 0.7
+		owner.physiology.stun_mod *= 0.85
+
+/datum/mutation/human/cerebral/on_losing(mob/living/carbon/human/owner)
+	. = ..()
+	if(owner.physiology)
+		owner.physiology.stamina_mod /= 0.7
+		owner.physiology.stun_mod /= 0.85

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -465,11 +465,10 @@
 
 /datum/mutation/human/densebones/on_losing(mob/living/carbon/human/owner)
 	. = ..()
-	if(owner.physiology)
-		owner.physiology.armor.melee += 5
-		owner.physiology.armor.wound += 10
-		if(GET_MUTATION_POWER(src) > 1)
-			REMOVE_TRAIT(owner, TRAIT_HARDLY_WOUNDED, "genetics")
+	owner?.physiology?.armor?.melee += 5
+	owner?.physiology?.armor?.wound += 10
+	if(GET_MUTATION_POWER(src) > 1)
+		REMOVE_TRAIT(owner, TRAIT_HARDLY_WOUNDED, "genetics")
 
 /datum/mutation/human/cerebral
 	name = "Cerebral Neuroplasticity"

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -481,12 +481,10 @@
 
 /datum/mutation/human/cerebral/on_acquiring(mob/living/carbon/human/owner)
 	. = ..()
-	if(owner.physiology)
-		owner.physiology.stamina_mod *= 0.7
-		owner.physiology.stun_mod *= 0.85
+	owner?.physiology?.stamina_mod *= 0.7
+	owner?.physiology?.stun_mod *= 0.85
 
 /datum/mutation/human/cerebral/on_losing(mob/living/carbon/human/owner)
 	. = ..()
-	if(owner.physiology)
-		owner.physiology.stamina_mod /= 0.7
-		owner.physiology.stun_mod /= 0.85
+	owner?.physiology?.stamina_mod /= 0.7
+	owner?.physiology?.stun_mod /= 0.85

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -458,11 +458,10 @@
 
 /datum/mutation/human/densebones/on_acquiring(mob/living/carbon/human/owner)
 	. = ..()
-	if(owner.physiology)
-		owner.physiology.armor.melee += 5
-		owner.physiology.armor.wound += 10
-		if(GET_MUTATION_POWER(src) > 1)
-			ADD_TRAIT(owner, TRAIT_HARDLY_WOUNDED, "genetics")
+	owner?.physiology?.armor?.melee += 5
+	owner?.physiology?.armor?.wound += 10
+	if(GET_MUTATION_POWER(src) > 1)
+		ADD_TRAIT(owner, TRAIT_HARDLY_WOUNDED, "genetics")
 
 /datum/mutation/human/densebones/on_losing(mob/living/carbon/human/owner)
 	. = ..()

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -444,7 +444,7 @@
 /datum/mutation/human/hypermarrow/on_life()
 	if(owner.blood_volume < BLOOD_VOLUME_NORMAL(owner))
 		owner.blood_volume += GET_MUTATION_POWER(src) * 2 - 1
-		owner.physiology.hunger_mod *= GET_MUTATION_POWER(src) * 2 - 0.8
+		owner?.physiology?.hunger_mod *= GET_MUTATION_POWER(src) * 2 - 0.8
 
 /datum/mutation/human/densebones
 	name = "Bone Densification"


### PR DESCRIPTION
Mmmgh genetic variety...

# Document the changes in your pull request

Adds Hyperactive Bone Marrow, a genetic mutation that regenerates the user's blood and can be powered. Equivalent to self-respiration until powered, where it gives double its amount of blood.
Adds Bone Densification, a mutation that gives the user 5 melee armor and 10 wound armor. Can be powered to give the trait TRAIT_HARDLY_WOUNDED.
Adds Cerebral Neuroplasticity, a combined mutation that gives the user 0.7 stamina resistance, making the user able to take 1 extra shot from most stamina damage sources. This enables them to take 4 telescopic, 3 classical and stunprod, and 2 stun baton hits.

The reasoning behind the creation of this pr was the lack of variety in genetic loadouts while also adding simple mutations to that pool of "useful" genes that people might consider using. 

I chose a blood regeneration mutation because there weren't; that many ways to get passive blood regeneration. Despite there being multiple ways; to quickly regain lost blood, I still thought that this mutation would be a neat inconsequential addition to the rather lackluster mutation pool. 

This pr first started with the idea of bone armor because dealing with bone fractures and joint dislocations was a major pain in the ass, and I thought maybe adding a new mutation would kill two birds with one stone. Despite this, I am not fully sure if TRAIT_HARDLY_WOUNDED actually does anything, and unfortunately, wound armor only seemingly really affects the bare_wound_bonus of attacks and doesn't make that big of a noticeable difference, so even if wound armor affects all types of wounds I could specify it if I gave the mutation some melee armor to screw over any weapons that get hampered by any form of armor protection whatsoever.

Lastly, the thick skin mutation "stamina edition" the reason why this got even chosen to be a good idea to give to genetics was that I couldn't find a way to turn the preternis virus resistance into an actual mutation, same with simply making the virus itself weaker to being cured or boost the effectiveness of the cure so I thought that Brains would have been a better alternative to Biruses. And so, with that out of the way, I made the mutation incredibly expensive while also being extremely hard to get despite it just letting you take one extra shot from most stamina sources.

I know that making Cerebral Neuroplasticity cost 70 instability is absurd, and I am willing to lessen it down to at most 50, but I want the mutation to be an option that people can use if they think the tradeoff is worth it but not the industry standard when people make their genetic loadouts; with its cost, Cerebral Neuroplasticity's locked from being used with the following accessible mutations in descending order: 40 Instability, Space Adaptation, Heat Adaptation, Telekinesis, 30 Instability, Extendo Arm, Extended Shock Touch, Thick skin, Void Magnet, Fire Breath, and Transcendent Olfaction. So if you honestly think that the Instability should drop down, here is a list of the mutations that I think might be a bit too gamer to use in conjunction.

Also because I thought that BBB would make a funny pr title. What could possibly go wrong?

Edit: Specified that the stamina modifier mutation is a combo mutation while fixing a typo in the Changelog. Also fixing some grammatical mistakes in the giant wall of text and Wiki Documentation.
Edit 2: Further explains my thought process on why I set the third mutations Instability to fucking 70 of all things.
# Wiki Documentation

Hyperactive Bone Marrow, a difficulty = 12, instability = 20, mutation that adds 1 blood or 2 if powered directly into the bloodstream while draining some hunger that scales with power.
Bone Densification, a difficulty = 16, instability = 25, mutation that adds 5 melee armor and 10 wound armor that can be powered to give the trait TRAIT_HARDLY_WOUNDED.
Cerebral Neuroplasticity, a combination mutation created from insulated and mindreader that has a whopping instability = 70. This mutation gives the user a 0.7 stamina_mod and a 0.85 stun_mod.

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
rscadd: Adds blood regen mutation
rscadd: Adds wound armor mutation
rscadd: Adds stamina modifier combined mutation
/:cl:
