### PR TITLE
makes vehicles respect slowdown modifiers

### DIFF
--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -158,11 +158,16 @@
 	if(user.incapacitated())
 		Unbuckle(user)
 		return
+	
+	var/slowness = 0
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		slowness = H.dna?.species.movement_delay(H)
 
-	if(world.time < last_vehicle_move + ((last_move_diagonal? 2 : 1) * vehicle_move_delay * CONFIG_GET(number/movedelay/run_delay))) //yogs - fixed this to work with movespeed
+	if(world.time < last_vehicle_move + ((last_move_diagonal? 2 : 1) * (vehicle_move_delay + slowness) * CONFIG_GET(number/movedelay/run_delay))) //yogs - fixed this to work with movespeed
 		return
 
-	AM.set_glide_size((last_move_diagonal? 2 : 1) * DELAY_TO_GLIDE_SIZE(vehicle_move_delay) * CONFIG_GET(number/movedelay/run_delay))
+	AM.set_glide_size((last_move_diagonal? 2 : 1) * DELAY_TO_GLIDE_SIZE(vehicle_move_delay + slowness) * CONFIG_GET(number/movedelay/run_delay))
 	for(var/mob/M in AM.buckled_mobs)
 		ride_check(M)
 		M.set_glide_size(AM.glide_size)
@@ -184,7 +189,7 @@
 			last_move_diagonal = TRUE
 		else
 			last_move_diagonal = FALSE
-		AM.set_glide_size((last_move_diagonal? 2 : 1) * DELAY_TO_GLIDE_SIZE(vehicle_move_delay) * CONFIG_GET(number/movedelay/run_delay))
+		AM.set_glide_size((last_move_diagonal? 2 : 1) * DELAY_TO_GLIDE_SIZE(vehicle_move_delay + slowness) * CONFIG_GET(number/movedelay/run_delay))
 		for(var/mob/M in AM.buckled_mobs)
 			ride_check(M)
 			M.set_glide_size(AM.glide_size)

--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -162,7 +162,7 @@
 	var/slowness = 0
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		slowness = max(0, H.dna?.species.movement_delay(H))
+		slowness = max(0, H.dna?.species.movement_delay(H) / 2)
 
 	if(world.time < last_vehicle_move + ((last_move_diagonal? 2 : 1) * (vehicle_move_delay + slowness) * CONFIG_GET(number/movedelay/run_delay))) //yogs - fixed this to work with movespeed
 		return

--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -162,7 +162,7 @@
 	var/slowness = 0
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		slowness = H.dna?.species.movement_delay(H)
+		slowness = max(0, H.dna?.species.movement_delay(H))
 
 	if(world.time < last_vehicle_move + ((last_move_diagonal? 2 : 1) * (vehicle_move_delay + slowness) * CONFIG_GET(number/movedelay/run_delay))) //yogs - fixed this to work with movespeed
 		return


### PR DESCRIPTION
# Document the changes in your pull request

you will properly slow down depending on your slowdown modifiers (hurt, clothing, etc)

vehicles reduce slowdown by 50%

speed ups do not count because it wouldnt make much sense

# Changelog

:cl:  
tweak: vehicles now respect slowdown modifiers
/:cl:
