### PR TITLE
Nerfs plasmemes because people don't know how code works

### DIFF
--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -47,6 +47,7 @@
 	var/brightness_on = 4 //luminosity when the light is on
 	var/on = FALSE
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
+	flash_protect = 0
 
 /obj/item/clothing/head/helmet/space/plasmaman/attack_self(mob/user)
 	toggle_helmet_light(user)


### PR DESCRIPTION
# Document the changes in your pull request

Plasmeme helmets by default inherit flash protection from spacesuit helmets
This was intentionally disabled
The disabling was removed in pr #14679, re-enabling it, despite the hc requesting it not be re-enabled
This pr fixes that

# Changelog

:cl:  
bugfix: fixed envirosuit helmets having flash protected
/:cl:
