### PR TITLE
Replaces supermatter crate with supermatter beacon

### DIFF
--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -63,6 +63,16 @@
 
 	new /obj/effect/DPtarget(get_turf(src), pod)
 
+/obj/item/choice_beacon/supermatter
+	name = "Supermatter Kit"
+	desc = "Kit containing a supermatter shard."
+	icon = 'icons/obj/device.dmi'
+	icon_state = "gangtool-blue"
+	item_state = "radio"
+
+/obj/item/choice_beacon/supermatter/generate_display_names()
+	return list("Supermatter Shard" = /obj/machinery/power/supermatter_crystal/shard)
+
 /obj/item/choice_beacon/hero
 	name = "heroic beacon"
 	desc = "To summon heroes from the past to protect the future."

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1018,7 +1018,7 @@
 	desc = "The power of the heavens condensed into a single crystal. Requires CE access to open."
 	cost = 10000
 	access = ACCESS_CE
-	contains = list(/obj/machinery/power/supermatter_crystal/shard)
+	contains = list(/obj/item/choice_beacon/supermatter)
 	crate_name = "supermatter shard crate"
 	crate_type = /obj/structure/closet/crate/secure/engineering
 	dangerous = TRUE


### PR DESCRIPTION
# Document the changes in your pull request

prevents crate from self consuming along with being a *bit* more convenient when setting up some setups

~~also abuses choice beacon as a confirm choice~~

# Changelog

:cl:  
tweak: Replaces supermatter crate with supermatter beacon
/:cl:
