### PR TITLE
GIve construction bag and decal painter to engineering cyborg

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -346,6 +346,8 @@
 		/obj/item/stack/rods/cyborg,
 		/obj/item/stack/tile/plasteel/cyborg,
 		/obj/item/stack/cable_coil/cyborg,
+		/obj/item/storage/bag/construction,
+		/obj/item/airlock_painter/decal,
 		/obj/item/barrier_taperoll/engineering)
 	radio_channels = list(RADIO_CHANNEL_ENGINEERING)
 	emag_modules = list(/obj/item/borg/stun)


### PR DESCRIPTION
# About PR
engineering cyborg gets two new module: construction bag and decal painter


# Wiki Documentation
engineering cyborg gets two new module: construction bag and decal painter
# Changelog

:cl:  
rscadd: Decal painter and construction bag added to cyborg module
/:cl:
