### PR TITLE
Blazing Oil blobs are now immune to burn damage

### DIFF
--- a/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
+++ b/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
@@ -3,9 +3,9 @@
 /datum/blobstrain/reagent/blazing_oil
 	name = "Blazing Oil"
 	description = "will do medium burn damage and set targets on fire."
-	effectdesc = "will also release bursts of flame when burnt, but takes damage from water."
+	effectdesc = "is completely immune to burn damage and will also release bursts of flame when burnt, but takes damage from water."
 	analyzerdescdamage = "Does medium burn damage and sets targets on fire."
-	analyzerdesceffect = "Releases fire when burnt, but takes damage from water and other extinguishing liquids."
+	analyzerdesceffect = "Releases fire when burnt and is completely immune to burning, but takes damage from water and other extinguishing liquids."
 	color = "#B68D00"
 	complementary_color = "#BE5532"
 	blobbernaut_message = "splashes"
@@ -18,6 +18,9 @@
 
 /datum/blobstrain/reagent/blazing_oil/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag)
 	if(damage_type == BURN && damage_flag != ENERGY)
+		var/mob/camera/blob/O = overmind
+		O.add_points(damage / 10)//burn damage causes the blob to gain a very small amount of points: the 20 damage of a laser will generate 2 BP.
+		damage = 0 //completely and entirely immune to burn damage!
 		for(var/turf/open/T in range(1, B))
 			var/obj/structure/blob/C = locate() in T
 			if(!(C && C.overmind && C.overmind.blobstrain.type == B.overmind.blobstrain.type) && prob(80))


### PR DESCRIPTION
this tiny change took a long ass time to do since I had to update my shit from 4 years ago

# changes
Blazing Oil blob is now COMPLETELY immune to burn damage. Welders, laser guns, PA rifles. All of them do nothing. 
In fact, they give the blob a little bit of points back, too. This is reflected in the health analyzer / medHUD examine as well as in the blob's little blurb when selecting the thing.

**Before you say that this is overkill**, Blazing Oil has notoriously been horrifically awful because it allows crew to effectively spam AOE laser beams via fire extinguishers. I'd like to change blazing oil to be something similar to networked fibers where it completely alters the way you have to fight the blob- you now HAVE to use water to kill it, instead of getting to use water and also shoot lasers at it.

I'd be open to also adding a weakness to brute damage as well- anything that steers the strategy away from continuing to use burn damage against it.

I've tested this and everything works as intended- while water DOES count as burn damage, it's considered ENERGY damage, which ironically enough doesn't include energy weaponry (that's normal burn damage).

# Wiki Documentation
Blob wiki page for the Blazing Oil reagent needs to be updated to reflect the changes made in this pull.

# Changelog

:cl:  ShadowDeath6
tweak: Blazing Oil blobs are now entirely immune to all burn damage. Use those extinguishers!
/:cl:
