### PR TITLE
Gas Station has a chance to spawn in with Drip

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_gas_station.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_gas_station.dmm
@@ -543,6 +543,16 @@
 "GX" = (
 /turf/open/floor/plasteel,
 /area/ruin/powered/gasstation)
+"HB" = (
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/table/wood/fancy/royalblack,
+/obj/effect/spawner/lootdrop/twenty_percent_drip_shoes,
+/obj/effect/spawner/lootdrop/twenty_percent_drip_suit,
+/obj/item/clothing/neck/necklace/dope,
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/gasstation)
 "HU" = (
 /obj/structure/table,
 /obj/structure/window{
@@ -1279,7 +1289,7 @@ cV
 cV
 qf
 JS
-KZ
+HB
 OI
 rQ
 cV

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -489,3 +489,19 @@
 				/obj/item/circuitboard/computer/apc_control,
 				/obj/item/circuitboard/computer/robotics
 				)
+
+/obj/effect/spawner/lootdrop/twenty_percent_drip_suit
+	name = "20% incredibly fashionable outfit spawner"
+	lootdoubles = FALSE
+
+	loot = list(
+		/obj/item/clothing/under/drip = 20,
+		"" = 80)
+
+/obj/effect/spawner/lootdrop/twenty_percent_drip_shoes
+	name = "20% fashionable shoes spawner"
+	lootdoubles = FALSE
+
+	loot = list(
+		/obj/item/clothing/shoes/drip = 20,
+		"" = 80)


### PR DESCRIPTION
Hahaha miner you are stealing my drip

# Document the changes in your pull request

Adds in a 20% chance spawner for the Drip suit and shoes. Both spawn individually from each other and would rarely spawn in pairs. These spawners are added to the Gas Station ruin alongside a gold chain necklace on a fancy black table.

This PR is untested,

This PR would give the clerks a reason to shoot at the miners for committing very valuable theft. Also because having mall-type clothing inside the closest thing we had to a mall made sense to me.

# Wiki Documentation

Gas Station now has a chance to spawn drip and I replaced a Display case with a fancy black table so the drip can go there.

# Changelog

:cl:  
rscadd: Adds 20% drip spawners
rscadd: Adds a chance for the Gas Station to spawn in with Drip individually from each other and a Gold Chain as well
tweak: Tweaked the Gas Station to have a pedestal for the Drip removing one of the Display Cases 
/:cl:
