### PR TITLE
It has the Syndicate Saboteur module loaded.

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
+++ b/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
@@ -124,7 +124,7 @@
 	user.name = savedName
 	user.module.cyborg_base_icon = initial(user.module.cyborg_base_icon)
 	user.bubble_icon = initial(user.bubble_icon)
-	user.module.name = "Syndicate Saboteur"
+	user.module.name = initial(user.module.name)
 	active = FALSE
 	user.update_icons()
 	src.user = user

--- a/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
+++ b/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
@@ -104,6 +104,7 @@
 	user.name = friendlyName
 	user.module.cyborg_base_icon = disguise
 	user.bubble_icon = "robot"
+	user.module.name = "Engineering"
 	active = TRUE
 	user.update_icons()
 	
@@ -123,6 +124,7 @@
 	user.name = savedName
 	user.module.cyborg_base_icon = initial(user.module.cyborg_base_icon)
 	user.bubble_icon = initial(user.bubble_icon)
+	user.module.name = "Syndicate Saboteur"
 	active = FALSE
 	user.update_icons()
 	src.user = user


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/70169560/180670606-9541347e-41cd-45a0-8a3a-5a201d76b7ff.png)
I think this is an oversight, because in no right mind would you have them being this obvious, especially since they're meant to be sneaky...

# Changelog

:cl:  
bugfix: the cyborg chameleon projector now actually works
/:cl:
