### PR TITLE
[Meta] Fixes Telecomms Room

### DIFF
--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -2690,6 +2690,10 @@
 "agF" = (
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"agH" = (
+/obj/machinery/rack_creator,
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "agK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -25872,16 +25876,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"bfJ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
 "bfK" = (
 /obj/structure/closet/emcloset,
 /obj/structure/sign/map/left{
@@ -26040,6 +26034,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"bfZ" = (
+/obj/structure/lattice,
+/turf/closed/wall/r_wall,
+/area/aisat)
 "bga" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -26323,25 +26321,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"bgL" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
 "bgM" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
-"bgN" = (
-/obj/structure/chair/office/dark,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -29726,13 +29706,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"boa" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/landmark/start/yogs/network_admin,
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
 "bob" = (
 /obj/machinery/light/small,
 /obj/machinery/camera{
@@ -31949,17 +31922,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
-"btf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
 "btg" = (
 /obj/structure/table/wood,
 /obj/item/hand_tele,
@@ -33202,19 +33164,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
-"bxs" = (
-/obj/machinery/computer/security/telescreen{
-	dir = 8;
-	name = "Telecomms Camera Monitor";
-	network = list("tcomms");
-	pixel_x = 26
-	},
-/obj/machinery/computer/telecomms/traffic{
-	dir = 8;
-	network = "tcommsat"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
 "bxt" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/stripes/line,
@@ -34134,10 +34083,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/space,
 /area/maintenance/disposal/incinerator)
-"bAY" = (
-/obj/machinery/vending/wardrobe/sig_wardrobe,
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
 "bAZ" = (
 /obj/machinery/camera{
 	c_tag = "Head of Personnel's Office";
@@ -39693,6 +39638,10 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/server)
+"bRN" = (
+/obj/machinery/rnd/production/circuit_imprinter/department/netmin,
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "bRU" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -57996,7 +57945,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm{
-	pixel_y = 27
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms/room_b)
@@ -58161,6 +58110,17 @@
 /obj/structure/sign/directions/evac,
 /turf/closed/wall,
 /area/maintenance/department/science/central)
+"ecT" = (
+/obj/structure/table/wood,
+/obj/machinery/microwave{
+	pixel_y = 4
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "edk" = (
 /obj/machinery/door/airlock/external{
 	name = "Transport Airlock"
@@ -58456,21 +58416,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"eqz" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	freerange = 1;
-	name = "Station Intercom (Telecomms)";
-	pixel_y = 30
-	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-18"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
 "eqG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -59102,6 +59047,12 @@
 /obj/effect/turf_decal/trimline/yellow/warning,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"eMg" = (
+/obj/machinery/computer/message_monitor{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "eMO" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/structure/chair,
@@ -59394,13 +59345,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
-"eXV" = (
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
-/obj/machinery/computer/ai_server_console,
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
 "eYu" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -59728,6 +59672,12 @@
 /obj/item/clothing/mask/breath,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"fmK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "fnc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -61208,6 +61158,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"goF" = (
+/obj/machinery/computer/security/telescreen{
+	name = "Telecomms Camera Monitor";
+	network = list("tcomms");
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "goG" = (
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel/white,
@@ -62375,6 +62333,15 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"hlp" = (
+/obj/machinery/status_display/ai{
+	pixel_y = 31
+	},
+/obj/structure/rack,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/suit/hooded/wintercoat,
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "hmq" = (
 /turf/closed/wall/r_wall,
 /area/security/interrogation)
@@ -63356,11 +63323,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"ibd" = (
-/obj/machinery/light/small,
-/obj/machinery/rnd/production/circuit_imprinter/department/netmin,
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
 "ibf" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -65636,6 +65598,15 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"jOq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "jOM" = (
 /obj/machinery/reagentgrinder{
 	pixel_y = 8
@@ -69215,6 +69186,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/interrogation)
+"mIU" = (
+/obj/machinery/modular_computer/console/preset/tcomms{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "mJX" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -70642,6 +70622,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"nPX" = (
+/obj/machinery/light_switch{
+	pixel_y = 28
+	},
+/obj/machinery/space_heater,
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "nQn" = (
 /obj/structure/bed,
 /obj/item/bedsheet/captain,
@@ -70969,6 +70956,12 @@
 	},
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
+"ocM" = (
+/obj/machinery/computer/ai_server_console{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "odb" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -71318,6 +71311,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"oos" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "opk" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -71603,23 +71605,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
-"oBN" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Telecomms Admin";
-	departmentType = 5;
-	name = "Telecomms RC";
-	pixel_y = -30
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26
-	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
 "oBY" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -72417,6 +72402,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"pea" = (
+/obj/item/phone{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/structure/table/wood,
+/obj/item/folder/blue,
+/obj/item/book/manual/wiki/tcomms,
+/obj/item/pen,
+/obj/item/cigbutt/cigarbutt{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "pep" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -72703,6 +72706,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"ptA" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "puB" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -73119,6 +73139,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"pHt" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "pHN" = (
 /obj/item/beacon,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
@@ -73729,20 +73755,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"qdY" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/item/radio/off{
-	pixel_y = 4
-	},
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
-/obj/item/flashlight/lamp,
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
 "qek" = (
 /obj/structure/lattice,
 /turf/closed/wall,
@@ -73786,6 +73798,15 @@
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"qgv" = (
+/obj/item/radio/intercom{
+	dir = 8;
+	freerange = 1;
+	name = "Station Intercom (Telecomms)";
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "qgJ" = (
 /obj/machinery/stasis{
 	dir = 1
@@ -73947,24 +73968,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/wood,
 /area/library)
-"qlO" = (
-/obj/structure/table/wood,
-/obj/machinery/status_display/evac{
-	pixel_y = 31
-	},
-/obj/item/book/manual/wiki/tcomms,
-/obj/item/folder/blue,
-/obj/item/pen,
-/obj/item/phone{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/cigbutt/cigarbutt{
-	pixel_x = 5;
-	pixel_y = -1
-	},
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
 "qlP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -74661,7 +74664,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/airalarm{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -24
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -74763,6 +74766,19 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"qNK" = (
+/obj/machinery/turretid{
+	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
+	name = "Antechamber Turret Control";
+	pixel_y = 25;
+	req_access = null;
+	req_one_access_txt = "61;65"
+	},
+/obj/machinery/firealarm{
+	pixel_y = 38
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "qOw" = (
 /obj/machinery/sleeper{
 	dir = 1
@@ -75706,6 +75722,13 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
+"rAW" = (
+/obj/machinery/computer/telecomms/traffic{
+	dir = 8;
+	network = "tcommsat"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "rBh" = (
 /obj/item/storage/box/gloves{
 	pixel_x = 3;
@@ -75872,7 +75895,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm{
-	pixel_y = 27
+	pixel_y = 24
 	},
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/plasteel/white,
@@ -76076,6 +76099,16 @@
 	dir = 5
 	},
 /area/crew_quarters/heads/hor)
+"rTR" = (
+/obj/structure/chair/office/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "rTU" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -76549,6 +76582,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"srW" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "ssr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -77048,20 +77090,6 @@
 /obj/machinery/vending/gifts,
 /turf/open/floor/wood,
 /area/clerk)
-"sKk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/machinery/turretid{
-	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
-	name = "Antechamber Turret Control";
-	pixel_y = 30;
-	req_access = null;
-	req_one_access_txt = "61;65"
-	},
-/obj/machinery/modular_computer/console/preset/tcomms,
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
 "sKw" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -79152,14 +79180,6 @@
 /obj/machinery/vending/assist,
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
-"uuA" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/rack_creator,
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
 "uvi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -81121,14 +81141,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"vUl" = (
-/obj/machinery/microwave{
-	pixel_y = 4
-	},
-/obj/structure/table/wood,
-/obj/item/storage/box/donkpockets,
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
 "vUv" = (
 /obj/machinery/light{
 	dir = 4
@@ -82200,13 +82212,6 @@
 /mob/living/simple_animal/bot/secbot/pingsky,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"wMU" = (
-/obj/machinery/status_display/ai{
-	pixel_y = 31
-	},
-/obj/machinery/computer/message_monitor,
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
 "wMY" = (
 /obj/structure/table,
 /obj/item/candle,
@@ -82379,6 +82384,13 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/ai_monitored/turret_protected/ai)
+"wXx" = (
+/obj/effect/landmark/start/yogs/network_admin,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "wXB" = (
 /obj/machinery/camera{
 	c_tag = "Departure Lounge - Port Aft";
@@ -82792,6 +82804,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"xnA" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/item/radio/off{
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "xog" = (
 /obj/effect/turf_decal/trimline/blue/filled/end{
 	dir = 8
@@ -82863,6 +82889,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"xsG" = (
+/obj/machinery/light/small,
+/obj/machinery/vending/wardrobe/sig_wardrobe,
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "xsR" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -83162,6 +83193,16 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/wood,
 /area/library)
+"xEu" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Telecomms Admin";
+	departmentType = 5;
+	name = "Telecomms RC";
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "xGn" = (
 /obj/item/radio/intercom{
 	pixel_x = 0;
@@ -137193,11 +137234,11 @@ aXC
 bnL
 bbp
 aRy
-bvt
-aaa
-aTU
-aaa
-aaa
+aRy
+aRy
+bfZ
+aRy
+aRy
 aaa
 aaa
 aaa
@@ -137450,10 +137491,10 @@ aXD
 bnX
 bbu
 aRy
-aRy
-aRy
-aRy
-aRy
+btL
+btL
+btL
+btL
 aRy
 aRy
 aRy
@@ -137707,10 +137748,10 @@ nul
 bof
 bby
 btL
-btL
-btL
-btL
-btL
+xnA
+nzX
+agH
+ecT
 bCD
 bEf
 bGc
@@ -137964,10 +138005,10 @@ bjQ
 bok
 rYW
 btL
-qdY
-nzX
-uuA
-vUl
+pea
+bfH
+wXx
+bRN
 bCD
 bEg
 bGd
@@ -138221,10 +138262,10 @@ aXF
 boA
 bbz
 btL
-qlO
-bfH
-boa
-ibd
+goF
+bxq
+pHt
+xsG
 bCD
 bEh
 nsP
@@ -138478,10 +138519,10 @@ aXG
 boS
 bbA
 btL
-eXV
+nPX
 bxq
-bxq
-bAY
+fmK
+ocM
 bCE
 bCE
 bCE
@@ -138735,9 +138776,9 @@ sKG
 wMA
 bry
 brS
-btf
-bfJ
-bgL
+jOq
+srW
+ptA
 bev
 bic
 bjC
@@ -138992,9 +139033,9 @@ aXI
 dFq
 bbI
 btL
-sKk
+qNK
 bxq
-bgM
+oos
 qDL
 bCE
 bCE
@@ -139249,9 +139290,9 @@ aXJ
 bpA
 beZ
 btL
-wMU
-bxr
-bgN
+hlp
+bxq
+rTR
 mQM
 bCD
 bEj
@@ -139506,10 +139547,10 @@ bjQ
 bpE
 rYW
 btL
-eqz
-bxs
-bzt
-oBN
+qgv
+bxr
+bgM
+xEu
 bCD
 bEg
 bGd
@@ -139763,10 +139804,10 @@ aXK
 bpF
 bbQ
 btL
-btL
-btL
-btL
-btL
+mIU
+rAW
+bzt
+eMg
 bCD
 bEk
 bGf
@@ -140020,10 +140061,10 @@ aXL
 bpG
 bbR
 aRy
-aRy
-aRy
-aRy
-aRy
+btL
+btL
+btL
+btL
 aRy
 aRy
 aRy
@@ -140277,11 +140318,11 @@ aXM
 bpH
 bbS
 aRy
-bvt
-aaa
-aTU
-aaa
-aaa
+aRy
+aRy
+bfZ
+aRy
+aRy
 aaa
 aaa
 aaa


### PR DESCRIPTION
# Document the changes in your pull request

Adjusts the telecomm room so it is 2 tiles wider, and repositions some equipment so you can actually reach the wall mounted devices. Replaces the donk pockets with a spawner for random donk pockets. Adds a rack of spare winter gear, and a space heater.
deletes the two potted plants.


pixel shifts three air alarms in medbay despite never touching them, because ??????

# Changelog

:cl:  
tweak: Adjusts the size of the Yogsmeta telecomms room
tweak: Repositions the equipment in the Yogsmeta telecomms room
bugfix: you can now reach the turret controls, requests console, fire alarm, air alarm and telescreen, in Yogsmeta telecomms.
/:cl:
