### PR TITLE
Fixes AI whale gax spawn for the final time (maybe)

### DIFF
--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -48687,7 +48687,7 @@ vRP
 vRP
 vRP
 vRP
-iYZ
+vRP
 vRP
 vRP
 vRP
@@ -51526,7 +51526,7 @@ vRP
 vRP
 vRP
 vRP
-vRP
+iYZ
 vRP
 vRP
 vRP


### PR DESCRIPTION
# Document the changes in your pull request

I analyzed 20+ rounds of gax and it spawns in every position except the bottom left, so I am thinking that's where it tries to spawn but can't.

# Changelog

:cl:  
bugfix: ai whale on gax will spawn more consistently (at all this time)
/:cl:
