### PR TITLE
Adds new 3x5 Maint Ruin & Adds newer ruins to Landmarks.dm

### DIFF
--- a/_maps/RandomRuins/StationRuins/maint/3x5/3x5_gaxbotany.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/3x5/3x5_gaxbotany.dmm
@@ -1,7 +1,18 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"o" = (
-/obj/machinery/light/broken,
-/turf/open/floor/plating,
+"e" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"r" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
 /area/template_noop)
 "s" = (
 /obj/machinery/chem_dispenser/mutagensaltpeter,
@@ -10,9 +21,19 @@
 /area/template_noop)
 "C" = (
 /obj/machinery/hydroponics/constructable,
+/turf/open/floor/plating,
+/area/template_noop)
+"G" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/template_noop)
-"D" = (
+"O" = (
+/obj/machinery/light/broken,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/template_noop)
 "Q" = (
@@ -28,34 +49,34 @@
 /obj/item/seeds/wheat,
 /turf/open/floor/plasteel,
 /area/template_noop)
-"V" = (
-/turf/open/floor/plating,
-/area/template_noop)
-"W" = (
-/obj/machinery/light{
+"R" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"V" = (
 /turf/open/floor/plating,
 /area/template_noop)
 
 (1,1,1) = {"
 V
+G
+G
 V
-V
-V
-o
+O
 "}
 (2,1,1) = {"
-D
+R
 C
 s
 Q
-D
+V
 "}
 (3,1,1) = {"
-W
+r
 V
-V
-V
+e
+e
 V
 "}

--- a/_maps/RandomRuins/StationRuins/maint/3x5/3x5_gaxbotany.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/3x5/3x5_gaxbotany.dmm
@@ -1,13 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"b" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/template_noop)
-"g" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel,
+"o" = (
+/obj/machinery/light/broken,
+/turf/open/floor/plating,
 /area/template_noop)
 "s" = (
 /obj/machinery/chem_dispenser/mutagensaltpeter,
@@ -16,6 +10,9 @@
 /area/template_noop)
 "C" = (
 /obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"D" = (
 /turf/open/floor/plasteel,
 /area/template_noop)
 "Q" = (
@@ -34,23 +31,29 @@
 "V" = (
 /turf/open/floor/plating,
 /area/template_noop)
+"W" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/template_noop)
 
 (1,1,1) = {"
 V
 V
 V
 V
-V
+o
 "}
 (2,1,1) = {"
-b
+D
 C
 s
 Q
-g
+D
 "}
 (3,1,1) = {"
-V
+W
 V
 V
 V

--- a/_maps/RandomRuins/StationRuins/maint/3x5/3x5_gaxbotany.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/3x5/3x5_gaxbotany.dmm
@@ -1,0 +1,58 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"b" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"g" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"s" = (
+/obj/machinery/chem_dispenser/mutagensaltpeter,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"C" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"Q" = (
+/obj/machinery/seed_extractor,
+/obj/item/seeds/tower,
+/obj/item/seeds/watermelon,
+/obj/item/seeds/sugarcane,
+/obj/item/seeds/grape,
+/obj/item/seeds/cocoapod,
+/obj/item/seeds/banana,
+/obj/item/seeds/apple,
+/obj/item/seeds/orange,
+/obj/item/seeds/wheat,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"V" = (
+/turf/open/floor/plating,
+/area/template_noop)
+
+(1,1,1) = {"
+V
+V
+V
+V
+V
+"}
+(2,1,1) = {"
+b
+C
+s
+Q
+g
+"}
+(3,1,1) = {"
+V
+V
+V
+V
+V
+"}

--- a/yogstation/code/datums/ruins/station.dm
+++ b/yogstation/code/datums/ruins/station.dm
@@ -609,6 +609,12 @@
 	suffix = "3x5_kilomobden.dmm"
 	name = "Maint kilomobden"
 
+//Author: Vaelophis
+/datum/map_template/ruin/station/maint/threexfive/gaxbotany
+	id = "gaxbotany"
+	suffix = "3x5_gaxbotany.dmm"
+	name = "Maint gaxbotany"
+
 /datum/map_template/ruin/station/maint/threexfive/laststand
 	id = "laststand"
 	suffix = "3x5_laststand.dmm"

--- a/yogstation/code/game/objects/effects/landmarks.dm
+++ b/yogstation/code/game/objects/effects/landmarks.dm
@@ -146,15 +146,15 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 	template_names = list("Maint 2storage", "Maint 9storage", "Maint airstation", "Maint biohazard", "Maint boxbedroom", "Maint boxchemcloset", "Maint boxclutter2", "Maint boxclutter3", "Maint boxclutter4", "Maint boxclutter5", "Maint boxclutter6", "Maint boxclutter8",
 	"Maint boxwindow", "Maint bubblegumaltar", "Maint deltajanniecloset", "Maint deltaorgantrade", "Maint donutcapgun", "Maint dronehole", "Maint gibs", "Maint hazmat", "Maint hobohut", "Maint hullbreach", "Maint kilolustymaid", "Maint kilomechcharger", "Maint kilotheatre",
 	"Maint medicloset", "Maint memorial", "Maint metaclutter2", "Maint metaclutter4", "Maint metagamergear", "Maint owloffice", "Maint plasma", "Maint pubbyartism", "Maint pubbyclutter1", "Maint pubbyclutter2", "Maint pubbyclutter3", "Maint radspill", "Maint shrine", "Maint singularity",
-	"Maint tanning", "Maint tranquility", "Maint wash", "Maint command", "Maint dummy", "Maint spaceart", "Maint containmentcell", "Maint naughtyroom")
+	"Maint tanning", "Maint tranquility", "Maint wash", "Maint command", "Maint dummy", "Maint spaceart", "Maint containmentcell", "Maint naughtyroom", "Maint vendoraccident")
 
 /obj/effect/landmark/stationroom/maint/threexfive
 	template_names = list("Maint airlockstorage", "Maint boxclutter7", "Maint boxkitchen", "Maint boxmaintfreezers", "Maint canisterroom", "Maint checkpoint", "Maint hank", "Maint junkcloset", "Maint kilomobden", "Maint laststand", "Maint monky", "Maint onioncult", "Maint pubbyclutter5",
-	"Maint pubbyclutter6", "Maint pubbyrobotics", "Maint ripleywreck", "Maint churchroach", "Maint mirror", "Maint chromosomes", "Maint clutter", "Maint dissection", "Maint emergencyoxy", "Maint oreboxes")
+	"Maint pubbyclutter6", "Maint pubbyrobotics", "Maint ripleywreck", "Maint churchroach", "Maint mirror", "Maint chromosomes", "Maint clutter", "Maint dissection", "Maint emergencyoxy", "Maint oreboxes", "Maint gaxbotany")
 
 /obj/effect/landmark/stationroom/maint/fivexthree
 	template_names = list("Maint boxclutter1", "Maint breach", "Maint cloner", "Maint deltaclutter2", "Maint deltaclutter3", "Maint incompletefloor", "Maint kiloclutter1", "Maint metaclutter1", "Maint metaclutter3", "Maint minibreakroom", "Maint nastytrap", "Maint pills", "Maint pubbybedroom",
-	"Maint pubbyclutter4", "Maint pubbyclutter7", "Maint pubbykitchen", "Maint storeroom", "Maint yogsmaintdet", "Maint yogsmaintrpg", "Maint waitingroom", "Maint podmin", "Maint highqualitysurgery", "Maint chestburst", "Maint gloveroom", "Maint magicroom", "Maint spareparts")
+	"Maint pubbyclutter4", "Maint pubbyclutter7", "Maint pubbykitchen", "Maint storeroom", "Maint yogsmaintdet", "Maint yogsmaintrpg", "Maint waitingroom", "Maint podmin", "Maint highqualitysurgery", "Maint chestburst", "Maint gloveroom", "Maint magicroom", "Maint spareparts", "Maint smallfish")
 
 /obj/effect/landmark/stationroom/maint/fivexfour
 	template_names = list("Maint blasted", "Maint boxbar", "Maint boxdinner", "Maint boxsurgery", "Maint comproom", "Maint deltabar", "Maint deltadetective", "Maint deltadressing", "Maint deltaEVA", "Maint deltagamble", "Maint deltalounge", "Maint deltasurgery", "Maint firemanroom", "Maint icicle",
@@ -162,11 +162,11 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 
 /obj/effect/landmark/stationroom/maint/tenxfive
 	template_names = list("Maint barbershop", "Maint deltaarcade", "Maint deltabotnis", "Maint deltacafeteria", "Maint deltaclutter1", "Maint deltarobotics", "Maint factory", "Maint maintmedical", "Maint meetingroom", "Maint phage", "Maint skidrow", "Maint transit", "Maint ballpit", "Maint commie", "Maint firingrange", "Maint clothingstore",
-	"Maint butchersden", "Maint courtroom", "Maint gaschamber", "Maint oldaichamber", "Maint radiationtherapy", "Maint ratburger")
+	"Maint butchersden", "Maint courtroom", "Maint gaschamber", "Maint oldaichamber", "Maint radiationtherapy", "Maint ratburger", "Maint tank_heaven", "Maint bamboo")
 
 /obj/effect/landmark/stationroom/maint/tenxten
 	template_names = list("Maint aquarium", "Maint bigconstruction", "Maint bigtheatre", "Maint deltalibrary", "Maint graffitiroom", "Maint junction", "Maint podrepairbay", "Maint pubbybar", "Maint roosterdome", "Maint sanitarium", "Maint snakefighter", "Maint vault", "Maint ward", "Maint assaultpod", "Maint maze", "Maint maze2", "Maint boxfactory",
-	"Maint sixsectorsdown", "Maint advbotany", "Maint beach", "Maint botany_apiary", "Maint gamercave", "Maint ladytesla_altar", "Maint olddiner", "Maint smallmagician", "Maint fourshops")
+	"Maint sixsectorsdown", "Maint advbotany", "Maint beach", "Maint botany_apiary", "Maint gamercave", "Maint ladytesla_altar", "Maint olddiner", "Maint smallmagician", "Maint fourshops", "Maint fishinghole")
 
 /// Type of landmark that find all others of the same type, and only spawns count number of ruins at them
 /obj/effect/landmark/stationroom/limited_spawn


### PR DESCRIPTION
# Document the changes in your pull request

Adds a new Gax-botany themed maint ruin to the 3x5 category
features a seed extractor, some garden-approved seeds, a bucket, a hydro tray, and a botanical chem dispenser*.
Also adds a lot of the newer ruins by me and @GraveHat to Landmarks.dm, which I was unaware existed.

*the only "op" things you can dispense from this for non-botany are Mutagen for gambling for mutations; Ash for maint chemistry, and cryoxodone, for turbo healing.

![ss (2022-08-21 at 07 22 37)](https://user-images.githubusercontent.com/1534478/185817745-fc1c1c9d-919a-4408-be3e-81872999aa09.png)
![ss (2022-08-21 at 07 06 33)](https://user-images.githubusercontent.com/1534478/185817082-785cab95-3857-48d9-bcc8-1ece570a2b15.png)


# Changelog

:cl:  
rscadd: Added a Gax Botany themed main ruin
/:cl:
