### PR TITLE
Syndie Soap and Throwing Cards no longer give illegal tech

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1614,6 +1614,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 1
 	manufacturer = /datum/corporation/traitor/donkco
 	surplus = 50
+	illegal_tech = FALSE
 
 /datum/uplink_item/device_tools/surgerybag
 	name = "Syndicate Surgery Duffel Bag"
@@ -2240,6 +2241,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 1
 	manufacturer = /datum/corporation/traitor/donkco
 	surplus = 40
+	illegal_tech = FALSE
 
 /datum/uplink_item/badass/syndiecigs
 	name = "Syndicate Smokes"


### PR DESCRIPTION
# Document the changes in your pull request

More elegant solution to https://github.com/yogstation13/Yogstation/pull/14811

Adds Illegal_Tech = FALSE to Syndicate Soap and Throwing Cards
Illegal tech should not be easy.

# Changelog

:cl:  
tweak: Syndicate Soap can no longer provide Illegal Tech progress
tweak: Syndicate Cards can no longer provide Illegal Tech progress
/:cl:
