### PR TITLE
Makes wizard cluwne curse respect antimagic

### DIFF
--- a/yogstation/code/modules/spells/cluwnecurse.dm
+++ b/yogstation/code/modules/spells/cluwnecurse.dm
@@ -27,6 +27,9 @@
 	if(!(target in oview(range)))
 		to_chat(user, span_notice("They are too far away!"))
 		return
+	if(target.anti_magic_check())
+		to_chat(user, span_notice("They didn't laugh!"))
+		return
 	var/mob/living/carbon/human/H = target
 	H.cluwneify()
 


### PR DESCRIPTION
Not sure why it ignores antimagic.


# Wiki Documentation

If there's a bit about ignoring antimagic, now it should respect it.

# Changelog



:cl:  
tweak: Chaplains now hate jokes, but only magic ones.
/:cl:
