### PR TITLE
Makes 11 year old vendor code work again

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -98,6 +98,9 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	var/product_slogans = ""
 	///String of small ad messages in the vending screen - random chance
 	var/product_ads = ""
+	var/current_ad = ""
+	var/product_cd = 10 SECONDS
+	COOLDOWN_DECLARE(product_ad_cooldown)
 
 	var/list/product_records = list()
 	var/list/hidden_records = list()
@@ -190,6 +193,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 		build_inventory(premium, coin_records)
 
 	slogan_list = splittext(product_slogans, ";")
+	small_ads = splittext(product_ads, ";")
 	// So not all machines speak at the exact same time.
 	// The first time this machine says something will be at slogantime + this random value,
 	// so if slogantime is 10 minutes, it will say it at somewhere between 10 and 20 minutes after the machine is crated.
@@ -697,6 +701,9 @@ GLOBAL_LIST_EMPTY(vending_products)
 
 /obj/machinery/vending/ui_data(mob/user)
 	. = list()
+
+	.["product_ad"] = current_ad
+
 	var/mob/living/carbon/human/H
 	var/obj/item/card/id/C
 
@@ -827,6 +834,10 @@ GLOBAL_LIST_EMPTY(vending_products)
 	if(!active)
 		return
 
+	if(COOLDOWN_FINISHED(src, product_ad_cooldown) && LAZYLEN(small_ads) > 0)
+		COOLDOWN_START(src, product_ad_cooldown, product_cd)
+		current_ad = pick(small_ads)
+	
 	if(seconds_electrified > MACHINE_NOT_ELECTRIFIED)
 		seconds_electrified--
 

--- a/tgui/packages/tgui/interfaces/Vending.js
+++ b/tgui/packages/tgui/interfaces/Vending.js
@@ -119,7 +119,7 @@ export const Vending = (props, context) => {
       resizable>
       <Window.Content scrollable>
         {product_ad && (
-          <Section textAlign='center' textColor='green'>
+          <Section textAlign="center" textColor="green">
             {product_ad}
           </Section>
         )}

--- a/tgui/packages/tgui/interfaces/Vending.js
+++ b/tgui/packages/tgui/interfaces/Vending.js
@@ -91,6 +91,9 @@ const VendingRow = (props, context) => {
 
 export const Vending = (props, context) => {
   const { act, data } = useBackend(context);
+  const {
+    product_ad,
+  } = data;
   let inventory;
   let custom = false;
   if (data.vending_machine_input) {
@@ -115,6 +118,11 @@ export const Vending = (props, context) => {
       height={600}
       resizable>
       <Window.Content scrollable>
+        {product_ad && (
+          <Section textAlign='center' textColor='green'>
+            {product_ad}
+          </Section>
+        )}
         {!!data.onstation && (
           <Section title="User">
             {data.user && (


### PR DESCRIPTION
# Document the changes in your pull request

This variable. `product_ads`. This has sat here for 11 years, defunct. On December 15, 2011, vageyenaman poured his heart out and made several phrases that vendors had used in their old archaic days. 7 months later, some code was reverted, and the code that used this variable was removed aswell.

For 11 long years, this variable has survived. Through every refactor, every rework, every new vendor, it has persisted and lived just outside of the perspective of us ignorant & negligent spacemen.

Today, I bring it back. Today, the phrases return.

![](https://i.imgur.com/t0syA2D.png)

# Changelog

:cl:  
bugfix: fixed product ads not showing on vendors
/:cl:
