### PR TITLE
adds liver damage to rhigoxane's overdose

### DIFF
--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -140,6 +140,7 @@
 
 /datum/reagent/medicine/c2/rhigoxane/overdose_process(mob/living/carbon/M)
 	M.adjust_bodytemperature(-10 * TEMPERATURE_DAMAGE_COEFFICIENT * REM, 50) //chilly chilly
+	M.adjustOrganLoss(ORGAN_SLOT_LIVER, 1.5 * REM )
 	..()
 
 


### PR DESCRIPTION
why this is good-

I've seen chemists doing this a little bit too often and it annoys me that overdosing on a drug has no tangible downsides. Number can be adjusted higher because I honestly don't know precise values and how this would interact with things like the upgraded cybernetic liver.

# Wiki Documentation
Add something to Rhigoxane's OD effect thing on the Guide to Chemistry page.

# Changelog

:cl: ShadowDeath6
tweak: Overdosing on Rhixogane now causes significant liver damage.
/:cl:
