### PR TITLE
Removes a duplicate chest in the Ashwalker Meteorite

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_meteorite.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_meteorite.dmm
@@ -1438,6 +1438,18 @@
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"Ar" = (
+/obj/structure/stone_tile/cracked,
+/obj/structure/stone_tile{
+	dir = 8
+	},
+/obj/structure/closet/crate/necropolis{
+	anchored = 1
+	},
+/obj/item/survivalcapsule/luxuryelite,
+/obj/item/magmite_parts,
+/turf/open/lava/smooth,
+/area/ruin/unpowered/ash_walkers)
 "AM" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -1990,21 +2002,6 @@
 /obj/structure/stone_tile/slab,
 /obj/structure/stone_tile/slab,
 /turf/open/lava/smooth/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
-"Kj" = (
-/obj/structure/stone_tile/cracked,
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/closet/crate/necropolis{
-	anchored = 1
-	},
-/obj/item/survivalcapsule/luxuryelite,
-/obj/item/magmite_parts,
-/obj/structure/closet/crate/necropolis{
-	anchored = 1
-	},
-/turf/open/lava/smooth,
 /area/ruin/unpowered/ash_walkers)
 "Kv" = (
 /obj/structure/stone_tile/burnt{
@@ -3215,7 +3212,7 @@ ix
 gC
 gD
 WN
-Kj
+Ar
 zR
 WN
 WN

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_meteorite.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_meteorite.dmm
@@ -1438,18 +1438,6 @@
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"Ar" = (
-/obj/structure/stone_tile/cracked,
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/obj/structure/closet/crate/necropolis{
-	anchored = 1
-	},
-/obj/item/survivalcapsule/luxuryelite,
-/obj/item/magmite_parts,
-/turf/open/lava/smooth,
-/area/ruin/unpowered/ash_walkers)
 "AM" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -2292,6 +2280,18 @@
 /obj/structure/stone_tile/center/cracked,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"Pc" = (
+/obj/structure/stone_tile/cracked,
+/obj/structure/stone_tile{
+	dir = 8
+	},
+/obj/structure/closet/crate/necropolis{
+	anchored = 1
+	},
+/obj/item/survivalcapsule/luxuryelite,
+/obj/item/magmite_parts,
+/turf/open/lava/smooth,
+/area/ruin/unpowered/ash_walkers)
 "Pi" = (
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion/dwarf,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -3212,7 +3212,7 @@ ix
 gC
 gD
 WN
-Ar
+Pc
 zR
 WN
 WN


### PR DESCRIPTION
Oops

# Document the changes in your pull request

Removes a duplicate chest in the Ashwalker Meteorite ruin

# Changelog

:cl:  
bugfix: Removes a duplicate chest in the Ashwalker Meteorite
/:cl:
