### PR TITLE
Observe Button Improvements

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -186,14 +186,14 @@
 				client.screen += A.button
 	else
 		for(var/datum/action/A in actions)
-			var/isowner = (A.owner == src)
+			var/is_owner = (A.owner == src)
 			A.UpdateButtonIcon()
 			var/obj/screen/movable/action_button/B = A.button
 			if(B.ordered)
 				button_number++
-			if(B.moved && isowner)
+			if(B.moved && is_owner)
 				B.screen_loc = B.moved
-			else if(isowner) // Prevent buttons from shifting around to the original owner
+			else if(is_owner) // Prevent buttons from shifting around to the original owner
 				B.screen_loc = hud_used.ButtonNumberToScreenCoords(button_number)
 			if(reload_screen)
 				client.screen += B

--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -170,13 +170,6 @@
 		var/datum/action/A = X
 		A.UpdateButtonIcon(status_only)
 
-
-/**
-		for(var/mob/dead/observer/O in M.observers)
-			O.actions = M.actions.Copy() // Copy to prevent self referencing
-			O.actions += O.temporaryactions
-*/
-
 //This is the proc used to update all the action buttons.
 /mob/proc/update_action_buttons(reload_screen)
 	if(!hud_used || !client)

--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -210,8 +210,8 @@
 		client.screen += hud_used.hide_actions_toggle
 
 	for(var/mob/dead/observer/O in observers) // This is usually always called instead of Grant() or Remove()
-		O.actions = actions.Copy() // Copy to prevent self referencing
-		O.actions += O.temporaryactions
+		O.temporaryactions = actions.Copy()
+		O.actions = O.temporaryactions + O.originalactions
 		O.update_action_buttons()
 
 

--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -170,6 +170,13 @@
 		var/datum/action/A = X
 		A.UpdateButtonIcon(status_only)
 
+
+/**
+		for(var/mob/dead/observer/O in M.observers)
+			O.actions = M.actions.Copy() // Copy to prevent self referencing
+			O.actions += O.temporaryactions
+*/
+
 //This is the proc used to update all the action buttons.
 /mob/proc/update_action_buttons(reload_screen)
 	if(!hud_used || !client)
@@ -179,7 +186,6 @@
 		return
 
 	var/button_number = 0
-
 	if(hud_used.action_buttons_hidden)
 		for(var/datum/action/A in actions)
 			A.button.screen_loc = null
@@ -187,13 +193,14 @@
 				client.screen += A.button
 	else
 		for(var/datum/action/A in actions)
+			var/isowner = (A.owner == src)
 			A.UpdateButtonIcon()
 			var/obj/screen/movable/action_button/B = A.button
 			if(B.ordered)
 				button_number++
-			if(B.moved)
+			if(B.moved && isowner)
 				B.screen_loc = B.moved
-			else
+			else if(isowner) // Prevent buttons from shifting around to the original owner
 				B.screen_loc = hud_used.ButtonNumberToScreenCoords(button_number)
 			if(reload_screen)
 				client.screen += B
@@ -208,6 +215,11 @@
 		hud_used.hide_actions_toggle.screen_loc = hud_used.hide_actions_toggle.moved
 	if(reload_screen)
 		client.screen += hud_used.hide_actions_toggle
+
+	for(var/mob/dead/observer/O in observers) // This is usually always called instead of Grant() or Remove()
+		O.actions = actions.Copy() // Copy to prevent self referencing
+		O.actions += O.temporaryactions
+		O.update_action_buttons()
 
 
 

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -73,11 +73,7 @@
 			M.client.screen += button
 			button.locked = M.client.prefs.buttons_locked || button.id ? M.client.prefs.action_buttons_screen_locs["[name]_[button.id]"] : FALSE //even if it's not defaultly locked we should remember we locked it before
 			button.moved = button.id ? M.client.prefs.action_buttons_screen_locs["[name]_[button.id]"] : FALSE
-		for(var/mob/dead/observer/O in M.observers)
-			O.temporaryactions |= src
-			O.actions |= src
-			O.update_action_buttons()
-		M.update_action_buttons()
+		M.update_action_buttons() // Now push the owners buttons back
 	else
 		Remove(owner)
 
@@ -86,11 +82,7 @@
 		if(M.client)
 			M.client.screen -= button
 		M.actions -= src
-		for(var/mob/dead/observer/O in M.observers)
-			O.temporaryactions -= src
-			O.actions -= src
-			O.update_action_buttons()
-		M.update_action_buttons() // This needs to run after the above code. Dont ask.
+		M.update_action_buttons()
 	owner = null
 	button.moved = FALSE //so the button appears in its normal position when given to another owner.
 	button.locked = FALSE

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -44,6 +44,7 @@
 
 /datum/action/proc/Grant(mob/M)
 	if(M)
+		M.originalactions += src
 		if(owner)
 			if(owner == M)
 				return
@@ -74,6 +75,7 @@
 			button.locked = M.client.prefs.buttons_locked || button.id ? M.client.prefs.action_buttons_screen_locs["[name]_[button.id]"] : FALSE //even if it's not defaultly locked we should remember we locked it before
 			button.moved = button.id ? M.client.prefs.action_buttons_screen_locs["[name]_[button.id]"] : FALSE
 		for(var/mob/dead/observer/O in M.observers)
+			O.temporaryactions += src
 			O?.client.screen += button
 		M.update_action_buttons() // Now push the owners buttons back
 	else
@@ -84,7 +86,9 @@
 		if(M.client)
 			M.client.screen -= button
 		for(var/mob/dead/observer/O in M.observers)
+			O.temporaryactions -= src
 			O?.client.screen -= button
+		M.originalactions -= src
 		M.actions -= src
 		M.update_action_buttons()
 	owner = null

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -73,6 +73,8 @@
 			M.client.screen += button
 			button.locked = M.client.prefs.buttons_locked || button.id ? M.client.prefs.action_buttons_screen_locs["[name]_[button.id]"] : FALSE //even if it's not defaultly locked we should remember we locked it before
 			button.moved = button.id ? M.client.prefs.action_buttons_screen_locs["[name]_[button.id]"] : FALSE
+		for(var/mob/dead/observer/O in M.observers)
+			O?.client.screen += button
 		M.update_action_buttons() // Now push the owners buttons back
 	else
 		Remove(owner)
@@ -81,6 +83,8 @@
 	if(M)
 		if(M.client)
 			M.client.screen -= button
+		for(var/mob/dead/observer/O in M.observers)
+			O?.client.screen -= button
 		M.actions -= src
 		M.update_action_buttons()
 	owner = null

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -859,9 +859,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if(!UO)
 			UO = new // Convinent way to unobserve
 		UO.Grant(src)
-		temporaryactions = actions.Copy()
+		originalactions = actions.Copy()
 		if(mob_eye.hud_used)
-			actions = mob_eye.actions.Copy() // Copy to prevent self referencing
+			temporaryactions = mob_eye.actions.Copy() // Copy to prevent self referencing
 			actions += temporaryactions
 			LAZYINITLIST(mob_eye.observers)
 			mob_eye.observers |= src

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -827,7 +827,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		target.observers -= src
 		UNSETEMPTY(target.observers)
 	observetarget = null
-	actions -= temporaryactions
+	actions = temporaryactions
+	actions -= UO
+	update_action_buttons()
 
 /mob/dead/observer/verb/observe()
 	set name = "Observe"
@@ -854,18 +856,19 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if(is_secret_level(mob_eye.z) && !client?.holder)
 			sight = null //we dont want ghosts to see through walls in secret areas
 		RegisterSignal(mob_eye, COMSIG_MOVABLE_Z_CHANGED, .proc/on_observing_z_changed, TRUE)
-		if(mob_eye.hud_used)
-			for(var/datum/action/A in mob_eye.actions)
-				actions += A
-				temporaryactions += A
-			update_action_buttons()
-			LAZYINITLIST(mob_eye.observers)
-			mob_eye.observers |= src
-			mob_eye.hud_used.show_hud(mob_eye.hud_used.hud_version, src)
-			observetarget = mob_eye
 		if(!UO)
 			UO = new // Convinent way to unobserve
 		UO.Grant(src)
+		temporaryactions = actions.Copy()
+		if(mob_eye.hud_used)
+			actions = mob_eye.actions.Copy() // Copy to prevent self referencing
+			actions += temporaryactions
+			LAZYINITLIST(mob_eye.observers)
+			mob_eye.observers |= src
+			mob_eye.hud_used.show_hud(mob_eye.hud_used.hud_version, src)
+			update_action_buttons()
+			mob_eye.update_action_buttons()
+			observetarget = mob_eye
 
 /datum/action/unobserve
 	name = "Stop Observing"

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -28,6 +28,8 @@
 	var/cached_multiplicative_slowdown
 	/// List of action hud items the user has
 	var/list/datum/action/actions = list()
+	/// Actions that belong to this mob used in observers
+	var/list/datum/action/originalactions = list()
 	/// A special action? No idea why this lives here
 	var/list/datum/action/chameleon_item_actions
 


### PR DESCRIPTION
# Document the changes in your pull request

Refactors a bunch of code without introducing severe bugs this time
Item actions now work
Observer/Ghost buttons are appended to the end of the list.

:cl:  
tweak: Refactors ghost buttons code to prevent ghost button separation
/:cl:
