### PR TITLE
Replace roundstart PDA (2010) with PDA (2021)

### DIFF
--- a/code/modules/clothing/outfits/plasmaman.dm
+++ b/code/modules/clothing/outfits/plasmaman.dm
@@ -3,7 +3,7 @@
 	
 	jobtype = /datum/job/bartender
 
-	pda_type = /obj/item/pda/bar
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
@@ -20,7 +20,7 @@
 	
 	jobtype = /datum/job/cook
 
-	pda_type = /obj/item/pda/cook
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
@@ -35,7 +35,7 @@
 	
 	jobtype = /datum/job/hydro
 
-	pda_type = /obj/item/pda/botanist
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/blue
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
@@ -54,7 +54,7 @@
 	
 	jobtype = /datum/job/curator
 
-	pda_type = /obj/item/pda/curator
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/curator
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
@@ -72,7 +72,7 @@
 	
 	jobtype = /datum/job/chaplain
 
-	pda_type = /obj/item/pda/chaplain
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
@@ -88,7 +88,7 @@
 	
 	jobtype = /datum/job/janitor
 
-	pda_type = /obj/item/pda/janitor
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
@@ -103,7 +103,7 @@
 	
 	jobtype = /datum/job/officer
 
-	pda_type = /obj/item/pda/security
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/security
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
@@ -126,7 +126,7 @@
 	
 	jobtype = /datum/job/detective
 
-	pda_type = /obj/item/pda/detective
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
@@ -145,7 +145,7 @@
 	
 	jobtype = /datum/job/warden
 
-	pda_type = /obj/item/pda/warden
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/security
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
@@ -170,7 +170,7 @@
 	
 	jobtype = /datum/job/cargo_tech
 
-	pda_type = /obj/item/pda/cargo
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
@@ -185,7 +185,7 @@
 	
 	jobtype = /datum/job/qm
 
-	pda_type = /obj/item/pda/quartermaster
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
@@ -202,7 +202,7 @@
 	
 	jobtype = /datum/job/mining
 
-	pda_type = /obj/item/pda/shaftminer
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
@@ -224,7 +224,7 @@
 	
 	jobtype = /datum/job/lawyer
 
-	pda_type = /obj/item/pda/lawyer
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
@@ -246,7 +246,7 @@
 	
 	jobtype = /datum/job/doctor
 
-	pda_type = /obj/item/pda/medical
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/blue
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
@@ -266,7 +266,7 @@
 	
 	jobtype = /datum/job/virologist
 
-	pda_type = /obj/item/pda/viro
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/viro
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
@@ -286,7 +286,7 @@
 	
 	jobtype = /datum/job/chemist
 
-	pda_type = /obj/item/pda/chemist
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/blue
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
@@ -306,7 +306,7 @@
 	
 	jobtype = /datum/job/geneticist
 
-	pda_type = /obj/item/pda/geneticist
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/blue
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
@@ -328,7 +328,7 @@
 	
 	jobtype = /datum/job/scientist
 
-	pda_type = /obj/item/pda/toxins
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
@@ -346,7 +346,7 @@
 	
 	jobtype = /datum/job/roboticist
 
-	pda_type = /obj/item/pda/roboticist
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
@@ -366,7 +366,7 @@
 	
 	jobtype = /datum/job/engineer
 
-	pda_type = /obj/item/pda/engineering
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/engineering
 	uniform = /obj/item/clothing/under/plasmaman/engineering
@@ -388,7 +388,7 @@
 	
 	jobtype = /datum/job/atmos
 
-	pda_type = /obj/item/pda/atmos
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic/atmos
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/engineering
 	uniform = /obj/item/clothing/under/plasmaman/atmospherics
@@ -409,7 +409,7 @@
 	
 	jobtype = /datum/job/mime
 
-	pda_type = /obj/item/pda/mime
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/mime
 	uniform = /obj/item/clothing/under/plasmaman/mime
@@ -427,7 +427,7 @@
 	
 	jobtype = /datum/job/clown
 
-	pda_type = /obj/item/pda/clown
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic/clown
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/clown
 	uniform = /obj/item/clothing/under/plasmaman/clown
@@ -446,7 +446,7 @@
 	
 	jobtype = /datum/job/network_admin
 
-	pda_type = /obj/item/pda/network_admin
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/engineering
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
@@ -495,7 +495,7 @@
 	
 	jobtype = /datum/job/paramedic
 
-	pda_type = /obj/item/pda/para
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/blue
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
@@ -534,7 +534,7 @@
 	
 	jobtype = /datum/job/brigphysician
 
-	pda_type = /obj/item/pda/physician
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/blue
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
@@ -602,7 +602,7 @@
 	jobtype = /datum/job/artist
 
 	id_type = /obj/item/card/id/silver
-	pda_type = /obj/item/pda/artist
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
@@ -621,7 +621,7 @@
 	jobtype = /datum/job/chief_engineer
 
 	id_type = /obj/item/card/id/silver
-	pda_type = /obj/item/pda/heads/ce
+	pda_type = /obj/item/modular_computer/tablet/phone/preset/advanced/command/atmos
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/engineering
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
@@ -642,7 +642,7 @@
 	jobtype = /datum/job/rd
 
 	id_type = /obj/item/card/id/silver
-	pda_type = /obj/item/pda/heads/rd
+	pda_type = /obj/item/modular_computer/tablet/phone/preset/advanced/command
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -195,7 +195,7 @@
 	box = /obj/item/storage/box/survival
 
 	var/obj/item/id_type = /obj/item/card/id
-	var/obj/item/pda_type = /obj/item/pda
+	var/obj/item/pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 	var/backpack = /obj/item/storage/backpack
 	var/satchel  = /obj/item/storage/backpack/satchel
 	var/duffelbag = /obj/item/storage/backpack/duffelbag
@@ -263,14 +263,8 @@
 				break
 		H.sec_hud_set_ID()
 
-	var/obj/item/pda/PDA = new pda_type()
+	var/obj/item/modular_computer/tablet/PDA = new pda_type()
 	if(istype(PDA))
-		PDA.owner = H.real_name
-		if(H.mind?.role_alt_title)
-			PDA.ownjob = H.mind.role_alt_title
-		else
-			PDA.ownjob = J.title
-
 		if (H.id_in_pda)
 			PDA.InsertID(C)
 			H.equip_to_slot_if_possible(PDA, SLOT_WEAR_ID)

--- a/code/modules/jobs/job_types/artist.dm
+++ b/code/modules/jobs/job_types/artist.dm
@@ -23,7 +23,7 @@
 	name = "Artist"
 	jobtype = /datum/job/artist
 
-	pda_type = /obj/item/pda/artist
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 	
 	head = /obj/item/clothing/head/frenchberet
 	ears = /obj/item/radio/headset/headset_srv

--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -35,7 +35,7 @@
 	name = "Atmospheric Technician"
 	jobtype = /datum/job/atmos
 
-	pda_type = /obj/item/pda/atmos
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic/atmos
 
 	belt = /obj/item/storage/belt/utility/atmostech
 	ears = /obj/item/radio/headset/headset_eng
@@ -48,7 +48,6 @@
 	satchel = /obj/item/storage/backpack/satchel/eng
 	duffelbag = /obj/item/storage/backpack/duffelbag/engineering
 	box = /obj/item/storage/box/engineer
-	backpack_contents = list(/obj/item/modular_computer/tablet/pda/preset/basic/atmos=1)
 
 	pda_slot = SLOT_L_STORE
 

--- a/code/modules/jobs/job_types/bartender.dm
+++ b/code/modules/jobs/job_types/bartender.dm
@@ -31,7 +31,7 @@
 	name = "Bartender"
 	jobtype = /datum/job/bartender
 
-	pda_type = /obj/item/pda/bar
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	glasses = /obj/item/clothing/glasses/sunglasses/reagent
 	ears = /obj/item/radio/headset/headset_srv

--- a/code/modules/jobs/job_types/botanist.dm
+++ b/code/modules/jobs/job_types/botanist.dm
@@ -34,7 +34,7 @@
 	name = "Botanist"
 	jobtype = /datum/job/hydro
 
-	pda_type = /obj/item/pda/botanist
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	ears = /obj/item/radio/headset/headset_srv
 	uniform = /obj/item/clothing/under/rank/hydroponics

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -41,7 +41,7 @@
 	jobtype = /datum/job/captain
 
 	id_type = /obj/item/card/id/gold
-	pda_type = /obj/item/pda/captain
+	pda_type = /obj/item/modular_computer/tablet/phone/preset/advanced/command
 	
 	glasses = /obj/item/clothing/glasses/sunglasses
 	ears = /obj/item/radio/headset/heads/captain/alt
@@ -52,7 +52,7 @@
 	shoes = /obj/item/clothing/shoes/sneakers/brown
 	digitigrade_shoes = /obj/item/clothing/shoes/xeno_wraps/command
 	head = /obj/item/clothing/head/caphat
-	backpack_contents = list(/obj/item/melee/classic_baton/telescopic=1, /obj/item/station_charter=1, /obj/item/gun/energy/e_gun=1, /obj/item/modular_computer/tablet/phone/preset/advanced/command=1) //yogs - adds egun/removes civ budget
+	backpack_contents = list(/obj/item/melee/classic_baton/telescopic=1, /obj/item/station_charter=1, /obj/item/gun/energy/e_gun=1) //yogs - adds egun/removes civ budget
 
 	backpack = /obj/item/storage/backpack/captain
 	satchel = /obj/item/storage/backpack/satchel/cap

--- a/code/modules/jobs/job_types/cargo_technician.dm
+++ b/code/modules/jobs/job_types/cargo_technician.dm
@@ -38,7 +38,7 @@
 	name = "Cargo Technician"
 	jobtype = /datum/job/cargo_tech
 
-	pda_type = /obj/item/pda/cargo
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	ears = /obj/item/radio/headset/headset_cargo
 	uniform = /obj/item/clothing/under/rank/cargotech

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -159,7 +159,7 @@
 	name = "Chaplain"
 	jobtype = /datum/job/chaplain
 
-	pda_type = /obj/item/pda/chaplain
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	ears = /obj/item/radio/headset/headset_srv
 	uniform = /obj/item/clothing/under/rank/chaplain

--- a/code/modules/jobs/job_types/chemist.dm
+++ b/code/modules/jobs/job_types/chemist.dm
@@ -37,7 +37,7 @@
 	name = "Chemist"
 	jobtype = /datum/job/chemist
 
-	pda_type = /obj/item/pda/chemist
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	glasses = /obj/item/clothing/glasses/science
 	ears = /obj/item/radio/headset/headset_med

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -35,7 +35,7 @@
 	jobtype = /datum/job/chief_engineer
 
 	id_type = /obj/item/card/id/silver
-	pda_type = /obj/item/pda/heads/ce
+	pda_type = /obj/item/modular_computer/tablet/phone/preset/advanced/command/atmos
 
 	belt = /obj/item/storage/belt/utility/chief/full
 	ears = /obj/item/radio/headset/heads/ce
@@ -45,7 +45,7 @@
 	digitigrade_shoes = /obj/item/clothing/shoes/xeno_wraps/command
 	head = /obj/item/clothing/head/hardhat/white
 	gloves = /obj/item/clothing/gloves/color/black
-	backpack_contents = list(/obj/item/melee/classic_baton/telescopic=1, /obj/item/modular_computer/tablet/phone/preset/advanced/command/atmos=1) //yogs - removes eng budget
+	backpack_contents = list(/obj/item/melee/classic_baton/telescopic=1) //yogs - removes eng budget
 	glasses = /obj/item/clothing/glasses/meson/sunglasses
 
 	backpack = /obj/item/storage/backpack/industrial

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -39,7 +39,7 @@
 	jobtype = /datum/job/cmo
 
 	id_type = /obj/item/card/id/silver
-	pda_type = /obj/item/pda/heads/cmo
+	pda_type = /obj/item/modular_computer/tablet/phone/preset/advanced/command
 
 	belt = /obj/item/storage/belt/medical/chief/full
 	ears = /obj/item/radio/headset/heads/cmo
@@ -51,7 +51,7 @@
 	l_hand = /obj/item/storage/firstaid/medical
 	suit_store = /obj/item/flashlight/pen/paramedic
 	glasses = /obj/item/clothing/glasses/hud/health/sunglasses
-	backpack_contents = list(/obj/item/melee/classic_baton/telescopic=1, /obj/item/modular_computer/tablet/phone/preset/advanced/command=1) //yogs - removes med budget
+	backpack_contents = list(/obj/item/melee/classic_baton/telescopic=1) //yogs - removes med budget
 
 	backpack = /obj/item/storage/backpack/medic
 	satchel = /obj/item/storage/backpack/satchel/med

--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -30,7 +30,7 @@
 	name = "Clown"
 	jobtype = /datum/job/clown
 
-	pda_type = /obj/item/pda/clown
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic/clown
 
 	ears = /obj/item/radio/headset/headset_srv
 	uniform = /obj/item/clothing/under/rank/clown

--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -36,7 +36,7 @@
 	name = "Cook"
 	jobtype = /datum/job/cook
 
-	pda_type = /obj/item/pda/cook
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	ears = /obj/item/radio/headset/headset_srv
 	uniform = /obj/item/clothing/under/rank/chef

--- a/code/modules/jobs/job_types/curator.dm
+++ b/code/modules/jobs/job_types/curator.dm
@@ -25,7 +25,7 @@
 	name = "Curator"
 	jobtype = /datum/job/curator
 
-	pda_type = /obj/item/pda/curator
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	ears = /obj/item/radio/headset/headset_srv
 	uniform = /obj/item/clothing/under/rank/curator

--- a/code/modules/jobs/job_types/detective.dm
+++ b/code/modules/jobs/job_types/detective.dm
@@ -41,7 +41,7 @@
 	name = "Detective"
 	jobtype = /datum/job/detective
 
-	pda_type = /obj/item/pda/detective
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	ears = /obj/item/radio/headset/headset_sec/alt
 	uniform = /obj/item/clothing/under/rank/det
@@ -56,8 +56,7 @@
 	r_pocket = /obj/item/lighter
 	backpack_contents = list(/obj/item/storage/box/evidence=1,\
 		/obj/item/detective_scanner=1,\
-		/obj/item/melee/classic_baton=1,\
-		/obj/item/modular_computer/tablet/pda/preset/basic=1)
+		/obj/item/melee/classic_baton=1)
 	mask = /obj/item/clothing/mask/cigarette
 
 	implants = list(/obj/item/implant/mindshield)

--- a/code/modules/jobs/job_types/geneticist.dm
+++ b/code/modules/jobs/job_types/geneticist.dm
@@ -35,7 +35,7 @@
 	name = "Geneticist"
 	jobtype = /datum/job/geneticist
 
-	pda_type = /obj/item/pda/geneticist
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	ears = /obj/item/radio/headset/headset_medsci
 	uniform = /obj/item/clothing/under/rank/geneticist

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -44,7 +44,7 @@
 	jobtype = /datum/job/hop
 
 	id_type = /obj/item/card/id/silver
-	pda_type = /obj/item/pda/heads/hop
+	pda_type = /obj/item/modular_computer/tablet/phone/preset/advanced/command
 
 	ears = /obj/item/radio/headset/heads/hop
 	uniform = /obj/item/clothing/under/rank/head_of_personnel
@@ -53,6 +53,6 @@
 	digitigrade_shoes = /obj/item/clothing/shoes/xeno_wraps/command
 	head = /obj/item/clothing/head/hopcap
 	backpack_contents = list(/obj/item/storage/box/ids=1,\
-		/obj/item/melee/classic_baton/telescopic=1, /obj/item/modular_computer/tablet/phone/preset/advanced/command=1) //yogs - removes serv budget
+		/obj/item/melee/classic_baton/telescopic=1) //yogs - removes serv budget
 
 	chameleon_extras = list(/obj/item/gun/energy/e_gun, /obj/item/stamp/hop)

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -41,7 +41,7 @@
 	jobtype = /datum/job/hos
 
 	id_type = /obj/item/card/id/silver
-	pda_type = /obj/item/pda/heads/hos
+	pda_type = /obj/item/modular_computer/tablet/phone/preset/advanced/command
 
 	belt = /obj/item/storage/belt/security/chief/full
 	ears = /obj/item/radio/headset/heads/hos/alt
@@ -54,7 +54,6 @@
 	head = /obj/item/clothing/head/HoS/beret
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	suit_store = /obj/item/gun/energy/e_gun
-	backpack_contents = list(/obj/item/modular_computer/tablet/phone/preset/advanced/command=1) //yogs - removed departmental budget ID //come here often?
 
 	backpack = /obj/item/storage/backpack/security
 	satchel = /obj/item/storage/backpack/satchel/sec

--- a/code/modules/jobs/job_types/janitor.dm
+++ b/code/modules/jobs/job_types/janitor.dm
@@ -36,7 +36,7 @@
 	name = "Janitor"
 	jobtype = /datum/job/janitor
 
-	pda_type = /obj/item/pda/janitor
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	ears = /obj/item/radio/headset/headset_srv
 	uniform = /obj/item/clothing/under/rank/janitor

--- a/code/modules/jobs/job_types/lawyer.dm
+++ b/code/modules/jobs/job_types/lawyer.dm
@@ -31,7 +31,7 @@
 	name = "Lawyer"
 	jobtype = /datum/job/lawyer
 
-	pda_type = /obj/item/pda/lawyer
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	ears = /obj/item/radio/headset/headset_srvsec
 	uniform = /obj/item/clothing/under/lawyer/bluesuit

--- a/code/modules/jobs/job_types/medical_doctor.dm
+++ b/code/modules/jobs/job_types/medical_doctor.dm
@@ -40,7 +40,7 @@
 	name = "Medical Doctor"
 	jobtype = /datum/job/doctor
 
-	pda_type= /obj/item/pda/medical
+	pda_type= /obj/item/modular_computer/tablet/pda/preset/basic
 
 	ears = /obj/item/radio/headset/headset_med
 	uniform = /obj/item/clothing/under/rank/medical

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -28,7 +28,7 @@
 	name = "Mime"
 	jobtype = /datum/job/mime
 
-	pda_type = /obj/item/pda/mime
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	ears = /obj/item/radio/headset/headset_srv
 	uniform = /obj/item/clothing/under/rank/mime

--- a/code/modules/jobs/job_types/quartermaster.dm
+++ b/code/modules/jobs/job_types/quartermaster.dm
@@ -30,7 +30,7 @@
 	name = "Quartermaster"
 	jobtype = /datum/job/qm
 
-	pda_type = /obj/item/pda/quartermaster
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	ears = /obj/item/radio/headset/headset_cargo
 	uniform = /obj/item/clothing/under/rank/cargo

--- a/code/modules/jobs/job_types/research_director.dm
+++ b/code/modules/jobs/job_types/research_director.dm
@@ -42,7 +42,7 @@
 	jobtype = /datum/job/rd
 
 	id_type = /obj/item/card/id/silver
-	pda_type = /obj/item/pda/heads/rd
+	pda_type = /obj/item/modular_computer/tablet/phone/preset/advanced/command
 
 	ears = /obj/item/radio/headset/heads/rd
 	glasses = /obj/item/clothing/glasses/hud/diagnostic/sunglasses
@@ -53,7 +53,7 @@
 	suit = /obj/item/clothing/suit/toggle/labcoat
 	l_hand = /obj/item/clipboard
 	l_pocket = /obj/item/laser_pointer
-	backpack_contents = list(/obj/item/melee/classic_baton/telescopic=1, /obj/item/modular_computer/tablet/phone/preset/advanced/command=1) //yogs - removes sci budget
+	backpack_contents = list(/obj/item/melee/classic_baton/telescopic=1) //yogs - removes sci budget
 
 	backpack = /obj/item/storage/backpack/science
 	satchel = /obj/item/storage/backpack/satchel/tox

--- a/code/modules/jobs/job_types/roboticist.dm
+++ b/code/modules/jobs/job_types/roboticist.dm
@@ -31,7 +31,7 @@
 	name = "Roboticist"
 	jobtype = /datum/job/roboticist
 
-	pda_type = /obj/item/pda/roboticist
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	belt = /obj/item/storage/belt/utility/full
 	ears = /obj/item/radio/headset/headset_sci

--- a/code/modules/jobs/job_types/scientist.dm
+++ b/code/modules/jobs/job_types/scientist.dm
@@ -39,7 +39,7 @@
 	name = "Scientist"
 	jobtype = /datum/job/scientist
 
-	pda_type = /obj/item/pda/toxins
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	ears = /obj/item/radio/headset/headset_sci
 	uniform = /obj/item/clothing/under/rank/scientist

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -138,7 +138,7 @@ GLOBAL_LIST_INIT(available_depts_sec, list(SEC_DEPT_ENGINEERING, SEC_DEPT_MEDICA
 	name = "Security Officer"
 	jobtype = /datum/job/officer
 
-	pda_type = /obj/item/pda/security
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	ears = /obj/item/radio/headset/headset_sec/alt
 	uniform = /obj/item/clothing/under/rank/security

--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -39,7 +39,7 @@
 	var/static/gps_number = 1
 	jobtype = /datum/job/mining
 
-	pda_type = /obj/item/pda/shaftminer
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	ears = /obj/item/radio/headset/headset_cargo/mining
 	shoes = /obj/item/clothing/shoes/workboots/mining

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -91,7 +91,7 @@ GLOBAL_LIST_INIT(available_depts_eng, list(ENG_DEPT_MEDICAL, ENG_DEPT_SCIENCE, E
 	name = "Station Engineer"
 	jobtype = /datum/job/engineer
 
-	pda_type = /obj/item/pda/engineering
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	belt = /obj/item/storage/belt/utility/full/engi
 	ears = /obj/item/radio/headset/headset_eng
@@ -106,7 +106,6 @@ GLOBAL_LIST_INIT(available_depts_eng, list(ENG_DEPT_MEDICAL, ENG_DEPT_SCIENCE, E
 	satchel = /obj/item/storage/backpack/satchel/eng
 	duffelbag = /obj/item/storage/backpack/duffelbag/engineering
 	box = /obj/item/storage/box/engineer
-	backpack_contents = list(/obj/item/modular_computer/tablet/pda/preset/basic=1)
 
 	pda_slot = SLOT_L_STORE
 

--- a/code/modules/jobs/job_types/virologist.dm
+++ b/code/modules/jobs/job_types/virologist.dm
@@ -33,7 +33,7 @@
 	name = "Virologist"
 	jobtype = /datum/job/virologist
 
-	pda_type = /obj/item/pda/viro
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	ears = /obj/item/radio/headset/headset_med
 	uniform = /obj/item/clothing/under/rank/virologist

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -44,7 +44,7 @@
 	name = "Warden"
 	jobtype = /datum/job/warden
 
-	pda_type = /obj/item/pda/warden
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	ears = /obj/item/radio/headset/headset_sec/alt
 	uniform = /obj/item/clothing/under/rank/warden

--- a/yogstation/code/modules/jobs/job_types/brig_physician.dm
+++ b/yogstation/code/modules/jobs/job_types/brig_physician.dm
@@ -34,7 +34,7 @@
 	name = "Brig Physician"
 	jobtype = /datum/job/brigphysician
 
-	pda_type = /obj/item/pda/physician
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	backpack_contents = list(/obj/item/roller = 1)
 	ears = /obj/item/radio/headset/headset_medsec

--- a/yogstation/code/modules/jobs/job_types/mining_medic.dm
+++ b/yogstation/code/modules/jobs/job_types/mining_medic.dm
@@ -31,7 +31,7 @@
 	name = "Mining Medic"
 	jobtype = /datum/job/miningmedic
 	
-	pda_type = /obj/item/pda/miningmed
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	backpack_contents = list(/obj/item/roller = 1,\
 		/obj/item/kitchen/knife/combat/survival = 1)

--- a/yogstation/code/modules/jobs/job_types/network_admin.dm
+++ b/yogstation/code/modules/jobs/job_types/network_admin.dm
@@ -32,7 +32,7 @@
 	name = "Network Admin"
 	jobtype = /datum/job/network_admin
 
-	pda_type = /obj/item/pda/network_admin
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	belt = /obj/item/storage/belt/utility/full/engi
 	ears = /obj/item/radio/headset/headset_network

--- a/yogstation/code/modules/jobs/job_types/paramedic.dm
+++ b/yogstation/code/modules/jobs/job_types/paramedic.dm
@@ -34,7 +34,7 @@
 	name = "Paramedic"
 	jobtype = /datum/job/paramedic
 
-	pda_type = /obj/item/pda/para
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
 	backpack_contents = list(/obj/item/storage/firstaid/regular)
 	ears = /obj/item/radio/headset/headset_med


### PR DESCRIPTION
# Document the changes in your pull request

The code is all here. These were supposed to replace the old PDAs from the start.

Everyone gets an NTOS PDA in place of their old PDA that is preloaded with the chat client

Anyone that started with an NTOS item in their backpack now starts with that in their PDA slot (i.e. heads have their phone in PDA slot now), only exception being network admin who starts with a tablet because it doesn't fit in ID slot.

Clown PDA is still slippery

Old PDAs still exist in vendors and HoP line, they are just no longer roundstart; they may be removed in the future since the majority of their functions are redundant and they look and feel terrible

Biggest downside to this by far is the loss of PDA messaging system. Fortunately, NTOS has its own messaging system, and even more fortunately, the basic NTOS PDA starts with this program preloaded.

I believe that replicating the old PDA messaging system into NTOS would be a terrible idea. Think about it for a minute. Every NTOS computer registered into this arbitrary mailing list. The same effect is achieved in a far more genius way in the chat client, the largest penalty being that you have to set it up yourself instead of being handed a messaging list.

Net admin also has a reason to look over NTOS monitoring now

Donor PDA reskins will still reskin the PDA

Also some plasmamen roles were supposed to spawn with NTOS devices but never got updated to, so I went through and fixed that here

# Changelog

:cl:  
tweak: replaced roundstart PDAs with NTOS PDAs
bugfix: fixed some plasmaman roles not getting NTOS devices when their other-race counterparts would
/:cl:
