### PR TITLE
Lets vampires drink blood packs to increase usable blood & fixes horrendously broken code

### DIFF
--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -31,6 +31,7 @@
 		if(is_vampire(target))
 			var/datum/antagonist/vampire/V = is_vampire(target)
 			V.usable_blood += 5
+		
 		if(IS_BLOODSUCKER(target))
 			var/datum/antagonist/bloodsucker/bloodsuckerdatum = target.mind.has_antag_datum(/datum/antagonist/bloodsucker)
 			bloodsuckerdatum.AddBloodVolume(5)

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -28,17 +28,20 @@
 		if(reagents.total_volume <= 0)
 			return
 		var/gulp_size = 5
-		if(IS_BLOODSUCKER(user))
-			var/datum/antagonist/bloodsucker/bloodsuckerdatum = user.mind.has_antag_datum(/datum/antagonist/bloodsucker)
+		if(IS_BLOODSUCKER(target))
+			var/datum/antagonist/bloodsucker/bloodsuckerdatum = target.mind.has_antag_datum(/datum/antagonist/bloodsucker)
 			bloodsuckerdatum.AddBloodVolume(5)
-			var/mob/living/carbon/H = user
-			reagents.trans_to(user, INGEST, 500)
+			var/mob/living/carbon/H = target
+			reagents.trans_to(target, INGEST, 500)
 			if(H.blood_volume >= bloodsuckerdatum.max_blood_volume)
-				to_chat(user, span_notice("You are full, and can't consume more blood"))
+				to_chat(target, span_notice("You are full, and can't consume more blood"))
 				return
+		else if(is_vampire(target))
+			var/datum/antagonist/vampire/V = has_antag_datum(ANTAG_DATUM_VAMPIRE)
+			V.usable_blood += 5
 		else
-			reagents.reaction(user, INGEST, gulp_size)
-			addtimer(CALLBACK(reagents, /datum/reagents.proc/trans_to, user, 5), 5)
+			reagents.reaction(target, INGEST, gulp_size)
+			addtimer(CALLBACK(reagents, /datum/reagents.proc/trans_to, target, 5), 5)
 		playsound(user.loc, 'sound/items/drink.ogg', rand(10,50), 1)
 	return ..()
 

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -29,7 +29,7 @@
 			return
 		var/gulp_size = 5
 		if(is_vampire(target))
-			gulp_size = 20
+			gulp_size = 10
 			var/datum/antagonist/vampire/V = is_vampire(target)
 			V.usable_blood += 5
 		

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -29,21 +29,22 @@
 			return
 		var/gulp_size = 5
 		if(is_vampire(target))
+			gulp_size = 20
 			var/datum/antagonist/vampire/V = is_vampire(target)
 			V.usable_blood += 5
 		
 		if(IS_BLOODSUCKER(target))
 			var/datum/antagonist/bloodsucker/bloodsuckerdatum = target.mind.has_antag_datum(/datum/antagonist/bloodsucker)
-			bloodsuckerdatum.AddBloodVolume(5)
+			bloodsuckerdatum.AddBloodVolume(gulp_size)
 			var/mob/living/carbon/H = target
-			addtimer(CALLBACK(reagents, /datum/reagents.proc/trans_to, target, 5), 5)
-			reagents.reaction(target, INGEST, 500)
+			addtimer(CALLBACK(reagents, /datum/reagents.proc/trans_to, target, gulp_size), 5)
+			reagents.reaction(target, INGEST, 100*gulp_size)
 			if(H.blood_volume >= bloodsuckerdatum.max_blood_volume)
 				to_chat(target, span_notice("You are full, and can't consume more blood"))
 				return
 		else
 			reagents.reaction(target, INGEST, gulp_size)
-			addtimer(CALLBACK(reagents, /datum/reagents.proc/trans_to, target, 5), 5)
+			addtimer(CALLBACK(reagents, /datum/reagents.proc/trans_to, target, gulp_size), 5)
 		playsound(user.loc, 'sound/items/drink.ogg', rand(10,50), 1)
 	return ..()
 

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -28,17 +28,18 @@
 		if(reagents.total_volume <= 0)
 			return
 		var/gulp_size = 5
+		if(is_vampire(target))
+			var/datum/antagonist/vampire/V = is_vampire(target)
+			V.usable_blood += 5
 		if(IS_BLOODSUCKER(target))
 			var/datum/antagonist/bloodsucker/bloodsuckerdatum = target.mind.has_antag_datum(/datum/antagonist/bloodsucker)
 			bloodsuckerdatum.AddBloodVolume(5)
 			var/mob/living/carbon/H = target
-			reagents.trans_to(target, INGEST, 500)
+			addtimer(CALLBACK(reagents, /datum/reagents.proc/trans_to, target, 5), 5)
+			reagents.reaction(target, INGEST, 500)
 			if(H.blood_volume >= bloodsuckerdatum.max_blood_volume)
 				to_chat(target, span_notice("You are full, and can't consume more blood"))
 				return
-		else if(is_vampire(target))
-			var/datum/antagonist/vampire/V = has_antag_datum(ANTAG_DATUM_VAMPIRE)
-			V.usable_blood += 5
 		else
 			reagents.reaction(target, INGEST, gulp_size)
 			addtimer(CALLBACK(reagents, /datum/reagents.proc/trans_to, target, 5), 5)


### PR DESCRIPTION
# Document the changes in your pull request

Vampires can now sip from IV blood packs to gain 5 usable blood per sip
Vampires will sip 10u per sip, which will result in 100 usable blood per pack (200u roundstart)

Using a live human + IV setup would result in twice as much usable blood and total blood alongside it

Shouldn't be too broken and adds some useful interaction for a vampire down on their luck 

Also fixes misused reagent functions from bloodsucker interaction with blood packs & changes all the stupid `user` checks to `target` checks so you don't get blood from feeding other people

# Wiki Documentation

Vamps can now drink from IV blood packs

# Changelog

:cl:  
rscadd: Vampires can now drink from IV blood packs
bugfix: Fixed bloodsuckers not drinking properly from IV blood packs 
/:cl:
