### PR TITLE
Replaces singularity gen with tesla gen in charlie station

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -3220,8 +3220,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/betacorridor)
 "hK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/rad_collector,
+/obj/machinery/power/tesla_coil,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "hL" = (
@@ -4476,7 +4475,7 @@
 /area/ruin/space/has_grav/ancientstation/proto)
 "kl" = (
 /obj/structure/table/reinforced,
-/obj/machinery/the_singularitygen,
+/obj/machinery/the_singularitygen/tesla,
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/ancientstation/proto)
 "km" = (
@@ -8353,14 +8352,6 @@
 "Ll" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/secure/engineering{
-	name = "plasma tank crate";
-	req_access_txt = "204"
-	},
-/obj/item/tank/internals/plasma/full,
-/obj/item/tank/internals/plasma/full,
-/obj/item/tank/internals/plasma/full,
-/obj/item/tank/internals/plasma/full,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "Ln" = (
@@ -8401,6 +8392,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/atmo)
+"LT" = (
+/obj/machinery/power/grounding_rod,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/ancientstation/deltacorridor)
 "LW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -12852,7 +12847,7 @@ bE
 eZ
 fz
 fz
-dh
+LT
 dh
 dh
 dh
@@ -12901,7 +12896,7 @@ bE
 bE
 fz
 fz
-fz
+LT
 hK
 hK
 hK

--- a/code/modules/ruins/spaceruin_code/oldstation.dm
+++ b/code/modules/ruins/spaceruin_code/oldstation.dm
@@ -30,15 +30,15 @@
 	'disable' setting in an attempt to bypass the ammo issues."
 
 /obj/item/paper/fluff/ruins/oldstation/protosing
-	name = "Singularity Generator"
-	info = "<b>*Singularity Generator*</b><br><br>Modern power generation typically comes in two forms, a Fusion Generator or a Fission Generator. Fusion provides the best space to power \
+	name = "Tesla Generator"
+	info = "<b>*Tesla Generator*</b><br><br>Modern power generation typically comes in two forms, a Fusion Generator or a Fission Generator. Fusion provides the best space to power \
 	ratio, and is typically seen on military or high security ships and stations, however Fission reactors require the usage of expensive, and rare, materials in its construction.. Fission generators are massive and bulky, and require a large reserve of uranium to power, however they are extremely cheap to operate and oft need little maintenance once \
-	operational.<br><br>The Singularity aims to alter this, a functional Singularity is essentially a controlled Black Hole, a Black Hole that generates far more power than Fusion or Fission \
+	operational.<br><br>The Tesla aims to alter this, a functional Tesla is essentially a controlled Energy Ball, an Energy Ball that generates far more power than Fusion or Fission \
 	generators can ever hope to produce. "
 
 /obj/item/paper/fluff/ruins/oldstation/protoinv
 	name = "Laboratory Inventory"
-	info = "<b>*Inventory*</b><br><br>(1) Prototype Hardsuit<br><br>(1)Health Analyser<br><br>(1)Prototype Energy Gun<br><br>(1)Singularity Generation Disk<br><br><b>DO NOT REMOVE WITHOUT \
+	info = "<b>*Inventory*</b><br><br>(1) Prototype Hardsuit<br><br>(1)Health Analyser<br><br>(1)Prototype Energy Gun<br><br>(1)Tesla Generation Disk<br><br><b>DO NOT REMOVE WITHOUT \
 	THE CAPTAIN AND RESEARCH DIRECTOR'S AUTHORISATION</b>"
 
 /obj/item/paper/fluff/ruins/oldstation/report


### PR DESCRIPTION
# About pr
Tesla gen is far more better and easier to set up in chalie station
Singularity gen is cringe and can easily get loose if not properly set up for new player

# Document the changes in your pull request
Replaced singulo gen with tesla gen
Removed plasma tanks
Changed some documents for tesla
Replaced rad collector with tesla coil
Added some grounding rods

# Wiki Documentation
Charlie station prefered tesla gen i guess
Replaced singulo gen with tesla gen
Removed plasma tanks
Changed some documents for tesla
Replaced rad collector with tesla coil
Added some grounding rods

# Changelog



:cl:  
tweak: Replaced singulo gen with tesla gen
rscdel: Removed plasma tanks
tweak: Changed some documents for tesla
tweak: Replaced rad collector with tesla coil
tweak: Added some grounding rods
/:cl:
