### PR TITLE
Netherworld creatures now attack unconscious mob untill its dead

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/netherworld.dm
+++ b/code/modules/mob/living/simple_animal/hostile/netherworld.dm
@@ -17,6 +17,7 @@
 	gold_core_spawnable = HOSTILE_SPAWN
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
+	stat_attack = UNCONSCIOUS
 	faction = list("nether")
 
 

--- a/code/modules/mob/living/simple_animal/hostile/netherworld.dm
+++ b/code/modules/mob/living/simple_animal/hostile/netherworld.dm
@@ -17,6 +17,7 @@
 	gold_core_spawnable = HOSTILE_SPAWN
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
+	robust_searching = 1
 	stat_attack = UNCONSCIOUS
 	faction = list("nether")
 


### PR DESCRIPTION
# About pr
Netherworld creatures are pure evil and shouldn't spare unconscious mobs
# Document the changes in your pull request
Netherworld creatures now attack unconscious mob untill its dead



# Wiki Documentation
Netherworld creatures now attack unconscious mob untill its dead

# Changelog

:cl:  

tweak: Netherworld creatures now attack unconscious mob untill its dead
/:cl:
