### PR TITLE
Animal pet code cleaning + fixes a runtime in mood caused by petting hologram animals by removing the mood buff from petting hologram animals

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -34,6 +34,8 @@
 	collar_type = "cat"
 	can_be_held = TRUE
 	do_footstep = TRUE
+	wuv_happy = "purrs!"
+	wuv_angy = "hisses!"
 
 /mob/living/simple_animal/pet/cat/Initialize()
 	. = ..()
@@ -234,26 +236,6 @@
 			if(movement_target)
 				stop_automated_movement = 1
 				walk_to(src,movement_target,0,3)
-
-/mob/living/simple_animal/pet/cat/attack_hand(mob/living/carbon/human/M)
-	. = ..()
-	switch(M.a_intent)
-		if(INTENT_HELP)
-			wuv(M)
-		if(INTENT_HARM)
-			wuv(M, FALSE)
-
-/mob/living/simple_animal/pet/cat/wuv(mob/M, change = TRUE)
-	if(change)
-		if(M && stat != DEAD)
-			new /obj/effect/temp_visual/heart(loc)
-			emote("me", 1, "purrs!", TRUE)
-			if(flags_1 & HOLOGRAM_1)
-				return
-			SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, src, /datum/mood_event/pet_animal, src)
-	else
-		if(M && stat != DEAD)
-			emote("me", 1, "hisses!", TRUE)
 
 /mob/living/simple_animal/pet/cat/cak //I told you I'd do it, Remie
 	name = "Keeki"

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -22,6 +22,8 @@
 	gold_core_spawnable = FRIENDLY_SPAWN
 	can_be_held = TRUE
 	do_footstep = TRUE
+	wuv_happy = "yaps happily!"
+	wuv_angy = "growls!"
 
 //Corgis and pugs are now under one dog subtype
 

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -680,14 +680,6 @@
 					setDir(i)
 					sleep(0.1 SECONDS)
 
-/mob/living/simple_animal/pet/dog/attack_hand(mob/living/carbon/human/M)
-	. = ..()
-	switch(M.a_intent)
-		if(INTENT_HELP)
-			wuv(M)
-		if(INTENT_HARM)
-			wuv(M, FALSE)
-
 /mob/living/simple_animal/pet/dog/bullterrier
 	name = "\improper bull terrier"
 	real_name = "bull terrier"

--- a/code/modules/mob/living/simple_animal/friendly/fox.dm
+++ b/code/modules/mob/living/simple_animal/friendly/fox.dm
@@ -21,6 +21,8 @@
 	gold_core_spawnable = FRIENDLY_SPAWN
 	can_be_held = TRUE
 	do_footstep = TRUE
+	wuv_happy = "yaps happily!"
+	wuv_angy = "growls!"
 
 //Captain fox
 /mob/living/simple_animal/pet/fox/Renault

--- a/code/modules/mob/living/simple_animal/friendly/fox.dm
+++ b/code/modules/mob/living/simple_animal/friendly/fox.dm
@@ -29,11 +29,3 @@
 	gender = FEMALE
 	gold_core_spawnable = NO_SPAWN
 	unique_pet = TRUE
-
-/mob/living/simple_animal/pet/fox/attack_hand(mob/living/carbon/human/M)
-	. = ..()
-	switch(M.a_intent)
-		if(INTENT_HELP)
-			wuv(M)
-		if(INTENT_HARM)
-			wuv(M, FALSE)

--- a/code/modules/mob/living/simple_animal/friendly/penguin.dm
+++ b/code/modules/mob/living/simple_animal/friendly/penguin.dm
@@ -17,6 +17,8 @@
 	butcher_results = list(/obj/item/organ/ears/penguin = 1, /obj/item/reagent_containers/food/snacks/meat/slab/penguin = 3)
 
 	do_footstep = TRUE
+	wuv_happy = "noots happily!"
+	wuv_angy = "hisses!" //I think birds tend to hiss when they're upset right
 
 /mob/living/simple_animal/pet/penguin/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/friendly/pet.dm
+++ b/code/modules/mob/living/simple_animal/friendly/pet.dm
@@ -7,9 +7,9 @@
 	var/obj/item/clothing/neck/petcollar/pcollar
 	var/collar_type //if the mob has collar sprites, define them.
 	/// wuv emote for being pet
-	var/wuv_happy = "yaps happily!"
+	var/wuv_happy = "looks happy!"
 	/// wuv emote for being slapped
-	var/wuv_angy = "growls!"
+	var/wuv_angy = "looks upset!"
 
 /mob/living/simple_animal/pet/handle_atom_del(atom/A)
 	if(A == pcollar)

--- a/code/modules/mob/living/simple_animal/friendly/pet.dm
+++ b/code/modules/mob/living/simple_animal/friendly/pet.dm
@@ -6,6 +6,10 @@
 	var/unique_pet = FALSE // if the mob can be renamed
 	var/obj/item/clothing/neck/petcollar/pcollar
 	var/collar_type //if the mob has collar sprites, define them.
+	/// wuv emote for being pet
+	var/wuv_happy = "yaps happily!"
+	/// wuv emote for being slapped
+	var/wuv_angy = "growls!"
 
 /mob/living/simple_animal/pet/handle_atom_del(atom/A)
 	if(A == pcollar)
@@ -52,6 +56,14 @@
 	else
 		..()
 
+/mob/living/simple_animal/pet/attack_hand(mob/living/carbon/human/M)
+	. = ..()
+	switch(M.a_intent)
+		if(INTENT_HELP)
+			wuv(M)
+		if(INTENT_HARM)
+			wuv(M, FALSE)
+
 /mob/living/simple_animal/pet/Initialize()
 	. = ..()
 	if(pcollar)
@@ -91,8 +103,10 @@
 	if(change)
 		if(M && stat != DEAD)
 			new /obj/effect/temp_visual/heart(loc)
-			emote("me", 1, "yaps happily!", TRUE)
+			emote("me", 1, wuv_happy, TRUE)
+			if(flags_1 & HOLOGRAM_1)
+				return
 			SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, src, /datum/mood_event/pet_animal, src)
 	else
 		if(M && stat != DEAD)
-			emote("me", 1, "growls!", TRUE)
+			emote("me", 1, wuv_angy, TRUE)


### PR DESCRIPTION
# Document the changes in your pull request

All pets are now pettable, rather than just dogs/cats/etc
repeated code for each pettable animal type is now gone and replaced with a string variable played in the requisite spot

fixes #14331

# Changelog

:cl:  
rscadd: you can now pet several more animals. Probably. Like penguins.
bugfix: you can no longer get your mood permanently stuck by petting animals on the holodeck
rscdel: you can also no longer get a mood buff from petting animals on the holodeck, maybe think about this before killing ian. again.
/:cl:
