### PR TITLE
bloodsucker trespass sound buff

### DIFF
--- a/code/modules/antagonists/bloodsuckers/powers/targeted/trespass.dm
+++ b/code/modules/antagonists/bloodsuckers/powers/targeted/trespass.dm
@@ -77,7 +77,8 @@
 	)
 	// Effect Origin
 	var/sound_strength = max(60, 70 - level_current * 10)
-	playsound(get_turf(owner), 'sound/magic/summon_karp.ogg', sound_strength, 1)
+	var/sound_dist = max(-6, -level_current) // world.view is 7, so 7-6 = hearing distance of 1
+	playsound(get_turf(owner), 'sound/magic/summon_karp.ogg', sound_strength, 1, sound_dist)
 	var/datum/effect_system/steam_spread/puff = new /datum/effect_system/steam_spread/()
 	puff.effect_type = /obj/effect/particle_effect/smoke/vampsmoke
 	puff.set_up(3, 0, my_turf)
@@ -106,7 +107,7 @@
 	user.density = 1
 	user.invisibility = invis_was
 	// Effect Destination
-	playsound(get_turf(owner), 'sound/magic/summon_karp.ogg', 60, 1)
+	playsound(get_turf(owner), 'sound/magic/summon_karp.ogg', sound_strength, 1, sound_dist)
 	puff = new /datum/effect_system/steam_spread/()
 	puff.effect_type = /obj/effect/particle_effect/smoke/vampsmoke
 	puff.set_up(3, 0, target_turf)


### PR DESCRIPTION
# Document the changes in your pull request

Trespass is a very neat and frankly underused ability, as it stands it is INCREDIBLY obvious and everyone in a 7 tile radius will hear you and valid call you. This makes it a little easier to maintain stealth as it gets leveled by adding onto an already existing level buff.

It already gets quieter as you level it, but it isn't that effective as everyone in viewing distance will still hear it

This PR makes it so every level shrinks the hearing distance by 1 (for a minimum of 1 tile) and also makes the exit sound as quiet as the enter sound

# Wiki Documentation

Trespass will be heard at a shorter distance as it gets quieter by leveling

# Changelog

:cl:  
tweak: Trespass will be heard at shorter distances as it is made quieter by leveling
/:cl:
