### PR TITLE
makes crayons have min color

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -76,6 +76,25 @@
 	user.visible_message(span_suicide("[user] is jamming [src] up [user.p_their()] nose and into [user.p_their()] brain. It looks like [user.p_theyre()] trying to commit suicide!"))
 	return (BRUTELOSS|OXYLOSS)
 
+/obj/item/toy/crayon/proc/min_value() // Makes the paint color brighter if it is below quarter bright (V < 64)
+	var/list/read = ReadRGB(paint_color) // Converts the RGB string into a list
+	var/value = max(read) // Reads the V from HSV, essentially the brightness
+
+	if(value >= 64) // Min V is 64, 3 quarters to black from white
+		return
+	
+	if(value > 0) // Div by zero avoidance
+		var/difference = 64/value
+		read[1] *= difference
+		read[2] *= difference
+		read[3] *= difference
+	else
+		read[1] = 64
+		read[2] = 64
+		read[3] = 64
+
+	paint_color = rgb(read[1], read[1], read[3])
+
 /obj/item/toy/crayon/Initialize()
 	. = ..()
 	// Makes crayons identifiable in things like grinders
@@ -234,6 +253,7 @@
 		if("select_colour")
 			if(can_change_colour)
 				paint_color = input(usr,"","Choose Color",paint_color) as color|null
+				min_value()
 				. = TRUE
 		if("enter_text")
 			var/txt = stripped_input(usr,"Choose what to write.",
@@ -465,7 +485,7 @@
 
 /obj/item/toy/crayon/black
 	icon_state = "crayonblack"
-	paint_color = "#1C1C1C" //Not completely black because total black looks bad. So Mostly Black.
+	paint_color = "#404040" //Not completely black because total black looks bad. So Mostly Black.
 	crayon_color = "black"
 	reagent_contents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/colorful_reagent/crayonpowder/black = 1)
 	dye_color = DYE_BLACK
@@ -498,6 +518,7 @@
 
 /obj/item/toy/crayon/rainbow/afterattack(atom/target, mob/user, proximity, params)
 	paint_color = rgb(rand(0,255), rand(0,255), rand(0,255))
+	min_value()
 	. = ..()
 
 /*

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -93,7 +93,7 @@
 		read[2] = 64
 		read[3] = 64
 
-	paint_color = rgb(read[1], read[1], read[3])
+	paint_color = rgb(read[1], read[2], read[3])
 
 /obj/item/toy/crayon/Initialize()
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1455,7 +1455,7 @@
 /datum/reagent/colorful_reagent/crayonpowder/black
 	name = "Black Crayon Powder"
 	colorname = "black"
-	color = "#1C1C1C" // not quite black
+	color = "#404040" // not quite black
 	random_color_list = list("#404040")
 
 /datum/reagent/colorful_reagent/crayonpowder/white


### PR DESCRIPTION
# Document the changes in your pull request

Crayons & spray cans can not have be below 25% brightness

Still pretty dark, but not unbearably so, darkest possible color is #404040
![](https://i.imgur.com/KxGI6VJ.png)

May increase minimum in future if 25% is still problematic

## Why?

players (regulars) have been found to abuse the color black in spray cans in order to make their entire sprite one singular color

im not going into detail of why this is the case but the darker you set the color, the more unicolor your sprite becomes

players combine this with making entire areas pitch black and suddenly you can't see them or anything that's there but hey they have some guns and they can sure as hell see you

# Changelog

:cl:  
tweak: Crayons & spray cans now have a minimum color brightness of 25%
/:cl:
