### PR TITLE
Fixes Necropolis chest from rune scrimitar not spawning any loot, part two

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -661,7 +661,7 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 		if(96 to 99) //4% DHIDE ARMOR
 			new /obj/item/stack/sheet/animalhide/ashdrake(spot)
 		if(100)
-			new /obj/structure/closet/crate/necropolis(spot)
+			new /obj/structure/closet/crate/necropolis/tendril(spot)
 
 //Potion of Flight
 /obj/item/reagent_containers/glass/bottle/potion


### PR DESCRIPTION
# Document the changes in your pull request
Changes the typepath to the proper one so the chest actually spawns with loot

# Changelog
:cl:  
bugfix: Necropolis chests, spawned from the rune scimitar, will now also come with necropolis loot. Rejoice!
/:cl: