### PR TITLE
Wearing magboots will no longer send you flying when unwrenching pipes

### DIFF
--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -238,8 +238,6 @@ GLOBAL_LIST_EMPTY(pipeimages)
 		var/obj/item/clothing/shoes/magboots/magboot = H.get_item_by_slot(SLOT_SHOES)
 		if(magboot && istype(magboot) && magboot.magpulse)
 			return // Dont send you flying
-		
-
 	user.visible_message(span_danger("[user] is sent flying by pressure!"),span_userdanger("The pressure sends you flying!"))
 
 	// if get_dir(src, user) is not 0, target is the edge_target_turf on that dir

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -233,6 +233,13 @@ GLOBAL_LIST_EMPTY(pipeimages)
 		var/datum/gas_mixture/env_air = loc.return_air()
 		pressures = int_air.return_pressure() - env_air.return_pressure()
 
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		var/obj/item/clothing/shoes/magboots/magboot = H.get_item_by_slot(SLOT_SHOES)
+		if(magboot && istype(magboot) && magboot.magpulse)
+			return // Dont send you flying
+		
+
 	user.visible_message(span_danger("[user] is sent flying by pressure!"),span_userdanger("The pressure sends you flying!"))
 
 	// if get_dir(src, user) is not 0, target is the edge_target_turf on that dir

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -236,8 +236,15 @@ GLOBAL_LIST_EMPTY(pipeimages)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		var/obj/item/clothing/shoes/magboots/magboot = H.get_item_by_slot(SLOT_SHOES)
+		var/turf/T = get_turf(user)
 		if(magboot && istype(magboot) && magboot.magpulse)
 			return // Dont send you flying
+
+	if(iscyborg(user))
+		var/mob/living/silicon/robot/R = user
+		if(R.module.magpulsing)
+			return // Cyborg has magpulse	
+
 	user.visible_message(span_danger("[user] is sent flying by pressure!"),span_userdanger("The pressure sends you flying!"))
 
 	// if get_dir(src, user) is not 0, target is the edge_target_turf on that dir

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -233,17 +233,8 @@ GLOBAL_LIST_EMPTY(pipeimages)
 		var/datum/gas_mixture/env_air = loc.return_air()
 		pressures = int_air.return_pressure() - env_air.return_pressure()
 
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		var/obj/item/clothing/shoes/magboots/magboot = H.get_item_by_slot(SLOT_SHOES)
-		var/turf/T = get_turf(user)
-		if(magboot && istype(magboot) && magboot.magpulse)
-			return // Dont send you flying
-
-	if(iscyborg(user))
-		var/mob/living/silicon/robot/R = user
-		if(R.module.magpulsing)
-			return // Cyborg has magpulse	
+	if(user.mob_has_heavy_gravity())
+		return
 
 	user.visible_message(span_danger("[user] is sent flying by pressure!"),span_userdanger("The pressure sends you flying!"))
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -49,6 +49,9 @@
 /mob/living/carbon/human/mob_negates_gravity()
 	return ((shoes && shoes.negates_gravity()) || (dna.species.negates_gravity(src)))
 
+/mob/living/carbon/human/mob_has_heavy_gravity()
+	return (shoes && shoes.negates_gravity())
+
 /mob/living/carbon/human/Move(NewLoc, direct)
 	. = ..()
 

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -9,6 +9,9 @@
 /mob/living/silicon/robot/mob_negates_gravity()
 	return magpulse
 
+/mob/living/silicon/robot/mob_has_heavy_gravity()
+	return magpulse
+
 /mob/living/silicon/robot/mob_has_gravity()
 	return ..() || mob_negates_gravity()
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -336,6 +336,12 @@
 /mob/proc/mob_negates_gravity()
 	return FALSE
 
+/**
+ * used for determining if a mob should be flung
+ */
+/mob/proc/mob_has_heavy_gravity()
+	return FALSE
+
 /// Called when this mob slips over, override as needed
 /mob/proc/slip(knockdown_amount, obj/O, lube, stun, force_drop)
 	return


### PR DESCRIPTION
# Document the changes in your pull request

Closes: #14813

having magboots equipped and having them on will no longer launch you (or being a cyborg)

mostly just a QOL feature

# Wiki Documentation

Magboots help you not get thrown away

# Changelog

:cl:  
rscadd: having magboots equipped and having them on will no longer launch you when unwrenching pipes
/:cl:
