### PR TITLE
slightly reduces the hugboxxing on the exofab

### DIFF
--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -481,9 +481,6 @@
 	return ..()
 
 /obj/machinery/mecha_part_fabricator/ui_interact(mob/user, datum/tgui/ui)
-	if(!allowed(user) && !combat_parts_allowed && !isobserver(user))
-		to_chat(user, span_warning("You do not have the proper credentials to operate this device!"))
-		return
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "ExosuitFabricator")


### PR DESCRIPTION
needing an emag or whatever for combat mechs is OK and fine and good, but being unable to use the exofab at all without robotics access is cringe, and was removed years ago and for good reason. you still need your special access to make combat mechs but you can now use the exofab again normally without robotics access. Wow.

# Changelog

:cl:  
tweak: exofab no longer requires robotics access to print non-combat shit
/:cl:
