### PR TITLE
Holy melons now have the same size as a watermelon

### DIFF
--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -56,6 +56,7 @@
 	icon_state = "holymelon"
 	filling_color = "#FFD700"
 	dried_type = null
+	w_class = WEIGHT_CLASS_NORMAL
 	wine_power = 70 //Water to wine, baby.
 	wine_flavor = "divinity"
 


### PR DESCRIPTION
# Document the changes in your pull request

Holy melon is the same size as a normal melon (sprite wise) and is a mutation of melon and is also majorly mass producible so it should have the same weight as a normal melon. Looking at the code it looks like they were tiny weight which is wtf.

# Wiki Documentation

Holy melon strat is a bit weaker

# Changelog

:cl:  
tweak: Holy melons now have normal instead of tinyweight
/:cl:
