### PR TITLE
Removes the Vampire species from the Pride Mirror

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -6,7 +6,7 @@
 	inherent_traits = list(TRAIT_NOHUNGER,TRAIT_NOBREATH)
 	inherent_biotypes = list(MOB_UNDEAD, MOB_HUMANOID)
 	default_features = list("mcolor" = "FFF", "tail_human" = "None", "ears" = "None", "wings" = "None")
-	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | ERT_SPAWN
+	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | ERT_SPAWN
 	exotic_bloodtype = "U"
 	use_skintones = TRUE
 	mutant_heart = /obj/item/organ/heart/vampire


### PR DESCRIPTION
God these get confusing

# Document the changes in your pull request

Removes Vampires the species as an option from the Pride Mirror.

Why? They confuse the hell out of people thinking they're the Priority Threat Entity Vampire despite being normal crew, which leaves everyone with a sour experience as they had the complete right to beat their ass if the vampire was a dumbass and didn't explain themselves until after they died.

Another problem with the species is that it forces people to act like an actual vampire or _dust_ so even if they don't want to act like the antagonist vampire they have to or they **die permanently.** Another issue with regards to the species Is the bat form, which allows them to escape nearly every form of confinement security has.

And instead of fixing these problems with the very niche race only obtainable through the pride mirror, I would much rather just make them inaccessible.

All in all the vampire race should be made inaccessible because it forces you to self-antag or dust, confuses literally everyone as it is nearly indistinguishable from the PTE vampires.

# Wiki Documentation

Removes Vampire the RaceTM from the pride mirror

# Changelog

:cl:  
rscdel: Vampire race is now Inaccessible to the crew
/:cl:
