### PR TITLE
[AI] Cryptomining upgrade allows for idle CPU to be used for generating credits

### DIFF
--- a/code/__DEFINES/ai.dm
+++ b/code/__DEFINES/ai.dm
@@ -51,3 +51,13 @@ GLOBAL_LIST_INIT(ai_project_categories, list(
 
 //How long between each data core being able to send a warning. Wouldn't want any spam if we had jittery temps would we?
 #define AI_DATA_CORE_WARNING_COOLDOWN (5 MINUTES)
+
+
+//Self explanatory. 1 bitcoin is equals to 1 CPU * AI_RESEARCH_PER_CPU
+//EXAMPLE (with initial values as of feature introduction)
+//20 free CPU. 10 are used for research, 10 are used for bitcoin
+//10 * AI_RESEARCH_PER_CPU = 85 bitcoin per tick. Modified for scaling 85*0.54=46
+//46 * AI_BITCOIN_PRICE = 9,2 credits per 2 seconds (8280 credits per 30 min)
+#define MAX_AI_BITCOIN_MINED_PER_TICK 100
+//Self explanatory, see MAX_AI_BITCOIN_MINED_PER_TICK * this = max money 1 AI can contribute per tick. (20 credits every 2 seconds, max 72k over 2 hours)
+#define AI_BITCOIN_PRICE 0.2

--- a/code/__DEFINES/ai.dm
+++ b/code/__DEFINES/ai.dm
@@ -57,7 +57,7 @@ GLOBAL_LIST_INIT(ai_project_categories, list(
 //EXAMPLE (with initial values as of feature introduction)
 //20 free CPU. 10 are used for research, 10 are used for bitcoin
 //10 * AI_RESEARCH_PER_CPU = 85 bitcoin per tick. Modified for scaling 85*0.54=46
-//46 * AI_BITCOIN_PRICE = 9,2 credits per 2 seconds (8280 credits per 30 min)
-#define MAX_AI_BITCOIN_MINED_PER_TICK 100
-//Self explanatory, see MAX_AI_BITCOIN_MINED_PER_TICK * this = max money 1 AI can contribute per tick. (20 credits every 2 seconds, max 72k over 2 hours)
-#define AI_BITCOIN_PRICE 0.2
+//46 * AI_BITCOIN_PRICE = 2,3 credits per 2 seconds (2070 credits per 30 min)
+#define MAX_AI_BITCOIN_MINED_PER_TICK 350
+//Self explanatory, see MAX_AI_BITCOIN_MINED_PER_TICK * this = max money 1 AI can contribute per tick. (17,5 credits every 2 seconds, max 63k over 2 hours)
+#define AI_BITCOIN_PRICE 0.05

--- a/code/modules/mob/living/silicon/ai/decentralized/management/ai_dashboard.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/management/ai_dashboard.dm
@@ -13,6 +13,8 @@
 	var/running_projects
 	///Should we be contributing spare CPU to generate research points?
 	var/contribute_spare_cpu = TRUE
+	///Are we using 50% of our spare CPU to mine bitcoin?
+	var/crypto_mining = FALSE
 
 /datum/ai_dashboard/New(mob/living/silicon/ai/new_owner)
 	if(!istype(new_owner))
@@ -258,6 +260,11 @@
 	if(notify_user)
 		to_chat(owner, span_notice("'[ability.name]' has been recharged."))
 
+/datum/ai_dashboard/proc/is_project_running(datum/ai_project/project)
+	var/datum/ai_project/found_project = locate(project) in running_projects
+	if(found_project)
+		return found_project.running
+
 
 //Stuff is handled in here per tick :)
 /datum/ai_dashboard/proc/tick(seconds)
@@ -290,9 +297,20 @@
 	for(var/I in cpu_usage)
 		remaining_cpu -= cpu_usage[I]
 
-	if(remaining_cpu > 0)
-		var/points = round(AI_RESEARCH_PER_CPU * (remaining_cpu * current_cpu) * owner.research_point_booster)
+	if(remaining_cpu > 0 && contribute_spare_cpu)
+		var/points = max(round(AI_RESEARCH_PER_CPU * (remaining_cpu * current_cpu) * owner.research_point_booster), 0)
+
+		if(crypto_mining)
+			points *= 0.5
+			var/bitcoin_mined = points * (1-0.05*sqrt(points))	
+			bitcoin_mined = clamp(bitcoin_mined, 0, MAX_AI_BITCOIN_MINED_PER_TICK)
+			var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
+			if(D)
+				D.adjust_money(bitcoin_mined * AI_BITCOIN_PRICE)
+
 		SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_AI = points))
+		
+
 
 	for(var/project_being_researched in cpu_usage)
 		if(!cpu_usage[project_being_researched])

--- a/code/modules/mob/living/silicon/ai/decentralized/projects/_ai_project.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/projects/_ai_project.dm
@@ -52,12 +52,14 @@ GLOBAL_LIST_EMPTY(ai_projects)
 		if(!canRun())
 			return FALSE
 	running = TRUE
+	dashboard.running_projects += src
 	return TRUE
 
 
 /datum/ai_project/proc/stop()
 	SHOULD_CALL_PARENT(TRUE)
 	running = FALSE
+	dashboard.running_projects -= src
 	return TRUE
 	
 //Important! This isn't for checking processing requirements. That is checked on the AI for ease of references (See ai_dashboard.dm). This is just for special cases (Like uhh, not wanting the program to run while X runs or similar)

--- a/code/modules/mob/living/silicon/ai/decentralized/projects/cryptominer.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/projects/cryptominer.dm
@@ -1,0 +1,17 @@
+/datum/ai_project/crypto_miner
+	name = "Crypto Miner"
+	description = "Allocating spare CPU capacity to mining crypto currency should be able to help fund the station budget. This would however reduce AI research point generation by 50%"
+	category = AI_PROJECT_MISC
+	
+	research_cost = 2000
+	
+
+/datum/ai_project/crypto_miner/run_project(force_run = FALSE)
+	. = ..(force_run)
+	if(!.)
+		return .
+	dashboard.crypto_mining = TRUE
+
+/datum/ai_project/crypto_miner/stop()
+	dashboard.crypto_mining = FALSE
+	..()

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2441,6 +2441,7 @@
 #include "code\modules\mob\living\silicon\ai\decentralized\projects\ai_huds.dm"
 #include "code\modules\mob\living\silicon\ai\decentralized\projects\camera_mobility.dm"
 #include "code\modules\mob\living\silicon\ai\decentralized\projects\coolant_manager.dm"
+#include "code\modules\mob\living\silicon\ai\decentralized\projects\cryptominer.dm"
 #include "code\modules\mob\living\silicon\ai\decentralized\projects\examine.dm"
 #include "code\modules\mob\living\silicon\ai\decentralized\projects\firewall.dm"
 #include "code\modules\mob\living\silicon\ai\decentralized\projects\induction.dm"


### PR DESCRIPTION
# Document the changes in your pull request
Capped to provide at maximum 17,5 credits per second if you go absolutely ham with CPU (theoretically)
Something semi-easy to obtain would give 2,3 credits a second. 
There's diminishing returns so obtaining the full credits per second requires upwards of 10000 CPU

# Wiki Documentation

# Changelog

:cl:  
rscadd: The AI can now mine cryptocurrency  
/:cl:
