### PR TITLE
Unreverts #7770, & makes Mech RCDs have variable power use

### DIFF
--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -284,7 +284,7 @@
 					chassis.spark_system.start()
 					W.ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 					playsound(W, 'sound/items/deconstruct.ogg', 50, 1)
-				if(target = /turf/closed/wall/r_wall)
+				if(target == /turf/closed/wall/r_wall)
 					energy_drain = 2000
 			else if(isfloorturf(target))
 				energy_drain = 100

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -251,7 +251,7 @@
 	desc = "An exosuit-mounted Rapid Construction Device."
 	icon_state = "mecha_rcd"
 	equip_cooldown = 10
-	energy_drain = 250
+	energy_drain = 50
 	range = MECHA_MELEE|MECHA_RANGED
 	item_flags = NO_MAT_REDEMPTION
 	var/mode = 0 //0 - deconstruct, 1 - wall or floor, 2 - airlock.
@@ -277,13 +277,17 @@
 	switch(mode)
 		if(0)
 			if(iswallturf(target))
+				energy_drain = 500
 				var/turf/closed/wall/W = target
 				occupant_message("Deconstructing [W]...")
 				if(do_after_cooldown(W))
 					chassis.spark_system.start()
 					W.ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 					playsound(W, 'sound/items/deconstruct.ogg', 50, 1)
+				if(target = /turf/closed/wall/r_wall)
+					energy_drain = 2000
 			else if(isfloorturf(target))
+				energy_drain = 100
 				var/turf/open/floor/F = target
 				occupant_message("Deconstructing [F]...")
 				if(do_after_cooldown(target))
@@ -291,6 +295,7 @@
 					F.ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 					playsound(F, 'sound/items/deconstruct.ogg', 50, 1)
 			else if (istype(target, /obj/machinery/door/airlock))
+				energy_drain = 500
 				occupant_message("Deconstructing [target]...")
 				if(do_after_cooldown(target))
 					chassis.spark_system.start()
@@ -306,6 +311,7 @@
 					chassis.spark_system.start()
 			else if(isfloorturf(target))
 				var/turf/open/floor/F = target
+				energy_drain = 750
 				occupant_message("Building Wall...")
 				if(do_after_cooldown(F))
 					F.PlaceOnTop(/turf/closed/wall)
@@ -313,6 +319,7 @@
 					chassis.spark_system.start()
 		if(2)
 			if(isfloorturf(target))
+				energy_drain = 750
 				occupant_message("Building Airlock...")
 				if(do_after_cooldown(target))
 					chassis.spark_system.start()

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -750,7 +750,6 @@ RLD
 /obj/item/construction/rcd/borg
 	no_ammo_message = span_warning("Insufficient charge.")
 	desc = "A device used to rapidly build walls and floors."
-	canRturf = TRUE
 	banned_upgrades = RCD_UPGRADE_SILO_LINK
 	var/energyfactor = 72
 
@@ -784,6 +783,7 @@ RLD
 /obj/item/construction/rcd/borg/syndicate
 	icon_state = "ircd"
 	item_state = "ircd"
+	canRturf = TRUE
 	energyfactor = 66
 
 /obj/item/construction/rcd/loaded


### PR DESCRIPTION
# Document the changes in your pull request

https://github.com/yogstation13/Yogstation/pull/7770 unreverts this PR, which got undone at somepoint.

Also makes mech RCDs not turbo-cancer within as little effort as I was up to expend, by making them alter their power use depending on what they're doing.

# Changelog

:cl:  
tweak: mech RCDs use differing amounts of charge depending on what they do now
bugfix: non-syndicate borg RCDs do not deconstruct Reinforced Walls again
/:cl:
