### PR TITLE
Makes it so the tracking revolver can only be acquired through cargo.

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -336,7 +336,7 @@
 
 /datum/supply_pack/security/caldwell
 	name = "Tracking Revolver Crate"
-	desc = "Contains one Caldwell Tracking Revolver and a spare clip."
+	desc = "Contains one Caldwell Tracking Revolver and a spare clip. Requires Security access to open."
 	cost = 5000
 	contains = list(
 		/obj/item/gun/ballistic/revolver/tracking,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -334,6 +334,15 @@
 					/obj/item/gun/energy/laser)
 	crate_name = "laser crate"
 
+/datum/supply_pack/security/caldwell
+	name = "Tracking Revolver Crate"
+	desc = "Contains one Caldwell Tracking Revolver and a spare clip."
+	cost = 5000
+	contains = list(
+		/obj/item/gun/ballistic/revolver/tracking,
+		/obj/item/ammo_box/tra32)
+	crate_name = "tracking revolver crate"
+
 /datum/supply_pack/security/securitybarriers
 	name = "Security Barrier Grenades"
 	desc = "Stem the tide with four Security Barrier grenades. Requires Security access to open."

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -39,26 +39,6 @@
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
 
-/datum/design/tracrevolver
-	name = "Caldwell Tracking Revolver"
-	desc = "A modified autorevolver initially designed by colonists on hostile worlds, now utilized by security personnel. Uses .32 TRAC ammo."
-	id = "tracrevolver"
-	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 10000, /datum/material/silver = 3000, /datum/material/titanium = 2000)
-	build_path = /obj/item/gun/ballistic/revolver/tracking
-	category = list("Weapons")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
-
-/datum/design/tra32
-	name = "Speed Loader (.32 TRAC)"
-	desc = "Designed to quickly reload revolvers. TRAC bullets embed a tracking implant."
-	id = "tra32"
-	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 20000, /datum/material/silver = 5000, /datum/material/gold = 1000)
-	build_path = /obj/item/ammo_box/tra32
-	category = list("Ammo")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
-
 /datum/design/rubbershot/sec
 	id = "sec_rshot"
 	build_type = PROTOLATHE

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -520,7 +520,7 @@
 	display_name = "Subdermal Implants"
 	description = "Electronic implants buried beneath the skin."
 	prereq_ids = list("biotech")
-	design_ids = list("implanter", "implantcase", "implant_chem", "implant_tracking", "locator", "pinpointer_tracker", "tra32", "tracrevolver")
+	design_ids = list("implanter", "implantcase", "implant_chem", "implant_tracking", "locator", "pinpointer_tracker")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 


### PR DESCRIPTION

# Document the changes in your pull request

Removes the Caldwell Tracking revolver from RnD. It is now only acquirable via cargo.

I have only used the Caldwell AS sec, not faced it as an antag, but from my experiences as sec it makes any kind of evasion by traitors, heretics, changelings, and other solo/nearly solo antags nearly pointless because a single hit from the Caldwell gives you the ability to track the person anywhere on the station. This makes it better than any other security weapon, because even a buckshot blast to the face at point blank is less likely to roundend an antag than the Caldwell is, since if you buckshot somebody they at least have the chance to teleport away.

An example:
Yesterday I was the HoS and I was fighting a chemist who had a seemingly infinite amount of teleports. It didn't matter what I did to him, he'd always escape and heal up. So, I shot him ONCE with the Caldwell, and suddenly I was able to know where he was at all times. The Chemist's infinite teleports couldn't save them, the AI deliberately giving me false information so I wouldn't harm them couldn't save them, they were just screwed because no matter what they did I would find them instantly and be there to start shooting them again.

A weapon which with a single shot is a 90% guarantee security will catch the baddie they shoot it with shouldn't be able to be acquired by just PDAing your local scientist "Hey can you grab Subdermal Implants please?"

Subdermal Implants, which is the technology that the Caldwell is inside of, costs 2500 points. Biological Technology, the only requirement for Subdermal Implants will likely get researched early into the round anyways.

On the other hand, other powerful security weapons, such as the Advanced Energy Gun or X-Ray Laser Gun require 20,000 Points of weapons technology to be researched beforehand. Meanwhile the Caldwell is way stronger than both of those because they can't track your target across the station.

The Caldwell being a cargo-only item doesn't completely remove it from the game, but instead makes getting your hands on one slightly more difficult then PDAing a scientist.

I've priced the Caldwell about 1000 points below the single pack for the combat shotgun because it's a ridiculously powerful weapon that is arguably on par or stronger than the combat shotgun.

Tech stuff:

crate costs 5000
is in the security tab
I assume that means it requires security access to open
contains: 1x Caldwell Revolver, 1x Quickloader for Caldwell

Mention if you have tested your changes. 

Crate is orderable and contains a working revolver.
Did not test removing it from lathe and RnD but I assume removing those portions from the original Caldwell PR should work fine to remove them.

# Wiki Documentation

Removes the Caldwell from subdermal implants. (Not there anyway on the wiki, fail)
Adds a new crate.

# Changelog

:cl:  
rscdel: Removed the Caldwell Tracking Revolver from RnD and the Seclathe
rscadd: Added a new crate to cargo for 5000 containing a Caldwell Tracking Revolver and spare ammo
/:cl:
