### PR TITLE
Fixes bad dialogue when using condiment packs, improves grammar & phrasing

### DIFF
--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -80,15 +80,20 @@
 		to_chat(user, span_notice("You fill [src] with [trans] units of the contents of [target]."))
 
 	//Something like a glass or a food item. Player probably wants to transfer TO it.
-	else if(target.is_drainable() || istype(target, /obj/item/reagent_containers/food/snacks))
+	else if(target.is_drainable()) // Yogs -- condiment fix, created food_transfer helper proc
 		if(!reagents.total_volume)
 			to_chat(user, span_warning("[src] is empty!"))
 			return
 		if(target.reagents.total_volume >= target.reagents.maximum_volume)
-			to_chat(user, span_warning("you can't add anymore to [target]!"))
+			to_chat(user, span_warning("You can't add anymore to [target]!")) // Yogs -- capitalization fix
 			return
 		var/trans = src.reagents.trans_to(target, amount_per_transfer_from_this, transfered_by = user)
 		to_chat(user, span_notice("You transfer [trans] units of the condiment to [target]."))
+	//yogs start -- condiment fix
+	else if(istype(target, /obj/item/reagent_containers/food/snacks))
+		food_transfer(target,user)
+		return
+	//yogs end
 
 /obj/item/reagent_containers/food/condiment/on_reagent_change(changetype)
 	if(!possible_states.len)
@@ -314,6 +319,8 @@
 /obj/item/reagent_containers/food/condiment/pack/attack(mob/M, mob/user, def_zone) //Can't feed these to people directly.
 	return
 
+//yogs -- commenting this out as part of the condiment fix
+/*
 /obj/item/reagent_containers/food/condiment/pack/afterattack(obj/target, mob/user , proximity)
 	. = ..()
 	if(!proximity)
@@ -333,6 +340,7 @@
 			to_chat(user, span_notice("You tear open [src] above [target] and the condiments drip onto it."))
 			src.reagents.trans_to(target, amount_per_transfer_from_this, transfered_by = user)
 			qdel(src)
+*/
 
 /obj/item/reagent_containers/food/condiment/pack/on_reagent_change(changetype)
 	if(reagents.reagent_list.len > 0)

--- a/yogstation/code/modules/food_and_drinks/food/condiment.dm
+++ b/yogstation/code/modules/food_and_drinks/food/condiment.dm
@@ -9,6 +9,7 @@
 	to_chat(user, span_notice("You pour [trans] units of the condiment onto [target]."))
 
 /obj/item/reagent_containers/food/condiment/pack/food_transfer(obj/item/reagent_containers/food/snacks/target, mob/user)
+	user.playsound_local(get_turf(src),'sound/effects/rip1.ogg', 18)
 	if(!reagents.total_volume)
 		to_chat(user, span_warning("You tear open [src], but there's nothing in it."))
 		qdel(src)

--- a/yogstation/code/modules/food_and_drinks/food/condiment.dm
+++ b/yogstation/code/modules/food_and_drinks/food/condiment.dm
@@ -1,3 +1,27 @@
+/obj/item/reagent_containers/food/condiment/proc/food_transfer(obj/item/reagent_containers/food/snacks/target, mob/user)
+	if(!reagents.total_volume)
+		to_chat(user, span_warning("[src] is empty!"))
+		return
+	if(target.reagents.total_volume >= target.reagents.maximum_volume)
+		to_chat(user, span_warning("You can't add anymore to [target]!"))
+		return
+	var/trans = src.reagents.trans_to(target, amount_per_transfer_from_this, transfered_by = user)
+	to_chat(user, span_notice("You pour [trans] units of the condiment onto [target]."))
+
+/obj/item/reagent_containers/food/condiment/pack/food_transfer(obj/item/reagent_containers/food/snacks/target, mob/user)
+	if(!reagents.total_volume)
+		to_chat(user, span_warning("You tear open [src], but there's nothing in it."))
+		qdel(src)
+		return
+	if(target.reagents.total_volume >= target.reagents.maximum_volume)
+		to_chat(user, span_warning("You tear open [src], but [target] is stacked so high that it just drips off!") )
+		qdel(src)
+		return
+	else
+		to_chat(user, span_notice("You tear open [src] above [target] and the condiments drip onto it."))
+		src.reagents.trans_to(target, amount_per_transfer_from_this, transfered_by = user)
+		qdel(src)
+
 /obj/item/reagent_containers/food/condiment/cinnamon
 	name = "cinnamon shaker"
 	desc = "A spice obtained from the bark of a cinnamomum tree"


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/29939414/183771568-f5168de0-8344-42d0-96e7-f0e833b5ada9.png)

Fixes #15028 by adding a new proc, `food_transfer`, which handles how each condiment container handles being poured onto food.

Doing this let us also make the dialogue for that more specific and ergo sound better. You no longer "transfer units into" the burger, you just pour it on.

## Changelog

:cl:  Altoids
bugfix: Fixed ketchup packets telling you they are empty every time you use one.
soundadd: Tearing open hotsauce packs now makes a small noise.
spellcheck: Fixed missing capitalization, and improved the phrasing of, pouring condiments onto food.
/:cl:
