### PR TITLE
Makes my halo go to the Fancy Hat slot and not the Fancy Item slot

### DIFF
--- a/yogstation/code/modules/donor/unique_donator_items.dm
+++ b/yogstation/code/modules/donor/unique_donator_items.dm
@@ -153,6 +153,7 @@ Uncomment this and use atomproccall as necessary, then copypaste the output into
 	name = "Transdimensional halo"
 	ckey = "Hisakaki"
 	unlock_path = /obj/item/clothing/head/halo
+	slot = SLOT_HEAD
 
 /datum/donator_gear/skrem
 	name = "Rainbow flower"


### PR DESCRIPTION
# Document the changes in your pull request

Does what it says on the title, thanks Vaelophis Nyx for helping!~


# Changelog

:cl:  
tweak: makes the transdimensional halo go on the Fancy Hat slot instead of the Fancy Item slot
/:cl:
