### PR TITLE
Fixes blastdoor wonkieness + improvements

### DIFF
--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -102,7 +102,7 @@
 				if(controller.id)
 					id = controller.id
 				else if(!id) // Generate New ID if none exists
-					id = rand(1, 25565) // rare enough that ids should never conflict
+					id = getnewid()
 					to_chat(user, span_notice("No ID found. Generating New ID"))
 
 				P.buffer = id

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -97,8 +97,11 @@
 
 		if(W.tool_behaviour == TOOL_MULTITOOL)
 			if(istype(device, /obj/item/assembly/control)) // User Feedback
+				var/obj/item/assembly/control/controller = device
 				var/obj/item/multitool/P = W
-				if(!id) // Generate New ID if none exists
+				if(controller.id)
+					id = controller.id
+				else if(!id) // Generate New ID if none exists
 					id = rand(1, 25565) // rare enough that ids should never conflict
 					to_chat(user, span_notice("No ID found. Generating New ID"))
 

--- a/code/modules/assembly/doorcontrol.dm
+++ b/code/modules/assembly/doorcontrol.dm
@@ -24,6 +24,16 @@
 			INVOKE_ASYNC(M, openclose ? /obj/machinery/door/poddoor.proc/open : /obj/machinery/door/poddoor.proc/close)
 	addtimer(VARSET_CALLBACK(src, cooldown, FALSE), 10)
 
+/obj/item/assembly/control/attackby(obj/item/W, mob/user, params)
+	. = ..()
+	if(W.tool_behaviour == TOOL_MULTITOOL)
+		var/obj/item/multitool/P = W
+		if(!id) // Generate New ID if none exists
+			id = getnewid()
+			to_chat(user, span_notice("No ID found. Generating New ID"))
+			return
+		P.buffer = id
+		to_chat(user, span_notice("You link the [src] to the [P]."))
 
 /obj/item/assembly/control/airlock
 	name = "airlock controller"
@@ -160,3 +170,10 @@
 			H.toggle()
 
 	addtimer(VARSET_CALLBACK(src, cooldown, FALSE), 50)
+
+GLOBAL_VAR_INIT(counter, 0)
+
+/// Return a unique ID
+/proc/getnewid()
+	GLOB.counter += 1
+	return GLOB.counter


### PR DESCRIPTION
# Document the changes in your pull request

Allows you to multitool the control board to give it an id if it doesnt
button will copy ID if board has one

also no chances for random collision IDs

Fixes: #15124
# Changelog

:cl:  
rscadd: Multitooling a blastdoor board will copy or generate a new ID 
bugfix: Buttons now inherit device id if it has one
/:cl:
