### PR TITLE
makes chemistry actually have to put in a single iota of effort to get station destroying explosives

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -51,12 +51,18 @@
 /datum/chemical_reaction/reagent_explosion/potassium_explosion
 	name = "Explosion"
 	id = "potassium_explosion"
+	var/size_cap = 50
 	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/potassium = 1)
 	strengthdiv = 10
+
+/datum/chemical_reaction/reagent_explosion/potassium_explosion/on_reaction(datum/reagents/holder, created_volume)
+	created_volume = min(created_volume, size_cap)
+	..()
 
 /datum/chemical_reaction/reagent_explosion/potassium_explosion/holyboom
 	name = "Holy Explosion"
 	id = "holyboom"
+	size_cap = 100
 	required_reagents = list(/datum/reagent/water/holywater = 1, /datum/reagent/potassium = 1)
 
 /datum/chemical_reaction/reagent_explosion/potassium_explosion/holyboom/on_reaction(datum/reagents/holder, created_volume)


### PR DESCRIPTION
potassium + water explosions are now volume capped. potassium + water is capped at 50u explosion, potassium + holywater is capped at 100u of holy explosion.

this means potassium + water is capped at a bomb size of roughly 0,1,3 while holywater + potassium is capped at roughly 1,2,5

potassium + water explosions are literally two buttons on the chem dispenser. with large frame grenades you can brute force the high strength divisor with more reagent. if you want to make station destroying explosives, you should need to put in effort. also n3d6 wanted this lol

# Wiki Documentation

guide to chemistry

# Changelog

:cl:  
tweak: potassium + water explosions are now capped at 50u volume created
tweak: potassium + holywater explosions are now capped at 100u volume
/:cl:
