### PR TITLE
fixes a runtime in mood caused by petting hologram animals by removing the mood buff from petting hologram animals

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/pet.dm
+++ b/code/modules/mob/living/simple_animal/friendly/pet.dm
@@ -92,6 +92,8 @@
 		if(M && stat != DEAD)
 			new /obj/effect/temp_visual/heart(loc)
 			emote("me", 1, "yaps happily!", TRUE)
+			if(flags_1 & HOLOGRAM_1)
+				return
 			SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, src, /datum/mood_event/pet_animal, src)
 	else
 		if(M && stat != DEAD)


### PR DESCRIPTION
# Document the changes in your pull request

Go pet real animals you shut-in

fixes #14331

:cl:  
bugfix: you can no longer get your mood permanently stuck by petting animals on the holodeck
rscdel: you can also no longer get a mood buff from petting animals on the holodeck, maybe think about this before killing ian. again.
/:cl:
