### PR TITLE
Species with no blood can no longer be Bloodsuckers

### DIFF
--- a/code/game/gamemodes/bloodsuckers/bloodsucker.dm
+++ b/code/game/gamemodes/bloodsuckers/bloodsucker.dm
@@ -38,6 +38,12 @@
 		if(!antag_candidates.len)
 			break
 		var/datum/mind/bloodsucker = antag_pick(antag_candidates)
+		//Yogs start -- fixes plasmaman vampires
+		if(bloodsucker?.current?.client.prefs.pref_species && (NOBLOOD in bloodsucker.current.client.prefs.pref_species.species_traits))
+			antag_candidates -= bloodsucker // kinda need to do this to prevent some edge-case infinite loop or whatever
+			i-- // to undo the imminent increment
+			continue
+		//yog end
 		bloodsuckers += bloodsucker
 		bloodsucker.restricted_roles = restricted_jobs
 		log_game("[bloodsucker.key] (ckey) has been selected as a Bloodsucker.")


### PR DESCRIPTION
Fixes #14678 by just imposing a blanket filter against giving the Bloodsucker role to players who do not even have blood to begin with.

## Wiki Documentation

Might be reasonable to mention that plasmamen can no longer be bloodsuckers.

## Changelog
:cl:  Altoids
tweak: Plasmamen and other bloodless races are no longer able to be bloodsuckers.
/:cl:
