### PR TITLE
Adds Miner Gear To Plasmaman Shaft Miner/Mining Medic Emergency Boxes

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -175,6 +175,13 @@
 	new /obj/item/tank/internals/plasmaman/belt/full(src)
 	new /obj/item/reagent_containers/autoinjector/medipen(src)
 
+/obj/item/storage/box/plasmaman/miner/PopulateContents() //mining box for plasmemes
+	new /obj/item/clothing/mask/gas/explorer(src)
+	new /obj/item/tank/internals/plasmaman/belt/full(src)
+	new /obj/item/crowbar/red(src)
+	new /obj/item/gps/mining(src)
+	new /obj/item/reagent_containers/autoinjector/medipen(src)
+
 /obj/item/storage/box/gloves
 	name = "box of latex gloves"
 	desc = "Contains sterile latex gloves."

--- a/code/modules/clothing/outfits/plasmaman.dm
+++ b/code/modules/clothing/outfits/plasmaman.dm
@@ -216,7 +216,7 @@
 	backpack = /obj/item/storage/backpack/explorer
 	satchel = /obj/item/storage/backpack/satchel/explorer
 	duffelbag = /obj/item/storage/backpack/duffelbag
-	backpack_contents = list(/obj/item/storage/box/plasmaman = 1)
+	backpack_contents = list(/obj/item/storage/box/plasmaman/miner = 1)
 
 
 /datum/outfit/job/plasmaman/lawyer
@@ -475,7 +475,7 @@
 	backpack_contents = list(/obj/item/roller = 1,\
 		/obj/item/kitchen/knife/combat/survival = 1,\
 		/obj/item/gps/mining = 1,\
-		/obj/item/storage/box/plasmaman = 1)
+		/obj/item/storage/box/plasmaman/miner = 1)
 	belt = /obj/item/storage/belt/medical/mining
 	ears = /obj/item/radio/headset/headset_medcargo
 	glasses = /obj/item/clothing/glasses/hud/health/meson


### PR DESCRIPTION
# Document the changes in your pull request

just adds relevant miner gear to the plasmaman box if they're a miner or mining medic

closes #15037

# Changelog

:cl:  
bugfix: Plasmamen now get a GPS, Crowbar, and Explorer Mask in their box as shaft miner & mining medic
/:cl:
