### PR TITLE
Adds 10x5 Maint-Ruin Tank Heaven 

### DIFF
--- a/_maps/RandomRuins/StationRuins/maint/10x5/10x5_tank_heaven.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/10x5/10x5_tank_heaven.dmm
@@ -1,20 +1,5 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/template_noop)
-"b" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/stripes,
-/turf/open/floor/plating,
-/area/template_noop)
-"d" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
+"c" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/template_noop)
@@ -31,6 +16,13 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
+/area/template_noop)
+"i" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/gloves,
+/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/robot_debris,
+/turf/open/floor/plating,
 /area/template_noop)
 "j" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -53,50 +45,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/template_noop)
-"m" = (
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
+"n" = (
+/obj/effect/spawner/lootdrop/tanks/lowchance,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"o" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plating,
+/area/template_noop)
+"p" = (
 /obj/structure/mecha_wreckage/ripley/mkii,
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/template_noop)
-"n" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/lootdrop/tanks/highchance,
-/turf/open/floor/plasteel/dark,
-/area/template_noop)
-"o" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/machinery/light/broken,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/template_noop)
-"q" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/template_noop)
-"t" = (
-/obj/effect/turf_decal/stripes,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/trashbin,
+"s" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/template_noop)
 "w" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/vomit/old,
+/obj/machinery/light/broken,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/template_noop)
 "x" = (
@@ -122,11 +92,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/template_noop)
-"A" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/lootdrop/tanks/lowchance,
-/turf/open/floor/plasteel/dark,
-/area/template_noop)
 "C" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -143,6 +108,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/template_noop)
+"E" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/template_noop)
 "F" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/stripes/corner{
@@ -155,10 +124,10 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel,
 /area/template_noop)
-"H" = (
+"I" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plating,
+/obj/effect/spawner/lootdrop/tanks/lowchance,
+/turf/open/floor/plasteel/dark,
 /area/template_noop)
 "J" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -181,20 +150,12 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel,
 /area/template_noop)
-"N" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+"O" = (
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/spawner/lootdrop/gloves,
-/obj/effect/decal/cleanable/oil/streak,
-/obj/effect/decal/cleanable/robot_debris,
-/turf/open/floor/plating,
-/area/template_noop)
-"Q" = (
-/obj/effect/turf_decal/stripes/corner,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trashbin,
 /turf/open/floor/plating,
 /area/template_noop)
 "R" = (
@@ -202,10 +163,8 @@
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/plasteel,
 /area/template_noop)
-"T" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/lootdrop/tanks/lowchance,
+"S" = (
+/obj/effect/spawner/lootdrop/tanks/highchance,
 /turf/open/floor/plasteel/dark,
 /area/template_noop)
 "U" = (
@@ -224,58 +183,39 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/template_noop)
-"W" = (
+"Y" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/template_noop)
-"X" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/bot,
 /obj/effect/spawner/lootdrop/tanks/highchance,
 /turf/open/floor/plasteel/dark,
 /area/template_noop)
-"Y" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/template_noop)
 
 (1,1,1) = {"
-Q
+c
 D
-q
+c
 z
-w
-"}
-(2,1,1) = {"
-t
-n
-y
-T
 o
 "}
+(2,1,1) = {"
+O
+S
+y
+I
+w
+"}
 (3,1,1) = {"
-b
-T
+E
+I
 U
-T
-W
+I
+s
 "}
 (4,1,1) = {"
 R
-T
+I
 U
-T
-a
+I
+E
 "}
 (5,1,1) = {"
 j
@@ -285,37 +225,37 @@ l
 e
 "}
 (6,1,1) = {"
-H
-m
-N
+E
+p
+i
 z
 L
 "}
 (7,1,1) = {"
 R
-A
+n
 U
-T
+I
 h
 "}
 (8,1,1) = {"
 M
-A
+n
 U
-A
+n
 h
 "}
 (9,1,1) = {"
 x
-T
+I
 V
-X
+Y
 C
 "}
 (10,1,1) = {"
 J
 k
-Y
+E
 l
-d
+c
 "}

--- a/_maps/RandomRuins/StationRuins/maint/10x5/10x5_tank_heaven.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/10x5/10x5_tank_heaven.dmm
@@ -1,0 +1,321 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"b" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/plating,
+/area/template_noop)
+"d" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/template_noop)
+"e" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"h" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"j" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"k" = (
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"l" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"m" = (
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/obj/structure/mecha_wreckage/ripley/mkii,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating,
+/area/template_noop)
+"n" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/lootdrop/tanks/highchance,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"o" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/machinery/light/broken,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/template_noop)
+"q" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/template_noop)
+"t" = (
+/obj/effect/turf_decal/stripes,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trashbin,
+/turf/open/floor/plating,
+/area/template_noop)
+"w" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plating,
+/area/template_noop)
+"x" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"y" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"z" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"A" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/lootdrop/tanks/lowchance,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"C" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trashbin,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"D" = (
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"F" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/glowstick,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"H" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating,
+/area/template_noop)
+"J" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"L" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"M" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"N" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/spawner/lootdrop/gloves,
+/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/robot_debris,
+/turf/open/floor/plating,
+/area/template_noop)
+"Q" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/template_noop)
+"R" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"T" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/lootdrop/tanks/lowchance,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"U" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"V" = (
+/obj/effect/turf_decal/stripes,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"W" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/template_noop)
+"X" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/lootdrop/tanks/highchance,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"Y" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+
+(1,1,1) = {"
+Q
+D
+q
+z
+w
+"}
+(2,1,1) = {"
+t
+n
+y
+T
+o
+"}
+(3,1,1) = {"
+b
+T
+U
+T
+W
+"}
+(4,1,1) = {"
+R
+T
+U
+T
+a
+"}
+(5,1,1) = {"
+j
+l
+F
+l
+e
+"}
+(6,1,1) = {"
+H
+m
+N
+z
+L
+"}
+(7,1,1) = {"
+R
+A
+U
+T
+h
+"}
+(8,1,1) = {"
+M
+A
+U
+A
+h
+"}
+(9,1,1) = {"
+x
+T
+V
+X
+C
+"}
+(10,1,1) = {"
+J
+k
+Y
+l
+d
+"}

--- a/yogstation/code/datums/ruins/station.dm
+++ b/yogstation/code/datums/ruins/station.dm
@@ -1112,6 +1112,12 @@
 	suffix = "10x5_ratburger.dmm"
 	name = "Maint ratburger"
 
+///Author: Vaelophis
+/datum/map_template/ruin/station/maint/tenxfive/tank_heaven
+	id = "tank_heaven"
+	suffix = "10x5_tank_heaven.dmm"
+	name = "Maint tank_heaven"
+
 ///The base for the 10x10 rooms.
 /datum/map_template/ruin/station/maint/tenxten
 	prefix = "_maps/RandomRuins/StationRuins/maint/10x10/"


### PR DESCRIPTION
# Document the changes in your pull request

Adds a maint ruin to the 10x5 set, using the new random chance tank spawners
![ss (2022-07-25 at 02 06 37)](https://user-images.githubusercontent.com/1534478/180718167-e096c11b-afec-4e63-a07a-e70d0284d4e5.png)

and for an example of how random this really is:
![ss (2022-07-25 at 02 00 38)](https://user-images.githubusercontent.com/1534478/180718193-b8ffaa72-3794-4576-aa41-0d86e15fa900.png)

Gives cargo techies a reason to scour maints; so they can find the potentially juicy fuel tank cache...or just find out it's two water tanks.

non-tank Spawners are trash, a glowstick, and random gloves.

# Changelog

:cl:  
rscadd: Adds a new 10x5 maint ruin theme'd around water/fuel/foam tanks
/:cl:
