### PR TITLE
Makes Preterni walking tanks instead of squishy crappy IPCs

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -534,6 +534,8 @@
 	. = ..()
 	if(. & EMP_PROTECT_CONTENTS)
 		return
+	if(ispreternis(src)) //Snowflake-ass way to make preternis limbs immune to emp
+		return
 	var/informed = FALSE
 	for(var/obj/item/bodypart/L in src.bodyparts)
 		if(L.status == BODYPART_ROBOTIC)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -30,6 +30,9 @@
 	var/high_threshold_cleared
 	var/low_threshold_cleared
 
+	//Variable for a component to define if the organ should be immune to EMP's
+	var/datum/component/empprotection/emp_component
+
 /obj/item/organ/proc/Insert(mob/living/carbon/M, special = 0, drop_if_replaced = TRUE,special_zone = null)
 	if(!iscarbon(M) || owner == M)
 		return
@@ -45,6 +48,8 @@
 		else
 			qdel(replaced)
 
+	if(ispreternis(M)) //Baby-ass way to do this
+		addEmpProof()
 	owner = M
 	M.internal_organs |= src
 	M.internal_organs_slot[slot] = src
@@ -55,6 +60,8 @@
 
 //Special is for instant replacement like autosurgeons
 /obj/item/organ/proc/Remove(mob/living/carbon/M, special = FALSE)
+	if(ispreternis(M)) //Baby-ass way to do this
+		removeEmpProof()
 	owner = null
 	if(M)
 		M.internal_organs -= src
@@ -66,6 +73,12 @@
 		var/datum/action/A = X
 		A.Remove(M)
 
+//Simple procs to add or remove EMP_PROOF
+/obj/item/organ/proc/addEmpProof()
+	emp_component = AddComponent(/datum/component/empprotection, EMP_PROTECT_SELF)
+
+/obj/item/organ/proc/removeEmpProof()
+	emp_component.RemoveComponent()
 
 /obj/item/organ/proc/on_find(mob/living/finder)
 	return

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
@@ -77,7 +77,7 @@
 
 /obj/item/organ/lungs/preternis
 	name = "preternis lungs"
-	desc = "An experimental set of lungs.Due to the cybernetic nature of these lungs,they are less resistant to heat and cold but are more efficent at filtering oxygen."
+	desc = "An experimental set of lungs. Due to the cybernetic nature of these lungs, they are less resistant to heat and cold but are more efficent at filtering oxygen."
 	icon_state = "lungs-c"
 	safe_oxygen_min = 12
 	safe_toxins_max = 10

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -20,7 +20,7 @@ adjust_charge - take a positive or negative value to adjust the charge level
 	burnmod = 0.9 //Circuitry isn't happy with the heat, even if plasma plating lessens it
 	coldmod = 0.8 //Cold can help to regulate, but it's not perfect
 	heatmod = 0.9 //Again, circuitry isn't happy, but the plating they have on the outside can protect a little
-	speedmod = 1 //Effectively a plasteel body, big and slow
+	speedmod = 0.5 //Effectively a plasteel body, big and slow, not so brutally slow that you can't actually do anything
 	punchstunthreshold = 9 //Stun range 9-10 on punch, you are being slugged in the brain by a metal robot fist.
 	siemens_coeff = 1.75 //Computers REALLY don't like being shorted out
 	payday_modifier = 0.8 //Useful to NT for engineering, but relations between humans and preterni tend to not be the greatest

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -16,14 +16,14 @@ adjust_charge - take a positive or negative value to adjust the charge level
 	attack_verb = "assault"
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/synthmeat
 	toxic_food = NONE
-	brutemod = 1.25 //Have you ever punched a metal plate?
-	burnmod = 1.5 //Computers don't like heat
-	coldmod = 0.8 //Computers like cold, but their lungs may not
-	heatmod = 1.75 //Again, computers don't like heat
-	speedmod = 0.1 //Metal legs are heavy and slow
+	brutemod = 0.8 //Robusto plasma plating
+	burnmod = 0.9 //Circuitry isn't happy with the heat, even if plasma plating lessens it
+	coldmod = 0.8 //Cold can help to regulate, but it's not perfect
+	heatmod = 0.9 //Again, circuitry isn't happy, but the plating they have on the outside can protect a little
+	speedmod = 1 //Effectively a plasteel body, big and slow
 	punchstunthreshold = 9 //Stun range 9-10 on punch, you are being slugged in the brain by a metal robot fist.
 	siemens_coeff = 1.75 //Computers REALLY don't like being shorted out
-	payday_modifier = 0.8 //Useful to NT for engineering + very close to Human
+	payday_modifier = 0.8 //Useful to NT for engineering, but relations between humans and preterni tend to not be the greatest
 	yogs_draw_robot_hair = TRUE
 	mutanteyes = /obj/item/organ/eyes/robotic/preternis
 	mutantlungs = /obj/item/organ/lungs/preternis
@@ -60,24 +60,6 @@ adjust_charge - take a positive or negative value to adjust the charge level
 	C.clear_alert("preternis_emag") //this means a changeling can transform from and back to a preternis to clear the emag status but w/e i cant find a solution to not do that
 	C.clear_fullscreen("preternis_emag")
 	C.remove_movespeed_modifier("preternis_teslium")
-
-/datum/species/preternis/spec_emp_act(mob/living/carbon/human/H, severity)
-	. = ..()
-	switch(severity)
-		if(EMP_HEAVY)
-			H.adjustBruteLoss(20)
-			H.adjustFireLoss(20)
-			H.Paralyze(50)
-			charge *= 0.4
-			H.visible_message(span_danger("Electricity ripples over [H]'s subdermal implants, smoking profusely."), \
-							span_userdanger("A surge of searing pain erupts throughout your very being! As the pain subsides, a terrible sensation of emptiness is left in its wake."))
-		if(EMP_LIGHT)
-			H.adjustBruteLoss(10)
-			H.adjustFireLoss(10)
-			H.Paralyze(20)
-			charge *= 0.6
-			H.visible_message(span_danger("A faint fizzling emanates from [H]."), \
-							span_userdanger("A fit of twitching overtakes you as your subdermal implants convulse violently from the electromagnetic disruption. Your sustenance reserves have been partially depleted from the blast."))
 
 /datum/species/preternis/spec_emag_act(mob/living/carbon/human/H, mob/user)
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request

Reworks preternis damage, slowdown, and emp mods to better make them more of a unique species relative to IPCs as well as being more in-line with what lore exists for them (like that fucking matters)

If anything else it's more logical chances to a "I am hunk of metal designed for work, fear me"

Open to suggestions for change so far I'm debating giving them more unarmed damage but double chance to knockdown is already absurd + more damage means even more of a chance to knockdown potentially if it's done stupidly

Tested in a private server seems to work fine

See changes in Wiki Documentation

# Wiki Documentation

Preterni now have zero innate interaction with EMPs.
Any preternis limb can no longer be affected by EMPs.
Any organ type inside of a preternis cannot be affected by EMPs. This includes implants.
Preternis brute mod to 0.8 from 1.25
Preternis burn mod to 0.9 from 1.5
Preternis heat mod to 0.9 from 1.75
Preternis slowdown mod to **1** from 0.1 (equivalent to wearing a space suit all the time, never mind another space suit/injury)

# Changelog

:cl:  
tweak: Preterni and their innards are no longer affected by EMPs (except for nanites)
tweak: Preterni are now very very slow
tweak: Preterni are actually more resilient to damage than your average human now
/:cl:
