### PR TITLE
[Meta] moves the orm to the mining office, from the cargo lobby

### DIFF
--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -9424,20 +9424,6 @@
 "axx" = (
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"axy" = (
-/obj/structure/rack,
-/obj/item/pickaxe{
-	pixel_x = 5
-	},
-/obj/item/shovel{
-	pixel_x = -5
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningoffice)
 "axz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -9904,10 +9890,6 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"ayE" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/quartermaster/miningoffice)
 "ayF" = (
 /turf/closed/wall/r_wall,
 /area/security/detectives_office)
@@ -28970,14 +28952,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bmh" = (
-/obj/machinery/mineral/ore_redemption,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/dark,
-/area/quartermaster/office)
 "bmi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -70710,6 +70684,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"nEl" = (
+/obj/machinery/mineral/ore_redemption,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningoffice)
 "nFe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -70990,6 +70973,14 @@
 /obj/structure/frame/machine,
 /turf/open/floor/engine,
 /area/engine/atmos_distro)
+"nTn" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/arrows,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningoffice)
 "nTE" = (
 /obj/structure/table,
 /obj/item/taperecorder{
@@ -101110,8 +101101,8 @@ aAC
 bED
 avV
 aAC
-axy
-ayE
+nTn
+nEl
 azq
 aAm
 aKQ
@@ -103445,7 +103436,7 @@ lDr
 lzS
 aPN
 bkp
-bmh
+bbN
 aXS
 bpT
 bcf


### PR DESCRIPTION

# Document the changes in your pull request

The orm was in a very shitty spot, making breaking into cargo free by unwrenching the ORM and walking right in.

Plus, having to walk across the entire cargo bay just to deposit ores is a massive pain in the ass.
# Spriting


# Wiki Documentation

New screenshot perhaps
# Changelog



:cl:  
tweak: meta orm is in the mining office and not the cargo lobby
/:cl:
