### PR TITLE
Gutlunches now obliterate their udders on dying

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
@@ -46,6 +46,11 @@
 	udder = new()
 	. = ..()
 
+/mob/living/simple_animal/hostile/asteroid/gutlunch/Destroy()
+	qdel(udder)
+	udder = null
+	return ..()
+
 /mob/living/simple_animal/hostile/asteroid/gutlunch/CanAttack(atom/the_target) // Gutlunch-specific version of CanAttack to handle stupid stat_exclusive = true crap so we don't have to do it for literally every single simple_animal/hostile except the two that spawn in lavaland
 	if(isturf(the_target) || !the_target || the_target.type == /atom/movable/lighting_object) // bail out on invalids
 		return FALSE

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
@@ -47,8 +47,7 @@
 	. = ..()
 
 /mob/living/simple_animal/hostile/asteroid/gutlunch/Destroy()
-	qdel(udder)
-	udder = null
+	QDEL_NULL(udder)
 	return ..()
 
 /mob/living/simple_animal/hostile/asteroid/gutlunch/CanAttack(atom/the_target) // Gutlunch-specific version of CanAttack to handle stupid stat_exclusive = true crap so we don't have to do it for literally every single simple_animal/hostile except the two that spawn in lavaland


### PR DESCRIPTION
No gameplay impact but stuff should generally delete itself when it is being deleted yes?

:cl:  
bugfix: gutlunch udders now die when they are killed
/:cl:
