### PR TITLE
Fixes lack of armor and storage on certain detective jackets

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -717,9 +717,9 @@
 	new /obj/item/clothing/under/yogs/golddetective(src)
 	new /obj/item/clothing/under/yogs/greydetective(src)
 	new /obj/item/clothing/under/yogs/blackdetective(src)
-	new /obj/item/clothing/suit/yogs/golddetective(src)
-	new /obj/item/clothing/suit/yogs/detectivecoat(src)
-	new /obj/item/clothing/suit/yogs/bluedetective(src)
+	new /obj/item/clothing/suit/det_suit/golddetective(src)
+	new /obj/item/clothing/suit/det_suit/detectivecoat(src)
+	new /obj/item/clothing/suit/det_suit/bluedetective(src)
 
 /obj/item/storage/backpack/duffelbag/clothing/sec/warden
 	name = "Warden's clothing duffelbag"

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -710,6 +710,7 @@
 	new /obj/item/clothing/accessory/waistcoat(src)
 	new /obj/item/clothing/suit/det_suit/grey(src)
 	new /obj/item/clothing/suit/det_suit/noir(src)
+	new /obj/item/clothing/suit/det_suit/tan(src)
 	new /obj/item/clothing/head/fedora(src)
 	new /obj/item/clothing/shoes/laceup(src)
 	new /obj/item/clothing/under/yogs/forensictech(src)

--- a/yogstation/code/modules/clothing/suits/miscellaneous.dm
+++ b/yogstation/code/modules/clothing/suits/miscellaneous.dm
@@ -248,6 +248,7 @@
 	desc = "A detective jacket, in gold!"
 	icon_state = "gold_detective"
 	item_state = "gold_item"
+	armor = list(MELEE = 25, BULLET = 10, LASER = 25, ENERGY = 10, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 45)
 
 /obj/item/clothing/suit/yogs/leathercoat
 	name = "black leather coat"
@@ -272,7 +273,7 @@
 	desc = "For those detectives that value fashion over function."
 	icon_state = "detective_coat"
 	item_state = "detective_item"
-
+	armor = list(MELEE = 25, BULLET = 10, LASER = 25, ENERGY = 10, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 45)
 
 /obj/item/clothing/suit/yogs/blacktrenchcoat
 	name = "black trenchcoat"

--- a/yogstation/code/modules/clothing/suits/miscellaneous.dm
+++ b/yogstation/code/modules/clothing/suits/miscellaneous.dm
@@ -301,11 +301,6 @@
 	item_state = "blue_item"
 	mutantrace_variation = NO_MUTANTRACE_VARIATION //Check inherits from det_suit
 
-/obj/item/clothing/suit/yogs/bluedetective/Initialize()
-	. = ..()
-	allowed = GLOB.detective_vest_allowed
-
-
 /obj/item/clothing/suit/hooded/spesshoodie
     mob_overlay_icon = 'yogstation/icons/mob/clothing/suit/suit.dmi'
     icon = 'yogstation/icons/obj/clothing/suits.dmi'

--- a/yogstation/code/modules/clothing/suits/miscellaneous.dm
+++ b/yogstation/code/modules/clothing/suits/miscellaneous.dm
@@ -243,12 +243,12 @@
     icon_state = "caretakerhood"
     flags_inv = HIDEEARS|HIDEEYES|HIDEFACE|HIDEFACIALHAIR|HIDEHAIR
 
-/obj/item/clothing/suit/yogs/golddetective
+/obj/item/clothing/suit/det_suit/golddetective
 	name = "gold detective jacket"
 	desc = "A detective jacket, in gold!"
 	icon_state = "gold_detective"
 	item_state = "gold_item"
-	armor = list(MELEE = 25, BULLET = 10, LASER = 25, ENERGY = 10, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 45)
+	mutantrace_variation = NO_MUTANTRACE_VARIATION //Check inherits from det_suit
 
 /obj/item/clothing/suit/yogs/leathercoat
 	name = "black leather coat"
@@ -268,12 +268,12 @@
 	icon_state = "janitor_coat"
 	item_state = "janitor_item"
 
-/obj/item/clothing/suit/yogs/detectivecoat
+/obj/item/clothing/suit/det_suit/detectivecoat
 	name = "detective long coat"
 	desc = "For those detectives that value fashion over function."
 	icon_state = "detective_coat"
 	item_state = "detective_item"
-	armor = list(MELEE = 25, BULLET = 10, LASER = 25, ENERGY = 10, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 45)
+	mutantrace_variation = NO_MUTANTRACE_VARIATION //Check inherits from det_suit
 
 /obj/item/clothing/suit/yogs/blacktrenchcoat
 	name = "black trenchcoat"
@@ -294,12 +294,12 @@
 	icon_state = "monkrobes"
 	item_state = "monkrobes"
 
-/obj/item/clothing/suit/yogs/bluedetective
+/obj/item/clothing/suit/det_suit/bluedetective
 	name = "blue detective jacket"
 	desc = "A detective jacket that is blue!"
 	icon_state = "blue_detective"
 	item_state = "blue_item"
-	armor = list(MELEE = 25, BULLET = 10, LASER = 25, ENERGY = 10, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 45)
+	mutantrace_variation = NO_MUTANTRACE_VARIATION //Check inherits from det_suit
 
 /obj/item/clothing/suit/yogs/bluedetective/Initialize()
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request

Simply splats armor onto two jackets that lacked it, despite the fact that one of the detective jackets in the same file had armor. These two jackets should only be obtainable via the duffle bag, so no quirky clothes grabbed by assistants.

Also makes it so these two jackets plus the one that already had armor (?) now inherit all the funny stuff from det_suit, which basically just means their armor, covered parts, and exosuit capabilities are identical.

# Wiki Documentation

I mean, if you want to list all the detective coats in a list (a gif would work well), go ahead.

# Changelog

:cl:  
tweak: Gold and normal detective jackets now have proper tailoring for noir-level protection
tweak: The three quirky short jackets for detective should proper hold detective equipment now
/:cl:
