### PR TITLE
Changes firebreath mutation's noise

### DIFF
--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -125,7 +125,7 @@
 	projectile_type = /obj/item/projectile/magic/aoe/fireball/firebreath
 	base_icon_state = "fireball"
 	action_icon_state = "fireball0"
-	sound = 'sound/magic/demon_dies.ogg' //horrifying lizard noises
+	sound = 'sound/magic/fireball.ogg'
 	active_msg = "You build up heat in your mouth."
 	deactive_msg = "You swallow the flame."
 	var/strength = 1


### PR DESCRIPTION
# Document the changes in your pull request

Changes firebreath mutation's noise to instead be the same sound used for space dragon and ash drake firebreath, and wizard fireballs

the demon scream was a bit.....ehhhhhhh

# Changelog

:cl:  
tweak: firebreath uses a different sound now
/:cl:
