### PR TITLE
most energy weapons can no longer be akimboed because i hate fun :(

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -21,6 +21,7 @@
 	var/charge_amount = 1
 	var/use_cyborg_cell = FALSE //whether the gun's cell drains the cyborg user's cell to recharge
 	var/dead_cell = FALSE //set to true so the gun is given an empty cell
+	weapon_weight = WEAPON_MEDIUM //most energy weapons cannot be dual wielded
 
 /obj/item/gun/energy/emp_act(severity)
 	. = ..()

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -20,6 +20,7 @@
 	ammo_x_offset = 2
 	charge_sections = 3
 	can_flashlight = FALSE // Can't attach or detach the flashlight, and override it's icon update
+	weapon_weight = WEAPON_LIGHT
 
 /obj/item/gun/energy/e_gun/mini/Initialize()
 	gun_light = new /obj/item/flashlight/seclite(src)


### PR DESCRIPTION
Security has been powercreeped a LOT, especially recently. First with the addition (and then rapid removal) of winsticks, and with the recent development of them being able to print ERT armor. Akimbo is one of the worst offenders in terms of this, as very little can stop someone pissing dual disablers/lasers, and the 'downside' of inaccuracy is negligible at worst, and helpful at best. Being able to double your DPS with very little or no cost isn't OK, and just inflicts a burden on anyone trying to balance the game, because you have to balance around people using these with akimbo, the autorifle is a good example of this. The general consensus I've received has been to either remove akimbo or change it to have a delay between shots. I think this is a fair middle ground, as this restricts most dual wielding to antagonists. (more specifically ops/traitors) If ballistic dual wielding turns out to be an issue after this, which it currently is not, it can be removed in the future. The proto-kinetic accelerator retains its ability to be dual-wielded, because miners are going to be primarily using these against fauna. The miniature energy gun can also be dual wielded, since these are mainly used by syndicate infiltrators, as a free alternative to their actual uplink items.

# Wiki Documentation

guide to combat

# Changelog

:cl:  
tweak: most energy weapons now have a weapon_weight of WEAPON_MEDIUM  
/:cl:
