### PR TITLE
[PORT] Examine Block

### DIFF
--- a/code/__DEFINES/chat.dm
+++ b/code/__DEFINES/chat.dm
@@ -19,3 +19,6 @@
 #define MESSAGE_TYPE_DEBUG "debug"
 #define MESSAGE_TYPE_MENTORPM "mentorpm"
 #define MESSAGE_TYPE_DONATOR "donator"
+
+/// Adds a generic box around whatever message you're sending in chat. Really makes things stand out.
+#define examine_block(str) ("<div class='examine_block'>" + str + "</div>")

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -467,7 +467,7 @@ SUBSYSTEM_DEF(ticker)
 			m = pick(memetips)
 
 	if(m)
-		to_chat(world, span_purple("<b>Tip of the round: </b>[html_encode(m)]"))
+		to_chat(world, span_purple(examine_block("<b>Tip of the round: </b>[html_encode(m)]")))
 
 /datum/controller/subsystem/ticker/proc/check_queue()
 	if(!queued_players.len)

--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -35,7 +35,7 @@
 	return ..()
 
 /datum/component/mood/proc/print_mood(mob/user)
-	var/msg = "<span class='info'>*---------*\n<EM>Your current mood</EM>\n"
+	var/msg = "<span class='info'><EM>Your current mood</EM>\n"
 	msg += span_notice("My mental status: ") //Long term
 	switch(sanity)
 		if(SANITY_GREAT to INFINITY)
@@ -79,7 +79,7 @@
 			msg += event.description
 	else
 		msg += "<span class='nicegreen'>I don't have much of a reaction to anything right now.<span>\n"
-	to_chat(user || parent, msg)
+	to_chat(user || parent, examine_block(msg))
 
 /datum/component/mood/proc/update_mood() //Called whenever a mood event is added or removed
 	mood = 0

--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -35,7 +35,7 @@
 	return ..()
 
 /datum/component/mood/proc/print_mood(mob/user)
-	var/msg = "<span class='info'><EM>Your current mood</EM>\n"
+	var/msg = "[span_info("<EM>Your Current Mood:</EM>")]\n"
 	msg += span_notice("My mental status: ") //Long term
 	switch(sanity)
 		if(SANITY_GREAT to INFINITY)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -444,10 +444,10 @@
   * COMSIG_ATOM_GET_EXAMINE_NAME signal
   */
 /atom/proc/get_examine_name(mob/user)
-	. = "\a [src]"
+	. = "\a <b>[src]</b>"
 	var/list/override = list(gender == PLURAL ? "some" : "a", " ", "[name]")
 	if(article)
-		. = "[article] [src]"
+		. = "[article] <b>[src]</b>"
 		override[EXAMINE_POSITION_ARTICLE] = article
 	if(SEND_SIGNAL(src, COMSIG_ATOM_GET_EXAMINE_NAME, user, override) & COMPONENT_EXNAME_CHANGED)
 		. = override.Join("")
@@ -465,7 +465,11 @@
   * Produces a signal COMSIG_PARENT_EXAMINE
   */
 /atom/proc/examine(mob/user)
-	. = list("[get_examine_string(user, TRUE)].")
+	var/examine_string = get_examine_string(user, thats = TRUE)
+	if(examine_string)
+		. = list("[examine_string].")
+	else
+		. = list()
 
 	if(desc)
 		. += desc

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -484,8 +484,8 @@
 			. += "It contains:"
 			if(length(reagents.reagent_list))
 				if(user.can_see_reagents()) //Show each individual reagent
-					for(var/datum/reagent/R in reagents.reagent_list)
-						. += "[R.volume] units of [R.name]"
+					for(var/datum/reagent/current_reagent in reagents.reagent_list)
+						. += "&bull; [round(current_reagent.volume, 0.01)] units of [current_reagent.name]"
 				else //Otherwise, just show the total volume
 					var/total_volume = 0
 					for(var/datum/reagent/R in reagents.reagent_list)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -512,9 +512,9 @@ GENE SCANNER
 		if(istype(scanner))
 			// Only emit the cheerful scanner message if this scan came from a scanner
 			playsound(scanner, 'sound/machines/ping.ogg', 50, FALSE)
-			render_list += span_notice("\The [scanner] makes a happy ping and briefly displays a smiley face with several exclamation points! It's really excited to report that [patient] has no wounds!")
+			to_chat(user, span_notice("\The [scanner] makes a happy ping and briefly displays a smiley face with several exclamation points! It's really excited to report that [patient] has no wounds!"))
 		else
-			render_list += "<span class='notice ml-1'>No wounds detected in subject.</span>"
+			to_chat(user, "<span class='notice ml-1'>No wounds detected in subject.</span>")
 	else
 		to_chat(user, examine_block(jointext(render_list, "")))
 

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -511,7 +511,7 @@ GENE SCANNER
 		else
 			to_chat(user, "<span class='notice ml-1'>No wounds detected in subject.</span>")
 	else
-		to_chat(user, jointext(render_list, ""))
+		to_chat(user, examine_block(jointext(render_list, "")))
 
 /obj/item/healthanalyzer/wound
 	name = "first aid analyzer"

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -117,6 +117,7 @@ GENE SCANNER
 		beep_cooldown = world.time+40
 
 	// Clumsiness/brain damage check
+	/* This needs to be reformated, along with 99% of this stuff
 	if ((HAS_TRAIT(user, TRAIT_CLUMSY) || HAS_TRAIT(user, TRAIT_DUMB)) && prob(50))
 		to_chat(user, span_notice("You stupidly try to analyze the floor's vitals!"))
 		user.visible_message(span_warning("[user] has analyzed the floor's vitals!"))
@@ -125,7 +126,7 @@ GENE SCANNER
 		to_chat(user, span_info("\tDamage specifics: <font color='blue'>0</font>-<font color='green'>0</font>-<font color='#FF8000'>0</font>-<font color='red'>0</font>"))
 		to_chat(user, span_info("Body temperature: ???"))
 		return
-
+*/
 	user.visible_message(span_notice("[user] has analyzed [M]'s vitals."))
 
 	switch(scanmode)
@@ -141,6 +142,7 @@ GENE SCANNER
 
 // Used by the PDA medical scanner too
 /proc/healthscan(mob/user, mob/living/M, advanced = FALSE)
+	var/list/combined_msg = list()
 	if(isliving(user) && (user.incapacitated() || user.eye_blind))
 		return
 	//Damage specifics
@@ -157,29 +159,29 @@ GENE SCANNER
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.undergoing_cardiac_arrest() && H.stat != DEAD)
-			to_chat(user, span_danger("Subject suffering from heart attack: Apply defibrillation or other electric shock immediately!"))
+			combined_msg += span_danger("Subject suffering from heart attack: Apply defibrillation or other electric shock immediately!")
 
-	to_chat(user, span_info("Analyzing results for [M]:\n\tOverall status: [mob_status]"))
+	combined_msg += span_info("Analyzing results for [M]:\n\tOverall status: [mob_status]")
 
 	// Damage descriptions
 	if(brute_loss > 10)
-		to_chat(user, "\t[span_alert("[brute_loss > 50 ? "Severe" : "Minor"] tissue damage detected.")]")
+		combined_msg += "\t[span_alert("[brute_loss > 50 ? "Severe" : "Minor"] tissue damage detected.")]"
 	if(fire_loss > 10)
-		to_chat(user, "\t[span_alert("[fire_loss > 50 ? "Severe" : "Minor"] burn damage detected.")]")
+		combined_msg += "\t[span_alert("[fire_loss > 50 ? "Severe" : "Minor"] burn damage detected.")]"
 	if(oxy_loss > 10)
-		to_chat(user, "\t<span class='info'>[span_alert("[oxy_loss > 50 ? "Severe" : "Minor"] oxygen deprivation detected.")]")
+		combined_msg += "\t<span class='info'>[span_alert("[oxy_loss > 50 ? "Severe" : "Minor"] oxygen deprivation detected.")]"
 	if(tox_loss > 10)
-		to_chat(user, "\t[span_alert("[tox_loss > 50 ? "Severe" : "Minor"] amount of toxin damage detected.")]")
+		combined_msg += "\t[span_alert("[tox_loss > 50 ? "Severe" : "Minor"] amount of toxin damage detected.")]"
 	if(M.getStaminaLoss())
-		to_chat(user, "\t[span_alert("Subject appears to be suffering from fatigue.")]")
+		combined_msg += "\t[span_alert("Subject appears to be suffering from fatigue.")]"
 		if(advanced)
-			to_chat(user, "\t[span_info("Fatigue Level: [M.getStaminaLoss()]%.")]")
+			combined_msg += "\t[span_info("Fatigue Level: [M.getStaminaLoss()]%.")]"
 	if (M.getCloneLoss())
-		to_chat(user, "\t[span_alert("Subject appears to have [M.getCloneLoss() > 30 ? "Severe" : "Minor"] cellular damage.")]")
+		combined_msg += "\t[span_alert("Subject appears to have [M.getCloneLoss() > 30 ? "Severe" : "Minor"] cellular damage.")]"
 		if(advanced)
-			to_chat(user, "\t[span_info("Cellular Damage Level: [M.getCloneLoss()].")]")
+			combined_msg += "\t[span_info("Cellular Damage Level: [M.getCloneLoss()].")]"
 	if (!M.getorgan(/obj/item/organ/brain))
-		to_chat(user, "\t[span_alert("Subject lacks a brain.")]")
+		combined_msg += "\t[span_alert("Subject lacks a brain.")]"
 	if(iscarbon(M))
 		var/mob/living/carbon/C = M
 		if(LAZYLEN(C.get_traumas()))
@@ -197,73 +199,73 @@ GENE SCANNER
 						trauma_desc += "permanent "
 				trauma_desc += B.scan_desc
 				trauma_text += trauma_desc
-			to_chat(user, "\t[span_alert("Cerebral traumas detected: subject appears to be suffering from [english_list(trauma_text)].")]")
+			combined_msg += "\t[span_alert("Cerebral traumas detected: subject appears to be suffering from [english_list(trauma_text)].")]"
 		if(C.roundstart_quirks.len)
-			to_chat(user, "\t[span_info("Subject has the following physiological traits: [C.get_trait_string()].")]")
+			combined_msg += "\t[span_info("Subject has the following physiological traits: [C.get_trait_string()].")]"
 		if(C.has_quirk(/datum/quirk/allergic))
-			to_chat(user, "\t[span_info("Subject is allergic to the chemical [C.allergies].")]")
+			combined_msg += "\t[span_info("Subject is allergic to the chemical [C.allergies].")]"
 	if(advanced)
-		to_chat(user, "\t[span_info("Brain Activity Level: [(200 - M.getOrganLoss(ORGAN_SLOT_BRAIN))/2]%.")]")
+		combined_msg += "\t[span_info("Brain Activity Level: [(200 - M.getOrganLoss(ORGAN_SLOT_BRAIN))/2]%.")]"
 		if(M.has_horror_inside())
-			to_chat(user, "\t[span_alert("Detected parasitic organism residing in the cranial area.")]")
-			to_chat(user, "\t[span_alert("Recommended course of action: <b>organ manipulation surgery performed on head.</b>.")]")
+			combined_msg += "\t[span_alert("Detected parasitic organism residing in the cranial area.")]"
+			combined_msg += "\t[span_alert("Recommended course of action: <b>organ manipulation surgery performed on head.</b>.")]"
 
 	if (M.radiation)
-		to_chat(user, "\t[span_alert("Subject is irradiated.")]")
+		combined_msg += "\t[span_alert("Subject is irradiated.")]"
 		if(advanced)
-			to_chat(user, "\t[span_info("Radiation Level: [M.radiation]%.")]")
+			combined_msg += "\t[span_info("Radiation Level: [M.radiation]%.")]"
 
 	if(advanced && M.hallucinating())
-		to_chat(user, "\t[span_info("Subject is hallucinating.")]")
+		combined_msg += "\t[span_info("Subject is hallucinating.")]"
 
 	//Eyes and ears
 	if(advanced)
 		if(iscarbon(M))
 			var/mob/living/carbon/C = M
 			var/obj/item/organ/ears/ears = C.getorganslot(ORGAN_SLOT_EARS)
-			to_chat(user, "\t<span class='info'><b>==EAR STATUS==</b></span>")
+			combined_msg += "\t<span class='info'><b>==EAR STATUS==</b></span>"
 			if(istype(ears))
 				var/healthy = TRUE
 				if(HAS_TRAIT_FROM(C, TRAIT_DEAF, GENETIC_MUTATION))
 					healthy = FALSE
-					to_chat(user, "\t[span_alert("Subject is genetically deaf.")]")
+					combined_msg += "\t[span_alert("Subject is genetically deaf.")]"
 				else if(HAS_TRAIT(C, TRAIT_DEAF))
 					healthy = FALSE
-					to_chat(user, "\t[span_alert("Subject is deaf.")]")
+					combined_msg += "\t[span_alert("Subject is deaf.")]"
 				else
 					if(ears.damage)
-						to_chat(user, "\t[span_alert("Subject has [ears.damage > ears.maxHealth ? "permanent ": "temporary "]hearing damage.")]")
+						combined_msg += "\t[span_alert("Subject has [ears.damage > ears.maxHealth ? "permanent ": "temporary "]hearing damage.")]"
 						healthy = FALSE
 					if(ears.deaf)
-						to_chat(user, "\t[span_alert("Subject is [ears.damage > ears.maxHealth ? "permanently ": "temporarily "] deaf.")]")
+						combined_msg += "\t[span_alert("Subject is [ears.damage > ears.maxHealth ? "permanently ": "temporarily "] deaf.")]"
 						healthy = FALSE
 				if(healthy)
-					to_chat(user, "\t[span_info("Healthy.")]")
+					combined_msg += "\t[span_info("Healthy.")]"
 			else
-				to_chat(user, "\t[span_alert("Subject does not have ears.")]")
+				combined_msg += "\t[span_alert("Subject does not have ears.")]"
 			var/obj/item/organ/eyes/eyes = C.getorganslot(ORGAN_SLOT_EYES)
-			to_chat(user, "\t<span class='info'><b>==EYE STATUS==</b></span>")
+			combined_msg += "\t<span class='info'><b>==EYE STATUS==</b></span>"
 			if(istype(eyes))
 				var/healthy = TRUE
 				if(HAS_TRAIT(C, TRAIT_BLIND))
-					to_chat(user, "\t[span_alert("Subject is blind.")]")
+					combined_msg += "\t[span_alert("Subject is blind.")]"
 					healthy = FALSE
 				if(HAS_TRAIT(C, TRAIT_NEARSIGHT))
-					to_chat(user, "\t[span_alert("Subject is nearsighted.")]")
+					combined_msg += "\t[span_alert("Subject is nearsighted.")]"
 					healthy = FALSE
 				if(eyes.damage > 30)
-					to_chat(user, "\t[span_alert("Subject has severe eye damage.")]")
+					combined_msg += "\t[span_alert("Subject has severe eye damage.")]"
 					healthy = FALSE
 				else if(eyes.damage > 20)
-					to_chat(user, "\t[span_alert("Subject has significant eye damage.")]")
+					combined_msg += "\t[span_alert("Subject has significant eye damage.")]"
 					healthy = FALSE
 				else if(eyes.damage)
-					to_chat(user, "\t[span_alert("Subject has minor eye damage.")]")
+					combined_msg += "\t[span_alert("Subject has minor eye damage.")]"
 					healthy = FALSE
 				if(healthy)
-					to_chat(user, "\t[span_info("Healthy.")]")
+					combined_msg += "\t[span_info("Healthy.")]"
 			else
-				to_chat(user, "\t[span_alert("Subject does not have eyes.")]")
+				combined_msg += "\t[span_alert("Subject does not have eyes.")]"
 
 
 	// Body part damage report
@@ -271,9 +273,9 @@ GENE SCANNER
 		var/mob/living/carbon/C = M
 		var/list/damaged = C.get_damaged_bodyparts(1,1)
 		if(length(damaged)>0 || oxy_loss>0 || tox_loss>0 || fire_loss>0)
-			to_chat(user, span_info("\tDamage: <span class='info'><font color='red'>Brute</font></span>-<font color='#FF8000'>Burn</font>-<font color='green'>Toxin</font>-<font color='blue'>Suffocation</font>\n\t\tSpecifics: <font color='red'>[brute_loss]</font>-<font color='#FF8000'>[fire_loss]</font>-<font color='green'>[tox_loss]</font>-<font color='blue'>[oxy_loss]</font>"))
+			combined_msg += span_info("\tDamage: <span class='info'><font color='red'>Brute</font></span>-<font color='#FF8000'>Burn</font>-<font color='green'>Toxin</font>-<font color='blue'>Suffocation</font>\n\t\tSpecifics: <font color='red'>[brute_loss]</font>-<font color='#FF8000'>[fire_loss]</font>-<font color='green'>[tox_loss]</font>-<font color='blue'>[oxy_loss]</font>")
 			for(var/obj/item/bodypart/org in damaged)
-				to_chat(user, "\t\t<span class='info'>[capitalize(org.name)]: [(org.brute_dam > 0) ? "<font color='red'>[org.brute_dam]</font></span>" : "<font color='red'>0</font>"]-[(org.burn_dam > 0) ? "<font color='#FF8000'>[org.burn_dam]</font>" : "<font color='#FF8000'>0</font>"]")
+				combined_msg += "\t\t<span class='info'>[capitalize(org.name)]: [(org.brute_dam > 0) ? "<font color='red'>[org.brute_dam]</font></span>" : "<font color='red'>0</font>"]-[(org.burn_dam > 0) ? "<font color='#FF8000'>[org.burn_dam]</font>" : "<font color='#FF8000'>0</font>"]"
 
 	//Organ damages report
 	if(ishuman(M))
@@ -341,13 +343,13 @@ GENE SCANNER
 				no_damage = "\t[span_info("Healthy Organs: ")]"
 			else
 				no_damage += "</span>"
-			to_chat(user, no_damage)
-			to_chat(user, minor_damage)
-			to_chat(user, major_damage)
-			to_chat(user, max_damage)
+			combined_msg += no_damage
+			combined_msg += minor_damage
+			combined_msg += major_damage
+			combined_msg += max_damage
 		//Genetic damage
 		if(advanced && H.has_dna())
-			to_chat(user, "\t[span_info("Genetic Stability: [H.dna.stability]%.")]")
+			combined_msg += "\t[span_info("Genetic Stability: [H.dna.stability]%.")]"
 
 	// Species and body temperature
 	if(ishuman(M))
@@ -377,19 +379,19 @@ GENE SCANNER
 		else if (S.mutantstomach != initial(S.mutantstomach))
 			mutant = TRUE
 
-		to_chat(user, span_info("Species: [S.name][mutant ? "-derived mutant" : ""]"))
+		combined_msg += span_info("Species: [S.name][mutant ? "-derived mutant" : ""]")
 	var/temp_span = "notice"
 	if(M.bodytemperature <= BODYTEMP_HEAT_DAMAGE_LIMIT || M.bodytemperature >= BODYTEMP_COLD_DAMAGE_LIMIT)
 		temp_span = "warning"
 	
-	to_chat(user, "<span_class = '[temp_span]'>Body temperature: [round(M.bodytemperature-T0C,0.1)] &deg;C ([round(M.bodytemperature*1.8-459.67,0.1)] &deg;F)</span>")
+	combined_msg += "<span_class = '[temp_span]'>Body temperature: [round(M.bodytemperature-T0C,0.1)] &deg;C ([round(M.bodytemperature*1.8-459.67,0.1)] &deg;F)</span>"
 
 	// Time of death
 	if(M.tod && (M.stat == DEAD || ((HAS_TRAIT(M, TRAIT_FAKEDEATH)) && !advanced)))
-		to_chat(user, "[span_info("Time of Death:")] [M.tod]")
+		combined_msg += "[span_info("Time of Death:")] [M.tod]"
 		var/tdelta = round(world.time - M.timeofdeath)
 		if(tdelta < (DEFIB_TIME_LIMIT))
-			to_chat(user, span_danger("Subject died [DisplayTimeText(tdelta)] ago, defibrillation may be possible!"))
+			combined_msg += span_danger("Subject died [DisplayTimeText(tdelta)] ago, defibrillation may be possible!")
 
 	// Wounds
 	if(iscarbon(M))
@@ -407,7 +409,7 @@ GENE SCANNER
 	for(var/thing in M.diseases)
 		var/datum/disease/D = thing
 		if(!(D.visibility_flags & HIDDEN_SCANNER))
-			to_chat(user, span_alert("<b>Warning: [D.form] detected</b>\nName: [D.name].\nType: [D.spread_text].\nStage: [D.stage]/[D.max_stages].\nPossible Cure: [D.cure_text].")) //Yogs - Added a "."
+			combined_msg += span_alert("<b>Warning: [D.form] detected</b>\nName: [D.name].\nType: [D.spread_text].\nStage: [D.stage]/[D.max_stages].\nPossible Cure: [D.cure_text].") //Yogs - Added a "."
 
 	// Blood Level
 	if(M.has_dna())
@@ -417,7 +419,7 @@ GENE SCANNER
 			if(ishuman(C))
 				var/mob/living/carbon/human/H = C
 				if(H.is_bleeding())
-					to_chat(user, span_danger("Subject is bleeding!"))
+					combined_msg += span_danger("Subject is bleeding!")
 			var/blood_percent =  round((C.blood_volume / BLOOD_VOLUME_NORMAL(C))*100)
 			var/blood_type = C.dna.blood_type
 			if(blood_id != /datum/reagent/blood)//special blood substance
@@ -427,38 +429,41 @@ GENE SCANNER
 				else
 					blood_type = blood_id
 			if(HAS_TRAIT(M, TRAIT_MASQUERADE)) //bloodsuckers
-				to_chat(user, span_info("Blood level 100%, 560 cl, type: [blood_type]"))
+				combined_msg += span_info("Blood level 100%, 560 cl, type: [blood_type]")
 			else if(C.blood_volume <= BLOOD_VOLUME_SAFE(C) && C.blood_volume > BLOOD_VOLUME_OKAY(C))
-				to_chat(user, "[span_danger("LOW blood level [blood_percent] %, [C.blood_volume] cl,")] [span_info("type: [blood_type]")]")
+				combined_msg += "[span_danger("LOW blood level [blood_percent] %, [C.blood_volume] cl,")] [span_info("type: [blood_type]")]"
 			else if(C.blood_volume <= BLOOD_VOLUME_OKAY(C))
-				to_chat(user, "[span_danger("CRITICAL blood level [blood_percent] %, [C.blood_volume] cl,")] [span_info("type: [blood_type]")]")
+				combined_msg += "[span_danger("CRITICAL blood level [blood_percent] %, [C.blood_volume] cl,")] [span_info("type: [blood_type]")]"
 			else
-				to_chat(user, span_info("Blood level [blood_percent] %, [C.blood_volume] cl, type: [blood_type]"))
+				combined_msg += span_info("Blood level [blood_percent] %, [C.blood_volume] cl, type: [blood_type]")
 
 		var/cyberimp_detect
 		for(var/obj/item/organ/cyberimp/CI in C.internal_organs)
 			if(CI.status == ORGAN_ROBOTIC && !CI.syndicate_implant)
 				cyberimp_detect += "[C.name] is modified with a [CI.name].<br>"
 		if(cyberimp_detect)
-			to_chat(user, span_notice("Detected cybernetic modifications:"))
-			to_chat(user, span_notice("[cyberimp_detect]"))
+			combined_msg += span_notice("Detected cybernetic modifications:")
+			combined_msg += span_notice("[cyberimp_detect]")
+	to_chat(user, examine_block(combined_msg.Join("\n")))
 	SEND_SIGNAL(M, COMSIG_NANITE_SCAN, user, FALSE)
 
 /proc/chemscan(mob/living/user, mob/living/M)
+	var/list/combined_msg = list()
 	if(istype(M))
 		if(M.reagents)
 			if(M.reagents.reagent_list.len)
-				to_chat(user, span_notice("Subject contains the following reagents:"))
+				combined_msg += span_notice("Subject contains the following reagents:")
 				for(var/datum/reagent/R in M.reagents.reagent_list)
-					to_chat(user, "[span_notice("[round(R.volume, 0.001)] units of [R.name]")][R.overdosed == 1 ? "- [span_boldannounce("OVERDOSING")]" : "."]")
+					combined_msg += "[span_notice("[round(R.volume, 0.001)] units of [R.name]")][R.overdosed == 1 ? "- [span_boldannounce("OVERDOSING")]" : "."]"
 			else
-				to_chat(user, span_notice("Subject contains no reagents."))
+				combined_msg += span_notice("Subject contains no reagents.")
 			if(M.reagents.addiction_list.len)
-				to_chat(user, span_boldannounce("Subject is addicted to the following reagents:"))
+				combined_msg += span_boldannounce("Subject is addicted to the following reagents:")
 				for(var/datum/reagent/R in M.reagents.addiction_list)
-					to_chat(user, span_danger("[R.name]"))
+					combined_msg += span_danger("[R.name]")
 			else
-				to_chat(user, span_notice("Subject is not addicted to any reagents."))
+				combined_msg += span_notice("Subject is not addicted to any reagents.")
+	to_chat(user, examine_block(combined_msg.Join("\n")))
 
 /obj/item/healthanalyzer/advanced
 	name = "advanced health analyzer"
@@ -507,9 +512,9 @@ GENE SCANNER
 		if(istype(scanner))
 			// Only emit the cheerful scanner message if this scan came from a scanner
 			playsound(scanner, 'sound/machines/ping.ogg', 50, FALSE)
-			to_chat(user, span_notice("\The [scanner] makes a happy ping and briefly displays a smiley face with several exclamation points! It's really excited to report that [patient] has no wounds!"))
+			render_list += span_notice("\The [scanner] makes a happy ping and briefly displays a smiley face with several exclamation points! It's really excited to report that [patient] has no wounds!")
 		else
-			to_chat(user, "<span class='notice ml-1'>No wounds detected in subject.</span>")
+			render_list += "<span class='notice ml-1'>No wounds detected in subject.</span>"
 	else
 		to_chat(user, examine_block(jointext(render_list, "")))
 
@@ -598,6 +603,7 @@ GENE SCANNER
 	scangasses(user)			//yogs start: Makes the gas scanning able to be used elseware
 
 /obj/item/proc/scangasses(mob/user)
+	var/list/combined_msg = list()
 	//yogs stop
 
 	if (user.stat || user.eye_blind)
@@ -612,11 +618,11 @@ GENE SCANNER
 	var/pressure = environment.return_pressure()
 	var/total_moles = environment.total_moles()
 
-	to_chat(user, span_info("<B>Results:</B>"))
+	combined_msg += span_info("<B>Results:</B>")
 	if(abs(pressure - ONE_ATMOSPHERE) < 10)
-		to_chat(user, span_info("Pressure: [round(pressure, 0.01)] kPa"))
+		combined_msg += span_info("Pressure: [round(pressure, 0.01)] kPa")
 	else
-		to_chat(user, span_alert("Pressure: [round(pressure, 0.01)] kPa"))
+		combined_msg += span_alert("Pressure: [round(pressure, 0.01)] kPa")
 	if(total_moles)
 		var/o2_concentration = environment.get_moles(/datum/gas/oxygen)/total_moles
 		var/n2_concentration = environment.get_moles(/datum/gas/nitrogen)/total_moles
@@ -624,31 +630,32 @@ GENE SCANNER
 		var/plasma_concentration = environment.get_moles(/datum/gas/plasma)/total_moles
 
 		if(abs(n2_concentration - N2STANDARD) < 20)
-			to_chat(user, span_info("Nitrogen: [round(n2_concentration*100, 0.01)] % ([round(environment.get_moles(/datum/gas/nitrogen), 0.01)] mol)"))
+			combined_msg += span_info("Nitrogen: [round(n2_concentration*100, 0.01)] % ([round(environment.get_moles(/datum/gas/nitrogen), 0.01)] mol)")
 		else
-			to_chat(user, span_alert("Nitrogen: [round(n2_concentration*100, 0.01)] % ([round(environment.get_moles(/datum/gas/nitrogen), 0.01)] mol)"))
+			combined_msg += span_alert("Nitrogen: [round(n2_concentration*100, 0.01)] % ([round(environment.get_moles(/datum/gas/nitrogen), 0.01)] mol)")
 
 		if(abs(o2_concentration - O2STANDARD) < 2)
-			to_chat(user, span_info("Oxygen: [round(o2_concentration*100, 0.01)] % ([round(environment.get_moles(/datum/gas/oxygen), 0.01)] mol)"))
+			combined_msg += span_info("Oxygen: [round(o2_concentration*100, 0.01)] % ([round(environment.get_moles(/datum/gas/oxygen), 0.01)] mol)")
 		else
-			to_chat(user, span_alert("Oxygen: [round(o2_concentration*100, 0.01)] % ([round(environment.get_moles(/datum/gas/oxygen), 0.01)] mol)"))
+			combined_msg += span_alert("Oxygen: [round(o2_concentration*100, 0.01)] % ([round(environment.get_moles(/datum/gas/oxygen), 0.01)] mol)")
 
 		if(co2_concentration > 0.01)
-			to_chat(user, span_alert("CO2: [round(co2_concentration*100, 0.01)] % ([round(environment.get_moles(/datum/gas/carbon_dioxide), 0.01)] mol)"))
+			combined_msg += span_alert("CO2: [round(co2_concentration*100, 0.01)] % ([round(environment.get_moles(/datum/gas/carbon_dioxide), 0.01)] mol)")
 		else
-			to_chat(user, span_info("CO2: [round(co2_concentration*100, 0.01)] % ([round(environment.get_moles(/datum/gas/carbon_dioxide), 0.01)] mol)"))
+			combined_msg += span_info("CO2: [round(co2_concentration*100, 0.01)] % ([round(environment.get_moles(/datum/gas/carbon_dioxide), 0.01)] mol)")
 
 		if(plasma_concentration > 0.005)
-			to_chat(user, span_alert("Plasma: [round(plasma_concentration*100, 0.01)] % ([round(environment.get_moles(/datum/gas/plasma), 0.01)] mol)"))
+			combined_msg += span_alert("Plasma: [round(plasma_concentration*100, 0.01)] % ([round(environment.get_moles(/datum/gas/plasma), 0.01)] mol)")
 		else
-			to_chat(user, span_info("Plasma: [round(plasma_concentration*100, 0.01)] % ([round(environment.get_moles(/datum/gas/plasma), 0.01)] mol)"))
+			combined_msg += span_info("Plasma: [round(plasma_concentration*100, 0.01)] % ([round(environment.get_moles(/datum/gas/plasma), 0.01)] mol)")
 
 		for(var/id in environment.get_gases())
 			if(id in GLOB.hardcoded_gases)
 				continue
 			var/gas_concentration = environment.get_moles(id)/total_moles
-			to_chat(user, span_alert("[GLOB.meta_gas_info[id][META_GAS_NAME]]: [round(gas_concentration*100, 0.01)] % ([round(environment.get_moles(id), 0.01)] mol)"))
-		to_chat(user, span_info("Temperature: [round(environment.return_temperature()-T0C, 0.01)] &deg;C ([round(environment.return_temperature(), 0.01)] K)"))
+			combined_msg += span_alert("[GLOB.meta_gas_info[id][META_GAS_NAME]]: [round(gas_concentration*100, 0.01)] % ([round(environment.get_moles(id), 0.01)] mol)")
+		combined_msg += span_info("Temperature: [round(environment.return_temperature()-T0C, 0.01)] &deg;C ([round(environment.return_temperature(), 0.01)] K)")
+	to_chat(user, examine_block(combined_msg.Join("\n")))
 
 /obj/item/analyzer/AltClick(mob/user) //Barometer output for measuring when the next storm happens
 	..()
@@ -714,14 +721,15 @@ GENE SCANNER
 	return DisplayTimeText(max(1,amount))
 
 /proc/atmosanalyzer_scan(mixture, mob/living/user, atom/target = src)
+	var/list/combined_msg = list()
 	var/icon = target
 	user.visible_message("[user] has used the analyzer on [icon2html(icon, viewers(user))] [target].", span_notice("You use the analyzer on [icon2html(icon, user)] [target]."))
-	to_chat(user, span_boldnotice("Results of analysis of [icon2html(icon, user)] [target]."))
+	combined_msg += span_boldnotice("Results of analysis of [icon2html(icon, user)] [target].")
 
 	var/list/airs = islist(mixture) ? mixture : list(mixture)
 	for(var/g in airs)
 		if(airs.len > 1) //not a unary gas mixture
-			to_chat(user, span_boldnotice("Node [airs.Find(g)]"))
+			combined_msg += span_boldnotice("Node [airs.Find(g)]")
 		var/datum/gas_mixture/air_contents = g
 
 		var/total_moles = air_contents.total_moles()
@@ -731,25 +739,26 @@ GENE SCANNER
 		var/cached_scan_results = air_contents.analyzer_results
 
 		if(total_moles > 0)
-			to_chat(user, span_notice("Moles: [round(total_moles, 0.01)] mol"))
-			to_chat(user, span_notice("Volume: [volume] L"))
-			to_chat(user, span_notice("Pressure: [round(pressure,0.01)] kPa"))
+			combined_msg += span_notice("Moles: [round(total_moles, 0.01)] mol")
+			combined_msg += span_notice("Volume: [volume] L")
+			combined_msg += span_notice("Pressure: [round(pressure,0.01)] kPa")
 
 			for(var/id in air_contents.get_gases())
 				var/gas_concentration = air_contents.get_moles(id)/total_moles
-				to_chat(user, span_notice("[GLOB.meta_gas_info[id][META_GAS_NAME]]: [round(gas_concentration*100, 0.01)] % ([round(air_contents.get_moles(id), 0.01)] mol)"))
-			to_chat(user, span_notice("Temperature: [round(temperature - T0C,0.01)] &deg;C ([round(temperature, 0.01)] K)"))
+				combined_msg += span_notice("[GLOB.meta_gas_info[id][META_GAS_NAME]]: [round(gas_concentration*100, 0.01)] % ([round(air_contents.get_moles(id), 0.01)] mol)")
+			combined_msg += span_notice("Temperature: [round(temperature - T0C,0.01)] &deg;C ([round(temperature, 0.01)] K)")
 
 		else
 			if(airs.len > 1)
-				to_chat(user, span_notice("This node is empty!"))
+				combined_msg += span_notice("This node is empty!")
 			else
-				to_chat(user, span_notice("[target] is empty!"))
+				combined_msg += span_notice("[target] is empty!")
 
 		if(cached_scan_results && cached_scan_results["fusion"]) //notify the user if a fusion reaction was detected
 			var/instability = round(cached_scan_results["fusion"], 0.01)
-			to_chat(user, span_boldnotice("Large amounts of free neutrons detected in the air indicate that a fusion reaction took place."))
-			to_chat(user, span_notice("Instability of the last fusion reaction: [instability]."))
+			combined_msg += span_boldnotice("Large amounts of free neutrons detected in the air indicate that a fusion reaction took place.")
+			combined_msg += span_notice("Instability of the last fusion reaction: [instability].")
+	to_chat(user, examine_block(combined_msg.Join("\n")))
 	return
 
 //slime scanner
@@ -767,10 +776,10 @@ GENE SCANNER
 	throwforce = 0
 	throw_speed = 3
 	throw_range = 7
-	materials = list(/datum/material/iron=30, /datum/material/glass=20)
+	custom_materials = list(/datum/material/iron=30, /datum/material/glass=20)
 
 /obj/item/slime_scanner/attack(mob/living/M, mob/living/user)
-	if(user.stat || user.eye_blind)
+	if(user.stat || !user.can_read(src))
 		return
 	if (!isslime(M))
 		to_chat(user, span_warning("This device can only scan slimes!"))
@@ -780,36 +789,34 @@ GENE SCANNER
 	slime_scan(T, user)
 
 /proc/slime_scan(mob/living/simple_animal/slime/T, mob/living/user)
-	to_chat(user, "========================")
-	to_chat(user, "<b>Slime scan results:</b>")
-	to_chat(user, span_notice("[T.colour] [T.is_adult ? "adult" : "baby"] slime"))
-	to_chat(user, "Nutrition: [T.nutrition]/[T.get_max_nutrition()]")
+	var/to_render = "<b>Slime scan results:</b>\
+					\n[span_notice("[T.colour] [T.is_adult ? "adult" : "baby"] slime")]\
+					\nNutrition: [T.nutrition]/[T.get_max_nutrition()]"
 	if (T.nutrition < T.get_starve_nutrition())
-		to_chat(user, span_warning("Warning: slime is starving!"))
+		to_render += "\n[span_warning("Warning: slime is starving!")]"
 	else if (T.nutrition < T.get_hunger_nutrition())
-		to_chat(user, span_warning("Warning: slime is hungry"))
-	to_chat(user, "Electric charge strength: [T.powerlevel]")
-	to_chat(user, "Health: [round(T.health/T.maxHealth,0.01)*100]%")
+		to_render += "\n[span_warning("Warning: slime is hungry")]"
+	to_render += "\nElectric change strength: [T.powerlevel]\nHealth: [round(T.health/T.maxHealth,0.01)*100]%"
 	if (T.slime_mutation[4] == T.colour)
-		to_chat(user, "This slime does not evolve any further.")
+		to_render += "\nThis slime does not evolve any further."
 	else
 		if (T.slime_mutation[3] == T.slime_mutation[4])
 			if (T.slime_mutation[2] == T.slime_mutation[1])
-				to_chat(user, "Possible mutation: [T.slime_mutation[3]]")
-				to_chat(user, "Genetic instability: [T.mutation_chance/2] % chance of mutation on splitting")
+				to_render += "\nPossible mutation: [T.slime_mutation[3]]\
+							  \nGenetic destability: [T.mutation_chance/2] % chance of mutation on splitting"
 			else
-				to_chat(user, "Possible mutations: [T.slime_mutation[1]], [T.slime_mutation[2]], [T.slime_mutation[3]] (x2)")
-				to_chat(user, "Genetic instability: [T.mutation_chance] % chance of mutation on splitting")
+				to_render += "\nPossible mutations: [T.slime_mutation[1]], [T.slime_mutation[2]], [T.slime_mutation[3]] (x2)\
+							  \nGenetic destability: [T.mutation_chance] % chance of mutation on splitting"
 		else
-			to_chat(user, "Possible mutations: [T.slime_mutation[1]], [T.slime_mutation[2]], [T.slime_mutation[3]], [T.slime_mutation[4]]")
-			to_chat(user, "Genetic instability: [T.mutation_chance] % chance of mutation on splitting")
+			to_render += "\nPossible mutations: [T.slime_mutation[1]], [T.slime_mutation[2]], [T.slime_mutation[3]], [T.slime_mutation[4]]\
+						  \nGenetic destability: [T.mutation_chance] % chance of mutation on splitting"
 	if (T.cores > 1)
-		to_chat(user, "Multiple cores detected")
-	to_chat(user, "Growth progress: [T.amount_grown]/[SLIME_EVOLUTION_THRESHOLD]")
+		to_render += "\nMultiple cores detected"
+	to_render += "\nGrowth progress: [T.amount_grown]/[SLIME_EVOLUTION_THRESHOLD]"
 	if(T.effectmod)
-		to_chat(user, span_notice("Core mutation in progress: [T.effectmod]"))
-		to_chat(user, "<span class = 'notice'>Progress in core mutation: [T.applied] / [SLIME_EXTRACT_CROSSING_REQUIRED]</span>")
-	to_chat(user, "========================")
+		to_render += "\n[span_notice("Core mutation in progress: [T.effectmod]")]\
+					  \n[span_notice("Progress in core mutation: [T.applied] / [SLIME_EXTRACT_CROSSING_REQUIRED]")]"
+	to_chat(user, examine_block(to_render))
 
 
 /obj/item/nanite_scanner

--- a/code/modules/antagonists/clockcult/clock_mobs.dm
+++ b/code/modules/antagonists/clockcult/clock_mobs.dm
@@ -43,7 +43,7 @@
 /mob/living/simple_animal/hostile/clockwork/examine(mob/user)
 	var/t_He = p_they(TRUE)
 	var/t_s = p_s()
-	var/msg = "<span class='brass'>*---------*\nThis is [icon2html(src, user)] \a <b>[src]</b>!\n"
+	var/msg = "<span class='brass'>This is [icon2html(src, user)] \a <b>[src]</b>!\n"
 	msg += "[desc]\n"
 	if(health < maxHealth)
 		msg += "<span class='warning'>"
@@ -55,7 +55,7 @@
 	var/addendum = examine_info()
 	if(addendum)
 		msg += "[addendum]\n"
-	msg += "*---------*</span>"
+	msg += "</span>"
 
 	return list(msg)
 

--- a/code/modules/antagonists/devil/true_devil/_true_devil.dm
+++ b/code/modules/antagonists/devil/true_devil/_true_devil.dm
@@ -64,7 +64,7 @@
 
 
 /mob/living/carbon/true_devil/examine(mob/user)
-	. = list("<span class='info'>*---------*\nThis is [icon2html(src, user)] <b>[src]</b>!")
+	. = list("<span class='info'>This is [icon2html(src, user)] <b>[src]</b>!")
 
 	//Left hand items
 	for(var/obj/item/I in held_items)
@@ -82,7 +82,7 @@
 		. += span_warning("You can see hellfire inside its gaping wounds.")
 	else if(health < (maxHealth/2))
 		. += span_warning("You can see hellfire inside its wounds.")
-	. += "*---------*</span>"
+	. += "</span>"
 
 /mob/living/carbon/true_devil/IsAdvancedToolUser()
 	return 1

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -65,7 +65,7 @@
 /// Ghost attack proc
 /obj/item/reagent_containers/food/snacks/grown/attack_ghost(mob/user)
 	..()
-	var/msg = "<span class='info'>*---------*\n This is \a [span_name("[src]")].\n"
+	var/msg = "<span class='info'>This is \a [span_name("[src]")].\n"
 	if(seed)
 		msg += seed.get_analyzer_text()
 	var/reag_txt = ""
@@ -77,14 +77,14 @@
 
 	if(reag_txt)
 		msg += reag_txt
-		msg += "<br>[span_info("*---------*")]"
+		msg += "<br>[span_info("")]"
 	to_chat(user, msg)
 
 /obj/item/reagent_containers/food/snacks/grown/attackby(obj/item/O, mob/user, params)
 	..()
 	if (istype(O, /obj/item/plant_analyzer))
 		playsound(src, 'sound/effects/fastbeep.ogg', 30)
-		var/msg = "<span class='info'>*---------*\n This is \a [span_name("[src]")].\n"
+		var/msg = "<span class='info'>This is \a [span_name("[src]")].\n"
 		if(seed)
 			msg += seed.get_analyzer_text()
 		var/reag_txt = ""
@@ -96,7 +96,7 @@
 
 		if(reag_txt)
 			msg += reag_txt
-			msg += "<br>[span_info("*---------*")]"
+			msg += "<br>[span_info("")]"
 		to_chat(user, msg)
 	else
 		if(seed)

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -78,7 +78,7 @@
 	if(reag_txt)
 		msg += reag_txt
 		msg += "<br>[span_info("")]"
-	to_chat(user, msg)
+	to_chat(user, examine_block(msg))
 
 /obj/item/reagent_containers/food/snacks/grown/attackby(obj/item/O, mob/user, params)
 	..()
@@ -97,7 +97,7 @@
 		if(reag_txt)
 			msg += reag_txt
 			msg += "<br>[span_info("")]"
-		to_chat(user, msg)
+		to_chat(user, examine_block(msg))
 	else
 		if(seed)
 			for(var/datum/plant_gene/trait/T in seed.genes)

--- a/code/modules/hydroponics/grown/kudzu.dm
+++ b/code/modules/hydroponics/grown/kudzu.dm
@@ -52,7 +52,7 @@
 	var/text_string = ""
 	for(var/datum/spacevine_mutation/SM in mutations)
 		text_string += "[(text_string == "") ? "" : ", "][SM.name]"
-	text += "\n- Plant Mutations: [(text_string == "") ? "None" : text_string]"
+	text += "\n Plant Mutations: [(text_string == "") ? "None" : text_string]"
 	return text
 
 /obj/item/seeds/kudzu/on_chem_reaction(datum/reagents/S)

--- a/code/modules/hydroponics/growninedible.dm
+++ b/code/modules/hydroponics/growninedible.dm
@@ -38,7 +38,7 @@
 	if(seed)
 		msg += seed.get_analyzer_text()
 	msg += "</span>"
-	to_chat(usr, msg)
+	to_chat(usr, examine_block(msg))
 	return
 
 /obj/item/grown/attackby(obj/item/O, mob/user, params)
@@ -49,7 +49,7 @@
 		if(seed)
 			msg += seed.get_analyzer_text()
 		msg += "</span>"
-		to_chat(usr, msg)
+		to_chat(usr, examine_block(msg))
 		return
 
 /obj/item/grown/proc/add_juice()

--- a/code/modules/hydroponics/growninedible.dm
+++ b/code/modules/hydroponics/growninedible.dm
@@ -34,7 +34,7 @@
 /// Ghost attack proc
 /obj/item/grown/attack_ghost(mob/user)
 	..()
-	var/msg = "<span class='info'>*---------*\n This is \a [span_name("[src]")]\n"
+	var/msg = "<span class='info'>This is \a [span_name("[src]")]\n"
 	if(seed)
 		msg += seed.get_analyzer_text()
 	msg += "</span>"
@@ -45,7 +45,7 @@
 	..()
 	if (istype(O, /obj/item/plant_analyzer))
 		playsound(src, 'sound/effects/fastbeep.ogg', 30)
-		var/msg = "<span class='info'>*---------*\n This is \a [span_name("[src]")]\n"
+		var/msg = "<span class='info'>This is \a [span_name("[src]")]\n"
 		if(seed)
 			msg += seed.get_analyzer_text()
 		msg += "</span>"

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -800,21 +800,24 @@
 			to_chat(user, span_warning("[src] already has seeds in it!"))
 
 	else if(istype(O, /obj/item/plant_analyzer))
+		var/list/combined_msg = list()
 		playsound(src, 'sound/effects/fastbeep.ogg', 30)
 		if(myseed)
-			to_chat(user, "*** <B>[myseed.plantname]</B> ***" )
-			to_chat(user, "- Plant Age: [span_notice("[age]")]")
+			combined_msg +="*** <B>[myseed.plantname]</B> ***" 
+			combined_msg +="- Plant Age: [span_notice("[age]")]"
 			var/list/text_string = myseed.get_analyzer_text()
 			if(text_string)
-				to_chat(user, text_string)
+				combined_msg += "[text_string]"
 		else
-			to_chat(user, "<B>No plant found.</B>")
-		to_chat(user, "- Weed level: [span_notice("[weedlevel] / 10")]")
-		to_chat(user, "- Pest level: [span_notice("[pestlevel] / 10")]")
-		to_chat(user, "- Toxicity level: [span_notice("[toxic] / 100")]")
-		to_chat(user, "- Water level: [span_notice("[waterlevel] / [maxwater]")]")
-		to_chat(user, "- Nutrition level: [span_notice("[nutrilevel] / [maxnutri]")]")
-		to_chat(user, "")
+			combined_msg += "<B>No plant found.</B>"
+		combined_msg += "- Weed level: <span class='notice'>[weedlevel] / 10</span>"
+		combined_msg += "- Pest level: <span class='notice'>[pestlevel] / 10</span>"
+		combined_msg += "- Toxicity level: <span class='notice'>[toxic] / 100</span>"
+		combined_msg += "- Water level: <span class='notice'>[waterlevel] / [maxwater]</span>"
+		combined_msg += "- Nutrition level: <span class='notice'>[nutrilevel] / [maxnutri]</span>"
+		combined_msg += ""
+
+		to_chat(user, examine_block(combined_msg))
 
 	else if(istype(O, /obj/item/cultivator))
 		if(weedlevel > 0)

--- a/code/modules/hydroponics/sample.dm
+++ b/code/modules/hydroponics/sample.dm
@@ -13,7 +13,7 @@
 		add_overlay(filling)
 
 /obj/item/seeds/sample/get_analyzer_text()
-	return " The DNA of this sample is damaged beyond recovery, it can't support life on its own.\n*---------*"
+	return " The DNA of this sample is damaged beyond recovery, it can't support life on its own."
 
 /obj/item/seeds/sample/alienweed
 	name = "alien weed sample"

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -318,7 +318,7 @@
 		all_traits += " [traits.get_name()]"
 	text += "- Plant Traits:[all_traits]\n"
 
-	text += "*---------*"
+	text += ""
 
 	return text
 
@@ -327,7 +327,7 @@
 
 /// Ghost attack proc
 /obj/item/seeds/attack_ghost(mob/user)
-	to_chat(user, span_info("*---------*\n This is \a [span_name("[src]")]."))
+	to_chat(user, span_info("This is \a [span_name("[src]")]."))
 	var/text = get_analyzer_text()
 	if(text)
 		to_chat(user, span_notice("[text]"))
@@ -335,7 +335,7 @@
 /obj/item/seeds/attackby(obj/item/O, mob/user, params)
 	if (istype(O, /obj/item/plant_analyzer))
 		playsound(src, 'sound/effects/fastbeep.ogg', 30)
-		to_chat(user, span_info("*---------*\n This is \a [span_name("[src]")]."))
+		to_chat(user, span_info("This is \a [span_name("[src]")]."))
 		var/text = get_analyzer_text()
 		if(text)
 			to_chat(user, span_notice("[text]"))

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -6,7 +6,7 @@
 	var/t_has = p_have()
 	var/t_is = p_are()
 
-	. = list("<span class='info'>This is [icon2html(src, user)] \a <EM>[src]</EM>!")
+	. = list("<span class='info'>This is [icon2html(src, user)] \a <EM>[src]</EM>!>")
 	var/list/obscured = check_obscured_slots()
 
 	if (handcuffed)

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -6,7 +6,7 @@
 	var/t_has = p_have()
 	var/t_is = p_are()
 
-	. = list("<span class='info'>*---------*\nThis is [icon2html(src, user)] \a <EM>[src]</EM>!")
+	. = list("<span class='info'>This is [icon2html(src, user)] \a <EM>[src]</EM>!")
 	var/list/obscured = check_obscured_slots()
 
 	if (handcuffed)
@@ -150,7 +150,7 @@
 				. += "[t_He] look[p_s()] very happy."
 			if(MOOD_LEVEL_HAPPY4 to INFINITY)
 				. += "[t_He] look[p_s()] ecstatic."
-	. += "*---------*</span>"
+	. += "</span>"
 
 /mob/living/carbon/examine_more(mob/user)
 	if(!all_scars)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -13,7 +13,7 @@
 		if(HAS_TRAIT(L, TRAIT_PROSOPAGNOSIA))
 			obscure_name = TRUE
 
-	. = list("<span class='info'>This is <EM>[!obscure_name ? name : "Unknown"]</EM>!")
+	. = list("<span class='info'>This is <EM>[!obscure_name ? name : "Unknown"]</EM>!>")
 
 	var/vampDesc = ReturnVampExamine(user) // Fulpstation Bloodsuckers edit STARTS
 	var/vassDesc = ReturnVassalExamine(user)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -13,7 +13,7 @@
 		if(HAS_TRAIT(L, TRAIT_PROSOPAGNOSIA))
 			obscure_name = TRUE
 
-	. = list("<span class='info'>*---------*\nThis is <EM>[!obscure_name ? name : "Unknown"]</EM>!")
+	. = list("<span class='info'>This is <EM>[!obscure_name ? name : "Unknown"]</EM>!")
 
 	var/vampDesc = ReturnVampExamine(user) // Fulpstation Bloodsuckers edit STARTS
 	var/vassDesc = ReturnVassalExamine(user)
@@ -438,7 +438,7 @@
 							"<a href='?src=[REF(src)];hud=s;add_comment=1'>\[Add comment\]</a>"), "")
 	else if(isobserver(user) && traitstring)
 		. += "<span class='info'><b>Traits:</b> [traitstring]</span><br>"
-	. += "*---------*</span>"
+	. += "</span>"
 
 /mob/living/proc/status_effect_examines(pronoun_replacement) //You can include this in any mob's examine() to show the examine texts of status effects!
 	var/list/dat = list()
@@ -463,7 +463,7 @@
 	var/t_has = p_have()
 	var/t_is = p_are()
 	
-	. = list("<span class='info'>*---------*\nThis is <EM>[name]</EM>!")
+	. = list("<span class='info'>This is <EM>[name]</EM>!")
 
 	var/list/obscured = check_obscured_slots()
 
@@ -567,4 +567,4 @@
 	if (length(msg))
 		. += span_warning("[msg.Join("")]")
 
-	. += "*---------*</span>"
+	. += "</span>"

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -932,7 +932,7 @@
 	if(roundstart_quirks.len)
 		combined_msg += span_notice("You have these quirks: [get_trait_string()].")
 
-	to_chat(src, combined_msg.Join("\n"))
+	to_chat(src, examine_block(combined_msg.Join("\n")))
 
 /mob/living/carbon/human/damage_clothes(damage_amount, damage_type = BRUTE, damage_flag = 0, def_zone)
 	if(damage_type != BRUTE && damage_type != BURN)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -746,8 +746,9 @@
 		return
 	var/list/combined_msg = list()
 
-	visible_message("[src] examines [p_them()]self.", \
-		span_notice("You check yourself for injuries."))
+	visible_message(span_notice("[src] examines [p_them()]self."))
+
+	combined_msg += span_notice("<b>You check yourself for injuries.</b>")
 
 	var/list/missing = list(BODY_ZONE_HEAD, BODY_ZONE_CHEST, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
 	for(var/X in bodyparts)

--- a/code/modules/mob/living/silicon/ai/examine.dm
+++ b/code/modules/mob/living/silicon/ai/examine.dm
@@ -1,5 +1,5 @@
 /mob/living/silicon/ai/examine(mob/user)
-	. = list("<span class='info'>*---------*\nThis is [icon2html(src, user)] <EM>[src]</EM>!")
+	. = list("<span class='info'>This is [icon2html(src, user)] <EM>[src]</EM>!")
 	if (stat == DEAD)
 		. += span_deadsay("It appears to be powered-down.")
 	else
@@ -17,6 +17,6 @@
 			. += "The wireless networking light is blinking.\n"
 		else if (!shunted && !client)
 			. += "[src]Core.exe has stopped responding! NTOS is searching for a solution to the problem...\n"
-	. += "*---------*</span>"
+	. += "</span>"
 
 	. += ..()

--- a/code/modules/mob/living/silicon/ai/examine.dm
+++ b/code/modules/mob/living/silicon/ai/examine.dm
@@ -20,3 +20,6 @@
 	. += "</span>"
 
 	. += ..()
+
+/mob/living/silicon/ai/get_examine_string(mob/user, thats = FALSE)
+	return null

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -1,5 +1,5 @@
 /mob/living/silicon/robot/examine(mob/user)
-	. = list("<span class='info'>*---------*\nThis is [icon2html(src, user)] \a <EM>[src]</EM>!")
+	. = list("<span class='info'>This is [icon2html(src, user)] \a <EM>[src]</EM>!")
 	if(desc)
 		. += "[desc]"
 
@@ -46,6 +46,6 @@
 			. += span_warning("It doesn't seem to be responding.")
 		if(DEAD)
 			. += span_deadsay("It looks like its system is corrupted and requires a reset.")
-	. += "*---------*</span>"
+	. += "</span>"
 
 	. += ..()

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -49,3 +49,6 @@
 	. += "</span>"
 
 	. += ..()
+
+/mob/living/silicon/robot/get_examine_string(mob/user, thats = FALSE)
+	return null

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -69,13 +69,13 @@
 /mob/living/simple_animal/hostile/construct/examine(mob/user)
 	var/t_He = p_they(TRUE)
 	var/t_s = p_s()
-	. = list("<span class='cult'>*---------*\nThis is [icon2html(src, user)] \a <b>[src]</b>!\n[desc]")
+	. = list("<span class='cult'>This is [icon2html(src, user)] \a <b>[src]</b>!\n[desc]")
 	if(health < maxHealth)
 		if(health >= maxHealth/2)
 			. += span_warning("[t_He] look[t_s] slightly dented.")
 		else
 			. += span_warning("<b>[t_He] look[t_s] severely dented!</b>")
-	. += "*---------*</span>"
+	. += "</span>"
 
 /mob/living/simple_animal/hostile/construct/attack_animal(mob/living/simple_animal/M)
 	if(isconstruct(M)) //is it a construct?

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -182,7 +182,7 @@
 
 
 /mob/living/simple_animal/drone/examine(mob/user)
-	. = list("<span class='info'>*---------*\nThis is [icon2html(src, user)] \a <b>[src]</b>!")
+	. = list("<span class='info'>This is [icon2html(src, user)] \a <b>[src]</b>!")
 
 	//Hands
 	for(var/obj/item/I in held_items)
@@ -218,7 +218,7 @@
 			. += span_deadsay("A message repeatedly flashes on its display: \"REBOOT -- REQUIRED\".")
 		else
 			. += span_deadsay("A message repeatedly flashes on its display: \"ERROR -- OFFLINE\".")
-	. += "*---------*</span>"
+	. += "</span>"
 
 
 /mob/living/simple_animal/drone/assess_threat(judgement_criteria, lasercolor = "", datum/callback/weaponcheck=null) //Secbots won't hunt maintenance drones.

--- a/code/modules/mob/living/simple_animal/guardian/types/dextrous.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/dextrous.dm
@@ -18,13 +18,13 @@
 
 /mob/living/simple_animal/hostile/guardian/dextrous/examine(mob/user)
 	if(dextrous)
-		. = list("<span class='info'>*---------*\nThis is [icon2html(src)] \a <b>[src]</b>!\n[desc]")
+		. = list("<span class='info'>This is [icon2html(src)] \a <b>[src]</b>!\n[desc]")
 		for(var/obj/item/I in held_items)
 			if(!(I.item_flags & ABSTRACT))
 				. += "It has [I.get_examine_string(user)] in its [get_held_index_name(get_held_index_of_item(I))]."
 		if(internal_storage && !(internal_storage.item_flags & ABSTRACT))
 			. += "It is holding [internal_storage.get_examine_string(user)] in its internal storage."
-		. += "*---------*</span>"
+		. += "</span>"
 	else
 		return ..()
 

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -438,7 +438,7 @@
 	return
 
 /mob/living/simple_animal/slime/examine(mob/user)
-	. = list("<span class='info'>*---------*\nThis is [icon2html(src, user)] \a <EM>[src]</EM>!")
+	. = list("<span class='info'>This is [icon2html(src, user)] \a <EM>[src]</EM>!")
 	if (stat == DEAD)
 		. += span_deadsay("It is limp and unresponsive.")
 	else
@@ -465,7 +465,7 @@
 			if(10)
 				. += span_warning("<B>It is radiating with massive levels of electrical activity!</B>")
 
-	. += "*---------*</span>"
+	. += "</span>"
 
 /mob/living/simple_animal/slime/proc/discipline_slime(mob/user)
 	if(stat)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -454,7 +454,11 @@
 	else
 		result = A.examine(src) // if a tree is examined but no client is there to see it, did the tree ever really exist?
 
-	to_chat(src, result.Join("\n"))
+	if(result.len)
+		for(var/i in 1 to (length(result) - 1))
+			result[i] += "\n"
+
+	to_chat(src, examine_block("<span class='infoplain'>[result.Join()]</span>"))
 	SEND_SIGNAL(src, COMSIG_MOB_EXAMINATE, A)
 
 

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -899,3 +899,10 @@ em {
 .ml-3 {
   margin-left: 3em;
 }
+
+.examine_block {
+  background: #1b1c1e;
+  border: 1px solid #a4bad6;
+  margin: 0.5em;
+  padding: 0.5em 0.75em;
+}

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -944,3 +944,10 @@ h1.alert, h2.alert {
 .ml-3 {
   margin-left: 3em;
 }
+
+.examine_block {
+  background: #f2f7fa;
+  border: 1px solid #111a27;
+  margin: 0.5em;
+  padding: 0.5em 0.75em;
+}


### PR DESCRIPTION
# About PR
Ports from [#599](https://github.com/Monkestation/MonkeStation/pull/599) from [#67937](https://github.com/tgstation/tgstation/pull/67937)

# Document the changes in your pull request
Adds Examine Blocks as seen on Skyrat and other servers, but tweaked a bit to look better


# Wiki Documentation
Adds Examine Blocks as seen on Skyrat and other servers, but tweaked a bit to look better

# Images
<details><summary>images</summary>

![image](https://user-images.githubusercontent.com/89688125/184336863-a04e5e5e-2ab3-4a48-961b-c101e8bb9e84.png)

![image](https://user-images.githubusercontent.com/89688125/184336897-c84bbe9a-221f-4adb-bc89-e936ca18093b.png)



</details>

# Changelog


:cl:  13spacemen, Gandalf2k15, dwasint. Ported by warface1234455
rscadd: Examining and other chat outputs now display in blocks to make them easier to see
bugfix: AI and borgs no longer have their name show twice upon being examined
/:cl:
