### PR TITLE
supermatter tongs no longer redtext you if you mess up and touch the supermatter with them

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -871,6 +871,9 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			else
 				to_chat(user, span_notice("You fail to extract a sliver from \The [src]. \the [W] isn't sharp enough anymore!"))
 			return
+	if(istype(W, /obj/item/hemostat/supermatter))
+		to_chat(user, span_boldwarning("[W]'s tongs produce an unhealthy sizzling sound as they come into contact with [src]; it seems you will need to part a sample from [src] with another tool.")
+		return
 	if(istype(W, /obj/item/supermatter_corruptor))
 		if(corruptor_attached)
 			to_chat(user, "A corruptor is already attached!")

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -872,7 +872,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 				to_chat(user, span_notice("You fail to extract a sliver from \The [src]. \the [W] isn't sharp enough anymore!"))
 			return
 	if(istype(W, /obj/item/hemostat/supermatter))
-		to_chat(user, span_boldwarning("[W]'s tongs produce an unhealthy sizzling sound as they come into contact with [src]; it seems you will need to part a sample from [src] with another tool.")
+		to_chat(user, span_boldwarning("[W]'s tongs produce an unhealthy sizzling sound as they come into contact with [src]; it seems you will need to part a sample from [src] with another tool."))
 		return
 	if(istype(W, /obj/item/supermatter_corruptor))
 		if(corruptor_attached)


### PR DESCRIPTION
# Document the changes in your pull request

blah blah hugbox shut up, no other objective says "lmao eat shit" if you make a minor misclick or forget to read the instruction booklet first, or requires you to go somewhere that can otherwise kill you in the first place.

# Changelog


:cl:  
tweak: supermatter tongs for the supermatter objective now don't obliterate themselves if you click on the supermatter with them
/:cl:
