### PR TITLE
chem disp energy is now floored (js alt)

### DIFF
--- a/tgui/packages/tgui/interfaces/ChemDispenser.js
+++ b/tgui/packages/tgui/interfaces/ChemDispenser.js
@@ -1,4 +1,4 @@
-import { toFixed } from 'common/math';
+import { floor } from 'common/math';
 import { toTitleCase } from 'common/string';
 import { Fragment } from 'inferno';
 import { useBackend } from '../backend';
@@ -43,7 +43,7 @@ export const ChemDispenser = (props, context) => {
             <LabeledList.Item label="Energy">
               <ProgressBar
                 value={data.energy / data.maxEnergy}>
-                {toFixed(data.energy) + ' units'}
+                {floor(data.energy) + ' units'}
               </ProgressBar>
             </LabeledList.Item>
           </LabeledList>


### PR DESCRIPTION
# Document the changes in your pull request

closes #15342

Chemical dispenser will no longer round up energy (showing 15 units when <15 units of energy are present)

Not enough energy to complete operation!
Not enough energy to complete operation!
Not enough energy to complete operation!
Not enough energy to complete operation!

# Changelog

:cl:  
tweak: Chemical dispenser energy display is now floored
/:cl:
