### PR TITLE
Small camera console QoL change

### DIFF
--- a/tgui/packages/tgui/interfaces/CameraConsole.js
+++ b/tgui/packages/tgui/interfaces/CameraConsole.js
@@ -131,9 +131,9 @@ export const CameraConsoleContent = (props, context) => {
                 && camera.name === activeCamera.name
                 && 'Button--selected',
               ])}
-              onClick={() => act('switch_camera', {
+              onClick={() => [act('switch_camera', {
                 name: camera.name,
-              })}>
+              }), document.getElementsByClassName('CameraConsole__left')[0].focus()]}>
               {camera.name}
             </div>
           ))}


### PR DESCRIPTION
This makes it so that you can scroll right after clicking a camera name in the box, just so there is less mouse movement, and you don't have to scroll it manually after changing each camera. I just wanted this because I was playing warden.

:cl:  
tweak: Camera Console QoL change
/:cl:
