### PR TITLE
makes mk4 plates cheaper

### DIFF
--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -512,7 +512,7 @@
 	desc = "Plating fitted for a plated vest or helmet. Turns you into a walking tank."
 	id = "platingmkiv"
 	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 40000, /datum/material/titanium = 30000, /datum/material/gold = 15000, /datum/material/diamond = 15000)
+	materials = list(/datum/material/iron = 20000, /datum/material/titanium = 10000, /datum/material/gold = 7500, /datum/material/diamond = 2000)
 	build_path = /obj/item/kevlar_plating/mkiv
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY


### PR DESCRIPTION
# Document the changes in your pull request

Apparently sec was draining the ore silo with these and they ARE hugely more expensive than the others when they are supposed to be sidegrades so reducing it seems reasonable

/datum/material/iron = 40000, /datum/material/titanium = 30000, /datum/material/gold = 15000, /datum/material/diamond = 15000
->
/datum/material/iron = 20000, /datum/material/titanium = 10000, /datum/material/gold = 7500, /datum/material/diamond = 2000

# Wiki Documentation

Iron sheets 20 -> 10
Titanium sheets 15 -> 5
Gold sheets 7.5 -> 3.75
Diamond sheets 7.5 -> 1

# Changelog

:cl:  
tweak: MK IV armor plates are now cheaper
/:cl:
