### PR TITLE
Fixes automatic greentexting of "Protect the nuke" objective

### DIFF
--- a/code/modules/goals/department_goals/security.dm
+++ b/code/modules/goals/department_goals/security.dm
@@ -7,6 +7,7 @@
 	name = "Protect the nuke"
 	desc = "Protect the nuclear core of the station's self-destruct device, by keeping it in the device"
 	fail_if_failed = TRUE // Set this to false if we ever bother making it so you can stuff the core back into the self-destruct device
+	endround = TRUE // Yogs -- Fixes spontaneously winning this objective at roundstart
 
 /datum/department_goal/sec/nukecore/check_complete()
 	for(var/obj/machinery/nuclearbomb/selfdestruct/s in GLOB.nuke_list)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/183306761-c55a64d9-67e9-4a1a-9d9d-9e215770d4ed.png)
*Image above displays the bug, not the fix*

I happened to notice this while doing my other bugfix today. I'm assuming I can just toss the `endround` marker on this event and then it will actually check itself properly.

## Changelog
:cl:  Altoids
bugfix: Fixed automatically greentexting the Protect The Nuke objective.
/:cl:
