### PR TITLE
Makes stasis bed sped up shutdown/startup reflect on sprite

### DIFF
--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -118,7 +118,7 @@
 		if(mattress_on.alpha ? !_running : _running) //check the inverse of _running compared to truthy alpha, to see if they differ
 			var/new_alpha = _running ? 255 : 0
 			var/easing_direction = _running ? EASE_OUT : EASE_IN
-			animate(mattress_on, alpha = new_alpha, time = 5 SECONDS, easing = CUBIC_EASING|easing_direction)
+			animate(mattress_on, alpha = new_alpha, time = stasis_cooldown, easing = CUBIC_EASING|easing_direction)
 
 		overlays_to_remove = managed_vis_overlays - mattress_on
 


### PR DESCRIPTION
# Document the changes in your pull request

Previously the shutdown/startup animation would still take 5 seconds, and you could start it back up before the animation was over

This lets users know that it's off and can be restarted sooner than normal

# Changelog

:cl:  
tweak: Stasis bed now visually shuts down and starts up faster to reflect its better parts
/:cl:
