### PR TITLE
Fixes Exosuit Plasma Cutters requiring head authorization

### DIFF
--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -482,7 +482,7 @@
 
 /obj/machinery/mecha_part_fabricator/ui_interact(mob/user, datum/tgui/ui)
 	if(!allowed(user) && !combat_parts_allowed && !isobserver(user))
-		to_chat(user, span_warning("You do not have the proper credentials to operate this device"))
+		to_chat(user, span_warning("You do not have the proper credentials to operate this device!"))
 		return
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
@@ -549,7 +549,7 @@
 
 	data["isProcessingQueue"] = process_queue
 	data["authorization"] = authorization_override
-	data["user_clearance"] = head_or_sillicon(user)
+	data["user_clearance"] = head_or_silicon(user)
 	data["alert_level"] = GLOB.security_level 
 	data["combat_parts_allowed"] = combat_parts_allowed
 	data["emagged"] = (obj_flags & EMAGGED)
@@ -560,17 +560,16 @@
 /// Updates the various authorization checks used to determine if combat parts are available to the current user
 /obj/machinery/mecha_part_fabricator/proc/check_auth_changes(mob/user)
 	red_alert = (GLOB.security_level >= SEC_LEVEL_RED)
-	if(combat_parts_allowed != (authorization_override || red_alert || head_or_sillicon(user)))
-		combat_parts_allowed = (authorization_override || red_alert || head_or_sillicon(user))
+	if(combat_parts_allowed != (authorization_override || red_alert || head_or_silicon(user)))
+		combat_parts_allowed = (authorization_override || red_alert || head_or_silicon(user))
 		update_static_data(user)
 
 /// made as a lazy check to allow silicons full access always
-/obj/machinery/mecha_part_fabricator/proc/head_or_sillicon(mob/user)
-	if(!issilicon(user))
-		id_card = user.get_idcard(hand_first = TRUE)
-		return ACCESS_HEADS in id_card.access
-	return issilicon(user)
-
+/obj/machinery/mecha_part_fabricator/proc/head_or_silicon(mob/user)
+	if(issilicon(user))
+		return TRUE
+	id_card = user.get_idcard(hand_first = TRUE)
+	return ACCESS_HEADS in id_card.access
 
 /obj/machinery/mecha_part_fabricator/ui_act(action, list/params)
 	. = ..()

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -502,8 +502,9 @@
 	for(var/v in stored_research.researched_designs)
 		var/datum/design/D = SSresearch.techweb_design_by_id(v)
 		if(D.build_type & MECHFAB)
-			if(ispath(D.build_path, /obj/item/mecha_parts/mecha_equipment/weapon) && !combat_parts_allowed)
-				continue
+			if(ispath(D.build_path, /obj/item/mecha_parts/mecha_equipment/weapon) && !combat_parts_allowed) // Yogs -- ID swiping for combat parts
+				if(D.build_path != /obj/item/mecha_parts/mecha_equipment/weapon/energy/plasma) // Yogs -- Special snowflake exception for mecha plasma cutters.
+					continue
 			// This is for us.
 			var/list/part = output_part_info(D, TRUE)
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/183306404-d2d34f5d-05dd-40f4-819d-5fb3c92bfc98.png)

Fixes #15186 by adding a snowflake exemption in the code. Yell if there are more than one exosuit designs accidentally affected by the new authorization requirements.

I also went ahead and did some minor typographical fix-ups of #15114 while I was here.

## Changelog
:cl:  Altoids
bugfix: Your 2nd Space Amendment rights have been buffed; Roboticists no longer require head authorization to make plasma cutters for exosuits.
/:cl:
