### PR TITLE
OpenDream Cleanup Pass

### DIFF
--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -201,10 +201,10 @@
 		var/datum/nanite_program/NP = X
 		NP.on_death(gibbed)
 
-/datum/component/nanites/proc/receive_signal(datum/source, code, source = "an unidentified source")
+/datum/component/nanites/proc/receive_signal(datum/source, code, signal_source = "an unidentified source")
 	for(var/X in programs)
 		var/datum/nanite_program/NP = X
-		NP.receive_signal(code, source)
+		NP.receive_signal(code, signal_source)
 
 /datum/component/nanites/proc/receive_comm_signal(datum/source, comm_code, comm_message, comm_source = "an unidentified source")
 	for(var/X in programs)

--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -79,7 +79,7 @@
 	UnregisterSignal(user, COMSIG_MOVABLE_DISPOSING)
 
 // Disposal pipes related shit
-/datum/component/squeak/proc/disposing_react(datum/source, obj/structure/disposalholder/holder, obj/machinery/disposal/source)
+/datum/component/squeak/proc/disposing_react(datum/source, obj/structure/disposalholder/holder, obj/machinery/disposal/disposal_source)
 	//We don't need to worry about unregistering this signal as it will happen for us automaticaly when the holder is qdeleted
 	RegisterSignal(holder, COMSIG_ATOM_DIR_CHANGE, .proc/holder_dir_change)
 

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -8,17 +8,17 @@
 	var/unique_blood = null
 	var/labelled = 0
 
-/obj/item/reagent_containers/blood/attack(mob/user, mob/user, def_zone)
+/obj/item/reagent_containers/blood/attack(mob/target, mob/user, def_zone)
 	if(reagents.total_volume > 0)
-		if(user != user)
+		if(target != user)
 			user.visible_message(
-				span_notice("[user] forces [user] to drink from the [src]."),
-				span_notice("You put the [src] up to [user]'s mouth."),
+				span_notice("[user] forces [target] to drink from the [src]."),
+				span_notice("You put the [src] up to [target]'s mouth."),
 			)
-			if(!do_mob(user, user, 5 SECONDS))
+			if(!do_mob(user, target, 5 SECONDS))
 				return
 		else
-			if(!do_mob(user, user, 1 SECONDS))
+			if(!do_mob(user, target, 1 SECONDS))
 				return
 			user.visible_message(
 				span_notice("[user] puts the [src] up to their mouth."),

--- a/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
@@ -336,7 +336,7 @@
 	action_icon = 'yogstation/icons/mob/actions.dmi'
 	action_icon_state = "commune"
 
-/obj/effect/proc_holder/spell/self/shadowling_hivemind/cast(mob/living/user,mob/user = usr)
+/obj/effect/proc_holder/spell/self/shadowling_hivemind/cast(list/targets, mob/user = usr)
 	if(!is_shadow(user))
 		to_chat(user, span_warning("You must be a shadowling to do that!"))
 		return


### PR DESCRIPTION
[OpenDream](https://github.com/wixoaGit/OpenDream) catches problems that BYOND silently ignores. This PR addresses everything OD found in Yogs.

The only real problem it found in Yogs is duplicate arg names. When you duplicate arg names, BYOND will silently use either the first or last arg and ignore the other instances, I forgot which way it goes.