### PR TITLE
fixes holobeds doubling your life tickrate

### DIFF
--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -218,7 +218,7 @@
 /obj/structure/holobed/proc/handle_stasis(mob/living/target)
 	if(target == occupant && stasis)
 		if(!target.has_status_effect(STATUS_EFFECT_STASIS))
-			target.apply_status_effect(STATUS_EFFECT_STASIS, null, TRUE, 1)
+			target.apply_status_effect(STATUS_EFFECT_STASIS, null, TRUE, -1)
 	else
 		if(istype(target) && target.has_status_effect(STATUS_EFFECT_STASIS))
 			target.remove_status_effect(STATUS_EFFECT_STASIS)


### PR DESCRIPTION
# Document the changes in your pull request

holobeds no longer double your life tickrate by adding 1 to it, they now subtract 1 which properly sets it to 0

# Changelog

:cl:  
bugfix: fixed holobeds doubling your life tickrate instead of freezing it  
/:cl:
