### PR TITLE
Removes vise grip cooldown for bloody knuckles and fixes blood splash cooldown

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1269,7 +1269,6 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 	w_class = WEIGHT_CLASS_SMALL
 	force = 18
 	var/next_reach = 0
-	var/next_grip = 0
 	var/next_splash = 0
 	var/next_knuckle = 0
 	var/splash_range = 9
@@ -1303,7 +1302,7 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 		if(T)
 			new /obj/effect/decal/cleanable/blood(T)
 		T = get_step(T,user.dir)
-	next_splash = world.time + COOLDOWN
+	next_splash = world.time + COOLDOWN_SPLASH
 
 /obj/item/melee/knuckles/ui_action_click(mob/living/user, action)
 	var/mob/living/U = user
@@ -1324,9 +1323,6 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 			return
 		next_reach = world.time + COOLDOWN
 	else if(istype(action, /datum/action/item_action/visegrip))
-		if(next_grip > world.time)
-			to_chat(U, span_warning("You can't do that yet!"))
-			return
 		var/valid_casting = FALSE
 		for(var/mob/living/L in view(8, U))
 			if(L.has_status_effect(STATUS_EFFECT_KNUCKLED))
@@ -1335,7 +1331,6 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 		if(!valid_casting)
 			to_chat(U, span_warning("There's nobody to use this on!"))
 			return
-		next_grip = world.time + COOLDOWN
 		#undef COOLDOWN
 		#undef COOLDOWN_HUMAN
 		#undef COOLDOWN_ANIMAL


### PR DESCRIPTION
# Document the changes in your pull request

having to wait on a cooldown to trigger an effect that also has a cooldown to be applied is a hassle and leads to the ability being ignored/inflexible so i'm changing it so users of the knuckles only have to wait on the cooldown for applying the effect. additionally, i forgot to actually apply the cooldown_splash of 10 seconds to the splash effect so i'm fixing that too from the mistaken 15 seconds.

:cl:  
rscdel: Removed vise grip cooldown
bugfix: fixed knuckles' splash cooldown
/:cl:
