### PR TITLE
Lowers heresy required player count to 25 from 35

### DIFF
--- a/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
+++ b/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
@@ -6,7 +6,7 @@
 	false_report_weight = 5
 	protected_jobs = list("Chaplain","Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Research Director", "Chief Engineer", "Chief Medical Officer", "Brig Physician") //Yogs: Added Brig Physician
 	restricted_jobs = list("AI", "Cyborg")
-	required_players = 35
+	required_players = 25
 	required_enemies = 1
 	recommended_enemies = 4
 	reroll_friendly = 1


### PR DESCRIPTION

# Document the changes in your pull request

Heretic is a great mode that almost never gets picked because it (for some stupid reason) requires more pop than the majority of team antags. 35 is way too high, 25 is better, not too low, not too high. We need more mode variety, not less.
# Spriting


# Wiki Documentation

If it shows how many needed players there are, lower it as needed
# Changelog



:cl:  
tweak: heretic player count lowered to 25 from 35
/:cl:
