### PR TITLE
[MDB IGNORE][Gax] Fixes a single tile hole in EVA maint's ruin door tile

### DIFF
--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -18539,11 +18539,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jwt" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/turf/open/space/basic,
-/area/maintenance/department/eva)
 "jww" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -93560,7 +93555,7 @@ iLQ
 dYL
 dYL
 dYL
-jwt
+wUc
 bvm
 xgw
 fnc


### PR DESCRIPTION
# Document the changes in your pull request

does what it says on the tin

# Changelog

:cl:  
bugfix: Gax EVA maint should no longer have a space tile in it
/:cl:
