### PR TITLE
Adds crafting recipe to high traction floor tiles

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -781,6 +781,7 @@ GLOBAL_LIST_INIT(plastic_recipes, list(
 	new /datum/stack_recipe("colo cups", /obj/item/reagent_containers/food/drinks/colocup, 1), \
 	new /datum/stack_recipe("large water bottle", /obj/item/reagent_containers/glass/beaker/waterbottle/large/empty,3), \
 	new /datum/stack_recipe("plastic flaps", /obj/structure/plasticflaps, 5, one_per_turf = TRUE, on_floor = TRUE, time = 40), \
+	new /datum/stack_recipe("high-traction floor tiles", /obj/item/stack/tile/noslip, 1, 4, 20), \
 	new /datum/stack_recipe("water bottle", /obj/item/reagent_containers/glass/beaker/waterbottle/empty), \
 	new /datum/stack_recipe("wet floor sign", /obj/item/clothing/suit/caution, 2)))
 

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -317,6 +317,9 @@
 /obj/item/stack/tile/noslip/thirty
 	amount = 30
 
+/obj/item/stack/tile/noslip/sixty
+	amount = 60
+
 //Circuit
 /obj/item/stack/tile/circuit
 	name = "blue circuit tile"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1567,9 +1567,15 @@
 
 /datum/supply_pack/service/noslipfloor
 	name = "High-traction Floor Tiles"
-	desc = "Make slipping a thing of the past with thirty industrial-grade anti-slip floortiles!"
+	desc = "Make slipping a thing of the past with three hundred and sixty industrial-grade anti-slip floortiles!"
 	cost = 2000
-	contains = list(/obj/item/stack/tile/noslip/thirty)
+	contains = list(/obj/item/stack/tile/noslip/sixty,
+					/obj/item/stack/tile/noslip/sixty,
+					/obj/item/stack/tile/noslip/sixty,
+					/obj/item/stack/tile/noslip/sixty,
+					/obj/item/stack/tile/noslip/sixty,
+					/obj/item/stack/tile/noslip/sixty,
+					/obj/item/stack/tile/noslip/sixty)
 	crate_name = "high-traction floor tiles crate"
 
 /datum/supply_pack/service/janitor


### PR DESCRIPTION
# Document the changes in your pull request

Adds a Crafting Recipe to high traction floor tiles, costing 1 plastic sheet for four

# Changelog

:cl:  
rscadd: Added a crafting recipe to high traction floor tiles
tweak: cargo's crate of high-traction tiles now comes with 360 tiles, making it still more efficient than buying plastic and hand-crafting it
/:cl:
