### PR TITLE
[MDB IGNORE] Adds a new Lavaland Ruin (Ritual Bunker)

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_hellwater.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_hellwater.dmm
@@ -31,9 +31,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"co" = (
+"ck" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/candle,
+/obj/structure/closet/secure_closet/freezer/fridge{
+	req_access = null
+	},
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
 "ct" = (
@@ -57,16 +59,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"dS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/candle,
-/mob/living/simple_animal/hostile/skeleton/plasmaminer,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"eb" = (
-/obj/effect/mapping_helpers/no_lava,
-/turf/template_noop,
-/area/lavaland/surface/outdoors)
 "eC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/cooking_oil,
@@ -112,17 +104,25 @@
 /mob/living/simple_animal/hostile/skeleton/plasmaminer,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"jN" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/laser_pointer/purple,
-/mob/living/simple_animal/hostile/skeleton/plasmaminer,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
 "kg" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/mineral/cult,
+/area/ruin/powered/hell_bunker)
+"kX" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/skeleton/plasmaminer,
+/turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
 "lB" = (
 /obj/machinery/oven,
@@ -142,6 +142,19 @@
 "mv" = (
 /obj/machinery/deepfryer,
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"nf" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/skeleton/plasmaminer,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"nm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/freezer/kitchen{
+	req_access = null
+	},
+/obj/item/paper/secretrecipe,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
 "oC" = (
@@ -183,22 +196,10 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"pp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/freezer/meat{
-	req_access = null
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
 "pI" = (
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/chasm/lavaland,
 /area/lavaland/surface/outdoors)
-"pS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/crate_spawner,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
 "pU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/cult,
@@ -208,6 +209,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/food/drinks/bottle/holywater/hell,
 /obj/item/coin/adamantine,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"qI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/crate_spawner,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
 "qM" = (
@@ -225,12 +231,28 @@
 /obj/effect/mob_spawn/human/corpse/damaged,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
+"tK" = (
+/obj/structure/chair/bronze{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit/old,
+/mob/living/simple_animal/hostile/skeleton/plasmaminer,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
 "tX" = (
 /obj/effect/mapping_helpers/no_lava,
 /obj/structure/fence/corner,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cult,
 /area/lavaland/surface/outdoors)
+"ub" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/freezer/meat{
+	req_access = null
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
 "vq" = (
 /obj/structure/table/bronze,
 /obj/effect/decal/cleanable/blood/old,
@@ -265,6 +287,15 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mob_spawn/human/corpse/damaged,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"vx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/candle{
+	infinite = 1;
+	lit = 1;
+	start_lit = 1
+	},
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
 "xh" = (
@@ -303,6 +334,16 @@
 /obj/effect/mob_spawn/human/corpse/damaged,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
+"zf" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/skeleton/plasmaminer,
+/obj/item/candle{
+	infinite = 1;
+	lit = 1;
+	start_lit = 1
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
 "zA" = (
 /obj/machinery/reagentgrinder/kitchen{
 	pixel_y = 9
@@ -310,13 +351,6 @@
 /obj/structure/table/bronze,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"AN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/freezer/fridge{
-	req_access = null
-	},
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
 "Br" = (
@@ -328,12 +362,31 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
+"BS" = (
+/obj/effect/mapping_helpers/no_lava,
+/turf/template_noop,
+/area/lavaland/surface/outdoors)
 "CG" = (
 /obj/machinery/door/airlock/cult/weak,
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Dy" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/laser_pointer/purple,
+/mob/living/simple_animal/hostile/skeleton/plasmaminer,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"ED" = (
+/obj/structure/chair/bronze{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/skeleton/plasmaminer,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
 "ET" = (
@@ -386,17 +439,6 @@
 /mob/living/simple_animal/hostile/carp/eyeball,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"IM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/organ/heart/demon,
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/rune/apocalypse{
-	icon_state = "rune_large"
-	},
-/obj/effect/mob_spawn/human/corpse/damaged,
-/obj/item/kitchen/knife/ritual,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
 "IZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/no_lava,
@@ -405,11 +447,6 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/lavaland/surface/outdoors)
-"Jp" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/skeleton/plasmaminer,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
 "Lj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/bronze,
@@ -499,37 +536,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/mineral/cult,
 /area/ruin/powered/hell_bunker)
-"Rl" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/footprints,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Sw" = (
-/obj/structure/chair/bronze{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/vomit/old,
-/mob/living/simple_animal/hostile/skeleton/plasmaminer,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"SQ" = (
-/obj/structure/chair/bronze{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/skeleton/plasmaminer,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
 "Tw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/bronze,
@@ -610,6 +616,17 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
+"YO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/organ/heart/demon,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/rune/apocalypse{
+	icon_state = "rune_large"
+	},
+/obj/effect/mob_spawn/human/corpse/damaged,
+/obj/item/kitchen/knife/ritual,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
 "YP" = (
 /obj/structure/table/bronze,
 /obj/structure/light_prism{
@@ -618,12 +635,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"Zp" = (
+"Zl" = (
+/obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/freezer/kitchen{
-	req_access = null
-	},
-/obj/item/paper/secretrecipe,
+/mob/living/simple_animal/hostile/skeleton/plasmaminer,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
 "ZS" = (
@@ -1079,7 +1094,7 @@ MG
 MG
 MG
 MG
-Jp
+nf
 MG
 MG
 MG
@@ -1124,22 +1139,22 @@ bM
 bM
 MG
 MG
-co
+vx
 MG
 MG
 MG
-co
+vx
 MG
 MG
 OH
 gc
 bM
-AN
+ck
 pb
 MG
 MG
 MG
-pp
+ub
 bM
 al
 al
@@ -1181,8 +1196,8 @@ MG
 bM
 gc
 bM
-Zp
-MG
+nm
+nf
 bM
 bM
 bM
@@ -1216,15 +1231,15 @@ qa
 qa
 bM
 bM
-co
+vx
 MG
 GX
 MG
-co
+vx
 MG
 GX
 MG
-co
+vx
 bM
 MG
 bM
@@ -1266,7 +1281,7 @@ bM
 MG
 MG
 MG
-Jp
+nf
 MG
 MG
 MG
@@ -1279,7 +1294,7 @@ QE
 OA
 oC
 MG
-Sw
+tK
 jn
 bM
 MG
@@ -1312,11 +1327,11 @@ bM
 bM
 MG
 MG
-co
+vx
 MG
-IM
+YO
 MG
-dS
+zf
 MG
 MG
 bM
@@ -1351,13 +1366,13 @@ al
 bM
 bM
 MG
-Jp
+nf
 MG
 MG
 MG
 bM
 bM
-Jp
+nf
 MG
 MG
 MG
@@ -1367,12 +1382,12 @@ MG
 MG
 MG
 bM
-MG
+nf
 bM
 zA
 OA
 hV
-Jp
+nf
 Xg
 Xg
 bM
@@ -1400,19 +1415,19 @@ bM
 MG
 MG
 MG
-Jp
+nf
 MG
 bM
 bM
-co
+vx
 MG
 GX
 MG
-co
+vx
 MG
 GX
 MG
-co
+vx
 bM
 MG
 bM
@@ -1421,7 +1436,7 @@ FJ
 OU
 MG
 jn
-SQ
+ED
 bM
 MG
 OH
@@ -1454,12 +1469,12 @@ FZ
 MG
 MG
 MG
-Jp
+nf
 MG
 MG
 MG
 MG
-Jp
+nf
 bM
 gc
 bM
@@ -1500,11 +1515,11 @@ MG
 FZ
 MG
 MG
-co
+vx
 MG
 MG
 MG
-co
+vx
 MG
 MG
 bM
@@ -1519,7 +1534,7 @@ Xg
 bM
 MG
 bM
-Jp
+nf
 bM
 MG
 bM
@@ -1540,7 +1555,7 @@ bM
 bM
 yn
 MG
-Jp
+nf
 MG
 yn
 bM
@@ -1592,7 +1607,7 @@ MG
 yn
 bM
 bM
-MG
+nf
 MG
 MG
 bM
@@ -1605,7 +1620,7 @@ kg
 MG
 bM
 yg
-Rl
+kX
 oF
 oF
 Br
@@ -1639,9 +1654,9 @@ MG
 yn
 bM
 bM
-pS
-pS
-pS
+qI
+qI
+qI
 bM
 Tw
 MG
@@ -1708,7 +1723,7 @@ bM
 gc
 bM
 gc
-jN
+Dy
 Wz
 bM
 al
@@ -1744,15 +1759,15 @@ MG
 iE
 bM
 MG
+Zl
+gc
+MG
+MG
 gc
 gc
 MG
-MG
 gc
-gc
-MG
-gc
-MG
+nf
 bM
 Vg
 Vg
@@ -2127,8 +2142,8 @@ aD
 aD
 pI
 pI
-eb
-eb
+BS
+BS
 pI
 pI
 aD

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_hellwater.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_hellwater.dmm
@@ -2,107 +2,26 @@
 "al" = (
 /turf/closed/mineral/random/high_chance,
 /area/lavaland/surface/outdoors)
+"aB" = (
+/obj/machinery/chem_dispenser/drinks/fullupgrade,
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
 "aD" = (
 /turf/template_noop,
 /area/lavaland/surface/outdoors)
-"ci" = (
-/obj/effect/decal/cleanable/blood/footprints,
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"dF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/cult,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"dI" = (
-/obj/machinery/door/airlock/cult/weak,
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"dQ" = (
-/obj/machinery/gibber/autogibber,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"es" = (
-/obj/machinery/oven,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"fW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/no_lava,
-/obj/structure/fence{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cult,
-/area/lavaland/surface/outdoors)
-"gp" = (
-/obj/effect/decal/cleanable/blood/gibs/up,
-/obj/effect/decal/cleanable/blood/footprints,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"gD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/washing_machine,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"jn" = (
-/obj/structure/table/bronze,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/light_prism{
-	pixel_y = 9
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"kd" = (
-/obj/structure/table/bronze,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/drinks/shaker,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"kI" = (
-/obj/machinery/door/airlock/cult/friendly,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fans/tiny,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"kL" = (
-/obj/item/bedsheet/cult,
-/obj/structure/bed,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"kS" = (
+"bt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/magmite,
+/obj/item/book_of_babel,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"kZ" = (
-/obj/machinery/chem_master,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
+"bM" = (
+/turf/closed/wall/mineral/cult,
 /area/ruin/powered/hell_bunker)
-"lM" = (
-/obj/structure/mirror{
-	pixel_y = 29
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"mN" = (
+"bN" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 4
 	},
@@ -112,57 +31,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"mS" = (
-/obj/structure/table/bronze,
-/obj/structure/light_prism{
-	pixel_y = 9
-	},
+"co" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/item/candle,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"ng" = (
-/obj/machinery/processor,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"pc" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/blood/footprints,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"qO" = (
-/obj/structure/chair/bronze{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/vomit/old,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"qQ" = (
-/obj/machinery/door/airlock/cult/weak,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"rD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/mob_spawn/human/corpse/damaged,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"rW" = (
-/obj/machinery/griddle,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mob_spawn/human/corpse/damaged,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"sC" = (
+"ct" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 4
 	},
@@ -173,61 +47,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"sD" = (
+"cW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/dresser,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"tj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sink/kitchen{
-	dir = 4;
-	pixel_x = -14;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"tR" = (
-/obj/effect/mapping_helpers/no_lava,
-/obj/structure/fence/corner,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/lavaland/surface/outdoors)
-"uy" = (
-/obj/effect/mapping_helpers/no_lava,
-/turf/open/chasm/lavaland,
-/area/lavaland/surface/outdoors)
-"wl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/item/paper/secretrecipe,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"wJ" = (
-/turf/closed/wall/mineral/cult,
-/area/ruin/powered/hell_bunker)
-"xu" = (
-/obj/machinery/reagentgrinder/kitchen{
-	pixel_y = 9
-	},
-/obj/structure/table/bronze,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"yN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/dinnerware,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"yV" = (
-/obj/structure/chair/bronze{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"zf" = (
+"dk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/organ/heart/demon,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -239,34 +64,153 @@
 /mob/living/simple_animal/lesserdemon/gluttony,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"Ar" = (
+"dD" = (
+/obj/machinery/processor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"eC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/cooking_oil,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"fk" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/mimic,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"gc" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"ho" = (
+/obj/machinery/door/airlock/cult/friendly,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"hV" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/drinks/shaker,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"iE" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/light_prism{
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"jn" = (
+/obj/structure/chair/bronze{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"jy" = (
+/obj/item/bedsheet/cult,
+/obj/structure/bed,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/skeleton/plasmaminer,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"kg" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/mineral/cult,
+/area/ruin/powered/hell_bunker)
+"kn" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/lesserdemon/wrath,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"lB" = (
+/obj/machinery/oven,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"me" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/no_lava,
+/turf/open/floor/plasteel/cult,
+/area/lavaland/surface/outdoors)
+"mh" = (
+/obj/machinery/hydroponics/soil,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"mv" = (
+/obj/machinery/deepfryer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"oC" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/drinks/flask,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"oF" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"oH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/no_lava,
+/obj/structure/fence/door/opened,
+/turf/open/floor/plasteel/cult,
+/area/lavaland/surface/outdoors)
+"oS" = (
+/obj/machinery/griddle,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mob_spawn/human/corpse/damaged,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"pb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -14;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"pI" = (
+/obj/effect/mapping_helpers/no_lava,
+/turf/open/chasm/lavaland,
+/area/lavaland/surface/outdoors)
+"pU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/cult,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"qa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/drinks/bottle/holywater/hell,
+/obj/item/coin/adamantine,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"qM" = (
 /obj/structure/table/bronze,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/randomfood,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"AL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/no_lava,
-/obj/effect/mapping_helpers/teleport_anchor,
-/turf/open/floor/plasteel/cult,
-/area/lavaland/surface/outdoors)
-"AV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/bronze,
-/obj/item/clothing/suit/cultrobes,
-/obj/item/clothing/suit/cultrobes,
-/obj/item/clothing/shoes/cult,
-/obj/item/clothing/shoes/cult,
-/obj/item/clothing/head/kitty/genuine,
-/obj/item/clothing/gloves/color/red,
-/obj/item/clothing/gloves/color/red,
-/obj/item/clothing/under/color/red,
-/obj/item/clothing/under/color/red,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"BL" = (
+"sQ" = (
 /obj/structure/table/bronze,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
@@ -274,248 +218,18 @@
 /obj/effect/mob_spawn/human/corpse/damaged,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"BT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/no_lava,
-/turf/open/floor/plasteel/cult,
-/area/lavaland/surface/outdoors)
-"BU" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Cl" = (
-/obj/machinery/deepfryer,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Cm" = (
-/obj/structure/table/bronze,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/light_prism{
-	pixel_y = 9
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Cy" = (
-/obj/structure/table/bronze,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/lighter,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Dv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/freezer/fridge,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"DH" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Eb" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/lesserdemon/wrath,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"FK" = (
-/obj/item/bedsheet/cult,
-/obj/structure/bed,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/skeleton/plasmaminer,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Hf" = (
-/obj/structure/table/bronze,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"HL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/drinks/bottle/holywater/hell,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Id" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/rune/apocalypse,
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/mob_spawn/human/corpse/damaged,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Is" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/cooking_oil,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Jc" = (
-/obj/structure/table/bronze,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/randomdrink,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Lo" = (
-/obj/structure/chair/bronze{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"LH" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/mineral/cult,
-/area/ruin/powered/hell_bunker)
-"MP" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Nq" = (
-/obj/machinery/chem_dispenser/drinks/fullupgrade,
-/obj/structure/table/bronze,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"NE" = (
-/obj/effect/mapping_helpers/no_lava,
-/obj/structure/fence/corner{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/lavaland/surface/outdoors)
-"NG" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/lesserdemon,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"NU" = (
+"td" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"Om" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/carp/eyeball,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Ov" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/bronze,
-/obj/item/clothing/suit/magusred,
-/obj/item/clothing/shoes/cult,
-/obj/item/clothing/head/magus,
-/obj/item/clothing/gloves/bracer,
-/obj/item/nullrod/pitchfork,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"OE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/bronze,
-/obj/structure/light_prism{
-	pixel_y = 9
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"OI" = (
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
-/obj/structure/table/bronze,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"QM" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Rj" = (
-/obj/effect/decal/cleanable/blood/gibs/body,
-/obj/effect/decal/cleanable/blood/gibs/down,
-/obj/effect/decal/cleanable/blood/footprints,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mob_spawn/human/corpse/damaged,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Sr" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/blood/footprints,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"SM" = (
-/obj/machinery/microwave,
-/obj/structure/table/bronze,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"TA" = (
-/obj/effect/decal/cleanable/dirt,
+"tX" = (
 /obj/effect/mapping_helpers/no_lava,
-/obj/structure/fence{
-	dir = 8
-	},
+/obj/structure/fence/corner,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cult,
 /area/lavaland/surface/outdoors)
-"Uc" = (
-/obj/structure/table/bronze,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/drinks/flask,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Uh" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/laser_pointer/purple,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"UL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/bronze,
-/obj/item/clothing/glasses/sunglasses{
-	pixel_y = 11
-	},
-/obj/item/pen/fourcolor{
-	pixel_x = 7;
-	pixel_y = -1
-	},
-/obj/item/phone{
-	pixel_x = -4;
-	pixel_y = -3
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Vu" = (
+"vq" = (
 /obj/structure/table/bronze,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
@@ -540,48 +254,87 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"VB" = (
+"vr" = (
+/obj/effect/decal/cleanable/blood/gibs/body,
+/obj/effect/decal/cleanable/blood/gibs/down,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/mimic,
+/obj/effect/mob_spawn/human/corpse/damaged,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"VE" = (
+"xh" = (
+/obj/machinery/gibber/autogibber,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/no_lava,
-/obj/structure/fence/door/opened,
 /turf/open/floor/plasteel/cult,
-/area/lavaland/surface/outdoors)
-"Wi" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8
-	},
+/area/ruin/powered/hell_bunker)
+"xF" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/footprints,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"WJ" = (
+"xH" = (
+/obj/machinery/chem_master,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"yg" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"yn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/mob_spawn/human/corpse/damaged,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"zA" = (
+/obj/machinery/reagentgrinder/kitchen{
+	pixel_y = 9
+	},
 /obj/structure/table/bronze,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"WK" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 4
-	},
+"Br" = (
+/obj/effect/decal/cleanable/blood/gibs/up,
 /obj/effect/decal/cleanable/blood/footprints,
 /obj/effect/decal/cleanable/blood/tracks{
-	dir = 8
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"Yv" = (
+"CG" = (
+/obj/machinery/door/airlock/cult/weak,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"ET" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/lighter,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"FJ" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/blood/gibs/torso,
 /obj/effect/decal/cleanable/blood/footprints{
@@ -597,17 +350,270 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"YM" = (
+"FZ" = (
 /obj/machinery/door/airlock/cult,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/trap/fire,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"YY" = (
+"GX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/rune/apocalypse,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/mob_spawn/human/corpse/damaged,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"HE" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/light_prism{
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Is" = (
 /obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/carp/eyeball,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"IZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/no_lava,
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cult,
+/area/lavaland/surface/outdoors)
+"Jl" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/lesserdemon,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Lj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/bronze,
+/obj/structure/light_prism{
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"LO" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"MG" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Nf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/bronze,
+/obj/item/clothing/suit/magusred,
+/obj/item/clothing/shoes/cult,
+/obj/item/clothing/head/magus,
+/obj/item/clothing/gloves/bracer,
+/obj/item/nullrod/pitchfork,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"NO" = (
+/obj/machinery/microwave,
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"OA" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"OH" = (
+/obj/machinery/door/airlock/cult/weak,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"OU" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"OW" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/randomdrink,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"PQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/no_lava,
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cult,
+/area/lavaland/surface/outdoors)
+"QE" = (
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"QY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/mineral/cult,
 /area/ruin/powered/hell_bunker)
+"Rl" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"RX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/obj/item/paper/secretrecipe,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Su" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"SE" = (
+/obj/structure/chair/bronze{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Tw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/bronze,
+/obj/item/clothing/suit/cultrobes,
+/obj/item/clothing/suit/cultrobes,
+/obj/item/clothing/shoes/cult,
+/obj/item/clothing/shoes/cult,
+/obj/item/clothing/head/kitty/genuine,
+/obj/item/clothing/gloves/color/red,
+/obj/item/clothing/gloves/color/red,
+/obj/item/clothing/under/color/red,
+/obj/item/clothing/under/color/red,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"TC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/no_lava,
+/obj/effect/mapping_helpers/teleport_anchor,
+/turf/open/floor/plasteel/cult,
+/area/lavaland/surface/outdoors)
+"Vg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/washing_machine,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Vn" = (
+/obj/item/bedsheet/cult,
+/obj/structure/bed,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"VI" = (
+/obj/structure/mirror{
+	pixel_y = 29
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Wu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/bronze,
+/obj/item/clothing/glasses/sunglasses{
+	pixel_y = 11
+	},
+/obj/item/pen/fourcolor{
+	pixel_x = 7;
+	pixel_y = -1
+	},
+/obj/item/phone{
+	pixel_x = -4;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Wz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Xg" = (
+/obj/structure/chair/bronze{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"XC" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Yz" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/laser_pointer/purple,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"YP" = (
+/obj/structure/table/bronze,
+/obj/structure/light_prism{
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"ZS" = (
+/obj/effect/mapping_helpers/no_lava,
+/obj/structure/fence/corner{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/lavaland/surface/outdoors)
 
 (1,1,1) = {"
 aD
@@ -716,25 +722,25 @@ aD
 aD
 aD
 aD
-uy
-uy
-uy
-uy
-uy
+pI
+pI
+pI
+pI
+pI
 aD
 aD
 aD
 aD
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
 aD
 aD
 aD
@@ -760,28 +766,28 @@ aD
 aD
 aD
 aD
-uy
-uy
-uy
-uy
-uy
-uy
-uy
+pI
+pI
+pI
+pI
+pI
+pI
+pI
 aD
 aD
 aD
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
 aD
 aD
 aD
@@ -806,32 +812,32 @@ aD
 aD
 aD
 aD
-uy
-uy
-uy
-uy
-uy
-uy
-uy
+pI
+pI
+pI
+pI
+pI
+pI
+pI
 aD
 aD
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
 aD
 aD
 aD
@@ -851,19 +857,19 @@ aD
 aD
 aD
 aD
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
 al
 al
 al
@@ -872,21 +878,21 @@ al
 al
 al
 al
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
 aD
 aD
-uy
-uy
-uy
+pI
+pI
+pI
 aD
 aD
 aD
@@ -896,19 +902,19 @@ aD
 aD
 aD
 aD
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
 al
 al
 al
@@ -919,22 +925,22 @@ al
 al
 al
 al
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
 aD
 aD
 "}
@@ -942,14 +948,14 @@ aD
 aD
 aD
 aD
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
 al
 al
 al
@@ -968,20 +974,20 @@ al
 al
 al
 al
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
 aD
 aD
 "}
@@ -989,31 +995,31 @@ aD
 aD
 aD
 aD
-uy
-uy
-uy
-uy
-uy
+pI
+pI
+pI
+pI
+pI
 al
 al
 al
 al
 al
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
 al
 al
 al
@@ -1022,13 +1028,13 @@ al
 al
 al
 al
-uy
-uy
-uy
-uy
-uy
-uy
-uy
+pI
+pI
+pI
+pI
+pI
+pI
+pI
 aD
 aD
 "}
@@ -1036,9 +1042,9 @@ aD
 aD
 aD
 aD
-uy
-uy
-uy
+pI
+pI
+pI
 al
 al
 al
@@ -1046,704 +1052,704 @@ al
 al
 al
 al
-wJ
-wJ
-wJ
-QM
-QM
-QM
-QM
-QM
-QM
-QM
-QM
-QM
-qQ
-QM
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
+bM
+bM
+bM
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+OH
+MG
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
 al
 al
 al
 al
-uy
-uy
-uy
-uy
-uy
+pI
+pI
+pI
+pI
+pI
 aD
 "}
 (11,1,1) = {"
 aD
 aD
 aD
-uy
-uy
-uy
+pI
+pI
+pI
 al
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-QM
-QM
-QM
-QM
-Eb
-QM
-QM
-QM
-QM
-qQ
-DH
-wJ
-Dv
-tj
-QM
-QM
-QM
-NU
-wJ
-al
-al
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+MG
+MG
+co
+MG
+kn
+MG
+co
+MG
+MG
+OH
+gc
+bM
+Su
+pb
+MG
+MG
+MG
+td
+bM
 al
 al
 al
 al
 al
-uy
-uy
-uy
+al
+al
+pI
+pI
+pI
 "}
 (12,1,1) = {"
 aD
 aD
 aD
-uy
-uy
-uy
+pI
+pI
+pI
 al
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-QM
-QM
-QM
-QM
-QM
-QM
-QM
-QM
-QM
-wJ
-DH
-wJ
-wl
-QM
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+bM
+gc
+bM
+RX
+MG
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
 al
-uy
-uy
-uy
+pI
+pI
+pI
 "}
 (13,1,1) = {"
 aD
 aD
 aD
-uy
-uy
-uy
+pI
+pI
+pI
 al
-wJ
-wJ
-HL
-HL
-kS
-HL
-HL
-wJ
-wJ
-QM
-QM
-Id
-QM
-QM
-QM
-Id
-QM
-QM
-wJ
-QM
-wJ
-kZ
-mN
-Cm
-QM
-QM
-QM
-qQ
-QM
-wJ
-MP
-MP
-mS
-wJ
+bM
+bM
+qa
+qa
+bt
+qa
+qa
+bM
+bM
+co
+MG
+GX
+MG
+co
+MG
+GX
+MG
+co
+bM
+MG
+bM
+xH
+bN
+HE
+MG
+MG
+MG
+OH
+MG
+bM
+mh
+mh
+YP
+bM
 al
-uy
-uy
-uy
+pI
+pI
+pI
 "}
 (14,1,1) = {"
 aD
 aD
 aD
-uy
-uy
+pI
+pI
 al
 al
-wJ
-wJ
-QM
-QM
-QM
-QM
-QM
-wJ
-wJ
-QM
-QM
-QM
-QM
-QM
-QM
-QM
-QM
-QM
-wJ
-QM
-wJ
-OI
-Wi
-Uc
-QM
-qO
-yV
-wJ
-QM
-wJ
-QM
-Om
-MP
-wJ
+bM
+bM
+MG
+MG
+MG
+MG
+MG
+bM
+bM
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+bM
+MG
+bM
+QE
+OA
+oC
+MG
+SE
+jn
+bM
+MG
+bM
+MG
+Is
+mh
+bM
 al
-uy
-uy
+pI
+pI
 aD
 "}
 (15,1,1) = {"
 aD
 aD
 aD
-uy
-uy
+pI
+pI
 al
 al
-wJ
-wJ
-QM
-QM
-QM
-QM
-QM
-wJ
-wJ
-Eb
-QM
-QM
-QM
-zf
-QM
-QM
-Eb
-QM
-wJ
-DH
-wJ
-Nq
-Wi
-Uc
-QM
-Jc
-WJ
-wJ
-QM
-wJ
-DH
-QM
-MP
-wJ
+bM
+bM
+MG
+MG
+MG
+MG
+MG
+bM
+bM
+kn
+MG
+co
+MG
+dk
+MG
+co
+kn
+MG
+bM
+gc
+bM
+aB
+OA
+oC
+MG
+OW
+OU
+bM
+MG
+bM
+gc
+MG
+mh
+bM
 al
-uy
-uy
+pI
+pI
 aD
 "}
 (16,1,1) = {"
 aD
 aD
 aD
-uy
-uy
+pI
+pI
 al
 al
-wJ
-wJ
-QM
-QM
-Eb
-QM
-QM
-wJ
-wJ
-QM
-QM
-QM
-QM
-QM
-QM
-QM
-QM
-QM
-wJ
-QM
-wJ
-xu
-Wi
-kd
-NG
-Lo
-Lo
-wJ
-DH
-wJ
-qQ
-wJ
-wJ
-wJ
+bM
+bM
+MG
+MG
+kn
+MG
+MG
+bM
+bM
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+MG
+bM
+MG
+bM
+zA
+OA
+hV
+Jl
+Xg
+Xg
+bM
+gc
+bM
+OH
+bM
+bM
+bM
 al
-NE
-BT
+ZS
+me
 aD
 "}
 (17,1,1) = {"
 aD
 aD
 aD
-uy
-uy
+pI
+pI
 al
 al
-wJ
-wJ
-QM
-QM
-QM
-QM
-QM
-wJ
-wJ
-QM
-QM
-Id
-QM
-QM
-QM
-Id
-QM
-QM
-wJ
-QM
-wJ
-BL
-Yv
-WJ
-QM
-yV
-yV
-wJ
-QM
-qQ
-QM
-qQ
-QM
-kI
-AL
-TA
-BT
+bM
+bM
+MG
+MG
+MG
+MG
+MG
+bM
+bM
+co
+MG
+GX
+MG
+co
+MG
+GX
+MG
+co
+bM
+MG
+bM
+sQ
+FJ
+OU
+MG
+jn
+jn
+bM
+MG
+OH
+MG
+OH
+MG
+ho
+TC
+IZ
+me
 aD
 "}
 (18,1,1) = {"
 aD
 aD
 aD
-uy
-uy
+pI
+pI
 al
 al
-wJ
-wJ
-QM
-QM
-QM
-QM
-QM
-QM
-YM
-QM
-QM
-QM
-QM
-Eb
-QM
-QM
-QM
-QM
-wJ
-DH
-wJ
-Cl
-BU
-Hf
-QM
-Cy
-Ar
-wJ
-DH
-wJ
-DH
-wJ
-QM
-wJ
-AL
-VE
-BT
+bM
+bM
+MG
+MG
+MG
+MG
+MG
+MG
+FZ
+MG
+MG
+MG
+MG
+kn
+MG
+MG
+MG
+MG
+bM
+gc
+bM
+mv
+LO
+XC
+MG
+ET
+qM
+bM
+gc
+bM
+gc
+bM
+MG
+bM
+TC
+oH
+me
 aD
 "}
 (19,1,1) = {"
 aD
 aD
 aD
-uy
-uy
+pI
+pI
 al
 al
-wJ
-wJ
-QM
-QM
-QM
-QM
-QM
-QM
-YM
-QM
-QM
-QM
-QM
-QM
-QM
-QM
-QM
-QM
-wJ
-QM
-wJ
-es
-BU
-Cm
-QM
-Lo
-Lo
-wJ
-QM
-wJ
-QM
-wJ
-QM
-wJ
-AL
-VE
-BT
+bM
+bM
+MG
+MG
+MG
+MG
+MG
+MG
+FZ
+MG
+MG
+co
+MG
+MG
+MG
+co
+MG
+MG
+bM
+MG
+bM
+lB
+LO
+HE
+MG
+Xg
+Xg
+bM
+MG
+bM
+MG
+bM
+MG
+bM
+TC
+oH
+me
 aD
 "}
 (20,1,1) = {"
 aD
 aD
 aD
-uy
-uy
+pI
+pI
 al
 al
-wJ
-wJ
-rD
-QM
-Eb
-QM
-rD
-wJ
-wJ
-LH
-dF
-LH
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-QM
-wJ
-rW
-BU
-wJ
-wJ
-wJ
-wJ
-wJ
-QM
-qQ
-QM
-qQ
-DH
-kI
-AL
-fW
-BT
+bM
+bM
+yn
+MG
+kn
+MG
+yn
+bM
+bM
+QY
+pU
+QY
+bM
+bM
+OH
+bM
+bM
+bM
+bM
+MG
+bM
+oS
+LO
+bM
+bM
+bM
+bM
+bM
+MG
+OH
+MG
+OH
+gc
+ho
+TC
+PQ
+me
 aD
 "}
 (21,1,1) = {"
 aD
 aD
 aD
-uy
-uy
-uy
+pI
+pI
+pI
 al
-wJ
-wJ
-rD
-QM
-QM
-QM
-rD
-wJ
-wJ
-QM
-QM
-QM
-wJ
-sD
-QM
-AV
-AV
-OE
-YY
-QM
-wJ
-ci
-WK
-pc
-pc
-gp
-Rj
-wJ
-DH
-wJ
-qQ
-wJ
-wJ
-wJ
+bM
+bM
+yn
+MG
+MG
+MG
+yn
+bM
+bM
+MG
+MG
+MG
+bM
+cW
+MG
+Tw
+Tw
+Lj
+kg
+MG
+bM
+yg
+Rl
+oF
+oF
+Br
+vr
+bM
+gc
+bM
+OH
+bM
+bM
+bM
 al
-tR
-BT
+tX
+me
 aD
 "}
 (22,1,1) = {"
 aD
 aD
 aD
-uy
-uy
+pI
+pI
 al
 al
-wJ
-wJ
-rD
-QM
-QM
-QM
-rD
-wJ
-wJ
-VB
-VB
-VB
-wJ
-AV
-QM
-QM
-QM
-Ov
-LH
-QM
-wJ
-sC
-Sr
-Vu
-SM
-ng
-dQ
-wJ
-QM
-wJ
-QM
-DH
-Is
-wJ
+bM
+bM
+yn
+MG
+MG
+MG
+yn
+bM
+bM
+fk
+fk
+fk
+bM
+Tw
+MG
+MG
+MG
+Nf
+QY
+MG
+bM
+ct
+xF
+vq
+NO
+dD
+xh
+bM
+MG
+bM
+MG
+gc
+eC
+bM
 al
-uy
-uy
+pI
+pI
 aD
 "}
 (23,1,1) = {"
 aD
 aD
 aD
-uy
-uy
+pI
+pI
 al
 al
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-AV
-QM
-QM
-QM
-UL
-wJ
-QM
-wJ
-dI
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-DH
-wJ
-DH
-Uh
-yN
-wJ
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+Tw
+MG
+MG
+MG
+Wu
+bM
+MG
+bM
+CG
+bM
+bM
+bM
+bM
+bM
+bM
+gc
+bM
+gc
+Yz
+Wz
+bM
 al
-uy
-uy
+pI
+pI
 aD
 "}
 (24,1,1) = {"
 aD
 aD
 aD
-uy
-uy
+pI
+pI
 al
 al
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
 al
 al
 al
-wJ
-OE
-QM
-QM
-QM
-jn
-wJ
-QM
-DH
-DH
-QM
-QM
-DH
-DH
-QM
-DH
-QM
-wJ
-gD
-gD
-mS
-wJ
+bM
+Lj
+MG
+MG
+MG
+iE
+bM
+MG
+gc
+gc
+MG
+MG
+gc
+gc
+MG
+gc
+MG
+bM
+Vg
+Vg
+YP
+bM
 al
-uy
-uy
+pI
+pI
 aD
 "}
 (25,1,1) = {"
 aD
 aD
 aD
-uy
-uy
-uy
+pI
+pI
+pI
 al
 al
 al
@@ -1757,31 +1763,31 @@ al
 al
 al
 al
-wJ
-QM
-QM
-QM
-QM
-QM
-wJ
-qQ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
+bM
+MG
+MG
+MG
+MG
+MG
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
 al
-uy
-uy
+pI
+pI
 aD
 "}
 (26,1,1) = {"
@@ -1789,35 +1795,30 @@ aD
 aD
 aD
 aD
-uy
-uy
-uy
-uy
-uy
+pI
+pI
+pI
+pI
+pI
 al
 al
 al
 al
-uy
-uy
-uy
+pI
+pI
+pI
 al
 al
 al
-wJ
-lM
-QM
-QM
-QM
-QM
-QM
-QM
-wJ
-al
-al
-al
-al
-al
+bM
+VI
+MG
+MG
+MG
+MG
+MG
+MG
+bM
 al
 al
 al
@@ -1827,8 +1828,13 @@ al
 al
 al
 al
-uy
-uy
+al
+al
+al
+al
+al
+pI
+pI
 aD
 "}
 (27,1,1) = {"
@@ -1836,45 +1842,45 @@ aD
 aD
 aD
 aD
-uy
-uy
+pI
+pI
 al
 al
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
 al
-wJ
-FK
-FK
-FK
-FK
-FK
-kL
-kL
-wJ
-al
-al
-al
+bM
+jy
+jy
+jy
+jy
+jy
+Vn
+Vn
+bM
 al
 al
 al
 al
 al
 al
-uy
-uy
-uy
-uy
-uy
-uy
+al
+al
+al
+pI
+pI
+pI
+pI
+pI
+pI
 aD
 aD
 "}
@@ -1883,45 +1889,45 @@ aD
 aD
 aD
 aD
-uy
-uy
+pI
+pI
 al
 al
 al
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
 al
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-wJ
-al
-al
-al
-al
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
 al
 al
 al
 al
-uy
-uy
-uy
-uy
-uy
-uy
-uy
+al
+al
+al
+al
+pI
+pI
+pI
+pI
+pI
+pI
+pI
 aD
 aD
 "}
@@ -1931,7 +1937,7 @@ aD
 aD
 aD
 aD
-uy
+pI
 al
 al
 al
@@ -1939,19 +1945,11 @@ al
 al
 al
 al
-uy
-uy
-uy
-uy
-uy
-al
-al
-al
-al
-al
-al
-al
-al
+pI
+pI
+pI
+pI
+pI
 al
 al
 al
@@ -1962,11 +1960,19 @@ al
 al
 al
 al
-uy
-uy
-uy
-uy
-uy
+al
+al
+al
+al
+al
+al
+al
+al
+pI
+pI
+pI
+pI
+pI
 aD
 aD
 aD
@@ -1978,40 +1984,40 @@ aD
 aD
 aD
 aD
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
 aD
 aD
 aD
@@ -2026,39 +2032,39 @@ aD
 aD
 aD
 aD
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
 aD
 aD
 aD
 aD
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
 aD
 aD
 aD
@@ -2079,32 +2085,32 @@ aD
 aD
 aD
 aD
-uy
-uy
-uy
+pI
+pI
+pI
 aD
 aD
 aD
 aD
 aD
 aD
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
-uy
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
+pI
 aD
 aD
 aD

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_hellwater.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_hellwater.dmm
@@ -52,31 +52,24 @@
 /obj/structure/dresser,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"dk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/organ/heart/demon,
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/rune/apocalypse{
-	icon_state = "rune_large"
-	},
-/obj/effect/mob_spawn/human/corpse/damaged,
-/obj/item/kitchen/knife/ritual,
-/mob/living/simple_animal/lesserdemon/gluttony,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
 "dD" = (
 /obj/machinery/processor,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
+"dS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/candle,
+/mob/living/simple_animal/hostile/skeleton/plasmaminer,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"eb" = (
+/obj/effect/mapping_helpers/no_lava,
+/turf/template_noop,
+/area/lavaland/surface/outdoors)
 "eC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/cooking_oil,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"fk" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/mimic,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
 "gc" = (
@@ -119,15 +112,17 @@
 /mob/living/simple_animal/hostile/skeleton/plasmaminer,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
+"jN" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/laser_pointer/purple,
+/mob/living/simple_animal/hostile/skeleton/plasmaminer,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
 "kg" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/mineral/cult,
-/area/ruin/powered/hell_bunker)
-"kn" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/lesserdemon/wrath,
-/turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
 "lB" = (
 /obj/machinery/oven,
@@ -188,10 +183,22 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
+"pp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/freezer/meat{
+	req_access = null
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
 "pI" = (
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/chasm/lavaland,
 /area/lavaland/surface/outdoors)
+"pS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/crate_spawner,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
 "pU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/cult,
@@ -216,11 +223,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kitchen/knife/butcher,
 /obj/effect/mob_spawn/human/corpse/damaged,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"td" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
 "tX" = (
@@ -310,6 +312,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
+"AN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/freezer/fridge{
+	req_access = null
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
 "Br" = (
 /obj/effect/decal/cleanable/blood/gibs/up,
 /obj/effect/decal/cleanable/blood/footprints,
@@ -377,6 +386,17 @@
 /mob/living/simple_animal/hostile/carp/eyeball,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
+"IM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/organ/heart/demon,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/rune/apocalypse{
+	icon_state = "rune_large"
+	},
+/obj/effect/mob_spawn/human/corpse/damaged,
+/obj/item/kitchen/knife/ritual,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
 "IZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/no_lava,
@@ -385,9 +405,9 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/lavaland/surface/outdoors)
-"Jl" = (
+"Jp" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/lesserdemon,
+/mob/living/simple_animal/hostile/skeleton/plasmaminer,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
 "Lj" = (
@@ -493,23 +513,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"RX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/item/paper/secretrecipe,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Su" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/freezer/fridge,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"SE" = (
+"Sw" = (
 /obj/structure/chair/bronze{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/vomit/old,
+/mob/living/simple_animal/hostile/skeleton/plasmaminer,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"SQ" = (
+/obj/structure/chair/bronze{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/skeleton/plasmaminer,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
 "Tw" = (
@@ -592,18 +610,20 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"Yz" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/laser_pointer/purple,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
 "YP" = (
 /obj/structure/table/bronze,
 /obj/structure/light_prism{
 	pixel_y = 9
 	},
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Zp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/freezer/kitchen{
+	req_access = null
+	},
+/obj/item/paper/secretrecipe,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
 "ZS" = (
@@ -1059,7 +1079,7 @@ MG
 MG
 MG
 MG
-MG
+Jp
 MG
 MG
 MG
@@ -1106,7 +1126,7 @@ MG
 MG
 co
 MG
-kn
+MG
 MG
 co
 MG
@@ -1114,12 +1134,12 @@ MG
 OH
 gc
 bM
-Su
+AN
 pb
 MG
 MG
 MG
-td
+pp
 bM
 al
 al
@@ -1161,7 +1181,7 @@ MG
 bM
 gc
 bM
-RX
+Zp
 MG
 bM
 bM
@@ -1246,7 +1266,7 @@ bM
 MG
 MG
 MG
-MG
+Jp
 MG
 MG
 MG
@@ -1259,7 +1279,7 @@ QE
 OA
 oC
 MG
-SE
+Sw
 jn
 bM
 MG
@@ -1290,14 +1310,14 @@ MG
 MG
 bM
 bM
-kn
+MG
 MG
 co
 MG
-dk
+IM
 MG
-co
-kn
+dS
+MG
 MG
 bM
 gc
@@ -1331,13 +1351,13 @@ al
 bM
 bM
 MG
+Jp
 MG
-kn
 MG
 MG
 bM
 bM
-MG
+Jp
 MG
 MG
 MG
@@ -1352,7 +1372,7 @@ bM
 zA
 OA
 hV
-Jl
+Jp
 Xg
 Xg
 bM
@@ -1380,7 +1400,7 @@ bM
 MG
 MG
 MG
-MG
+Jp
 MG
 bM
 bM
@@ -1401,7 +1421,7 @@ FJ
 OU
 MG
 jn
-jn
+SQ
 bM
 MG
 OH
@@ -1434,12 +1454,12 @@ FZ
 MG
 MG
 MG
-MG
-kn
-MG
+Jp
 MG
 MG
 MG
+MG
+Jp
 bM
 gc
 bM
@@ -1499,7 +1519,7 @@ Xg
 bM
 MG
 bM
-MG
+Jp
 bM
 MG
 bM
@@ -1520,7 +1540,7 @@ bM
 bM
 yn
 MG
-kn
+Jp
 MG
 yn
 bM
@@ -1619,9 +1639,9 @@ MG
 yn
 bM
 bM
-fk
-fk
-fk
+pS
+pS
+pS
 bM
 Tw
 MG
@@ -1688,7 +1708,7 @@ bM
 gc
 bM
 gc
-Yz
+jN
 Wz
 bM
 al
@@ -2053,9 +2073,9 @@ pI
 pI
 pI
 pI
-pI
-pI
-pI
+aD
+aD
+aD
 pI
 pI
 pI
@@ -2097,18 +2117,18 @@ aD
 pI
 pI
 pI
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
 pI
 pI
-pI
-pI
-pI
-pI
-pI
-pI
-pI
-pI
-pI
-pI
+eb
+eb
 pI
 pI
 aD

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_hellwater.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_hellwater.dmm
@@ -1,0 +1,2325 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"al" = (
+/turf/closed/mineral/random/high_chance,
+/area/lavaland/surface/outdoors)
+"ap" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/lighter,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"aD" = (
+/turf/template_noop,
+/area/lavaland/surface/outdoors)
+"aJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/no_lava,
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cult,
+/area/lavaland/surface/outdoors)
+"aT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/no_lava,
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cult,
+/area/lavaland/surface/outdoors)
+"bj" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/laser_pointer/purple,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"by" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/crab/evil,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"bZ" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/netherworld/migo,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"eJ" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"eR" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/mineral/cult,
+/area/ruin/powered/hell_bunker)
+"fM" = (
+/obj/item/bedsheet/cult,
+/obj/structure/bed,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"fZ" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/retaliate/goat/horror,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"gi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -14;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"jO" = (
+/obj/structure/chair/bronze{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/shade,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"jR" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"jU" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"ks" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/no_lava,
+/obj/effect/mapping_helpers/teleport_anchor,
+/turf/open/floor/plasteel/cult,
+/area/lavaland/surface/outdoors)
+"kT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/cooking_oil,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"kW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"nj" = (
+/obj/machinery/hydroponics/soil,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"nW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/no_lava,
+/obj/structure/fence/door/opened,
+/turf/open/floor/plasteel/cult,
+/area/lavaland/surface/outdoors)
+"og" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/bronze,
+/obj/structure/light_prism{
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"pi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/bronze,
+/obj/item/clothing/glasses/sunglasses{
+	pixel_y = 11
+	},
+/obj/item/pen/fourcolor{
+	pixel_x = 7;
+	pixel_y = -1
+	},
+/obj/item/phone{
+	pixel_x = -4;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"pG" = (
+/obj/structure/chair/bronze{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"pK" = (
+/obj/effect/mapping_helpers/no_lava,
+/obj/structure/fence/corner{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/lavaland/surface/outdoors)
+"qf" = (
+/obj/effect/mapping_helpers/no_lava,
+/turf/open/chasm/lavaland,
+/area/lavaland/surface/outdoors)
+"qF" = (
+/obj/machinery/chem_master,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"qU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/bronze,
+/obj/item/clothing/suit/magusred,
+/obj/item/clothing/shoes/cult,
+/obj/item/clothing/head/magus,
+/obj/item/clothing/gloves/bracer,
+/obj/item/nullrod/pitchfork,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"ry" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/netherworld,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"rD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"sH" = (
+/obj/machinery/door/airlock/cult/weak,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"sJ" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/construct/armored/noncult,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"sN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/washing_machine,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"tv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old,
+/mob/living/simple_animal/hostile/netherworld/blankbody,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"tK" = (
+/obj/effect/decal/cleanable/blood/gibs/body,
+/obj/effect/decal/cleanable/blood/gibs/down,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/organ_spawner{
+	pixel_x = -4;
+	pixel_y = -5
+	},
+/obj/effect/spawner/lootdrop/organ_spawner{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/effect/mapping_helpers/dead_body_placer,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"ug" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/obj/item/paper/secretrecipe,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"uh" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_x = -9;
+	pixel_y = -6
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/item/book/manual/chef_recipes,
+/obj/item/kitchen/rollingpin{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/glass/mixbowl{
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/condiment/enzyme{
+	layer = 5
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"un" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/bronze,
+/obj/item/clothing/suit/cultrobes,
+/obj/item/clothing/suit/cultrobes,
+/obj/item/clothing/shoes/cult,
+/obj/item/clothing/shoes/cult,
+/obj/item/clothing/head/kitty/genuine,
+/obj/item/clothing/gloves/color/red,
+/obj/item/clothing/gloves/color/red,
+/obj/item/clothing/under/color/red,
+/obj/item/clothing/under/color/red,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"uV" = (
+/obj/machinery/reagentgrinder/kitchen{
+	pixel_y = 9
+	},
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"wd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/cult,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"xx" = (
+/obj/effect/mapping_helpers/no_lava,
+/obj/structure/fence/corner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/lavaland/surface/outdoors)
+"xH" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/drinks/flask,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"xM" = (
+/obj/machinery/door/airlock/cult/weak,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/trap/stun,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"yu" = (
+/obj/machinery/door/airlock/cult/friendly,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"yG" = (
+/obj/effect/rune/narsie,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/mapping_helpers/dead_body_placer,
+/obj/item/kitchen/knife/ritual,
+/obj/item/organ/heart/demon,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"yS" = (
+/obj/machinery/gibber/autogibber,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"zU" = (
+/obj/effect/rune/apocalypse,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/mapping_helpers/dead_body_placer,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Ac" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/randomdrink,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Ar" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Bt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/drinks/bottle/holywater/hell,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"BW" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/dead_body_placer,
+/obj/item/kitchen/knife/butcher,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Cg" = (
+/obj/structure/table/bronze,
+/obj/structure/light_prism{
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Cq" = (
+/obj/machinery/chem_dispenser/drinks/fullupgrade,
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"CF" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/light_prism{
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"CX" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Gk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"GK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/trap/fire,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"HB" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Ia" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/drinks/shaker,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"IU" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"JB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/dresser,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"JH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/mapping_helpers/dead_body_placer,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"JV" = (
+/obj/structure/chair/bronze{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Ko" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Ks" = (
+/obj/structure/mirror{
+	pixel_y = 29
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Mh" = (
+/turf/closed/wall/mineral/cult,
+/area/ruin/powered/hell_bunker)
+"Mi" = (
+/obj/effect/decal/cleanable/blood/gibs/up,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"MH" = (
+/obj/structure/chair/bronze{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit/old,
+/mob/living/simple_animal/shade,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Nx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/magmite,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"OK" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"OL" = (
+/obj/machinery/door/airlock/cult,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/trap/fire,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"OY" = (
+/obj/machinery/processor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Pc" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/blood/gibs/torso,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/innards,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Pr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/no_lava,
+/turf/open/floor/plasteel/cult,
+/area/lavaland/surface/outdoors)
+"RI" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Sn" = (
+/obj/machinery/deepfryer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"SV" = (
+/obj/machinery/microwave,
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"UM" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"UQ" = (
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Vk" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/light_prism{
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Vq" = (
+/obj/machinery/oven,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"WN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/mineral/cult,
+/area/ruin/powered/hell_bunker)
+"Xg" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/mimic,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Yd" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Yt" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/randomfood,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Zs" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/glockroach,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"ZR" = (
+/obj/machinery/griddle,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/organ_spawner{
+	pixel_x = 7
+	},
+/obj/effect/spawner/lootdrop/organ_spawner{
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/obj/effect/spawner/lootdrop/organ_spawner{
+	pixel_x = -7;
+	pixel_y = 1
+	},
+/obj/effect/spawner/lootdrop/organ_spawner{
+	pixel_x = -1
+	},
+/obj/effect/spawner/lootdrop/organ_spawner{
+	pixel_x = 11;
+	pixel_y = 8
+	},
+/obj/effect/spawner/lootdrop/organ_spawner{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/effect/spawner/lootdrop/organ_spawner{
+	pixel_x = -4;
+	pixel_y = 11
+	},
+/obj/effect/spawner/lootdrop/organ_spawner{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"ZZ" = (
+/obj/machinery/door/airlock/cult/weak,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/space/basic,
+/area/ruin/powered/hell_bunker)
+
+(1,1,1) = {"
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+"}
+(2,1,1) = {"
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+"}
+(3,1,1) = {"
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+qf
+qf
+qf
+qf
+qf
+aD
+aD
+aD
+aD
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+"}
+(4,1,1) = {"
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+aD
+aD
+aD
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+"}
+(5,1,1) = {"
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+aD
+aD
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+"}
+(6,1,1) = {"
+aD
+aD
+aD
+aD
+aD
+aD
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+al
+al
+al
+al
+al
+al
+al
+al
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+aD
+aD
+qf
+qf
+qf
+aD
+aD
+aD
+"}
+(7,1,1) = {"
+aD
+aD
+aD
+aD
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+aD
+aD
+"}
+(8,1,1) = {"
+aD
+aD
+aD
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+aD
+aD
+"}
+(9,1,1) = {"
+aD
+aD
+aD
+qf
+qf
+qf
+qf
+qf
+al
+al
+al
+al
+al
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+al
+al
+al
+al
+al
+al
+al
+al
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+aD
+aD
+"}
+(10,1,1) = {"
+aD
+aD
+aD
+qf
+qf
+qf
+al
+al
+al
+al
+al
+al
+al
+Mh
+Mh
+Mh
+CX
+CX
+CX
+CX
+CX
+CX
+CX
+CX
+CX
+sH
+CX
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+al
+al
+al
+al
+qf
+qf
+qf
+qf
+qf
+aD
+"}
+(11,1,1) = {"
+aD
+aD
+aD
+qf
+qf
+qf
+al
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+CX
+CX
+CX
+CX
+CX
+CX
+CX
+CX
+CX
+sH
+HB
+Mh
+Gk
+gi
+CX
+CX
+CX
+rD
+Mh
+al
+al
+al
+al
+al
+al
+al
+qf
+qf
+qf
+"}
+(12,1,1) = {"
+aD
+aD
+aD
+qf
+qf
+qf
+al
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+CX
+CX
+zU
+CX
+sJ
+CX
+zU
+CX
+CX
+Mh
+HB
+Mh
+ug
+CX
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+al
+qf
+qf
+qf
+"}
+(13,1,1) = {"
+aD
+aD
+aD
+qf
+qf
+qf
+al
+Mh
+Mh
+Bt
+Bt
+Nx
+Bt
+Bt
+Mh
+Mh
+CX
+CX
+CX
+CX
+CX
+CX
+CX
+CX
+CX
+Mh
+CX
+Mh
+qF
+Ar
+Vk
+CX
+CX
+CX
+sH
+sJ
+Mh
+nj
+nj
+Cg
+Mh
+al
+qf
+qf
+qf
+"}
+(14,1,1) = {"
+aD
+aD
+aD
+qf
+qf
+al
+al
+Mh
+Mh
+CX
+CX
+CX
+CX
+CX
+Mh
+Mh
+CX
+CX
+sJ
+CX
+yG
+CX
+sJ
+CX
+CX
+Mh
+CX
+Mh
+UQ
+jR
+xH
+CX
+MH
+pG
+Mh
+CX
+Mh
+CX
+fZ
+nj
+Mh
+al
+qf
+qf
+aD
+"}
+(15,1,1) = {"
+aD
+aD
+aD
+qf
+qf
+al
+al
+Mh
+Mh
+bZ
+CX
+ry
+CX
+CX
+Mh
+Mh
+CX
+CX
+CX
+CX
+CX
+CX
+CX
+CX
+CX
+Mh
+HB
+Mh
+Cq
+jR
+xH
+CX
+Ac
+UM
+Mh
+CX
+Mh
+HB
+CX
+nj
+Mh
+al
+qf
+qf
+aD
+"}
+(16,1,1) = {"
+aD
+aD
+aD
+qf
+qf
+al
+al
+Mh
+Mh
+CX
+CX
+CX
+CX
+CX
+Mh
+Mh
+CX
+CX
+zU
+CX
+sJ
+CX
+zU
+CX
+CX
+Mh
+CX
+Mh
+uV
+jR
+Ia
+CX
+JV
+JV
+Mh
+HB
+Mh
+sH
+Mh
+Mh
+Mh
+al
+pK
+Pr
+aD
+"}
+(17,1,1) = {"
+aD
+aD
+aD
+qf
+qf
+al
+al
+Mh
+Mh
+CX
+CX
+CX
+CX
+ry
+Mh
+Mh
+CX
+CX
+CX
+CX
+CX
+CX
+CX
+CX
+CX
+Mh
+CX
+Mh
+BW
+Pc
+UM
+CX
+pG
+jO
+Mh
+CX
+xM
+CX
+sH
+CX
+yu
+ks
+aT
+Pr
+aD
+"}
+(18,1,1) = {"
+aD
+aD
+aD
+qf
+qf
+al
+al
+Mh
+Mh
+CX
+ry
+CX
+CX
+CX
+GK
+OL
+CX
+CX
+CX
+CX
+CX
+CX
+CX
+CX
+CX
+Mh
+HB
+Mh
+Sn
+eJ
+jU
+CX
+ap
+Yt
+Mh
+HB
+Mh
+HB
+Mh
+CX
+Mh
+ks
+nW
+Pr
+aD
+"}
+(19,1,1) = {"
+aD
+aD
+aD
+qf
+qf
+al
+al
+Mh
+Mh
+CX
+CX
+CX
+CX
+CX
+GK
+OL
+CX
+CX
+CX
+CX
+CX
+CX
+CX
+CX
+CX
+Mh
+CX
+Mh
+Vq
+eJ
+Vk
+CX
+JV
+JV
+Mh
+CX
+Mh
+CX
+Mh
+CX
+Mh
+ks
+nW
+Pr
+aD
+"}
+(20,1,1) = {"
+aD
+aD
+aD
+qf
+qf
+al
+al
+Mh
+Mh
+tv
+CX
+CX
+CX
+JH
+Mh
+Mh
+WN
+wd
+WN
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+CX
+Mh
+ZR
+eJ
+Mh
+Mh
+Mh
+Mh
+Mh
+CX
+xM
+CX
+sH
+HB
+yu
+ks
+aJ
+Pr
+aD
+"}
+(21,1,1) = {"
+aD
+aD
+aD
+qf
+qf
+qf
+al
+Mh
+Mh
+JH
+CX
+CX
+CX
+JH
+Mh
+Mh
+CX
+CX
+CX
+Mh
+JB
+by
+un
+un
+og
+eR
+CX
+Mh
+Ko
+RI
+OK
+OK
+Mi
+tK
+Mh
+HB
+Mh
+sH
+Mh
+Mh
+Mh
+al
+xx
+Pr
+aD
+"}
+(22,1,1) = {"
+aD
+aD
+aD
+qf
+qf
+al
+al
+Mh
+Mh
+JH
+CX
+bZ
+CX
+JH
+Mh
+Mh
+Xg
+Xg
+Xg
+Mh
+un
+CX
+CX
+CX
+qU
+WN
+CX
+Mh
+IU
+Yd
+uh
+SV
+OY
+yS
+Mh
+CX
+Mh
+CX
+HB
+kT
+Mh
+al
+qf
+qf
+aD
+"}
+(23,1,1) = {"
+aD
+aD
+aD
+qf
+qf
+al
+al
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+un
+CX
+CX
+CX
+pi
+Mh
+CX
+Mh
+ZZ
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+HB
+Mh
+Zs
+bj
+kW
+Mh
+al
+qf
+qf
+aD
+"}
+(24,1,1) = {"
+aD
+aD
+aD
+qf
+qf
+al
+al
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+al
+al
+al
+Mh
+og
+CX
+CX
+CX
+CF
+Mh
+CX
+HB
+HB
+CX
+CX
+HB
+HB
+CX
+HB
+CX
+Mh
+sN
+sN
+Cg
+Mh
+al
+qf
+qf
+aD
+"}
+(25,1,1) = {"
+aD
+aD
+aD
+qf
+qf
+qf
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+Mh
+CX
+CX
+CX
+CX
+CX
+Mh
+sH
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+al
+qf
+qf
+aD
+"}
+(26,1,1) = {"
+aD
+aD
+aD
+aD
+qf
+qf
+qf
+qf
+qf
+al
+al
+al
+al
+qf
+qf
+qf
+al
+al
+al
+Mh
+Ks
+by
+CX
+CX
+by
+CX
+CX
+Mh
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+qf
+qf
+aD
+"}
+(27,1,1) = {"
+aD
+aD
+aD
+aD
+qf
+qf
+al
+al
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+al
+Mh
+fM
+fM
+fM
+fM
+fM
+fM
+fM
+Mh
+al
+al
+al
+al
+al
+al
+al
+al
+al
+qf
+qf
+qf
+qf
+qf
+qf
+aD
+aD
+"}
+(28,1,1) = {"
+aD
+aD
+aD
+aD
+qf
+qf
+al
+al
+al
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+al
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+al
+al
+al
+al
+al
+al
+al
+al
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+aD
+aD
+"}
+(29,1,1) = {"
+aD
+aD
+aD
+aD
+aD
+qf
+al
+al
+al
+al
+al
+al
+al
+qf
+qf
+qf
+qf
+qf
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+qf
+qf
+qf
+qf
+qf
+aD
+aD
+aD
+aD
+"}
+(30,1,1) = {"
+aD
+aD
+aD
+aD
+aD
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+aD
+aD
+aD
+aD
+aD
+aD
+"}
+(31,1,1) = {"
+aD
+aD
+aD
+aD
+aD
+aD
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+aD
+aD
+aD
+aD
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+aD
+aD
+aD
+aD
+aD
+aD
+"}
+(32,1,1) = {"
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+qf
+qf
+qf
+aD
+aD
+aD
+aD
+aD
+aD
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+qf
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+"}
+(33,1,1) = {"
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+"}
+(34,1,1) = {"
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+"}
+(35,1,1) = {"
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+aD
+"}

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_hellwater.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_hellwater.dmm
@@ -2,17 +2,41 @@
 "al" = (
 /turf/closed/mineral/random/high_chance,
 /area/lavaland/surface/outdoors)
-"ap" = (
-/obj/structure/table/bronze,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/lighter,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
 "aD" = (
 /turf/template_noop,
 /area/lavaland/surface/outdoors)
-"aJ" = (
+"ci" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"dF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/cult,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"dI" = (
+/obj/machinery/door/airlock/cult/weak,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"dQ" = (
+/obj/machinery/gibber/autogibber,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"es" = (
+/obj/machinery/oven,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"fW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/no_lava,
 /obj/structure/fence{
@@ -20,31 +44,242 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/lavaland/surface/outdoors)
-"aT" = (
+"gp" = (
+/obj/effect/decal/cleanable/blood/gibs/up,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/no_lava,
-/obj/structure/fence{
-	dir = 8
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"gD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/washing_machine,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"jn" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/light_prism{
+	pixel_y = 9
 	},
 /turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"kd" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/drinks/shaker,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"kI" = (
+/obj/machinery/door/airlock/cult/friendly,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"kL" = (
+/obj/item/bedsheet/cult,
+/obj/structure/bed,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"kS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/magmite,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"kZ" = (
+/obj/machinery/chem_master,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"lM" = (
+/obj/structure/mirror{
+	pixel_y = 29
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"mN" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"mS" = (
+/obj/structure/table/bronze,
+/obj/structure/light_prism{
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"ng" = (
+/obj/machinery/processor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"pc" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"qO" = (
+/obj/structure/chair/bronze{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"qQ" = (
+/obj/machinery/door/airlock/cult/weak,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"rD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/mob_spawn/human/corpse/damaged,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"rW" = (
+/obj/machinery/griddle,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mob_spawn/human/corpse/damaged,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"sC" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"sD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/dresser,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"tj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -14;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"tR" = (
+/obj/effect/mapping_helpers/no_lava,
+/obj/structure/fence/corner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
 /area/lavaland/surface/outdoors)
-"bj" = (
-/obj/effect/decal/cleanable/blood/drip,
+"uy" = (
+/obj/effect/mapping_helpers/no_lava,
+/turf/open/chasm/lavaland,
+/area/lavaland/surface/outdoors)
+"wl" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/laser_pointer/purple,
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/obj/item/paper/secretrecipe,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"by" = (
+"wJ" = (
+/turf/closed/wall/mineral/cult,
+/area/ruin/powered/hell_bunker)
+"xu" = (
+/obj/machinery/reagentgrinder/kitchen{
+	pixel_y = 9
+	},
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/crab/evil,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"bZ" = (
+"yN" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/netherworld/migo,
+/obj/machinery/vending/dinnerware,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"eJ" = (
+"yV" = (
+/obj/structure/chair/bronze{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"zf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/organ/heart/demon,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/rune/apocalypse{
+	icon_state = "rune_large"
+	},
+/obj/effect/mob_spawn/human/corpse/damaged,
+/obj/item/kitchen/knife/ritual,
+/mob/living/simple_animal/lesserdemon/gluttony,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Ar" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/randomfood,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"AL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/no_lava,
+/obj/effect/mapping_helpers/teleport_anchor,
+/turf/open/floor/plasteel/cult,
+/area/lavaland/surface/outdoors)
+"AV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/bronze,
+/obj/item/clothing/suit/cultrobes,
+/obj/item/clothing/suit/cultrobes,
+/obj/item/clothing/shoes/cult,
+/obj/item/clothing/shoes/cult,
+/obj/item/clothing/head/kitty/genuine,
+/obj/item/clothing/gloves/color/red,
+/obj/item/clothing/gloves/color/red,
+/obj/item/clothing/under/color/red,
+/obj/item/clothing/under/color/red,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"BL" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kitchen/knife/butcher,
+/obj/effect/mob_spawn/human/corpse/damaged,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"BT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/no_lava,
+/turf/open/floor/plasteel/cult,
+/area/lavaland/surface/outdoors)
+"BU" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 8
 	},
@@ -57,51 +292,50 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"eR" = (
+"Cl" = (
+/obj/machinery/deepfryer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Cm" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/light_prism{
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Cy" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/lighter,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Dv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"DH" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/mineral/cult,
+/turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"fM" = (
+"Eb" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/lesserdemon/wrath,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"FK" = (
 /obj/item/bedsheet/cult,
 /obj/structure/bed,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/skeleton/plasmaminer,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"fZ" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/retaliate/goat/horror,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"gi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sink/kitchen{
-	dir = 4;
-	pixel_x = -14;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"jO" = (
-/obj/structure/chair/bronze{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/shade,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"jR" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"jU" = (
+"Hf" = (
 /obj/structure/table/bronze,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
@@ -115,34 +349,88 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"ks" = (
+"HL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/no_lava,
-/obj/effect/mapping_helpers/teleport_anchor,
+/obj/item/reagent_containers/food/drinks/bottle/holywater/hell,
 /turf/open/floor/plasteel/cult,
-/area/lavaland/surface/outdoors)
-"kT" = (
+/area/ruin/powered/hell_bunker)
+"Id" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/rune/apocalypse,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/mob_spawn/human/corpse/damaged,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Is" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"kW" = (
+"Jc" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/dinnerware,
+/obj/effect/spawner/lootdrop/randomdrink,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"nj" = (
+"Lo" = (
+/obj/structure/chair/bronze{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"LH" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/mineral/cult,
+/area/ruin/powered/hell_bunker)
+"MP" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"nW" = (
+"Nq" = (
+/obj/machinery/chem_dispenser/drinks/fullupgrade,
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"NE" = (
 /obj/effect/mapping_helpers/no_lava,
-/obj/structure/fence/door/opened,
+/obj/structure/fence/corner{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cult,
 /area/lavaland/surface/outdoors)
-"og" = (
+"NG" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/lesserdemon,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"NU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Om" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/carp/eyeball,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Ov" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/bronze,
+/obj/item/clothing/suit/magusred,
+/obj/item/clothing/shoes/cult,
+/obj/item/clothing/head/magus,
+/obj/item/clothing/gloves/bracer,
+/obj/item/nullrod/pitchfork,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"OE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/bronze,
 /obj/structure/light_prism{
@@ -150,7 +438,68 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"pi" = (
+"OI" = (
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"QM" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Rj" = (
+/obj/effect/decal/cleanable/blood/gibs/body,
+/obj/effect/decal/cleanable/blood/gibs/down,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mob_spawn/human/corpse/damaged,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Sr" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"SM" = (
+/obj/machinery/microwave,
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"TA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/no_lava,
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cult,
+/area/lavaland/surface/outdoors)
+"Uc" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/drinks/flask,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"Uh" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/laser_pointer/purple,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"UL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/bronze,
 /obj/item/clothing/glasses/sunglasses{
@@ -166,98 +515,7 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"pG" = (
-/obj/structure/chair/bronze{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"pK" = (
-/obj/effect/mapping_helpers/no_lava,
-/obj/structure/fence/corner{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/lavaland/surface/outdoors)
-"qf" = (
-/obj/effect/mapping_helpers/no_lava,
-/turf/open/chasm/lavaland,
-/area/lavaland/surface/outdoors)
-"qF" = (
-/obj/machinery/chem_master,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"qU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/bronze,
-/obj/item/clothing/suit/magusred,
-/obj/item/clothing/shoes/cult,
-/obj/item/clothing/head/magus,
-/obj/item/clothing/gloves/bracer,
-/obj/item/nullrod/pitchfork,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"ry" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/netherworld,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"rD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/freezer/meat,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"sH" = (
-/obj/machinery/door/airlock/cult/weak,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"sJ" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/construct/armored/noncult,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"sN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/washing_machine,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"tv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/old,
-/mob/living/simple_animal/hostile/netherworld/blankbody,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"tK" = (
-/obj/effect/decal/cleanable/blood/gibs/body,
-/obj/effect/decal/cleanable/blood/gibs/down,
-/obj/effect/decal/cleanable/blood/footprints,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/organ_spawner{
-	pixel_x = -4;
-	pixel_y = -5
-	},
-/obj/effect/spawner/lootdrop/organ_spawner{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/effect/mapping_helpers/dead_body_placer,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"ug" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/item/paper/secretrecipe,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"uh" = (
+"Vu" = (
 /obj/structure/table/bronze,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
@@ -282,253 +540,48 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"un" = (
+"VB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/bronze,
-/obj/item/clothing/suit/cultrobes,
-/obj/item/clothing/suit/cultrobes,
-/obj/item/clothing/shoes/cult,
-/obj/item/clothing/shoes/cult,
-/obj/item/clothing/head/kitty/genuine,
-/obj/item/clothing/gloves/color/red,
-/obj/item/clothing/gloves/color/red,
-/obj/item/clothing/under/color/red,
-/obj/item/clothing/under/color/red,
+/mob/living/simple_animal/hostile/mimic,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"uV" = (
-/obj/machinery/reagentgrinder/kitchen{
-	pixel_y = 9
-	},
-/obj/structure/table/bronze,
-/obj/effect/decal/cleanable/blood/old,
+"VE" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"wd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/cult,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"xx" = (
 /obj/effect/mapping_helpers/no_lava,
-/obj/structure/fence/corner,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/fence/door/opened,
 /turf/open/floor/plasteel/cult,
 /area/lavaland/surface/outdoors)
-"xH" = (
-/obj/structure/table/bronze,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/drinks/flask,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"xM" = (
-/obj/machinery/door/airlock/cult/weak,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/trap/stun,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"yu" = (
-/obj/machinery/door/airlock/cult/friendly,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fans/tiny,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"yG" = (
-/obj/effect/rune/narsie,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/mapping_helpers/dead_body_placer,
-/obj/item/kitchen/knife/ritual,
-/obj/item/organ/heart/demon,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"yS" = (
-/obj/machinery/gibber/autogibber,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"zU" = (
-/obj/effect/rune/apocalypse,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/mapping_helpers/dead_body_placer,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Ac" = (
-/obj/structure/table/bronze,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/randomdrink,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Ar" = (
+"Wi" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"WJ" = (
+/obj/structure/table/bronze,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult,
+/area/ruin/powered/hell_bunker)
+"WK" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Bt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/drinks/bottle/holywater/hell,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"BW" = (
-/obj/structure/table/bronze,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/dead_body_placer,
-/obj/item/kitchen/knife/butcher,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Cg" = (
-/obj/structure/table/bronze,
-/obj/structure/light_prism{
-	pixel_y = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Cq" = (
-/obj/machinery/chem_dispenser/drinks/fullupgrade,
-/obj/structure/table/bronze,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"CF" = (
-/obj/structure/table/bronze,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/light_prism{
-	pixel_y = 9
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"CX" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Gk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/freezer/fridge,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"GK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/trap/fire,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"HB" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Ia" = (
-/obj/structure/table/bronze,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/drinks/shaker,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"IU" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/blood/footprints,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"JB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/dresser,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"JH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/mapping_helpers/dead_body_placer,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"JV" = (
-/obj/structure/chair/bronze{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Ko" = (
-/obj/effect/decal/cleanable/blood/footprints,
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Ks" = (
-/obj/structure/mirror{
-	pixel_y = 29
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Mh" = (
-/turf/closed/wall/mineral/cult,
-/area/ruin/powered/hell_bunker)
-"Mi" = (
-/obj/effect/decal/cleanable/blood/gibs/up,
-/obj/effect/decal/cleanable/blood/footprints,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"MH" = (
-/obj/structure/chair/bronze{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/vomit/old,
-/mob/living/simple_animal/shade,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Nx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/magmite,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"OK" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 1
 	},
 /obj/effect/decal/cleanable/blood/footprints,
 /obj/effect/decal/cleanable/blood/tracks{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"OL" = (
-/obj/machinery/door/airlock/cult,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/trap/fire,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"OY" = (
-/obj/machinery/processor,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Pc" = (
+"Yv" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/blood/gibs/torso,
 /obj/effect/decal/cleanable/blood/footprints{
@@ -544,138 +597,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"Pr" = (
+"YM" = (
+/obj/machinery/door/airlock/cult,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/no_lava,
-/turf/open/floor/plasteel/cult,
-/area/lavaland/surface/outdoors)
-"RI" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/footprints,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/trap/fire,
 /turf/open/floor/plasteel/cult,
 /area/ruin/powered/hell_bunker)
-"Sn" = (
-/obj/machinery/deepfryer,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"SV" = (
-/obj/machinery/microwave,
-/obj/structure/table/bronze,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"UM" = (
-/obj/structure/table/bronze,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"UQ" = (
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
-/obj/structure/table/bronze,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Vk" = (
-/obj/structure/table/bronze,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/light_prism{
-	pixel_y = 9
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Vq" = (
-/obj/machinery/oven,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"WN" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/mineral/cult,
-/area/ruin/powered/hell_bunker)
-"Xg" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/mimic,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Yd" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/blood/footprints,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Yt" = (
-/obj/structure/table/bronze,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/randomfood,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"Zs" = (
+"YY" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/glockroach,
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"ZR" = (
-/obj/machinery/griddle,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/organ_spawner{
-	pixel_x = 7
-	},
-/obj/effect/spawner/lootdrop/organ_spawner{
-	pixel_x = 1;
-	pixel_y = 1
-	},
-/obj/effect/spawner/lootdrop/organ_spawner{
-	pixel_x = -7;
-	pixel_y = 1
-	},
-/obj/effect/spawner/lootdrop/organ_spawner{
-	pixel_x = -1
-	},
-/obj/effect/spawner/lootdrop/organ_spawner{
-	pixel_x = 11;
-	pixel_y = 8
-	},
-/obj/effect/spawner/lootdrop/organ_spawner{
-	pixel_x = 3;
-	pixel_y = 8
-	},
-/obj/effect/spawner/lootdrop/organ_spawner{
-	pixel_x = -4;
-	pixel_y = 11
-	},
-/obj/effect/spawner/lootdrop/organ_spawner{
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/cult,
-/area/ruin/powered/hell_bunker)
-"ZZ" = (
-/obj/machinery/door/airlock/cult/weak,
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/space/basic,
+/turf/closed/wall/mineral/cult,
 /area/ruin/powered/hell_bunker)
 
 (1,1,1) = {"
@@ -785,25 +716,25 @@ aD
 aD
 aD
 aD
-qf
-qf
-qf
-qf
-qf
+uy
+uy
+uy
+uy
+uy
 aD
 aD
 aD
 aD
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
 aD
 aD
 aD
@@ -829,28 +760,28 @@ aD
 aD
 aD
 aD
-qf
-qf
-qf
-qf
-qf
-qf
-qf
+uy
+uy
+uy
+uy
+uy
+uy
+uy
 aD
 aD
 aD
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
 aD
 aD
 aD
@@ -875,32 +806,32 @@ aD
 aD
 aD
 aD
-qf
-qf
-qf
-qf
-qf
-qf
-qf
+uy
+uy
+uy
+uy
+uy
+uy
+uy
 aD
 aD
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
 aD
 aD
 aD
@@ -920,19 +851,19 @@ aD
 aD
 aD
 aD
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
 al
 al
 al
@@ -941,21 +872,21 @@ al
 al
 al
 al
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
 aD
 aD
-qf
-qf
-qf
+uy
+uy
+uy
 aD
 aD
 aD
@@ -965,19 +896,19 @@ aD
 aD
 aD
 aD
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
 al
 al
 al
@@ -988,22 +919,22 @@ al
 al
 al
 al
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
 aD
 aD
 "}
@@ -1011,14 +942,14 @@ aD
 aD
 aD
 aD
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
 al
 al
 al
@@ -1037,20 +968,20 @@ al
 al
 al
 al
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
 aD
 aD
 "}
@@ -1058,31 +989,31 @@ aD
 aD
 aD
 aD
-qf
-qf
-qf
-qf
-qf
+uy
+uy
+uy
+uy
+uy
 al
 al
 al
 al
 al
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
 al
 al
 al
@@ -1091,13 +1022,13 @@ al
 al
 al
 al
-qf
-qf
-qf
-qf
-qf
-qf
-qf
+uy
+uy
+uy
+uy
+uy
+uy
+uy
 aD
 aD
 "}
@@ -1105,9 +1036,9 @@ aD
 aD
 aD
 aD
-qf
-qf
-qf
+uy
+uy
+uy
 al
 al
 al
@@ -1115,704 +1046,704 @@ al
 al
 al
 al
-Mh
-Mh
-Mh
-CX
-CX
-CX
-CX
-CX
-CX
-CX
-CX
-CX
-sH
-CX
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
+wJ
+wJ
+wJ
+QM
+QM
+QM
+QM
+QM
+QM
+QM
+QM
+QM
+qQ
+QM
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
 al
 al
 al
 al
-qf
-qf
-qf
-qf
-qf
+uy
+uy
+uy
+uy
+uy
 aD
 "}
 (11,1,1) = {"
 aD
 aD
 aD
-qf
-qf
-qf
+uy
+uy
+uy
 al
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-CX
-CX
-CX
-CX
-CX
-CX
-CX
-CX
-CX
-sH
-HB
-Mh
-Gk
-gi
-CX
-CX
-CX
-rD
-Mh
-al
-al
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+QM
+QM
+QM
+QM
+Eb
+QM
+QM
+QM
+QM
+qQ
+DH
+wJ
+Dv
+tj
+QM
+QM
+QM
+NU
+wJ
 al
 al
 al
 al
 al
-qf
-qf
-qf
+al
+al
+uy
+uy
+uy
 "}
 (12,1,1) = {"
 aD
 aD
 aD
-qf
-qf
-qf
+uy
+uy
+uy
 al
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-CX
-CX
-zU
-CX
-sJ
-CX
-zU
-CX
-CX
-Mh
-HB
-Mh
-ug
-CX
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+QM
+QM
+QM
+QM
+QM
+QM
+QM
+QM
+QM
+wJ
+DH
+wJ
+wl
+QM
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
 al
-qf
-qf
-qf
+uy
+uy
+uy
 "}
 (13,1,1) = {"
 aD
 aD
 aD
-qf
-qf
-qf
+uy
+uy
+uy
 al
-Mh
-Mh
-Bt
-Bt
-Nx
-Bt
-Bt
-Mh
-Mh
-CX
-CX
-CX
-CX
-CX
-CX
-CX
-CX
-CX
-Mh
-CX
-Mh
-qF
-Ar
-Vk
-CX
-CX
-CX
-sH
-sJ
-Mh
-nj
-nj
-Cg
-Mh
+wJ
+wJ
+HL
+HL
+kS
+HL
+HL
+wJ
+wJ
+QM
+QM
+Id
+QM
+QM
+QM
+Id
+QM
+QM
+wJ
+QM
+wJ
+kZ
+mN
+Cm
+QM
+QM
+QM
+qQ
+QM
+wJ
+MP
+MP
+mS
+wJ
 al
-qf
-qf
-qf
+uy
+uy
+uy
 "}
 (14,1,1) = {"
 aD
 aD
 aD
-qf
-qf
+uy
+uy
 al
 al
-Mh
-Mh
-CX
-CX
-CX
-CX
-CX
-Mh
-Mh
-CX
-CX
-sJ
-CX
-yG
-CX
-sJ
-CX
-CX
-Mh
-CX
-Mh
-UQ
-jR
-xH
-CX
-MH
-pG
-Mh
-CX
-Mh
-CX
-fZ
-nj
-Mh
+wJ
+wJ
+QM
+QM
+QM
+QM
+QM
+wJ
+wJ
+QM
+QM
+QM
+QM
+QM
+QM
+QM
+QM
+QM
+wJ
+QM
+wJ
+OI
+Wi
+Uc
+QM
+qO
+yV
+wJ
+QM
+wJ
+QM
+Om
+MP
+wJ
 al
-qf
-qf
+uy
+uy
 aD
 "}
 (15,1,1) = {"
 aD
 aD
 aD
-qf
-qf
+uy
+uy
 al
 al
-Mh
-Mh
-bZ
-CX
-ry
-CX
-CX
-Mh
-Mh
-CX
-CX
-CX
-CX
-CX
-CX
-CX
-CX
-CX
-Mh
-HB
-Mh
-Cq
-jR
-xH
-CX
-Ac
-UM
-Mh
-CX
-Mh
-HB
-CX
-nj
-Mh
+wJ
+wJ
+QM
+QM
+QM
+QM
+QM
+wJ
+wJ
+Eb
+QM
+QM
+QM
+zf
+QM
+QM
+Eb
+QM
+wJ
+DH
+wJ
+Nq
+Wi
+Uc
+QM
+Jc
+WJ
+wJ
+QM
+wJ
+DH
+QM
+MP
+wJ
 al
-qf
-qf
+uy
+uy
 aD
 "}
 (16,1,1) = {"
 aD
 aD
 aD
-qf
-qf
+uy
+uy
 al
 al
-Mh
-Mh
-CX
-CX
-CX
-CX
-CX
-Mh
-Mh
-CX
-CX
-zU
-CX
-sJ
-CX
-zU
-CX
-CX
-Mh
-CX
-Mh
-uV
-jR
-Ia
-CX
-JV
-JV
-Mh
-HB
-Mh
-sH
-Mh
-Mh
-Mh
+wJ
+wJ
+QM
+QM
+Eb
+QM
+QM
+wJ
+wJ
+QM
+QM
+QM
+QM
+QM
+QM
+QM
+QM
+QM
+wJ
+QM
+wJ
+xu
+Wi
+kd
+NG
+Lo
+Lo
+wJ
+DH
+wJ
+qQ
+wJ
+wJ
+wJ
 al
-pK
-Pr
+NE
+BT
 aD
 "}
 (17,1,1) = {"
 aD
 aD
 aD
-qf
-qf
+uy
+uy
 al
 al
-Mh
-Mh
-CX
-CX
-CX
-CX
-ry
-Mh
-Mh
-CX
-CX
-CX
-CX
-CX
-CX
-CX
-CX
-CX
-Mh
-CX
-Mh
-BW
-Pc
-UM
-CX
-pG
-jO
-Mh
-CX
-xM
-CX
-sH
-CX
-yu
-ks
-aT
-Pr
+wJ
+wJ
+QM
+QM
+QM
+QM
+QM
+wJ
+wJ
+QM
+QM
+Id
+QM
+QM
+QM
+Id
+QM
+QM
+wJ
+QM
+wJ
+BL
+Yv
+WJ
+QM
+yV
+yV
+wJ
+QM
+qQ
+QM
+qQ
+QM
+kI
+AL
+TA
+BT
 aD
 "}
 (18,1,1) = {"
 aD
 aD
 aD
-qf
-qf
+uy
+uy
 al
 al
-Mh
-Mh
-CX
-ry
-CX
-CX
-CX
-GK
-OL
-CX
-CX
-CX
-CX
-CX
-CX
-CX
-CX
-CX
-Mh
-HB
-Mh
-Sn
-eJ
-jU
-CX
-ap
-Yt
-Mh
-HB
-Mh
-HB
-Mh
-CX
-Mh
-ks
-nW
-Pr
+wJ
+wJ
+QM
+QM
+QM
+QM
+QM
+QM
+YM
+QM
+QM
+QM
+QM
+Eb
+QM
+QM
+QM
+QM
+wJ
+DH
+wJ
+Cl
+BU
+Hf
+QM
+Cy
+Ar
+wJ
+DH
+wJ
+DH
+wJ
+QM
+wJ
+AL
+VE
+BT
 aD
 "}
 (19,1,1) = {"
 aD
 aD
 aD
-qf
-qf
+uy
+uy
 al
 al
-Mh
-Mh
-CX
-CX
-CX
-CX
-CX
-GK
-OL
-CX
-CX
-CX
-CX
-CX
-CX
-CX
-CX
-CX
-Mh
-CX
-Mh
-Vq
-eJ
-Vk
-CX
-JV
-JV
-Mh
-CX
-Mh
-CX
-Mh
-CX
-Mh
-ks
-nW
-Pr
+wJ
+wJ
+QM
+QM
+QM
+QM
+QM
+QM
+YM
+QM
+QM
+QM
+QM
+QM
+QM
+QM
+QM
+QM
+wJ
+QM
+wJ
+es
+BU
+Cm
+QM
+Lo
+Lo
+wJ
+QM
+wJ
+QM
+wJ
+QM
+wJ
+AL
+VE
+BT
 aD
 "}
 (20,1,1) = {"
 aD
 aD
 aD
-qf
-qf
+uy
+uy
 al
 al
-Mh
-Mh
-tv
-CX
-CX
-CX
-JH
-Mh
-Mh
-WN
-wd
-WN
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-CX
-Mh
-ZR
-eJ
-Mh
-Mh
-Mh
-Mh
-Mh
-CX
-xM
-CX
-sH
-HB
-yu
-ks
-aJ
-Pr
+wJ
+wJ
+rD
+QM
+Eb
+QM
+rD
+wJ
+wJ
+LH
+dF
+LH
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+QM
+wJ
+rW
+BU
+wJ
+wJ
+wJ
+wJ
+wJ
+QM
+qQ
+QM
+qQ
+DH
+kI
+AL
+fW
+BT
 aD
 "}
 (21,1,1) = {"
 aD
 aD
 aD
-qf
-qf
-qf
+uy
+uy
+uy
 al
-Mh
-Mh
-JH
-CX
-CX
-CX
-JH
-Mh
-Mh
-CX
-CX
-CX
-Mh
-JB
-by
-un
-un
-og
-eR
-CX
-Mh
-Ko
-RI
-OK
-OK
-Mi
-tK
-Mh
-HB
-Mh
-sH
-Mh
-Mh
-Mh
+wJ
+wJ
+rD
+QM
+QM
+QM
+rD
+wJ
+wJ
+QM
+QM
+QM
+wJ
+sD
+QM
+AV
+AV
+OE
+YY
+QM
+wJ
+ci
+WK
+pc
+pc
+gp
+Rj
+wJ
+DH
+wJ
+qQ
+wJ
+wJ
+wJ
 al
-xx
-Pr
+tR
+BT
 aD
 "}
 (22,1,1) = {"
 aD
 aD
 aD
-qf
-qf
+uy
+uy
 al
 al
-Mh
-Mh
-JH
-CX
-bZ
-CX
-JH
-Mh
-Mh
-Xg
-Xg
-Xg
-Mh
-un
-CX
-CX
-CX
-qU
-WN
-CX
-Mh
-IU
-Yd
-uh
-SV
-OY
-yS
-Mh
-CX
-Mh
-CX
-HB
-kT
-Mh
+wJ
+wJ
+rD
+QM
+QM
+QM
+rD
+wJ
+wJ
+VB
+VB
+VB
+wJ
+AV
+QM
+QM
+QM
+Ov
+LH
+QM
+wJ
+sC
+Sr
+Vu
+SM
+ng
+dQ
+wJ
+QM
+wJ
+QM
+DH
+Is
+wJ
 al
-qf
-qf
+uy
+uy
 aD
 "}
 (23,1,1) = {"
 aD
 aD
 aD
-qf
-qf
+uy
+uy
 al
 al
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-un
-CX
-CX
-CX
-pi
-Mh
-CX
-Mh
-ZZ
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-HB
-Mh
-Zs
-bj
-kW
-Mh
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+AV
+QM
+QM
+QM
+UL
+wJ
+QM
+wJ
+dI
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+DH
+wJ
+DH
+Uh
+yN
+wJ
 al
-qf
-qf
+uy
+uy
 aD
 "}
 (24,1,1) = {"
 aD
 aD
 aD
-qf
-qf
+uy
+uy
 al
 al
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
 al
 al
 al
-Mh
-og
-CX
-CX
-CX
-CF
-Mh
-CX
-HB
-HB
-CX
-CX
-HB
-HB
-CX
-HB
-CX
-Mh
-sN
-sN
-Cg
-Mh
+wJ
+OE
+QM
+QM
+QM
+jn
+wJ
+QM
+DH
+DH
+QM
+QM
+DH
+DH
+QM
+DH
+QM
+wJ
+gD
+gD
+mS
+wJ
 al
-qf
-qf
+uy
+uy
 aD
 "}
 (25,1,1) = {"
 aD
 aD
 aD
-qf
-qf
-qf
+uy
+uy
+uy
 al
 al
 al
@@ -1826,31 +1757,31 @@ al
 al
 al
 al
-Mh
-CX
-CX
-CX
-CX
-CX
-Mh
-sH
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
+wJ
+QM
+QM
+QM
+QM
+QM
+wJ
+qQ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
 al
-qf
-qf
+uy
+uy
 aD
 "}
 (26,1,1) = {"
@@ -1858,35 +1789,30 @@ aD
 aD
 aD
 aD
-qf
-qf
-qf
-qf
-qf
+uy
+uy
+uy
+uy
+uy
 al
 al
 al
 al
-qf
-qf
-qf
+uy
+uy
+uy
 al
 al
 al
-Mh
-Ks
-by
-CX
-CX
-by
-CX
-CX
-Mh
-al
-al
-al
-al
-al
+wJ
+lM
+QM
+QM
+QM
+QM
+QM
+QM
+wJ
 al
 al
 al
@@ -1896,8 +1822,13 @@ al
 al
 al
 al
-qf
-qf
+al
+al
+al
+al
+al
+uy
+uy
 aD
 "}
 (27,1,1) = {"
@@ -1905,45 +1836,45 @@ aD
 aD
 aD
 aD
-qf
-qf
+uy
+uy
 al
 al
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
 al
-Mh
-fM
-fM
-fM
-fM
-fM
-fM
-fM
-Mh
-al
-al
-al
+wJ
+FK
+FK
+FK
+FK
+FK
+kL
+kL
+wJ
 al
 al
 al
 al
 al
 al
-qf
-qf
-qf
-qf
-qf
-qf
+al
+al
+al
+uy
+uy
+uy
+uy
+uy
+uy
 aD
 aD
 "}
@@ -1952,45 +1883,45 @@ aD
 aD
 aD
 aD
-qf
-qf
+uy
+uy
 al
 al
 al
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
 al
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
-al
-al
-al
-al
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
+wJ
 al
 al
 al
 al
-qf
-qf
-qf
-qf
-qf
-qf
-qf
+al
+al
+al
+al
+uy
+uy
+uy
+uy
+uy
+uy
+uy
 aD
 aD
 "}
@@ -2000,7 +1931,7 @@ aD
 aD
 aD
 aD
-qf
+uy
 al
 al
 al
@@ -2008,19 +1939,11 @@ al
 al
 al
 al
-qf
-qf
-qf
-qf
-qf
-al
-al
-al
-al
-al
-al
-al
-al
+uy
+uy
+uy
+uy
+uy
 al
 al
 al
@@ -2031,11 +1954,19 @@ al
 al
 al
 al
-qf
-qf
-qf
-qf
-qf
+al
+al
+al
+al
+al
+al
+al
+al
+uy
+uy
+uy
+uy
+uy
 aD
 aD
 aD
@@ -2047,40 +1978,40 @@ aD
 aD
 aD
 aD
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
 aD
 aD
 aD
@@ -2095,39 +2026,39 @@ aD
 aD
 aD
 aD
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
 aD
 aD
 aD
 aD
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
 aD
 aD
 aD
@@ -2148,32 +2079,32 @@ aD
 aD
 aD
 aD
-qf
-qf
-qf
+uy
+uy
+uy
 aD
 aD
 aD
 aD
 aD
 aD
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
-qf
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
 aD
 aD
 aD

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -337,6 +337,13 @@
 	cost = 5
 	allow_duplicates = FALSE
 
+/datum/map_template/ruin/lavaland/hellwater
+	name = "Ritual Bunker"
+	id = "hellwater"
+	description = "A terrible hive of scum, villany, and daemonic summonings."
+	suffix = "lavaland_surface_hellwater.dmm"
+	cost = 10
+
 /datum/map_template/ruin/lavaland/legionbarracks
 	name = "Legion Barracks"
 	id = "legionbarracks"

--- a/code/game/area/areas/ruins/lavaland.dm
+++ b/code/game/area/areas/ruins/lavaland.dm
@@ -78,7 +78,7 @@
 	icon_state = "dk_yellow"
 
 /area/ruin/powered/hell_bunker
-	name = "Ritual Bunker"
+	name = "Ritual Bunker" 
 	noteleport = TRUE
 
 /area/ruin/unpowered/russianbunker

--- a/code/game/area/areas/ruins/lavaland.dm
+++ b/code/game/area/areas/ruins/lavaland.dm
@@ -75,7 +75,11 @@
 	name = "King Goat Arena"
 	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
 	noteleport = TRUE
-	icon_state = "dk_yellow" //yogs end
+	icon_state = "dk_yellow"
+
+/area/ruin/powered/hell_bunker
+	name = "Ritual Bunker"
+	noteleport = TRUE
 
 /area/ruin/unpowered/russianbunker
 	name = "Russian Bunker"


### PR DESCRIPTION
# Document the changes in your pull request

Adds a new ruin to lavaland, themed around demon summoning and such
uses a fake Nar'sie summon decal*

loot you can obtain here:

- one Demon Heart
- one Null Rod (Pitchfork variant)
- Ancient Cult Robes (moderately ok armor)
- Red Magus Robes (moderately ok armor)
- One pair of real sunglasses
- cat ears
- one Butcher's Knife
- 4 bottles of Hell Water
- one Book of Babel
- one Plasma Magmite Crystal
- 3 randomized loot crates
- Ritual Knife (Not the cult one)
- Secret Sauce recipe
- one random drink & food item
- two boxes of random donk pockets

Featuring:

- A full kitchen + Bar setup (sans boozomat, has a gibber)
- a wash room
- four dirt plots (no other botany supplies)
- real cult doors (gotta break them)
- a full bunkroom with a mirror and wardrobe

enemies consist of:
1 Eyeball
25 shambling miners (Tested, surprisingly strong in numbers)

surrounded by a Chasm moat and marked NOTELEPORT

# Wiki Documentation

![ss (2022-08-12 at 06 56 02)](https://user-images.githubusercontent.com/1534478/184458735-1ac11da0-a4ee-4aa4-838e-8d05dd3d55d5.png)

Will need to be added to the Ruins page

# Changelog

:cl:  
rscadd: Adds a new lavaland ruin, the Ritual Bunker
/:cl:
