### PR TITLE
Gives polysmorphs wound armor

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/polysmorphs.dm
+++ b/code/modules/mob/living/carbon/human/species_types/polysmorphs.dm
@@ -39,3 +39,14 @@
 	var/randname = polysmorph_name()
 
 	return randname
+
+/datum/species/polysmorph/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
+	.=..()
+	var/mob/living/carbon/human/H = C
+	if(H.physiology)
+		H.physiology.armor.wound += 10	//Pseudo-exoskeleton makes them harder to wound
+
+/datum/species/polysmorph/on_species_loss(mob/living/carbon/human/C, datum/species/new_species, pref_load)
+	.=..()
+	if(C.physiology)
+		C.physiology.armor.wound -= 10


### PR DESCRIPTION
Polysmorphs really don't have a lot going for them aside from resistance to acid and toxins, and even then they have OTHER issues with toxins. This is just a nice little buff that's unique to them.




# Wiki Documentation

Note that polysmorphs also have a small amount of resistance to wounds, but not the damage that caused them.

# Changelog


:cl:  

tweak: Polysmorphs now have 10 wound armor naturally

/:cl:
