### PR TITLE
Redmoogle fixes the observer button for real this time but this time it wasnt my fault it was caused by the RegisterSignal runtiming

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -807,7 +807,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 				remove_verb(src, /mob/dead/observer/verb/possess)
 
 /mob/dead/observer/reset_perspective(atom/A)
-	src.actions -= UO
+	UO?.Remove(src)
 	if(client)
 		if(ismob(client.eye) && (client.eye != src))
 			cleanup_observe()
@@ -819,13 +819,13 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/dead/observer/proc/cleanup_observe()
 	var/mob/target = observetarget
-	observetarget = null
 	client?.perspective = initial(client.perspective)
 	sight = initial(sight)
 	UnregisterSignal(target, COMSIG_MOVABLE_Z_CHANGED)
-	if(target.observers)
+	if(target && target.observers)
 		target.observers -= src
 		UNSETEMPTY(target.observers)
+	observetarget = null
 
 /mob/dead/observer/verb/observe()
 	set name = "Observe"
@@ -851,7 +851,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		client.perspective = EYE_PERSPECTIVE
 		if(is_secret_level(mob_eye.z) && !client?.holder)
 			sight = null //we dont want ghosts to see through walls in secret areas
-		RegisterSignal(mob_eye, COMSIG_MOVABLE_Z_CHANGED, .proc/on_observing_z_changed)
+		RegisterSignal(mob_eye, COMSIG_MOVABLE_Z_CHANGED, .proc/on_observing_z_changed, TRUE)
 		if(mob_eye.hud_used)
 			client.screen = list()
 			LAZYINITLIST(mob_eye.observers)


### PR DESCRIPTION
# Document the changes in your pull request

*scream

also minor code cleanup

# Changelog

:cl:  
bugfix: Finally fixes unobserve button
/:cl:
