### PR TITLE
fixes hallucinations being retarted

### DIFF
--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -26,7 +26,7 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 
 
 /mob/living/carbon/proc/handle_hallucinations()
-	hallucination = round(hallucination, 1)
+	hallucination = max(0, hallucination)
 	if(hallucination <= 0)
 		return
 

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -26,7 +26,8 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 
 
 /mob/living/carbon/proc/handle_hallucinations()
-	if(!hallucination)
+	hallucination = round(hallucination, 1)
+	if(hallucination <= 0)
 		return
 
 	hallucination--


### PR DESCRIPTION
# Document the changes in your pull request

It still ticks even when below 0 bad

# Changelog

:cl:  
bugfix: having 3.4 hallucination stacks will no longer give you infinite hallucinations
/:cl:
