### PR TITLE
makes repair organs not useless

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -208,7 +208,7 @@
 						var/healed = FALSE
 						var/obj/item/organ/heal_target = C.getorganslot(o)
 						if(heal_target?.damage >= 1)
-							var/organ_healing = C.stat == DEAD ? 0.05 : 0.2
+							var/organ_healing = C.stat == DEAD ? 0.5 : 1
 							heal_target.applyOrganDamage(-organ_healing)
 							healed = TRUE
 						if(healed)


### PR DESCRIPTION
# Document the changes in your pull request

0.05/0.2 organ healing per tick, do you realize how long it would take to heal a fucking organ if it were half broken? organs have 100 health; it would take 8 1⁄3 MINUTES OF SITTING IN A SLEEPER JUST TO REPAIR 50 ORGAN HEALTH

with this change it would still take 100 seconds to repair 50 organ health, but it's a hell of a lot better than it was

# Changelog

:cl:  
tweak: buffed organ repair in sleepers
/:cl:
