### PR TITLE
[s] Fixes duping robot suits

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -335,13 +335,13 @@
 				to_chat(O, span_danger("You must obey your silicon laws and master AI above all else. Your objectives will consider you to be dead."))
 
 			SSblackbox.record_feedback("amount", "cyborg_birth", 1)
-			forceMove(O)
-			O.robot_suit = src
 
 			if(!locomotion)
 				O.lockcharge = TRUE
 				O.update_mobility()
 				to_chat(O, span_warning("Error: Servo motors unresponsive."))
+			
+			qdel(src)
 
 		else
 			to_chat(user, span_warning("The MMI must go in after everything else!"))
@@ -375,11 +375,11 @@
 			chest.cell = null
 			O.locked = panel_locked
 			O.job = "Cyborg"
-			forceMove(O)
-			O.robot_suit = src
 			if(!locomotion)
 				O.lockcharge = TRUE
 				O.update_mobility()
+			
+			qdel(src)
 
 	else if(istype(W, /obj/item/pen))
 		to_chat(user, span_warning("You need to use a multitool to name [src]!"))

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -13,7 +13,6 @@
 
 	var/custom_name = ""
 	var/braintype = "Cyborg"
-	var/obj/item/robot_suit/robot_suit = null ///Used for deconstruction to remember what the borg was constructed out of..
 	var/obj/item/mmi/mmi = null
 
 	var/throwcooldown = FALSE /// Used to determine cooldown for spin.
@@ -817,42 +816,18 @@
 		new /obj/vehicle/ridden/janicart(T) // Janiborg deconstructs into a janicart. So brave.
 		new /obj/item/key/janitor(T)
 	else
-		if (robot_suit)
-			robot_suit.forceMove(T)
-			robot_suit.l_leg.forceMove(T)
-			robot_suit.l_leg = null
-			robot_suit.r_leg.forceMove(T)
-			robot_suit.r_leg = null
-			new /obj/item/stack/cable_coil(T, robot_suit.chest.wired)
-			robot_suit.chest.forceMove(T)
-			robot_suit.chest.wired = 0
-			robot_suit.chest = null
-			robot_suit.l_arm.forceMove(T)
-			robot_suit.l_arm = null
-			robot_suit.r_arm.forceMove(T)
-			robot_suit.r_arm = null
-			robot_suit.head.forceMove(T)
-			robot_suit.head.flash1.forceMove(T)
-			robot_suit.head.flash1.burn_out()
-			robot_suit.head.flash1 = null
-			robot_suit.head.flash2.forceMove(T)
-			robot_suit.head.flash2.burn_out()
-			robot_suit.head.flash2 = null
-			robot_suit.head = null
-			robot_suit.update_icon()
-		else
-			new /obj/item/robot_suit(T)
-			new /obj/item/bodypart/l_leg/robot(T)
-			new /obj/item/bodypart/r_leg/robot(T)
-			new /obj/item/stack/cable_coil(T, 1)
-			new /obj/item/bodypart/chest/robot(T)
-			new /obj/item/bodypart/l_arm/robot(T)
-			new /obj/item/bodypart/r_arm/robot(T)
-			new /obj/item/bodypart/head/robot(T)
-			var/b
-			for(b=0, b!=2, b++)
-				var/obj/item/assembly/flash/handheld/F = new /obj/item/assembly/flash/handheld(T)
-				F.burn_out()
+		new /obj/item/robot_suit(T)
+		new /obj/item/bodypart/l_leg/robot(T)
+		new /obj/item/bodypart/r_leg/robot(T)
+		new /obj/item/stack/cable_coil(T, 1)
+		new /obj/item/bodypart/chest/robot(T)
+		new /obj/item/bodypart/l_arm/robot(T)
+		new /obj/item/bodypart/r_arm/robot(T)
+		new /obj/item/bodypart/head/robot(T)
+		var/b
+		for(b=0, b!=2, b++)
+			var/obj/item/assembly/flash/handheld/F = new /obj/item/assembly/flash/handheld(T)
+			F.burn_out()
 		if (cell) //Sanity check.
 			cell.forceMove(T)
 			cell = null


### PR DESCRIPTION
# Document the changes in your pull request

Apparently if you apply an mmi/boris module while clicking fast enough with high enough ping, you manage to pick up the robot suit after the borg is made, effectively duplicating it. This is a band-aid fix that just deletes the suit. Code already existed to handle if the suit wasn't present, and I'm pretty sure it served minimal purpose.

Not sure what else the underlying bug can result in, too tired to care, have your bandaid


# Changelog

:cl:  
bugfix: fixed being able to dupe robot suits with high ping
/:cl:
