### PR TITLE
Warmed Meatpocket Reagent Reduction

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_pastry.dm
+++ b/code/modules/food_and_drinks/food/snacks_pastry.dm
@@ -313,8 +313,8 @@
 	name = "warm meatpocket"
 	desc = "Can this really be called a donkpocket?"
 	icon_state = "donkpocketcookedmeaty"
-	bonus_reagents = list(/datum/reagent/consumable/nutriment/protein = 8, /datum/reagent/consumable/nutriment/vitamin = 6, /datum/reagent/consumable/drippings = 3)
-	list_reagents = list(/datum/reagent/consumable/nutriment/protein = 8, /datum/reagent/consumable/nutriment/vitamin = 6, /datum/reagent/consumable/drippings = 3)
+	bonus_reagents = list(/datum/reagent/consumable/nutriment/protein = 4, /datum/reagent/consumable/nutriment/vitamin = 4, /datum/reagent/consumable/drippings = 2)
+	list_reagents = list(/datum/reagent/consumable/nutriment/protein = 4, /datum/reagent/consumable/nutriment/vitamin = 4, /datum/reagent/consumable/drippings = 2)
 	tastes = list("meat" = 4)
 	foodtype = MEAT
 


### PR DESCRIPTION
1 of these bad boys can still take you from starving to well-fed in just 5 bites.

# Document the changes in your pull request

Changes the reagents that the meatpockets gave you from 8, 6, 3 to 4, 4, 2 bonus reagents included.

Doesn't really change much except makes meat pockets less likely to make you clinically obese and lessens their healing potential from the vitamins. They were twice as good before and they still fill you from 150 nutrition to 250 so if you're starving you can eat one and be fine. 

# Wiki Documentation

Meatpocket is half as good now.

# Changelog

:cl:  
tweak: Halved the reagents found inside Meatpockets
/:cl:
