### PR TITLE
PK borg's emagged shock hands are no longer an unblockable melee stun

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -137,7 +137,7 @@
 			if(scooldown < world.time)
 				if(M.health >= 0)
 					if(ishuman(M)||ismonkey(M))
-						M.electrocute_act(5, "[user]", safety = 1)
+						electrocute_mob(M, user.cell, src, 1)
 						user.visible_message(span_userdanger("[user] electrocutes [M] with [user.p_their()] touch!"), \
 							span_danger("You electrocute [M] with your touch!"))
 						M.update_mobility()
@@ -150,7 +150,6 @@
 							user.visible_message(span_userdanger("[user] shocks [M]. It does not seem to have an effect"), \
 								span_danger("You shock [M] to no effect."))
 					playsound(loc, 'sound/effects/sparks2.ogg', 50, 1, -1)
-					user.cell.charge -= 500
 					scooldown = world.time + 20
 		if(3)
 			if(ccooldown < world.time)


### PR DESCRIPTION
emagged PK borgs are really, really strong. INSANELY strong. their full equipment currently measures out to:
mostly unblockable instant melee stun
Flashbang
portable doorshock except it also ignores insulated gloves
a ton of poisons

Which makes them, ironically, the most combat-oriented of all the emagged cyborgs. This PR just changes the shock hands to respect shockproofing like insulated gloves, because unlike engineer cyborg's stun arm, you can't avoid this. You WILL get melee stunned.
 
Before you call this an Ided, I have never died to this, but I have gotten a ton of cheap kills, and it feels really dirty.

# Changelog

:cl:  
tweak: Emagged peacekeeper cyborg's shock-hugs now respect insulation.
/:cl:
