### PR TITLE
Fixes Crystallizer Logic

### DIFF
--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
@@ -154,11 +154,11 @@
 
 	if(	(internal.return_temperature() >= (selected_recipe.min_temp * MIN_DEVIATION_RATE) && internal.return_temperature() <= selected_recipe.min_temp) || \
 		(internal.return_temperature() >= selected_recipe.max_temp && internal.return_temperature() <= (selected_recipe.max_temp * MAX_DEVIATION_RATE)))
-		quality_loss = min(quality_loss + 1.5, -100)
+		quality_loss = min(quality_loss + 1.5, 100)
 
-	var/median_temperature = (selected_recipe.max_temp - selected_recipe.min_temp) * 0.5
+	var/median_temperature = (selected_recipe.max_temp + selected_recipe.min_temp) * 0.5
 	if(internal.return_temperature() >= (median_temperature * MIN_DEVIATION_RATE) && internal.return_temperature() <= (median_temperature * MAX_DEVIATION_RATE))
-		quality_loss = max(quality_loss - 5.5, 100)
+		quality_loss = max(quality_loss - 5.5, -100)
 
 /obj/machinery/atmospherics/components/binary/crystallizer/proc/apply_cooling()
 	var/datum/gas_mixture/cooling_port = airs[1]


### PR DESCRIPTION
# Document the changes in your pull request

The crystallizer has a quality system to determine how many moles are used in each instance of crafting an item. This PR fixes how the quality_loss var is calculated because the old way had several logic errors in /proc/heat_calculations. This isn't a change but more like a fix to the intended system. 

I have tested this on a private instance of Yogs and the quality system now seems to be working as intended.

# Wiki Documentation

The crystallizer currently has next to no documentation as to actually use it on the wiki, so I guess nothing needs to be "changed" but maybe someone can write about it.

# Changelog

:cl:  NovaAzure
tweak: Fixed Crystallizer logic
/:cl:
