### PR TITLE
Nuclear Operative Mechs & Borgs Not Discountable & Reduces Mech Cost

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1205,7 +1205,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A massive and incredibly deadly military-grade exosuit. Features long-range targeting, thrust vectoring \
 			and deployable smoke. Comes equipped with an LMG, scattershot carbine, missile rack, an antiprojectile armor booster and a Tesla energy array."
 	item = /obj/mecha/combat/marauder/mauler/loaded
-	cost = 90
+	cost = 100
 	cant_discount = TRUE
 
 // Stealth Items

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1189,14 +1189,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A lightweight exosuit, painted in a dark scheme. Its speed and equipment selection make it excellent \
 			for hit-and-run style attacks. Features an incendiary carbine, flash bang launcher, teleporter, ion thrusters and a Tesla energy array."
 	item = /obj/mecha/combat/gygax/dark/loaded
-	cost = 80
+	cost = 70
 	cant_discount = TRUE
 
 /datum/uplink_item/support/honker
 	name = "Dark H.O.N.K."
 	desc = "A clown combat mech equipped with bombanana peel and tearstache grenade launchers, as well as the ubiquitous HoNkER BlAsT 5000."
 	item = /obj/mecha/combat/honker/dark/loaded
-	cost = 80
+	cost = 70
 	include_modes = list(/datum/game_mode/nuclear/clown_ops)
 	cant_discount = TRUE
 
@@ -1205,7 +1205,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A massive and incredibly deadly military-grade exosuit. Features long-range targeting, thrust vectoring \
 			and deployable smoke. Comes equipped with an LMG, scattershot carbine, missile rack, an antiprojectile armor booster and a Tesla energy array."
 	item = /obj/mecha/combat/marauder/mauler/loaded
-	cost = 140
+	cost = 90
 	cant_discount = TRUE
 
 // Stealth Items

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1160,6 +1160,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	refundable = TRUE
 	cost = 65
 	restricted = TRUE
+	cant_discount = TRUE
 
 /datum/uplink_item/support/reinforcement/medical_borg
 	name = "Syndicate Medical Cyborg"
@@ -1170,6 +1171,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	refundable = TRUE
 	cost = 35
 	restricted = TRUE
+	cant_discount = TRUE
 
 /datum/uplink_item/support/reinforcement/saboteur_borg
 	name = "Syndicate Saboteur Cyborg"
@@ -1180,6 +1182,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	refundable = TRUE
 	cost = 35
 	restricted = TRUE
+	cant_discount = TRUE
 
 /datum/uplink_item/support/gygax
 	name = "Dark Gygax Exosuit"
@@ -1187,6 +1190,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			for hit-and-run style attacks. Features an incendiary carbine, flash bang launcher, teleporter, ion thrusters and a Tesla energy array."
 	item = /obj/mecha/combat/gygax/dark/loaded
 	cost = 80
+	cant_discount = TRUE
 
 /datum/uplink_item/support/honker
 	name = "Dark H.O.N.K."
@@ -1194,6 +1198,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/mecha/combat/honker/dark/loaded
 	cost = 80
 	include_modes = list(/datum/game_mode/nuclear/clown_ops)
+	cant_discount = TRUE
 
 /datum/uplink_item/support/mauler
 	name = "Mauler Exosuit"
@@ -1201,6 +1206,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			and deployable smoke. Comes equipped with an LMG, scattershot carbine, missile rack, an antiprojectile armor booster and a Tesla energy array."
 	item = /obj/mecha/combat/marauder/mauler/loaded
 	cost = 140
+	cant_discount = TRUE
 
 // Stealth Items
 /datum/uplink_item/stealthy_tools


### PR DESCRIPTION
# Document the changes in your pull request

Nukeops no longer can be offered discounts on mechs or borgs. These options are f a r too powerful to let them be discounted in general, typically enabling braindead curbstomps. does not touch mech ammo.

Reduces the cost of mechs by a bit to compensate

Dark Gygax and HONK down to 70 from 80
Mauler down to 100 from 140

# Changelog

:cl:  
tweak: Nuke Ops no longer get discount mechs or borgs.
tweak: Very slight cost reduction on all uplink mechs
/:cl:
