### PR TITLE
telecrystal jumping

### DIFF
--- a/code/game/objects/items/stacks/telecrystal.dm
+++ b/code/game/objects/items/stacks/telecrystal.dm
@@ -23,7 +23,7 @@
 	new /obj/effect/particle_effect/sparks(loc)
 	playsound(loc, "sparks", 50, 1)
 
-	if(do_teleport(L, destination, asoundin = 'sound/effects/phasein.ogg', channel = TELEPORT_CHANNEL_BLUESPACE))
+	if(!do_teleport(L, destination, asoundin = 'sound/effects/phasein.ogg', channel = TELEPORT_CHANNEL_BLUESPACE))
 		L.visible_message(span_warning("[src] refuses to be crushed by [L]! There must be something interfering!"), span_danger("[src] suddenly hardens in your hand! There must be something interfering!"))
 		return
 

--- a/code/game/objects/items/stacks/telecrystal.dm
+++ b/code/game/objects/items/stacks/telecrystal.dm
@@ -8,6 +8,34 @@
 	max_amount = 50
 	item_flags = NOBLUDGEON
 
+/obj/item/stack/telecrystal/attack_self(mob/user)
+	if(!isliving(user))
+		return
+	
+	var/mob/living/L = user
+
+	var/turf/destination = get_teleport_loc(loc, L, rand(3,6)) // Gets 3-6 tiles in the user's direction
+
+	if(!istype(destination))
+		return
+
+	L.visible_message(span_warning("[L] crushes [src]!"), span_danger("You crush [src]!"))
+	new /obj/effect/particle_effect/sparks(loc)
+	playsound(loc, "sparks", 50, 1)
+
+	if(do_teleport(L, destination, asoundin = 'sound/effects/phasein.ogg', channel = TELEPORT_CHANNEL_BLUESPACE))
+		L.visible_message(span_warning("[src] refuses to be crushed by [L]! There must be something interfering!"), span_danger("[src] suddenly hardens in your hand! There must be something interfering!"))
+		return
+
+	// Throws you one additional tile, giving it that cool "exit portal" effect and also throwing people very far if they are in space
+	L.throw_at(get_edge_target_turf(L, L.dir), 1, 3, spin = FALSE, diagonals_first = TRUE)
+	if(iscarbon(L))
+		var/mob/living/carbon/C = L
+		// Half as debilitating than a bluespace crystal, as this is a precious resource you're using
+		C.adjust_disgust(15)
+	
+	use(1)
+
 /obj/item/stack/telecrystal/attack(mob/target, mob/user)
 	if(target == user) //You can't go around smacking people with crystals to find out if they have an uplink or not.
 		for(var/obj/item/implant/uplink/I in target)


### PR DESCRIPTION
# Document the changes in your pull request

Telecrystals can now be crushed in hand, similar to their bluespace cousins, but as they are much more rare and precious, they are much more precise and can be used as a sort of ghetto launchpad or get-the-fuck-out utility.

When crushing a telecrystal, you will be teleported 3-6 tiles forward and suffer minor nausea, about half of the effects that crushing a bluespace crystal has (Teleportation is still nauseating, but you have a good idea of where you're ending up at least)

You are also moved forward one tile, to give a cool 'exit portal' effect and also to make you go really fast if you end up in zero gravity. This WILL throw you into walls/other people, so be a little cautious!

# Wiki Documentation

Using a telecrystal in hand will now teleport you forward 3-6 tiles

# Changelog

:cl:  
rscadd: Added telecrystal jumping, which teleports you forward 3-6 tiles when you crush one!
/:cl:
