### PR TITLE
Mantis blade changes

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1807,13 +1807,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	surplus = 0
 	include_modes = list(/datum/game_mode/nuclear)
 
-/datum/uplink_item/implants/mantis_kit
-	name = "G.O.R.L.E.X.. Mantis Blades Kit"
-	desc = "Comes with 2 G.O.R.L.E.X. Mantis blades. All packaged with autosurgeons."
-	item = /obj/item/storage/briefcase/syndie_mantis
-	cost = 16
-	surplus = 0
-	exclude_modes = list(/datum/game_mode/infiltration) // yogs: infiltration
+/datum/uplink_item/implants/mantis
+    name = "G.O.R.L.E.X. Mantis Blade"
+    desc = "One G.O.R.L.E.X Mantis blade implant able to be retracted inside your body at will for easy storage and concealing, 2 blades can be used at once."
+    item = /obj/item/autosurgeon/organ/syndicate/syndie_mantis
+    cost = 7
+    surplus = 0
+    exclude_modes = list(/datum/game_mode/infiltration) // yogs: infiltration
 
 // Events
 /datum/uplink_item/services

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1808,12 +1808,12 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/implants/mantis
-    name = "G.O.R.L.E.X. Mantis Blade"
-    desc = "One G.O.R.L.E.X Mantis blade implant able to be retracted inside your body at will for easy storage and concealing, 2 blades can be used at once."
-    item = /obj/item/autosurgeon/organ/syndicate/syndie_mantis
-    cost = 7
-    surplus = 0
-    exclude_modes = list(/datum/game_mode/infiltration) // yogs: infiltration
+	name = "G.O.R.L.E.X. Mantis Blade"
+	desc = "One G.O.R.L.E.X Mantis blade implant able to be retracted inside your body at will for easy storage and concealing, 2 blades can be used at once."
+	item = /obj/item/autosurgeon/organ/syndicate/syndie_mantis
+	cost = 7
+	surplus = 0
+	exclude_modes = list(/datum/game_mode/infiltration) // yogs: infiltration
 
 // Events
 /datum/uplink_item/services


### PR DESCRIPTION
# Document the changes in your pull request
Changes the mantis blades to work in a sort of stealthy alt to the esword well still being useful enough to warrant their existence. Instead of 2 mantis blades you only get one with the difference being instead you only have to spend 7 tc allowing you to get other items compared to their current form where you get two for 16tc and end up being unable to buy anything else. Now the question comes to why not esword, With mantis blades you lose your ap but gain a 20% block chance and the fact its completely undetectable unless you either get caught with it out or implant checked (making it an insane backup if you get permed)

# Wiki Documentation

The gorlax mantis kit is now just gorlax mantis blade

# Changelog
:cl:  
tweak: changed cost of GORLEX mantis blade in the uplink to 7Tc
tweak: GORLEX mantis blade kit replaced with a single mantis blade
tweak: GORLEX mantis blade uplink description altered to reflect giving you only a single blade.
/:cl:
