### PR TITLE
Adds new 10x5 Maint ruin: Bamboo Party

### DIFF
--- a/_maps/RandomRuins/StationRuins/maint/10x5/10x5_bamboo.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/10x5/10x5_bamboo.dmm
@@ -1,0 +1,268 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"b" = (
+/obj/item/ammo_casing/caseless/arrow/bamboo{
+	pixel_x = 2;
+	pixel_y = -1
+	},
+/obj/item/ammo_casing/caseless/arrow/bamboo{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/ammo_casing/caseless/arrow/bamboo{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/structure/table/wood,
+/turf/open/floor/bamboo,
+/area/template_noop)
+"f" = (
+/turf/open/floor/wood,
+/area/template_noop)
+"g" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/wood,
+/area/template_noop)
+"i" = (
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating,
+/area/template_noop)
+"j" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/template_noop)
+"k" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/wood,
+/area/template_noop)
+"l" = (
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/template_noop)
+"m" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/clothing/gloves/color/white{
+	pixel_x = -1;
+	pixel_y = -5
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"q" = (
+/obj/item/shard{
+	pixel_x = -20;
+	pixel_y = -3
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"r" = (
+/obj/effect/spawner/lootdrop/glowstick{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"s" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/template_noop)
+"t" = (
+/turf/closed/wall/mineral/bamboo,
+/area/template_noop)
+"u" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/randomdrink{
+	pixel_x = 7;
+	pixel_y = 15
+	},
+/obj/item/reagent_containers/food/snacks/sashimi{
+	name = "old sashimi"
+	},
+/turf/open/floor/bamboo,
+/area/template_noop)
+"w" = (
+/obj/item/seeds/bamboo{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/template_noop)
+"x" = (
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/template_noop)
+"y" = (
+/obj/structure/chair/sofa/bamboo/right,
+/turf/open/floor/bamboo,
+/area/template_noop)
+"B" = (
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/template_noop)
+"C" = (
+/obj/structure/mineral_door/paperframe,
+/turf/open/floor/wood,
+/area/template_noop)
+"D" = (
+/obj/structure/chair/sofa/bamboo/left,
+/turf/open/floor/bamboo,
+/area/template_noop)
+"I" = (
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/template_noop)
+"J" = (
+/obj/item/stack/tile/bamboo{
+	amount = 50
+	},
+/turf/open/floor/bamboo,
+/area/template_noop)
+"K" = (
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/bamboo,
+/area/template_noop)
+"M" = (
+/obj/structure/table/wood,
+/obj/item/candle{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/drinks/bottle/sake{
+	desc = "Nearly identical to Ryo's, just a tad laxer.";
+	name = "Kel's modernized sake";
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/turf/open/floor/bamboo,
+/area/template_noop)
+"N" = (
+/obj/effect/spawner/lootdrop/glowstick{
+	pixel_x = -1;
+	pixel_y = -4
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"O" = (
+/obj/effect/spawner/lootdrop/lizardboots,
+/turf/open/floor/wood,
+/area/template_noop)
+"P" = (
+/turf/open/floor/plating,
+/area/template_noop)
+"Q" = (
+/obj/structure/chair/sofa/bamboo,
+/turf/open/floor/bamboo,
+/area/template_noop)
+"R" = (
+/obj/item/stack/tile/bamboo,
+/turf/open/floor/plating,
+/area/template_noop)
+"S" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/wood,
+/area/template_noop)
+"T" = (
+/obj/structure/window/paperframe{
+	CanAtmosPass = 0
+	},
+/turf/open/floor/bamboo,
+/area/template_noop)
+"U" = (
+/obj/structure/table/wood,
+/obj/item/stack/sheet/mineral/bamboo{
+	amount = 5
+	},
+/turf/open/floor/bamboo,
+/area/template_noop)
+"V" = (
+/obj/structure/chair/stool/bamboo,
+/turf/open/floor/bamboo,
+/area/template_noop)
+"W" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/template_noop)
+"Z" = (
+/obj/structure/mineral_door/paperframe,
+/turf/open/floor/bamboo,
+/area/template_noop)
+
+(1,1,1) = {"
+K
+J
+B
+s
+P
+"}
+(2,1,1) = {"
+V
+M
+t
+W
+j
+"}
+(3,1,1) = {"
+C
+t
+t
+N
+P
+"}
+(4,1,1) = {"
+f
+g
+f
+S
+O
+"}
+(5,1,1) = {"
+l
+t
+Z
+t
+f
+"}
+(6,1,1) = {"
+I
+T
+y
+b
+k
+"}
+(7,1,1) = {"
+R
+Z
+Q
+u
+q
+"}
+(8,1,1) = {"
+R
+T
+D
+U
+x
+"}
+(9,1,1) = {"
+w
+t
+Z
+t
+r
+"}
+(10,1,1) = {"
+s
+m
+W
+f
+i
+"}

--- a/yogstation/code/datums/ruins/station.dm
+++ b/yogstation/code/datums/ruins/station.dm
@@ -1124,6 +1124,12 @@
 	suffix = "10x5_tank_heaven.dmm"
 	name = "Maint tank_heaven"
 
+///Author: Gravehat
+/datum/map_template/ruin/station/maint/tenxfive/bamboo
+	id = "bamboo"
+	suffix = "10x5_bamboo.dmm"
+	name = "Maint bamboo"
+
 ///The base for the 10x10 rooms.
 /datum/map_template/ruin/station/maint/tenxten
 	prefix = "_maps/RandomRuins/StationRuins/maint/10x10/"


### PR DESCRIPTION
What do you mean I can't put in a bamboo spear!?

# Document the changes in your pull request

Adds another maintenance ruin to the 10x5 ruin pool.

![image](https://user-images.githubusercontent.com/107460718/182325580-16db0f10-3c8d-42e1-836b-7c87a1db220e.png)
![image](https://user-images.githubusercontent.com/107460718/182323773-877b94f4-6417-4471-96e4-22064d4f02a2.png)
The camera isn't a part of the ruin it's just because I used the Thunderdome.

This ruin contains 52 bamboo flooring, 5 bamboo cuttings, 3 bamboo arrows, a seed packet for bamboo, white gloves, sake, and sashimi.
The spawners are random glowsticks, drinks, and lizard skin boots.

Bamboo needs to see more use, and this is an excuse to get people to know it exists and give them a stack of bamboo tiles, lizard skin boots are there just because they look similar to bamboo, and I want to see them in-game more.

# Changelog

:cl:  
rscadd: Adds a 10x5 bamboo-themed maint ruin that makes people question what the hell went on in there 
/:cl:
