### PR TITLE
Mini sleeping carp nerf

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -74,6 +74,7 @@
 					else
 						visible_message(span_danger("[src] deflects the projectile!"), span_userdanger("You deflect the projectile!"))
 					playsound(src, pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, 1)
+					src.adjustStaminaLoss(10)
 					if(!mind.martial_art.reroute_deflection)
 						return BULLET_ACT_BLOCK
 					else

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -74,7 +74,8 @@
 					else
 						visible_message(span_danger("[src] deflects the projectile!"), span_userdanger("You deflect the projectile!"))
 					playsound(src, pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, 1)
-					src.adjustStaminaLoss(P.damage / 4)
+					if(P.damage)
+						src.adjustStaminaLoss(P.damage / 4)
 					if(!mind.martial_art.reroute_deflection)
 						return BULLET_ACT_BLOCK
 					else

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -74,7 +74,7 @@
 					else
 						visible_message(span_danger("[src] deflects the projectile!"), span_userdanger("You deflect the projectile!"))
 					playsound(src, pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, 1)
-					src.adjustStaminaLoss(10)
+					src.adjustStaminaLoss(P.damage / 4)
 					if(!mind.martial_art.reroute_deflection)
 						return BULLET_ACT_BLOCK
 					else


### PR DESCRIPTION
Yes, you all saw this coming. The sleeping carp nerf! Deflecting stuff with sleeping carp will now cause you to take the damage of the projectile divided by 4 for every projectile deflected, because infinite projectile blocking allowing you to slide close enough to land your signature instant-win melee stun move is pretty lame. the stamina isn't really that bad. This is just to discourage face-tanking hundreds and hundreds of bullets so now it's actually possible to fight sleeping carp users without having to do the fucking coin toss that is "Will I instantly get aggro grabbed if I move in and try to hit them with a melee weapon, while I am holding a riot shield in my offhand?" Also makes sleeping carp less of the indisputably best martial art, because unlike CQC you not only instantly win in melee, but you ignore ranged combat as well.


# Changelog

:cl:  
tweak: For every projectile blocked with sleeping carp, you'll take the damage of the projectile divided by 4 in stamina damage
/:cl:
