### PR TITLE
Heretic blade buff

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -79,7 +79,8 @@
 	flags_1 = CONDUCT_1
 	sharpness = SHARP_EDGED
 	w_class = WEIGHT_CLASS_NORMAL
-	force = 25
+	force = 20
+	armour_penetration = 25
 	throwforce = 10
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "rends")

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -79,7 +79,7 @@
 	flags_1 = CONDUCT_1
 	sharpness = SHARP_EDGED
 	w_class = WEIGHT_CLASS_NORMAL
-	force = 17
+	force = 25
 	throwforce = 10
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "rends")


### PR DESCRIPTION
# Document the changes in your pull request
Increases damage of all heretic blades to 20, from 17, and adds 25 AP
Heretics are fairly underpowered when it comes to fighting security, and 9/10 times a roundstart security officer can beat a heretic by just stunning them. The ash jaunt doesnt last long enough to really escape security with it, you cant break a blade when your stunned or cuffed, and almost all heretics will be fighting security, due to the nature of the antag.
# Wiki Documentation
Update the value if its mentioned anywhere
:cl:    
tweak: Heretic blade now has 25 AP, and 20 damage, from 17
/:cl:
