### PR TITLE
Fixes Floorbot, some explosions and singularities not exposing tile to space properly

### DIFF
--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -318,5 +318,5 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	SSair.add_to_active(src)
 
 /turf/proc/ReplaceWithLattice()
-	ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
+	ScrapeToBottom(flags = CHANGETURF_INHERIT_AIR) // Yogs -- fixes this not actually replacing the turf with a lattice, lmao (ScrapeToBottom defined in yogs file)
 	new /obj/structure/lattice(locate(x, y, z))

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3499,6 +3499,7 @@
 #include "yogstation\code\game\objects\structures\beds_chairs\chair.dm"
 #include "yogstation\code\game\objects\structures\beds_chairs\electric_bed.dm"
 #include "yogstation\code\game\objects\structures\signs\signs_plaques.dm"
+#include "yogstation\code\game\turfs\change_turf.dm"
 #include "yogstation\code\game\turfs\simulated\ballpit.dm"
 #include "yogstation\code\game\turfs\simulated\minerals.dm"
 #include "yogstation\code\game\turfs\simulated\floor\fancy_floor.dm"

--- a/yogstation/code/game/turfs/change_turf.dm
+++ b/yogstation/code/game/turfs/change_turf.dm
@@ -1,0 +1,8 @@
+// Take every layer off and bring us to the bottom layer.
+/turf/proc/ScrapeToBottom(flags)
+    if(baseturfs == type) // Already at the bottom
+        return src
+    if(islist(baseturfs))
+        return ChangeTurf(baseturfs[1],baseturfs[1],flags)
+    else
+        return ChangeTurf(baseturfs, baseturfs, flags) // The bottom baseturf will never go away


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/183778470-f47d3559-6133-44cd-861b-12e585ac3398.png)

Fixes #15231 by altering `ReplaceWithLattice` so that it actually, like, replaces the tile with lattice.

This most importantly fixes emagged floorbots, but also just improves the behaviour of everything that needs to do this sort of lattice replacement, including some explosions & singularity-act turf conversion.

## Changelog
:cl:  Altoids
bugfix: Emagged floorbots have been given slightly stronger robo-arms, and can now actually breach the hull of the space station when turning tiles into lattice, as intended.
bugfix: Fixed explosions and singularities not always breaching floor tiles when they should.
/:cl:
