### PR TITLE
IAA Change #1 - Silicons are no longer eligible to be IAA.

### DIFF
--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -18,6 +18,7 @@
 	traitors_possible = 10 //hard limit on traitors if scaling is turned off
 	num_modifier = 4 // Four additional traitors
 	antag_datum = /datum/antagonist/traitor/internal_affairs
+	restricted_jobs = list("AI", "Cyborg")//Yogs -- Silicons can no longer be IAA
 
 	announce_text = "There are Nanotrasen Internal Affairs Agents trying to kill each other!\n\
 	<span class='danger'>IAA</span>: Eliminate your targets and protect yourself!\n\


### PR DESCRIPTION
# Document the changes in your pull request

Revives #6472

## AI being IAA is the antithesis to IAA

What happens when the AI is attacked? The entire crew is encouraged to rise up and defend their important station artifact! And if that isn't enough, plasmaflood and kill everyone anyways!

What happens when the AI is seen to be antagonist? The entire crew is encouraged to rise up and **KILL** the station-wide threat because it could superheat the entire station in a matter of seconds and kill everyone.

How the fuck does this fit anywhere into IAA except for at the very end of the round?

IAA are supposed to be *discreet* in some fashion. They are not supposed to be killing non-targets. They should be killing EACH OTHER and trying to limit outside involvement I.E. security.

So what happens when the AI is getting attacked? Of course it's going to call for help and all of the crew is going to completely gear up and rush the AI Sat and one of two things happen: The IAA human is killed, or the entire security team and helping crew is wiped by one IAA traitor who just wanted to accomplish ONE TARGET but that ONE TARGET is behind 5 rwalls and has two core locations (or more if built!).

This is comparable to if heads could still roll IAA, or hell, even captain, but somehow even worse, because at least the captain isn't in space and science and behind several bolted doors and rwalls.

## Why it sucks for the human IAA

You could have gone and rolled a human target, but no, you rolled a target that is harder to kill than the actual captain. One of the hardest objectives, and it's now your main target, and you can't do shit else until that is done. Good luck with the other 6 people trying to kill you by the way.

If you aren't lucky enough to roll the AI as a target yet, keep in mind that the AI very much has you as a target and WILL use security and the entire crew to validhunt against you. So much fun.

## Why it sucks for the AI IAA

The AI is pretty much defenseless on its own. It doesn't feel good to have to force people into validhunting your targets for you and turning it into an essentially hijack situation for your assailant/target, but unless you have enough borgs to make a malf AI mouthwater, that's your only option. You as an AI are this stationary object with no malf abilities and you just have to sit there and pray that the entire crew can come to your aid. So it sucks. For everyone involved. Maybe not the validhunting crew, but it will suck if they get killed.

## Why it sucks for the crew

Wow! The AI is antagonist. Guess we'll die. Or all arm up and kill the AI. Who will now try to kill all of us. And now the entire crew is armed to deal with the station-wide threat. Fun for security to deal with.

Wait, the gamemode isn't malf?

# Changelog

:cl:  
rscdel: Removed AI from IAA
/:cl:
