### PR TITLE
Doing engineering things rewards ENGINEERING instead of the lazy CARGO DEPARMENT

### DIFF
--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -103,7 +103,7 @@ SUBSYSTEM_DEF(economy)
 	engineering_cash *= station_integrity
 	if(moneysink)
 		engineering_cash += moneysink.payout()
-	var/datum/bank_account/D = get_dep_account(ACCOUNT_CAR)
+	var/datum/bank_account/D = get_dep_account(ACCOUNT_ENG)
 	if(D)
 		D.adjust_money(engineering_cash)
 


### PR DESCRIPTION
# Document the changes in your pull request
Engis should get paid again for doing their job

# Wiki Documentation

Cargo doesnt get free money from engineers anymore

# Changelog

:cl:  
bugfix: Engineers get paid again
tweak: Cargo is no longer a leach on engineering
/:cl:
