### PR TITLE
Underutilized DNA vault choice buffs

### DIFF
--- a/code/modules/goals/station_goals/dna_vault.dm
+++ b/code/modules/goals/station_goals/dna_vault.dm
@@ -4,7 +4,7 @@
 // DNA vaults require high tier stock parts and cold
 // After completion each crewmember can receive single upgrade chosen out of 2 for the mob.
 #define VAULT_TOXIN "Toxin Adaptation"
-#define VAULT_NOBREATH "Lung Enhancement"
+#define VAULT_NOBLOOD "Lung Enhancement"
 #define VAULT_FIREPROOF "Thermal Regulation"
 #define VAULT_STUNTIME "Neural Repathing"
 #define VAULT_ARMOUR "Bone Reinforcement"
@@ -188,7 +188,7 @@
 	if(user in power_lottery)
 		return
 	var/list/L = list()
-	var/list/possible_powers = list(VAULT_TOXIN,VAULT_NOBREATH,VAULT_FIREPROOF,VAULT_STUNTIME,VAULT_ARMOUR,VAULT_SPEED,VAULT_QUICK)
+	var/list/possible_powers = list(VAULT_TOXIN,VAULT_NOBLOOD,VAULT_FIREPROOF,VAULT_STUNTIME,VAULT_ARMOUR,VAULT_SPEED,VAULT_QUICK)
 	L += pick_n_take(possible_powers)
 	L += pick_n_take(possible_powers)
 	power_lottery[user] = L
@@ -255,29 +255,32 @@
 /obj/machinery/dna_vault/proc/upgrade(mob/living/carbon/human/H,upgrade_type)
 	if(!(upgrade_type in power_lottery[H]))
 		return
-	var/datum/species/S = H.dna.species
+	var/datum/physiology/P = H.physiology
 	switch(upgrade_type)
 		if(VAULT_TOXIN)
-			to_chat(H, span_notice("You feel resistant to airborne toxins."))
+			to_chat(H, span_notice("You feel resistant to toxins."))
 			if(locate(/obj/item/organ/lungs) in H.internal_organs)
 				var/obj/item/organ/lungs/L = H.internal_organs_slot[ORGAN_SLOT_LUNGS]
 				L.tox_breath_dam_min = 0
 				L.tox_breath_dam_max = 0
 			ADD_TRAIT(H, TRAIT_VIRUSIMMUNE, "dna_vault")
-		if(VAULT_NOBREATH)
-			to_chat(H, span_notice("Your lungs feel great."))
+			P.tox_mod *= 0.2
+		if(VAULT_NOBLOOD)
+			to_chat(H, span_notice("Oxygen doesn't seem so attractive any more."))
 			ADD_TRAIT(H, TRAIT_NOBREATH, "dna_vault")
+			H.dna.species.species_traits += NOBLOOD
 		if(VAULT_FIREPROOF)
 			to_chat(H, span_notice("You feel fireproof."))
-			S.burnmod *= 0.5
+			P.burn_mod *= 0.5
 			ADD_TRAIT(H, TRAIT_RESISTHEAT, "dna_vault")
 			ADD_TRAIT(H, TRAIT_NOFIRE, "dna_vault")
 		if(VAULT_STUNTIME)
 			to_chat(H, span_notice("Nothing can keep you down for long."))
-			S.stunmod *= 0.5
+			P.stun_mod *= 0.5
+			P.stamina_mod *= 0.5
 		if(VAULT_ARMOUR)
 			to_chat(H, span_notice("You feel tough."))
-			S.armor += 30
+			P.armor += 30
 			ADD_TRAIT(H, TRAIT_PIERCEIMMUNE, "dna_vault")
 		if(VAULT_SPEED)
 			to_chat(H, span_notice("Your legs feel faster."))

--- a/code/modules/goals/station_goals/dna_vault.dm
+++ b/code/modules/goals/station_goals/dna_vault.dm
@@ -4,7 +4,7 @@
 // DNA vaults require high tier stock parts and cold
 // After completion each crewmember can receive single upgrade chosen out of 2 for the mob.
 #define VAULT_TOXIN "Toxin Adaptation"
-#define VAULT_NOBLOOD "Lung Enhancement"
+#define VAULT_SELFSUFFICIENT "Celluar Self-Sufficiency"
 #define VAULT_FIREPROOF "Thermal Regulation"
 #define VAULT_STUNTIME "Neural Repathing"
 #define VAULT_ARMOUR "Bone Reinforcement"
@@ -188,7 +188,7 @@
 	if(user in power_lottery)
 		return
 	var/list/L = list()
-	var/list/possible_powers = list(VAULT_TOXIN,VAULT_NOBLOOD,VAULT_FIREPROOF,VAULT_STUNTIME,VAULT_ARMOUR,VAULT_SPEED,VAULT_QUICK)
+	var/list/possible_powers = list(VAULT_TOXIN,VAULT_SELFSUFFICIENT,VAULT_FIREPROOF,VAULT_STUNTIME,VAULT_ARMOUR,VAULT_SPEED,VAULT_QUICK)
 	L += pick_n_take(possible_powers)
 	L += pick_n_take(possible_powers)
 	power_lottery[user] = L
@@ -265,10 +265,13 @@
 				L.tox_breath_dam_max = 0
 			ADD_TRAIT(H, TRAIT_VIRUSIMMUNE, "dna_vault")
 			P.tox_mod *= 0.2
-		if(VAULT_NOBLOOD)
-			to_chat(H, span_notice("Oxygen doesn't seem so attractive any more."))
+			H.dna.species.acidmod *= 0.2	//Remind me to move this to physiolgy later - Mqiib
+		if(VAULT_SELFSUFFICIENT)
+			to_chat(H, span_notice("You feel suddenly rejuvenated."))
 			ADD_TRAIT(H, TRAIT_NOBREATH, "dna_vault")
-			H.dna.species.species_traits += NOBLOOD
+			H.dna.species.species_traits += NOBLOOD	//This will definitely not create some strange interactions
+			P.oxy_mod *= 0							//To be triple hella sure
+			P.hunger_mod *= 0.1
 		if(VAULT_FIREPROOF)
 			to_chat(H, span_notice("You feel fireproof."))
 			P.burn_mod *= 0.5


### PR DESCRIPTION
Some of the DNA vault buffs were absolutely eclipsed by other choices so I've buffed them a bit.
Stun resistance now grants a 0.5x stamina modifier.
No breath has been turned into cellular self-sufficiency, making you completely immune to oxygen damage and blood stuff. Also grants a 0.1x hunger mod.
Toxin adaptation now grants a 0.2x toxin mod and a 0.2x acid mod.




# Wiki Documentation

See above changes, add them to the page

# Changelog


:cl:  
tweak: DNA vault toxin adaptation grants 0.2x toxin and acid mods
tweak: DNA vault self respiration now self-sufficiency, grants immunity to oxyloss, blood stuff, breathing, and a 0.1x hunger mod
tweak: DNA vault stun resistance now also grants a 0.5x stamina mod

/:cl:
