### PR TITLE
Cult artificer magic missiles now no longer affect cultists

### DIFF
--- a/code/modules/spells/spell_types/construct_spells.dm
+++ b/code/modules/spells/spell_types/construct_spells.dm
@@ -163,7 +163,7 @@
 	if(ismob(target))
 		var/mob/M = target
 		if(iscultist(target))//cultists can't be harmed by their own constructs' spells!
-		        to_chat(target, span_danger("[src] harmlessly dissipates into crimson particles upon contacting your body!"))
+			to_chat(target, span_danger("[src] harmlessly dissipates into crimson particles upon contacting your body!"))
 			return BULLET_ACT_BLOCK
 		if(M.anti_magic_check())
 			M.visible_message(span_warning("[src] vanishes on contact with [target]!"))

--- a/code/modules/spells/spell_types/construct_spells.dm
+++ b/code/modules/spells/spell_types/construct_spells.dm
@@ -163,7 +163,7 @@
 	if(ismob(target))
 		var/mob/M = target
 		if(iscultist(target))//cultists can't be harmed by their own constructs' spells!
-		to_chat(target, span_danger("[src] harmlessly dissipates into crimson particles upon contacting your body!"))
+		        to_chat(target, span_danger("[src] harmlessly dissipates into crimson particles upon contacting your body!"))
 			return BULLET_ACT_BLOCK
 		if(M.anti_magic_check())
 			M.visible_message(span_warning("[src] vanishes on contact with [target]!"))

--- a/code/modules/spells/spell_types/construct_spells.dm
+++ b/code/modules/spells/spell_types/construct_spells.dm
@@ -155,8 +155,20 @@
 	proj_type = /obj/item/projectile/magic/spell/magic_missile/lesser
 
 /obj/item/projectile/magic/spell/magic_missile/lesser
+	name = "lesser magic missile"
 	color = "red" //Looks more culty this way
 	range = 10
+
+/obj/item/projectile/magic/spell/magic_missile/lesser/on_hit(target)
+	if(ismob(target))
+		var/mob/M = target
+		if(iscultist(target))//cultists can't be harmed by their own constructs' spells!
+		to_chat(target, span_danger("[src] harmlessly dissipates into crimson particles upon contacting your body!"))
+			return BULLET_ACT_BLOCK
+		if(M.anti_magic_check())
+			M.visible_message(span_warning("[src] vanishes on contact with [target]!"))
+			return BULLET_ACT_BLOCK
+	. = ..()
 
 /obj/effect/proc_holder/spell/targeted/smoke/disable
 	name = "Paralysing Smoke"


### PR DESCRIPTION
Steals one change from #14891 that I thought was already implemented within the game.

_Noncult_ artificers also can't target cultists with their magic missiles. I could code a way around this but I think it's more lore-friendly that they're all powered by Nar-Sie and thus their magic still can't harm her followers.

I also could have implemented it that it wouldn't TARGET cultists at all, either, but I prefer it as is since I don't particularly think massive groups of cultists and artificers running around KOing everyone would be really fun. This means that magic missile is still much weaker in large groups since it'll be "wasted" on some cultists.

:cl: ShadowDeath6
tweak: Artificers' Magic Missile spell no longer affects cultists.
/:cl:
