### PR TITLE
Adds new Lavaland ruin: The Ash Walker Meteorite

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_meteorite.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_meteorite.dmm
@@ -1,0 +1,4666 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ac" = (
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"aw" = (
+/mob/living/simple_animal/hostile/asteroid/marrowweaver,
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"aB" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"aE" = (
+/turf/open/floor/plating/lavaland_baseturf{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered/ash_walkers)
+"aR" = (
+/obj/effect/turf_decal/sand,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/unpowered/ash_walkers)
+"aS" = (
+/obj/structure/stone_tile/slab,
+/obj/structure/destructible/cult/tome,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"aU" = (
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 9
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"bo" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/item/stack/marker_beacon,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"bt" = (
+/turf/closed/indestructible/riveted/boss,
+/area/lavaland/surface/outdoors)
+"bv" = (
+/obj/structure/stone_tile/burnt{
+	dir = 8
+	},
+/obj/item/clothing/under/ash_robe/tunic,
+/mob/living/simple_animal/hostile/skeleton/plasmaminer/jackhammer{
+	desc = "A plasma-soaked miner, this one still seems to hold their mining tool in their hand, gripping tightly. Seemed to have been quite the crafty miner in their past life.";
+	faction = list("mining");
+	name = "steve"
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"bw" = (
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion/advanced,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"bE" = (
+/obj/structure/statue/resin/ashwalker{
+	anchored = 1
+	},
+/obj/structure/stone_tile/surrounding/burnt,
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"bM" = (
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"bY" = (
+/obj/structure/stone_tile/burnt{
+	dir = 8
+	},
+/obj/structure/stone_tile/block{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"cd" = (
+/obj/structure/stone_tile/burnt{
+	dir = 8
+	},
+/obj/structure/stone_tile/block/burnt{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"cf" = (
+/obj/structure/stone_tile/block/burnt{
+	dir = 4
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"cm" = (
+/obj/effect/turf_decal/sand,
+/obj/item/pickaxe/silver{
+	pixel_x = 8;
+	pixel_y = -2
+	},
+/obj/item/pickaxe/mini{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/shovel{
+	pixel_x = 2
+	},
+/obj/structure/table/wood{
+	pixel_y = -2
+	},
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/unpowered/ash_walkers)
+"cr" = (
+/obj/structure/stone_tile/surrounding_tile/burnt{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"cA" = (
+/obj/structure/stone_tile/cracked{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"cC" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 10
+	},
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"cI" = (
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"cL" = (
+/obj/effect/decal/cleanable/blood/innards,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"cN" = (
+/obj/structure/stone_tile/block/burnt{
+	dir = 4
+	},
+/obj/structure/stone_tile{
+	dir = 8
+	},
+/obj/structure/stone_tile/block/cracked{
+	dir = 9
+	},
+/mob/living/simple_animal/hostile/drakeling{
+	faction = list("mining")
+	},
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/ash_walkers)
+"cQ" = (
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/closed/wall/mineral/sandstone,
+/area/ruin/unpowered/ash_walkers)
+"cX" = (
+/obj/structure/stone_tile/surrounding/burnt,
+/obj/structure/marker_beacon,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"dc" = (
+/turf/closed/wall/mineral/wood,
+/area/lavaland/surface/outdoors)
+"dd" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"do" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 1
+	},
+/obj/structure/stone_tile/block/burnt,
+/obj/structure/spider/stickyweb,
+/turf/open/lava/smooth/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"dq" = (
+/obj/structure/stone_tile{
+	dir = 8
+	},
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"ds" = (
+/turf/open/floor/plating/lavaland_baseturf{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/unpowered/ash_walkers)
+"du" = (
+/obj/structure/stone_tile/slab,
+/turf/closed/indestructible/riveted/boss,
+/area/ruin/unpowered/ash_walkers)
+"dx" = (
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"dz" = (
+/turf/template_noop,
+/area/template_noop)
+"dF" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 10
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"dL" = (
+/obj/structure/stone_tile/center/burnt,
+/obj/structure/stone_tile/surrounding/cracked{
+	dir = 5
+	},
+/turf/open/lava/smooth,
+/area/ruin/unpowered/ash_walkers)
+"dM" = (
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 10
+	},
+/obj/effect/mob_spawn/human/corpse/damaged/legioninfested,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"ei" = (
+/obj/structure/stone_tile/block/burnt{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"eB" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"eJ" = (
+/obj/effect/decal/cleanable/insectguts,
+/turf/open/floor/plating/lavaland_baseturf{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/unpowered/ash_walkers)
+"eK" = (
+/obj/item/kitchen/knife/combat/bone,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"eL" = (
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion/random,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"fM" = (
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 4
+	},
+/obj/structure/stone_tile/center,
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 8
+	},
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 1
+	},
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"fO" = (
+/obj/structure/fluff/grave/empty,
+/obj/effect/mob_spawn/human/corpse/damaged/legioninfested,
+/obj/item/ammo_casing/caseless/arrow/ash{
+	pixel_x = 11;
+	pixel_y = 2
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"fY" = (
+/obj/structure/stone_tile/center/cracked,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"ga" = (
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"ge" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"gg" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 4
+	},
+/obj/structure/stone_tile/burnt{
+	dir = 8
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 4
+	},
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/ash_walkers)
+"gn" = (
+/obj/structure/stone_tile/slab,
+/obj/structure/chair/pew/right{
+	dir = 8
+	},
+/obj/structure/spider{
+	icon_state = "stickyweb2"
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"gC" = (
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 8
+	},
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"gD" = (
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/turf/closed/indestructible/riveted/boss,
+/area/ruin/unpowered/ash_walkers)
+"gR" = (
+/mob/living/simple_animal/hostile/asteroid/goliath/beast,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"gS" = (
+/obj/structure/stone_tile{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/asteroid/goliath/beast,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"hb" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 6
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"hf" = (
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 9
+	},
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion/advanced,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"hn" = (
+/obj/structure/stone_tile/center,
+/obj/structure/stone_tile/surrounding/burnt,
+/mob/living/simple_animal/hostile/skeleton/plasmaminer{
+	faction = list("mining")
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"hr" = (
+/obj/structure/stone_tile/block/cracked,
+/obj/structure/stone_tile/burnt{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"ht" = (
+/obj/effect/turf_decal/sand,
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/unpowered/ash_walkers)
+"hx" = (
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/obj/structure/stone_tile/block,
+/obj/structure/stone_tile/burnt{
+	dir = 1
+	},
+/obj/item/mining_scanner{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"hA" = (
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/asteroid/marrowweaver,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"hW" = (
+/obj/structure/marker_beacon,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"ib" = (
+/turf/closed/mineral/bscrystal/volcanic/hard,
+/area/lavaland/surface/outdoors)
+"id" = (
+/obj/structure/stone_tile/block/burnt,
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"if" = (
+/obj/structure/stone_tile/block/cracked,
+/turf/closed/indestructible/riveted/boss,
+/area/ruin/unpowered/ash_walkers)
+"ih" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 5
+	},
+/obj/structure/stone_tile/burnt,
+/turf/closed/indestructible/riveted/boss,
+/area/ruin/unpowered/ash_walkers)
+"it" = (
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 1
+	},
+/turf/closed/indestructible/riveted/boss,
+/area/ruin/unpowered/ash_walkers)
+"ix" = (
+/obj/structure/stone_tile/surrounding_tile/burnt{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"iB" = (
+/mob/living/simple_animal/hostile/asteroid/goliath/beast,
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"iC" = (
+/obj/structure/stone_tile/slab,
+/obj/structure/chair/pew/right{
+	dir = 4
+	},
+/obj/structure/spider{
+	icon_state = "stickyweb2"
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"iE" = (
+/obj/effect/turf_decal/sand,
+/obj/structure/closet/cabinet,
+/obj/item/clothing/head/helmet/skull{
+	pixel_x = -1;
+	pixel_y = -2
+	},
+/obj/item/clothing/under/ash_robe/chief,
+/obj/item/clothing/suit/armor/bone/heavy,
+/obj/item/clothing/suit/armor/tribalcoat,
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/unpowered/ash_walkers)
+"iF" = (
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"iM" = (
+/obj/structure/stone_tile/block{
+	dir = 1
+	},
+/obj/structure/stone_tile/block/cracked,
+/mob/living/simple_animal/hostile/skeleton/plasmaminer{
+	faction = list("mining")
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"iN" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"iQ" = (
+/obj/structure/stone_tile/center,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"iU" = (
+/obj/structure/stone_tile/block/burnt{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"iX" = (
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 5
+	},
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 6
+	},
+/obj/item/stack/marker_beacon,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"js" = (
+/obj/structure/stone_tile/surrounding,
+/obj/structure/stone_tile/center,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"ju" = (
+/obj/structure/stone_tile/burnt{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"jw" = (
+/obj/structure/fluff/grave,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"jD" = (
+/obj/structure/stone_tile/block/cracked,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"jM" = (
+/obj/structure/stone_tile/surrounding/cracked,
+/obj/item/flashlight/lantern{
+	on = 1;
+	pixel_x = -1;
+	pixel_y = 6
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"jN" = (
+/obj/structure/stone_tile/surrounding,
+/obj/item/stack/marker_beacon,
+/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/icewing,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"jS" = (
+/obj/structure/stone_tile/surrounding_tile/burnt{
+	dir = 1
+	},
+/obj/structure/stone_tile/burnt,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"jT" = (
+/obj/structure/stone_tile/cracked{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"jU" = (
+/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/random,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"kb" = (
+/obj/structure/stone_tile/block/burnt{
+	dir = 4
+	},
+/obj/structure/stone_tile{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"kg" = (
+/obj/item/cultivator/bone{
+	pixel_x = -8;
+	pixel_y = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"kj" = (
+/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/magmawing,
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"ky" = (
+/obj/structure/stone_tile/burnt,
+/obj/structure/stone_tile/block/cracked{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/asteroid/marrowweaver,
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"kL" = (
+/obj/structure/stone_tile/slab,
+/obj/structure/spider/stickyweb,
+/turf/open/lava/smooth/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"kQ" = (
+/obj/item/storage/bag/ore{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"lb" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/burnt,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"ld" = (
+/obj/structure/stone_tile/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/burnt,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"lh" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 9
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"ly" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"lH" = (
+/obj/structure/stone_tile/block/burnt{
+	dir = 8
+	},
+/obj/structure/stone_tile/burnt{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"lM" = (
+/obj/effect/turf_decal/sand,
+/obj/structure/mineral_door/sandstone,
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/unpowered/ash_walkers)
+"lZ" = (
+/obj/structure/stone_tile/cracked,
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"mf" = (
+/obj/structure/stone_tile/surrounding,
+/obj/structure/altar_of_gods,
+/obj/item/flashlight/lantern{
+	on = 1
+	},
+/turf/open/lava/smooth/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"mj" = (
+/obj/effect/turf_decal/sand,
+/turf/closed/wall/mineral/sandstone,
+/area/ruin/unpowered/ash_walkers)
+"mm" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"mq" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/item/storage/bag/ore{
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/obj/effect/mob_spawn/human/corpse/damaged/legioninfested,
+/mob/living/simple_animal/hostile/asteroid/basilisk,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"mt" = (
+/obj/structure/stone_tile/block/burnt{
+	dir = 1
+	},
+/obj/structure/stone_tile/burnt,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"mC" = (
+/obj/structure/stone_tile/burnt{
+	dir = 8
+	},
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"mI" = (
+/obj/structure/stone_tile/block{
+	dir = 4
+	},
+/obj/structure/stone_tile/burnt{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"na" = (
+/obj/structure/stone_tile/block/burnt{
+	dir = 4
+	},
+/obj/structure/stone_tile/surrounding_tile/burnt{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"nb" = (
+/obj/structure/stone_tile/slab,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"ny" = (
+/obj/structure/stone_tile/surrounding,
+/obj/structure/spider/cocoon,
+/obj/structure/spider/stickyweb,
+/turf/open/lava/smooth/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"nA" = (
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/unpowered/ash_walkers)
+"nB" = (
+/obj/structure/stone_tile/burnt,
+/turf/closed/indestructible/riveted/boss,
+/area/ruin/unpowered/ash_walkers)
+"nD" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 6
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"nP" = (
+/turf/closed/mineral/random/high_chance/volcanic,
+/area/lavaland/surface/outdoors)
+"nQ" = (
+/obj/structure/stone_tile/slab,
+/turf/open/lava/smooth,
+/area/ruin/unpowered/ash_walkers)
+"oa" = (
+/obj/structure/stone_tile/slab/cracked,
+/turf/open/lava/smooth,
+/area/ruin/unpowered/ash_walkers)
+"oc" = (
+/obj/structure/stone_tile/slab,
+/obj/structure/marker_beacon,
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"oh" = (
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 1
+	},
+/obj/structure/marker_beacon,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"om" = (
+/obj/structure/stone_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile/burnt{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"oo" = (
+/obj/structure/stone_tile/surrounding_tile,
+/obj/structure/stone_tile/center,
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 8
+	},
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"op" = (
+/obj/item/mining_scanner{
+	pixel_x = -4;
+	pixel_y = -2
+	},
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"ov" = (
+/obj/item/ammo_casing/caseless/arrow/ash{
+	pixel_x = -10;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"ox" = (
+/obj/structure/table/wood,
+/obj/item/cultivator/rake{
+	pixel_x = 3
+	},
+/obj/item/storage/bag/plants/portaseeder{
+	pixel_x = -1;
+	pixel_y = -4
+	},
+/obj/structure/stone_tile/block/burnt,
+/obj/structure/stone_tile/block/cracked{
+	dir = 1
+	},
+/obj/item/cultivator/bone{
+	pixel_x = -3;
+	pixel_y = -6
+	},
+/mob/living/simple_animal/hostile/asteroid/gutlunch,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"oD" = (
+/obj/structure/stone_tile/center/cracked,
+/obj/structure/stone_tile/surrounding_tile/burnt{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"oH" = (
+/turf/closed/wall/mineral/wood,
+/area/ruin/unpowered/ash_walkers)
+"oN" = (
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"oQ" = (
+/obj/structure/stone_tile/burnt{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"pf" = (
+/obj/effect/mob_spawn/human/corpse/damaged/legioninfested,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"pj" = (
+/obj/structure/stone_tile/center/cracked,
+/obj/structure/stone_tile/surrounding_tile,
+/obj/structure/stone_tile/surrounding_tile/burnt{
+	dir = 1
+	},
+/obj/structure/stone_tile/surrounding/cracked,
+/mob/living/simple_animal/hostile/skeleton/plasmaminer{
+	desc = "A plasma-soaked miner, they seem to have been locked into this room that was only opened once by a master safecracker.";
+	faction = list("mining");
+	name = "vanderohe"
+	},
+/turf/open/lava/smooth,
+/area/ruin/unpowered/ash_walkers)
+"pk" = (
+/obj/structure/stone_tile/burnt,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"py" = (
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 4
+	},
+/obj/structure/marker_beacon,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"pJ" = (
+/obj/effect/turf_decal/sand,
+/obj/item/flashlight/lantern{
+	on = 1
+	},
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/unpowered/ash_walkers)
+"pK" = (
+/obj/structure/stone_tile/block{
+	dir = 8
+	},
+/obj/structure/stone_tile/surrounding_tile/cracked,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"pQ" = (
+/obj/structure/stone_tile/burnt{
+	dir = 1
+	},
+/obj/structure/stone_tile/block/burnt,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"pR" = (
+/obj/item/stack/marker_beacon,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"pT" = (
+/obj/item/pickaxe{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"qc" = (
+/obj/structure/stone_tile,
+/obj/structure/stone_tile/block/cracked{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"qk" = (
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 1
+	},
+/obj/structure/stone_tile/surrounding_tile,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"qr" = (
+/obj/structure/table/wood,
+/obj/structure/stone_tile/block{
+	dir = 4
+	},
+/obj/structure/stone_tile/burnt{
+	dir = 8
+	},
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/obj/item/scythe{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/structure/table/wood,
+/obj/structure/stone_tile/block{
+	dir = 4
+	},
+/obj/structure/stone_tile/burnt{
+	dir = 8
+	},
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/obj/item/scythe{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/retractor/bone{
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/item/hemostat/bone{
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/obj/item/clothing/suit/leather_mantle{
+	pixel_x = 2;
+	pixel_y = -7
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"qB" = (
+/obj/effect/turf_decal/sand,
+/obj/structure/table/wood,
+/obj/item/mining_scanner{
+	pixel_x = 10;
+	pixel_y = 1
+	},
+/obj/effect/turf_decal/sand,
+/obj/item/clothing/glasses/meson{
+	pixel_x = -3;
+	pixel_y = -4
+	},
+/obj/item/flashlight/lantern{
+	on = 1;
+	pixel_x = -6;
+	pixel_y = 14
+	},
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/unpowered/ash_walkers)
+"qG" = (
+/obj/structure/spawner/lavaland/legion,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"qX" = (
+/obj/effect/decal/remains/xeno,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"rF" = (
+/obj/effect/decal/remains/plasma,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"rP" = (
+/mob/living/simple_animal/hostile/skeleton/plasmaminer{
+	faction = list("mining")
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"sc" = (
+/obj/structure/stone_tile/block{
+	dir = 8
+	},
+/obj/structure/stone_tile/block/cracked{
+	dir = 4
+	},
+/turf/open/lava/smooth,
+/area/ruin/unpowered/ash_walkers)
+"sd" = (
+/obj/structure/stone_tile/block/burnt{
+	dir = 4
+	},
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"sp" = (
+/turf/closed/wall/mineral/sandstone,
+/area/ruin/unpowered/ash_walkers)
+"st" = (
+/obj/structure/stone_tile/surrounding_tile,
+/turf/closed/indestructible/riveted/boss,
+/area/ruin/unpowered/ash_walkers)
+"sP" = (
+/obj/structure/table/wood,
+/obj/structure/stone_tile/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/obj/structure/stone_tile/block/cracked{
+	dir = 4
+	},
+/obj/item/kitchen/knife/combat/bone{
+	pixel_x = 6;
+	pixel_y = -1
+	},
+/obj/item/pickaxe/bonepickaxe,
+/obj/item/bonesetter/bone{
+	pixel_x = -5;
+	pixel_y = -5
+	},
+/obj/item/clothing/under/ash_robe/hunter,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"sQ" = (
+/obj/structure/stone_tile/surrounding,
+/obj/item/flashlight/lantern{
+	pixel_x = -1;
+	pixel_y = 6
+	},
+/obj/structure/stone_tile/surrounding,
+/obj/item/flashlight/lantern{
+	on = 1;
+	pixel_x = -1;
+	pixel_y = 6
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"sW" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/cracked,
+/obj/structure/stone_tile/block/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/cracked,
+/mob/living/simple_animal/hostile/asteroid/gutlunch,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"tc" = (
+/obj/structure/table/wood,
+/obj/item/storage/bag/ore{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/clothing/glasses/meson{
+	pixel_x = -5;
+	pixel_y = -4
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/unpowered/ash_walkers)
+"tl" = (
+/obj/effect/turf_decal/sand,
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/unpowered/ash_walkers)
+"tm" = (
+/obj/structure/stone_tile/block/burnt{
+	dir = 1
+	},
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"tn" = (
+/obj/structure/stone_tile/center/burnt,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"tr" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"tw" = (
+/obj/structure/stone_tile/block/burnt{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"tF" = (
+/obj/effect/turf_decal/sand,
+/mob/living/simple_animal/hostile/skeleton/plasmaminer{
+	faction = list("mining")
+	},
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/unpowered/ash_walkers)
+"tW" = (
+/obj/structure/stone_tile/cracked,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"tZ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"ud" = (
+/turf/closed/mineral/random/volcanic/hard,
+/area/lavaland/surface/outdoors)
+"ur" = (
+/obj/structure/stone_tile/slab,
+/mob/living/simple_animal/hostile/skeleton/plasmaminer{
+	faction = list("mining")
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"uN" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"uX" = (
+/obj/structure/stone_tile/surrounding_tile/cracked,
+/obj/item/storage/bag/ore{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"vg" = (
+/obj/structure/mineral_door/sandstone,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/unpowered/ash_walkers)
+"vp" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 10
+	},
+/obj/structure/stone_tile/burnt{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"vx" = (
+/obj/structure/stone_tile/block/burnt{
+	dir = 8
+	},
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 6
+	},
+/obj/structure/stone_tile,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"vy" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"vz" = (
+/obj/structure/stone_tile/slab/cracked,
+/obj/structure/stone_tile/slab/cracked,
+/mob/living/simple_animal/hostile/skeleton/plasmaminer{
+	faction = list("mining")
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"vP" = (
+/obj/structure/stone_tile/cracked,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"wb" = (
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 6
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"wk" = (
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 4
+	},
+/obj/structure/stone_tile/surrounding_tile,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"ww" = (
+/obj/structure/stone_tile/surrounding_tile/burnt,
+/obj/structure/stone_tile/slab/cracked{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"wy" = (
+/obj/structure/stone_tile/block/cracked,
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"wz" = (
+/obj/structure/stone_tile/cracked,
+/obj/structure/stone_tile/block/cracked{
+	dir = 8
+	},
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"wD" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 1
+	},
+/obj/structure/stone_tile/burnt,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"wE" = (
+/obj/structure/stone_tile/burnt,
+/obj/structure/stone_tile/block/cracked{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"wL" = (
+/obj/structure/stone_tile/surrounding_tile,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"wQ" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 10
+	},
+/obj/structure/stone_tile/block/burnt{
+	dir = 4
+	},
+/turf/closed/indestructible/riveted/boss,
+/area/ruin/unpowered/ash_walkers)
+"wR" = (
+/obj/structure/stone_tile/slab,
+/obj/structure/table/wood,
+/obj/item/flashlight/lantern{
+	pixel_x = -6;
+	pixel_y = 14
+	},
+/obj/item/nullrod/claymore/glowing{
+	desc = "Don't tell anyone you put any points into dex, though.";
+	force = 10;
+	name = "moonlight greatsword"
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"xh" = (
+/obj/structure/stone_tile/block/burnt,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"xu" = (
+/obj/structure/stone_tile/burnt{
+	dir = 8
+	},
+/obj/structure/stone_tile{
+	dir = 1
+	},
+/obj/item/shovel{
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"xx" = (
+/obj/structure/stone_tile/surrounding_tile/cracked,
+/obj/structure/stone_tile/block/cracked{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/asteroid/goliath/beast/random,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"xB" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"xD" = (
+/obj/structure/stone_tile/cracked{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/asteroid/elite/broodmother_child{
+	faction = list("mining")
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"xY" = (
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"yj" = (
+/obj/structure/stone_tile,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"yp" = (
+/obj/structure/stone_tile/block/burnt{
+	dir = 8
+	},
+/obj/structure/stone_tile,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"yC" = (
+/obj/effect/turf_decal/sand,
+/mob/living/simple_animal/hostile/asteroid/goliath/beast/ancient,
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/unpowered/ash_walkers)
+"yF" = (
+/obj/structure/stone_tile/surrounding/burnt,
+/obj/structure/stone_tile/center/cracked,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"yJ" = (
+/obj/item/twohanded/bonespear{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"yL" = (
+/obj/structure/stone_tile/block/cracked,
+/obj/structure/stone_tile/surrounding_tile,
+/obj/structure/stone_tile{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"yQ" = (
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"zd" = (
+/obj/structure/stone_tile/block/burnt,
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"zs" = (
+/obj/structure/stone_tile/block{
+	dir = 4
+	},
+/obj/structure/stone_tile/block/cracked{
+	dir = 8
+	},
+/turf/open/lava/smooth,
+/area/ruin/unpowered/ash_walkers)
+"zA" = (
+/obj/structure/stone_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile/block,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"zJ" = (
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 4
+	},
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 8
+	},
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 4
+	},
+/obj/structure/stone_tile/surrounding_tile,
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile/center,
+/obj/structure/fans/tiny/invisible,
+/obj/machinery/door/keycard/necropolis,
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/ash_walkers)
+"zO" = (
+/obj/effect/mob_spawn/human/corpse/charredskeleton,
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"zR" = (
+/obj/structure/stone_tile/center/cracked,
+/obj/structure/stone_tile/surrounding,
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/ash_walkers)
+"Af" = (
+/obj/structure/stone_tile/surrounding_tile,
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 4
+	},
+/obj/structure/stone_tile/center,
+/obj/structure/stone_tile/surrounding_tile/burnt{
+	dir = 8
+	},
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 1
+	},
+/obj/structure/closet/crate/necropolis{
+	anchored = 1
+	},
+/obj/item/gun/magic/rune/resizement_rune,
+/obj/item/fugu_gland,
+/turf/open/lava/smooth,
+/area/ruin/unpowered/ash_walkers)
+"Ak" = (
+/obj/structure/stone_tile/block/burnt{
+	dir = 4
+	},
+/obj/structure/stone_tile/surrounding_tile/burnt{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Am" = (
+/obj/effect/decal/cleanable/blood/gibs/up,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"AM" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"AP" = (
+/obj/structure/stone_tile/surrounding,
+/obj/structure/chair/pew/left{
+	dir = 8
+	},
+/obj/structure/spider{
+	icon_state = "stickyweb2"
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"AV" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"AW" = (
+/obj/structure/stone_tile/block/burnt,
+/obj/item/mining_scanner{
+	pixel_x = 1;
+	pixel_y = -15
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Bx" = (
+/obj/structure/stone_tile/surrounding/cracked{
+	dir = 1
+	},
+/obj/item/stack/marker_beacon,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"BC" = (
+/obj/structure/stone_tile/block{
+	dir = 4
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"BJ" = (
+/obj/structure/falsewall/wood,
+/obj/structure/stone_tile/slab,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"BY" = (
+/obj/structure/stone_tile/slab,
+/obj/structure/chair/pew/left{
+	dir = 8
+	},
+/obj/structure/spider{
+	icon_state = "stickyweb2"
+	},
+/mob/living/simple_animal/hostile/asteroid/marrowweaver,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"Cb" = (
+/obj/structure/stone_tile/surrounding_tile/burnt,
+/obj/structure/stone_tile/slab/cracked{
+	dir = 9
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Cm" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/item/shovel{
+	pixel_x = -2;
+	pixel_y = 12
+	},
+/obj/effect/mob_spawn/human/corpse/damaged/legioninfested,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Cv" = (
+/obj/structure/stone_tile/slab,
+/obj/structure/bookcase{
+	name = "Forbidden Knowledge"
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"CJ" = (
+/obj/structure/stone_tile/block{
+	dir = 8
+	},
+/obj/structure/stone_tile/block/burnt{
+	dir = 4
+	},
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/ash_walkers)
+"CK" = (
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"CS" = (
+/obj/structure/stone_tile/surrounding_tile/cracked,
+/obj/structure/stone_tile/slab/cracked{
+	dir = 9
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"CV" = (
+/obj/structure/marker_beacon,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Dc" = (
+/obj/structure/fluff/grave/empty,
+/obj/item/gun/ballistic/bow/ashen{
+	pixel_x = -1;
+	pixel_y = -1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Dk" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"Dq" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/item/stack/marker_beacon,
+/mob/living/simple_animal/hostile/asteroid/goliath/beast/ancient,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"DG" = (
+/obj/structure/stone_tile/cracked,
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 9
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"DK" = (
+/obj/structure/stone_tile/slab,
+/obj/structure/bonfire/prelit,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"DO" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 5
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"DT" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 6
+	},
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"DX" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"DZ" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Ec" = (
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/obj/structure/stone_tile/burnt{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"El" = (
+/mob/living/simple_animal/hostile/asteroid/marrowweaver,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Eo" = (
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile/surrounding_tile,
+/obj/structure/stone_tile/block/burnt{
+	dir = 8
+	},
+/obj/structure/spider/cocoon,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"Ep" = (
+/obj/structure/stone_tile/block/burnt{
+	dir = 4
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 8
+	},
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Er" = (
+/obj/structure/stone_tile,
+/obj/structure/stone_tile/block/burnt{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Eu" = (
+/obj/effect/decal/cleanable/molten_object,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Ew" = (
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Ey" = (
+/obj/structure/stone_tile/block/cracked,
+/obj/structure/stone_tile/block/cracked{
+	dir = 5
+	},
+/obj/structure/stone_tile/block/cracked,
+/obj/structure/stone_tile/block/cracked{
+	dir = 5
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"EB" = (
+/obj/structure/stone_tile/surrounding/cracked{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"EL" = (
+/obj/structure/stone_tile/surrounding/cracked,
+/obj/item/stack/marker_beacon,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"EM" = (
+/obj/structure/stone_tile/surrounding/cracked{
+	dir = 4
+	},
+/obj/structure/stone_tile/surrounding_tile/burnt{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"ET" = (
+/obj/structure/stone_tile/block/burnt{
+	dir = 4
+	},
+/obj/structure/stone_tile/burnt{
+	dir = 8
+	},
+/obj/effect/mob_spawn/human/corpse/damaged/legioninfested,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"EX" = (
+/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/random{
+	desc = "He watches the fallen. Also makes great sushi.";
+	name = "gerald"
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Fc" = (
+/obj/structure/sink/puddle,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"Fs" = (
+/obj/effect/turf_decal/sand,
+/obj/effect/turf_decal/sand,
+/obj/structure/table/wood,
+/obj/item/storage/bag/ore{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/mining_scanner{
+	pixel_x = 10;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/unpowered/ash_walkers)
+"FK" = (
+/obj/structure/stone_tile/burnt,
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"FM" = (
+/obj/structure/table/wood,
+/obj/structure/stone_tile/cracked,
+/obj/structure/stone_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile/block/burnt{
+	dir = 8
+	},
+/obj/item/gun/ballistic/bow/ashen{
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/obj/item/storage/belt/quiver/ashwalker{
+	pixel_x = -9;
+	pixel_y = -3
+	},
+/obj/item/circular_saw/bone{
+	pixel_x = 7
+	},
+/obj/item/ammo_casing/caseless/arrow/ash,
+/obj/item/ammo_casing/caseless/arrow/ash{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/ammo_casing/caseless/arrow/ash{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/ammo_casing/caseless/arrow/ash{
+	pixel_x = 9;
+	pixel_y = -6
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"FQ" = (
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Gg" = (
+/obj/structure/stone_tile/center,
+/obj/structure/stone_tile/surrounding/cracked{
+	dir = 1
+	},
+/obj/structure/stone_tile/slab/cracked{
+	dir = 9
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Gh" = (
+/obj/effect/turf_decal/sand,
+/obj/effect/turf_decal/sand,
+/obj/structure/mineral_door/sandstone,
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/unpowered/ash_walkers)
+"Gi" = (
+/obj/structure/stone_tile/center,
+/mob/living/simple_animal/hostile/asteroid/marrowweaver,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Gn" = (
+/obj/structure/stone_tile/block,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Gp" = (
+/obj/structure/stone_tile/burnt{
+	dir = 4
+	},
+/obj/structure/stone_tile/surrounding_tile/burnt,
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 10
+	},
+/obj/item/stack/marker_beacon,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"GD" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 1
+	},
+/obj/structure/stone_tile,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"GE" = (
+/obj/structure/stone_tile/surrounding/burnt,
+/obj/structure/stone_tile/center,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"GN" = (
+/obj/structure/stone_tile/cracked,
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"GO" = (
+/obj/structure/stone_tile/center/burnt,
+/obj/structure/stone_tile/surrounding_tile/cracked,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"HK" = (
+/obj/effect/turf_decal/sand,
+/obj/structure/closet/cabinet,
+/obj/item/clothing/suit/armor/pathfinder,
+/obj/item/clothing/under/rank/miner/lavaland,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/clothing/under/plasmaman/mining,
+/obj/item/clothing/under/plasmaman/mining,
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/unpowered/ash_walkers)
+"HN" = (
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 8
+	},
+/obj/structure/marker_beacon,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"HW" = (
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"HZ" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Ib" = (
+/obj/structure/stone_tile{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/obj/item/claymore/bone{
+	pixel_x = 2;
+	pixel_y = -4
+	},
+/obj/item/scalpel/bone{
+	pixel_y = 16
+	},
+/obj/item/clothing/under/ash_robe/shaman,
+/obj/item/oar{
+	pixel_y = -1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"If" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/cracked,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Ij" = (
+/obj/structure/stone_tile/slab,
+/obj/structure/chair/pew/left{
+	dir = 4
+	},
+/obj/structure/spider{
+	icon_state = "stickyweb2"
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"It" = (
+/obj/structure/stone_tile/block/burnt{
+	dir = 8
+	},
+/obj/structure/stone_tile/burnt,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"ID" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lantern{
+	on = 1;
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/sand,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/unpowered/ash_walkers)
+"IP" = (
+/obj/machinery/hydroponics/soil,
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"IS" = (
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 1
+	},
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 9
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Jc" = (
+/obj/structure/stone_tile,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Ji" = (
+/obj/structure/fluff/drake_statue/falling,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"JD" = (
+/obj/structure/stone_tile/slab,
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"JJ" = (
+/obj/structure/stone_tile/block,
+/obj/structure/stone_tile/block{
+	dir = 1
+	},
+/obj/structure/stone_tile/block,
+/obj/structure/stone_tile/block{
+	dir = 1
+	},
+/obj/item/stack/marker_beacon,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"JK" = (
+/obj/structure/stone_tile/surrounding,
+/obj/structure/stone_tile/center,
+/obj/structure/spider{
+	icon_state = "stickyweb2"
+	},
+/turf/open/lava/smooth/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"JS" = (
+/obj/structure/stone_tile/block/burnt{
+	dir = 4
+	},
+/obj/structure/stone_tile/block/cracked{
+	dir = 8
+	},
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"JU" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/xtracks{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Kb" = (
+/obj/structure/stone_tile/slab,
+/obj/structure/stone_tile/slab,
+/turf/open/lava/smooth/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"Kj" = (
+/obj/structure/stone_tile/cracked,
+/obj/structure/stone_tile{
+	dir = 8
+	},
+/obj/structure/closet/crate/necropolis{
+	anchored = 1
+	},
+/obj/item/survivalcapsule/luxuryelite,
+/obj/item/magmite_parts,
+/obj/structure/closet/crate/necropolis{
+	anchored = 1
+	},
+/turf/open/lava/smooth,
+/area/ruin/unpowered/ash_walkers)
+"Kv" = (
+/obj/structure/stone_tile/burnt{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"KA" = (
+/obj/structure/stone_tile/block,
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 9
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"KC" = (
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 9
+	},
+/obj/item/stack/marker_beacon,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"KF" = (
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion/random{
+	desc = "Was a nice young lad until he got transformed into a legion. Still staying strong and living his best life!";
+	name = "timothy"
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"KK" = (
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 6
+	},
+/obj/item/storage/bag/ore{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"KO" = (
+/obj/structure/stone_tile/center,
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 9
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"KQ" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"KS" = (
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"KU" = (
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/obj/structure/stone_tile/block/cracked{
+	dir = 6
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"La" = (
+/obj/structure/fluff/grave/empty,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Lg" = (
+/obj/structure/stone_tile/slab,
+/obj/structure/spider/cocoon,
+/obj/structure/spider/stickyweb,
+/turf/open/lava/smooth/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"Lv" = (
+/obj/structure/stone_tile/slab,
+/mob/living/simple_animal/hostile/skeleton/templar{
+	desc = "Forged in fire, this one has given up on their quest.";
+	name = "ashen one"
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"LM" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 1
+	},
+/obj/structure/stone_tile/cracked,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"LO" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/blood/innards,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Ma" = (
+/obj/structure/stone_tile/slab/burnt,
+/turf/open/lava/smooth,
+/area/ruin/unpowered/ash_walkers)
+"Mh" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Mp" = (
+/obj/item/pickaxe{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/effect/mob_spawn/human/corpse/damaged/legioninfested,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Mq" = (
+/obj/structure/stone_tile/block{
+	dir = 1
+	},
+/turf/closed/indestructible/riveted/boss,
+/area/ruin/unpowered/ash_walkers)
+"Mr" = (
+/obj/structure/stone_tile/cracked,
+/obj/structure/stone_tile/cracked,
+/obj/structure/stone_tile/block/burnt{
+	dir = 8
+	},
+/obj/structure/stone_tile/burnt{
+	dir = 1
+	},
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/ash_walkers)
+"Mw" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"MD" = (
+/obj/structure/stone_tile/block/burnt{
+	dir = 4
+	},
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"MO" = (
+/obj/structure/stone_tile/cracked,
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/obj/item/mining_scanner{
+	pixel_x = -4;
+	pixel_y = -13
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"MV" = (
+/obj/structure/stone_tile/center/burnt,
+/obj/structure/stone_tile/surrounding/cracked,
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 10
+	},
+/obj/structure/stone_tile/surrounding_tile/burnt,
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/ash_walkers)
+"MY" = (
+/mob/living/simple_animal/hostile/asteroid/hivelord,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Na" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Nl" = (
+/obj/structure/stone_tile/block/burnt{
+	dir = 8
+	},
+/obj/structure/stone_tile{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"ND" = (
+/obj/item/stack/marker_beacon,
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"NG" = (
+/obj/structure/table/wood,
+/obj/item/shovel/spade/bone,
+/obj/structure/stone_tile/block/cracked{
+	dir = 1
+	},
+/obj/structure/stone_tile/block,
+/obj/item/pickaxe/bonepickaxe{
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"NI" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/marker_beacon,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"NK" = (
+/obj/structure/stone_tile{
+	dir = 8
+	},
+/obj/structure/stone_tile/block/cracked{
+	dir = 4
+	},
+/obj/structure/stone_tile/slab,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"NT" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/xtracks{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"NV" = (
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile/block/cracked{
+	dir = 10
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"NZ" = (
+/obj/structure/stone_tile/burnt,
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Og" = (
+/obj/structure/stone_tile/surrounding,
+/obj/structure/stone_tile/center,
+/obj/effect/mob_spawn/human/corpse/damaged/legioninfested,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Oh" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"OB" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"OG" = (
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"OH" = (
+/obj/structure/stone_tile{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"OQ" = (
+/obj/structure/stone_tile/block/burnt,
+/obj/structure/stone_tile/cracked{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"OZ" = (
+/obj/structure/stone_tile/surrounding/cracked{
+	dir = 4
+	},
+/obj/structure/stone_tile/center/cracked,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Pi" = (
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion/dwarf,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Pl" = (
+/obj/structure/stone_tile/surrounding/cracked{
+	dir = 1
+	},
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 9
+	},
+/obj/structure/marker_beacon,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Pn" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 4
+	},
+/obj/item/shovel{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"PJ" = (
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 4
+	},
+/obj/structure/stone_tile/block/burnt{
+	dir = 4
+	},
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 8
+	},
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"PN" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/structure/stone_tile/block/cracked{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/xtracks{
+	dir = 10
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"PR" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 9
+	},
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 6
+	},
+/obj/item/stack/marker_beacon,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Qi" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"Qj" = (
+/obj/structure/stone_tile/block/burnt{
+	dir = 8
+	},
+/obj/structure/stone_tile/block/cracked{
+	dir = 4
+	},
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Qk" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 5
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Qs" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"QA" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/burnt{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"QC" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 6
+	},
+/obj/structure/stone_tile{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"QJ" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"QO" = (
+/obj/structure/stone_tile/block/burnt{
+	dir = 8
+	},
+/turf/closed/indestructible/riveted/boss,
+/area/ruin/unpowered/ash_walkers)
+"QQ" = (
+/obj/structure/stone_tile/slab,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"Rh" = (
+/obj/structure/stone_tile/surrounding,
+/obj/structure/chair/pew/right{
+	dir = 4
+	},
+/obj/structure/spider{
+	icon_state = "stickyweb2"
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"Rl" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"Rs" = (
+/obj/structure/stone_tile/surrounding/cracked,
+/obj/structure/stone_tile/center,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"RF" = (
+/obj/structure/marker_beacon,
+/obj/item/ammo_casing/caseless/arrow/ash{
+	pixel_x = 6;
+	pixel_y = -11
+	},
+/obj/item/ammo_casing/caseless/arrow/ash,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"RG" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/item/stack/marker_beacon,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"RH" = (
+/obj/structure/stone_tile/block{
+	dir = 4
+	},
+/obj/structure/stone_tile/burnt{
+	dir = 4
+	},
+/obj/structure/stone_tile/block/cracked{
+	dir = 10
+	},
+/mob/living/simple_animal/hostile/drakeling{
+	faction = list("mining")
+	},
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/ash_walkers)
+"RM" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"RR" = (
+/obj/structure/stone_tile/burnt,
+/turf/closed/wall/mineral/wood,
+/area/ruin/unpowered/ash_walkers)
+"Sl" = (
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Sn" = (
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 4
+	},
+/obj/item/stack/marker_beacon,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Sq" = (
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 1
+	},
+/obj/structure/stone_tile/center,
+/obj/structure/stone_tile/surrounding_tile,
+/obj/structure/stone_tile/surrounding_tile,
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 4
+	},
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"SC" = (
+/obj/structure/fluff/grave/empty,
+/obj/structure/fluff/grave/empty,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"SR" = (
+/obj/structure/stone_tile{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Tc" = (
+/obj/structure/stone_tile/surrounding_tile/burnt{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Tg" = (
+/obj/structure/stone_tile/block/cracked,
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
+/obj/structure/stone_tile/burnt{
+	dir = 4
+	},
+/obj/structure/closet/crate/necropolis{
+	anchored = 1
+	},
+/obj/item/dragon_egg,
+/obj/item/magmite{
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/turf/open/lava/smooth,
+/area/ruin/unpowered/ash_walkers)
+"Tq" = (
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"TA" = (
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/decal/cleanable/blood/gibs/core,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"TH" = (
+/obj/effect/turf_decal/siding/wood,
+/mob/living/simple_animal/hostile/skeleton/plasmaminer{
+	faction = list("mining")
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"TO" = (
+/obj/structure/stone_tile/block/burnt{
+	dir = 8
+	},
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"TT" = (
+/obj/structure/stone_tile/cracked,
+/obj/structure/stone_tile/block{
+	dir = 1
+	},
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Ul" = (
+/turf/closed/mineral/random/volcanic,
+/area/lavaland/surface/outdoors)
+"Um" = (
+/mob/living/simple_animal/hostile/asteroid/goliath/beast/ancient,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"UC" = (
+/obj/structure/stone_tile/surrounding_tile/cracked,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"UH" = (
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"UM" = (
+/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/random,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"UY" = (
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 4
+	},
+/obj/structure/stone_tile/surrounding/cracked{
+	dir = 4
+	},
+/obj/structure/stone_tile/center/cracked,
+/obj/structure/closet/crate/necropolis{
+	anchored = 1
+	},
+/obj/item/clothing/under/syndicate/combat,
+/obj/item/clothing/head/chameleon/syndicate,
+/turf/open/lava/smooth,
+/area/ruin/unpowered/ash_walkers)
+"Vf" = (
+/obj/structure/stone_tile/block,
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Vh" = (
+/obj/structure/stone_tile/slab/cracked,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Vo" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 9
+	},
+/obj/structure/stone_tile/block/cracked{
+	dir = 10
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Vp" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 1
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"VC" = (
+/obj/structure/stone_tile/block{
+	dir = 1
+	},
+/obj/structure/stone_tile,
+/obj/structure/stone_tile/block{
+	dir = 1
+	},
+/obj/structure/stone_tile,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"VH" = (
+/obj/effect/decal/cleanable/blood/gibs/body,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"VN" = (
+/obj/structure/table/wood,
+/obj/structure/stone_tile/block/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
+/obj/item/twohanded/bonespear{
+	pixel_x = -11;
+	pixel_y = 1
+	},
+/obj/item/twohanded/bonespear{
+	pixel_x = 3;
+	pixel_y = -1
+	},
+/obj/structure/table/wood,
+/obj/structure/stone_tile/block/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
+/obj/item/twohanded/bonespear{
+	pixel_x = -11;
+	pixel_y = 1
+	},
+/obj/item/twohanded/bonespear{
+	pixel_x = 3;
+	pixel_y = -1
+	},
+/obj/item/cautery/bone{
+	pixel_x = -4
+	},
+/obj/item/clothing/under/ash_robe/young,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"Wc" = (
+/obj/structure/stone_tile/block,
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/asteroid/goliath/beast,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"We" = (
+/obj/structure/stone_tile/surrounding_tile/burnt{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Wn" = (
+/obj/structure/stone_tile/slab/cracked{
+	dir = 10
+	},
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 9
+	},
+/obj/structure/marker_beacon,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Wo" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"WN" = (
+/turf/closed/indestructible/riveted/boss,
+/area/ruin/unpowered/ash_walkers)
+"WO" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 6
+	},
+/obj/structure/stone_tile/surrounding_tile/cracked{
+	dir = 9
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"WY" = (
+/obj/structure/stone_tile/block/cracked{
+	dir = 8
+	},
+/obj/structure/stone_tile/block{
+	dir = 4
+	},
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/ash_walkers)
+"Xc" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/mining_scanner{
+	pixel_x = 7;
+	pixel_y = -4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Xg" = (
+/obj/structure/stone_tile{
+	dir = 8
+	},
+/obj/structure/stone_tile/block{
+	dir = 1
+	},
+/obj/structure/stone_tile/burnt,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"Xt" = (
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 8
+	},
+/obj/structure/stone_tile/center,
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 4
+	},
+/obj/structure/stone_tile/surrounding_tile,
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"XD" = (
+/obj/structure/stone_tile/slab/burnt,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"XH" = (
+/mob/living/simple_animal/hostile/asteroid/goliath/beast/random,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Yc" = (
+/obj/structure/stone_tile{
+	dir = 1
+	},
+/turf/closed/indestructible/riveted/boss,
+/area/ruin/unpowered/ash_walkers)
+"Yd" = (
+/obj/structure/stone_tile/center,
+/obj/structure/stone_tile/surrounding/burnt,
+/turf/open/indestructible/necropolis,
+/area/ruin/unpowered/ash_walkers)
+"Yg" = (
+/obj/structure/stone_tile,
+/obj/structure/stone_tile/block{
+	dir = 8
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
+/obj/structure/marker_beacon,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"Yt" = (
+/obj/structure/stone_tile/surrounding_tile/burnt,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Yu" = (
+/obj/structure/fluff/grave/empty,
+/obj/effect/mob_spawn/human/corpse/damaged/legioninfested,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"YA" = (
+/obj/vehicle/ridden/lavaboat{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"YE" = (
+/obj/effect/decal/remains/xeno/larva,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Zt" = (
+/obj/structure/stone_tile/surrounding_tile{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Zx" = (
+/obj/item/shovel/spade/bone{
+	pixel_x = -9;
+	pixel_y = 1
+	},
+/obj/effect/decal/remains/xeno,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"ZH" = (
+/obj/structure/stone_tile{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"ZT" = (
+/obj/item/cultivator/rake{
+	pixel_x = 9;
+	pixel_y = 12
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"ZV" = (
+/obj/effect/turf_decal/sand,
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/obj/effect/mob_spawn/human/corpse/damaged/legioninfested,
+/turf/open/floor/plasteel/lavaland,
+/area/ruin/unpowered/ash_walkers)
+
+(1,1,1) = {"
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+Tq
+Tq
+Tq
+Tq
+Tq
+Tq
+Tq
+Tq
+Tq
+Tq
+Tq
+Tq
+Tq
+Tq
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+"}
+(2,1,1) = {"
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+Tq
+yQ
+Tq
+yQ
+yQ
+yQ
+El
+Tq
+Qk
+Tq
+yQ
+yQ
+iF
+Tq
+Tq
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+"}
+(3,1,1) = {"
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+Tq
+Tq
+La
+yQ
+yQ
+cI
+Yu
+IP
+yQ
+bY
+yQ
+Zx
+La
+yQ
+Tq
+Tq
+dz
+dz
+dz
+Tq
+Tq
+Tq
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+"}
+(4,1,1) = {"
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+Tq
+Tq
+Bx
+GD
+BC
+It
+nD
+wD
+kb
+cX
+Vp
+AM
+cC
+EL
+Tq
+Tq
+dz
+Tq
+hf
+Vo
+Qk
+Ec
+Tq
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+"}
+(5,1,1) = {"
+dz
+dz
+WN
+WN
+WN
+WN
+WN
+WN
+dz
+Tq
+Tq
+yQ
+La
+ZT
+yQ
+Tq
+yQ
+yQ
+QC
+Xc
+yQ
+jU
+yQ
+Tq
+Tq
+aU
+om
+tw
+UC
+CV
+wb
+Gi
+Tq
+Tq
+dz
+dz
+dz
+dz
+dz
+"}
+(6,1,1) = {"
+dz
+WN
+WN
+WN
+Rh
+Ij
+du
+WN
+Tq
+Tq
+Tq
+yQ
+yQ
+yQ
+Tq
+yQ
+yQ
+dd
+lb
+La
+Tq
+yQ
+Tq
+Tq
+aU
+wy
+Tq
+Tq
+WN
+WN
+Tq
+Tq
+qc
+UH
+Tq
+dz
+dz
+dz
+dz
+"}
+(7,1,1) = {"
+dz
+WN
+iC
+Ij
+PJ
+Lg
+hA
+WN
+ju
+Tq
+HZ
+OG
+Tq
+Tq
+Tq
+Tq
+kg
+gR
+vp
+OB
+Tq
+Tq
+Tq
+Tq
+Gp
+Tq
+WN
+WN
+wQ
+if
+WN
+WN
+dM
+Er
+ZH
+Tq
+dz
+dz
+dz
+"}
+(8,1,1) = {"
+WN
+WN
+ny
+do
+JK
+mf
+Kb
+ur
+xh
+If
+Tq
+Tq
+Tq
+Tq
+Kv
+KO
+qk
+KC
+xu
+Qs
+oD
+Zt
+Tq
+IS
+iQ
+WN
+WN
+cN
+CJ
+gg
+zs
+WN
+WN
+Tq
+mt
+Tq
+dz
+dz
+dz
+"}
+(9,1,1) = {"
+dz
+WN
+BY
+gn
+Eo
+kL
+wk
+WN
+pk
+oN
+vx
+HN
+gR
+lh
+Gn
+Tq
+Tq
+Qk
+Tq
+Tq
+Tq
+Cb
+ix
+gC
+gD
+WN
+Kj
+zR
+WN
+WN
+dL
+Ma
+WN
+gS
+PR
+vP
+dz
+dz
+dz
+"}
+(10,1,1) = {"
+dz
+WN
+WN
+WN
+AP
+gn
+du
+WN
+Tq
+iQ
+Tq
+iQ
+KQ
+Qk
+Tq
+WN
+WN
+ET
+oH
+RR
+eL
+Tq
+XD
+jD
+Mq
+Af
+nQ
+oa
+UY
+WN
+WN
+Yd
+zJ
+Gn
+Rs
+Tq
+dz
+dz
+dz
+"}
+(11,1,1) = {"
+dz
+dz
+WN
+WN
+BJ
+oH
+WN
+WN
+Tq
+AW
+Tq
+Tq
+Tq
+Tq
+Tq
+WN
+ox
+hn
+NG
+nB
+Tq
+Tq
+Nl
+vP
+Yc
+WN
+Tg
+MV
+WN
+WN
+pj
+nQ
+it
+Jc
+ZH
+dz
+dz
+dz
+dz
+"}
+(12,1,1) = {"
+dz
+dz
+oH
+Cv
+QQ
+oH
+jw
+Tq
+Tq
+CK
+Tq
+xY
+xY
+Tq
+Tq
+oH
+oH
+Fc
+WN
+WN
+Tq
+Kv
+Yt
+Zt
+Tq
+WN
+st
+Mr
+RH
+WY
+sc
+WN
+WN
+Tq
+jD
+Tq
+dz
+dz
+dz
+"}
+(13,1,1) = {"
+dz
+dz
+oH
+wR
+Lv
+oH
+jw
+Tq
+DO
+Tq
+Tq
+xY
+xY
+xY
+Tq
+Tq
+oH
+oH
+WN
+Tq
+Sn
+Ak
+cr
+Vh
+iU
+Tq
+WN
+WN
+QO
+ih
+WN
+WN
+Tq
+iX
+uX
+dz
+dz
+dz
+dz
+"}
+(14,1,1) = {"
+dz
+dz
+oH
+DK
+aS
+WN
+jw
+Tq
+yF
+Tq
+YA
+xY
+kj
+xY
+xY
+Tq
+Tq
+Tq
+Tq
+lh
+cd
+hb
+Tq
+SR
+Pl
+UH
+Tq
+Tq
+WN
+WN
+Tq
+cI
+ga
+Qk
+Tq
+Tq
+dz
+dz
+dz
+"}
+(15,1,1) = {"
+dz
+dz
+WN
+oH
+WN
+WN
+jw
+Tq
+Zt
+Tq
+xY
+xY
+xY
+zO
+xY
+xY
+xY
+Tq
+ga
+Og
+nb
+cL
+xY
+Eu
+Tq
+GO
+cA
+ju
+ix
+aU
+jT
+fY
+jS
+jU
+Tq
+Tq
+Tq
+dz
+dz
+"}
+(16,1,1) = {"
+dz
+dz
+dz
+dz
+dz
+dz
+Tq
+Tq
+AM
+iF
+xY
+Tq
+xY
+xY
+xY
+xY
+xY
+mC
+nb
+ky
+JD
+xY
+dq
+xY
+Tq
+Ew
+xx
+We
+tn
+ww
+op
+Yt
+WN
+WN
+WN
+WN
+Tq
+dz
+dz
+"}
+(17,1,1) = {"
+dz
+dz
+dz
+dz
+dz
+dz
+Tq
+py
+na
+OH
+Tq
+ga
+Tq
+xY
+xY
+xY
+xY
+xY
+wz
+TT
+JD
+FQ
+xY
+Tq
+Tq
+QJ
+vy
+Tq
+Tq
+Tq
+hW
+ld
+oH
+sP
+Xg
+iM
+Tq
+dz
+dz
+"}
+(18,1,1) = {"
+dz
+dz
+dz
+dz
+dz
+Tq
+Tq
+Wc
+Yt
+Qs
+yL
+NV
+lZ
+Tq
+eL
+Tq
+dx
+xY
+JD
+oc
+zd
+xY
+xY
+rF
+ga
+Qj
+JD
+Qj
+Zt
+Tq
+AV
+yj
+oH
+FM
+Yg
+WN
+WN
+dz
+dz
+"}
+(19,1,1) = {"
+dz
+dz
+dz
+dz
+dz
+Tq
+VH
+vy
+Am
+Tq
+UM
+iN
+ac
+DG
+pK
+Tq
+Tq
+xY
+Ep
+JD
+nb
+xY
+FK
+xY
+JD
+oo
+sd
+Sq
+JD
+Tq
+ei
+ju
+oH
+QQ
+hx
+jM
+WN
+dz
+dz
+"}
+(20,1,1) = {"
+dz
+dz
+dz
+dz
+dz
+dz
+Tq
+MD
+Tq
+nP
+nP
+nP
+nP
+Tq
+OZ
+pQ
+UH
+Tq
+NK
+js
+Yt
+xY
+zO
+xY
+JD
+id
+Ji
+tm
+JD
+Qk
+zA
+Tq
+WN
+WN
+oH
+oH
+oH
+dz
+dz
+"}
+(21,1,1) = {"
+dz
+dz
+dz
+dz
+dz
+dz
+Tq
+nP
+nP
+nP
+dc
+nP
+nP
+nP
+oQ
+jD
+Wn
+MO
+ju
+EM
+UH
+ge
+iB
+xY
+JD
+Xt
+TO
+fM
+JD
+OG
+dF
+Tq
+Tq
+dz
+dz
+dz
+dz
+dz
+dz
+"}
+(22,1,1) = {"
+dz
+dz
+dz
+dz
+dz
+nP
+nP
+nP
+nP
+bt
+ud
+ud
+dc
+nP
+nP
+nP
+Tq
+Yt
+GN
+CS
+Pn
+xD
+Tq
+Tq
+ac
+JS
+JD
+JS
+wL
+Tq
+CK
+pR
+Pi
+WN
+WN
+oH
+WN
+dz
+dz
+"}
+(23,1,1) = {"
+dz
+dz
+dz
+dz
+dz
+nP
+nP
+nP
+ud
+ud
+ud
+ud
+ud
+ud
+nP
+nP
+nP
+Tq
+Tq
+Tq
+Tq
+Gg
+OH
+Tq
+Tq
+Tq
+OQ
+Tq
+Tq
+KS
+Gn
+OB
+Tq
+JJ
+Ey
+qr
+WN
+dz
+dz
+"}
+(24,1,1) = {"
+dz
+dz
+dz
+dz
+nP
+nP
+dc
+ud
+ud
+ud
+bt
+ud
+ud
+ud
+ud
+nP
+nP
+nP
+WN
+rP
+oH
+oh
+MD
+hr
+lH
+NZ
+jN
+MD
+Qk
+Vf
+EB
+Tq
+oH
+WN
+sW
+VN
+oH
+dz
+dz
+"}
+(25,1,1) = {"
+dz
+dz
+dz
+dz
+dc
+nP
+ud
+ud
+ud
+ud
+ud
+ud
+ud
+ib
+ud
+ud
+nP
+bt
+nP
+nP
+nP
+Tq
+nP
+xh
+Tq
+Tq
+Tq
+Tq
+Tq
+oN
+cf
+Tq
+oH
+sQ
+VC
+vz
+oH
+dz
+dz
+"}
+(26,1,1) = {"
+dz
+dz
+dz
+dz
+nP
+nP
+bt
+ud
+ud
+ib
+ud
+Tq
+Tq
+ud
+ud
+ud
+nP
+nP
+nP
+nP
+bt
+nP
+nP
+nP
+nP
+nP
+WN
+oH
+Tq
+aU
+DT
+Tq
+WN
+WN
+WN
+WN
+oH
+dz
+dz
+"}
+(27,1,1) = {"
+dz
+dz
+dz
+dz
+nP
+dc
+nP
+ud
+ud
+bw
+Tq
+Tq
+Tq
+Tq
+ud
+ud
+ud
+dc
+dc
+nP
+nP
+nP
+nP
+nP
+oH
+tW
+xB
+LM
+yp
+wE
+KA
+VH
+Tq
+dz
+dz
+dz
+dz
+dz
+dz
+"}
+(28,1,1) = {"
+dz
+dz
+dz
+dz
+dz
+nP
+ud
+ud
+ud
+Tq
+Tq
+qG
+Tq
+bw
+ud
+ud
+ud
+Tc
+AM
+kQ
+Tq
+Tq
+nP
+nP
+nP
+nP
+Ib
+oH
+Tq
+wb
+Qk
+CV
+Tq
+Tq
+dz
+dz
+dz
+dz
+dz
+"}
+(29,1,1) = {"
+dz
+dz
+dz
+dz
+nP
+nP
+ud
+ud
+ud
+ud
+Tq
+Tq
+Tq
+ud
+ud
+ud
+ud
+DO
+bE
+xh
+Tq
+Mp
+Tq
+Mh
+nP
+nP
+nP
+nP
+HW
+Tq
+fY
+DZ
+Tq
+Am
+aw
+Ul
+Ul
+dz
+dz
+"}
+(30,1,1) = {"
+dz
+dz
+dz
+dz
+nP
+nP
+ud
+ud
+bt
+ud
+Tq
+Tq
+ud
+ud
+ud
+ud
+bt
+wb
+tw
+Yt
+nP
+nP
+Um
+Oh
+Wo
+LO
+mm
+bo
+KK
+KU
+jD
+Tq
+sp
+WN
+WN
+oH
+Ul
+Ul
+dz
+"}
+(31,1,1) = {"
+dz
+dz
+dz
+dz
+nP
+nP
+dc
+ud
+ud
+ud
+ud
+XH
+ud
+bt
+ud
+ud
+nP
+dc
+MY
+nP
+nP
+dc
+QA
+CV
+Am
+TA
+Cm
+Mw
+JU
+PN
+mI
+oH
+sp
+tl
+ZV
+oH
+sp
+Ul
+Ul
+"}
+(32,1,1) = {"
+dz
+dz
+dz
+dz
+nP
+nP
+ud
+ud
+ud
+ud
+ud
+ud
+ud
+ud
+ud
+nP
+nP
+nP
+nP
+nP
+nP
+bv
+WO
+WN
+Sl
+Na
+nP
+nP
+nP
+NT
+GE
+WN
+HK
+nA
+nA
+pJ
+sp
+Ul
+Ul
+"}
+(33,1,1) = {"
+dz
+dz
+dz
+dz
+Ul
+nP
+nP
+ud
+ud
+bt
+ud
+ib
+ud
+bt
+ud
+nP
+nP
+bt
+nP
+nP
+bt
+bt
+oH
+Sl
+mq
+nP
+nP
+nP
+sp
+eJ
+nA
+WN
+WN
+lM
+mj
+sp
+sp
+Ul
+Ul
+"}
+(34,1,1) = {"
+dz
+dz
+dz
+dz
+Ul
+Ul
+nP
+dc
+ud
+bt
+nP
+ud
+ud
+ud
+nP
+nP
+dc
+nP
+nP
+nP
+nP
+Dq
+Mw
+Na
+nP
+nP
+nP
+sp
+sp
+cm
+tF
+nA
+oH
+aR
+tl
+tl
+WN
+Ul
+Ul
+"}
+(35,1,1) = {"
+dz
+dz
+dz
+dz
+Ul
+Ul
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+bt
+nP
+dc
+fO
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+ly
+vg
+nA
+nA
+aR
+aR
+aE
+nA
+ht
+tF
+WN
+Ul
+Ul
+"}
+(36,1,1) = {"
+dz
+dz
+dz
+dz
+Ul
+Ul
+Ul
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+La
+La
+qX
+La
+nP
+nP
+nP
+nP
+nP
+nP
+RG
+Dk
+sp
+mj
+mj
+mj
+nA
+lM
+nA
+nA
+tl
+oH
+Ul
+Ul
+"}
+(37,1,1) = {"
+dz
+dz
+dz
+dz
+dz
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+SC
+Dc
+La
+pf
+ov
+yJ
+Tq
+ND
+RM
+uN
+eB
+Qi
+RM
+Dk
+Ul
+cQ
+Fs
+aR
+Gh
+tF
+mj
+ds
+yC
+WN
+oH
+Ul
+Ul
+"}
+(38,1,1) = {"
+dz
+dz
+dz
+dz
+dz
+dz
+Ul
+Ul
+Ul
+Ul
+jw
+KF
+Tq
+Tq
+Tq
+Tq
+La
+Tq
+Yu
+Ul
+oH
+DX
+Rl
+bM
+WN
+Ul
+Ul
+sp
+qB
+nA
+mj
+pJ
+mj
+iE
+nA
+sp
+Ul
+Ul
+Ul
+"}
+(39,1,1) = {"
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+Ul
+Ul
+Ul
+La
+YE
+EX
+RF
+eK
+aB
+La
+jw
+Ul
+Ul
+Ul
+NI
+TH
+Ul
+Ul
+Ul
+sp
+sp
+tc
+mj
+mj
+sp
+ID
+nA
+sp
+Ul
+Ul
+Ul
+"}
+(40,1,1) = {"
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+Ul
+Ul
+Yu
+La
+La
+La
+La
+La
+Ul
+Ul
+Ul
+Ul
+Ul
+tZ
+pT
+Ul
+Ul
+Ul
+Ul
+sp
+sp
+sp
+Ul
+sp
+sp
+sp
+WN
+Ul
+Ul
+Ul
+"}
+(41,1,1) = {"
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+DX
+tr
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+dz
+"}
+(42,1,1) = {"
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+dz
+dz
+dz
+dz
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+Ul
+dz
+dz
+"}
+(43,1,1) = {"
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+Ul
+Ul
+Ul
+Ul
+dz
+dz
+Ul
+Ul
+dz
+dz
+dz
+dz
+"}
+(44,1,1) = {"
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+dz
+"}

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -477,3 +477,11 @@
 	suffix = "lavaland_surface_shinobigraveyard.dmm"
 	allow_duplicates = FALSE
 	cost = 5
+
+/datum/map_template/ruin/lavaland/lavaland_surface_meteorite
+	name = "Ash Walker Meteorite"
+	id = "meteorite"
+	description = "A village bestowed with immense misfortune."
+	suffix = "lavaland_surface_meteorite.dmm"
+	allow_duplicates = FALSE
+	cost = 20

--- a/config/lavaruinblacklist.txt
+++ b/config/lavaruinblacklist.txt
@@ -42,4 +42,3 @@ _maps/RandomRuins/LavaRuins/lavaland_surface_prisoner_crash.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_surface_swarmer_crash.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_surface_library.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_surface_doorstuck.dmm
-#_maps/RandomRuins/LavaRuins/lavaland_surface_meteorite.dmm

--- a/config/lavaruinblacklist.txt
+++ b/config/lavaruinblacklist.txt
@@ -42,3 +42,4 @@ _maps/RandomRuins/LavaRuins/lavaland_surface_prisoner_crash.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_surface_swarmer_crash.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_surface_library.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_surface_doorstuck.dmm
+#_maps/RandomRuins/LavaRuins/lavaland_surface_meteorite.dmm


### PR DESCRIPTION
More murder is good for you.

# Document the changes in your pull request

Barren and desolate, two stories of a place have already unfolded, leaving nothing but the history of what could have once happened.

Adds a new ruin to lavaland. I personally thought the game could use some more ruins that you could backtrack to or do more things with in general. It has a general theme of a very unfortunate rock falling from the sky incident and a couple of references here and there with random items scattered about.

This map has been tested and can actually spawn on lavaland, well at least on localhost. I am open to changing the loot table but this is honestly the best I can think of that isn't blatantly overpowered or literally just admin items.

Edit: Adjusts the changelog, clarifies that the moonlight greatsword is not a null rod, and replaces the wiki doc image for a transparent version courtesy of @VaelophisNyx 

# Notable Loot and Structures

Church and Farmshed: An infested abandoned church near farmland, corpses litter the field after the short era of peaceful living has passed. The buckets got thrown into lava, bring your own.
Contains a very shitty force 10 claymore, 2 rakes, 2 bone cultivators, 2 bone spades, 2 lanterns, a bone pickaxe, and a gutlunch.
![image](https://user-images.githubusercontent.com/107460718/179646879-d7b9ee04-99b8-4cea-a427-50b6d6834310.png)

Intact Houses: A bunch of houses not totally destroyed by the meteor that contains most of if not all of their remaining equipment.
Contains a full set of bone surgery tools, 4 ashen arrows in conjunction with a leather quiver and a bone bow, a bone pickaxe, a bone dagger, and 2 bone spears, a scythe, tribal rags, a hide mantel, shaman tribal rags, and a gutlunch.
![image](https://user-images.githubusercontent.com/107460718/179648135-3d0a899a-9d57-4628-9656-4df48ec06d9d.png)

Repurposed Miner Shack: After the collapse of lizard society, a group of mostly plasma men alongside human miners find the ruin and try to take advantage of the meteor's resources by repurposing and harvesting a wrecked building, only to find something inside the meteor that is much much worse.
Contains 2 mining envirosuits, heavy bone armor coupled with a skull helmet, a tribal cloak, 4 lanterns, a silver pickaxe, a compact pickaxe, a shovel, 2 mesons, and 2 manual scanners, 2 mining satchels, and a pathfinder cloak.
![image](https://user-images.githubusercontent.com/107460718/179649378-56770417-0436-46d9-89d4-4ccd43d470f9.png)

The Meteor and the Graves: The meteor that landed in the middle of a village and the graveyard that sprouted from the miners' mass diggings. Be careful of the fauna that arrived when it crashed, miners have unleashed descent from an ancient past.
Contains a legion tendril, a shambling miner with a sonic jackhammer, 4 ashen arrows with a bone bow, a bone dagger, and a bone spear.
![image](https://user-images.githubusercontent.com/107460718/179651619-8a2d3035-9f0f-47d4-aab2-85f1125f91c0.png)

Egg: The only thing that will be left unharmed even if a space rock fell on it. With a locked door that could only be opened after killing the legion, this is a ruin where you can backtrack and get some free bonus loot without having to fight the necropolis dragon.
Contains a dragon's egg, 2 drakelings that will actively try to kill you, a piece of plasma magmite, plasma magmite upgrade parts, a rune of resizement, a fugu gland, syndicate combat uniforms, and a chameleon cap.
![image](https://user-images.githubusercontent.com/107460718/179652681-8c4399f3-d9df-4c8b-834b-e6f91863bb1d.png)

# Wiki Documentation

References include shambling miner as vanderohe from army of the dead, plasma miner as steve from minecraft, undead templar as ashen one from dark souls 3, and glowing claymore as moonlight greatsword from the darksouls franchise.
The ruins page will need an entry about this ruin existing.

![image](https://user-images.githubusercontent.com/107460718/179655867-c4a6710b-adf3-4379-9ce9-ef1dd078db3c.png)

# Changelog
:cl:  
rscadd: Adds new Ash Walker Meteorite ruin to lavaland
/:cl:
