### PR TITLE
Genetics Nerfs (and tiny buffs?)

### DIFF
--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -107,7 +107,8 @@
 	instability = 30
 	energy_coeff = 1
 	power_coeff = 1
-	
+	conflicts = list(/datum/mutation/human/cryokinesis)
+
 /datum/mutation/human/firebreath/modify()
 	if(power)
 		var/obj/effect/proc_holder/spell/aimed/firebreath/S = power

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -203,7 +203,7 @@
 	text_gain_indication = span_notice("Your skin begins to glow softly.")
 	instability = 5
 	var/obj/effect/dummy/luminescent_glow/glowth //shamelessly copied from luminescents
-	var/glow = 2.5
+	var/glow = 3.5
 	var/range = 2.5
 	var/color 
 	power_coeff = 1
@@ -240,7 +240,7 @@
 	name = "Anti-Glow"
 	desc = "Your skin seems to attract and absorb nearby light creating 'darkness' around you."
 	text_gain_indication = span_notice("Your light around you seems to disappear.")
-	glow = -2.5 //Slightly stronger, since negating light tends to be harder than making it.
+	glow = -3.5
 	conflicts = list(/datum/mutation/human/glow)
 	locked = TRUE
 

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -240,7 +240,7 @@
 	name = "Anti-Glow"
 	desc = "Your skin seems to attract and absorb nearby light creating 'darkness' around you."
 	text_gain_indication = span_notice("Your light around you seems to disappear.")
-	glow = -3.5 //Slightly stronger, since negating light tends to be harder than making it.
+	glow = -2.5 //Slightly stronger, since negating light tends to be harder than making it.
 	conflicts = list(/datum/mutation/human/glow)
 	locked = TRUE
 
@@ -283,6 +283,7 @@
 	owner.dna.species.punchdamagelow += strength_punchpower
 	owner.dna.species.punchdamagehigh += strength_punchpower
 	owner.dna.species.punchstunthreshold += strength_punchpower //So we dont change the stun chance
+	ADD_TRAIT(owner, TRAIT_QUICKER_CARRY, src)	
 
 /datum/mutation/human/strong/on_losing(mob/living/carbon/human/owner)
 	if(..())
@@ -291,6 +292,7 @@
 	owner.dna.species.punchdamagelow -= strength_punchpower
 	owner.dna.species.punchdamagehigh -= strength_punchpower
 	owner.dna.species.punchstunthreshold -= strength_punchpower
+	REMOVE_TRAIT(owner, TRAIT_QUICKER_CARRY, src)	
 //Yogs end
 
 /datum/mutation/human/insulated
@@ -301,6 +303,7 @@
 	text_lose_indication = span_notice("Your fingertips regain feeling.")
 	difficulty = 16
 	instability = 25
+	conflicts = list(/datum/mutation/human/shock, /datum/mutation/human/shock/far)
 
 /datum/mutation/human/insulated/on_acquiring(mob/living/carbon/human/owner)
 	if(..())

--- a/code/datums/mutations/chameleon.dm
+++ b/code/datums/mutations/chameleon.dm
@@ -8,6 +8,7 @@
 	text_lose_indication = span_notice("You feel oddly exposed.")
 	time_coeff = 5
 	instability = 25
+	conflicts = list(/datum/mutation/human/glow, /datum/mutation/human/glow/anti)
 
 /datum/mutation/human/chameleon/on_acquiring(mob/living/carbon/human/owner)
 	if(..())

--- a/code/datums/mutations/cold.dm
+++ b/code/datums/mutations/cold.dm
@@ -27,6 +27,7 @@
 	difficulty = 12
 	synchronizer_coeff = 1
 	power = /obj/effect/proc_holder/spell/aimed/cryo
+	conflicts = list(/datum/mutation/human/firebreath)
 
 /obj/effect/proc_holder/spell/aimed/cryo
 	name = "Cryobeam"

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -9,7 +9,7 @@
 	power = /obj/effect/proc_holder/spell/targeted/touch/shock
 	instability = 20
 	locked = TRUE
-	conflicts = list(/datum/mutation/human/shock/far)
+	conflicts = list(/datum/mutation/human/shock/far, /datum/mutation/human/insulated)
 
 /obj/effect/proc_holder/spell/targeted/touch/shock
 	name = "Shock Touch"

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -9,6 +9,7 @@
 	power = /obj/effect/proc_holder/spell/targeted/touch/shock
 	instability = 20
 	locked = TRUE
+	conflicts = list(/datum/mutation/human/shock/far)
 
 /obj/effect/proc_holder/spell/targeted/touch/shock
 	name = "Shock Touch"

--- a/code/datums/mutations/touchfar.dm
+++ b/code/datums/mutations/touchfar.dm
@@ -4,7 +4,7 @@
 	instability = 30
 	text_gain_indication = "<span class='notice'>You feel unlimited power flow through your hands.</span>"
 	power = /obj/effect/proc_holder/spell/targeted/touch/shock/far
-	conflicts = list(/datum/mutation/human/shock)
+	conflicts = list(/datum/mutation/human/shock, /datum/mutation/human/insulated)
 
 /obj/effect/proc_holder/spell/targeted/touch/shock/far
 	name = "Extended Shock Touch"

--- a/code/datums/mutations/touchfar.dm
+++ b/code/datums/mutations/touchfar.dm
@@ -4,6 +4,7 @@
 	instability = 30
 	text_gain_indication = "<span class='notice'>You feel unlimited power flow through your hands.</span>"
 	power = /obj/effect/proc_holder/spell/targeted/touch/shock/far
+	conflicts = list(/datum/mutation/human/shock)
 
 /obj/effect/proc_holder/spell/targeted/touch/shock/far
 	name = "Extended Shock Touch"

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -22,7 +22,7 @@
 	exotic_bloodtype = "L"
 	disliked_food = GRAIN | DAIRY
 	liked_food = GROSS | MEAT | GRILLED | SEAFOOD | MICE
-	inert_mutation = FIREBREATH
+	inert_mutation = GIGANTISM
 	deathsound = 'sound/voice/lizard/deathsound.ogg'
 	screamsound = 'yogstation/sound/voice/lizardperson/lizard_scream.ogg' //yogs - lizard scream
 	wings_icon = "Dragon"
@@ -100,6 +100,7 @@
 	mutantlungs = /obj/item/organ/lungs/ashwalker
 	breathid = "n2" // yogs end
 	species_language_holder = /datum/language_holder/lizard/ash
+	inert_mutation = FIREBREATH
 
 // yogs start - Ashwalkers now have ash immunity
 /datum/species/lizard/ashwalker/on_species_gain(mob/living/carbon/C, datum/species/old_species)
@@ -127,6 +128,7 @@
 	punchdamagelow = 3
 	punchdamagehigh = 12
 	punchstunthreshold = 12	//+2 claws of powergaming
+	inert_mutation = FIREBREATH
 
 /datum/species/lizard/draconid/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -22,7 +22,7 @@
 	exotic_bloodtype = "L"
 	disliked_food = GRAIN | DAIRY
 	liked_food = GROSS | MEAT | GRILLED | SEAFOOD | MICE
-	inert_mutation = CHAMELEON
+	inert_mutation = FIREBREATH
 	deathsound = 'sound/voice/lizard/deathsound.ogg'
 	screamsound = 'yogstation/sound/voice/lizardperson/lizard_scream.ogg' //yogs - lizard scream
 	wings_icon = "Dragon"
@@ -100,7 +100,6 @@
 	mutantlungs = /obj/item/organ/lungs/ashwalker
 	breathid = "n2" // yogs end
 	species_language_holder = /datum/language_holder/lizard/ash
-	inert_mutation = FIREBREATH
 
 // yogs start - Ashwalkers now have ash immunity
 /datum/species/lizard/ashwalker/on_species_gain(mob/living/carbon/C, datum/species/old_species)
@@ -128,7 +127,6 @@
 	punchdamagelow = 3
 	punchdamagehigh = 12
 	punchstunthreshold = 12	//+2 claws of powergaming
-	inert_mutation = FIREBREATH
 
 /datum/species/lizard/draconid/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -22,7 +22,7 @@
 	exotic_bloodtype = "L"
 	disliked_food = GRAIN | DAIRY
 	liked_food = GROSS | MEAT | GRILLED | SEAFOOD | MICE
-	inert_mutation = GIGANTISM
+	inert_mutation = CHAMELEON
 	deathsound = 'sound/voice/lizard/deathsound.ogg'
 	screamsound = 'yogstation/sound/voice/lizardperson/lizard_scream.ogg' //yogs - lizard scream
 	wings_icon = "Dragon"


### PR DESCRIPTION
# Document the changes in your pull request

Makes some mutations incompatible with each other:

- Shock Touch and Extended Shock Touch are incompatible. No more stacking them for nearly uncounterable confusion.
- Insulated and both shock touch mutations are incompatible. This fits thematically with not conducting electricity.
- Fire breath and cryokinesis are incompatible. These together make for a cancerous combo of cold slowdown and nearly unavoidable fireball projectile.
- glowy/antiglow, and chameleon are incompatible. no more becoming an invisible spotlight.
- makes glowy is now exactly as strong as antiglow instead of considerably weaker
- makes strength give you the TRAIT_QUICKER_CARRY trait so you can fast-carry someone

# Changelog

:cl:  
experimental: Initial steps to reeling in Genetic Mutations
tweak: Shock Touch is now Incompatible with Extended Shock Touch
tweak: (Extended) Shock Touch is now Incompatible with Insulated
tweak: Cryokinesis is now Incompatible with Fire Breath
tweak: (Anti) Glowy is now Incompatible with Chameleon
tweak: glowy is now exactly as strong as antiglow instead of considerably weaker
tweak: Strength now lets you fireman carry people very quickly
/:cl:
