### PR TITLE
Removes the vichy france anthem from the france holiday

### DIFF
--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -324,7 +324,6 @@
 		"https://www.youtube.com/watch?v=c5OdCqUWRyo", // Le Chant du Depart
 		"https://www.youtube.com/watch?v=wS10laW0rFo", // Chant du 9 Thermidor
 		"https://www.youtube.com/watch?v=o3wivTC1gOw", // Bonjour mon vieux Paris
-		"https://www.youtube.com/watch?v=8KdTChn-pEA" // Maréchal, nous voilà
 		)
 
 /datum/holiday/france/getStationPrefix()


### PR DESCRIPTION

# Document the changes in your pull request

who the fuck thought adding the anthem of france when it was a nazi puppet state into the game was a funny idea

# Changelog



:cl:  
rscdel: Removes vichy france anthem
/:cl:
