### PR TITLE
MMIs no longer appear to have laws because they don't

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1020,7 +1020,7 @@
 		to_chat(brainmob, "<b>As a synthetic intelligence, you answer to all crewmembers and the AI.\n\
 		Remember, the purpose of your existence is to serve the crew and the station. Above all else, do no harm.</b>")
 	else
-		to_chat(brainmob, "<b>Remember, you are still member of the crew act like it</b>")//yogs end
+		to_chat(brainmob, "<b>If you were a member of the crew, you still are! Do not use this new form as an excuse to break rules.</b>")//yogs end
 	if(!internal_damage)
 		SEND_SOUND(occupant, sound('sound/mecha/nominal.ogg',volume=50))
 	GrantActions(brainmob)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1020,7 +1020,7 @@
 		to_chat(brainmob, "<b>As a synthetic intelligence, you answer to all crewmembers and the AI.\n\
 		Remember, the purpose of your existence is to serve the crew and the station. Above all else, do no harm.</b>")
 	else
-		to_chat(brainmob, "<b>If you were a member of the crew, you still are! Do not use this new form as an excuse to break rules.</b>")//yogs end
+		to_chat(brainmob, "<b>If you were a member of the crew, you still are! Do not use this new form as an excuse to break rules. Similarly, if you were an antagonist, you still are!</b>")//yogs end
 	if(!internal_damage)
 		SEND_SOUND(occupant, sound('sound/mecha/nominal.ogg',volume=50))
 	GrantActions(brainmob)

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -234,7 +234,7 @@
 			. += span_notice("The MMI indicates the brain is active.")
 	. += span_notice("It has a port for reading AI law modules.")
 	if(laws)
-		. += span_notice("Any silicon created using this MMI will use these uploaded laws unless synced to an AI:")
+		. += span_notice("Any AI created using this MMI will use these uploaded laws:")
 		for(var/law in laws.get_law_list())
 			. += law
 

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -234,7 +234,7 @@
 			. += span_notice("The MMI indicates the brain is active.")
 	. += span_notice("It has a port for reading AI law modules.")
 	if(laws)
-		. += span_notice("Any AI uploaded using this MMI will use these uploaded laws:")
+		. += span_notice("Any silicon created using this MMI will use these uploaded laws:")
 		for(var/law in laws.get_law_list())
 			. += law
 

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -20,6 +20,9 @@
 	var/rebooting = FALSE /// If the MMI is rebooting after being deconstructed
 	var/remove_window = 10 SECONDS /// The window in which someone has to remove the brain to lose memory of being killed as a borg
 	var/reboot_timer = null
+	var/welcome_message = "<b>You are a brain within a Man-Machine Interface.\n\
+	Unless you are slaved as a silicon, you retain crew/antagonist/etc status and should behave as such.\n\
+	Being placed in a mech does not slave you to any laws.</b>"
 
 /obj/item/mmi/update_icon()
 	if(!brain)
@@ -155,6 +158,7 @@
 		brain.name = "[L.real_name]'s brain"
 
 	name = "[initial(name)]: [brainmob.real_name]"
+	to_chat(brainmob, welcome_message)
 	update_icon()
 	return
 

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -234,7 +234,7 @@
 			. += span_notice("The MMI indicates the brain is active.")
 	. += span_notice("It has a port for reading AI law modules.")
 	if(laws)
-		. += span_notice("Any silicon created using this MMI will use these uploaded laws:")
+		. += span_notice("Any silicon created using this MMI will use these uploaded laws unless synced to an AI:")
 		for(var/law in laws.get_law_list())
 			. += law
 

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -228,9 +228,9 @@
 
 		else
 			. += span_notice("The MMI indicates the brain is active.")
-	. += span_notice("It has a port for reading AI law modules. Any AI uploaded using this MMI will use these uploded laws.")
+	. += span_notice("It has a port for reading AI law modules.")
 	if(laws)
-		. += "<b>The following laws are loaded into [src]: </b>"
+		. += span_notice("Any AI uploaded using this MMI will use these uploaded laws:")
 		for(var/law in laws.get_law_list())
 			. += law
 

--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -18,7 +18,7 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	var/success_message = span_notice("The positronic brain pings, and its lights start flashing. Success!")
 	var/fail_message = span_notice("The positronic brain buzzes quietly, and the golden lights fade away. Perhaps you could try again?")
 	var/new_role = "Positronic Brain"
-	var/welcome_message = "<span class='warning'>ALL PAST LIVES ARE FORGOTTEN.</span>\n\
+	welcome_message = "<span class='warning'>ALL PAST LIVES ARE FORGOTTEN.</span>\n\
 	<b>You are a positronic brain, brought into existence aboard Space Station 13.\n\
 	As a synthetic intelligence, you answer to all crewmembers and the AI.\n\
 	Remember, the purpose of your existence is to serve the crew and the station. Above all else, do no harm.</b>"


### PR DESCRIPTION
# Document the changes in your pull request

read the changes

Welcome message:

"<b>You are a brain within a Man-Machine Interface.\n\
	Unless you are slaved as a silicon, you retain crew/antagonist/etc status and should behave as such.\n\
	Being placed in a mech does not slave you to any laws.</b>"

# Changelog

:cl:  
tweak: tweaked MMI flavor text
/:cl:
