### PR TITLE
Reimplements Cinnamon Shakers into the game

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1917,7 +1917,7 @@
 
 /datum/supply_pack/organic/food
 	name = "Food Crate"
-	desc = "Get things cooking with this crate full of useful ingredients! Contains a dozen eggs, three bananas, and some flour, rice, milk, soymilk, salt, pepper, enzyme, sugar, and monkeymeat."
+	desc = "Get things cooking with this crate full of useful ingredients! Contains a dozen eggs, three bananas, and some flour, rice, milk, soymilk, salt, pepper, cinnamon, enzyme, sugar, and monkeymeat." // yogs
 	cost = 1000
 	contains = list(/obj/item/reagent_containers/food/condiment/flour,
 					/obj/item/reagent_containers/food/condiment/rice,
@@ -1925,6 +1925,7 @@
 					/obj/item/reagent_containers/food/condiment/soymilk,
 					/obj/item/reagent_containers/food/condiment/saltshaker,
 					/obj/item/reagent_containers/food/condiment/peppermill,
+					/obj/item/reagent_containers/food/condiment/cinnamon, // Yogs -- Adds cinnamon shakers to this crate
 					/obj/item/storage/box/fancy/egg_box,
 					/obj/item/reagent_containers/food/condiment/enzyme,
 					/obj/item/reagent_containers/food/condiment/sugar,

--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -14,7 +14,7 @@
 	possible_transfer_amounts = list(1, 5, 10, 15, 20, 25, 30, 50)
 	volume = 50
 	//Possible_states has the reagent type as key and a list of, in order, the icon_state, the name and the desc as values. Used in the on_reagent_change(changetype) to change names, descs and sprites.
-	var/list/possible_states = list(
+	var/list/possible_states = list( // YOGS WARNING -- To avoid constant modularity problems, this list is now generated automagically at run-time. Do not amend this list to add your new condiments!
 	 /datum/reagent/consumable/ketchup = list("ketchup", "ketchup bottle", "You feel more American already."),
 	 /datum/reagent/consumable/capsaicin = list("hotsauce", "hotsauce bottle", "You can almost TASTE the stomach ulcers now!"),
 	 /datum/reagent/consumable/enzyme = list("enzyme", "universal enzyme bottle", "Used in cooking various dishes"),
@@ -30,7 +30,8 @@
 
 /obj/item/reagent_containers/food/condiment/Initialize()
 	. = ..()
-	possible_states = typelist("possible_states", possible_states)
+	//possible_states = typelist("possible_states", possible_states) // yogs -- commented out
+	initialize_possible_states() // yogs
 
 /obj/item/reagent_containers/food/condiment/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] is trying to eat the entire [src]! It looks like [user.p_they()] forgot how food works!"))

--- a/code/modules/vending/drinnerware.dm
+++ b/code/modules/vending/drinnerware.dm
@@ -16,6 +16,7 @@
 					/obj/item/kitchen/rollingpin = 2,
 					/obj/item/kitchen/knife = 2,
 					/obj/item/reagent_containers/glass/mixbowl = 3, // Yogs -- chef's mixing bowl 
+					/obj/item/reagent_containers/food/condiment/cinnamon = 5, // Yogs -- cinnamon shakers!
 					/obj/item/plate = 10) 
 	contraband = list(/obj/item/kitchen/knife/butcher = 2, // Yogs -- Pan
 					  /obj/item/melee/fryingpan = 2) // Yogs -- Pan

--- a/yogstation/code/modules/food_and_drinks/food/condiment.dm
+++ b/yogstation/code/modules/food_and_drinks/food/condiment.dm
@@ -1,3 +1,22 @@
+/obj/item/reagent_containers/food/condiment
+	var/static/list/yog_possible_states // Holding this in a static since it's cumbersome to calculate this every single time a saltshaker is instantiated
+	//(also, refactoring into a static means that condiments aren't hammering GLOB with a bunch of repetitive or empty typelists for every sort of condiment that exists.)
+
+/obj/item/reagent_containers/food/condiment/proc/initialize_possible_states()
+	if(!possible_states.len) // This is a signal used by some children types to mark that they can't really change themselves.
+		return
+	if(!yog_possible_states)
+		yog_possible_states = list()
+		//...And now we initialize possible_states PROPERLY
+		var/list/craftable_types = subtypesof(/obj/item/reagent_containers/food/condiment) - subtypesof(/obj/item/reagent_containers/food/condiment/pack) // Can't make ketchup packets
+		for(var/conditype in craftable_types)
+			var/obj/item/reagent_containers/food/condiment/dummy = new conditype()
+			if(LAZYLEN(dummy.list_reagents) == 1)
+				var/spice = dummy.list_reagents[1]
+				yog_possible_states[spice] = list(dummy.icon_state,dummy.name,dummy.desc)
+			qdel(dummy) // I have to do this, right?
+	possible_states = yog_possible_states
+
 /obj/item/reagent_containers/food/condiment/proc/food_transfer(obj/item/reagent_containers/food/snacks/target, mob/user)
 	if(!reagents.total_volume)
 		to_chat(user, span_warning("[src] is empty!"))
@@ -7,6 +26,9 @@
 		return
 	var/trans = src.reagents.trans_to(target, amount_per_transfer_from_this, transfered_by = user)
 	to_chat(user, span_notice("You pour [trans] units of the condiment onto [target]."))
+
+/obj/item/reagent_containers/food/condiment/pack/initialize_possible_states() // Condiment packs just behave like TG because we don't have any of our own.
+	possible_states = typelist("possible_states", possible_states)
 
 /obj/item/reagent_containers/food/condiment/pack/food_transfer(obj/item/reagent_containers/food/snacks/target, mob/user)
 	user.playsound_local(get_turf(src),'sound/effects/rip1.ogg', 18)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/183962240-842071e2-b720-4403-b969-3d5179548a99.png)

Manatee asked me in Discord yesterday to fix a few issues with the cinnamon shakers, which, apparently, were somewhat clobbered by some merge conflict resolution at some point.
![image](https://user-images.githubusercontent.com/29939414/183963593-f36be6ac-b45f-4f41-839c-af15d21a522e.png)

So I did that. They are now craftable, and appear in cargo crates and vending machines just like salt & pepper do.

## Coder Warning
The TG way that condiments remember which things they can morph into is really stupid and repetitive; every time a condiment is added to the game, its `icon_state`, `name`, `desc`, and reagent must be manually duplicated into the `possible_states` list. This list is then copied, repetitively, for each type of condiment container possible.

This was dumb and immodular (causing the problem to begin with) so I've refactored it.

Note that, since we're moving away from spammy typelists and going to a singular static, this means that new condiment types with special `possible_states` will have those states overwritten by `initialize_possible_states` unless this proc is overwritten for them (as it is for packs).

## Changelog

:cl:  Altoids
tweak: The cargo food crate and the chef's vending machine are now both stocked with some cinnamon shakers.
bugfix: Fixed bug that was preventing players from crafting new cinnamon shakers.
bugfix: If there was a bug that caused condiment containers to sometimes not change sprite when reagents were added, it's gone now.
/:cl:
