### PR TITLE
[MDB IGNORE][Meta] AI/Telecomms Maint Changes

### DIFF
--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -26281,11 +26281,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/security/warden)
-"bgC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden,
-/turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
 "bgE" = (
 /obj/structure/disposalpipe/sorting/wrap{
 	dir = 1
@@ -30307,6 +30302,29 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
+"bpK" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"bpL" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "bpM" = (
 /obj/machinery/holopad,
 /obj/structure/cable/yellow{
@@ -56722,6 +56740,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"dsN" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/plating,
+/area/ai_monitored/storage/satellite)
 "dtd" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -58478,6 +58500,22 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
+"euu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "MiniSat Maintenance";
+	req_access_txt = "32"
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/storage/satellite)
 "euB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -59976,13 +60014,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"fAE" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
 "fAK" = (
 /obj/item/storage/box/rxglasses{
 	pixel_x = 3;
@@ -63801,6 +63832,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"iwM" = (
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/gloves/color/black,
+/turf/open/floor/plating,
+/area/ai_monitored/storage/satellite)
 "ixs" = (
 /obj/machinery/light{
 	dir = 4
@@ -67077,12 +67116,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"lcb" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	target_temperature = 73
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
 "lch" = (
 /obj/effect/landmark/blobstart,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -67247,22 +67280,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
-"lfY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "MiniSat Maintenance";
-	req_access_txt = "32"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/aisat)
 "lgM" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -68097,14 +68114,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"lQa" = (
-/obj/structure/rack,
-/obj/item/clothing/gloves/color/black,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/emergency_oxygen,
-/turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
 "lQk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -71030,10 +71039,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"oeR" = (
-/obj/effect/spawner/lootdrop/tanks/highquality,
-/turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
 "ofy" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -71945,6 +71950,12 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"oQe" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/storage/satellite)
 "oQt" = (
 /obj/structure/window/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -73826,6 +73837,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"qhy" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plating,
+/area/ai_monitored/storage/satellite)
 "qhE" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -75320,6 +75338,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"rlK" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	target_temperature = 80
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/storage/satellite)
 "rlU" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -75731,19 +75755,6 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
-"rBV" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "rCh" = (
 /obj/machinery/camera{
 	c_tag = "Engineering - Foyer - Shared Storage";
@@ -141066,10 +141077,10 @@ bey
 bgn
 aaa
 aRy
-lcb
+rlK
 pSG
 ndM
-rYE
+dsN
 aRy
 aaa
 aMq
@@ -141323,10 +141334,10 @@ aNz
 iDk
 aaa
 aRy
-lcb
-bgC
+iwM
+qhy
 uGB
-oeR
+rYE
 aRy
 aaa
 pUF
@@ -141580,7 +141591,7 @@ aNz
 ozh
 hxn
 aRy
-lcb
+xtp
 glh
 vOC
 sBu
@@ -141837,10 +141848,10 @@ aNz
 iDk
 aaa
 aRy
-xtp
-glh
+oQe
+oQe
 nwS
-lQa
+ejI
 aRy
 aaa
 pUF
@@ -142094,10 +142105,10 @@ hWl
 iDk
 aaa
 aRy
-fAE
-fAE
-nwS
-ejI
+aRy
+aRy
+euu
+aRy
 aRy
 aaa
 pUF
@@ -142350,12 +142361,12 @@ pUF
 aNz
 iDk
 aaa
-aRy
-aRy
-aRy
-lfY
-aRy
-aRy
+aaa
+aaa
+aMq
+bpK
+bgn
+aaa
 aaa
 pUF
 aNz
@@ -142610,7 +142621,7 @@ aNw
 aNw
 aNw
 aSD
-rBV
+bpL
 bsj
 aNw
 aNw

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -30302,29 +30302,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
-"bpK" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"bpL" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "bpM" = (
 /obj/machinery/holopad,
 /obj/structure/cable/yellow{
@@ -55917,6 +55894,11 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space/nearstation)
+"dgE" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden,
+/turf/open/floor/plating,
+/area/ai_monitored/storage/satellite)
 "dgO" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
@@ -56740,10 +56722,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"dsN" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
 "dtd" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -58500,22 +58478,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
-"euu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "MiniSat Maintenance";
-	req_access_txt = "32"
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
 "euB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -61956,6 +61918,13 @@
 	},
 /turf/open/floor/grass,
 /area/medical/sleeper)
+"gWR" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/plating,
+/area/ai_monitored/storage/satellite)
 "gXd" = (
 /obj/machinery/mineral/stacking_unit_console{
 	machinedir = 8;
@@ -71950,12 +71919,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"oQe" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
 "oQt" = (
 /obj/structure/window/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -73837,13 +73800,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"qhy" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
 "qhE" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -75338,12 +75294,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"rlK" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	target_temperature = 80
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
 "rlU" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -79900,6 +79850,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"vbP" = (
+/obj/effect/spawner/lootdrop/tanks/highquality,
+/turf/open/floor/plating,
+/area/ai_monitored/storage/satellite)
 "vcc" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
@@ -80220,6 +80174,22 @@
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"vjy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "MiniSat Maintenance";
+	req_access_txt = "32"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/storage/satellite)
 "vkS" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -80407,6 +80377,12 @@
 	},
 /turf/open/floor/plating,
 /area/science/research)
+"vsX" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	target_temperature = 73
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/storage/satellite)
 "vtO" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -81874,6 +81850,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"wCp" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "wCu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -141077,10 +141066,10 @@ bey
 bgn
 aaa
 aRy
-rlK
+vsX
 pSG
 ndM
-dsN
+rYE
 aRy
 aaa
 aMq
@@ -141334,10 +141323,10 @@ aNz
 iDk
 aaa
 aRy
-iwM
-qhy
+vsX
+dgE
 uGB
-rYE
+vbP
 aRy
 aaa
 pUF
@@ -141591,7 +141580,7 @@ aNz
 ozh
 hxn
 aRy
-xtp
+vsX
 glh
 vOC
 sBu
@@ -141848,10 +141837,10 @@ aNz
 iDk
 aaa
 aRy
-oQe
-oQe
+xtp
+glh
 nwS
-ejI
+iwM
 aRy
 aaa
 pUF
@@ -142105,10 +142094,10 @@ hWl
 iDk
 aaa
 aRy
-aRy
-aRy
-euu
-aRy
+gWR
+gWR
+nwS
+ejI
 aRy
 aaa
 pUF
@@ -142361,12 +142350,12 @@ pUF
 aNz
 iDk
 aaa
-aaa
-aaa
-aMq
-bpK
-bgn
-aaa
+aRy
+aRy
+aRy
+vjy
+aRy
+aRy
 aaa
 pUF
 aNz
@@ -142621,7 +142610,7 @@ aNw
 aNw
 aNw
 aSD
-bpL
+wCp
 bsj
 aNw
 aNw

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -26281,6 +26281,11 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/security/warden)
+"bgC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden,
+/turf/open/floor/plating,
+/area/ai_monitored/storage/satellite)
 "bgE" = (
 /obj/structure/disposalpipe/sorting/wrap{
 	dir = 1
@@ -30302,29 +30307,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
-"bpK" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"bpL" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "bpM" = (
 /obj/machinery/holopad,
 /obj/structure/cable/yellow{
@@ -56740,10 +56722,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"dsN" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
 "dtd" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -58500,22 +58478,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
-"euu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "MiniSat Maintenance";
-	req_access_txt = "32"
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
 "euB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -60014,6 +59976,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"fAE" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/plating,
+/area/ai_monitored/storage/satellite)
 "fAK" = (
 /obj/item/storage/box/rxglasses{
 	pixel_x = 3;
@@ -63832,14 +63801,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"iwM" = (
-/obj/structure/rack,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/gloves/color/black,
-/turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
 "ixs" = (
 /obj/machinery/light{
 	dir = 4
@@ -67116,6 +67077,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"lcb" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	target_temperature = 73
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/storage/satellite)
 "lch" = (
 /obj/effect/landmark/blobstart,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -67280,6 +67247,22 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
+"lfY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "MiniSat Maintenance";
+	req_access_txt = "32"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/aisat)
 "lgM" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -68114,6 +68097,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"lQa" = (
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/black,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/emergency_oxygen,
+/turf/open/floor/plating,
+/area/ai_monitored/storage/satellite)
 "lQk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -71039,6 +71030,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"oeR" = (
+/obj/effect/spawner/lootdrop/tanks/highquality,
+/turf/open/floor/plating,
+/area/ai_monitored/storage/satellite)
 "ofy" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -71950,12 +71945,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"oQe" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
 "oQt" = (
 /obj/structure/window/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -73837,13 +73826,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"qhy" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
 "qhE" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -75338,12 +75320,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"rlK" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	target_temperature = 80
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
 "rlU" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -75755,6 +75731,19 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
+"rBV" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "rCh" = (
 /obj/machinery/camera{
 	c_tag = "Engineering - Foyer - Shared Storage";
@@ -141077,10 +141066,10 @@ bey
 bgn
 aaa
 aRy
-rlK
+lcb
 pSG
 ndM
-dsN
+rYE
 aRy
 aaa
 aMq
@@ -141334,10 +141323,10 @@ aNz
 iDk
 aaa
 aRy
-iwM
-qhy
+lcb
+bgC
 uGB
-rYE
+oeR
 aRy
 aaa
 pUF
@@ -141591,7 +141580,7 @@ aNz
 ozh
 hxn
 aRy
-xtp
+lcb
 glh
 vOC
 sBu
@@ -141848,10 +141837,10 @@ aNz
 iDk
 aaa
 aRy
-oQe
-oQe
+xtp
+glh
 nwS
-ejI
+lQa
 aRy
 aaa
 pUF
@@ -142105,10 +142094,10 @@ hWl
 iDk
 aaa
 aRy
-aRy
-aRy
-euu
-aRy
+fAE
+fAE
+nwS
+ejI
 aRy
 aaa
 pUF
@@ -142361,12 +142350,12 @@ pUF
 aNz
 iDk
 aaa
-aaa
-aaa
-aMq
-bpK
-bgn
-aaa
+aRy
+aRy
+aRy
+lfY
+aRy
+aRy
 aaa
 pUF
 aNz
@@ -142621,7 +142610,7 @@ aNw
 aNw
 aNw
 aSD
-bpL
+rBV
 bsj
 aNw
 aNw


### PR DESCRIPTION
closes #15284 

# Document the changes in your pull request

Telecomms/AI Sat maint on Meta now has 2 more freezers, and is one tile longer to make room for it.
adds a random tank spawner to fill an awkward gap
adds a second spare N2 can

Before
![ss (2022-08-12 at 07 28 47)](https://user-images.githubusercontent.com/1534478/184460643-dbea0e8e-2ca0-494f-a48f-8a80a12b9531.png)

After
![ss (2022-08-12 at 07 28 29)](https://user-images.githubusercontent.com/1534478/184460642-c9d275cd-4a30-474b-80a0-31350e92a334.png)


# Changelog

:cl:  
bugfix: Metastation AI/Telecomms should not overheat as much now (Added more freezers)
tweak: Metastation AI satellite maint adjusted in length to fit new freezers and a second N2 canister
/:cl:
