### PR TITLE
Captain's Space Suit Protects Masks

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -656,6 +656,7 @@
 	icon_state = "capspace"
 	item_state = "capspacehelmet"
 	desc = "A tactical MK.II SWAT helmet boasting better protection and a horrible fashion sense."
+	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR	//Full helmet
 
 /obj/item/clothing/suit/space/hardsuit/swat/captain
 	name = "captain's SWAT suit"


### PR DESCRIPTION
So the captain's SWAT suit protects against fire and heat sure but your mask burns off and you die ANYWAYS so this fixes that because it's kinda dumb.

Note: Captain's hardsuit might need a tweak to the sprite to make it look a little less weird, because looking at it, it's kinda janky.

# Changelog


:cl:  

tweak: Your mask will no longer burn off in a fire while wearing the captain's hardsuit.

/:cl:
