### PR TITLE
Syndicate hardlight bow buffs

### DIFF
--- a/code/modules/projectiles/guns/ballistic/bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bow.dm
@@ -297,9 +297,11 @@
 		return FALSE
 
 /obj/item/gun/ballistic/bow/energy/syndicate/CtrlClick(mob/living/user)
+	if(!user.is_holding(src))
+		to_chat(user, span_notice("You need be holding [src] to do that!"))
+		return
 	folded = !folded
 	playsound(src.loc, 'sound/weapons/batonextend.ogg', 50, 1)
-	
 	if(folded)
 		to_chat(user, span_notice("You fold [src]."))
 		w_class = WEIGHT_CLASS_NORMAL

--- a/code/modules/projectiles/guns/ballistic/bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bow.dm
@@ -276,22 +276,22 @@
 	var/stored_ammo ///what was stored in the magazine before being folded?
 
 /obj/item/gun/ballistic/bow/energy/syndicate/shoot_live_shot(mob/living/user, pointblank, atom/pbtarget, message)
-	if(folded == FALSE)
-		. = ..()
+	if(!folded)
+		return ..()
 	else
 		to_chat(user, span_notice("You must unfold [src] before firing it!"))
 		return FALSE
 
 /obj/item/gun/ballistic/bow/energy/syndicate/attack_self(mob/living/user)
-	if(folded == FALSE)
-		. = ..()
+	if(!folded)
+		return ..()
 	else
 		to_chat(user, span_notice("You must unfold [src] to chamber a round!"))
 		return FALSE
 
 /obj/item/gun/ballistic/bow/energy/syndicate/AltClick(mob/living/user)
-	if(folded == FALSE)
-		. = ..()
+	if(!folded)
+		return ..()
 	else
 		to_chat(user, span_notice("You must unfold [src] to switch firing modes!"))
 		return FALSE

--- a/code/modules/projectiles/guns/ballistic/bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bow.dm
@@ -269,9 +269,51 @@
 	zoomable = TRUE
 	zoom_amt = 10
 	zoom_out_amt = 5
-	pin = /obj/item/firing_pin/implant/pindicate
+	pin = /obj/item/firing_pin
 	fire_sound = null
 	draw_sound = null
+	var/folded = FALSE
+	var/stored_ammo ///what was stored in the magazine before being folded?
+
+/obj/item/gun/ballistic/bow/energy/syndicate/shoot_live_shot(mob/living/user, pointblank, atom/pbtarget, message)
+	if(folded == FALSE)
+		. = ..()
+	else
+		to_chat(user, span_notice("You must unfold [src] before firing it!"))
+		return FALSE
+
+/obj/item/gun/ballistic/bow/energy/syndicate/attack_self(mob/living/user)
+	if(folded == FALSE)
+		. = ..()
+	else
+		to_chat(user, span_notice("You must unfold [src] to chamber a round!"))
+		return FALSE
+
+/obj/item/gun/ballistic/bow/energy/syndicate/AltClick(mob/living/user)
+	if(folded == FALSE)
+		. = ..()
+	else
+		to_chat(user, span_notice("You must unfold [src] to switch firing modes!"))
+		return FALSE
+
+/obj/item/gun/ballistic/bow/energy/syndicate/CtrlClick(mob/living/user)
+	folded = !folded
+	playsound(src.loc, 'sound/weapons/batonextend.ogg', 50, 1)
+	
+	if(folded)
+		to_chat(user, span_notice("You fold [src]."))
+		w_class = WEIGHT_CLASS_NORMAL
+		chambered = null
+		icon_state = "bow_syndicate_folded"
+		stored_ammo = magazine.ammo_list()
+		magazine.stored_ammo = null
+		update_icon()
+	else
+		w_class = WEIGHT_CLASS_BULKY
+		to_chat(user, span_notice("You extend [src], allowing it to be fired."))
+		icon_state = "bow_syndicate"
+		magazine.stored_ammo = stored_ammo
+		update_icon()
 
 /obj/item/gun/ballistic/bow/energy/clockwork
 	name = "Brass Bow"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -572,7 +572,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/gun/ballistic/bow/energy/syndicate
 	cost = 12
 	surplus = 25
-	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/infiltration)
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 
 // Stealthy Weapons
 /datum/uplink_item/stealthy_weapons


### PR DESCRIPTION
# Document the changes in your pull request

The syndicate hardlight bow is a very cool weapon. However, it's unfortunately rarely (read: never) used. its 12tc price tag, lack of concealability, and worst of all, lack of ability to be purchased by traitors (only nukies and infils can buy it currently) render it a hard sell.

solving these issues, the hardlight bow has been buffed. it can now be control clicked to be folded, making it normal-size, and capable of fitting into bags. traitors can also buy this now too, giving them an option for stealth ranged assassinations, although with an additional 4tc pricetag for thermal goggles, and a requirement of a bit of luck.

# Spriting
conveniently already sprited, sprite was just unused.
sprite for folded bow:
![image](https://user-images.githubusercontent.com/70169560/179421755-5394c1b2-108c-4f57-8908-4ec1dbdd1ca8.png)


# Wiki Documentation

uplink items page, guide to combat. mention that you need to control click the bow to fold/unfold it.

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
rscadd: the syndicate hardlight bow can now be folded to become size normal, at the cost of being unable to fire.
tweak: traitors can now buy the syndicate hardlight bow
tweak: syndicate hardlight bow now comes with an electronic firing pin instead of a syndicate firing pin
/:cl:
