### PR TITLE
Significantly adjusts minimum age requirements for most jobs

### DIFF
--- a/code/modules/jobs/job_types/artist.dm
+++ b/code/modules/jobs/job_types/artist.dm
@@ -17,6 +17,7 @@
 	paycheck_department = ACCOUNT_CIV
 
 	display_order = JOB_DISPLAY_ORDER_ARTIST
+	minimal_character_age = 18 //Young folks can be crazy crazy artists, something talented that can be self-taught feasibly
 
 /datum/outfit/job/artist
 	name = "Artist"

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -17,6 +17,7 @@ Assistant
 	paycheck = PAYCHECK_ASSISTANT // Get a job. Job reassignment changes your paycheck now. Get over it.
 	paycheck_department = ACCOUNT_CIV
 	display_order = JOB_DISPLAY_ORDER_ASSISTANT
+	minimal_character_age = 18 //Would make it even younger if I could because this role turns men into little brat boys and likewise for the other genders
 
 	alt_titles = list("Intern", "Apprentice", "Subordinate", "Temporary Worker", "Associate")
 

--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -19,6 +19,7 @@
 	paycheck = PAYCHECK_MEDIUM
 	paycheck_department = ACCOUNT_ENG
 	display_order = JOB_DISPLAY_ORDER_ATMOSPHERIC_TECHNICIAN
+	minimal_character_age = 24 //Intense understanding of thermodynamics, gas law, gas interaction, construction and safe containment of gases, creation of new ones, math beyond your wildest imagination
 
 	changed_maps = list("OmegaStation", "EclipseStation")
 

--- a/code/modules/jobs/job_types/bartender.dm
+++ b/code/modules/jobs/job_types/bartender.dm
@@ -19,6 +19,7 @@
 	paycheck = PAYCHECK_EASY
 	paycheck_department = ACCOUNT_SRV
 	display_order = JOB_DISPLAY_ORDER_BARTENDER
+	minimal_character_age = 21 //I shouldn't have to explain this one
 
 	changed_maps = list("OmegaStation")
 

--- a/code/modules/jobs/job_types/botanist.dm
+++ b/code/modules/jobs/job_types/botanist.dm
@@ -18,6 +18,7 @@
 	paycheck = PAYCHECK_EASY
 	paycheck_department = ACCOUNT_SRV
 	display_order = JOB_DISPLAY_ORDER_BOTANIST
+	minimal_character_age = 22 //Biological understanding of plants and how to manipulate their DNAs and produces relatively "safely". Not just something that comes to you without education
 
 	changed_maps = list("OmegaStation", "EclipseStation")
 

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -27,7 +27,7 @@
 	mind_traits = list(TRAIT_DISK_VERIFIER)
 
 	display_order = JOB_DISPLAY_ORDER_CAPTAIN
-	minimal_character_age = 28
+	minimal_character_age = 35 //Feasibly expected to know everything and potentially do anything. Leagues of experience, briefing, training, and trust required for this role
 
 /datum/job/captain/get_access()
 	return get_all_accesses()

--- a/code/modules/jobs/job_types/cargo_technician.dm
+++ b/code/modules/jobs/job_types/cargo_technician.dm
@@ -19,6 +19,7 @@
 	paycheck_department = ACCOUNT_CAR
 
 	display_order = JOB_DISPLAY_ORDER_CARGO_TECHNICIAN
+	minimal_character_age = 18 //We love manual labor and exploiting the young for our corporate purposes
 
 	changed_maps = list("EclipseStation", "OmegaStation")
 

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -19,6 +19,7 @@
 	paycheck_department = ACCOUNT_CIV
 
 	display_order = JOB_DISPLAY_ORDER_CHAPLAIN
+	minimal_character_age = 18 //My guy you are literally just a priest
 
 
 /datum/job/chaplain/after_spawn(mob/living/H, mob/M)

--- a/code/modules/jobs/job_types/chemist.dm
+++ b/code/modules/jobs/job_types/chemist.dm
@@ -22,6 +22,7 @@
 	paycheck_department = ACCOUNT_MED
 
 	display_order = JOB_DISPLAY_ORDER_CHEMIST
+	minimal_character_age = 24 //A lot of experimental drugs plus understanding the facilitation and purpose of several subtances; what treats what and how to safely manufacture it
 
 	changed_maps = list("OmegaStation", "EclipseStation")
 

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -28,7 +28,7 @@
 	paycheck_department = ACCOUNT_ENG
 
 	display_order = JOB_DISPLAY_ORDER_CHIEF_ENGINEER
-	minimal_character_age = 25 // Geordi LaForge became CE of the Entreprise when he was 30, for comparison.
+	minimal_character_age = 30 //Combine all the jobs together; that's a lot of physics, mechanical, electrical, and power-based knowledge
 
 /datum/outfit/job/ce
 	name = "Chief Engineer"

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -27,7 +27,7 @@
 	paycheck_department = ACCOUNT_MED
 
 	display_order = JOB_DISPLAY_ORDER_CHIEF_MEDICAL_OFFICER
-	minimal_character_age = 25
+	minimal_character_age = 30 //Do you knoW HOW MANY JOBS YOU HAVE TO KNOW TO DO?? This should really be like 35 or something
 
 	changed_maps = list("OmegaStation")
 

--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -19,6 +19,7 @@
 	paycheck_department = ACCOUNT_SRV
 
 	display_order = JOB_DISPLAY_ORDER_CLOWN
+	minimal_character_age = 18 //Honk
 
 
 /datum/job/clown/after_spawn(mob/living/carbon/human/H, mob/M)

--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -20,6 +20,7 @@
 	paycheck_department = ACCOUNT_SRV
 
 	display_order = JOB_DISPLAY_ORDER_COOK
+	minimal_character_age = 18 //My guy they just a cook
 
 	changed_maps = list("OmegaStation", "EclipseStation")
 

--- a/code/modules/jobs/job_types/curator.dm
+++ b/code/modules/jobs/job_types/curator.dm
@@ -19,6 +19,7 @@
 	paycheck_department = ACCOUNT_CIV
 
 	display_order = JOB_DISPLAY_ORDER_CURATOR
+	minimal_character_age = 18 //Don't need to be some aged-ass fellow to know how to care for things, possessions could easily have come from parents and the like. Bloodsucker knowledge is another thing, though that's likely mostly consulted by the book
 
 /datum/outfit/job/curator
 	name = "Curator"

--- a/code/modules/jobs/job_types/detective.dm
+++ b/code/modules/jobs/job_types/detective.dm
@@ -24,6 +24,7 @@
 	mind_traits = list(TRAIT_LAW_ENFORCEMENT_METABOLISM)
 
 	display_order = JOB_DISPLAY_ORDER_DETECTIVE
+	minimal_character_age = 22 //Understanding of forensics, crime analysis, and theory. Less of a grunt officer and more of an intellectual, theoretically, despite how this is never reflected in-game
 
 	changed_maps = list("EclipseStation", "OmegaStation")
 

--- a/code/modules/jobs/job_types/geneticist.dm
+++ b/code/modules/jobs/job_types/geneticist.dm
@@ -20,6 +20,7 @@
 	paycheck_department = ACCOUNT_MED
 
 	display_order = JOB_DISPLAY_ORDER_GENETICIST
+	minimal_character_age = 24 //Genetics would likely require more education than your average position due to the sheer number of alien physiologies and experimental nature of the field
 
 	changed_maps = list("OmegaStation", "EclipseStation")
 

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -31,7 +31,7 @@
 	paycheck_department = ACCOUNT_SRV
 
 	display_order = JOB_DISPLAY_ORDER_HEAD_OF_PERSONNEL
-	minimal_character_age = 25
+	minimal_character_age = 26 //Baseline age requirement and competency, as well as ability to assume leadership in shite situations
 
 	changed_maps = list("OmegaStation")
 

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -29,7 +29,7 @@
 	paycheck_department = ACCOUNT_SEC
 
 	display_order = JOB_DISPLAY_ORDER_HEAD_OF_SECURITY
-	minimal_character_age = 28
+	minimal_character_age = 28 //You need some experience on your belt and a little gruffiness; you're still a foot soldier, not quite a tactician commander back at base
 
 	changed_maps = list("YogsPubby")
 

--- a/code/modules/jobs/job_types/janitor.dm
+++ b/code/modules/jobs/job_types/janitor.dm
@@ -19,7 +19,7 @@
 	paycheck_department = ACCOUNT_SRV
 
 	display_order = JOB_DISPLAY_ORDER_JANITOR
-	minimal_character_age = 18 //Theoretically janitors do actually need training and certifications in handling of certain hazardous materials as well as cleaning substances, but nothing absurd, I'd assume
+	minimal_character_age = 20 //Theoretically janitors do actually need training and certifications in handling of certain hazardous materials as well as cleaning substances, but nothing absurd, I'd assume
 
 	changed_maps = list("OmegaStation", "EclipseStation")
 

--- a/code/modules/jobs/job_types/janitor.dm
+++ b/code/modules/jobs/job_types/janitor.dm
@@ -19,6 +19,7 @@
 	paycheck_department = ACCOUNT_SRV
 
 	display_order = JOB_DISPLAY_ORDER_JANITOR
+	minimal_character_age = 18 //Theoretically janitors do actually need training and certifications in handling of certain hazardous materials as well as cleaning substances, but nothing absurd, I'd assume
 
 	changed_maps = list("OmegaStation", "EclipseStation")
 

--- a/code/modules/jobs/job_types/lawyer.dm
+++ b/code/modules/jobs/job_types/lawyer.dm
@@ -20,7 +20,7 @@
 	mind_traits = list(TRAIT_LAW_ENFORCEMENT_METABOLISM)
 
 	display_order = JOB_DISPLAY_ORDER_LAWYER
-	minimal_character_age = 24
+	minimal_character_age = 24 //Law is already absurd, never mind the wacky-ass shit that is space law
 
 	changed_maps = list("OmegaStation")
 

--- a/code/modules/jobs/job_types/medical_doctor.dm
+++ b/code/modules/jobs/job_types/medical_doctor.dm
@@ -20,7 +20,7 @@
 	paycheck_department = ACCOUNT_MED
 
 	display_order = JOB_DISPLAY_ORDER_MEDICAL_DOCTOR
-	minimal_character_age = 24
+	minimal_character_age = 24 //Barely acceptable considering the theoretically absurd knowledge they have, but fine
 
 	changed_maps = list("EclipseStation", "OmegaStation")
 

--- a/code/modules/jobs/job_types/medical_doctor.dm
+++ b/code/modules/jobs/job_types/medical_doctor.dm
@@ -20,7 +20,7 @@
 	paycheck_department = ACCOUNT_MED
 
 	display_order = JOB_DISPLAY_ORDER_MEDICAL_DOCTOR
-	minimal_character_age = 24 //Barely acceptable considering the theoretically absurd knowledge they have, but fine
+	minimal_character_age = 26 //Barely acceptable considering the theoretically absurd knowledge they have, but fine
 
 	changed_maps = list("EclipseStation", "OmegaStation")
 

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -19,6 +19,7 @@
 	paycheck_department = ACCOUNT_SRV
 
 	display_order = JOB_DISPLAY_ORDER_MIME
+	minimal_character_age = 18 //Mime?? Might increase this a LOT depending on how mime lore turns out
 
 /datum/job/mime/after_spawn(mob/living/carbon/human/H, mob/M)
 	H.apply_pref_name("mime", M.client)

--- a/code/modules/jobs/job_types/quartermaster.dm
+++ b/code/modules/jobs/job_types/quartermaster.dm
@@ -19,6 +19,7 @@
 	paycheck_department = ACCOUNT_CAR
 
 	display_order = JOB_DISPLAY_ORDER_QUARTERMASTER
+	minimal_character_age = 20 //Probably just needs some baseline experience with bureaucracy, enough trust to land the position
 
 	changed_maps = list("OmegaStation")
 

--- a/code/modules/jobs/job_types/research_director.dm
+++ b/code/modules/jobs/job_types/research_director.dm
@@ -30,7 +30,7 @@
 	paycheck_department = ACCOUNT_SCI
 
 	display_order = JOB_DISPLAY_ORDER_RESEARCH_DIRECTOR
-	minimal_character_age = 26 // "A PhD takes twice as long as a bachelor's degree to complete. The average student takes 8.2 years to slog through a PhD program and is 33 years old before earning that top diploma."
+	minimal_character_age = 26 //Barely knows more than actual scientists, just responsibility and AI things
 
 	changed_maps = list("OmegaStation")
 

--- a/code/modules/jobs/job_types/roboticist.dm
+++ b/code/modules/jobs/job_types/roboticist.dm
@@ -20,7 +20,7 @@
 	paycheck_department = ACCOUNT_SCI
 
 	display_order = JOB_DISPLAY_ORDER_ROBOTICIST
-	minimal_character_age = 18
+	minimal_character_age = 22 //Engineering, AI theory, robotic knowledge and the like
 
 	changed_maps = list("OmegaStation")
 

--- a/code/modules/jobs/job_types/scientist.dm
+++ b/code/modules/jobs/job_types/scientist.dm
@@ -20,7 +20,7 @@
 	paycheck_department = ACCOUNT_SCI
 
 	display_order = JOB_DISPLAY_ORDER_SCIENTIST
-	minimal_character_age = 18
+	minimal_character_age = 24 //Consider the level of knowledge that spans xenobio, nanites, and toxins
 
 	changed_maps = list("EclipseStation", "OmegaStation")
 

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -24,6 +24,7 @@
 	mind_traits = list(TRAIT_LAW_ENFORCEMENT_METABOLISM)
 
 	display_order = JOB_DISPLAY_ORDER_SECURITY_OFFICER
+	minimal_character_age = 18 //Just a few months of boot camp, not a whole year
 
 	changed_maps = list("EclipseStation", "YogsPubby", "OmegaStation")
 

--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -18,6 +18,7 @@
 	paycheck_department = ACCOUNT_CAR
 
 	display_order = JOB_DISPLAY_ORDER_SHAFT_MINER
+	minimal_character_age = 18 //Young and fresh bodies for a high mortality job, what more could you ask for
 
 	changed_maps = list("EclipseStation", "OmegaStation")
 

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -21,6 +21,7 @@
 	paycheck_department = ACCOUNT_ENG
 
 	display_order = JOB_DISPLAY_ORDER_STATION_ENGINEER
+	minimal_character_age = 22 //You need to know a lot of complicated stuff about engines, could theoretically just have a traditional bachelor's
 
 	changed_maps = list("EclipseStation", "OmegaStation")
 

--- a/code/modules/jobs/job_types/virologist.dm
+++ b/code/modules/jobs/job_types/virologist.dm
@@ -22,6 +22,7 @@
 	paycheck_department = ACCOUNT_MED
 
 	display_order = JOB_DISPLAY_ORDER_VIROLOGIST
+	minimal_character_age = 24 //Requires understanding of microbes, biology, infection, and all the like, as well as being able to understand how to interface the machines. Epidemiology is no joke of a field
 
 	changed_maps = list("OmegaStation")
 

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -25,6 +25,7 @@
 	mind_traits = list(TRAIT_LAW_ENFORCEMENT_METABOLISM)
 
 	display_order = JOB_DISPLAY_ORDER_WARDEN
+	minimal_character_age = 20 //You're a sergeant, probably has some experience in the field
 
 	changed_maps = list("YogsPubby", "OmegaStation")
 

--- a/yogstation/code/modules/jobs/job_types/brig_physician.dm
+++ b/yogstation/code/modules/jobs/job_types/brig_physician.dm
@@ -13,7 +13,7 @@
 
 	alt_titles = list("Security Medic", "Security Medical Support", "Penitentiary Medical Care Unit", "Junior Brig Physician", "Detention Center Health Officer") 
 
-	minimal_character_age = 24 // "According to age statistics published by the Association of American Medical Colleges, the average age among medical students who matriculated at U.S. medical schools in the 2017-2018 school year was 24"
+	minimal_character_age = 24 //Matches MD
 
 	added_access = list(ACCESS_SURGERY)
 	base_access = list(ACCESS_MEDICAL, ACCESS_MORGUE, ACCESS_BRIG, ACCESS_SEC_DOORS, ACCESS_COURT, ACCESS_MAINT_TUNNELS, ACCESS_MECH_MEDICAL, ACCESS_BRIG_PHYS)

--- a/yogstation/code/modules/jobs/job_types/brig_physician.dm
+++ b/yogstation/code/modules/jobs/job_types/brig_physician.dm
@@ -13,7 +13,7 @@
 
 	alt_titles = list("Security Medic", "Security Medical Support", "Penitentiary Medical Care Unit", "Junior Brig Physician", "Detention Center Health Officer") 
 
-	minimal_character_age = 24 //Matches MD
+	minimal_character_age = 26 //Matches MD
 
 	added_access = list(ACCESS_SURGERY)
 	base_access = list(ACCESS_MEDICAL, ACCESS_MORGUE, ACCESS_BRIG, ACCESS_SEC_DOORS, ACCESS_COURT, ACCESS_MAINT_TUNNELS, ACCESS_MECH_MEDICAL, ACCESS_BRIG_PHYS)

--- a/yogstation/code/modules/jobs/job_types/clerk.dm
+++ b/yogstation/code/modules/jobs/job_types/clerk.dm
@@ -15,6 +15,7 @@
 	paycheck = PAYCHECK_EASY
 	paycheck_department = ACCOUNT_SRV
 	display_order = JOB_DISPLAY_ORDER_CLERK
+	minimal_character_age = 18 //Capitalism doesn't care about age
 
 	changed_maps = list("EclipseStation", "OmegaStation")
 

--- a/yogstation/code/modules/jobs/job_types/mining_medic.dm
+++ b/yogstation/code/modules/jobs/job_types/mining_medic.dm
@@ -13,7 +13,7 @@
 
 	alt_titles = list("Mining Medical Support", "Lavaland Medical Care Unit", "Junior Mining Medic", "Planetside Health Officer")
 
-	minimal_character_age = 24 // "According to age statistics published by the Association of American Medical Colleges, the average age among medical students who matriculated at U.S. medical schools in the 2017-2018 school year was 24"
+	minimal_character_age = 24 //Matches MD
 
 	added_access = list(ACCESS_SURGERY, ACCESS_CARGO)
 	base_access = list(ACCESS_MEDICAL, ACCESS_MORGUE, ACCESS_MINING, ACCESS_MINING_STATION, ACCESS_MAILSORTING, ACCESS_MINERAL_STOREROOM, ACCESS_MECH_MINING, ACCESS_MECH_MEDICAL)

--- a/yogstation/code/modules/jobs/job_types/mining_medic.dm
+++ b/yogstation/code/modules/jobs/job_types/mining_medic.dm
@@ -13,7 +13,7 @@
 
 	alt_titles = list("Mining Medical Support", "Lavaland Medical Care Unit", "Junior Mining Medic", "Planetside Health Officer")
 
-	minimal_character_age = 24 //Matches MD
+	minimal_character_age = 26 //Matches MD
 
 	added_access = list(ACCESS_SURGERY, ACCESS_CARGO)
 	base_access = list(ACCESS_MEDICAL, ACCESS_MORGUE, ACCESS_MINING, ACCESS_MINING_STATION, ACCESS_MAILSORTING, ACCESS_MINERAL_STOREROOM, ACCESS_MECH_MINING, ACCESS_MECH_MEDICAL)

--- a/yogstation/code/modules/jobs/job_types/network_admin.dm
+++ b/yogstation/code/modules/jobs/job_types/network_admin.dm
@@ -19,6 +19,7 @@
 	paycheck = PAYCHECK_MEDIUM
 	paycheck_department = ACCOUNT_ENG
 	display_order = JOB_DISPLAY_ORDER_NETWORK_ADMIN
+	minimal_character_age = 22 //Feasibly same level as engineer, mostly a data engineer instead of a mechanical or construction-based one, though is still capable of making certain machines
 
 	changed_maps = list("OmegaStation")
 

--- a/yogstation/code/modules/jobs/job_types/paramedic.dm
+++ b/yogstation/code/modules/jobs/job_types/paramedic.dm
@@ -12,13 +12,12 @@
 
 	outfit = /datum/outfit/job/paramedic
 
-	minimal_character_age = 24 // "According to age statistics published by the Association of American Medical Colleges, the average age among medical students who matriculated at U.S. medical schools in the 2017-2018 school year was 24"
-
 	added_access = list(ACCESS_CLONING)
 	base_access = list(ACCESS_MEDICAL, ACCESS_MORGUE, ACCESS_MAINT_TUNNELS, ACCESS_EXTERNAL_AIRLOCKS, ACCESS_PARAMEDIC, ACCESS_MECH_MEDICAL)
 	paycheck = PAYCHECK_MEDIUM
 	paycheck_department = ACCOUNT_MED
 	display_order = JOB_DISPLAY_ORDER_PARAMEDIC
+	minimal_character_age = 20 //As a paramedic you just need to know basic first aid and handling of patients in shock. Ideally you're also strong and able to stay cool. You don't know surgery
 
 	changed_maps = list("OmegaStation", "EclipseStation")
 

--- a/yogstation/code/modules/jobs/job_types/psychiatrist.dm
+++ b/yogstation/code/modules/jobs/job_types/psychiatrist.dm
@@ -12,13 +12,12 @@
 
 	outfit = /datum/outfit/job/psych
 
-	minimal_character_age = 24 // "According to age statistics published by the Association of American Medical Colleges, the average age among medical students who matriculated at U.S. medical schools in the 2017-2018 school year was 24"
-
 	added_access = list()
 	base_access = list(ACCESS_MEDICAL)
 	paycheck = PAYCHECK_MEDIUM
 	paycheck_department = ACCOUNT_MED
 	display_order = JOB_DISPLAY_ORDER_PSYCHIATRIST
+	minimal_character_age = 24 //Psychology, therapy, and the like; all branches that would probably need to be certified as properly educated
 
 	changed_maps = list("OmegaStation","GaxStation")
 

--- a/yogstation/code/modules/jobs/job_types/tourist.dm
+++ b/yogstation/code/modules/jobs/job_types/tourist.dm
@@ -14,6 +14,7 @@
 	paycheck = PAYCHECK_EASY
 	paycheck_department = ACCOUNT_CIV
 	display_order = JOB_DISPLAY_ORDER_TOURIST
+	minimal_character_age = 18 //Gotta go explore the galaxy and see the stuff
 
 /datum/outfit/job/tourist
 	name = "Tourist"


### PR DESCRIPTION
# Document the changes in your pull request

Goes through and adjusts a lot of the age requirements for each job as well as adding comments with general justification and thinking behind each one. Even those that haven't been changed have received a line indicating that they're the base value to explain WHY they're being left at that value of not feasibly requiring education.

Inspired by a lot of things but namely a level of absurdity that comes around from situations such as a bartender younger than 21 and a station engineer that can somehow put together MARVELOUSLY EXPERIMENTAL ENGINES as well as having perfect mechanical knowledge at the age of 18. I understand apprenticeships exist but being that NT is a corporation that wants at least baseline competency from their workers I assume documentation or otherwise evidence of certain knowledge or skills is warranted.

# New Minimum Age per Job
**Artist**: 18 (from 18)
**Assistant**: 18 (from 18)
**Atmospheric Technician**: 24 (from 18)
**Bartender**: 21 (from 18)
**Botanist**: 22 (from 18)
**Brig Physician**: 26 (from 24)
**Captain**: 35 (from 28)
**Cargo Technician**: 18 (from 18)
**Chaplain**: 18 (from 18)
**Chemist**: 24 (from 18)
**Chief Engineer**: 30 (from 25)
**Chief Medical Officer**: 30 (from 25)
**Clerk**: 18 (from 18)
**Clown**: 18 (from 18)
**Cook**: 18 (from 18)
**Curator**: 18 (from 18)
**Detective**: 22 (from 18)
**Geneticist**: 24 (from 18)
**Head of Personnel**: 26 (from 25)
**Head of Security**: 28 (from 28)
**Janitor**: 20 (from 18)
**Lawyer**: 24 (from 24)
**Medical Doctor**: 26 (from 24)
**Mime**: 18 (from 18)
**Mining Medic**: 26 (from 24)
**Network Admin**: 22 (from 18)
**Paramedic**: 20 (from 24)
**Psychiatrist**: 24 (from 24)
**Quartermaster**: 20 (from 18)
**Research Director**: 26 (from 26)
**Roboticist**: 22 (from 18)
**Scientist**: 24 (from 18)
**Security Officer**: 18 (from 18)
**Shaft Miner**: 18 (from 18)
**Station Engineer**: 22 (from 18)
**Tourist**: 18 (from 18)
**Virologist**: 24 (from 18)
**Warden**: 20 (from 18)

# Wiki Documentation

If you want to have a minimum age thing per job to make it clear and accessible it wouldn't be the worst thing would be a nice thing to fill in the baseline format

# Changelog

:cl:  
tweak: Most, if not all jobs have had their minimum ages given a pass-over
experimental: Code-enforced RP
/:cl:
