### PR TITLE
Mining charges and Minerals go into Explorer webbing

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -365,7 +365,9 @@
 		/obj/item/stack/marker_beacon,
 		/obj/item/handdrill,
 		/obj/item/jawsoflife,
-		/obj/item/restraints/legcuffs/bola/watcher
+		/obj/item/restraints/legcuffs/bola/watcher,
+		/obj/item/stack/sheet/mineral,
+		/obj/item/grenade/plastic/miningcharge
 		))
 
 


### PR DESCRIPTION
Why yes I do have several mining explosives and 50 sheets of raw plasma strapped to my chest rig.

# Document the changes in your pull request

Made it so that you can store mining charges on the explorer webbing for ease of access, mineral sheets, on the other hand, are mostly there if you just so happen to fancy using actual plasma sheets instead of plasma ore in refueling your plasma cutters, although this change does mean that any stackable mineral can be placed on the webbing if you're into picking up the heated materials that you get after fighting an ash drake.

This has been tested in a local host.

# Changelog
:cl:  
rscadd: Lets you store Mining Charges and Mineral Sheets inside Explorer Webbing
/:cl:
