### PR TITLE
sling: you need eyes to glare also examine adj

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -307,7 +307,10 @@
 				msg += "[t_He] [t_is][stun_absorption[i]["examine_message"]]\n"
 
 	if(!glasses && mind && mind.has_antag_datum(ANTAG_DATUM_THRALL))
-		msg += "[t_His] eyes seem unnaturally dark and soulless.\n" // I'VE BECOME SO NUMB, I CAN'T FEEL YOU THERE
+		if(getorganslot(ORGAN_SLOT_EYES))
+			msg += "[t_His] eyes seem unnaturally dark and soulless.\n" // I'VE BECOME SO NUMB, I CAN'T FEEL YOU THERE
+		else
+			msg += "The pair of holes where [t_His] eyes would be seem unnaturally dark and soulless.\n"
 
 	if(!appears_dead)
 		if(drunkenness && !skipface) //Drunkenness

--- a/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
@@ -892,7 +892,7 @@
 
 /obj/effect/proc_holder/spell/targeted/lesser_glare/cast(list/targets,mob/user = usr)
 	for(var/mob/living/target in targets)
-		if(!caller.getorganslot(ORGAN_SLOT_EYES))
+		if(!user.getorganslot(ORGAN_SLOT_EYES))
 			to_chat(user, span_warning("You need eyes to glare!"))
 			revert_cast()
 			return

--- a/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
@@ -62,7 +62,7 @@
 	. = ..()
 	if(!target)
 		return
-	if(!getorganslot(ORGAN_SLOT_EYES))
+	if(!caller.getorganslot(ORGAN_SLOT_EYES))
 		to_chat(user, span_warning("You need eyes to glare!"))
 		revert_cast()
 		return
@@ -892,7 +892,7 @@
 
 /obj/effect/proc_holder/spell/targeted/lesser_glare/cast(list/targets,mob/user = usr)
 	for(var/mob/living/target in targets)
-		if(!getorganslot(ORGAN_SLOT_EYES))
+		if(!caller.getorganslot(ORGAN_SLOT_EYES))
 			to_chat(user, span_warning("You need eyes to glare!"))
 			revert_cast()
 			return

--- a/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
@@ -62,6 +62,10 @@
 	. = ..()
 	if(!target)
 		return
+	if(!getorganslot(ORGAN_SLOT_EYES))
+		to_chat(user, span_warning("You need eyes to glare!"))
+		revert_cast()
+		return
 	if(target.stat)
 		to_chat(usr, span_warning("[target] must be conscious!"))
 		revert_cast()
@@ -888,8 +892,12 @@
 
 /obj/effect/proc_holder/spell/targeted/lesser_glare/cast(list/targets,mob/user = usr)
 	for(var/mob/living/target in targets)
+		if(!getorganslot(ORGAN_SLOT_EYES))
+			to_chat(user, span_warning("You need eyes to glare!"))
+			revert_cast()
+			return
 		if(!ishuman(target) || !target)
-			to_chat(user, span_warning("You nay only glare at humans!"))
+			to_chat(user, span_warning("You may only glare at humans!"))
 			revert_cast()
 			return
 		if(target.stat)


### PR DESCRIPTION
# Document the changes in your pull request

if examining a thrall with no eyes it instead says

"The pair of holes where [t_His] eyes would be seem unnaturally dark and soulless.\n"

you now need eyes to glare/lesser glare

# Changelog

:cl:  
tweak: You now need eyes to shadowling glare
spellfix: You nay -> may only glare at humans
/:cl:
