### PR TITLE
Makes Glowing Goo Not PERMANENTLY radioactive

### DIFF
--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -94,7 +94,8 @@
 	light_power = 0
 	light_range = 0
 	update_light()
-	R.RemoveComponent()
+	if(R)
+		R.RemoveComponent()
 
 /obj/effect/decal/cleanable/greenglow/filled/Initialize()
 	. = ..()

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -89,10 +89,12 @@
 	addtimer(CALLBACK(src, .proc/Decay), 24 SECONDS)
 
 /obj/effect/decal/cleanable/greenglow/proc/Decay()
+	var/datum/component/radioactive/R = src.GetComponent(/datum/component/radioactive)
 	name = "dried goo"
 	light_power = 0
 	light_range = 0
 	update_light()
+	R.RemoveComponent()
 
 /obj/effect/decal/cleanable/greenglow/filled/Initialize()
 	. = ..()

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -89,7 +89,7 @@
 	addtimer(CALLBACK(src, .proc/Decay), 24 SECONDS)
 
 /obj/effect/decal/cleanable/greenglow/proc/Decay()
-	var/datum/component/radioactive/R = src.GetComponent(/datum/component/radioactive)
+	var/datum/component/radioactive/R = GetComponent(/datum/component/radioactive)
 	name = "dried goo"
 	light_power = 0
 	light_range = 0


### PR DESCRIPTION
# Document the changes in your pull request

reasons you shouldn't blindly merge PRs:

just makes radiation from glowing goo go away with the light too.

# Changelog


:cl:  
bugfix: glowing goo from spilled radium or uranium is no longer PERMANENTLY radioactive
/:cl:
