### PR TITLE
Moves mindshield firing pins to Cargo from the security protolathe.

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -605,6 +605,14 @@
 	for(var/i in 1 to 5)
 		new /obj/item/firing_pin(src)
 
+/obj/item/storage/box/firingpins/loyalty
+	name = "box of mindshield firing pins"
+	desc = "A box full of mindshield firing pins, only authorizing firing for those with mindshield implants."
+
+/obj/item/storage/box/firingpins/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/firing_pin/implant/mindshield(src)
+
 /obj/item/storage/box/lasertagpins
 	name = "box of laser tag firing pins"
 	desc = "A box full of laser tag firing pins, to allow newly-developed firearms to require wearing brightly coloured plastic armor before being able to be used."

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -434,10 +434,9 @@
 
 /datum/supply_pack/security/armory/mindpins
 	name = "Mindshield Firing Pin Crate"
-	desc = "Contains ten mindshield firing pins, perfect for the security team that slips on the Clown's bananas and loses their guns. Requires Armory access to open."
+	desc = "Contains five mindshield firing pins, perfect for the security team that slips on the Clown's bananas and loses their guns. Requires Armory access to open."
 	cost = 10000
-	contains = list(/obj/item/storage/box/firingpins/loyalty,
-					/obj/item/storage/box/firingpins/loyalty)
+	contains = list(/obj/item/storage/box/firingpins/loyalty)
 	crate_name = "mindshield firing pin crate"
 
 /datum/supply_pack/security/armory/bulletarmor

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -432,6 +432,14 @@
 	access = ACCESS_ARMORY
 	crate_type = /obj/structure/closet/crate/secure/weapon
 
+/datum/supply_pack/security/armory/mindpins
+	name = "Mindshield Firing Pin Crate"
+	desc = "Contains ten mindshield firing pins, perfect for the security team that slips on the Clown's bananas and loses their guns. Requires Armory access to open."
+	cost = 10000
+	contains = list(/obj/item/storage/box/firingpins/loyalty,
+					/obj/item/storage/box/firingpins/loyalty)
+	crate_name = "mindshield firing pin crate"
+
 /datum/supply_pack/security/armory/bulletarmor
 	name = "Bulletproof Armor Crate"
 	desc = "Contains three sets of bulletproof armor. Guaranteed to reduce a bullet's stopping power by over half. Requires Armory access to open."

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -94,16 +94,6 @@
 	category = list("Firing Pins")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
-/datum/design/pin_mindshield
-	name = "Mindshield Firing Pin"
-	desc = "This is a security firing pin which only authorizes users who are mindshield-implanted."
-	id = "pin_loyalty"
-	build_type = PROTOLATHE
-	materials = list(/datum/material/silver = 600, /datum/material/diamond = 600, /datum/material/uranium = 200)
-	build_path = /obj/item/firing_pin/implant/mindshield
-	category = list("Firing Pins")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
-
 /datum/design/stunmine/sec //mines ported from BeeStation
 	name = "Stun Mine"
 	desc = "A basic non-lethal stunning mine. Stuns anyone who walks over it."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -697,7 +697,7 @@
 	display_name = "Advanced Weapon Development Technology"
 	description = "Our weapons are breaking the rules of reality by now."
 	prereq_ids = list("adv_engi", "weaponry")
-	design_ids = list("pin_loyalty", "borg_transform_security")
+	design_ids = list("borg_transform_security")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	export_price = 5000
 


### PR DESCRIPTION
# Document the changes in your pull request

Security protolathes can no longer print mindshield firing pins. Cargo can get them for 10k credits for a box of five.

Infinite guns are bad. Especially since pretty much every gun that can be printed is a direct upgrade to the guns that start in the armory at the start of the game. Mindshield pins make guns essentially unlootable without Cargo, so even if you take down the four or five security officers with akimbo AEGs, you can't use the guns unless you steal their mindshield implants too, which makes you stick out like a sore thumb on security HUDs, and requires special surgical equipment. You can still print guns, and the Warden has two boxes of five standard firing pins in their office, so while you can still print guns from the armory protolathe, you're capped at ten that anyone can use unless you buy more firing pins from Cargo.

# Wiki Documentation

Supply crates page, techwebs page.

# Changelog

:cl:  
rscadd: Cargo can now order 5 mindshield firing pins for 10000 credits
rscdel: the security protolathes can no longer make mindshield firing pins
/:cl:
