### PR TITLE
Adds Hydrogen Miner & Air-Floor For Mapping/Admin-Use

### DIFF
--- a/code/game/turfs/simulated/floor/reinf_floor.dm
+++ b/code/game/turfs/simulated/floor/reinf_floor.dm
@@ -126,7 +126,9 @@
 	name = "air floor"
 	initial_gas_mix = ATMOS_TANK_AIRMIX
 
-
+/turf/open/floor/engine/hydrogen
+	name = "\improper H2 floor"
+	initial_gas_mix = ATMOS_TANK_H2
 
 /turf/open/floor/engine/cult
 	name = "engraved floor"

--- a/code/modules/atmospherics/machinery/other/miner.dm
+++ b/code/modules/atmospherics/machinery/other/miner.dm
@@ -156,9 +156,14 @@
 	overlay_color = "#007FFF"
 	spawn_id = /datum/gas/oxygen
 
+/obj/machinery/atmospherics/miner/hydrogen
+	name = "\improper H2 Gas Miner"
+	overlay_color = "#ff0000"
+	spawn_id = /datum/gas/hydrogen
+
 /obj/machinery/atmospherics/miner/toxins
 	name = "\improper Plasma Gas Miner"
-	overlay_color = "#FF0000"
+	overlay_color = "#ff6600"
 	spawn_id = /datum/gas/plasma
 
 /obj/machinery/atmospherics/miner/carbon_dioxide


### PR DESCRIPTION
# Document the changes in your pull request

Was trying to play around with hydrogen stuff on a local host and found there was no miner nor floor tiles to produce it at all. Simply makes them exist, currently unused...probably won't get used, this would be an insane atmos buff if given to a map.

# Changelog

:cl:  
rscadd: Adds Hydrogen Gas Miner
rscadd: Adds Hydrogen Air Floor
tweak: adjusts plasma miner color to better match plasma tank colors so hydrogen miners can be red
/:cl:
