### PR TITLE
Limits slaved mobs to 5

### DIFF
--- a/code/controllers/subsystem/mobs.dm
+++ b/code/controllers/subsystem/mobs.dm
@@ -1,3 +1,5 @@
+#define MAX_SLAVE_MOBS 5
+
 SUBSYSTEM_DEF(mobs)
 	name = "Mobs"
 	priority = FIRE_PRIORITY_MOBS
@@ -9,6 +11,7 @@ SUBSYSTEM_DEF(mobs)
 	var/static/list/dead_players_by_zlevel[][] = list(list()) // Needs to support zlevel 1 here, MaxZChanged only happens when z2 is created and new_players can login before that.
 	var/static/list/cubemonkeys = list()
 	var/static/list/cheeserats = list()
+	var/static/list/slavemobs = list()
 
 /datum/controller/subsystem/mobs/stat_entry(msg)
 	msg = "P:[length(GLOB.mob_living_list)]"

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -183,12 +183,19 @@
 		Serve [creator.real_name], and assist [creator.p_them()] in completing [creator.p_their()] goals at any cost."
 		owner = creator
 
+/obj/effect/mob_spawn/human/golem/attack_ghost(mob/user)
+	if(owner && LAZYLEN(SSmobs.slavemobs) >= MAX_SLAVE_MOBS)
+		to_chat(user, span_warning("The max amount of slaved mobs ([MAX_SLAVE_MOBS]) has already been created this round!"))
+		return
+	. = ..()
+
 /obj/effect/mob_spawn/human/golem/special(mob/living/new_spawn, name)
 	var/datum/species/golem/X = mob_species
 	to_chat(new_spawn, "[initial(X.info_text)]")
 	if(!owner)
 		to_chat(new_spawn, "Build golem shells in the autolathe, and feed refined mineral sheets to the shells to bring them to life! You are generally a peaceful group unless provoked.")
 	else
+		SSmobs.slavemobs += new_spawn
 		new_spawn.mind.store_memory("<b>Serve [owner.real_name], your creator.</b>")
 		new_spawn.mind.enslave_mind_to_creator(owner)
 		log_game("[key_name(new_spawn)] possessed a golem shell enslaved to [key_name(owner)].")

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -684,6 +684,9 @@
 	var/intel_cooldown = 200 // in deciseconds, the cooldown in between uses
 
 /obj/item/slimepotion/slime/sentience/attack(mob/living/M, mob/user)
+	if(LAZYLEN(SSmobs.slavemobs) >= MAX_SLAVE_MOBS)
+		to_chat(user, span_warning("The max amount of slaved mobs ([MAX_SLAVE_MOBS]) has already been created this round!"))
+		return
 	if(being_used || !ismob(M))
 		return
 	if(!isanimal(M) || M.ckey) //only works on animals that aren't player controlled
@@ -707,6 +710,7 @@
 
 	var/list/candidates = pollCandidatesForMob("Do you want to play as [SM.name]?", ROLE_SENTIENCE, null, ROLE_SENTIENCE, 50, SM, POLL_IGNORE_SENTIENCE_POTION) // see poll_ignore.dm
 	if(LAZYLEN(candidates))
+		SSmobs.slavemobs += SM
 		var/mob/dead/observer/C = pick(candidates)
 		SM.key = C.key
 		SM.sentience_act()


### PR DESCRIPTION
# Document the changes in your pull request

5 golems is hell to deal with, but manageable.

Golems & sentience potions are affected.

Syndicate sentience potions are affected.

Free golems are not affected.

Presently, the cap is 5 slaved mobs.

This cap is global to prevent "hierarchy" loopholing or metafriends grouping to make armies.

If there are 5 or more slaved mobs in existence, dead (people would kill and revive to loophole) or alive, creation will be refused.

# Changelog

:cl:  
rscadd: Added a slaved mob cap, which is 5
/:cl:
