### PR TITLE
fixes CLEAN_TYPE_RUNES not cleaning runes

### DIFF
--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -50,7 +50,7 @@ Runes can either be invoked by one's self or with many different cultists. Each 
 	. = ..()
 	RegisterSignal(src, COMSIG_COMPONENT_CLEAN_ACT, .proc/clean_act)
 
-/obj/effect/rune/clean_act(datum/source, clean_types)
+/obj/effect/rune/proc/clean_act(datum/source, clean_types)
 	if(clean_types & CLEAN_TYPE_RUNES)
 		qdel(src)
 		return TRUE

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -46,6 +46,15 @@ Runes can either be invoked by one's self or with many different cultists. Each 
 	I.override = TRUE
 	add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/silicons, "cult_runes", I)
 
+/obj/effect/rune/ComponentInitialize()
+	. = ..()
+	RegisterSignal(src, COMSIG_COMPONENT_CLEAN_ACT, .proc/clean_act)
+
+/obj/effect/rune/clean_act(datum/source, clean_types)
+	if(clean_types & CLEAN_TYPE_RUNES)
+		qdel(src)
+		return TRUE
+
 /obj/effect/rune/examine(mob/user)
 	. = ..()
 	if(iscultist(user) || user.stat == DEAD) //If they're a cultist or a ghost, tell them the effects

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -50,6 +50,10 @@ Runes can either be invoked by one's self or with many different cultists. Each 
 	. = ..()
 	RegisterSignal(src, COMSIG_COMPONENT_CLEAN_ACT, .proc/clean_act)
 
+/obj/effect/rune/Destroy()
+	UnregisterSignal(src, COMSIG_COMPONENT_CLEAN_ACT)
+	return ..()
+
 /obj/effect/rune/proc/clean_act(datum/source, clean_types)
 	if(clean_types & CLEAN_TYPE_RUNES)
 		qdel(src)


### PR DESCRIPTION
# Document the changes in your pull request

CLEAN_TYPE_RUNES seemed to be a completely dead flag, guess someone forgot to set it up

# Changelog

:cl:  
tweak: fixed runes not being cleaned when they should be
/:cl:
