### PR TITLE
Fix custom shuttle mass problem

### DIFF
--- a/code/modules/shuttle/custom_shuttle.dm
+++ b/code/modules/shuttle/custom_shuttle.dm
@@ -128,7 +128,8 @@
 	//Calculate all the data
 	var/list/areas = M.shuttle_areas
 	for(var/shuttleArea in areas)
-		calculated_mass += length(get_area_turfs(shuttleArea))
+		for(var/turf/T in shuttleArea)
+			calculated_mass += 1
 		for(var/obj/machinery/shuttle/engine/E in shuttleArea)
 			E.check_setup()
 			if(!E.thruster_active)	//Skipover thrusters with no valid heater


### PR DESCRIPTION
# About PR
port from [singulo](https://github.com/SinguloStation13/SinguloStation13/pull/77) from [bee](https://github.com/BeeStation/BeeStation-Hornet/pull/5493)

Due to a code oversight, custom shuttles currently calculate mass based on amount of tiles in the type of the shuttle's area. Because all custom shuttles' areas have the same types, this means the mass uses the sum of all custom shuttle areas. 


# Wiki Documentation



# Changelog
:cl:  

bugfix: fixed custom shuttle mass problem

/:cl:
