### PR TITLE
Updates Donkpocket Boxes In Space Ruins/Shuttles/CC-ZL

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -873,21 +873,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/deepstorage)
-"bX" = (
-/obj/structure/table,
-/obj/item/storage/box/donkpockets,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/deepstorage)
 "bY" = (
 /obj/machinery/airalarm/away{
 	pixel_y = 24
@@ -1600,87 +1585,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/deepstorage)
-"dw" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/crate{
-	name = "food crate"
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = -2
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 5
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 1;
-	pixel_y = -3
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/vending_refill/cigarette{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/vending_refill/cigarette,
-/obj/item/vending_refill/coffee{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/deepstorage/storage)
-"dx" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/crate{
-	name = "food crate"
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = -2
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 5
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 1;
-	pixel_y = -3
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/obj/item/vending_refill/cigarette{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/vending_refill/cigarette,
-/obj/item/vending_refill/coffee{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/deepstorage/storage)
 "dy" = (
 /obj/structure/cable/yellow,
 /obj/machinery/power/apc/away{
@@ -3253,6 +3157,96 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/crusher)
+"Ng" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate{
+	name = "food crate"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/vending_refill/cigarette{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/vending_refill/cigarette,
+/obj/item/vending_refill/coffee{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/storage)
+"RA" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate{
+	name = "food crate"
+	},
+/obj/item/vending_refill/cigarette{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/vending_refill/cigarette,
+/obj/item/vending_refill/coffee{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/storage)
+"SX" = (
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage)
 
 (1,1,1) = {"
 aa
@@ -3850,7 +3844,7 @@ bU
 cB
 cB
 cB
-dw
+Ng
 dB
 ei
 ey
@@ -3902,7 +3896,7 @@ bU
 cB
 cB
 cB
-dx
+RA
 dB
 dH
 em
@@ -4262,7 +4256,7 @@ af
 af
 af
 af
-bX
+SX
 cI
 cT
 dl

--- a/_maps/RandomRuins/SpaceRuins/derelict6.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict6.dmm
@@ -289,10 +289,6 @@
 /mob/living/simple_animal/hostile/retaliate/ghost,
 /turf/open/floor/plasteel/airless/cafeteria,
 /area/ruin/unpowered)
-"bb" = (
-/obj/item/reagent_containers/food/snacks/donkpocket,
-/turf/open/floor/plasteel/airless/cafeteria,
-/area/ruin/unpowered)
 "bc" = (
 /obj/structure/table,
 /obj/item/shard,
@@ -497,6 +493,13 @@
 /mob/living/simple_animal/hostile/retaliate/ghost,
 /turf/open/floor/plasteel/airless,
 /area/ruin/unpowered)
+"LY" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/airless/cafeteria,
+/area/ruin/unpowered)
 
 (1,1,1) = {"
 aa
@@ -695,7 +698,7 @@ aC
 ai
 aI
 aR
-aW
+LY
 aW
 bh
 ap
@@ -765,7 +768,7 @@ ai
 aL
 aR
 aR
-bb
+aR
 aR
 aR
 aR

--- a/_maps/RandomRuins/SpaceRuins/gameroom.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gameroom.dmm
@@ -931,7 +931,17 @@
 /obj/item/radio,
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/powered/gaming)
-"Tv" = (
+"TK" = (
+/obj/structure/chair/sofa/right{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/powered/gaming)
+"TW" = (
+/obj/machinery/computer/arcade/minesweeper,
+/turf/open/floor/carpet,
+/area/ruin/space/has_grav/powered/gaming)
+"Ui" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/food/snacks/chocolatebar{
 	pixel_x = -9;
@@ -965,25 +975,13 @@
 	pixel_x = -5;
 	pixel_y = 8
 	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 6;
-	pixel_y = 7
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
 	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 7;
-	pixel_y = 8
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
 	},
 /turf/open/floor/circuit,
-/area/ruin/space/has_grav/powered/gaming)
-"TK" = (
-/obj/structure/chair/sofa/right{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/ruin/space/has_grav/powered/gaming)
-"TW" = (
-/obj/machinery/computer/arcade/minesweeper,
-/turf/open/floor/carpet,
 /area/ruin/space/has_grav/powered/gaming)
 "US" = (
 /obj/machinery/light_switch{
@@ -1628,7 +1626,7 @@ IX
 XL
 wv
 yl
-Tv
+Ui
 XL
 XL
 XL

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -761,6 +761,38 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/listeningstation)
+"lY" = (
+/obj/structure/table,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/listeningstation)
 "na" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -1178,38 +1210,6 @@
 /obj/item/paper_bin,
 /obj/item/paper/fluff/ruins/listeningstation/reports/november,
 /obj/item/pen,
-/turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
-"Xp" = (
-/obj/structure/table,
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_y = 3
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 2
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation)
 "Yt" = (
@@ -1988,7 +1988,7 @@ cy
 aN
 dc
 aZ
-Xp
+lY
 ac
 jY
 ac

--- a/_maps/RandomRuins/SpaceRuins/nicelittlenest.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nicelittlenest.dmm
@@ -139,11 +139,6 @@
 "kr" = (
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/powered)
-"ky" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/donkpockets,
-/turf/open/floor/plasteel/checker,
-/area/ruin/space/has_grav/powered)
 "kJ" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -211,6 +206,13 @@
 /obj/structure/sink/kitchen{
 	dir = 8;
 	pixel_x = 11
+	},
+/turf/open/floor/plasteel/checker,
+/area/ruin/space/has_grav/powered)
+"op" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
 	},
 /turf/open/floor/plasteel/checker,
 /area/ruin/space/has_grav/powered)
@@ -1106,7 +1108,7 @@ Qa
 Qa
 Hj
 Gk
-ky
+op
 MJ
 MJ
 kr

--- a/_maps/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacebar.dmm
@@ -137,12 +137,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/ruin/space/has_grav/powered/spacebar)
-"fg" = (
-/obj/structure/table,
-/obj/item/storage/box/donkpockets,
-/obj/item/reagent_containers/food/condiment/enzyme,
-/turf/open/floor/plasteel/cafeteria,
-/area/ruin/space/has_grav/powered/spacebar)
 "fy" = (
 /obj/structure/chair{
 	dir = 8
@@ -226,6 +220,14 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
+/area/ruin/space/has_grav/powered/spacebar)
+"hp" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/ruin/space/has_grav/powered/spacebar)
 "if" = (
 /obj/structure/urinal{
@@ -1965,7 +1967,7 @@ FB
 go
 rp
 vR
-fg
+hp
 FD
 FB
 sZ

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -2371,10 +2371,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/ruin/space/has_grav/hotel/bar)
-"fZ" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/freezer,
-/area/ruin/space/has_grav/hotel/bar)
 "ga" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -2622,14 +2618,6 @@
 "gK" = (
 /obj/structure/table,
 /obj/machinery/microwave,
-/turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/hotel/workroom)
-"gL" = (
-/obj/structure/table,
-/obj/item/storage/box/donkpockets,
-/obj/structure/sign/warning/nosmoking/circle{
-	pixel_y = 32
-	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/hotel/workroom)
 "gM" = (
@@ -4980,6 +4968,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/pool)
+"xy" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ruin/space/has_grav/hotel/bar)
 "xO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/carpet,
@@ -5045,6 +5040,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/hotel/bar)
+"LM" = (
+/obj/structure/table,
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_y = 32
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/hotel/workroom)
 "ON" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/freezer,
@@ -6166,7 +6171,7 @@ eK
 eL
 fi
 fQ
-fZ
+xy
 go
 gk
 go
@@ -7848,7 +7853,7 @@ de
 cF
 cF
 di
-gL
+LM
 gG
 gG
 hF

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -16858,23 +16858,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
-"aIb" = (
-/obj/structure/rack,
-/obj/item/storage/box/donkpockets,
-/obj/item/storage/box/donkpockets,
-/obj/item/clothing/head/chefhat,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/tdome/tdomeobserve)
 "aIc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -18355,15 +18338,6 @@
 /obj/item/gun/magic/staff/cheese,
 /turf/open/floor/wood,
 /area/centcom/testchamber)
-"aKL" = (
-/obj/item/storage/box/donkpockets,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/structure/table,
-/turf/open/floor/plasteel,
-/area/centcom/evac)
 "aKM" = (
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/mineral/titanium,
@@ -18735,27 +18709,6 @@
 	icon_state = "darkfull"
 	},
 /area/holodeck/rec_center/chapelcourt)
-"aLv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate,
-/obj/item/storage/box/donkpockets{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_y = 3
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 2
-	},
-/obj/item/reagent_containers/food/snacks/chocolatebar{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/dark,
-/area/yogs/infiltrator_base)
 "aLw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -21677,14 +21630,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bluespace_locker)
-"aRo" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/donkpockets,
-/obj/item/storage/box/fancy/cigarettes/cigars/cohiba{
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/supplypod)
 "aRp" = (
 /obj/item/transfer_valve{
 	pixel_x = -5
@@ -25824,11 +25769,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
-"aZG" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/fancy/donut_box,
-/turf/open/floor/plasteel,
-/area/centcom/testchamber)
 "aZH" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -26029,6 +25969,18 @@
 /obj/effect/penance_giver/eldritch,
 /turf/open/indestructible/brazil/necropolis,
 /area/brazil)
+"bfK" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/fancy/donut_box{
+	pixel_x = 12;
+	pixel_y = 7
+	},
+/obj/item/storage/box/donkpockets/donkpocketgondola{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel,
+/area/centcom/testchamber)
 "bEO" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info16"
@@ -26086,6 +26038,16 @@
 	icon_state = "info23"
 	},
 /area/centcom/testchamber)
+"fpM" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/fancy/cigarettes/cigars/cohiba{
+	pixel_y = 3
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/supplypod)
 "fwB" = (
 /turf/open/indestructible/wiki/title{
 	icon_state = "title5"
@@ -26127,6 +26089,26 @@
 	icon_state = "title7"
 	},
 /area/centcom/testchamber)
+"hEo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/food/snacks/chocolatebar{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/bot_white,
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/dark,
+/area/yogs/infiltrator_base)
 "ilg" = (
 /turf/open/indestructible/wiki/title{
 	icon_state = "title11"
@@ -26258,6 +26240,16 @@
 	icon_state = "info8"
 	},
 /area/centcom/testchamber)
+"nWp" = (
+/obj/item/storage/box/donkpockets/donkpocketgondola,
+/obj/structure/closet/crate,
+/obj/item/paper/fluff/stations/centcom/disk_memo{
+	info = "Wizard Federation Reminder: Gondola Meat causes Gondola Transformation. Use only in Emergencies.";
+	infolang = /datum/language/common;
+	name = "warning"
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
 "oAH" = (
 /obj/machinery/light{
 	dir = 1
@@ -26373,6 +26365,27 @@
 "uEX" = (
 /turf/open/indestructible/wiki/greenscreen/border,
 /area/centcom/testchamber)
+"uNA" = (
+/obj/structure/rack,
+/obj/item/clothing/head/chefhat,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/dark,
+/area/tdome/tdomeobserve)
 "vci" = (
 /turf/open/indestructible/wiki/bluescreen,
 /area/centcom/testchamber)
@@ -26401,6 +26414,17 @@
 	icon_state = "info15"
 	},
 /area/centcom/testchamber)
+"wdp" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "wdW" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info32"
@@ -26447,6 +26471,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
+"xxr" = (
+/obj/structure/table/wood,
+/obj/machinery/microwave{
+	name = "box of cooking";
+	pixel_y = 10
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
 "xGe" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info31"
@@ -32548,8 +32580,8 @@ axv
 aqE
 ayD
 aqZ
-aqZ
-aqZ
+nWp
+xxr
 aBg
 aqE
 aqZ
@@ -43261,7 +43293,7 @@ aQr
 aSA
 aSA
 aYI
-aLv
+hEo
 aSA
 abq
 ael
@@ -52645,7 +52677,7 @@ aWi
 aKQ
 aVt
 aKH
-aKL
+wdp
 aKO
 aWl
 aVV
@@ -66977,7 +67009,7 @@ aHo
 aHB
 aHJ
 aHU
-aIb
+uNA
 aIi
 aEp
 aIB
@@ -70850,7 +70882,7 @@ aKw
 aIR
 aKG
 aXX
-aZG
+bfK
 aZr
 awS
 aSJ
@@ -77755,7 +77787,7 @@ arS
 aqz
 aqx
 aNh
-aRo
+fpM
 aYn
 aSe
 aSi

--- a/_maps/shuttles/emergency_cere.dmm
+++ b/_maps/shuttles/emergency_cere.dmm
@@ -838,22 +838,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
-"bJ" = (
-/obj/structure/table,
-/obj/item/storage/box/donkpockets,
-/obj/item/storage/box/donkpockets,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/escape)
 "bK" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -870,6 +854,26 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"bL" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
@@ -2487,7 +2491,7 @@ be
 be
 bw
 ac
-bJ
+bL
 bR
 bT
 pm

--- a/_maps/shuttles/emergency_transtar.dmm
+++ b/_maps/shuttles/emergency_transtar.dmm
@@ -438,6 +438,13 @@
 /obj/machinery/light,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
+"xD" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
 "yf" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/firedoor/border_only{
@@ -686,11 +693,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"PA" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/donkpockets,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "Qn" = (
@@ -1088,7 +1090,7 @@ rY
 dp
 or
 ad
-PA
+xD
 dp
 wK
 dp

--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -22,7 +22,6 @@
 /obj/item/ammo_casing/caseless/cannonball,
 /obj/item/ammo_casing/caseless/cannonball,
 /obj/item/ammo_casing/caseless/cannonball,
-
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -94,40 +93,6 @@
 /area/shuttle/pirate)
 "aj" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/shuttle/pirate)
-"ak" = (
-/obj/machinery/airalarm/all_access{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/freezer{
-	locked = 0;
-	name = "fridge"
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/storage/box/donkpockets,
-/obj/item/storage/box/fancy/donut_box,
-/obj/item/reagent_containers/food/snacks/cookie,
-/obj/item/reagent_containers/food/snacks/cookie{
-	pixel_x = -6;
-	pixel_y = -6
-	},
-/obj/item/reagent_containers/food/snacks/chocolatebar,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/item/reagent_containers/food/condiment/milk,
-/turf/open/floor/plasteel,
 /area/shuttle/pirate)
 "al" = (
 /obj/machinery/loot_locator,
@@ -1139,6 +1104,41 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/pirate)
+"wP" = (
+/obj/machinery/airalarm/all_access{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/freezer{
+	locked = 0;
+	name = "fridge"
+	},
+/obj/item/storage/box/fancy/donut_box,
+/obj/item/reagent_containers/food/snacks/cookie,
+/obj/item/reagent_containers/food/snacks/cookie{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/reagent_containers/food/snacks/chocolatebar,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/pirate)
 "wR" = (
 /obj/machinery/porta_turret/syndicate/energy{
 	dir = 8;
@@ -1329,7 +1329,7 @@ eA
 aa
 ap
 aw
-ak
+wP
 bF
 aj
 aj

--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -608,52 +608,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/crew)
-"aR" = (
-/obj/structure/closet/crate{
-	name = "food crate"
-	},
-/obj/item/reagent_containers/glass/beaker/waterbottle/large{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/glass/beaker/waterbottle/large{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/glass/beaker/waterbottle/large{
-	pixel_x = -2
-	},
-/obj/item/reagent_containers/glass/beaker/waterbottle/large{
-	pixel_x = 5
-	},
-/obj/item/reagent_containers/glass/beaker/waterbottle/large{
-	pixel_x = 1;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/glass/beaker/waterbottle/large{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/donkpockets,
-/obj/machinery/light/small/built{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/crew)
 "aS" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/engine)
@@ -2327,6 +2281,53 @@
 	},
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/engine)
+"LY" = (
+/obj/structure/closet/crate{
+	name = "food crate"
+	},
+/obj/item/reagent_containers/glass/beaker/waterbottle/large{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/glass/beaker/waterbottle/large{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/glass/beaker/waterbottle/large{
+	pixel_x = -2
+	},
+/obj/item/reagent_containers/glass/beaker/waterbottle/large{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/glass/beaker/waterbottle/large{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/glass/beaker/waterbottle/large{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/machinery/light/small/built{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/crew)
 "Rx" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
@@ -2854,7 +2855,7 @@ aa
 aa
 ab
 ac
-aR
+LY
 be
 be
 dv

--- a/_maps/shuttles/whiteship_delta.dmm
+++ b/_maps/shuttles/whiteship_delta.dmm
@@ -989,26 +989,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/bar)
-"bJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/item/trash/plate{
-	pixel_x = 12
-	},
-/obj/item/kitchen/fork{
-	pixel_x = 12;
-	pixel_y = 3
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/bar)
 "bK" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
@@ -2666,6 +2646,25 @@
 "vm" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/medbay)
+"zh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/item/trash/plate{
+	pixel_x = 12
+	},
+/obj/item/kitchen/fork{
+	pixel_x = 12;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/bar)
 "DZ" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3068,7 +3067,7 @@ aq
 aH
 bb
 bu
-bJ
+zh
 bI
 aa
 aa

--- a/_maps/shuttles/whiteship_meta.dmm
+++ b/_maps/shuttles/whiteship_meta.dmm
@@ -1178,25 +1178,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/cargo)
-"bM" = (
-/obj/machinery/light/small/built{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/machinery/microwave,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 32
-	},
-/obj/item/storage/box/donkpockets,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/abandoned/bar)
 "bN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
@@ -3069,6 +3050,27 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/cargo)
+"oA" = (
+/obj/machinery/light/small/built{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/abandoned/bar)
 "qY" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 4
@@ -3476,7 +3478,7 @@ ai
 YT
 ai
 bD
-bM
+oA
 bZ
 cn
 cz

--- a/_maps/shuttles/whiteship_miner.dmm
+++ b/_maps/shuttles/whiteship_miner.dmm
@@ -553,17 +553,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/abandoned)
-"cq" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/item/storage/box/donkpockets,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
 "cw" = (
 /obj/structure/sink{
 	dir = 4;
@@ -679,6 +668,19 @@
 	pixel_y = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/abandoned)
+"fr" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/abandoned)
 "fw" = (
@@ -897,7 +899,7 @@
 	height = 15;
 	id = "whiteship";
 	launch_status = 0;
-	movement_force = list("KNOCKDOWN"=0,"THROW"=0);
+	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "Free Miner Ship";
 	port_direction = 8;
 	preferred_direction = 4;
@@ -1445,7 +1447,7 @@ JR
 JR
 JR
 bk
-cq
+fr
 eH
 ry
 bk

--- a/_maps/templates/infiltrator_base.dmm
+++ b/_maps/templates/infiltrator_base.dmm
@@ -164,33 +164,12 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
 /area/yogs/infiltrator_base)
-"au" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate,
-/obj/item/storage/box/donkpockets{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_y = 3
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 2
-	},
-/obj/item/reagent_containers/food/snacks/chocolatebar{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/dark,
-/area/yogs/infiltrator_base)
 "av" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 9
 	},
 /obj/machinery/airalarm{
-	pixel_y = 23;
+	pixel_y = 24;
 	req_access = 150
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -312,7 +291,7 @@
 "aH" = (
 /obj/structure/chair/stool,
 /obj/machinery/airalarm{
-	pixel_y = 23;
+	pixel_y = 24;
 	req_access = list(150)
 	},
 /obj/effect/landmark/start/infiltrator,
@@ -611,7 +590,7 @@
 /area/yogs/infiltrator_base)
 "bn" = (
 /obj/machinery/airalarm{
-	pixel_y = 23;
+	pixel_y = 24;
 	req_access = 150
 	},
 /obj/structure/bed,
@@ -781,7 +760,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm{
-	pixel_y = 23;
+	pixel_y = 24;
 	req_access = 150
 	},
 /obj/machinery/light/small{
@@ -1119,7 +1098,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm{
-	pixel_y = 23;
+	pixel_y = 24;
 	req_access = 150
 	},
 /obj/structure/table,
@@ -1691,6 +1670,26 @@
 	},
 /turf/open/floor/plating/asteroid/snow/airless,
 /area/yogs/infiltrator_base/outside)
+"wp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/food/snacks/chocolatebar{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/bot_white,
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/dark,
+/area/yogs/infiltrator_base)
 "Lx" = (
 /obj/machinery/vending/cigarette/syndicate,
 /turf/closed/indestructible/riveted,
@@ -2235,7 +2234,7 @@ ad
 ab
 ab
 aq
-au
+wp
 ab
 aJ
 aW


### PR DESCRIPTION
# Document the changes in your pull request

Updates donkpocket boxes in all the space ruins, shuttles, and places in Centcomm's zlevel I could find them, turning them into randomized spawners
also touches the infil template map that I am not confident is even used.

gives the wizard spawn ship a "box of cooking" microwave and a crate with a warning paper (information on gondola meat) and a single box of gondola pockets.

# Changelog

:cl:  
tweak: updates donkpockets in space ruins/infil-base/whiteships/shuttles to be randomized
/:cl:
