### PR TITLE
changes plasma extraction bounty to be less terrible

### DIFF
--- a/code/modules/cargo/bounties/progression.dm
+++ b/code/modules/cargo/bounties/progression.dm
@@ -23,9 +23,9 @@
 /datum/bounty/item/progression/mining_plasma
 	name = "Plasma Extraction"
 	description = "The reason you're here: plasma. Ship us a stack of it and we can certify your mining program as \"profitable\", allowing access to plasma-based mining equipment."
-	reward = 9000 //1000 less than a normal ship of plasma as a fee
+	reward = 4000
 	wanted_types = list(/obj/item/stack/sheet/mineral/plasma)
-	required_count = 50
+	required_count = 10
 	unlocked_crates = list(/datum/supply_pack/clearance/plasmacutter)
 
 /datum/bounty/item/progression/mining_plasma/reward_string()

--- a/code/modules/cargo/bounties/progression.dm
+++ b/code/modules/cargo/bounties/progression.dm
@@ -22,7 +22,7 @@
 
 /datum/bounty/item/progression/mining_plasma
 	name = "Plasma Extraction"
-	description = "The reason you're here: plasma. Ship us a stack of it and we can certify your mining program as \"profitable\", allowing access to plasma-based mining equipment."
+	description = "The reason you're here: plasma. Ship us 10 sheets of it and we can certify your mining program as \"profitable\", allowing access to plasma-based mining equipment."
 	reward = 4000
 	wanted_types = list(/obj/item/stack/sheet/mineral/plasma)
 	required_count = 10


### PR DESCRIPTION
# Document the changes in your pull request

Reduces required material from 50 sheets to 10 sheets, since bounties are done before exports trying to sell plasma while the bounty is active gives you a fat load of nothing

decreases payment from 9000 to 4000, to be in line with the new sheet requirement. This does mean each sheet for the bounty is actually worth twice the export price of plasma, and is because the whole "the point is to get mining crates" is stupid and bounties shouldn't be worth less than exports

# Wiki Documentation

doubt bounties are actually recorded but
plasma extraction: sheet requirement reduced from 50 to 10, price reduced from 9000 to 4000

# Changelog


:cl:  
tweak: plasma extraction bounty is now more worthwhile and requires less plasma to complete
/:cl:
