### PR TITLE
Adds Arm Laser/Disabler Implants To Illegal Cybernetic Implants Tech Node & Autosurgeons To Uplinks

### DIFF
--- a/code/game/objects/items/storage/briefcase.dm
+++ b/code/game/objects/items/storage/briefcase.dm
@@ -54,3 +54,11 @@
 	..()
 	new /obj/item/autosurgeon/organ/syndicate/syndie_mantis(src)
 	new /obj/item/autosurgeon/organ/syndicate/syndie_mantis/l(src)
+
+/obj/item/storage/briefcase/armguns
+	desc = "A sleek briefcase. It has the brand symbol CYBERSUN on it"
+
+/obj/item/storage/briefcase/syndie_mantis/PopulateContents()
+	..()
+	new /obj/item/autosurgeon/organ/syndicate/laser(src)
+	new /obj/item/autosurgeon/organ/syndicate/disabler/l(src)

--- a/code/game/objects/items/storage/briefcase.dm
+++ b/code/game/objects/items/storage/briefcase.dm
@@ -54,11 +54,3 @@
 	..()
 	new /obj/item/autosurgeon/organ/syndicate/syndie_mantis(src)
 	new /obj/item/autosurgeon/organ/syndicate/syndie_mantis/l(src)
-
-/obj/item/storage/briefcase/armguns
-	desc = "A sleek briefcase. It has the brand symbol CYBERSUN on it"
-
-/obj/item/storage/briefcase/syndie_mantis/PopulateContents()
-	..()
-	new /obj/item/autosurgeon/organ/syndicate/laser(src)
-	new /obj/item/autosurgeon/organ/syndicate/disabler/l(src)

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -14,8 +14,8 @@
 
 /obj/item/ammo_casing/energy/lasergun/mounted
 	projectile_type = /obj/item/projectile/beam/laser/mounted
-	e_cost = 120
-	variance = 10
+	e_cost = 140
+	variance = 15
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/lasergun/old

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -12,6 +12,12 @@
 	e_cost = 83
 	select_name = "kill"
 
+/obj/item/ammo_casing/energy/lasergun/mounted
+	projectile_type = /obj/item/projectile/beam/laser/mounted
+	e_cost = 120
+	variance = 10
+	select_name = "kill"
+
 /obj/item/ammo_casing/energy/lasergun/old
 	projectile_type = /obj/item/projectile/beam/laser
 	e_cost = 200

--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -24,3 +24,6 @@
 
 /obj/item/ammo_casing/energy/disabler/cyborg
 	e_cost = 100
+
+/obj/item/ammo_casing/energy/disabler/cyborg/weak
+	e_cost = 150

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -15,7 +15,8 @@
 	ammo_x_offset = 2
 	var/shaded_charge = FALSE //if this gun uses a stateful charge bar for more detail
 	var/old_ratio = 0 // stores the gun's previous ammo "ratio" to see if it needs an updated icon
-	var/selfcharge = 0
+	var/selfcharge = FALSE
+	var/slowcharge = FALSE //do we charge at half speed?
 	var/charge_tick = 0
 	var/charge_delay = 4
 	var/charge_amount = 1
@@ -65,7 +66,10 @@
 
 /obj/item/gun/energy/process()
 	if(selfcharge && cell && cell.percent() < 100)
-		charge_tick++
+		if(!slowcharge)
+			charge_tick++
+		if(slowcharge)
+			charge_tick += 0.5
 		if(charge_tick < charge_delay)
 			return
 		charge_tick = 0

--- a/code/modules/projectiles/guns/energy/mounted.dm
+++ b/code/modules/projectiles/guns/energy/mounted.dm
@@ -17,9 +17,11 @@
 	desc = "An arm mounted weapon that fires disabler shots."
 	icon = 'icons/obj/items_cyborg.dmi'
 	icon_state = "taser"
-	item_state = "taser"
+	item_state = "armcannonstun4"
+	ammo_type = list(/obj/item/ammo_casing/energy/disabler/cyborg/weak)
 	force = 5
 	selfcharge = 1
+	slowcharge = TRUE
 	can_flashlight = FALSE
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL // Has no trigger at all, uses neural signals instead
 
@@ -43,6 +45,7 @@
 
 /obj/item/gun/energy/laser/mounted/weak
 	ammo_type = list(/obj/item/ammo_casing/energy/lasergun/mounted)
+	slowcharge = TRUE
 
 /obj/item/gun/energy/laser/mounted/weak/dropped()
 	..()

--- a/code/modules/projectiles/guns/energy/mounted.dm
+++ b/code/modules/projectiles/guns/energy/mounted.dm
@@ -3,7 +3,7 @@
 	desc = "An arm mounted dual-mode weapon that fires electrodes and disabler shots."
 	icon = 'icons/obj/items_cyborg.dmi'
 	icon_state = "taser"
-	item_state = "armcannonstun4"
+	item_state = "taser"
 	force = 5
 	selfcharge = 1
 	can_flashlight = FALSE
@@ -12,15 +12,37 @@
 /obj/item/gun/energy/e_gun/advtaser/mounted/dropped()//if somebody manages to drop this somehow...
 	..()
 
+/obj/item/gun/energy/disabler/cyborg/mounted
+	name = "mounted disabler"
+	desc = "An arm mounted weapon that fires disabler shots."
+	icon = 'icons/obj/items_cyborg.dmi'
+	icon_state = "taser"
+	item_state = "taser"
+	force = 5
+	selfcharge = 1
+	can_flashlight = FALSE
+	trigger_guard = TRIGGER_GUARD_ALLOW_ALL // Has no trigger at all, uses neural signals instead
+
+/obj/item/gun/energy/disabler/cyborg/mounted/dropped()//if somebody manages to drop this somehow...
+	..()
+
 /obj/item/gun/energy/laser/mounted
 	name = "mounted laser"
 	desc = "An arm mounted cannon that fires lethal lasers."
 	icon = 'icons/obj/items_cyborg.dmi'
 	icon_state = "laser"
-	item_state = "armcannonlase"
+	item_state = "laser"
+	ammo_type = list(/obj/item/ammo_casing/energy/lasergun)
 	force = 5
 	selfcharge = 1
+	can_charge = FALSE
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
 
 /obj/item/gun/energy/laser/mounted/dropped()
+	..()
+
+/obj/item/gun/energy/laser/mounted/weak
+	ammo_type = list(/obj/item/ammo_casing/energy/lasergun/mounted)
+
+/obj/item/gun/energy/laser/mounted/weak/dropped()
 	..()

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -24,6 +24,11 @@
 	wound_bonus = -30
 	bare_wound_bonus = 40
 
+/obj/item/projectile/beam/laser/mounted //shitty garbage lasers, because it's running off a bad power source.
+	damage = 17
+	wound_bonus = -35
+	bare_wound_bonus = 20
+
 //overclocked laser, does a bit more damage but has much higher wound power (-0 vs -20)
 /obj/item/projectile/beam/laser/hellfire
 	name = "hellfire laser"

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -435,7 +435,7 @@
 
 //armguns
 
-/datum/design/cyberimp_laser
+/*/datum/design/cyberimp_laser //commented out because ""sec printing bad"" - Gus
 	name = "Arm Laser Implant"
 	desc = "A concealed self-recharging low-power laser gun, designed to be installed on the subject's arm."
 	id = "ci-laser"
@@ -456,3 +456,4 @@
 	build_path = /obj/item/organ/cyberimp/arm/gun/disabler
 	category = list("Implants", "Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+*/

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -432,3 +432,27 @@
 	build_path = /obj/item/gun/ballistic/bow/energy
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+//armguns
+
+/datum/design/cyberimp_laser
+	name = "Arm Laser Implant"
+	desc = "A concealed self-recharging low-power laser gun, designed to be installed on the subject's arm."
+	id = "ci-laser"
+	build_type = PROTOLATHE
+	materials = list (/datum/material/iron = 8000, /datum/material/glass = 2000, /datum/material/uranium = 1500, /datum/material/titanium = 2000, /datum/material/silver = 1500)
+	construction_time = 200
+	build_path = /obj/item/organ/cyberimp/arm/gun/laser/weak
+	category = list("Implants", "Weapons")
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
+
+/datum/design/cyberimp_disabler
+	name = "Arm Disabler Implant"
+	desc = "A concealed self-recharging disabler gun, designed to be installed on the subject's arm."
+	id = "ci-disabler"
+	build_type = PROTOLATHE
+	materials = list (/datum/material/iron = 8000, /datum/material/glass = 2000, /datum/material/uranium = 1500, /datum/material/titanium = 2000, /datum/material/silver = 1500)
+	construction_time = 200
+	build_path = /obj/item/organ/cyberimp/arm/gun/disabler
+	category = list("Implants", "Weapons")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -440,7 +440,7 @@
 	desc = "A concealed self-recharging low-power laser gun, designed to be installed on the subject's arm."
 	id = "ci-laser"
 	build_type = PROTOLATHE
-	materials = list (/datum/material/iron = 8000, /datum/material/glass = 2000, /datum/material/uranium = 1500, /datum/material/titanium = 2000, /datum/material/silver = 1500)
+	materials = list (/datum/material/iron = 8000, /datum/material/glass = 2000, /datum/material/uranium = 1500, /datum/material/titanium = 2000, /datum/material/silver = 1500, /datum/material/plastic = 20000)
 	construction_time = 200
 	build_path = /obj/item/organ/cyberimp/arm/gun/laser/weak
 	category = list("Implants", "Weapons")
@@ -451,7 +451,7 @@
 	desc = "A concealed self-recharging disabler gun, designed to be installed on the subject's arm."
 	id = "ci-disabler"
 	build_type = PROTOLATHE
-	materials = list (/datum/material/iron = 8000, /datum/material/glass = 2000, /datum/material/uranium = 1500, /datum/material/titanium = 2000, /datum/material/silver = 1500)
+	materials = list (/datum/material/iron = 8000, /datum/material/glass = 2000, /datum/material/uranium = 1500, /datum/material/titanium = 2000, /datum/material/silver = 1500, /datum/material/plastic = 20000)
 	construction_time = 200
 	build_path = /obj/item/organ/cyberimp/arm/gun/disabler
 	category = list("Implants", "Weapons")

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -573,8 +573,8 @@
 	id = "illegal_cyber_implants"
 	display_name = "Illegal Cybernetic Implants"
 	description = "Nanotrasen would like to remind employees that use of unlicensed cybernetic implants violates multiple employee contract clauses."
-	prereq_ids = list("combat_cyber_implants","syndicate_basic")
-	design_ids = list("ci-xray")
+	prereq_ids = list("adv_weaponry", "combat_cyber_implants","syndicate_basic")
+	design_ids = list("ci-xray", "ci-laser", "ci-disabler")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	export_price = 5000
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -573,7 +573,7 @@
 	id = "illegal_cyber_implants"
 	display_name = "Illegal Cybernetic Implants"
 	description = "Nanotrasen would like to remind employees that use of unlicensed cybernetic implants violates multiple employee contract clauses."
-	prereq_ids = list("adv_weaponry", "combat_cyber_implants","syndicate_basic")
+	prereq_ids = list("mech_disabler", "mech_laser_heavy", "combat_cyber_implants","syndicate_basic", )
 	design_ids = list("ci-xray", "ci-laser", "ci-disabler")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	export_price = 5000

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -574,7 +574,8 @@
 	display_name = "Illegal Cybernetic Implants"
 	description = "Nanotrasen would like to remind employees that use of unlicensed cybernetic implants violates multiple employee contract clauses."
 	prereq_ids = list("mech_disabler", "mech_laser_heavy", "combat_cyber_implants","syndicate_basic", )
-	design_ids = list("ci-xray", "ci-laser", "ci-disabler")
+	//design_ids = list("ci-xray", "ci-laser", "ci-disabler")  //commented out because ""sec printing bad"" - Gus
+	design_ids = list("ci-xray") 
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	export_price = 5000
 

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -145,7 +145,7 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	if(prob(30/severity) && owner && (organ_flags & ORGAN_FAILING))
+	if(owner)
 		Retract()
 		owner.visible_message(span_danger("A loud bang comes from [owner]\'s [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm!"))
 		playsound(get_turf(owner), 'sound/weapons/flashbang.ogg', 100, 1)
@@ -161,6 +161,7 @@
 	desc = "An arm cannon implant that fires lethal laser beams. The cannon emerges from the subject's arm and remains inside when not in use. Has a non-replacible self-charging power cell."
 	icon_state = "arm_laser"
 	contents = newlist(/obj/item/gun/energy/laser/mounted)
+	syndicate_implant = TRUE
 
 /obj/item/organ/cyberimp/arm/gun/laser/l
 	zone = BODY_ZONE_L_ARM
@@ -179,6 +180,7 @@
 	desc = "A variant of the arm cannon implant that fires electrodes and disabler shots. The cannon emerges from the subject's arm and remains inside when not in use. Has a non-replacible self-charging power cell."
 	icon_state = "arm_taser"
 	contents = newlist(/obj/item/gun/energy/e_gun/advtaser/mounted)
+	syndicate_implant = TRUE
 
 /obj/item/organ/cyberimp/arm/gun/taser/l
 	zone = BODY_ZONE_L_ARM
@@ -188,6 +190,7 @@
 	desc = "A variant of the arm laser implant that fires disabler shots. The laser emerges from the subject's arm and remains inside when not in use. Has a non-replacible self-charging power cell."
 	icon_state = "arm_taser"
 	contents = newlist(/obj/item/gun/energy/disabler/cyborg/mounted)
+	syndicate_implant = TRUE
 
 /obj/item/organ/cyberimp/arm/gun/disabler/l
 	zone = BODY_ZONE_L_ARM

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -158,21 +158,38 @@
 
 /obj/item/organ/cyberimp/arm/gun/laser
 	name = "arm-mounted laser implant"
-	desc = "A variant of the arm cannon implant that fires lethal laser beams. The cannon emerges from the subject's arm and remains inside when not in use."
+	desc = "An arm cannon implant that fires lethal laser beams. The cannon emerges from the subject's arm and remains inside when not in use. Has a non-replacible self-charging power cell."
 	icon_state = "arm_laser"
 	contents = newlist(/obj/item/gun/energy/laser/mounted)
 
 /obj/item/organ/cyberimp/arm/gun/laser/l
 	zone = BODY_ZONE_L_ARM
 
+/obj/item/organ/cyberimp/arm/gun/laser/weak
+	name = "arm-mounted laser implant"
+	desc = "An arm laser implant that fires lethal laser beams. The laser emerges from the subject's arm and remains inside when not in use. Has a low quality non-replacible self-charging power cell."
+	icon_state = "arm_laser"
+	contents = newlist(/obj/item/gun/energy/laser/mounted/weak)
+
+/obj/item/organ/cyberimp/arm/gun/laser/weak/l
+	zone = BODY_ZONE_L_ARM
 
 /obj/item/organ/cyberimp/arm/gun/taser
-	name = "arm-mounted taser implant"
-	desc = "A variant of the arm cannon implant that fires electrodes and disabler shots. The cannon emerges from the subject's arm and remains inside when not in use."
+	name = "arm-mounted disabler implant"
+	desc = "A variant of the arm cannon implant that fires electrodes and disabler shots. The cannon emerges from the subject's arm and remains inside when not in use. Has a non-replacible self-charging power cell."
 	icon_state = "arm_taser"
 	contents = newlist(/obj/item/gun/energy/e_gun/advtaser/mounted)
 
 /obj/item/organ/cyberimp/arm/gun/taser/l
+	zone = BODY_ZONE_L_ARM
+
+/obj/item/organ/cyberimp/arm/gun/disabler
+	name = "arm-mounted disabler implant"
+	desc = "A variant of the arm laser implant that fires disabler shots. The laser emerges from the subject's arm and remains inside when not in use. Has a non-replacible self-charging power cell."
+	icon_state = "arm_taser"
+	contents = newlist(/obj/item/gun/energy/disabler/cyborg/mounted)
+
+/obj/item/organ/cyberimp/arm/gun/disabler/l
 	zone = BODY_ZONE_L_ARM
 
 /obj/item/organ/cyberimp/arm/toolset

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -147,7 +147,7 @@
 		return
 	if(owner)
 		Retract()
-		owner.visible_message(span_danger("A loud bang comes from [owner]\'s [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm!"))
+		owner.visible_message(span_danger("A loud bang comes from [owner]'s [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm!"))
 		playsound(get_turf(owner), 'sound/weapons/flashbang.ogg', 100, 1)
 		to_chat(owner, span_userdanger("You feel an explosion erupt inside your [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm as your implant breaks!"))
 		owner.adjust_fire_stacks(20)

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -99,6 +99,22 @@
 	uses = 1
 	starting_organ = /obj/item/organ/cyberimp/arm/medibeam
 
+/obj/item/autosurgeon/organ/syndicate/laser
+	uses = 1
+	starting_organ = /obj/item/organ/cyberimp/arm/gun/laser/weak
+
+/obj/item/autosurgeon/organ/syndicate/laser/l
+	uses = 1
+	starting_organ = /obj/item/organ/cyberimp/arm/gun/laser/weak/l
+
+/obj/item/autosurgeon/organ/syndicate/disabler
+	uses = 1
+	starting_organ = /obj/item/organ/cyberimp/arm/gun/disabler
+
+/obj/item/autosurgeon/organ/syndicate/disabler/l
+	uses = 1
+	starting_organ = /obj/item/organ/cyberimp/arm/gun/disabler/l
+
 /obj/item/autosurgeon/organ/syndicate/syndie_mantis
 	uses = 1
 	starting_organ = /obj/item/organ/cyberimp/arm/syndie_mantis

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1815,14 +1815,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	surplus = 0
 	exclude_modes = list(/datum/game_mode/infiltration) // yogs: infiltration
 
-/datum/uplink_item/implants/armgunkit
-	name = "Cybersun Arm Cannon Kit"
-	desc = "A special kit of Cybersun's new Arm Laser and Arm Disabler implants, ready to go. All packaged with autosurgeons."
-	item = /obj/item/storage/briefcase/armguns
-	cost = 30
-	surplus = 0
-	include_modes = list(/datum/game_mode/nuclear) // yogs: infiltration
-
 /datum/uplink_item/implants/laser
 	name = "Arm Laser Implant (Right Arm)"
 	desc = "A laser gun built into an internal implant that both charges it and conceals it from view, but not from external scans. Comes with an autosurgeon."

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1815,6 +1815,40 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	surplus = 0
 	exclude_modes = list(/datum/game_mode/infiltration) // yogs: infiltration
 
+/datum/uplink_item/implants/armgunkit
+	name = "Cybersun Arm Cannon Kit"
+	desc = "A special kit of Cybersun's new Arm Laser and Arm Disabler implants, ready to go. All packaged with autosurgeons."
+	item = /obj/item/storage/briefcase/armguns
+	cost = 30
+	surplus = 0
+	include_modes = list(/datum/game_mode/nuclear) // yogs: infiltration
+
+/datum/uplink_item/implants/laser
+	name = "Arm Laser Implant (Right Arm)"
+	desc = "A laser gun built into an internal implant that both charges it and conceals it from view, but not from external scans. Comes with an autosurgeon."
+	item = /obj/item/autosurgeon/organ/syndicate/laser
+	cost = 16
+	surplus = 0
+	exclude_modes = list(/datum/game_mode/infiltration) // yogs: infiltration
+	manufacturer = /datum/corporation/traitor/cybersun
+
+/datum/uplink_item/implants/laser/l
+	name = "Arm Laser Implant (Left Arm)"
+	item = /obj/item/autosurgeon/organ/syndicate/laser/l
+
+/datum/uplink_item/implants/disabler
+	name = "Arm Disabler Implant (Right Arm)"
+	desc = "A laser gun built into an internal implant that both charges it and conceals it from view, but not from external scans. Comes with an autosurgeon."
+	item = /obj/item/autosurgeon/organ/syndicate/disabler
+	cost = 14
+	surplus = 0
+	manufacturer = /datum/corporation/traitor/cybersun
+
+/datum/uplink_item/implants/disabler/l
+	name = "Arm Disabler Implant (Left Arm)"
+	item = /obj/item/autosurgeon/organ/syndicate/disabler/l
+
+
 // Events
 /datum/uplink_item/services
 	category = "Services"


### PR DESCRIPTION
# Document the changes in your pull request

Adds subtypes of the inaccessible arm-laser and a new arm-disabler implant; the arm laser doing less damage than normal and being less accurate, while the disabler is the cyborg variant using a different sprite

adds individual autosurgeons to the uplink for all, but excludes infils from getting the lethal laser implant. (16Tc lasers, 14tc disablers)

- [x] dial in # of shots for the laser
- [x] make them invisible to health analyzers
- [x] make them both self-charge slower
- [x] make the arm-gun EMP act not chance based

# Why is this good for the game?

Because it's an interesting thing for traitors to maybe buy and use, but also if illegal tech gets researched ever, sec *could* print off these implants and have them implanted in themselves. While this may seem alarmingly bad, they do less damage than normal lasers; and the disabler has less shots. Additionally getting EMPed with one of these royally fucks you up, and instantly sets you on fire as well as deals some burn damage at the same time.

# Wiki Documentation

might need addition to anything that lists uplink items, and also will need to be added to the protolathe item list under the security protolathe (disabler) and armor lathe (laser), behind Illegal Cybernetic Implants tech.

# Changelog

:cl:  
rscadd: Adds Laser/Disabler Arm Implants to the uplink, and adds them to the Illegal Cybernetic Implants tech node. 
/:cl:
