### PR TITLE
makes arcane barrage actually deal more damage than enchanted rifles

### DIFF
--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -788,6 +788,8 @@ GLOBAL_VAR_INIT(curselimit, 0)
 	nondirectional_sprite = TRUE
 	damage_type = BRUTE
 	impact_effect_type = /obj/effect/temp_visual/dir_setting/bloodsplatter
+	damage = 20
+	armour_penetration = 0
 
 /obj/item/projectile/magic/arcane_barrage/blood/Bump(atom/target)
 	var/turf/T = get_turf(target)

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -232,7 +232,7 @@
 /datum/spellbook_entry/arcane_barrage
 	name = "Arcane Barrage"
 	spell_type = /obj/effect/proc_holder/spell/targeted/infinite_guns/arcane_barrage
-	cost = 2
+	cost = 3
 	no_coexistance_typecache = /obj/effect/proc_holder/spell/targeted/infinite_guns/gun
 
 /datum/spellbook_entry/barnyard

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -398,7 +398,7 @@
 	damage_type = BURN
 	nodamage = FALSE
 	armour_penetration = 20
-	flag = MAGIC
+	flag = MAGIC 
 	hitsound = 'sound/weapons/barragespellhit.ogg'
 
 /obj/item/projectile/magic/locker

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -394,10 +394,10 @@
 /obj/item/projectile/magic/arcane_barrage
 	name = "arcane bolt"
 	icon_state = "arcane_barrage"
-	damage = 20
+	damage = 40
 	damage_type = BURN
 	nodamage = FALSE
-	armour_penetration = 0
+	armour_penetration = 20
 	flag = MAGIC
 	hitsound = 'sound/weapons/barragespellhit.ogg'
 


### PR DESCRIPTION
# Document the changes in your pull request

## BALANCE CHANGE

`desc = "Fire a torrent of arcane energy at your foes with this (powerful) spell. Deals much more damage than Lesser Summon Guns, but won't knock targets down. Requires both hands free to use. Learning this spell makes you unable to learn Lesser Summon Gun."`
??????????????

damage 20->40
armor pen 0->20

costs 3 now

# Changelog

:cl:  
bugfix: made arcane barrage actually do more damage than lesser summon guns but cost 3
/:cl:
