### PR TITLE
[MDB IGNORE] Comms console has smaller antenna

### DIFF
--- a/_maps/RandomZLevels/spacebattle.dmm
+++ b/_maps/RandomZLevels/spacebattle.dmm
@@ -1553,7 +1553,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/spacebattle/cruiser)
 "fP" = (
-/obj/machinery/computer/communications{
+/obj/machinery/computer/communications/unlocked{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6301,7 +6301,7 @@
 /turf/open/floor/carpet/green,
 /area/centcom/ferry)
 "aon" = (
-/obj/machinery/computer/communications,
+/obj/machinery/computer/communications/unlocked,
 /turf/open/floor/carpet/green,
 /area/centcom/ferry)
 "aoo" = (
@@ -9568,7 +9568,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "aum" = (
-/obj/machinery/computer/communications{
+/obj/machinery/computer/communications/unlocked{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -11387,7 +11387,7 @@
 /turf/open/floor/wood,
 /area/centcom/control)
 "axX" = (
-/obj/machinery/computer/communications{
+/obj/machinery/computer/communications/unlocked{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -12622,7 +12622,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/control)
 "aAs" = (
-/obj/machinery/computer/communications{
+/obj/machinery/computer/communications/unlocked{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{

--- a/_maps/shuttles/emergency_asteroid.dmm
+++ b/_maps/shuttles/emergency_asteroid.dmm
@@ -399,7 +399,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "bj" = (
-/obj/machinery/computer/communications{
+/obj/machinery/computer/communications/unlocked{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,

--- a/_maps/shuttles/emergency_bar.dmm
+++ b/_maps/shuttles/emergency_bar.dmm
@@ -129,7 +129,7 @@
 /turf/open/floor/carpet,
 /area/shuttle/escape)
 "au" = (
-/obj/machinery/computer/communications{
+/obj/machinery/computer/communications/unlocked{
 	dir = 8
 	},
 /turf/open/floor/carpet,

--- a/_maps/shuttles/emergency_birdboat.dmm
+++ b/_maps/shuttles/emergency_birdboat.dmm
@@ -314,7 +314,7 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "aS" = (
-/obj/machinery/computer/communications{
+/obj/machinery/computer/communications/unlocked{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,

--- a/_maps/shuttles/emergency_box.dmm
+++ b/_maps/shuttles/emergency_box.dmm
@@ -102,7 +102,7 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "au" = (
-/obj/machinery/computer/communications{
+/obj/machinery/computer/communications/unlocked{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,

--- a/_maps/shuttles/emergency_cere.dmm
+++ b/_maps/shuttles/emergency_cere.dmm
@@ -205,7 +205,7 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "au" = (
-/obj/machinery/computer/communications{
+/obj/machinery/computer/communications/unlocked{
 	dir = 8
 	},
 /obj/structure/window/reinforced{

--- a/_maps/shuttles/emergency_clown.dmm
+++ b/_maps/shuttles/emergency_clown.dmm
@@ -93,7 +93,7 @@
 /turf/open/floor/bluespace,
 /area/shuttle/escape)
 "ar" = (
-/obj/machinery/computer/communications{
+/obj/machinery/computer/communications/unlocked{
 	dir = 8
 	},
 /turf/open/floor/mineral/bananium,

--- a/_maps/shuttles/emergency_delta.dmm
+++ b/_maps/shuttles/emergency_delta.dmm
@@ -1326,7 +1326,7 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "cv" = (
-/obj/machinery/computer/communications{
+/obj/machinery/computer/communications/unlocked{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,

--- a/_maps/shuttles/emergency_discoinferno.dmm
+++ b/_maps/shuttles/emergency_discoinferno.dmm
@@ -74,7 +74,7 @@
 /turf/open/floor/mineral/gold,
 /area/shuttle/escape)
 "o" = (
-/obj/machinery/computer/communications{
+/obj/machinery/computer/communications/unlocked{
 	dir = 8
 	},
 /turf/open/floor/mineral/gold,

--- a/_maps/shuttles/emergency_donut.dmm
+++ b/_maps/shuttles/emergency_donut.dmm
@@ -32,7 +32,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "ah" = (
-/obj/machinery/computer/communications,
+/obj/machinery/computer/communications/unlocked,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "ai" = (

--- a/_maps/shuttles/emergency_kilo.dmm
+++ b/_maps/shuttles/emergency_kilo.dmm
@@ -17,7 +17,7 @@
 /area/shuttle/escape)
 "ae" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/computer/communications,
+/obj/machinery/computer/communications/unlocked,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "af" = (

--- a/_maps/shuttles/emergency_luxury.dmm
+++ b/_maps/shuttles/emergency_luxury.dmm
@@ -701,7 +701,7 @@
 /turf/open/floor/carpet,
 /area/shuttle/escape/luxury)
 "RU" = (
-/obj/machinery/computer/communications,
+/obj/machinery/computer/communications/unlocked,
 /turf/open/floor/mineral/diamond,
 /area/shuttle/escape/luxury)
 "SO" = (

--- a/_maps/shuttles/emergency_meta.dmm
+++ b/_maps/shuttles/emergency_meta.dmm
@@ -267,7 +267,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "aB" = (
-/obj/machinery/computer/communications{
+/obj/machinery/computer/communications/unlocked{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,

--- a/_maps/shuttles/emergency_mini.dmm
+++ b/_maps/shuttles/emergency_mini.dmm
@@ -555,7 +555,7 @@
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "zy" = (
-/obj/machinery/computer/communications{
+/obj/machinery/computer/communications/unlocked{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,

--- a/_maps/shuttles/emergency_narnar.dmm
+++ b/_maps/shuttles/emergency_narnar.dmm
@@ -83,7 +83,7 @@
 /turf/open/floor/plasteel/cult,
 /area/shuttle/escape)
 "ap" = (
-/obj/machinery/computer/communications{
+/obj/machinery/computer/communications/unlocked{
 	dir = 8
 	},
 /turf/open/floor/plasteel/cult,

--- a/_maps/shuttles/emergency_omega.dmm
+++ b/_maps/shuttles/emergency_omega.dmm
@@ -69,7 +69,7 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "ai" = (
-/obj/machinery/computer/communications,
+/obj/machinery/computer/communications/unlocked,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/_maps/shuttles/emergency_pool.dmm
+++ b/_maps/shuttles/emergency_pool.dmm
@@ -102,7 +102,7 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "au" = (
-/obj/machinery/computer/communications{
+/obj/machinery/computer/communications/unlocked{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,

--- a/_maps/shuttles/emergency_pubby.dmm
+++ b/_maps/shuttles/emergency_pubby.dmm
@@ -22,7 +22,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "af" = (
-/obj/machinery/computer/communications,
+/obj/machinery/computer/communications/unlocked,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "ag" = (

--- a/_maps/shuttles/emergency_raven.dmm
+++ b/_maps/shuttles/emergency_raven.dmm
@@ -44,7 +44,7 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "ah" = (
-/obj/machinery/computer/communications,
+/obj/machinery/computer/communications/unlocked,
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_rollerdome.dmm
+++ b/_maps/shuttles/emergency_rollerdome.dmm
@@ -310,7 +310,7 @@
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "Kv" = (
-/obj/machinery/computer/communications{
+/obj/machinery/computer/communications/unlocked{
 	dir = 8
 	},
 /obj/machinery/light{

--- a/_maps/shuttles/emergency_transtar.dmm
+++ b/_maps/shuttles/emergency_transtar.dmm
@@ -805,7 +805,7 @@
 /turf/open/floor/carpet,
 /area/shuttle/escape)
 "Wc" = (
-/obj/machinery/computer/communications{
+/obj/machinery/computer/communications/unlocked{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -100,6 +100,13 @@
 
 	. = TRUE
 
+	if(authenticated(usr) && !unlocked && !is_station_level(z) && !IsAdminGhost(usr))
+		if(issilicon(usr))
+			visible_message("An error appears on the screen: Unable to contact authentication servers. Please move closer to the station.")
+			return
+		action = "toggleAuthentication" // We actually want to log out
+		visible_message("An error appears on the screen: Unable to communicate with the station. Logging out.")
+
 	switch (action)
 		if ("answerMessage")
 			if (!authenticated(usr))
@@ -309,7 +316,7 @@
 				authorize_name = null
 				playsound(src, 'sound/machines/terminal_off.ogg', 50, FALSE)
 				return
-			if(!unlocked && !is_station_level(z))
+			if(!unlocked && !is_station_level(z) && !IsAdminGhost(usr))
 				visible_message("An error appears on the screen: Unable to contact authentication servers. Please move closer to the station.")
 				return
 			if (obj_flags & EMAGGED)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -41,6 +41,12 @@
 	/// The last lines used for changing the status display
 	var/static/last_status_display
 
+	/// Allows use off station z-level
+	var/unlocked = FALSE
+
+/obj/machinery/computer/communications/unlocked
+	unlocked = TRUE
+
 /obj/machinery/computer/communications/Initialize()
 	. = ..()
 	GLOB.shuttle_caller_list += src
@@ -303,7 +309,9 @@
 				authorize_name = null
 				playsound(src, 'sound/machines/terminal_off.ogg', 50, FALSE)
 				return
-
+			if(!unlocked && !is_station_level(z))
+				visible_message("An error appears on the screen: Unable to contact authentication servers. Please move closer to the station.")
+				return
 			if (obj_flags & EMAGGED)
 				authenticated = TRUE
 				authorize_access = get_all_accesses()


### PR DESCRIPTION
# Document the changes in your pull request

Built comms consoles now only work on station.
Mapped consoles, using the /unlocked subtype, can be used anywhere, if they are destroyed and rebuilt, they will no longer work anywhere.

# Changelog

:cl:  
tweak: Comms consoles built during the round only work on the station z-level
/:cl:
