### PR TITLE
Removes comms key from topic logging

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -173,7 +173,8 @@ GLOBAL_VAR(restart_counter)
 			break
 
 	if((!handler || initial(handler.log)) && config && CONFIG_LOADED && CONFIG_GET(flag/log_world_topic))
-		log_topic("\"[T]\", from:[addr], master:[master], key:[key]")
+		var/static/regex/key_regex = regex(@"(&?)key=[^&]+(&?)", "g")
+		log_topic("\"[key_regex.Replace(T, "$1\[COMMS KEY\]$2")]\", from:[addr], master:[master], key:[CONFIG_GET(string/comms_key) == input["key"] ? "" : "in"]correct")
 
 	if(!handler)
 		return

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -174,7 +174,7 @@ GLOBAL_VAR(restart_counter)
 
 	if((!handler || initial(handler.log)) && config && CONFIG_LOADED && CONFIG_GET(flag/log_world_topic))
 		var/static/regex/key_regex = regex(@"(&?)key=[^&]+(&?)", "g")
-		log_topic("\"[key_regex.Replace(T, "$1\[COMMS KEY\]$2")]\", from:[addr], master:[master], key:[CONFIG_GET(string/comms_key) == input["key"] ? "" : "in"]correct")
+		log_topic("\"[key_regex.Replace(T, "$1\[COMMS KEY\]$2")]\", from:[addr], master:[master], key:[CONFIG_GET(string/comms_key) == key ? "" : "in"]correct")
 
 	if(!handler)
 		return

--- a/config/config.txt
+++ b/config/config.txt
@@ -111,7 +111,7 @@ LOG_MANIFEST
 LOG_JOB_DEBUG
 
 ## log all world.Topic() calls
-# LOG_WORLD_TOPIC
+LOG_WORLD_TOPIC
 
 ## enables use of the proc twitterize() that lets you take a large list of strings and turn it into a JSON file of tweet sized strings.
 ## As an example of how this could be """useful""" look towards Poly (https://twitter.com/Poly_the_Parrot)


### PR DESCRIPTION
# Document the changes in your pull request

Comms key can be used to do some fun things on the server, this makes sure its not in the topic logs. Correctness of a key is still logged for debugging purposes. Also enables topic logging

# Changelog
Nothing user facing