### PR TITLE
new pointless traitor item: Guerrilla Tape

### DIFF
--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -11,6 +11,9 @@
 	grind_results = list(/datum/reagent/cellulose = 5)
 	var/maximum_weight_class = WEIGHT_CLASS_SMALL
 	var/static/list/tape_blacklist = typecacheof(/obj/item/grenade) //stuff you can't take that may or may not be max_weight_class
+	var/fall_chance = 10
+	var/removal_time = 0
+	var/removal_pain = 0
 
 /obj/item/stack/tape/attack(mob/living/M, mob/user)
 	. = ..()
@@ -49,5 +52,16 @@
 			return
 	to_chat(user, span_info("You wrap [I] with [src]."))
 	use(1)
-	I.embedding = I.embedding.setRating(100, 10, 0, 0, 0, 0, 0, 0, TRUE)
+	I.embedding = I.embedding.setRating(100, fall_chance, 0, 0, 0, 0, removal_pain, removal_time, TRUE)
 	I.taped = TRUE
+
+/obj/item/stack/tape/guerrilla
+	name = "guerrilla tape"
+	singular_name = "guerrilla tape"
+	desc = "A suspicious looking roll of tape. It seems to be much more adhesive than the standard variety."
+	icon_state = "tape_evil"
+	amount = 5
+	removal_pain = 10
+	removal_time = 2 SECONDS //six seconds
+	fall_chance = 5
+	maximum_weight_class = WEIGHT_CLASS_BULKY

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2249,6 +2249,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	manufacturer = /datum/corporation/traitor/donkco
 	illegal_tech = FALSE
 
+
+/datum/uplink_item/badass/syndietape
+	name = "Guerrilla Tape"
+	desc = "New from Donk Co! Stick it to the man with this ultra-adhesive roll of tape! Grabs on tight, and holds on tight, using our patented adhesive formula. Ten times stronger than our leading competitors!"
+	item = /obj/item/stack/tape/guerrilla
+	cost = 1
+	manufacturer = /datum/corporation/traitor/donkco
+
 /datum/uplink_item/badass/antagcape
 	name = "Red Syndicate Cape"
 	desc = "A cape to show off your small-time thuggery."


### PR DESCRIPTION
guerilla tape is tape that takes longer to remove, causes damage when you pull items wrapped in it off. it also can tape items up to the weight class of bulky instead of up to the weight class of small like normal rolls of tape, and of course functions like normal tape, eg taping people's mouths. i mostly made this for the pun, but it is also helpful, since it can be used to tape people's mouths, and can be used for the makeshift pistol, as getting tape can be a hassle.

# Spriting
i love to steal unused sprites
![image](https://user-images.githubusercontent.com/70169560/181352747-605fd5a1-ffc5-4191-b630-643579944a05.png)


# Wiki Documentation

syndicate items page

# Changelog

:cl:  
rscadd: Guerrilla tape
/:cl:
