### PR TITLE
Improves the description of the Bluespace Harvester, makes it easier to see when its done

### DIFF
--- a/code/modules/goals/station_goals/bluespace_tap.dm
+++ b/code/modules/goals/station_goals/bluespace_tap.dm
@@ -1,7 +1,8 @@
 //Station goal stuff goes here
+#define BLUESPACE_TAP_POINT_GOAL 45000 // Yogs
 /datum/station_goal/bluespace_tap
 	name = "Bluespace Harvester"
-	var/goal = 45000
+	var/goal = BLUESPACE_TAP_POINT_GOAL // Yogs
 
 /datum/station_goal/bluespace_tap/get_report()
 	return {"<b>Bluespace Harvester Experiment</b><br>

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3642,6 +3642,7 @@
 #include "yogstation\code\modules\events\weightless.dm"
 #include "yogstation\code\modules\food_and_drinks\food\condiment.dm"
 #include "yogstation\code\modules\food_and_drinks\food\snacks\meat.dm"
+#include "yogstation\code\modules\goals\station_goals\bluespace_tap.dm"
 #include "yogstation\code\modules\guardian\guardian.dm"
 #include "yogstation\code\modules\guardian\guardianability.dm"
 #include "yogstation\code\modules\guardian\guardianbuilder.dm"

--- a/yogstation/code/modules/goals/station_goals/bluespace_tap.dm
+++ b/yogstation/code/modules/goals/station_goals/bluespace_tap.dm
@@ -1,0 +1,8 @@
+/obj/machinery/power/bluespace_tap
+	name = "\improper Bluespace Harvester"
+	desc = "An elaborate device used to convert power into confusing bluespace science research." // The original didn't even have a description, so...
+
+/obj/machinery/power/bluespace_tap/examine(mob/user)
+	. = ..()
+	if(total_points >= BLUESPACE_TAP_POINT_GOAL)
+		. += span_notice("<span class='nicegreen'>Green text</span> displayed on the device informs you that the [src] has reached [src.p_their()] research goal!")


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/183311111-0ee1feae-74d6-4c9e-9557-536df8e86fea.png)

I was looking into #15207 and noticed that the Bluespace Harvester didn't have its own description (and was instead using the default one that all `/obj/machinery` have). So, I gave it one. I also marked the name as being `\improper` so that the examine text looks better (not shown in the above image because I just amended it on while writing this)

Beyond that, I made an attempt at making it more clear when greentext hath been achieved by adding a new message in the examine informing you whether or not the machine has reached its point requirement. I'm going to say that doing this closes #15207 (since the bug does not exist, and this resolves the UX problem that cause that person to file a bug report to begin with).

## Changelog
:cl:  Altoids
spellcheck: The Bluespace Harvester now has an actual, grammatically-correct description.
spellcheck: Examining the Bluespace Harvester now informs you whether or not you've reached its point goal.
/:cl:
