### PR TITLE
fixes the holodeck warning paper referencing a game mechanic that was removed 8 years ago

### DIFF
--- a/code/modules/holodeck/items.dm
+++ b/code/modules/holodeck/items.dm
@@ -228,4 +228,4 @@
 
 /obj/item/paper/fluff/holodeck/disclaimer
 	name = "Holodeck Disclaimer"
-	info = "Bruises sustained in the holodeck can be healed simply by sleeping."
+	info = "Any fatigue experienced in the holodeck will wear off by itself over time."


### PR DESCRIPTION
so turns out nobody noticed that this paper has been out of date for eight years. it references holodamage which was the predecessor to stamina damage that could only be healed by sleeping. holodamage no longer exists.

# Changelog

:cl:  
bugfix: the holodeck disclaimer will no longer reference a game mechanic removed eight years ago
/:cl:
