### PR TITLE
Gives stasis parts purpose

### DIFF
--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -27,9 +27,9 @@
 	// 4 life_tickrate is 25% organ decay or 75% stasis
 	// 5 life_tickrate is 20% organ decay or 80% stasis
 	var/stasis_amount = 1.5 // How much it adds to life tickrate
-	// T1 = 1.5, 33% stasis
-	// T2 = 2, 50% stasis
-	// T3 = 4, 75% stasis
+	// T1 = 0.5, 33% stasis
+	// T2 = 1, 50% stasis
+	// T3 = 3, 75% stasis
 	// T4 = -1, 100% stasis
 
 	
@@ -43,11 +43,11 @@
 	for(var/obj/item/stock_parts/capacitor/C in component_parts)
 		switch(C.rating)
 			if(1)
-				stasis_amount = 1.5 // 33% stasis
+				stasis_amount = 0.5 // 33% stasis
 			if(2)
-				stasis_amount = 2 // 50% stasis
+				stasis_amount = 1 // 50% stasis, equivalent to a holobed
 			if(3)
-				stasis_amount = 4 // 75% stasis
+				stasis_amount = 3 // 75% stasis
 			if(4)
 				stasis_amount = -1 // 100% stasis
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -15,7 +15,25 @@
 	var/last_stasis_sound = FALSE
 	var/stasis_can_toggle = 0
 	var/stasis_cooldown = 5 SECONDS
-	var/stasis_amount = -0.25 // -1 is completely frozen in time, 0 would do nothing, so -0.25 is 25% slow, -0.5 : 50%, etc
+
+	// Life tickrate is processed as follows
+	// if (living.life_tickrate && (tick % living.life_tickrate) == 0) is true, life will tick on that tick
+	// Thus,
+	// 0 life_tickrate is 0% organ decay or 100% stasis
+	// 1 life_tickrate is 100% organ decay or 0% stasis
+	// 1.5 life_tickrate is 66% orcan decay or 33% stasis
+	// 2 life_tickrate is 50% organ decay or 50% stasis
+	// 3 life_tickrate is 33% organ decay or 66% stasis
+	// 4 life_tickrate is 25% organ decay or 75% stasis
+	// 5 life_tickrate is 20% organ decay or 80% stasis
+	var/stasis_amount = 1.5 // How much it adds to life tickrate
+	// T1 = 1.5, 33% stasis
+	// T2 = 2, 50% stasis
+	// T3 = 4, 75% stasis
+	// T4 = -1, 100% stasis
+
+	
+
 	var/mattress_state = "stasis_on"
 	var/obj/effect/overlay/vis/mattress_on
 
@@ -23,7 +41,15 @@
 	stasis_amount = initial(stasis_amount)
 	stasis_cooldown = initial(stasis_cooldown)
 	for(var/obj/item/stock_parts/capacitor/C in component_parts)
-		stasis_amount *= C.rating // T1 is 75% organ decay, T4 is 0%
+		switch(C.rating)
+			if(1)
+				stasis_amount = 1.5 // 33% stasis
+			if(2)
+				stasis_amount = 2 // 50% stasis
+			if(3)
+				stasis_amount = 4 // 75% stasis
+			if(4)
+				stasis_amount = -1 // 100% stasis
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
 		stasis_cooldown *= 1/M.rating // 100%, 50%, 33%, 25%
 	if(occupant)

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -21,7 +21,7 @@
 
 /obj/machinery/stasis/RefreshParts()
 	stasis_amount = initial(stasis_amount)
-	stasis_cooldown = inital(stasis_cooldown)
+	stasis_cooldown = initial(stasis_cooldown)
 	for(var/obj/item/stock_parts/capacitor/C in component_parts)
 		stasis_amount *= C.rating // T1 is 75% organ decay, T4 is 0%
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -168,7 +168,17 @@
 		if(!L_occupant.has_status_effect(STATUS_EFFECT_STASIS))
 			chill_out(L_occupant)
 		if(obj_flags & EMAGGED && L_occupant.getStaminaLoss() <= 200)
-			L_occupant.adjustStaminaLoss(-20 * stasis_amount) // stasis_amount is -0.25 to -1 and this needs to be positive
+			var/stam_mult = 1
+			switch(stasis_amount)
+				if(0.5) // T1
+					stam_mult = 1
+				if(1) // T2
+					stam_mult = 2
+				if(3) // T3
+					stam_mult = 3
+				if(-1) // T4
+					stam_mult = 4
+			L_occupant.adjustStaminaLoss(5*stam_mult)
 	else if(L_occupant.has_status_effect(STATUS_EFFECT_STASIS))
 		thaw_them(L_occupant)
 

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -26,14 +26,13 @@
 	// 3 life_tickrate is 33% organ decay or 66% stasis
 	// 4 life_tickrate is 25% organ decay or 75% stasis
 	// 5 life_tickrate is 20% organ decay or 80% stasis
+	var/stasis_part = 1 // Tier part for easy reference
 	var/stasis_amount = 1.5 // How much it adds to life tickrate
 	// T1 = 0.5, 33% stasis
 	// T2 = 1, 50% stasis
 	// T3 = 3, 75% stasis
 	// T4 = -1, 100% stasis
-
 	
-
 	var/mattress_state = "stasis_on"
 	var/obj/effect/overlay/vis/mattress_on
 
@@ -44,12 +43,16 @@
 		switch(C.rating)
 			if(1)
 				stasis_amount = 0.5 // 33% stasis
+				stasis_part = 1
 			if(2)
 				stasis_amount = 1 // 50% stasis, equivalent to a holobed
+				stasis_part = 2
 			if(3)
 				stasis_amount = 3 // 75% stasis
+				stasis_part = 3
 			if(4)
 				stasis_amount = -1 // 100% stasis
+				stasis_part = 4
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
 		stasis_cooldown *= 1/M.rating // 100%, 50%, 33%, 25%
 	if(occupant)
@@ -62,7 +65,16 @@
 
 /obj/machinery/stasis/examine(mob/user)
 	. = ..()
+	if(panel_open)
+		. += span_notice("[src]'s maintenance hatch is open!")
 	. += span_notice("Alt-click to [stasis_enabled ? "turn off" : "turn on"] the machine.")
+	if(in_range(user, src) || isobserver(user))
+		var/stasis_percent = 33
+		if(stasis_part > 1)
+			stasis_percent = 25*stasis_part
+		. += "<span class='notice'>The status display reads: \n"+\
+		"Stasis efficiency at <b>[stasis_percent]%</b>.\n"+\
+		"[stasis_enabled ? "Shutdown" : "Startup"] will take <b>[stasis_cooldown/10]</b> seconds.</span>"
 	if(obj_flags & EMAGGED)
 		. += span_warning("There's a worrying blue mist surrounding it.")
 
@@ -168,17 +180,7 @@
 		if(!L_occupant.has_status_effect(STATUS_EFFECT_STASIS))
 			chill_out(L_occupant)
 		if(obj_flags & EMAGGED && L_occupant.getStaminaLoss() <= 200)
-			var/stam_mult = 1
-			switch(stasis_amount)
-				if(0.5) // T1
-					stam_mult = 1
-				if(1) // T2
-					stam_mult = 2
-				if(3) // T3
-					stam_mult = 3
-				if(-1) // T4
-					stam_mult = 4
-			L_occupant.adjustStaminaLoss(5*stam_mult)
+			L_occupant.adjustStaminaLoss(5*stasis_part)
 	else if(L_occupant.has_status_effect(STATUS_EFFECT_STASIS))
 		thaw_them(L_occupant)
 


### PR DESCRIPTION
# Document the changes in your pull request

Manipulator affects how fast the bed can be turned off and on

cooldown (5 seconds at time of writing) is multiplied by (1/manipulator tier)

Capacitor affects organ decay

Previously, stasis beds would freeze organs completely

Now, organ decay (life tickrate) is slowed to 66% at tier 1, 50% at tier 2, 25% at tier 3, and 0% at tier 4

You also take more stamina damage when the bed is emagged, used to take 5 every process

Now you take 5,10,15,20 depending on the capacitor part tier

# Wiki Documentation

see above

# Changelog

:cl:  
tweak: Statis beds now have a reason to be upgraded
/:cl:
