### PR TITLE
Removes DNA & ID locking mechs

### DIFF
--- a/code/game/mecha/combat/honker.dm
+++ b/code/game/mecha/combat/honker.dm
@@ -12,7 +12,6 @@
 	operation_req_access = list(ACCESS_THEATRE)
 	internals_req_access = list(ACCESS_MECH_SCIENCE, ACCESS_THEATRE)
 	wreckage = /obj/structure/mecha_wreckage/honker
-	add_req_access = 0
 	max_equip = 3
 	var/squeak = 0
 

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -12,7 +12,6 @@
 	operation_req_access = list(ACCESS_CENT_SPECOPS)
 	internals_req_access = list(ACCESS_CENT_SPECOPS)
 	wreckage = /obj/structure/mecha_wreckage/marauder
-	add_req_access = 0
 	internal_damage_threshold = 25
 	force = 45
 	max_equip = 4

--- a/code/game/mecha/combat/phazon.dm
+++ b/code/game/mecha/combat/phazon.dm
@@ -11,7 +11,6 @@
 	max_temperature = 25000
 	infra_luminosity = 3
 	wreckage = /obj/structure/mecha_wreckage/phazon
-	add_req_access = 1
 	internal_damage_threshold = 25
 	force = 15
 	max_equip = 3

--- a/code/game/mecha/combat/reticence.dm
+++ b/code/game/mecha/combat/reticence.dm
@@ -11,7 +11,6 @@
 	wreckage = /obj/structure/mecha_wreckage/reticence
 	operation_req_access = list(ACCESS_THEATRE)
 	internals_req_access = list(ACCESS_MECH_SCIENCE, ACCESS_THEATRE)
-	add_req_access = 0
 	internal_damage_threshold = 25
 	max_equip = 2
 	step_energy_drain = 3

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -43,7 +43,6 @@
 	var/obj/item/stock_parts/capacitor/capacitor ///Keeps track of the mech's capacitor
 	var/state = 0
 	var/last_message = 0
-	var/add_req_access = 1
 	var/maint_access = FALSE
 	var/dna_lock //dna-locking the mech
 	var/list/proc_res = list() //stores proc owners, like proc_res["functionname"] = owner reference

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -195,7 +195,7 @@
 		return
 
 	if(W.GetID())
-		if(add_req_access || maint_access)
+		if(maint_access)
 			if(internals_access_allowed(user))
 				var/obj/item/card/id/id_card
 				if(istype(W, /obj/item/card/id))


### PR DESCRIPTION
# Document the changes in your pull request

Removes the ability for players to change DNA/ID lock. It still exists for purposes of syndie mechs and other special mechs, but players cannot set them.

## Rationale

Mechs are strong, there is no denying that

In the right hands, a mech can be devestating to an entire unprepared station, especially if security's EMP tooling is targeted early

With the DNA/ID lock currently, a player can create a mech and simply forget about it until they need to use it, indefinitely declaring it their own, and have absolutely no risks to creating this weapon of mass destruction

This creates the risk of players having to watch over their weaponry, lest it be used against them, in a similar fashion to any other weapon in the game

Leaving your mech will leave you even more vulnerable than before, forcing you to either deal with the consequences of living inside a mech permanently (move slow as hell, not be able to interact with any items directly, not being able to repair it with a welding tool) or risk it being hijacked and turned against you

I believe this creates an interesting risk dynamic and opens up great opportunities to turn the tide of battle for both antagonists and security

It also encourages roboticists to hand over their weapons to those who are more able to protect it, like **security**

##

**Protect the weapon you have created, or face the consequences**

# Changelog

:cl:  
rscdel: Removed DNA/ID locking mechs
/:cl:
