### PR TITLE
chem disp energy is now floored

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -205,7 +205,7 @@
 /obj/machinery/chem_dispenser/ui_data(mob/user)
 	var/data = list()
 	data["amount"] = amount
-	data["energy"] = cell.charge ? cell.charge * powerefficiency : "0" //To prevent NaN in the UI.
+	data["energy"] = FLOOR(cell.charge, 1) ? FLOOR(cell.charge, 1) * powerefficiency : "0" //To prevent NaN in the UI.
 	data["maxEnergy"] = cell.maxcharge * powerefficiency
 	data["isBeakerLoaded"] = beaker ? 1 : 0
 


### PR DESCRIPTION
# Document the changes in your pull request

closes #15343

Chemical dispenser will no longer round up energy (showing 15 units when <15 units of energy are present)

Not enough energy to complete operation!
Not enough energy to complete operation!
Not enough energy to complete operation!
Not enough energy to complete operation!

# Changelog

:cl:  
tweak: Chemical dispenser energy display is now floored
/:cl:
