### PR TITLE
Adds more Botany Cargo Bounties, Adjusts Mining Progression Bounties, Adjusts Appendix Bounty, Adjusts Drink Bounty

### DIFF
--- a/code/modules/cargo/bounties/assistant.dm
+++ b/code/modules/cargo/bounties/assistant.dm
@@ -63,7 +63,7 @@
 	required_count = 5
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/cheesiehonkers)
 
-/*/datum/bounty/item/assistant/baseball_bat //yogs: we don't even have these
+/*/datum/bounty/item/assistant/baseball_bat //yogs: we don't even have these //we do but not for crew. Sadge.
 	name = "Baseball Bat"
 	description = "Baseball fever is going on at CentCom! Be a dear and ship them some baseball bats, so that management can live out their childhood dream."
 	reward = 2000

--- a/code/modules/cargo/bounties/botany.dm
+++ b/code/modules/cargo/bounties/botany.dm
@@ -217,19 +217,23 @@
 
 /datum/bounty/item/botany/steelcaps
 	name = "Steel-Cap Logs"
-	description = "Central Command's head chef wants only the best organic skewers for a fine [foodtype]."
 	wanted_types = list(/obj/item/grown/log/steel)
 	required_count = 20
 	multiplier = 5
 	foodtype = "kebab"
 
+/datum/bounty/item/botany/steelcaps/New()
+	description = "Central Command's head chef wants only the best organic skewers for a fine [foodtype]."
+
 /datum/bounty/item/botany/towercaps
 	name = "Tower-Cap Logs"
-	description = "Central Command's head chef wants only the best wood as fuel for a corporate [foodtype]."
 	wanted_types = list(/obj/item/grown/log)
 	exclude_types = list(/obj/item/grown/log/steel)
 	required_count = 20
 	foodtype = "grill-out"
+
+/datum/bounty/item/botany/towercaps/New()
+	description = "Central Command's head chef wants only the best wood as fuel for a corporate [foodtype]."
 
 /datum/bounty/item/botany/killertomato
 	name = "Killer Tomato Meat"

--- a/code/modules/cargo/bounties/botany.dm
+++ b/code/modules/cargo/bounties/botany.dm
@@ -82,7 +82,7 @@
 /datum/bounty/item/botany/cannabis_ultimate
 	name = "Omega Weed Leaves"
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/grown/cannabis/ultimate)
-	multiplier = 10 //omega weed is ACTUAL CBT to get to mutate.
+	multiplier = 10
 	bonus_desc = "Under no circumstances mention this shipment to security."
 	foodtype = "batch of \"brownies\""
 

--- a/code/modules/cargo/bounties/botany.dm
+++ b/code/modules/cargo/bounties/botany.dm
@@ -223,7 +223,7 @@
 	multiplier = 5
 	foodtype = "kebab"
 
-/datum/bounty/item/botany/steelcaps
+/datum/bounty/item/botany/towercaps
 	name = "Tower-Cap Logs"
 	description = "Central Command's head chef wants only the best wood as fuel for a corporate [foodtype]."
 	wanted_types = list(/obj/item/grown/log)

--- a/code/modules/cargo/bounties/botany.dm
+++ b/code/modules/cargo/bounties/botany.dm
@@ -82,7 +82,7 @@
 /datum/bounty/item/botany/cannabis_ultimate
 	name = "Omega Weed Leaves"
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/grown/cannabis/ultimate)
-	multiplier = 6
+	multiplier = 10 //omega weed is ACTUAL CBT to get to mutate.
 	bonus_desc = "Under no circumstances mention this shipment to security."
 	foodtype = "batch of \"brownies\""
 
@@ -170,10 +170,16 @@
 	multiplier = 2
 	foodtype = "omelet"
 
+/datum/bounty/item/botany/destryoingangels
+	name = "Destroying Angels"
+	wanted_types = list(/obj/item/reagent_containers/food/snacks/grown/mushroom/angel)
+	bonus_desc = "He insists that \"he knows what he's doing\"."
+	multiplier = 8
+	foodtype = "stroganoff"
+
 /datum/bounty/item/botany/nettles_death
 	name = "Death Nettles"
-	wanted_types = list(/obj/item/reagent_containers/food/snacks/grown/nettle/death)
-	multiplier = 2
+	wanted_types = list(/obj/item/reagent_containers/food/snacks/grown/nettle/death) //multiplier removed because botanists will have this by the 8 minute mark most often.
 	bonus_desc = "Wear protection when handling them."
 	foodtype = "cheese"
 
@@ -208,3 +214,33 @@
 	name = "Corn"
 	wanted_types = list(/obj/item/reagent_containers/food/snacks/grown/corn)
 	foodtype = "chowder"
+
+/datum/bounty/item/botany/steelcaps
+	name = "Steel-Cap Logs"
+	description = "Central Command's head chef wants only the best organic skewers for a fine [foodtype]."
+	wanted_types = list(/obj/item/grown/log/steel)
+	required_count = 20
+	multiplier = 5
+	foodtype = "kebab"
+
+/datum/bounty/item/botany/steelcaps
+	name = "Tower-Cap Logs"
+	description = "Central Command's head chef wants only the best wood as fuel for a corporate [foodtype]."
+	wanted_types = list(/obj/item/grown/log)
+	exclude_types = list(/obj/item/grown/log/steel)
+	required_count = 20
+	foodtype = "grill-out"
+
+/datum/bounty/item/botany/killertomato
+	name = "Killer Tomato Meat"
+	wanted_types = list(/obj/item/reagent_containers/food/snacks/meat/slab/killertomato)
+	required_count = 3
+	multiplier = 7
+	foodtype = "vegan raclette"
+
+/datum/bounty/item/botany/walkingshroom
+	name = "Walking Mushroom Meat"
+	wanted_types = list(/obj/item/reagent_containers/food/snacks/hugemushroomslice)
+	required_count = 6
+	multiplier = 6
+	foodtype = "vegan wellington"

--- a/code/modules/cargo/bounties/engineering.dm
+++ b/code/modules/cargo/bounties/engineering.dm
@@ -73,7 +73,7 @@
 
 /datum/bounty/item/h2metal/metallic_hydrogen_axe
 	name = "Metallic Hydrogen axes"
-	description = "Nanotrasen is requiring new axe to be made. Ship them some metallic hydrogen helmets."
+	description = "Nanotrasen is requiring new axes to be made. Ship them some metallic hydrogen helmets."
 	reward = 7500
 	required_count = 3
 	wanted_types = list(/obj/item/twohanded/fireaxe/metal_h2_axe)

--- a/code/modules/cargo/bounties/medical.dm
+++ b/code/modules/cargo/bounties/medical.dm
@@ -14,7 +14,7 @@
 /datum/bounty/item/medical/appendix
 	name = "Appendix"
 	description = "Chef Gibb of Central Command wants to prepare a meal using a very special delicacy: an appendix. If you ship one, he'll pay."
-	reward = 3000 //there are no synthetic appendixes //so about that....
+	reward = 3000
 	wanted_types = list(/obj/item/organ/appendix)
 
 /datum/bounty/item/medical/ears

--- a/code/modules/cargo/bounties/medical.dm
+++ b/code/modules/cargo/bounties/medical.dm
@@ -14,7 +14,7 @@
 /datum/bounty/item/medical/appendix
 	name = "Appendix"
 	description = "Chef Gibb of Central Command wants to prepare a meal using a very special delicacy: an appendix. If you ship one, he'll pay."
-	reward = 2200 //there are no synthetic appendixes
+	reward = 3000 //there are no synthetic appendixes //so about that....
 	wanted_types = list(/obj/item/organ/appendix)
 
 /datum/bounty/item/medical/ears

--- a/code/modules/cargo/bounties/progression.dm
+++ b/code/modules/cargo/bounties/progression.dm
@@ -13,7 +13,7 @@
 /datum/bounty/item/progression/mining_basic
 	name = "Common Mineral Prospecting"
 	description = "Basic materials are worth pocket change, but are integral for station longevity. Ship us a sheet of gold, uranium, or silver to certify your mining program as \"functional\""
-	reward = 1000
+	reward = 5000
 	wanted_types = list(/obj/item/stack/sheet/mineral/silver,/obj/item/stack/sheet/mineral/gold,/obj/item/stack/sheet/mineral/uranium)
 	unlocked_crates = list(/datum/supply_pack/clearance/ka_damage,/datum/supply_pack/clearance/ka_cooldown,/datum/supply_pack/clearance/ka_range)
 
@@ -34,7 +34,7 @@
 /datum/bounty/item/progression/mining_advanced
 	name = "Strange Material Prospecting"
 	description = "Initial scanning of your mining locale showed anomalous readings in line with that of bluespace crystals. ship us one to confirm their presence and we'll allow you to order a special treat."
-	reward = 1000
+	reward = 15000
 	wanted_types = list(/obj/item/stack/sheet/bluespace_crystal, /obj/item/stack/ore/bluespace_crystal) //we'll let them send artficial crystals since those would require department cooperation or shooting swarmers
 	unlocked_crates = list(/datum/supply_pack/clearance/plasmacutter_advanced)
 

--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -85,7 +85,7 @@
 	wanted_reagent = new reagent_type
 	name = wanted_reagent.name
 	description = "CentCom is thirsty! Send a shipment of [name] to CentCom to quench the company's thirst."
-	reward += rand(0, 2) * 500
+	reward += rand(0, 2) * 300
 
 /datum/bounty/reagent/complex_drink
 	name = "Complex Drink"
@@ -118,7 +118,7 @@
 	wanted_reagent = new reagent_type
 	name = wanted_reagent.name
 	description = "CentCom is offering a reward for talented mixologists. Ship a container of [name] to claim the prize."
-	reward += rand(0, 4) * 500
+	reward += rand(0, 4) * 650
 
 /datum/bounty/reagent/chemical_simple
 	name = "Simple Chemical"


### PR DESCRIPTION
# Document the changes in your pull request

Adds new bounties for tower cap logs, steel cap logs, destroying angels, walking mushroom meat, and killer tomato meat
adjusts the appendix bounty so it's 3,000 instead of 2,200.
increases Omega Weed bounty's payout because getting it to mutate is a special RNG hell since weed mutates into like 4 other variants.
Metal Hydrogen Axe bounty now mentions it wants multiple axes in the description.
Bar drink bounties now pay more or less depending on if it wants a basic or advanced drink

# Changelog

:cl:  
rscadd: Added new botany bounties!
tweak: Appendix bounty now pays more.
tweak: Mining Progression Bounties now pay considerably more instead of a pittance.
tweak: Omega Weed bounty now pays a lot more.
tweak: adjusts payout of basic and advanced bar drink bounties, to reflect the difficulty differences in making them
spellcheck: fixed Metal Hydrogen Axe bounty description.
/:cl:
