### PR TITLE
You can orbit planted bombs now

### DIFF
--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -126,7 +126,7 @@
 		log_game("[key_name(user)] planted [name] on [target.name] at [AREACOORD(user)] with a [det_time] second fuse")
 
 		if(notify_ghosts)
-			notify_ghosts("[user] has planted \a [src] on [target] with a [det_time] second fuse!", source = target, action = NOTIFY_ORBIT, header = "Bomb Planted" )
+			notify_ghosts("[user] has planted \a [src] on [target] with a [det_time] second fuse!", source = src, action = NOTIFY_ORBIT, header = "Bomb Planted" )
 
 		moveToNullspace()	//Yep
 


### PR DESCRIPTION
# Document the changes in your pull request
you cant orbit turfs as a ghost but you can orbit objects. Changes it to orbit the bomb instead of whatever it was planted on

# Changelog

:cl:  
bugfix: You can orbit bombs that have been planted on turfs now
/:cl:
