### PR TITLE
Fixes gax whale not spawning

### DIFF
--- a/yogstation/code/game/objects/effects/landmarks.dm
+++ b/yogstation/code/game/objects/effects/landmarks.dm
@@ -188,6 +188,8 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 	
 	for(var/obj/effect/landmark/stationroom/limited_spawn/L in landmarks)
 		L.choose_result = EMPTY_SPAWN
+	
+	return choose_result
 
 /obj/effect/landmark/stationroom/limited_spawn/gax/ai_whale
 	template_names = list("AI Whale")


### PR DESCRIPTION
# Document the changes in your pull request

The first limited_spawn landmark spawned never returns its choose_result, so nothing ever spawns there.

# Changelog

:cl:  
bugfix: fixed ai whale not spawning
/:cl:
