### PR TITLE
akimbo rework

### DIFF
--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -1,4 +1,4 @@
-/obj/item/ammo_casing/proc/fire_casing(atom/target, mob/living/user, params, distro, quiet, zone_override, spread, atom/fired_from)
+/obj/item/ammo_casing/proc/fire_casing(atom/target, mob/living/user, params, distro, quiet, zone_override, spread, atom/fired_from, cd_override_arg = FALSE)
 	distro += variance
 	for (var/i = max(1, pellets), i > 0, i--)
 		var/targloc = get_turf(target)
@@ -12,7 +12,9 @@
 			return 0
 		if(i > 1)
 			newshot()
-	if(click_cooldown_override)
+	if(cd_override_arg)
+		user.changeNext_move(cd_override_arg)
+	else if (click_cooldown_override)
 		user.changeNext_move(click_cooldown_override)
 	else
 		user.changeNext_move(CLICK_CD_RANGE)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -245,16 +245,12 @@
 
 	//DUAL (or more!) WIELDING
 	var/bonus_spread = 0
-	var/loop_counter = 0
 	if(ishuman(user) && user.a_intent == INTENT_HARM)
 		var/mob/living/carbon/human/H = user
-		for(var/obj/item/gun/G in H.held_items)
-			if(G == src || G.weapon_weight >= WEAPON_MEDIUM)
-				continue
-			else if(G.can_trigger_gun(user))
-				bonus_spread += 24 * G.weapon_weight
-				loop_counter++
-				addtimer(CALLBACK(G, /obj/item/gun.proc/process_fire, target, user, TRUE, params, null, bonus_spread), loop_counter)
+		if(weapon_weight < WEAPON_MEDIUM && istype(H.held_items[H.get_inactive_hand_index()], /obj/item/gun) && can_trigger_gun(user))
+			bonus_spread += 12 * weapon_weight
+			H.changeNext_move(CLICK_CD_RANGE*0.75)
+			H.swap_hand()
 
 	process_fire(target, user, TRUE, params, null, bonus_spread)
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -245,14 +245,18 @@
 
 	//DUAL (or more!) WIELDING
 	var/bonus_spread = 0
+	var/cd_mod = CLICK_CD_RANGE
+	if(chambered?.click_cooldown_override)
+		cd_mod = chambered.click_cooldown_override
+	
 	if(ishuman(user) && user.a_intent == INTENT_HARM)
 		var/mob/living/carbon/human/H = user
 		if(weapon_weight < WEAPON_MEDIUM && istype(H.held_items[H.get_inactive_hand_index()], /obj/item/gun) && can_trigger_gun(user))
-			bonus_spread += 12 * weapon_weight
-			H.changeNext_move(CLICK_CD_RANGE*0.75)
+			bonus_spread += 18 * weapon_weight
+			cd_mod = cd_mod * 0.75
 			H.swap_hand()
 
-	process_fire(target, user, TRUE, params, null, bonus_spread)
+	process_fire(target, user, TRUE, params, null, bonus_spread, cd_mod)
 
 /obj/item/gun/proc/check_botched(mob/living/user, params)
 	if(clumsy_check)
@@ -322,7 +326,8 @@
 	update_icon()
 	return TRUE
 
-/obj/item/gun/proc/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
+/// cd_override is FALSE or 0 by default (no override), if you want to make a gun have no click cooldown then just make it something small like 0.001
+/obj/item/gun/proc/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0, cd_override = FALSE)
 	if(user)
 		SEND_SIGNAL(user, COMSIG_MOB_FIRED_GUN, user, target, params, zone_override)
 
@@ -352,7 +357,7 @@
 					return
 			sprd = round((rand() - 0.5) * DUALWIELD_PENALTY_EXTRA_MULTIPLIER * (randomized_gun_spread + randomized_bonus_spread))
 			before_firing(target,user)
-			if(!chambered.fire_casing(target, user, params, , suppressed, zone_override, sprd, src))
+			if(!chambered.fire_casing(target, user, params, , suppressed, zone_override, sprd, src, cd_override))
 				shoot_with_empty_chamber(user)
 				return
 			else


### PR DESCRIPTION
# Document the changes in your pull request

Instead of firing both guns, you will instead swap between the guns and have a 1/4 faster click CD so you can fire faster

In theory this should improve DPS by a maximum of 50%

Spread penalty was decreased to accomodate (subject to change)

##

An interesting thing I noticed in testing is that **spam clicking is actually detrimental** to your fire-rate when dual wielding, and you will get faster fire rate from more controlled fire (You will notice in the bottom gif sometimes I fuck up and stop for a second)

I think this will be very interesting to see as people are typically very jumpy and anxious in tense situations, likely making this controlled fire a lot harder to achieve

Firing 1 laser gun
![](https://thumbs.gfycat.com/EnormousIdealGroundhog-size_restricted.gif)

Dual firing 2 laser guns
![](https://thumbs.gfycat.com/PotableClutteredIberianbarbel-size_restricted.gif)

# Changelog

:cl:  
tweak: Akimbo mechanics have been reworked, rewarding precise clicking and punishing spam
/:cl:
