### PR TITLE
Atmos firesuit can now be ordered from cargo

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -756,6 +756,20 @@
 					/obj/item/paper/guides/conveyor)
 	crate_name = "conveyor assembly crate"
 
+/datum/supply_pack/engineering/atmos/fire
+	name = "Advanced Atmos Firesuit Crate"
+	desc = "Contains 4 atmos firesuits"
+	cost = 2000
+	contains = list(/obj/item/clothing/suit/fire/atmos,
+					/obj/item/clothing/suit/fire/atmos,
+					/obj/item/clothing/suit/fire/atmos,
+					/obj/item/clothing/suit/fire/atmos,
+					/obj/item/clothing/head/hardhat/atmos,
+					/obj/item/clothing/head/hardhat/atmos,
+					/obj/item/clothing/head/hardhat/atmos,
+					/obj/item/clothing/head/hardhat/atmos)
+	crate_name = "advanced atmos firesuit crate"
+
 /datum/supply_pack/engineering/engiequipment
 	name = "Engineering Gear Crate"
 	desc = "Gear up with three toolbelts, high-visibility vests, welding goggles, hardhats, and two pairs of meson goggles!"


### PR DESCRIPTION
# About PR
Should be able to order them, its basically emergency firesuit but better 

# Wiki Documentation
Atmos firesuit can be ordered from cargo

# Changelog



:cl:  
tweak: Atmos firesuit can be ordered from cargo  
/:cl:
