### PR TITLE
Makes account ids not bad

### DIFF
--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -75,7 +75,7 @@ SUBSYSTEM_DEF(economy)
 		for(var/datum/mind/m in c.employees)
 			dictionary[c] += m.name
 	for(var/A in bank_accounts)
-		var/datum/bank_account/B = A
+		var/datum/bank_account/B = bank_accounts[A]
 		for(var/datum/corporation/c in dictionary)
 			if(B.account_holder in dictionary[c])
 				B.payday(c.paymodifier, TRUE)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -195,13 +195,13 @@
 		if(!new_bank_id || new_bank_id < 111111 || new_bank_id > 999999)
 			to_chat(user, span_warning("The account ID number needs to be between 111111 and 999999."))
 			return
-		for(var/A in SSeconomy.bank_accounts)
-			var/datum/bank_account/B = A
-			if(B.account_id == new_bank_id)
-				B.bank_cards += src
-				registered_account = B
-				to_chat(user, span_notice("The provided account has been linked to this ID card."))
-				return
+		var/bank_id = "[new_bank_id]"
+		if(bank_id in SSeconomy.bank_accounts)
+			var/datum/bank_account/B = SSeconomy.bank_accounts[bank_id]
+			B.bank_cards += src
+			registered_account = B
+			to_chat(user, span_notice("The provided account has been linked to this ID card."))
+			return
 		to_chat(user, span_warning("The account ID number provided is invalid."))
 		return
 
@@ -357,13 +357,12 @@ update_label("John Doe", "Clowny")
 			if (first_use && !registered_account)
 				if(ishuman(user))
 					var/mob/living/carbon/human/accountowner = user
-
-					for(var/bank_account in SSeconomy.bank_accounts)
-						var/datum/bank_account/account = bank_account
-						if(account.account_id == accountowner.account_id)
-							account.bank_cards += src
-							registered_account = account
-							to_chat(user, span_notice("Your account number has been automatically assigned."))
+					var/acc_id = "[accountowner.account_id]"
+					if(acc_id in SSeconomy.bank_accounts)
+						var/datum/bank_account/account = SSeconomy.bank_accounts[acc_id]
+						account.bank_cards += src
+						registered_account = account
+						to_chat(user, span_notice("Your account number has been automatically assigned."))
 			return
 		else if (popup_input == "Forge/Reset" && forged)
 			registered_name = initial(registered_name)
@@ -402,17 +401,16 @@ update_label("John Doe", "Clowny")
 		to_chat(user, span_warning("The account ID was already assigned to this card."))
 		return
 
-	for(var/A in SSeconomy.bank_accounts)
-		var/datum/bank_account/B = A
-		if(B.account_id == new_bank_id)
-			if (old_account)
-				old_account.bank_cards -= src
+	var/acc_id = "[new_bank_id]"
+	if(acc_id in SSeconomy.bank_accounts)
+		var/datum/bank_account/B = SSeconomy.bank_accounts[acc_id]
+		if (old_account)
+			old_account.bank_cards -= src
 
-			B.bank_cards += src
-			registered_account = B
-			to_chat(user, span_notice("The provided account has been linked to this ID card."))
-
-			return TRUE
+		B.bank_cards += src
+		registered_account = B
+		to_chat(user, span_notice("The provided account has been linked to this ID card."))
+		return TRUE
 
 	to_chat(user, span_warning("The account ID number provided is invalid."))
 	return

--- a/code/game/objects/items/crab17.dm
+++ b/code/game/objects/items/crab17.dm
@@ -156,9 +156,9 @@
 /obj/structure/checkoutmachine/proc/start_dumping()
 	accounts_to_rob = SSeconomy.bank_accounts.Copy()
 	if(bogdanoff)
-		accounts_to_rob -= bogdanoff.get_bank_account()
+		accounts_to_rob -= "[bogdanoff.get_bank_account().account_id]"
 	for(var/i in accounts_to_rob)
-		var/datum/bank_account/B = i
+		var/datum/bank_account/B = accounts_to_rob[i]
 		B.dumpeet()
 	dump()
 

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -14,16 +14,25 @@
 	var/bounties_claimed = 0 // Marks how many bounties this person has successfully claimed
 
 /datum/bank_account/New(newname, job, modifier = 1)
+	var/limiter = 0
+	while(limiter < 10)
+		account_id = rand(111111,999999)
+		if(!("[account_id]" in SSeconomy.bank_accounts))
+			break
+		limiter += 1
+	
+	if(limiter >= 10)
+		message_admins("Infinite loop prevented in bank account creation, unable to find bank account after [limiter] tries. Something has broken.")
+
 	if(add_to_accounts)
-		SSeconomy.bank_accounts += src
+		SSeconomy.bank_accounts["[account_id]"] = src
 	account_holder = newname
 	account_job = job
-	account_id = rand(111111,999999)
 	payday_modifier = modifier
 
 /datum/bank_account/Destroy()
 	if(add_to_accounts)
-		SSeconomy.bank_accounts -= src
+		SSeconomy.bank_accounts -= "[account_id]"
 	return ..()
 
 /datum/bank_account/proc/dumpeet()

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -255,12 +255,11 @@
 		if(H.age)
 			C.registered_age = H.age
 		C.update_label()
-		for(var/A in SSeconomy.bank_accounts)
-			var/datum/bank_account/B = A
-			if(B.account_id == H.account_id)
-				C.registered_account = B
-				B.bank_cards += C
-				break
+		var/acc_id = "[H.account_id]"
+		if(acc_id in SSeconomy.bank_accounts)
+			var/datum/bank_account/B = SSeconomy.bank_accounts[acc_id]
+			C.registered_account = B
+			B.bank_cards += C
 		H.sec_hud_set_ID()
 
 	var/obj/item/pda/PDA = new pda_type()


### PR DESCRIPTION
# Document the changes in your pull request

Account ids are now stored in an associative list, and checked for uniqueness

There is a limit for number of re-rolls, meaning it is possible to get duplicates, given 200 existing bank accounts, there is a 1 in 3.00729e36 chance of duplicates.

# Changelog

:cl:  
bugfix: Removed joint bank accounts
/:cl:
