### PR TITLE
shields no longer have 100% guaranteed chance to block everything

### DIFF
--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3446,7 +3446,6 @@
 #include "yogstation\code\game\objects\items\plushes.dm"
 #include "yogstation\code\game\objects\items\premadepapers.dm"
 #include "yogstation\code\game\objects\items\sharpener.dm"
-#include "yogstation\code\game\objects\items\shields.dm"
 #include "yogstation\code\game\objects\items\tool_switcher.dm"
 #include "yogstation\code\game\objects\items\tools.dm"
 #include "yogstation\code\game\objects\items\toys.dm"

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -1015,6 +1015,7 @@
 #include "code\game\objects\items\RSF.dm"
 #include "code\game\objects\items\scrolls.dm"
 #include "code\game\objects\items\sharpener.dm"
+#include "code\game\objects\items\shields.dm"
 #include "code\game\objects\items\shooting_range.dm"
 #include "code\game\objects\items\shuttle_creator.dm"
 #include "code\game\objects\items\shuttle_upgrades.dm"

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -1015,7 +1015,6 @@
 #include "code\game\objects\items\RSF.dm"
 #include "code\game\objects\items\scrolls.dm"
 #include "code\game\objects\items\sharpener.dm"
-#include "code\game\objects\items\shields.dm"
 #include "code\game\objects\items\shooting_range.dm"
 #include "code\game\objects\items\shuttle_creator.dm"
 #include "code\game\objects\items\shuttle_upgrades.dm"

--- a/yogstation/code/game/objects/items/shields.dm
+++ b/yogstation/code/game/objects/items/shields.dm
@@ -1,8 +1,0 @@
-/obj/item/shield/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	SEND_SIGNAL(src, COMSIG_ITEM_HIT_REACT, args)
-	if(transparent && (hitby.pass_flags & PASSGLASS))
-		return FALSE
-	if(!is_A_facing_B(owner, hitby))
-		return FALSE
-	owner.visible_message(span_danger("[owner] blocks [attack_text] with [src]!"))
-	return TRUE


### PR DESCRIPTION
Theos brought this gem of an override file on the discord. At first I didn't believe him, because a 100% block on shields seemed so stupid, but testing on a private server proves that it's true. What the fuck. Testing with a varedited shield with a ton of HP, nothing gets through the shield. Not bullets, not melee, not thrown stuff. The only thing that gets through is, obviously, energy weapons. These things can be printed from the security protolathe for essentially no cost once a very basic technology has been researched. They're an extra 75HP for you, with absolutely no downside. I made this PR whilst intending to tone down how strong shields are, but this explains why they are that way!

# Changelog

:cl:  
tweak: shields are now chance based instead of being an extra 75 HP sponge for you. I don't care if this is how it was prebase, we're not prebase anymore.
/:cl:
