### PR TITLE
mouse nerf

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1018,7 +1018,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	M.language_holder = new /datum/language_holder/mouse(M)
 	M.pass_flags |= PASSDOOR
 	M.sentience_act()
-	M.maxHealth = 15
+	M.maxHealth = 10
 	M.health = M.maxHealth
 
 	to_chat(M , "<span class='warning'>You are now possessing a mouse. \

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -250,7 +250,7 @@ GLOBAL_VAR_INIT(mouse_killed, 0)
 
 /mob/living/simple_animal/mouse/proc/cheese_down()
 	cheesed = FALSE
-	maxHealth = 15
+	maxHealth = 10
 	health = maxHealth
 	resize = 0.5
 	update_transform()


### PR DESCRIPTION
sentient player controlled mice now only have 10 health instead of 15. 
Player controlled mice can unironically be annoying and i hate em so i just want to be able to one shot them with a toolbox/fire extinguisher/baton, really.
Also makes mouse traps actually good against sentient mice since they only deal 7-12 damage so now occasionally mouse traps will oneshot player mice.

This does not effect cheesed up mice, they still have a full 30 health.

This PR was brought to you by the ANTI-MOUSE gang!

:cl:  
tweak: sentient mice health reduced to 10 from 15.
/:cl:
