### PR TITLE
Space Lube acts like bootleg meth for IPCs

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -397,12 +397,13 @@
 	L.remove_movespeed_modifier(type)
 	..()
 
-/datum/reagent/lube/on_mob_life(mob/living/carbon/M)
+/datum/reagent/lube/on_mob_life(mob/living/carbon/C)
 	. = ..()
-	if(isipc(M))
-		M.adjustFireLoss(3)
-		if(prob(10))
-			to_chat(M, "You slowly burn up as your internal mechanisms work faster than intended.")
+	if(!isipc(C))
+		return
+	C.adjustFireLoss(3)
+	if(prob(10))
+		to_chat(C, span_warning("You slowly burn up as your internal mechanisms work faster than intended."))
 
 /datum/reagent/spraytan
 	name = "Spray Tan"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -378,6 +378,9 @@
 	description = "Lubricant is a substance introduced between two moving surfaces to reduce the friction and wear between them. giggity."
 	color = "#009CA8" // rgb: 0, 156, 168
 	taste_description = "cherry" // by popular demand
+	process_flags = PROCESS_ORGANIC | PROCESS_SYNTHETIC
+	metabolization_rate = 2 * REAGENTS_METABOLISM // Double speed
+	
 
 /datum/reagent/lube/reaction_turf(turf/open/T, reac_volume)
 	if (!istype(T))

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -385,6 +385,22 @@
 	if(reac_volume >= 1)
 		T.MakeSlippery(TURF_WET_LUBE, 15 SECONDS, min(reac_volume * 2 SECONDS, 120))
 
+/datum/reagent/lube/on_mob_metabolize(mob/living/L)
+	..()
+	if(isipc(L))
+		L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=-0.8, blacklisted_movetypes=(FLYING|FLOATING))
+
+/datum/reagent/lube/on_mob_end_metabolize(mob/living/L)
+	L.remove_movespeed_modifier(type)
+	..()
+
+/datum/reagent/lube/on_mob_life(mob/living/carbon/M)
+	. = ..()
+	if(isipc(M))
+		M.adjustFireLoss(3)
+		if(prob(10))
+			to_chat(M, "You slowly burn up as your internal mechanisms work faster than intended.")
+
 /datum/reagent/spraytan
 	name = "Spray Tan"
 	description = "A substance applied to the skin to darken the skin."


### PR DESCRIPTION
# Document the changes in your pull request

Adds a shitty version of meth for space lube that only affects IPCs
Will deal 3 burn damage a second
Has half the speedup of meth (because its cheap)

# Wiki Documentation

1.8x speedup
3 burn per second
Affects only IPCs

# Changelog

:cl:  
rscadd: Space Lube makes IPC go fast
/:cl:
