### PR TITLE
TEG can no longer deplete the power grid

### DIFF
--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -119,6 +119,7 @@
 	add_avail(power_output)
 	lastgenlev = power_output
 	lastgen -= power_output
+	lastgen = max(lastgen, 0)
 	..()
 
 /obj/machinery/power/generator/proc/get_menu(include_link = TRUE)

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -93,6 +93,7 @@
 
 				//produce electricity
 				lastgen += (energy_transfer*efficiency) * powermodifier
+				lastgen = max(lastgen, 0)
 
 				//transfer rest of energy into waste heat/chill
 				internal_temp = cold_subsection_temp + energy_transfer * (1 - efficiency) / (internal_heat_cap * 2)


### PR DESCRIPTION
# Document the changes in your pull request
TEG generating negative many power is bad
Doesn't actually fix why the TEG was negative, just caps it at zero
# Changelog

:cl:  
bugfix: TEG can no longer produce negative many power
/:cl:
