### PR TITLE
Disabler Nerf Attempt #2

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -83,7 +83,7 @@
 /obj/item/projectile/beam/disabler
 	name = "disabler beam"
 	icon_state = "omnilaser"
-	damage = 30
+	damage = 25
 	damage_type = STAMINA
 	flag = ENERGY
 	hitsound = 'sound/weapons/tap.ogg'


### PR DESCRIPTION
# Document the changes in your pull request

Reduces the damage of the disabler considering security is getting a lot of other toys and gadgets and theoretically less-lethals should maybe be getting more buffs down the line (rubber pellets even better, mayhaps).

Plus the thing has TWENTY SHOTS. You can use an ebola or something else there are COUNTLESS other options and disabler doing more damage than a laser is still good.

"Why don't I just use a laser" my guy you are security it is your job to detain stop being so unrobust and learn to aim you LITERALLY get a shield on your belt you can just use a baton if you have to, they're still good. Sec has been in one of the best spots it's been in a while I would like to see antags get to exist

Only thing is that it makes armor actually matter more lmao

# Wiki Documentation

Disabler beam now does 25, instead of 30. Most relevant for disabler and egun.

# Changelog

:cl:  
tweak: Disabler beam does 25 stamina instead of 30
/:cl:
