### PR TITLE
Fixes handcuff overlay glitch

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -1,7 +1,6 @@
 /obj/item/restraints
 	icon = 'icons/obj/handcuffs.dmi'
 	breakouttime = 600
-	mob_overlay_icon = 'icons/mob/restraints.dmi'
 	var/break_strength = 2 // Minimum strength required for a holopara to break it
 
 /obj/item/restraints/suicide_act(mob/living/carbon/user)


### PR DESCRIPTION
# Document the changes in your pull request

item_state > mob_overlay_icon which isn't even used because they're dynamically created from an absolute file path

# Changelog

:cl:  
bugfix: no more looking like you're wearing cuffs if you have them on your belt
/:cl:
