### PR TITLE
Fixes the rune scrimitar's necropolis chest not spawning any loot

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -79,7 +79,8 @@
 	flags_1 = CONDUCT_1
 	sharpness = SHARP_EDGED
 	w_class = WEIGHT_CLASS_NORMAL
-	force = 25
+	force = 20
+	armour_penetration = 25
 	throwforce = 10
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "rends")

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -79,7 +79,7 @@
 	flags_1 = CONDUCT_1
 	sharpness = SHARP_EDGED
 	w_class = WEIGHT_CLASS_NORMAL
-	force = 17
+	force = 25
 	throwforce = 10
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "rends")

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -661,7 +661,7 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 		if(96 to 99) //4% DHIDE ARMOR
 			new /obj/item/stack/sheet/animalhide/ashdrake(spot)
 		if(100)
-			new /obj/structure/closet/crate/necropolis(spot)
+			new /obj/structure/closet/crate/necropolis/tendril(spot)
 
 //Potion of Flight
 /obj/item/reagent_containers/glass/bottle/potion


### PR DESCRIPTION
# Document the changes in your pull request
Changes the typepath to the proper one so the chest actually spawns with loot

# Changelog
:cl:  
bugfix: Necropolis chests, spawned from the rune scimitar, will now also come with necropolis loot. Rejoice!
/:cl:
