### PR TITLE
Regretfully fixes Honkmother sect causing all bibles to be slippery

### DIFF
--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -398,10 +398,11 @@
 	SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "blessing", /datum/mood_event/honk)
 	return TRUE
 
-/obj/item/storage/book/bible/ComponentInitialize()
+/datum/religion_sect/honkmother/on_conversion(mob/living/L)
 	. = ..()
-	AddComponent(/datum/component/slippery, 40)
-
+	for(var/obj/item/storage/book/bible/da_bible in L.get_contents())
+		da_bible.AddComponent(/datum/component/slippery, 40)
+		da_bible.desc += " It has an usually slippery texture."
 
 /datum/religion_sect/honkmother/on_sacrifice(obj/item/reagent_containers/food/snacks/grown/banana/offering, mob/living/user)
 	if(!istype(offering))


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/183308055-22ceb447-3793-408f-b336-f111a5785931.png)

Fixes #15185.

There's probably a smarter way of fixing this, but the way it works now is that only the bibles you are carrying at the time of conversion will be made slippery.

## Changelog
:cl:  Altoids
bugfix: Regretfully, not all bibles are slippery anymore. Only those held at the time of conversion to the religion of the Honkmother.
spellcheck: Bibles that are slippery now inform you of that property in their description.
/:cl:
