### PR TITLE
shifts the focus of ebow away from stun combat (except to borgs)

### DIFF
--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -9,6 +9,11 @@
 	jitter = 20
 	slur = 5
 
+/obj/item/projectile/energy/bolt/on_hit(atom/target, blocked = FALSE)
+	if(iscyborg(target))
+		target.emp_act(EMP_LIGHT)
+	. = ..()
+
 /obj/item/projectile/energy/bolt/halloween
 	name = "candy corn"
 	icon_state = "candy_corn"

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -4,9 +4,9 @@
 	damage = 15
 	damage_type = TOX
 	nodamage = FALSE
-	stamina = 60
 	eyeblur = 10
-	knockdown = 10
+	knockdown = 20
+	jitter = 20
 	slur = 5
 
 /obj/item/projectile/energy/bolt/halloween
@@ -14,4 +14,4 @@
 	icon_state = "candy_corn"
 
 /obj/item/projectile/energy/bolt/large
-	damage = 30 //we already deal 60 stamina damage per hit
+	damage = 30


### PR DESCRIPTION
# Document the changes in your pull request

Removes its stamina damage 60->0
Doubles its knockdown 10->20 (theoretically 1 second->2 seconds)
Adds cosmetic jitter 0->20 (theoretically 2 seconds)
Apply light EMP to cyborgs on hit

The energy crossbow is known for its two hit stun and subsequent do-whatever-you-want because you've won. This essentially sets it as a ranged stun baton, which is not great for gameplay.

This sets the ebow back a notch into a bit more debilitating but not fight-ending tool. It will now reign most effective when followed up with another weapon.

To make up for this setback, the energy crossbow now deals light EMP to cyborgs on hit, so they are no longer completely immune to its effects.

# Changelog

:cl:  
tweak: Energy crossbow now deals no stamina damage, but knocks down for twice the length it used to and EMPs cyborgs
/:cl:
