### PR TITLE
Fixes radstorms rescending if emergency access has already been disabled

### DIFF
--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -58,7 +58,8 @@
 	priority_announce("The radiation threat has passed. Please return to your workplaces.", "Anomaly Alert")
 	status_alarm(FALSE)
 	sleep(1 MINUTES) // Want to give them time to get out of maintenance.
-	revoke_maint_all_access()
+	if(GLOB.emergency_access)
+		revoke_maint_all_access()
 
 /datum/weather/rad_storm/proc/status_alarm(active)	//Makes the status displays show the radiation warning for those who missed the announcement.
 	var/datum/radio_frequency/frequency = SSradio.return_frequency(FREQ_STATUS_DISPLAYS)


### PR DESCRIPTION
# Document the changes in your pull request

bugfix

# Changelog

:cl:  
bugfix: Fixes rad storm double rescinding 
/:cl:
