### PR TITLE
Fixes some blast door bugs

### DIFF
--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -146,6 +146,8 @@
 			to_chat(user, span_notice("You start to remove the outer plasteel cover."))
 			playsound(src.loc, 'sound/items/welder.ogg', 50, 1)
 			if(W.use_tool(user, 10 SECONDS, src))
+				if(constructionstate != INTACT)
+					return
 				to_chat(user, span_notice("You remove the outer plasteel cover."))
 				constructionstate = CUT_COVER
 				id = null // Effectivley breaks the door

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -134,7 +134,7 @@
 		if(W.tool_behaviour == TOOL_WIRECUTTER)
 			if(id != null)
 				to_chat(user, span_notice("You start to unlink the door."))
-				if(do_after(user, 10 SECONDS, src))
+				if(W.use_tool(user, 10 SECONDS, src))
 					to_chat(user, span_notice("You unlink the door."))
 					id = null
 			else
@@ -156,8 +156,8 @@
 		
 		if(W.tool_behaviour == TOOL_CROWBAR && constructionstate == CUT_COVER)
 			to_chat(user, span_notice("You start to remove all of the internal components"))
-			if(do_after(user, 15 SECONDS, src))
-				if(QDELETED)
+			if(W.use_tool(user, 15 SECONDS, src))
+				if(QDELETED(src))
 					return
 				if(istype(src, /obj/machinery/door/poddoor/shutters)) // Simplified Code 
 					new /obj/item/stack/sheet/plasteel(loc, 5)

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -145,7 +145,7 @@
 		if(W.tool_behaviour == TOOL_WELDER && constructionstate == INTACT)
 			to_chat(user, span_notice("You start to remove the outer plasteel cover."))
 			playsound(src.loc, 'sound/items/welder.ogg', 50, 1)
-			if(do_after(user, 10 SECONDS, src))
+			if(W.use_tool(user, 10 SECONDS, src))
 				to_chat(user, span_notice("You remove the outer plasteel cover."))
 				constructionstate = CUT_COVER
 				id = null // Effectivley breaks the door
@@ -157,6 +157,8 @@
 		if(W.tool_behaviour == TOOL_CROWBAR && constructionstate == CUT_COVER)
 			to_chat(user, span_notice("You start to remove all of the internal components"))
 			if(do_after(user, 15 SECONDS, src))
+				if(QDELETED)
+					return
 				if(istype(src, /obj/machinery/door/poddoor/shutters)) // Simplified Code 
 					new /obj/item/stack/sheet/plasteel(loc, 5)
 					new /obj/item/electronics/airlock(loc)


### PR DESCRIPTION
# Document the changes in your pull request

welder now has its fuel used
Add sanity check to final deconstruction
Add sanity check for welding step

:cl:  
bugfix: Deconstructing blast doors now use welder fuel
bugfix: Welding blastdoors no longer gives you near infinite plasteel
/:cl:
