### PR TITLE
Glowing Goo Puddles Cease Glowing After 24 Seconds & Are Radioactive

### DIFF
--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -75,6 +75,7 @@
 	name = "glowing goo"
 	desc = "Jeez. I hope that's not for lunch."
 	icon_state = "greenglow"
+	var/lifetime = 240
 	light_power = 1
 	light_range = 2
 	light_color = LIGHT_COLOR_GREEN
@@ -82,9 +83,26 @@
 /obj/effect/decal/cleanable/greenglow/ex_act()
 	return
 
+/obj/effect/decal/cleanable/greenglow/Initialize()
+	. = ..()
+	START_PROCESSING(SSobj, src)
+
+/obj/effect/decal/cleanable/greenglow/process()
+	if(lifetime)
+		lifetime--
+	if(!lifetime)
+		name = "dried goo"
+		light_power = 0
+		light_range = 0
+		STOP_PROCESSING(SSobj, src)
+		update_light()
+	else
+		return
+
 /obj/effect/decal/cleanable/greenglow/filled/Initialize()
 	. = ..()
 	reagents.add_reagent(pick(/datum/reagent/uranium, /datum/reagent/uranium/radium), 5)
+
 
 /obj/effect/decal/cleanable/cobweb
 	name = "cobweb"

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -75,7 +75,6 @@
 	name = "glowing goo"
 	desc = "Jeez. I hope that's not for lunch."
 	icon_state = "greenglow"
-	var/lifetime = 240
 	light_power = 1
 	light_range = 2
 	light_color = LIGHT_COLOR_GREEN

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -79,12 +79,14 @@
 	light_power = 1
 	light_range = 2
 	light_color = LIGHT_COLOR_GREEN
+	rad_insulation = RAD_NO_INSULATION
 
 /obj/effect/decal/cleanable/greenglow/ex_act()
 	return
 
 /obj/effect/decal/cleanable/greenglow/Initialize()
 	. = ..()
+    AddComponent(/datum/component/radioactive, 15, src, 0, FALSE)
 	START_PROCESSING(SSobj, src)
 
 /obj/effect/decal/cleanable/greenglow/process()

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -98,7 +98,6 @@
 	. = ..()
 	reagents.add_reagent(pick(/datum/reagent/uranium, /datum/reagent/uranium/radium), 5)
 
-
 /obj/effect/decal/cleanable/cobweb
 	name = "cobweb"
 	desc = "Somebody should remove that."

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -86,7 +86,7 @@
 
 /obj/effect/decal/cleanable/greenglow/Initialize()
 	. = ..()
-    AddComponent(/datum/component/radioactive, 15, src, 0, FALSE)
+	AddComponent(/datum/component/radioactive, 15, src, 0, FALSE)
 	START_PROCESSING(SSobj, src)
 
 /obj/effect/decal/cleanable/greenglow/process()

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -87,19 +87,13 @@
 /obj/effect/decal/cleanable/greenglow/Initialize()
 	. = ..()
 	AddComponent(/datum/component/radioactive, 15, src, 0, FALSE)
-	START_PROCESSING(SSobj, src)
+	addtimer(CALLBACK(src, .proc/Decay), 24 SECONDS)
 
-/obj/effect/decal/cleanable/greenglow/process()
-	if(lifetime)
-		lifetime--
-	if(!lifetime)
-		name = "dried goo"
-		light_power = 0
-		light_range = 0
-		STOP_PROCESSING(SSobj, src)
-		update_light()
-	else
-		return
+/obj/effect/decal/cleanable/greenglow/proc/Decay()
+	name = "dried goo"
+	light_power = 0
+	light_range = 0
+	update_light()
 
 /obj/effect/decal/cleanable/greenglow/filled/Initialize()
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request

Makes Glowing Goo radioactive (minor enough unless you spam a room full of glowing goo spots)
Also makes them stop glowing after 24s

This will make radium spray bottles not shit on slings and dspawn quite so hard

# Changelog

:cl:  
tweak: Glowing Goo stops glowing after 24 seconds and is lightly radioactive
/:cl:
