### PR TITLE
Prevents Non-Engineers/AtmosTechs/Clowns/Mimes From Getting "Steal A sliver Of the Supermatter Crystal" and/or Buying Delaminators

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -107,6 +107,7 @@
 	name = "a sliver of a supermatter crystal. Be sure to use the proper safety equipment when extracting the sliver!"
 	targetitem = /obj/item/nuke_core/supermatter_sliver
 	difficulty = 15
+	excludefromjob = list("Cook","Scientist","Chaplain","Assistant","Curator","Network Admin","Medical Doctor","Chemist","Roboticist","Geneticist","Virologist","Paramedic","Psychiatrist","Mining Medic","Quartermaster","Shaft Miner","Cargo Technician","Bartender","Botanist","Janitor","Lawyer","Clerk","Tourist","Artist")
 
 /datum/objective_item/steal/supermatter/New()
 	special_equipment += /obj/item/storage/box/syndie_kit/supermatter

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1566,6 +1566,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndie_kit/supermatter_delaminator
 	cost = 10
 	manufacturer = /datum/corporation/traitor/waffleco
+	restricted_roles = list("Engineer", "Atmospheric Technician")
 	include_objectives = list(/datum/objective/hijack, /datum/objective/martyr, /datum/objective/nuclear) //yogs
 	exclude_modes = list(/datum/game_mode/infiltration) // yogs: infiltration
 


### PR DESCRIPTION
# Document the changes in your pull request

as the title says, makes engineers, atmos techs, clowns, and mimes the only jobs capable of having the objective to steal an SM shard. Exepecting non-engineers to do this at all is a stretch in most cases, which will usually just be impossible because the SM chamber is almost-always hot enough to husk you even if you siphon it empty, or worse, the engineers turn it into a bunker. Additionally this objective can lead to an inexperienced antagonist simply dusting by accident, which is no fun for them and also removes potential chaos from a round entirely.

Clowns and mimes because...haha funny (also most clowns/mimes are pretty good at the game for some reason??)

Antinoblium shards are also now engineer/atmos exclusive objects, because of a lot of the same reasons above.

# Changelog

:cl:  
tweak: Prevents non-engineers/atmos techs/clowns/mimes from getting the "Steal A Sliver of The Supermatter Crystal" objective
tweak: Prevents non-engineers/atmos techs from buying Antinoblium Shards
/:cl:
