### PR TITLE
Makes Botanical Chem Dispensers Possible To Build, Repaths Existing Seed Vault Dispenser To A Fullupgrade Subtype, Makes Basetype Not Start Upgraded, Locks Chems Behind Tiers

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -187,7 +187,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "E" = (
-/obj/machinery/chem_dispenser/mutagensaltpeter,
+/obj/machinery/chem_dispenser/mutagensaltpeter/fullupgrade,
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "F" = (

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -680,6 +680,21 @@
 	build_path = /obj/machinery/chem_dispenser/abductor
 	def_components = list(/obj/item/stock_parts/cell = /obj/item/stock_parts/cell/high)
 	needs_anchored = FALSE
+
+//botanical chem dispenser
+/obj/item/circuitboard/machine/chem_dispenser/mutagensaltpeter
+	name = "Botanical Chem Dispenser (Machine Board)"
+	icon_state = "service"
+	build_path = /obj/machinery/chem_dispenser/mutagensaltpeter
+	req_components = list(
+		/obj/item/stock_parts/matter_bin = 2,
+		/obj/item/stock_parts/capacitor = 1,
+		/obj/item/stock_parts/manipulator = 1,
+		/obj/item/stack/sheet/glass = 1,
+		/obj/item/stock_parts/cell = 1)
+	def_components = list(/obj/item/stock_parts/cell = /obj/item/stock_parts/cell/high)
+	needs_anchored = FALSE
+
 // yogs end
 /obj/item/circuitboard/machine/chem_heater
 	name = "Chemical Heater (Machine Board)"

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -617,30 +617,33 @@
 /obj/machinery/chem_dispenser/mutagensaltpeter
 	name = "botanical chemical dispenser"
 	desc = "Creates and dispenses chemicals useful for botany."
-	flags_1 = NODECONSTRUCT_1
+	circuit = /obj/item/circuitboard/machine/chem_dispenser/mutagensaltpeter
 
 	dispensable_reagents = list(
-		/datum/reagent/toxin/mutagen,
 		/datum/reagent/saltpetre,
+		/datum/reagent/ash,
+		/datum/reagent/ammonia,)
+	t2_upgrade_reagents = list(
 		/datum/reagent/plantnutriment/eznutriment,
 		/datum/reagent/plantnutriment/left4zednutriment,
 		/datum/reagent/plantnutriment/robustharvestnutriment,
-		/datum/reagent/water,
+		/datum/reagent/water,)
+	t3_upgrade_reagents = list(
 		/datum/reagent/toxin/plantbgone,
 		/datum/reagent/toxin/plantbgone/weedkiller,
-		/datum/reagent/toxin/pestkiller,
+		/datum/reagent/toxin/pestkiller,)
+	t4_upgrade_reagents = list(
+		/datum/reagent/toxin/mutagen,
 		/datum/reagent/medicine/cryoxadone,
-		/datum/reagent/ammonia,
-		/datum/reagent/ash,
 		/datum/reagent/diethylamine)
-	t2_upgrade_reagents = null
-	t3_upgrade_reagents = null
-	t4_upgrade_reagents = null
 
-/obj/machinery/chem_dispenser/mutagensaltpeter/Initialize()
+/obj/machinery/chem_dispenser/mutagensaltpeter/fullupgrade
+	name = "botanical chemical dispenser"
+
+/obj/machinery/chem_dispenser/mutagensaltpeter/fullupgrade/Initialize()
 	. = ..()
 	component_parts = list()
-	component_parts += new /obj/item/circuitboard/machine/chem_dispenser(null)
+	component_parts += new /obj/item/circuitboard/machine/chem_dispenser/mutagensaltpeter(null)
 	component_parts += new /obj/item/stock_parts/matter_bin/bluespace(null)
 	component_parts += new /obj/item/stock_parts/matter_bin/bluespace(null)
 	component_parts += new /obj/item/stock_parts/capacitor/quadratic(null)

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -218,6 +218,14 @@
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_MEDICAL
 	category = list ("Medical Machinery")
 
+/datum/design/board/chem_dispenser/mutagensaltpeter
+	name = "Machine Design (Botanical Chem Dispenser Board)"
+	desc = "The circuit board for a botanical chem dispenser."
+	id = "botany_chem_dispenser"
+	build_path = /obj/item/circuitboard/machine/chem_dispenser/mutagensaltpeter
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SERVICE
+	category = list ("Misc. Machinery")
+
 /datum/design/board/chem_master
 	name = "Machine Design (Chem Master Board)"
 	desc = "The circuit board for a Chem Master 3000."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -632,7 +632,7 @@
 	display_name = "Botanical Engineering"
 	description = "Botanical tools"
 	prereq_ids = list("adv_engi", "biotech")
-	design_ids = list("diskplantgene", "portaseeder", "plantgenes", "flora_gun", "hydro_tray", "biogenerator", "seed_extractor")
+	design_ids = list("diskplantgene", "portaseeder", "plantgenes", "flora_gun", "hydro_tray", "biogenerator", "seed_extractor", "botany_chem_dispenser")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 


### PR DESCRIPTION
# Document the changes in your pull request

Adds Botanical Chem Dispenser Boards to the Botanical Engineering tech node
Adds Fullupgrade subtype of Botanical chem dispensers
Makes the Seed Vault use that subtype
locks chems behind all four tiers of upgrades
makes them not init with all t4 parts now unless they're the subtype

# Changelog

:cl:  
rscadd: Added Botanical Chem Dispenser Boards to the Service Protolathe after researching the Botanical Engineering tech node
tweak: Botanical Chem Dispensers care about upgrades now
/:cl:
