### PR TITLE
Give AI more holopad icons

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -798,7 +798,6 @@
 			"mothroach" = 'icons/mob/animal.dmi',
 			"snake" = 'icons/mob/animal.dmi',
 			"goose" = 'icons/mob/animal.dmi',
-			"possum" = 'icons/mob/animal.dmi',
 			"poppypossum" = 'icons/mob/animal.dmi'
 			)
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -794,7 +794,12 @@
 			"cat2" = 'icons/mob/pets.dmi',
 			"poly" = 'icons/mob/animal.dmi',
 			"pug" = 'icons/mob/pets.dmi',
-			"spider" = 'icons/mob/animal.dmi'
+			"spider" = 'icons/mob/animal.dmi',
+			"mothroach" = 'icons/mob/animal.dmi',
+			"snake" = 'icons/mob/animal.dmi',
+			"goose" = 'icons/mob/animal.dmi',
+			"possum" = 'icons/mob/animal.dmi',
+			"poppypossum" = 'icons/mob/animal.dmi'
 			)
 
 			input = input("Please select a hologram:") as null|anything in icon_list

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -783,7 +783,7 @@
 		if("Animal")
 			var/list/icon_list = list(
 			"bear" = 'icons/mob/animal.dmi',
-			"carp" = 'icons/mob/animal.dmi',
+			"carp" = 'icons/mob/carp.dmi',
 			"chicken" = 'icons/mob/animal.dmi',
 			"corgi" = 'icons/mob/pets.dmi',
 			"cow" = 'icons/mob/animal.dmi',


### PR DESCRIPTION
# Document the changes in your pull request
Gives AI
 - Mothroach
![image](https://user-images.githubusercontent.com/20369082/184021302-1607bbd5-fe24-4879-bc69-577a27457299.png)
 - Snake
![image](https://user-images.githubusercontent.com/20369082/184021377-23dbddab-d04f-4f49-8345-a3e37d0aad7c.png)
 - Goose
![image](https://user-images.githubusercontent.com/20369082/184021420-c412cc09-f8cc-4fd3-b6e8-a310c4431ef7.png)
 - Poppy Possum
![image](https://user-images.githubusercontent.com/20369082/184021491-f5d61118-0797-4e97-8654-47c72cf1befa.png)

for holopad icons to use

# Wiki Documentation

Dont think holopads are documented

# Changelog

:cl:  
rscadd: AI has more holopad icons
/:cl:
