### PR TITLE
Fixes runtime (and missing admin logs) with radiation collectors with no fuel tank

### DIFF
--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -89,7 +89,11 @@
 			toggle_power()
 			user.visible_message("[user.name] turns the [src.name] [active? "on":"off"].", \
 			span_notice("You turn the [src.name] [active? "on":"off"]."))
-			var/fuel = loaded_tank.air_contents.get_moles(/datum/gas/plasma)
+			//yogs start -- fixes runtime with empty rad collectors
+			var/fuel = 0
+			if(loaded_tank)
+				fuel = loaded_tank.air_contents.get_moles(/datum/gas/plasma)
+			//yogs end
 			investigate_log("turned [active?"<font color='green'>on</font>":"<font color='red'>off</font>"] by [key_name(user)]. [loaded_tank?"Fuel: [round(fuel/0.29)]%":"<font color='red'>It is empty</font>"].", INVESTIGATE_SINGULO)
 			investigate_log("turned [active?"<font color='green'>on</font>":"<font color='red'>off</font>"] by [key_name(user)]. [loaded_tank?"Fuel: [round(fuel/0.29)]%":"<font color='red'>It is empty</font>"].", INVESTIGATE_SUPERMATTER) // yogs - so supermatter investigate is useful
 			return


### PR DESCRIPTION
Not too big of an issue, but it was causing some missing admin logs (and clogging up my daemon console during debugging) so might as well.

## Changelog
:cl:  Altoids
bugfix: Radiation collectors no longer runtime when you turn them on without a tank loaded in.
/:cl:
