### PR TITLE
Adds advanced medkit crate for cargo

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1256,6 +1256,14 @@
 	contains = list(/obj/item/storage/firstaid/o2)
 	crate_type = /obj/structure/closet/crate/secure/cheap
 
+/datum/supply_pack/medical/firstaidadvanced_single
+	name = "Advanced Treatment Kit Single-Pack"
+	desc = "Contains one advanced first aid kit able to heal many advanced ailments."
+	cost = 600
+	small_item = TRUE
+	contains = list(/obj/item/storage/firstaid/advanced)
+	crate_type = /obj/structure/closet/crate/secure/cheap
+
 /datum/supply_pack/medical/medipen_twopak
 	name = "Medipen Two-Pak"
 	desc = "Contains one standard epinephrine medipen and one standard emergency first-aid kit medipen. For when you want to prepare for the worst."


### PR DESCRIPTION
# Document the changes in your pull request

Adds an advanced medkit crate for 600c, simple enough and gives something for cargo to get medbay with their stacks of cash.

# Spriting
Nope

# Wiki Documentation

Will need to add it to the cargo crate wiki page. 

# Changelog

:cl:  
rscadd: Added an advance medkit cargo crate
/:cl:
