### PR TITLE
admin music now defaults to 10% volume

### DIFF
--- a/tgui/packages/tgui-panel/settings/reducer.js
+++ b/tgui/packages/tgui-panel/settings/reducer.js
@@ -12,7 +12,7 @@ const initialState = {
   fontSize: 13,
   lineHeight: 1.2,
   theme: 'light',
-  adminMusicVolume: 0.5,
+  adminMusicVolume: 0.1,
   highlightText: '',
   highlightColor: '#ffdd44',
   view: {

--- a/tgui/packages/tgui-panel/settings/reducer.js
+++ b/tgui/packages/tgui-panel/settings/reducer.js
@@ -12,7 +12,7 @@ const initialState = {
   fontSize: 13,
   lineHeight: 1.2,
   theme: 'light',
-  adminMusicVolume: 0.1,
+  adminMusicVolume: 0.15,
   highlightText: '',
   highlightColor: '#ffdd44',
   view: {


### PR DESCRIPTION
# Document the changes in your pull request

music player now defaults to 15% volume instead of 50%

50% is loud as hell

# Changelog

:cl:  
tweak: music player volume now defaults to 15% volume instead of 50%
/:cl:
