### PR TITLE
Adds in a Ninja NoGun Implant and Katana shock if user is not ninja or has no insulation

### DIFF
--- a/code/game/objects/items/implants/implant_honor.dm
+++ b/code/game/objects/items/implants/implant_honor.dm
@@ -19,7 +19,7 @@
 			var/mob/living/L = target
 			REMOVE_TRAIT(L, TRAIT_NOGUNS, "implant")
 		if(target.stat != DEAD && !silent)
-			to_chat(target, span_boldnotice("Your mind suddenly feels like guns are not dishonorable. You can now bear the thought of using guns."))
+			to_chat(target, span_boldnotice("Your mind no longer sees ranged weaponry as dishonorable. You can now bear the thought of pulling the trigger."))
 		return TRUE
 
 /obj/item/implanter/honor

--- a/code/game/objects/items/implants/implant_honor.dm
+++ b/code/game/objects/items/implants/implant_honor.dm
@@ -1,0 +1,32 @@
+/obj/item/implant/honor
+	name = "honor implant"
+	desc = "For the honorable."
+	activated = 0
+
+/obj/item/implant/honor/implant(mob/living/target, mob/user, silent = FALSE, force = FALSE) //Copied and adjusted from mindshields
+	if(..())
+		if(!target.mind)
+			ADD_TRAIT(target, TRAIT_NOGUNS, "implant")
+			return TRUE
+		if(!silent)
+			to_chat(target, span_notice("You feel that the use of guns would bring you shame. You no longer think that you can hold the trigger."))
+		ADD_TRAIT(target, TRAIT_NOGUNS, "implant")
+		return TRUE
+
+/obj/item/implant/honor/removed(mob/target, silent = FALSE, special = 0)
+	if(..())
+		if(isliving(target))
+			var/mob/living/L = target
+			REMOVE_TRAIT(L, TRAIT_NOGUNS, "implant")
+		if(target.stat != DEAD && !silent)
+			to_chat(target, span_boldnotice("Your mind suddenly feels like guns are not dishonorable. You can now bear the thought of using guns."))
+		return TRUE
+
+/obj/item/implanter/honor
+	name = "implanter (honor)"
+	imp_type = /obj/item/implant/honor
+
+/obj/item/implantcase/honor
+	name = "implant case - 'Honor'"
+	desc = "A glass case containing a honorable implant for those who seek to not use guns."
+	imp_type = /obj/item/implant/honor

--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -72,7 +72,7 @@
 			user.emote("scream")
 			user.electrocute_act(15,src)
 			user.dropItemToGround(src, TRUE)
-			user.Paralyze(5 seconds)
+			user.Paralyze(50)
 			return
 	jaunt.Grant(user, src)
 	user.update_icons()

--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -60,15 +60,17 @@
 	if(!is_ninja(user)) //stolen directly from the bloody bastard sword
 		if(HAS_TRAIT (user, TRAIT_SHOCKIMMUNE))
 			to_chat(user, span_danger("[src] attempts to shock you"))
+			user.electrocute_act(15,src)
 			return
 		if(user.gloves)
 			if(!user.gloves.siemens_coefficient)
 				to_chat(user, span_danger("[src] attempts to shock you"))
+				user.electrocute_act(15,src)
 				return
 		else
 			to_chat(user, span_userdanger("[src] shocks you."))
 			user.emote("scream")
-			user.apply_damage(30, BURN, pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
+			user.electrocute_act(15,src)
 			user.dropItemToGround(src, TRUE)
 			user.Paralyze(50)
 			return

--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -55,8 +55,23 @@
 		playsound(user, 'sound/weapons/blade1.ogg', 50, 1)
 		target.emag_act(user)
 
-/obj/item/energy_katana/pickup(mob/living/user)
+/obj/item/energy_katana/pickup(mob/living/carbon/human/user)
 	. = ..()
+	if(!is_ninja(user)) //stolen directly from the bloody bastard sword
+		if(HAS_TRAIT (user, TRAIT_SHOCKIMMUNE))
+			to_chat(user, span_danger("[src] attempts to shock you"))
+			return
+		if(user.gloves)
+			if(!user.gloves.siemens_coefficient)
+				to_chat(user, span_danger("[src] attempts to shock you"))
+				return
+		else
+			to_chat(user, span_userdanger("[src] shocks you."))
+			user.emote("scream")
+			user.apply_damage(30, BURN, pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
+			user.dropItemToGround(src, TRUE)
+			user.Paralyze(50)
+			return
 	jaunt.Grant(user, src)
 	user.update_icons()
 	playsound(src, 'sound/items/unsheath.ogg', 25, 1)

--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -59,20 +59,20 @@
 	. = ..()
 	if(!is_ninja(user)) //stolen directly from the bloody bastard sword
 		if(HAS_TRAIT (user, TRAIT_SHOCKIMMUNE))
-			to_chat(user, span_danger("[src] attempts to shock you"))
+			to_chat(user, span_warning("[src] attempts to shock you."))
 			user.electrocute_act(15,src)
 			return
 		if(user.gloves)
 			if(!user.gloves.siemens_coefficient)
-				to_chat(user, span_danger("[src] attempts to shock you"))
+				to_chat(user, span_warning("[src] attempts to shock you."))
 				user.electrocute_act(15,src)
 				return
 		else
-			to_chat(user, span_userdanger("[src] shocks you."))
+			to_chat(user, span_userdanger("[src] shocks you!"))
 			user.emote("scream")
 			user.electrocute_act(15,src)
 			user.dropItemToGround(src, TRUE)
-			user.Paralyze(50)
+			user.Paralyze(5 seconds)
 			return
 	jaunt.Grant(user, src)
 	user.update_icons()

--- a/code/modules/ninja/outfit.dm
+++ b/code/modules/ninja/outfit.dm
@@ -13,7 +13,7 @@
 	r_pocket = /obj/item/tank/internals/emergency_oxygen
 	internals_slot = SLOT_R_STORE
 	belt = /obj/item/energy_katana
-	implants = list(/obj/item/implant/explosive)
+	implants = list(/obj/item/implant/explosive, /obj/item/implant/honor)
 
 
 /datum/outfit/ninja/post_equip(mob/living/carbon/human/H)

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -1094,6 +1094,7 @@
 #include "code\game\objects\items\implants\implant_explosive.dm"
 #include "code\game\objects\items\implants\implant_freedom.dm"
 #include "code\game\objects\items\implants\implant_greytide.dm"
+#include "code\game\objects\items\implants\implant_honor.dm"
 #include "code\game\objects\items\implants\implant_krav_maga.dm"
 #include "code\game\objects\items\implants\implant_mindshield.dm"
 #include "code\game\objects\items\implants\implant_mindshieldtot.dm"


### PR DESCRIPTION
Hugboxing ninja clan learns that their masters of ninjutsu get their weapons stolen and used against them mid-combat. Also, they hate guns.

# Document the changes in your pull request

Removes the ability for ninjas to wield guns and removes the ability for the crew to nab the sword without full insulation.

This PR has been tested and works as intended.

Why? Because I don't think the ninjas we have would use guns over their high-tech spider clan technology even in dire straits as they quite literally have a suicide button to spite anyone who bests them. And so, to top that off, why not just make the sword unusable as it tries to kill you for not being a ninja, even if there is a workaround.

# Wiki Documentation

Ninja no use guns and ninja sword zaps non ninjas

# Changelog

:cl:  
rscadd: Adds the Honor Implant/Implanter/ImplantCase an implant that gives you the trait NOGUNS
tweak: Ninja now spawns in with the honor implant
tweak: All Energy Katanas now check if you are a ninja then shocks you if you aren't
/:cl:
