### PR TITLE
Concussive Gauntlets Buff and Gibtonite Defusal

### DIFF
--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -671,6 +671,9 @@
 	if(istype(I, /obj/item/mining_scanner) || istype(I, /obj/item/t_scanner/adv_mining_scanner) && stage == 1)
 		user.visible_message(span_notice("[user] holds [I] to [src]..."), span_notice("You use [I] to locate where to cut off the chain reaction and attempt to stop it..."))
 		defuse(force_perfect = FALSE)
+	if(istype(I, /obj/item/clothing/gloves/gauntlets))
+		user.visible_message(span_notice("[user] punches [src]..."), span_notice("The [I] shatter the chain reaction stopping it instantly..."))
+		defuse(force_perfect = FALSE)
 	..()
 
 /turf/closed/mineral/gibtonite/proc/explosive_reaction(mob/user = null, triggered_by_explosion = 0)

--- a/code/modules/cargo/exports/lavaland.dm
+++ b/code/modules/cargo/exports/lavaland.dm
@@ -25,7 +25,8 @@
 						/obj/item/kitchen/knife/envy,
 						/obj/item/gun/ballistic/revolver/russian/soul,
 						/obj/item/veilrender/vealrender,
-						/obj/item/keycard/necropolis)
+						/obj/item/keycard/necropolis,
+						/obj/item/clothing/gloves/gauntlets)
 
 /datum/export/lavaland/major //valuable chest/ruin loot and staff of storms
 	cost = 20000

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -195,7 +195,7 @@ obj/effect/proc_holder/swipe
 	item_state = "concussive_gauntlets"
 	mob_overlay_icon = 'icons/mob/clothing/hands/hands.dmi'
 	icon = 'icons/obj/lavaland/artefacts.dmi'
-	toolspeed = 0.1
+	toolspeed = 0.01
 	strip_delay = 40
 	equip_delay_other = 20
 	body_parts_covered = ARMS
@@ -212,6 +212,7 @@ obj/effect/proc_holder/swipe
 		tool_behaviour = TOOL_MINING
 		RegisterSignal(user, COMSIG_HUMAN_EARLY_UNARMED_ATTACK, .proc/rocksmash)
 		RegisterSignal(user, COMSIG_MOVABLE_BUMP, .proc/rocksmash)
+		mineral_scan_pulse(src, user)
 	else
 		stopmining(user)
 
@@ -224,8 +225,8 @@ obj/effect/proc_holder/swipe
 	UnregisterSignal(user, COMSIG_HUMAN_EARLY_UNARMED_ATTACK)
 	UnregisterSignal(user, COMSIG_MOVABLE_BUMP)
 
-/obj/item/clothing/gloves/gauntlets/proc/rocksmash(mob/living/carbon/human/H, atom/A, proximity)
+/obj/item/clothing/gloves/gauntlets/proc/rocksmash(mob/user, atom/A, proximity)
 	if(!istype(A, /turf/closed/mineral))
 		return
-	A.attackby(src, H)
+	A.attackby(src, user)
 	return COMPONENT_NO_ATTACK_OBJ

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -212,7 +212,6 @@ obj/effect/proc_holder/swipe
 		tool_behaviour = TOOL_MINING
 		RegisterSignal(user, COMSIG_HUMAN_EARLY_UNARMED_ATTACK, .proc/rocksmash)
 		RegisterSignal(user, COMSIG_MOVABLE_BUMP, .proc/rocksmash)
-		mineral_scan_pulse(src, user)
 	else
 		stopmining(user)
 


### PR DESCRIPTION
Kaboom goes the gibtonite

# Document the changes in your pull request

Increased mining speed to instantly mine bumped turfs after I noticed that the Sonic jackhammer was as good as the necropolis drop and also made it, so the gloves don't kill you via gibtonite while mining. Also adds it to the list as an artifact so it actually sells for 10k

These changes have already gone testing, except for the selling, and they feel a lot better to use than before, it isn't phenomenal and still gets outpaced by any cutter, but you could run and gun without having to worry about minerals getting in your way, do be wary of basalt though.

I noticed it was underperforming despite being necropolis chest loot, and this solves the issue of it being too dangerous to use.

# Changelog

:cl:  
rscadd: The Concussive Gauntlets defuses gibtonite now
rscadd: Adds Concussive Gauntlets to the Artifact list for cargo exports
tweak: Buffed mining speed from 0.1 to 0.01
/:cl:
