### PR TITLE
Fixes Cheese: Colossus Enrages Against Sand Golems

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -127,6 +127,9 @@ Difficulty: Very Hard
 		if(H.mind)
 			if(H.mind.martial_art && prob(H.mind.martial_art.deflection_chance))
 				. = TRUE
+		if(H.mind)
+			if(H.dna.species == /datum/species/golem/sand)
+				. = TRUE
 
 /mob/living/simple_animal/hostile/megafauna/colossus/proc/alternating_dir_shots()
 	ranged_cooldown = world.time + 40


### PR DESCRIPTION
# Document the changes in your pull request

Prevents easy cheese vs colossus by being a sand golem. Simply makes Colossus enrage in the same way as a sleeping carp user by checking your DNA for being a sand golem.
closes #15110

# Changelog

:cl:  
bugfix: Colossus now enrages against sand golems, to prevent ranged immunity cheese.
/:cl:
