### PR TITLE
Makes paydays no longer pull form department budgets

### DIFF
--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -84,7 +84,7 @@ SUBSYSTEM_DEF(economy)
 		var/datum/bank_account/B = bank_accounts[A]
 		for(var/datum/corporation/c in dictionary)
 			if(B.account_holder in dictionary[c])
-				B.payday(c.paymodifier, TRUE)
+				B.payday(c.paymodifier)
 		B.payday(1)	
 
 /datum/controller/subsystem/economy/proc/get_dep_account(dep_id)

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -66,24 +66,12 @@
 		return TRUE
 	return FALSE
 
-/datum/bank_account/proc/payday(amt_of_paychecks, free = FALSE)
+/datum/bank_account/proc/payday(amt_of_paychecks)
 	var/money_to_transfer = account_job.paycheck * payday_modifier * amt_of_paychecks
 	var/stolen_money = (1 - payday_modifier) * account_job.paycheck * amt_of_paychecks
 	GLOB.stolen_paycheck_money += stolen_money
-	if(free)
-		adjust_money(money_to_transfer)
-		return TRUE
-	else
-		var/datum/bank_account/D = SSeconomy.get_dep_account(account_job.paycheck_department)
-		if(D)
-			if(!transfer_money(D, money_to_transfer))
-				bank_card_talk("ERROR: Payday aborted, departmental funds insufficient.")
-				return FALSE
-			else
-				bank_card_talk("Payday processed, account now holds $[account_balance].")
-				return TRUE
-	bank_card_talk("ERROR: Payday aborted, unable to contact departmental account.")
-	return FALSE
+	adjust_money(money_to_transfer)
+	bank_card_talk("Payday processed, account now holds $[account_balance].")
 
 /datum/bank_account/proc/bank_card_talk(message, force)
 	if(!message || !bank_cards.len)


### PR DESCRIPTION
# Document the changes in your pull request

Removes paydays pulling from department budgets, fixing the budgets getting drained by them alone. I was under the impression that this was already the case when I reduced the amount budgets start with, but I guess I was wrong.

# Spriting
None.

# Wiki Documentation

Don't think paydays are mentioned on the wiki, if they are then maybe include this. 

# Changelog

:cl:  
tweak: paydays no longer pull from department budgets
/:cl:
