### PR TITLE
Fixes donors not being able to talk in donator chat

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -276,8 +276,6 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		if(!check_rights_for(src, R_ADMIN,0)) // don't add admins to mentor list.
 			GLOB.mentors += src
 
-	if(is_donator(src))
-		src.add_donator_verbs()
 	// yogs end
 
 	//preferences datum - also holds some persistent data for the client (because we may as well keep these datums to a minimum)
@@ -337,6 +335,10 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		if(prefs.yogtoggles & QUIET_ROUND)
 			prefs.yogtoggles &= ~QUIET_ROUND
 			prefs.save_preferences()
+	
+	if(is_donator(src))
+		src.add_donator_verbs()
+
 	// yogs end
 	. = ..()	//calls mob.Login()
 


### PR DESCRIPTION
# Document the changes in your pull request
Checking if someone is a donator, before their donor status has been set doesn't work

# Changelog

:cl:  
bugfix: fixed donor chat being read only for donators
/:cl:
