### PR TITLE
The amount of paycheck money withheld from non-humans due to NT favoritism is now displayed at round end

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -443,6 +443,8 @@
 	for(var/datum/department_goal/dg in SSYogs.department_goals)
 		goals[dg.account] += dg.get_result()
 
+	parts += "<br>Money diverted from non-human paychecks by NT: $[GLOB.stolen_paycheck_money]<br>"
+
 	parts += "<br>[span_header("Engineering department goals:")]<br>"
 	parts += goals[ACCOUNT_ENG]
 

--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -1,3 +1,5 @@
+GLOBAL_VAR_INIT(stolen_paycheck_money, 0)
+
 SUBSYSTEM_DEF(economy)
 	name = "Economy"
 	wait = 5 MINUTES

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -59,6 +59,8 @@
 
 /datum/bank_account/proc/payday(amt_of_paychecks, free = FALSE)
 	var/money_to_transfer = account_job.paycheck * payday_modifier * amt_of_paychecks
+	var/stolen_money = (1 - payday_modifier) * account_job.paycheck * amt_of_paychecks
+	GLOB.stolen_paycheck_money += stolen_money
 	if(free)
 		adjust_money(money_to_transfer)
 		return TRUE


### PR DESCRIPTION
# Document the changes in your pull request

All the money that non-humans have lost out on for the whole shift is tallied up and displayed under departmental goals


# Wiki Documentation


# Changelog

:cl:  
rscadd: All the money that should have been paid to workers that NT has stolen due to them being non-humans, is now displayed at round end
/:cl:
