### PR TITLE
fixes ion carbines being in the security protolathe

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -315,7 +315,7 @@
 	materials = list(/datum/material/silver = 6000, /datum/material/iron = 8000, /datum/material/uranium = 2000)
 	build_path = /obj/item/gun/energy/ionrifle/carbine
 	category = list("Weapons")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
 
 /datum/design/wormhole_projector
 	name = "Bluespace Wormhole Projector"


### PR DESCRIPTION
weapons aren't supposed to be printable from the sec protolathe. the ion carbine is a scaled down version of the ion rifle, which is housed in the armory, so i'm pretty sure this was an oversight when the armory protolathe was added.

# Changelog

:cl:  
bugfix: ion carbine has been moved to the armory protolathe since previously it could be printed from the normal security protolathe...
/:cl:
