### PR TITLE
Fixes RnD console access restrictions not working

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -706,7 +706,7 @@ Nothing else in the console has ID requirements.
 	return icon2html(initial(item.icon), usr, initial(item.icon_state), SOUTH)
 
 /obj/machinery/computer/rdconsole/proc/can_research(mob/user)
-	if(!locked || allowed(user))
+	if((obj_flags & EMAGGED) || allowed(user))
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
currently this checks if the console is locked (aka if the Lock button is pressed which already prevents researching) but because the console can never be locked while in a state where you can research stuff, the access check proc always returns true

# Changelog

:cl:  
bugfix: rnd console now actually requires correct access to use, emagging will allow you to research without access
/:cl:
