### PR TITLE
Adds the Box of Singulonuts & disguised donut traitor item.

### DIFF
--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -76,6 +76,21 @@
 	STR.max_items = 6
 	STR.set_holdable(list(/obj/item/reagent_containers/food/snacks/donut))
 
+/obj/item/storage/box/fancy/donut_box/deadly
+	icon = 'icons/obj/food/containers.dmi'
+	icon_state = "donutbox6"
+	icon_type = "donut"
+	name = "donut box"
+	spawn_type = /obj/item/reagent_containers/food/snacks/donut/deadly
+	fancy_open = TRUE
+
+/obj/item/storage/box/fancy/donut_box/ComponentInitialize()
+	. = ..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_items = 6
+	STR.set_holdable(list(/obj/item/reagent_containers/food/snacks/donut))
+
+
 /*
  * Egg Box
  */

--- a/code/modules/food_and_drinks/food/snacks_pastry.dm
+++ b/code/modules/food_and_drinks/food/snacks_pastry.dm
@@ -65,6 +65,16 @@
 	tastes = list("donut" = 3, "fizzy tutti frutti" = 1,)
 	filling_color = "#803280"
 
+/obj/item/reagent_containers/food/snacks/donut/deadly
+	name = "unusually heavy donut"
+	desc = "Man this thing weighs like...as much as a hundred donuts! Smells irresistable!"
+	icon_state = "donut1"
+	volume = 1000
+	bitesize = 1000
+	list_reagents = list(/datum/reagent/consumable/nutriment = 950, /datum/reagent/consumable/sugar = 50,)
+	tastes = list("infinity" = 2, "countless donuts" = 2, "sugar" = 2)
+	filling_color = "#D2691E"
+
 /obj/item/reagent_containers/food/snacks/donut/jelly
 	name = "jelly donut"
 	desc = "You jelly?"

--- a/code/modules/food_and_drinks/food/snacks_pastry.dm
+++ b/code/modules/food_and_drinks/food/snacks_pastry.dm
@@ -67,7 +67,7 @@
 
 /obj/item/reagent_containers/food/snacks/donut/deadly
 	name = "donut"
-	desc = "Goes great with robust coffee. This one feels...dense."
+	desc = "Goes great with Doctor's Delight."
 	icon_state = "donut1"
 	volume = 1000
 	bitesize = 1000

--- a/code/modules/food_and_drinks/food/snacks_pastry.dm
+++ b/code/modules/food_and_drinks/food/snacks_pastry.dm
@@ -66,19 +66,15 @@
 	filling_color = "#803280"
 
 /obj/item/reagent_containers/food/snacks/donut/deadly
-	name = "donut"
-	desc = "Goes great with Doctor's Delight."
-	icon_state = "donut1"
 	volume = 1000
 	bitesize = 1000
 	list_reagents = list(/datum/reagent/consumable/nutriment = 950, /datum/reagent/consumable/sugar = 50,)
 	tastes = list("countless donuts" = 2, "sugar" = 2)
-	filling_color = "#D2691E"
 	foodtype = SUGAR | FRIED | GRAIN
 
 /obj/item/reagent_containers/food/snacks/donut/deadly/On_Consume(mob/living/eater)
 	. = ..()
-	to_chat(eater, span_notice("You couldn't stop yourself...it was so delicious..."))
+	to_chat(eater, span_notice("You couldn't stop yourself... It was so delicious..."))
 	eater.set_nutrition(1000)
 
 /obj/item/reagent_containers/food/snacks/donut/jelly

--- a/code/modules/food_and_drinks/food/snacks_pastry.dm
+++ b/code/modules/food_and_drinks/food/snacks_pastry.dm
@@ -75,6 +75,11 @@
 	tastes = list("infinity" = 2, "countless donuts" = 2, "sugar" = 2)
 	filling_color = "#D2691E"
 
+/obj/item/reagent_containers/food/snacks/donut/deadly/On_Consume(mob/living/eater)
+	. = ..()
+	to_chat(eater, span_notice("You couldn't stop yourself...it was so delicious..."))
+	eater.set_nutrition(1000)
+
 /obj/item/reagent_containers/food/snacks/donut/jelly
 	name = "jelly donut"
 	desc = "You jelly?"

--- a/code/modules/food_and_drinks/food/snacks_pastry.dm
+++ b/code/modules/food_and_drinks/food/snacks_pastry.dm
@@ -66,14 +66,15 @@
 	filling_color = "#803280"
 
 /obj/item/reagent_containers/food/snacks/donut/deadly
-	name = "unusually heavy donut"
-	desc = "Man this thing weighs like...as much as a hundred donuts! Smells irresistable!"
+	name = "donut"
+	desc = "Goes great with robust coffee. This one feels...dense."
 	icon_state = "donut1"
 	volume = 1000
 	bitesize = 1000
 	list_reagents = list(/datum/reagent/consumable/nutriment = 950, /datum/reagent/consumable/sugar = 50,)
-	tastes = list("infinity" = 2, "countless donuts" = 2, "sugar" = 2)
+	tastes = list("countless donuts" = 2, "sugar" = 2)
 	filling_color = "#D2691E"
+	foodtype = SUGAR | FRIED | GRAIN
 
 /obj/item/reagent_containers/food/snacks/donut/deadly/On_Consume(mob/living/eater)
 	. = ..()

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1997,7 +1997,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/role_restricted/deadlydonut
 	name = "Box of Infinity Donuts"
-	desc = "A box with six Waffle Co. brand infinity donuts. Banned in four sectors for their shear calorie content. \
+	desc = "A box with six Waffle Co. brand infinity donuts. Banned in four sectors for their sheer calorie content. \
 			Caution: Product known to the safety board of Nanotrasen to increase risks of stomach cancer and cause instant obesity."
 	item = /obj/item/storage/box/fancy/donut_box/deadly
 	cost = 6

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1995,6 +1995,16 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	manufacturer = /datum/corporation/traitor/waffleco
 	restricted_roles = list("Geneticist", "Chief Medical Officer")
 
+/datum/uplink_item/role_restricted/deadlydonut
+	name = "Box of Infinity Donuts"
+	desc = "A box with six Waffle Co. brand infinity donuts. Banned in four sectors for their shear calorie content. \
+			Caution: Product known to the safety board of Nanotrasen to increase risks of stomach cancer and cause instant obesity."
+	item = /obj/item/storage/box/fancy/donut_box/deadly
+	cost = 6
+	manufacturer = /datum/corporation/traitor/waffleco
+	restricted_roles = list("Assistant", "Cook", "Clerk")
+	illegal_tech = FALSE
+
 /datum/uplink_item/role_restricted/clown_bomb
 	name = "Clown Bomb"
 	desc = "The Clown bomb is a hilarious device capable of massive pranks. It has an adjustable timer, \

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1996,9 +1996,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	restricted_roles = list("Geneticist", "Chief Medical Officer")
 
 /datum/uplink_item/role_restricted/deadlydonut
-	name = "Box of Infinity Donuts"
-	desc = "A box with six Waffle Co. brand infinity donuts. Banned in four sectors for their sheer calorie content. \
-			Caution: Product known to the safety board of Nanotrasen to increase risks of stomach cancer and cause instant obesity."
+	name = "Box of Singulonuts"
+	desc = "A box with six Waffle Co. brand Singulonuts. Banned in four sectors for their sheer calorie content. \
+			Caution: Product known to the safety board of Nanotrasen to increase risks of stomach cancer and cause instant obesity. \ Disguised as a regular box of regular donuts."
 	item = /obj/item/storage/box/fancy/donut_box/deadly
 	cost = 6
 	manufacturer = /datum/corporation/traitor/waffleco


### PR DESCRIPTION
# Document the changes in your pull request

Adds a Box of Singulonuts to the Traitor Uplink for Clerks, Cooks, and Assistants. Comes as a standard looking donut box with 6 "donuts" inside, that look like normal donuts but actually contain 950u of nutriment and 50u of sugar. Consumes the entire 1000u content in one bite. costs 6TC
Sets your nutrition to 1000 on consumption, instantly making you fat.
the box is flagged to prevent use of it to get illegal tech

new donuts cannot be crafted. Grinding them results in only 50u of nutriment.

# Wiki Documentation

Would need to be added to the traitor uplink page, and potentially the guide to food.

# Changelog

:cl:  
rscadd: Adds the Box of Singuloonuts to the traitor uplink
rscadd: adds traitor donuts to prefill the new donut box traitor item
/:cl:
