### PR TITLE
Makes clerk actually start with jumpskirt if clerk selects jumpskirt option at round start

### DIFF
--- a/yogstation/code/modules/jobs/job_types/clerk.dm
+++ b/yogstation/code/modules/jobs/job_types/clerk.dm
@@ -31,6 +31,7 @@
 
 	ears = /obj/item/radio/headset/headset_srv
 	uniform = /obj/item/clothing/under/yogs/rank/clerk
+	uniform_skirt = /obj/item/clothing/under/yogs/rank/clerk/skirt
 	shoes = /obj/item/clothing/shoes/sneakers/black
 	head = /obj/item/clothing/head/yogs/clerkcap
 	backpack_contents = list(/obj/item/circuitboard/machine/paystand = 1)


### PR DESCRIPTION
# Document the changes in your pull request

Let's clerk actually get their jumpskirt roundstart so there is no need for jumpskirt in box or anything. I'll have to hunt for other jobs that don't do this but yeah I'm doing this mainly so it's not a hassle and having to strip every round is not fun.

# Spriting
If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob.

# Wiki Documentation

N/A

# Changelog

Clerk can now have a skirt instead of being stuck with an ugly uniform all he time

:cl:  
rscadd: Gives clerk a skirt so they can go spinny
/:cl:
