### PR TITLE
Makes radioactive contamination less contagious (and minor radball tweak)

### DIFF
--- a/code/__DEFINES/radiation.dm
+++ b/code/__DEFINES/radiation.dm
@@ -39,11 +39,11 @@ Ask ninjanomnom if they're around
 #define RAD_FULL_INSULATION 0						// Unused
 
 // WARNING: The defines below could have disastrous consequences if tweaked incorrectly. See: The great SM purge of Oct.6.2017
-// contamination_chance = 		(strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_CHANCE_COEFFICIENT * min(1/(steps*RAD_DISTANCE_COEFFICIENT), 1))
-// contamination_strength = 	(strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_STR_COEFFICIENT
-#define RAD_MINIMUM_CONTAMINATION 350				// How strong does a radiation wave have to be to contaminate objects
+// contamination_chance		=	(strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_CHANCE_COEFFICIENT * min(1/(steps*RAD_DISTANCE_COEFFICIENT), 1))
+// contamination_strength	=	log(strength/RAD_MINIMUM_CONTAMINATION) * RAD_MINIMUM_CONTAMINATION * RAD_CONTAMINATION_STR_COEFFICIENT
+#define RAD_MINIMUM_CONTAMINATION 1000				// How strong does a radiation wave have to be to contaminate objects
 #define RAD_CONTAMINATION_CHANCE_COEFFICIENT 0.01	// Higher means higher strength scaling contamination chance
 #define RAD_CONTAMINATION_STR_COEFFICIENT 0.25		// Higher means higher strength scaling contamination strength
 #define RAD_DISTANCE_COEFFICIENT 1					// Lower means further rad spread
 
-#define RAD_HALF_LIFE 90							// The half-life of contaminated objects
+#define RAD_HALF_LIFE 30							// The half-life of contaminated objects

--- a/code/__DEFINES/radiation.dm
+++ b/code/__DEFINES/radiation.dm
@@ -43,7 +43,7 @@ Ask ninjanomnom if they're around
 // contamination_strength	=	log(strength/RAD_MINIMUM_CONTAMINATION) * RAD_MINIMUM_CONTAMINATION * RAD_CONTAMINATION_STR_COEFFICIENT
 #define RAD_MINIMUM_CONTAMINATION 1000				// How strong does a radiation wave have to be to contaminate objects
 #define RAD_CONTAMINATION_CHANCE_COEFFICIENT 0.01	// Higher means higher strength scaling contamination chance
-#define RAD_CONTAMINATION_STR_COEFFICIENT 0.25		// Higher means higher strength scaling contamination strength
+#define RAD_CONTAMINATION_STR_COEFFICIENT 0.6		// Higher means higher strength scaling contamination strength
 #define RAD_DISTANCE_COEFFICIENT 1					// Lower means further rad spread
 
 #define RAD_HALF_LIFE 30							// The half-life of contaminated objects

--- a/code/datums/radiation_wave.dm
+++ b/code/datums/radiation_wave.dm
@@ -111,8 +111,9 @@
 			continue
 		if(thing.flags_1 & RAD_NO_CONTAMINATE_1 || SEND_SIGNAL(thing, COMSIG_ATOM_RAD_CONTAMINATING, strength) & COMPONENT_BLOCK_CONTAMINATION)
 			continue
-		if(prob(contamination_chance)) // Only stronk rads get to have little baby rads
+		if(prob(contamination_chance)&&strength>0) // Only stronk rads get to have little baby rads
 			if(SEND_SIGNAL(thing, COMSIG_ATOM_RAD_CONTAMINATING, strength) & COMPONENT_BLOCK_CONTAMINATION)
 				continue
-			var/rad_strength = (strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_STR_COEFFICIENT
-			thing.AddComponent(/datum/component/radioactive, rad_strength, source)
+			var/rad_strength =  log(strength/RAD_MINIMUM_CONTAMINATION) * RAD_MINIMUM_CONTAMINATION * RAD_CONTAMINATION_STR_COEFFICIENT
+			if(rad_strength>0)
+				thing.AddComponent(/datum/component/radioactive, rad_strength, source)

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -96,7 +96,7 @@
 		if(EFFECT_UNCONSCIOUS)
 			Unconscious(effect * hit_percent)
 		if(EFFECT_IRRADIATE)
-			if(!HAS_TRAIT(src, TRAIT_RADIMMUNE))
+			if(!HAS_TRAIT(src, TRAIT_RADIMMUNE)&&!GODMODE)
 				radiation += max(effect * hit_percent, 0)
 		if(EFFECT_SLUR)
 			slurring = max(slurring,(effect * hit_percent))

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -131,7 +131,7 @@
 	if(immobilize)
 		apply_effect(immobilize, EFFECT_IMMOBILIZE, blocked)
 	if(irradiate)
-		apply_effect(irradiate, EFFECT_IRRADIATE, blocked)
+		apply_effect(irradiate, EFFECT_IRRADIATE, src.getarmor(null, RAD))
 	if(slur)
 		apply_effect(slur, EFFECT_SLUR, blocked)
 	if(stutter)

--- a/code/modules/projectiles/projectile/energy/nuclear_particle.dm
+++ b/code/modules/projectiles/projectile/energy/nuclear_particle.dm
@@ -2,9 +2,10 @@
 /obj/item/projectile/energy/nuclear_particle
 	name = "nuclear particle"
 	icon_state = "nuclear_particle"
-	pass_flags = PASSTABLE | PASSGRILLE
-	damage = 3
+	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
+	damage = 1
 	damage_type = BURN
+	irradiate = 20
 	speed = 0.4
 	hitsound = 'sound/weapons/emitter2.ogg'
 	impact_type = /obj/effect/projectile/impact/xray


### PR DESCRIPTION
# Document the changes in your pull request

Makes radioactive contamination on objects not spread to other objects as easily and reduces their half-life. Also makes nuclear particles do a small amount of radiation damage and slightly less burn damage, and allows them to go through glass without breaking it.

# Changelog

:cl:  
tweak: makes radioactive contamination less contagious
tweak: nuclear particles now cause a small amount of radiation damage and pass through windows, while doing less burn damage
tweak: godmode now protects from radiation
bugfix: fixes rad protection not protecting against radiation damage from projectiles
/:cl:
