### PR TITLE
fixes RnD console access

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -706,7 +706,7 @@ Nothing else in the console has ID requirements.
 	return icon2html(initial(item.icon), usr, initial(item.icon_state), SOUTH)
 
 /obj/machinery/computer/rdconsole/proc/can_research(mob/user)
-	if(!locked && allowed(user))
+	if(!locked && (allowed(user) || (obj_flags & EMAGGED)))
 		return TRUE
 	return FALSE
 

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -706,7 +706,7 @@ Nothing else in the console has ID requirements.
 	return icon2html(initial(item.icon), usr, initial(item.icon_state), SOUTH)
 
 /obj/machinery/computer/rdconsole/proc/can_research(mob/user)
-	if(!locked || allowed(user))
+	if(!locked && allowed(user))
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
you need to have access AND the console needs to not be locked.

We can't just check for access since href exploits. We don't need to check for emag since locked can never be true if the console is emagged