### PR TITLE
You can no longer add mecha parts (and exosuit tracking beacons) when someone is driving it

### DIFF
--- a/code/game/mecha/mecha_parts.dm
+++ b/code/game/mecha/mecha_parts.dm
@@ -13,6 +13,9 @@
 	if(!user.transferItemToLoc(src, M))
 		to_chat(user, span_warning("\The [src] is stuck to your hand, you cannot put it in \the [M]!"))
 		return FALSE
+	if(occupant && istype(occupant.loc, /obj/item/mmi/posibrain)) // Cannot attach parts when someone is driving, unless it is a posi
+		to_chat(user, span_warning("Someone is driving \the [M]!"))
+		return FALSE
 	user.visible_message("[user] attaches [src] to [M].", span_notice("You attach [src] to [M]."))
 	return TRUE
 

--- a/code/game/mecha/mecha_parts.dm
+++ b/code/game/mecha/mecha_parts.dm
@@ -13,7 +13,7 @@
 	if(!user.transferItemToLoc(src, M))
 		to_chat(user, span_warning("\The [src] is stuck to your hand, you cannot put it in \the [M]!"))
 		return FALSE
-	if(!istype(M.occupant?.loc, /obj/item/mmi/posibrain)) // Cannot attach parts when someone is driving, unless it is a posi
+	if(M.occupant || !istype(M.occupant?.loc, /obj/item/mmi/posibrain)) // Cannot attach parts when someone is driving, unless it is a posi
 		to_chat(user, span_warning("Someone is driving \the [M]!"))
 		return FALSE
 	user.visible_message("[user] attaches [src] to [M].", span_notice("You attach [src] to [M]."))

--- a/code/game/mecha/mecha_parts.dm
+++ b/code/game/mecha/mecha_parts.dm
@@ -15,7 +15,7 @@
 		return FALSE
 	
 	// If there is an occupant and it is not a posibrain
-	if(M.occupant && !istype(M.occupant.loc, /obj/item/mmi/posibrain)) 
+	if(M.occupant && !istype(M.occupant.loc, /obj/item/mmi)) 
 		to_chat(user, span_warning("Someone is driving \the [M]!"))
 		return FALSE
 	user.visible_message("[user] attaches [src] to [M].", span_notice("You attach [src] to [M]."))

--- a/code/game/mecha/mecha_parts.dm
+++ b/code/game/mecha/mecha_parts.dm
@@ -13,7 +13,7 @@
 	if(!user.transferItemToLoc(src, M))
 		to_chat(user, span_warning("\The [src] is stuck to your hand, you cannot put it in \the [M]!"))
 		return FALSE
-	if(M.occupant && !istype(M.occupant?.loc, /obj/item/mmi/posibrain)) // Cannot attach parts when someone is driving, unless it is a posi
+	if(M.occupant && !istype(M.occupant.loc, /obj/item/mmi/posibrain)) // Cannot attach parts when someone is driving, unless it is a posi
 		to_chat(user, span_warning("Someone is driving \the [M]!"))
 		return FALSE
 	user.visible_message("[user] attaches [src] to [M].", span_notice("You attach [src] to [M]."))

--- a/code/game/mecha/mecha_parts.dm
+++ b/code/game/mecha/mecha_parts.dm
@@ -13,7 +13,7 @@
 	if(!user.transferItemToLoc(src, M))
 		to_chat(user, span_warning("\The [src] is stuck to your hand, you cannot put it in \the [M]!"))
 		return FALSE
-	if(occupant && istype(occupant.loc, /obj/item/mmi/posibrain)) // Cannot attach parts when someone is driving, unless it is a posi
+	if(!istype(M.occupant?.loc, /obj/item/mmi/posibrain)) // Cannot attach parts when someone is driving, unless it is a posi
 		to_chat(user, span_warning("Someone is driving \the [M]!"))
 		return FALSE
 	user.visible_message("[user] attaches [src] to [M].", span_notice("You attach [src] to [M]."))

--- a/code/game/mecha/mecha_parts.dm
+++ b/code/game/mecha/mecha_parts.dm
@@ -13,7 +13,7 @@
 	if(!user.transferItemToLoc(src, M))
 		to_chat(user, span_warning("\The [src] is stuck to your hand, you cannot put it in \the [M]!"))
 		return FALSE
-	if(M.occupant || !istype(M.occupant?.loc, /obj/item/mmi/posibrain)) // Cannot attach parts when someone is driving, unless it is a posi
+	if(M.occupant && !istype(M.occupant?.loc, /obj/item/mmi/posibrain)) // Cannot attach parts when someone is driving, unless it is a posi
 		to_chat(user, span_warning("Someone is driving \the [M]!"))
 		return FALSE
 	user.visible_message("[user] attaches [src] to [M].", span_notice("You attach [src] to [M]."))

--- a/code/game/mecha/mecha_parts.dm
+++ b/code/game/mecha/mecha_parts.dm
@@ -13,7 +13,9 @@
 	if(!user.transferItemToLoc(src, M))
 		to_chat(user, span_warning("\The [src] is stuck to your hand, you cannot put it in \the [M]!"))
 		return FALSE
-	if(M.occupant && !istype(M.occupant.loc, /obj/item/mmi/posibrain)) // Cannot attach parts when someone is driving, unless it is a posi
+	
+	// If there is an occupant and it is not a posibrain
+	if(M.occupant && !istype(M.occupant.loc, /obj/item/mmi/posibrain)) 
 		to_chat(user, span_warning("Someone is driving \the [M]!"))
 		return FALSE
 	user.visible_message("[user] attaches [src] to [M].", span_notice("You attach [src] to [M]."))


### PR DESCRIPTION
# Document the changes in your pull request

I always just assumed it was this way because this made sense, but you can attach parts, equipment, anything willy as it stands

You can be piloting a mech and someone just attaches an exosuit beacon and you can't do shit about it

Posis/MMIs bypass this as they cannot exit the mech

# Changelog

:cl:  
tweak: You can no longer add mecha parts (and exosuit tracking beacons) when someone is driving it
/:cl:
