### PR TITLE
Adds balloon alerts to surgery

### DIFF
--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -82,8 +82,8 @@
 				if(S.self_operable || user != M)
 					procedure.next_step(user, user.a_intent)
 			else
-				to_chat(user, span_warning("You need to expose [M]'s [parse_zone(selected_zone)] first!"))
-				M.balloon_alert(user, "You need to expose [M]'s [parse_zone(selected_zone)] first!")
+				M.balloon_or_message(user, "need to expose the [parse_zone(selected_zone)]", \
+					span_warning("You need to expose [M]'s [parse_zone(selected_zone)] first!"))
 
 	else if(!current_surgery.step_in_progress)
 		attempt_cancel_surgery(current_surgery, I, M, user)

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -83,6 +83,7 @@
 					procedure.next_step(user, user.a_intent)
 			else
 				to_chat(user, span_warning("You need to expose [M]'s [parse_zone(selected_zone)] first!"))
+				M.balloon_alert(user, "You need to expose [M]'s [parse_zone(selected_zone)] first!")
 
 	else if(!current_surgery.step_in_progress)
 		attempt_cancel_surgery(current_surgery, I, M, user)

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -127,13 +127,14 @@
 
 		if((prob(prob_chance) || (iscyborg(user) && !silicons_obey_prob)) && chem_check(target, user, tool) && !try_to_fail)
 			if(success(user, target, target_zone, tool, surgery))
+				target.balloon_alert(user, "Success!")
 				play_success_sound(user, target, target_zone, tool, surgery)
 				advance = TRUE
 		else
 			if(failure(user, target, target_zone, tool, surgery))
-				play_failure_sound(user, target, target_zone, tool, surgery)
-				
 				advance = TRUE
+			target.balloon_alert(user, "Failure!")
+			play_failure_sound(user, target, target_zone, tool, surgery)
 		if(iscarbon(target) && !HAS_TRAIT(target, TRAIT_SURGERY_PREPARED) && target.stat != DEAD && !IS_IN_STASIS(target) && fuckup_damage) //not under the effects of anaesthetics or a strong painkiller, harsh penalty to success chance
 			if(!issilicon(user) && !HAS_TRAIT(user, TRAIT_SURGEON)) //borgs and abductors are immune to this
 				var/obj/item/bodypart/operated_bodypart = target.get_bodypart(target_zone)


### PR DESCRIPTION
# Document the changes in your pull request

Adds a balloon alert for when you fail/succeed a surgery step or when you start a surgery with a body part covered.

# Spriting
![image](https://user-images.githubusercontent.com/14363906/184863586-9b70363a-1d4c-4d80-9101-4569471c22fe.png)

# Wiki Documentation
No changes needed. 

# Changelog

:cl:  
tweak: surgeries now display a balloon alert when you fail/succeed a surgery step or when you start a surgery with a body part covered
/:cl:
