### PR TITLE
Tweaks Mothperson Food Tastes

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -12,7 +12,7 @@
 	attack_sound = 'sound/weapons/slash.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/moth
-	liked_food = VEGETABLES | FRUIT | SUGAR
+	liked_food = VEGETABLES | SUGAR
 	disliked_food = DAIRY | GROSS
 	toxic_food = MEAT | RAW | SEAFOOD | MICE
 	burnmod = 1.25 //Fluffy and flammable

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -12,8 +12,8 @@
 	attack_sound = 'sound/weapons/slash.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/moth
-	liked_food = VEGETABLES | DAIRY | CLOTH
-	disliked_food = FRUIT | GROSS
+	liked_food = VEGETABLES | FRUIT | SUGAR
+	disliked_food = DAIRY | GROSS
 	toxic_food = MEAT | RAW | SEAFOOD | MICE
 	burnmod = 1.25 //Fluffy and flammable
 	brutemod = 0.9 //Evasive buggers


### PR DESCRIPTION
# Document the changes in your pull request

Adjusts moths so they dislike dairy, and instead like sugar in its place. Also makes them not Love cloth, and instead can simply eat cloth with no up or downsides. It's the most available food to a moth on station, it's not going to be very interesting to them.

# Changelog

:cl:  
tweak: Mothpeople now dislike dairy
tweak: Mothpeople now like sugar in addition to vegetables
tweak: Mothpeople now do not love cloth (but don't dislike it)
/:cl:

