### PR TITLE
Lesser Mining Charge buff and moves them to the Explorer Belt Voucher

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -372,7 +372,10 @@
 
 
 /obj/item/storage/belt/mining/vendor
-	contents = newlist(/obj/item/survivalcapsule)
+	contents = newlist(/obj/item/survivalcapsule,
+	/obj/item/grenade/plastic/miningcharge/lesser,
+	/obj/item/grenade/plastic/miningcharge/lesser,
+	/obj/item/grenade/plastic/miningcharge/lesser,)
 
 /obj/item/storage/belt/mining/alt
 	icon_state = "explorer2"

--- a/code/modules/mining/equipment/mining_charges.dm
+++ b/code/modules/mining/equipment/mining_charges.dm
@@ -95,7 +95,7 @@
 	name = "lesser mining charge"
 	desc = "A mining charge. This one seems less powerful than normal. Only works on rocks!"
 	icon_state = "mining-charge-1"
-	boom_sizes = list(1,1,1)
+	boom_sizes = list(1,2,3)
 
 /obj/item/grenade/plastic/miningcharge/mega
 	name = "mega mining charge"
@@ -103,6 +103,3 @@
 	icon_state = "mining-charge-3"
 	boom_sizes = list(2,4,7)
 
-/obj/item/storage/backpack/duffelbag/miningcharges/PopulateContents()
-	for(var/i in 1 to 3)
-		new /obj/item/grenade/plastic/miningcharge/lesser(src)

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -188,13 +188,12 @@
 
 /obj/machinery/mineral/equipment_vendor/proc/RedeemVoucher(obj/item/mining_voucher/voucher, mob/redeemer)
 	var/items = list(
-		"Survival Capsule and Explorer's Webbing" = image(icon = 'icons/obj/clothing/belts.dmi', icon_state = "explorer1"),
+		"Explorer's Kit" = image(icon = 'icons/obj/clothing/belts.dmi', icon_state = "explorer1"),
 		"Resonator Kit" = image(icon = 'icons/obj/mining.dmi', icon_state = "resonator"),
 		"Minebot Kit" = image(icon = 'icons/mob/aibots.dmi', icon_state = "mining_drone"),
 		"Extraction and Rescue Kit" = image(icon = 'icons/obj/fulton.dmi', icon_state = "extraction_pack"),
 		"Crusher Kit" = image(icon = 'icons/obj/mining.dmi', icon_state = "mining_hammer1"),
-		"Mining Conscription Kit" = image(icon = 'icons/obj/storage.dmi', icon_state = "duffel"),
-		"Bag of Lesser Mining Charges" = image(icon= 'icons/obj/mining.dmi',icon_state = "mining-charge-1")
+		"Mining Conscription Kit" = image(icon = 'icons/obj/storage.dmi', icon_state = "duffel")
 		)
 
 	items = sortList(items)
@@ -204,7 +203,7 @@
 
 	var/drop_location = drop_location()
 	switch(selection)
-		if("Survival Capsule and Explorer's Webbing")
+		if("Explorer's Kit")
 			new /obj/item/storage/belt/mining/vendor(drop_location)
 		if("Resonator Kit")
 			new /obj/item/extinguisher/mini(drop_location)
@@ -223,8 +222,6 @@
 			new /obj/item/twohanded/required/kinetic_crusher(drop_location)
 		if("Mining Conscription Kit")
 			new /obj/item/storage/backpack/duffelbag/mining_conscript(drop_location)
-		if("Bag of Lesser Mining Charges")
-			new /obj/item/storage/backpack/duffelbag/miningcharges(drop_location)
 
 	SSblackbox.record_feedback("tally", "mining_voucher_redeemed", 1, selection)
 	qdel(voucher)
@@ -338,8 +335,7 @@
 		"Resonator Kit" = image(icon = 'icons/obj/mining.dmi', icon_state = "resonator"),
 		"Minebot Kit" = image(icon = 'icons/mob/aibots.dmi', icon_state = "mining_drone"),
 		"Crusher Kit" = image(icon = 'icons/obj/mining.dmi', icon_state = "mining_hammer1"),
-		"Advanced Scanner" = image(icon = 'icons/obj/device.dmi', icon_state = "adv_mining0"),
-		"Bag of Lesser Mining Charges" = image(icon= 'icons/obj/mining.dmi', icon_state = "mining-charge-1")
+		"Advanced Scanner" = image(icon = 'icons/obj/device.dmi', icon_state = "adv_mining0")
 		)
 
 	items = sortList(items)
@@ -364,8 +360,6 @@
 			new /obj/item/twohanded/required/kinetic_crusher(drop_location)
 		if("Advanced Scanner")
 			new /obj/item/t_scanner/adv_mining_scanner(drop_location)
-		if("Bag of Lesser Mining Charges")
-			new /obj/item/storage/backpack/duffelbag/miningcharges(drop_location)
 
 
 	SSblackbox.record_feedback("tally", "mining_voucher_redeemed", 1, selection)


### PR DESCRIPTION
Kaboom goes the belt miner as the crusher miner mines precariously into the distance.

# Document the changes in your pull request

Buffs the lesser charges boom radius to a size more acceptable than a cross. Removes the mining charge duffel bag and puts them inside the Survival Capsule and Explorer Belt kit then renamed it to the Explorer's Kit.

It works and has been tested.

The lesser mining charges used to have a boom radius with the grand total size of 5 rocks destroyed on maximum, even with the added ore bonus it and the regular mining charges just had too big of a gap to the point where it was more efficient to mass print regular mining charges that would get researched by sci 8 minutes into the round after your first ore deposit than even buy the lesser ones using points. Making them more worthwhile by being bundled into the explorer belt would hopefully be a nice buff for it and the belt itself for any miner who buys them.

# Wiki Documentation

The Mining Charge Duffel doesn't exist anymore. 
The Survival Capsule and Explorer's Belt voucher option has been renamed to the Explorer's Kit

# Changelog

:cl:  
tweak: Renamed the Survival Capsule and Explorer's Webbing to Explorer's Kit
rscadd: Adds lesser mining charges to the Explorer's Kit  
rscdel: Removed Bag of Lesser Mining Charges and all traces from the vending machine
tweak: Buffs lesser mining charge boom radius from 1,1,1 to 1,2,3 
/:cl:
