### PR TITLE
Fire breath nerf

### DIFF
--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -117,7 +117,7 @@
 	name = "Fire Breath"
 	desc = "You can breathe fire at a target."
 	school = "evocation"
-	charge_max = 600
+	charge_max = 450
 	clothes_req = FALSE
 	antimagic_allowed = TRUE
 	range = 20
@@ -144,8 +144,7 @@
 	if(!istype(P, /obj/item/projectile/magic/aoe/fireball))
 		return
 	var/obj/item/projectile/magic/aoe/fireball/F = P
-	F.exp_light = strength-1
-	F.exp_fire += strength
+	F.exp_fire += (strength - 1) * 4	// +0, +2 if empowered
 
 obj/effect/proc_holder/spell/aimed/firebreath/fire_projectile(mob/user)
 	. = ..()
@@ -156,7 +155,7 @@ obj/effect/proc_holder/spell/aimed/firebreath/fire_projectile(mob/user)
 	exp_heavy = 0
 	exp_light = 0
 	exp_flash = 0
-	exp_fire= 4
+	exp_fire= 3
 
 /datum/mutation/human/void
 	name = "Void Magnet"


### PR DESCRIPTION
Fire breath mutation now has a fire radius of 3 tiles, 5 if empowered, and NEVER has any actual damaging explosion radius. It also has a slightly lower cooldown to make up for the reduced radius.

# Wiki Documentation

Remove the mention about it actually exploding if empowered (I think that's in there)

# Changelog


:cl:  

tweak: Fire breath mutation no longer can be given damaging explosions
tweak: Fire breath mutation explosion radius reduced to 3 baseline
tweak: Fire breath mutation cooldown reduced from 60 to 45 seconds
/:cl:
