### PR TITLE
adds explorer firing pins, PKAs will now start with these instead of electronic ones.

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -605,6 +605,14 @@
 	for(var/i in 1 to 5)
 		new /obj/item/firing_pin(src)
 
+/obj/item/storage/box/firingpins/explorer
+	name = "box of explorer firing pins"
+	desc = "A box full of explorer firing pins, to allow firearms to operate while off-station."
+
+/obj/item/storage/box/firingpins/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/firing_pin/explorer(src)
+
 /obj/item/storage/box/lasertagpins
 	name = "box of laser tag firing pins"
 	desc = "A box full of laser tag firing pins, to allow newly-developed firearms to require wearing brightly coloured plastic armor before being able to be used."

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -69,6 +69,7 @@
 		new /datum/data/mining_equipment("Point Transfer Card (1000)", 	/obj/item/card/mining_point_card/thousand,							1000, VENDING_MISC),
 		new /datum/data/mining_equipment("Point Transfer Card (5000)", 	/obj/item/card/mining_point_card/fivethousand,						5000, VENDING_MISC),
 		new /datum/data/mining_equipment("Point Transfer Card (10000)",	/obj/item/card/mining_point_card/tenthousand,						10000, VENDING_MISC),
+		new /datum/data/mining_equipment("Box of Explorer Firing Pins",	/obj/item/storage/box/firingpins/explorer,						3000, VENDING_MISC),
 		new /datum/data/mining_equipment("Alien Toy",					/obj/item/clothing/mask/facehugger/toy,								300, VENDING_MISC),
 		new /datum/data/mining_equipment("Whiskey",						/obj/item/reagent_containers/food/drinks/bottle/whiskey,			100, VENDING_MISC),
 		new /datum/data/mining_equipment("Absinthe",					/obj/item/reagent_containers/food/drinks/bottle/absinthe/premium,	100, VENDING_MISC),

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -8,6 +8,7 @@
 	item_flags = NONE
 	obj_flags = UNIQUE_RENAME
 	weapon_weight = WEAPON_LIGHT
+	pin = /obj/item/firing_pin/explorer
 	can_flashlight = TRUE
 	flight_x_offset = 15
 	flight_y_offset = 9

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -73,6 +73,7 @@
 	holds_charge = TRUE
 	unique_frequency = TRUE
 	max_mod_capacity = 80
+	pin = /obj/item/firing_pin/explorer/cyborg
 
 /obj/item/gun/energy/kinetic_accelerator/minebot
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -234,8 +234,7 @@
 		var/mob/living/silicon/robot/R = user
 		if(R.emagged)
 			return TRUE
-		else
-			return ..()
+		return ..()
 
 
 

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -216,7 +216,6 @@
 /obj/item/firing_pin/explorer
 	name = "explorer firing pin"
 	desc = "A firing pin traditionally issued to shaft miners, to prevent malicious use of mining tools while on the station."
-	icon_state = "firing_pin"
 	fail_message = "<span class='warning'>LOCATION CHECK FAILED.</span>"
 
 /obj/item/firing_pin/explorer/pin_auth(mob/living/user)
@@ -229,12 +228,13 @@
 	name = "cyborg explorer firing pin"
 	desc = "You probably shouldn't be reading this."
 
-/obj/item/firing_pin/explorer/pin_auth(mob/living/user)
+/obj/item/firing_pin/explorer/cyborg/pin_auth(mob/living/user)
 	if(iscyborg(user))
 		var/mob/living/silicon/robot/R = user
 		if(R.emagged)
 			return TRUE
 		return ..()
+	return FALSE
 
 
 

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -225,6 +225,20 @@
 		return FALSE
 	return TRUE
 
+/obj/item/firing_pin/explorer/cyborg
+	name = "cyborg explorer firing pin"
+	desc = "You probably shouldn't be reading this."
+
+/obj/item/firing_pin/explorer/pin_auth(mob/living/user)
+	if(iscyborg(user))
+		var/mob/living/silicon/robot/R = user
+		if(R.emagged)
+			return TRUE
+		else
+			return ..()
+
+
+
 // Laser tag pins
 /obj/item/firing_pin/tag
 	name = "laser tag firing pin"

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -213,6 +213,18 @@
 	desc = "This is a DNA-locked firing pin which only authorizes one user. Attempt to fire once to DNA-link. It has a small explosive charge on it."
 	selfdestruct = TRUE
 
+/obj/item/firing_pin/explorer
+	name = "explorer firing pin"
+	desc = "A firing pin traditionally issued to shaft miners, to prevent malicious use of mining tools while on the station."
+	icon_state = "firing_pin"
+	fail_message = "<span class='warning'>LOCATION CHECK FAILED.</span>"
+
+/obj/item/firing_pin/explorer/pin_auth(mob/living/user)
+	var/turf/station_check = get_turf(user)
+	if(!station_check||is_station_level(station_check.z))
+		return FALSE
+	return TRUE
+
 // Laser tag pins
 /obj/item/firing_pin/tag
 	name = "laser tag firing pin"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2104,10 +2104,10 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	surplus = 0
 
 /datum/uplink_item/role_restricted/pressure_mod
-	name = "Kinetic Accelerator Pressure Mod"
+	name = "Kinetic Accelerator Pressure Kit"
 	desc = "A modification kit which allows Kinetic Accelerators to do greatly increased damage while indoors. \
-			Occupies 35% mod capacity."
-	item = /obj/item/borg/upgrade/modkit/indoors
+			Occupies 35% mod capacity. Comes with an electronic firing pin, enabling use while on-station."
+	item = /obj/item/storage/box/syndie_kit/pka
 	cost = 5 //you need two for full damage, so total of 10 for maximum damage
 	manufacturer = /datum/corporation/traitor/donkco // Unless you're donk co, then it's 8
 	limited_stock = 2 //you can't use more than two!

--- a/yogstation/code/game/objects/items/storage/uplink_kits.dm
+++ b/yogstation/code/game/objects/items/storage/uplink_kits.dm
@@ -30,3 +30,10 @@
 	new /obj/item/autosurgeon/plasmavessel(src)
 	new /obj/item/organ/alien/resinspinner(src)
 	new /obj/item/organ/alien/acid(src)
+
+/obj/item/storage/box/syndie_kit/pka
+	real_name = "proto-kinetic accelerator hacking kit"
+
+/obj/item/storage/box/syndie_kit/pka/PopulateContents()
+	new /obj/item/borg/upgrade/modkit/indoors(src)
+	new /obj/item/firing_pin(src)


### PR DESCRIPTION
probably a pretty controversial one, so let's cut to the chase. explorer firing pins will prevent guns from firing while on the station z-level. miners can buy a box of 5 more for use with whatever guns security is willing to give them, and also for emagging which disables the authentication check, allowing them to fire on-station.

But why?

pkas are too good for PVP, which our current mining design philosophy has been moving away from for quite some time. they've always been too good, but instead of completely crippling them, i've opted to take the middle ground approach of making it more difficult for validhunters to spam dual 4x cooldown PKAs, with serious need they can of course get normal firing pins for their guns. every other stat with PKA remains the same.
borgs deserve some love too so they get special firing pins that lets them fire on station but only when emagged to prevent malf AIs being cucked out of the extremely useful tool of full damage PKAs as people swarm the satellite

The traitor PKA pressure mod comes in a box with an electronic firing pin so you don't have to pay an extra 6tc to use it on-station.

# Wiki Documentation

cyborg page, the shaft miner page, uplink items page.

# Changelog

:cl:  
rscadd: adds explorer firing pins, and adds them to the mining rewards vendor at the price of 3k for a box of 5
tweak: proto-kinetic accelerators will now come with explorer firing pins. cyborgs get cyborg explorer firing pins, which can be fired on station while hacked/emagged
tweak: the pressure mod for the PKA will now come in a box also containing an electronic firing pin when purchased from an uplink
/:cl:
