### PR TITLE
Makes Vial boxes small

### DIFF
--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -235,7 +235,7 @@
 	name = "vial box"
 	desc = "A small box that can hold up to six vials in a sealed enviroment."
 	icon = 'icons/obj/vial_box.dmi'
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "vialbox"
 	req_access = list(ACCESS_MEDICAL)
 	icon_locked = "vialbox"


### PR DESCRIPTION
Box go back into box.

# Document the changes in your pull request

Changes the vial box weight from normal to small.

I don't see much of a problem with letting the vial boxes be able to be stored back inside the containers they come inside in thanks to the deluxe hypospray kits. This shouldn't change much in terms of balance as I've known they were infrequent to come across and unable to be crafted from cardboard alone, this shouldn't cause that many issues with storage either as the vial boxes only accept vials anyway.

This change has been untested.

# Wiki Documentation

Vial Boxes are small items now.

# Changelog

:cl:  
tweak: Vial Box weight is now small than normal
/:cl:
