### PR TITLE
Globally Enables Mood

### DIFF
--- a/code/__DEFINES/{yogs_defines}/preferences.dm
+++ b/code/__DEFINES/{yogs_defines}/preferences.dm
@@ -13,6 +13,5 @@
 //YOGS pref.yogstoggles enum's
 
 #define QUIET_ROUND				(1<<0) //Donor features, quiet round; in /~yogs_defines/, as god intended
-#define PREF_MOOD				(1<<1) //Toggles the use of the Mood feature. Defaults to off, thank god.
 
 #define YOGTOGGLES_DEFAULT 0

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -110,19 +110,7 @@
 
 /datum/mind/proc/transfer_to(mob/new_character, var/force_key_move = 0)
 	original_character = null
-	var/mood_was_enabled = FALSE//Yogs -- Mood Preferences
 	if(current)	// remove ourself from our old body's mind variable
-		// Yogs start -- Mood preferences
-		if(current.client && current.client.prefs.yogtoggles & PREF_MOOD)
-			mood_was_enabled = TRUE
-		else if(ishuman(current) && CONFIG_GET(flag/disable_human_mood))
-			var/mob/living/carbon/human/H = current
-			if(H.mood_enabled)
-				mood_was_enabled = TRUE
-				var/datum/component/mood/c = H.GetComponent(/datum/component/mood)
-				if(c)
-					c.RemoveComponent()
-		// Yogs End
 		current.mind = null
 		UnregisterSignal(current, COMSIG_MOB_DEATH)
 		UnregisterSignal(current, COMSIG_MOB_SAY)
@@ -149,11 +137,6 @@
 	if(iscarbon(new_character))
 		var/mob/living/carbon/C = new_character
 		C.last_mind = src
-		// Yogs start -- Mood preferences
-		if(ishuman(new_character) && mood_was_enabled && !new_character.GetComponent(/datum/component/mood))
-			var/mob/living/carbon/human/H = C
-			H.AddComponent(/datum/component/mood)
-		// Yogs End
 	transfer_antag_huds(hud_to_transfer)				//inherit the antag HUD
 	transfer_actions(new_character)
 	transfer_martial_arts(new_character)

--- a/code/modules/antagonists/creep/creep.dm
+++ b/code/modules/antagonists/creep/creep.dm
@@ -46,7 +46,7 @@
 	var/mob/living/M = mob_override || owner.current
 	update_obsession_icons_removed(M)
 	var/mob/living/carbon/human/H = M
-	if(H && !H.mood_enabled)
+	if(H)
 		var/datum/component/C = M.GetComponent(/datum/component/mood)
 		if(C) //we cannot be too sure they may have somehow removed it
 			to_chat(owner, span_danger("Your need for mental fitness vanishes alongside the voices, mood has been disabled."))

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -754,7 +754,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					dat += "<b>Preferred Map:</b> <a href='?_src_=prefs;preference=preferred_map;task=input'>[p_map]</a><br>"
 			//yogs start -- Mood preference toggling
 			if(CONFIG_GET(flag/disable_human_mood))
-				dat += "<b>Mood:</b> <a href='?_src_=prefs;preference=mood'>[yogtoggles & PREF_MOOD ? "Enabled" : "Disabled"]</a><br>"
 				dat += "<b>Mood Tail Wagging:</b> <a href='?_src_=prefs;preference=moodtailwagging'>[mood_tail_wagging  ? "Enabled" : "Disabled"] </a><br>"
 			//yogs end
 
@@ -1215,7 +1214,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			for(var/_V in all_quirks)
 				if(_V == quirk_name)
 					has_quirk = TRUE
-			if(initial(T.mood_quirk) && (CONFIG_GET(flag/disable_human_mood) && !(yogtoggles & PREF_MOOD)))//Yogs -- Adds mood to preferences
+			if(initial(T.mood_quirk) && (CONFIG_GET(flag/disable_human_mood)))//Yogs -- Adds mood to preferences
 				lock_reason = "Mood is disabled."
 			else
 				var/datum/quirk/t = new T(no_init = TRUE)
@@ -2084,9 +2083,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				// yogs start - Custom keybindings
 				if("reset_bindings")
 					reset_keybindings()
-
-				if("mood")
-					yogtoggles ^= PREF_MOOD
 
 				if("moodtailwagging")
 					mood_tail_wagging = !mood_tail_wagging

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1372,7 +1372,7 @@ GLOBAL_LIST_EMPTY(mentor_races)
 					. += (health_deficiency / 75)
 				else
 					. += (health_deficiency / 25)
-		if(CONFIG_GET(flag/disable_human_mood) && !H.mood_enabled) // Yogs -- Mood as preference
+		if(CONFIG_GET(flag/disable_human_mood)) // Yogs -- Mood as preference
 			if(!HAS_TRAIT(H, TRAIT_NOHUNGER))
 				var/hungry = (500 - H.nutrition) / 5 //So overeat would be 100 and default level would be 80
 				if((hungry >= 70) && !flight) //Being hungry will still allow you to use a flightsuit/wings.

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -167,7 +167,7 @@
 
 /datum/species/human/felinid/spec_life(mob/living/carbon/human/H)
 	. = ..()
-	if((H.client && H.client.prefs.mood_tail_wagging) && !is_wagging_tail() && H.mood_enabled)
+	if((H.client && H.client.prefs.mood_tail_wagging) && !is_wagging_tail())
 		var/datum/component/mood/mood = H.GetComponent(/datum/component/mood)
 		if(!istype(mood) || !(mood.shown_mood >= MOOD_LEVEL_HAPPY2)) 
 			return

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -64,7 +64,7 @@
 
 /datum/species/lizard/spec_life(mob/living/carbon/human/H)
 	. = ..()
-	if((H.client && H.client.prefs.mood_tail_wagging) && !is_wagging_tail() && H.mood_enabled)
+	if((H.client && H.client.prefs.mood_tail_wagging) && !is_wagging_tail())
 		var/datum/component/mood/mood = H.GetComponent(/datum/component/mood)
 		if(!istype(mood) || !(mood.shown_mood >= MOOD_LEVEL_HAPPY2)) 
 			return

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -649,7 +649,7 @@ MICE_ROUNDSTART 5
 ROUNDSTART_TRAITS
 
 ## Uncomment to disable human moods.
-DISABLE_HUMAN_MOOD
+#DISABLE_HUMAN_MOOD
 
 ## Enable night shifts ##
 #ENABLE_NIGHT_SHIFTS

--- a/yogstation/code/controllers/subsystem/processing/quirks.dm
+++ b/yogstation/code/controllers/subsystem/processing/quirks.dm
@@ -1,8 +1,5 @@
 /datum/controller/subsystem/processing/quirks/proc/checkquirks(mob/living/user,client/cli) // Returns true when the player isn't trying to fuckin scum the mood pref stuff to exploit
-	var/mob/living/carbon/human/U = user
-	U.mood_enabled = cli.prefs.yogtoggles & PREF_MOOD // Marks whether this player had moods enabled in preferences at the time of spawning (helps prevent exploitation)
-	
-	var/ismoody = (!CONFIG_GET(flag/disable_human_mood) || (cli.prefs.yogtoggles & PREF_MOOD)) // If moods are globally enabled, or this guy does indeed have his mood pref set to Enabled
+	var/ismoody = (!CONFIG_GET(flag/disable_human_mood)) // If moods are globally enabled, or this guy does indeed have his mood pref set to Enabled
 	
 	var/points = 0;
 	var/good_quirks = 0;

--- a/yogstation/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/human_defines.dm
@@ -1,3 +1,2 @@
 /mob/living/carbon/human
 	var/gender_ambiguous = 0 //if something goes wrong during gender reassignment this generates a line in examine
-	var/mood_enabled = FALSE // Marks whether this player had moods enabled in preferences at the time of spawning (helps prevent exploitation)


### PR DESCRIPTION
# Document the changes in your pull request

Its kinda stupid its a toggle. Removes said toggle. Now everyone is a moody ~~bitch~~

# Why this is good

Its unfair for some of the station to be unaffected by things such as mood slowdown or hunger

# Changelog

:cl:  
tweak: Mood is now globally enabled
/:cl:
