### PR TITLE
MDB IGNORE Adds 2 glass windoors to Brig turnstiles for reasons...

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -60565,6 +60565,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"vqk" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/turnstile/brig{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "vra" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -98372,7 +98382,7 @@ upk
 mLd
 lLO
 ebQ
-lpG
+vqk
 qad
 mqQ
 lpG

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -37843,6 +37843,21 @@
 "lpv" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"lpG" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/turnstile/brig{
+	dir = 1
+	},
+/obj/machinery/door/window/eastleft{
+	dir = 2;
+	name = "brig turnstile";
+	req_access_txt = "1"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "lpU" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -42867,16 +42882,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"nAp" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/turnstile/brig{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "nAY" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
@@ -98367,10 +98372,10 @@ upk
 mLd
 lLO
 ebQ
-nAp
+lpG
 qad
 mqQ
-nAp
+lpG
 oUJ
 hEG
 fkv

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -955,7 +955,6 @@
 		density = TRUE
 		open = FALSE
 		opacity = TRUE
-		
 
 	else
 		icon_state = "curtain_open"

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -955,6 +955,7 @@
 		density = TRUE
 		open = FALSE
 		opacity = TRUE
+		
 
 	else
 		icon_state = "curtain_open"


### PR DESCRIPTION
Adds windoors to the brig turnstiles that will need to be opened by a security personnel to allow infinite entering/exiting. 

Currently it's unblocked, allowing those in cuffs during a brig tussle to just run free, this is incredibly difficult for security in the less common occasions. You also see more often nowadays, wardens using a barrier nade to block the turnstiles. 

In addition - the firedoors do not function properly there allowing faulty atmos to flow through, no idea why. The windoors could be closed to prevent this. 

![image](https://user-images.githubusercontent.com/6155093/184515394-2d28897c-1a09-4750-82c0-333cac1352ef.png)

:cl:  
tweak: Adds 2 glass windoors to Brig turnstiles for reasons... 
/:cl:
