### PR TITLE
hardlight bow is armory access

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -431,4 +431,4 @@
 	materials = list(/datum/material/iron = 5000, /datum/material/glass = 1500, /datum/material/uranium = 1500, /datum/material/silver = 1500)
 	build_path = /obj/item/gun/ballistic/bow/energy
 	category = list("Weapons")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY


### PR DESCRIPTION
# Document the changes in your pull request

It's a weapon so it goes in the armory 

:cl:  
tweak: hardlight bow is armory lathe printed rather than security lathe printed
/:cl:
