### PR TITLE
bloodsucker trespass now removes restraints, like it's supposed to

### DIFF
--- a/code/modules/antagonists/bloodsuckers/powers/targeted/trespass.dm
+++ b/code/modules/antagonists/bloodsuckers/powers/targeted/trespass.dm
@@ -71,6 +71,7 @@
 	var/mob/living/carbon/user = owner
 	var/turf/my_turf = get_turf(owner)
 
+	user.uncuff()
 	user.visible_message(
 		span_warning("[user]'s form dissipates into a cloud of mist!"),
 		span_notice("You dissipate into formless mist."),


### PR DESCRIPTION
bloodsucker trespass now removes restraints like it's supposed to. Wow!
no idea why it DOESNT, seeing as how both the fulp and yogstation wiki say that it's meant to, but i'm going to label this as a tweak anyways. hopefully also makes bloodsuckers a bit less god awful


# Wiki Documentation

wiki already (incorrectly) states this so no changes are needed :)

# Changelog

:cl:  
tweak: bloodsucker trespass now removes restraints, like it's theoretically supposed to
/:cl:
