### PR TITLE
Gives suit storage units the ability to remove radiation from mobs and gives toxin meds to rad closet

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -25,7 +25,7 @@
 
 	var/uv = FALSE
 	var/uv_super = FALSE
-	var/uv_cycles = 6
+	var/uv_cycles = 3
 	var/message_cooldown
 	var/breakout_time = 300
 

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -297,6 +297,11 @@
 	open_machine()
 	dump_contents()
 
+/obj/machinery/suit_storage_unit/attackby(obj/item/W, mob/user)
+	if(default_unfasten_wrench(user, W))
+		return
+	return 
+
 /obj/machinery/suit_storage_unit/container_resist(mob/living/user)
 	if(!locked)
 		open_machine()
@@ -461,7 +466,7 @@
 			. = TRUE
 	update_icon()
 
-/obj/machinery/suit_storage_unit/CtrlClick(mob/user)
+/obj/machinery/suit_storage_unit/AltClick(mob/user)
 	if(!user.canUseTopic(src, !issilicon(user)))
 		return
 	if(state_open)
@@ -471,7 +476,7 @@
 		if(occupant)
 			dump_contents() // Dump out contents if someone is in there.
 
-/obj/machinery/suit_storage_unit/AltClick(mob/user)
+/obj/machinery/suit_storage_unit/CtrlShiftClick(mob/user)
 	if(!user.canUseTopic(src, !issilicon(user)) || state_open)
 		return
 	locked = !locked

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -220,17 +220,17 @@
 		add_fingerprint(user)
 
 /obj/machinery/suit_storage_unit/proc/cook()
+	var/mob/living/mob_occupant = occupant
 	if(uv_cycles)
 		uv_cycles--
 		uv = TRUE
 		locked = TRUE
 		update_icon()
 		if(occupant)
-			var/mob/living/mob_occupant = occupant
 			if(uv_super)
 				mob_occupant.adjustFireLoss(rand(20, 36))
 			else
-				mob_occupant.adjustFireLoss(rand(10, 16))
+				mob_occupant.adjustFireLoss(rand(2, 8))
 			mob_occupant.emote("scream")
 		addtimer(CALLBACK(src, .proc/cook), 50)
 	else
@@ -255,6 +255,7 @@
 				visible_message(span_notice("[src]'s door slides open. The glowing yellow lights dim to a gentle green."))
 			else
 				visible_message(span_warning("[src]'s door slides open, barraging you with the nauseating smell of charred flesh."))
+				mob_occupant.radiation = 0
 			playsound(src, 'sound/machines/airlockclose.ogg', 25, 1)
 			var/list/things_to_clear = list() //Done this way since using GetAllContents on the SSU itself would include circuitry and such.
 			if(suit)

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -138,6 +138,7 @@
 	new /obj/item/storage/firstaid/toxin(src)
 	new /obj/item/storage/pill_bottle/penacid(src)
 	new /obj/item/storage/pill_bottle/mutadone(src)
+	new /obj/item/reagent_containers/spray/radbgone(src)
 
 /*
  * Bombsuit closet

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -126,7 +126,7 @@
  */
 /obj/structure/closet/radiation
 	name = "radiation suit closet"
-	desc = "It's a storage unit for rad-protective suits."
+	desc = "It's a storage unit for rad-protective suits and anti radiation first-aids."
 	icon_state = "eng"
 	icon_door = "eng_rad"
 
@@ -135,6 +135,9 @@
 	new /obj/item/geiger_counter(src)
 	new /obj/item/clothing/suit/radiation(src)
 	new /obj/item/clothing/head/radiation(src)
+	new /obj/item/storage/firstaid/toxin(src)
+	new /obj/item/storage/pill_bottle/penacid(src)
+	new /obj/item/storage/pill_bottle/mutadone(src)
 
 /*
  * Bombsuit closet

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -385,3 +385,4 @@
 	desc = "Warning, do not consume."
 	volume = 100
 	list_reagents = list(/datum/reagent/medicine/radscrub = 100)
+	stream_amount = 5

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -378,3 +378,10 @@
 	righthand_file = 'icons/mob/inhands/equipment/hydroponics_righthand.dmi'
 	volume = 100
 	list_reagents = list(/datum/reagent/toxin/plantbgone = 100)
+
+// Rad-B-Gone
+/obj/item/reagent_containers/spray/radbgone
+	name = "Rad-B-Gone"
+	desc = "Warning, do not consume."
+	volume = 100
+	list_reagents = list(/datum/reagent/medicine/radscrub = 100)


### PR DESCRIPTION
# About PR
port from [tg](https://github.com/tgstation/tgstation/pull/46725)
Tired of seeing medbay getting hella rad everywhere because a medborg brought a dead contaminated dude? Now with this new suit storage ability you will no longer required to go to medbay to clear rad. Rad closet will have toxin medkit to aid irradiated engineers/atmos techs and cleaning rad contamination.
# Wiki doc
Suit storage units having the ability to remove radiation from mobs
Radiation closet now have toxin meds and radbgone
Suit storage can now be unanchored by wrenching
Keybind changes (Look in changelog)

:cl:  
rscadd: Suit storage units having the ability to remove radiation from mobs
rscadd: Radiation closet now have toxin meds
tweak: Makes SSU dragable by unwrenching
tweak: Keybind for opening changed CtrlClick -> AltclickClick (So you can use CtrlClick to drag it)
tweak: Keybind for Locking/Unlocking changed AltclickClick -> CtrlShiftClick
tweak: Nerfed SSU damage and cycle time
/:cl:
