### PR TITLE
Adds cycleable background to character setup

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -139,12 +139,15 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/disable_alternative_announcers = FALSE
 	var/icon/background = "floor"
 	var/list/background_options = list(
-		"floor" = "Default",
-		"darkfull" = "Dark",
+		"floor" = "Default Tile",
+		"white" = "Default White Tile",
+		"darkfull" = "Default Dark Tile",
 		"wood" = "Wood",
-		"black" = "Black",
-		"rockvault" = "Grey",
-		"purewhite" = "White"
+		"rockvault" = "Rock Vault",
+		"grass4" = "Grass",
+		"black" = "Pure Black",
+		"grey" = "Pure Grey",
+		"pure_white" = "Pure White"
 	)
 
 /datum/preferences/New(client/C)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -137,6 +137,15 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/persistent_scars = TRUE
 
 	var/disable_alternative_announcers = FALSE
+	var/icon/background = "floor"
+	var/list/background_options = list(
+		"floor" = "Default",
+		"darkfull" = "Dark",
+		"wood" = "Wood",
+		"black" = "Black",
+		"rockvault" = "Grey",
+		"purewhite" = "White"
+	)
 
 /datum/preferences/New(client/C)
 	parent = C
@@ -276,8 +285,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<h2>Body</h2>"
 			dat += "<a href='?_src_=prefs;preference=all;task=random'>Random Body</a> "
 			dat += "<a href='?_src_=prefs;preference=all'>Always Random Body: [be_random_body ? "Yes" : "No"]</a>"
-			dat += "<a href='?_src_=prefs;preference=u_all;task=lock'>Unlock all</a><br>"
+			dat += "<a href='?_src_=prefs;preference=u_all;task=lock'>Unlock all</a>"
 			dat += "<a href='?_src_=prefs;preference=l_all;task=lock'>Lock all</a><br>"
+			dat += "<a href='?_src_=prefs;preference=cycle_background;task=input'>Background: [background_options[background]]</a><br><br>"
 
 			dat += "<table width='100%'><tr><td width='24%' valign='top'>"
 
@@ -1541,6 +1551,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/new_age = input(user, "Choose your character's age:\n([AGE_MIN]-[AGE_MAX])", "Character Preference") as num|null
 					if(new_age)
 						age = max(min( round(text2num(new_age)), AGE_MAX),AGE_MIN)
+
+				if("cycle_background")
+					background = next_list_item(background, background_options)
 
 				if("hair")
 					var/new_hair = input(user, "Choose your character's hair colour:", "Character Preference","#"+hair_color) as color|null

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -53,6 +53,7 @@
 
 	// Set up the dummy for its photoshoot
 	var/mob/living/carbon/human/dummy/mannequin = generate_or_wait_for_human_dummy(DUMMY_HUMAN_SLOT_PREFERENCES)
+	mannequin.add_overlay(mutable_appearance('icons/turf/floors.dmi', background, layer = SPACE_LAYER))
 	copy_to(mannequin)
 
 	if(previewJob)


### PR DESCRIPTION
# Document the changes in your pull request

You can view your character under multiple floor sprites

Changes some UI elements (mainly the Lock All to be inline with Unlock All)

<details>
<summary>Backgrounds</summary>
<img align="left" width="200" src="https://user-images.githubusercontent.com/20369082/184564722-b1c6f2d4-65d5-4715-bef6-8ada1030e34a.png">
<img align="left" width="200" src="https://user-images.githubusercontent.com/20369082/184564725-cf3c9179-c4be-40d6-9536-28ca155d4d8d.png">
<img align="left" width="200" src="https://user-images.githubusercontent.com/20369082/184564732-d44e944a-de45-4371-9ea4-fb65d897dd24.png">
<img align="left" width="200" src="https://user-images.githubusercontent.com/20369082/184564736-36fce2ec-55a1-41e0-aaa4-08a123e9dd9f.png">
<img align="left" width="200" src="https://user-images.githubusercontent.com/20369082/184564743-5aba5d97-b72a-4649-a03c-9bc6080e1446.png">
<img align="left" width="200" src="https://user-images.githubusercontent.com/20369082/184564751-ddff2ead-4480-42bb-8baa-f863ffd0a766.png">
<img align="left" width="200" src="https://user-images.githubusercontent.com/20369082/184564757-9181d454-ef17-4e0f-a3af-f387b89efd9f.png">
<img align="left" width="200" src="https://user-images.githubusercontent.com/20369082/184564759-b84f6d82-d3da-4bb6-8dae-e68bee5e90e3.png">
<img width="200" src="https://user-images.githubusercontent.com/20369082/184564766-46495265-2783-498b-8d15-655881f2fe08.png">
<br>
</details>
<br>

# Changelog

:cl:  
rscadd: Character select has a background now and is cycleable 
/:cl:
