### PR TITLE
adds a collectable skull helmet for donators

### DIFF
--- a/code/modules/clothing/head/collectable.dm
+++ b/code/modules/clothing/head/collectable.dm
@@ -164,3 +164,11 @@
 	item_state = "swat"
 	resistance_flags = NONE
 	flags_inv = HIDEHAIR
+
+/obj/item/clothing/head/collectable/skull
+	name = "collectable skull helmet"
+	desc = "A decently authentic plastic shell that resembles a spooky skull. Probably not anywhere near as protective as the one in your head."
+	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE
+	flags_cover = HEADCOVERSEYES
+	icon_state = "skull"
+	item_state = "skull"

--- a/yogstation/code/modules/donor/unique_donator_items.dm
+++ b/yogstation/code/modules/donor/unique_donator_items.dm
@@ -421,6 +421,11 @@ Uncomment this and use atomproccall as necessary, then copypaste the output into
 	unlock_path = /obj/item/clothing/head/wizard/marisa/fake
 	slot = SLOT_HEAD
 
+/datum/donator_gear/skull
+	name = "Skull Helmet (Collectable)"
+	unlock_path = /obj/item/clothing/head/collectable/skull
+	slot = SLOT_HEAD
+
 //End of items
 
 //Generic donator items


### PR DESCRIPTION
adds a collectable version of the lavaland skull helmet for donators to pick for their hat choice

it looks cool, and i want to wear it without going to lavaland

as with all collectable versions of hats, it has zero armor or anything

# Changelog

:cl:  
rscadd: Adds a collectable version of the lavaland skull helmet that donators can pick up for their hat choice.
/:cl:
