### PR TITLE
Radiant dance machine mark IV can now be ordered from cargo

### DIFF
--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -18,7 +18,6 @@
 	name = "radiant dance machine mark IV"
 	desc = "The first three prototypes were discontinued after mass casualty incidents."
 	icon_state = "disco"
-	req_access = list(ACCESS_BAR)
 	anchored = FALSE
 	var/list/spotlights = list()
 	var/list/sparkles = list()

--- a/code/game/objects/items/etherealdiscoball.dm
+++ b/code/game/objects/items/etherealdiscoball.dm
@@ -71,3 +71,9 @@
 	var/mutable_appearance/base_overlay = mutable_appearance(icon, "ethdisco_base")
 	base_overlay.appearance_flags = RESET_COLOR
 	add_overlay(base_overlay)
+
+/obj/structure/etherealball/wrench_act(mob/living/user, obj/item/I)
+	. = ..()
+	to_chat(user, span_notice("You undeploy the Ethereal Disco Ball."))
+	new /obj/item/etherealballdeployer(user.loc)
+	qdel(src)

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2698,11 +2698,11 @@
 	crate_type = /obj/structure/closet/crate/large
 
 /datum/supply_pack/misc/jukebox/disco
-	name = "Disco Crate"
-	desc = "It's a jukebox but more lights!!"
+	name = "Radiant Dance Machine Mark IV Crate"
+	desc = "It's a jukebox with more lights."
 	cost = 6000
 	contains = list(/obj/machinery/jukebox/disco)
-	crate_name = "disco crate"
+	crate_name = "radiant dance machine mark IV crate"
 	crate_type = /obj/structure/closet/crate/large
 
 /datum/supply_pack/misc/pda

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2697,6 +2697,14 @@
 	crate_name = "jukebox crate"
 	crate_type = /obj/structure/closet/crate/large
 
+/datum/supply_pack/misc/jukebox/disco
+	name = "Disco Crate"
+	desc = "It's a jukebox but more lights!!"
+	cost = 6000
+	contains = list(/obj/machinery/jukebox/disco)
+	crate_name = "disco crate"
+	crate_type = /obj/structure/closet/crate/large
+
 /datum/supply_pack/misc/pda
 	name = "Modular Personal Digital Assistant Crate"
 	desc = "A create containing five modular PDAs, enough for an entire department."

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -1102,3 +1102,11 @@
 	build_path = /obj/item/airlock_painter/decal
 	category = list("initial","Tools","Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
+
+/datum/design/etherealdiscoball
+	name = "Ethereal Disco Ball"
+	id = "ethereal_disco_ball"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 300, /datum/material/glass = 100)
+	build_path = /obj/item/etherealballdeployer
+	category = list("initial","Miscellaneous")


### PR DESCRIPTION
# About PR
Radiant dance machine mark IV can be ordered from cargo for 6000cr
Everyone can access to this instead of having it only for Bartender
Ethereal disco ball can now be printed from autolathe and can be undeployed by unwrenching





:cl:  
tweak: radiant dance machine mark IV can be ordered from cargo for 6000cr
tweak: Everyone can now access radiant dance machine mark IV
tweak: Ethereal disco ball can be printed from autolathe and can be undeployed by unwrenching
/:cl:
