### PR TITLE
Decreases Blobbernaut Minimum Punch Damage & Brute Modifier & Increases distant health drain

### DIFF
--- a/code/modules/antagonists/blob/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob_mobs.dm
@@ -278,7 +278,7 @@
 					H.color = "#000000"
 		if(damagesources)
 			for(var/i in 1 to damagesources)
-				adjustHealth(maxHealth*0.05) //take 2.5% of max health as damage when not near the blob or if the naut has no factory, 5% if both
+				adjustHealth(maxHealth*0.05) //take 5% of max health as damage when not near the blob or if the naut has no factory, 10% if both
 			var/image/I = new('icons/mob/blob.dmi', src, "nautdamage", MOB_LAYER+0.01)
 			I.appearance_flags = RESET_COLOR
 			if(overmind)

--- a/code/modules/antagonists/blob/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob_mobs.dm
@@ -236,8 +236,8 @@
 	icon_dead = "blobbernaut_dead"
 	health = 200
 	maxHealth = 200
-	damage_coeff = list(BRUTE = 0.5, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
-	melee_damage_lower = 20
+	damage_coeff = list(BRUTE = 0.65, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
+	melee_damage_lower = 15
 	melee_damage_upper = 20
 	obj_damage = 60
 	attacktext = "slams"
@@ -278,7 +278,7 @@
 					H.color = "#000000"
 		if(damagesources)
 			for(var/i in 1 to damagesources)
-				adjustHealth(maxHealth*0.025) //take 2.5% of max health as damage when not near the blob or if the naut has no factory, 5% if both
+				adjustHealth(maxHealth*0.05) //take 2.5% of max health as damage when not near the blob or if the naut has no factory, 5% if both
 			var/image/I = new('icons/mob/blob.dmi', src, "nautdamage", MOB_LAYER+0.01)
 			I.appearance_flags = RESET_COLOR
 			if(overmind)


### PR DESCRIPTION
yeah yeah ided, whatever

# Document the changes in your pull request

Just makes blobbernauts not have a flat 20 base damage, and instead sets them to have actual damage variation (still chunky as fuck)
also makes blobs take just slightly more brute damage, because passive healing on blob tiles + 200 fucking HP means these guys are literally brick walls that shrug off nearly all forms of brute damage, even on brute-weak strains.
additionally makes them less capable of hyper-over-extension by increasing their health drain away from blobs & factories.

# Changelog

:cl:  
tweak: reduced blobbernaut minimum melee damage
tweak: reduced blobbernaut brute damage mod (they take just slightly more brute damage now)
tweak: makes blobbernauts take twice as much damage if away from their blob or they have no factory.
/:cl:
