### PR TITLE
adds necropolis seed as a virology traitor item

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1952,7 +1952,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Necropolis seed"
 	desc = "A virus our operatives extracted from lavaland use it to cause a symbiotic relationship with a lavaland tendril"
 	item = /obj/item/reagent_containers/glass/bottle/necropolis_seed
-	cost = 2
+	cost = 6
 	restricted_roles = list("Virologist")
 	surplus = 0
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1947,6 +1947,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 2
 	restricted_roles = list("Assistant")
 	surplus = 0
+	
+/datum/uplink_item/role_restricted/oldtoolboxclean
+	name = "Necropolis seed"
+	desc = "A virus our operatives extracted from lavaland use it to cause a symbiotic relationship with a lavaland tendril"
+	item = /obj/item/reagent_containers/glass/bottle/necropolis_seed
+	cost = 2
+	restricted_roles = list("Virologist")
+	surplus = 0
 
 /datum/uplink_item/role_restricted/pie_cannon
 	name = "Banana Cream Pie Cannon"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1948,7 +1948,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	restricted_roles = list("Assistant")
 	surplus = 0
 	
-/datum/uplink_item/role_restricted/oldtoolboxclean
+/datum/uplink_item/role_restricted/necroseed
 	name = "Necropolis seed"
 	desc = "A virus our operatives extracted from Lavaland. When infected with this virus, you become stronger and hardier, but slower. If the virus is cured, it cripples the body."
 	item = /obj/item/reagent_containers/glass/bottle/necropolis_seed

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1950,7 +1950,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	
 /datum/uplink_item/role_restricted/oldtoolboxclean
 	name = "Necropolis seed"
-	desc = "A virus our operatives extracted from lavaland use it to cause a symbiotic relationship with a lavaland tendril"
+	desc = "A virus our operatives extracted from Lavaland. When infected with this virus, you become stronger and hardier, but slower. If the virus is cured, it cripples the body."
 	item = /obj/item/reagent_containers/glass/bottle/necropolis_seed
 	cost = 6
 	restricted_roles = list("Virologist")


### PR DESCRIPTION
does what the title says doesnt make sense to lock it behind rng
:cl:  
rscadd: virology traitor item
/:cl:
