### PR TITLE
Mantis blade buff

### DIFF
--- a/code/game/objects/items/mantis.dm
+++ b/code/game/objects/items/mantis.dm
@@ -9,8 +9,8 @@
 	flags_1 = CONDUCT_1
 	force = 20
 	armour_penetration = 30
-	wound_bonus = 35
-	bare_wound_bonus = 40
+	wound_bonus = 40
+	bare_wound_bonus = 50
 	w_class = WEIGHT_CLASS_NORMAL
 	sharpness = SHARP_EDGED
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "lacerated", "ripped", "diced", "cut")

--- a/code/game/objects/items/mantis.dm
+++ b/code/game/objects/items/mantis.dm
@@ -9,8 +9,8 @@
 	flags_1 = CONDUCT_1
 	force = 20
 	armour_penetration = 30
-	wound_bonus = 40
-	bare_wound_bonus = 50
+	wound_bonus = 20
+	bare_wound_bonus = 20
 	w_class = WEIGHT_CLASS_NORMAL
 	sharpness = SHARP_EDGED
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "lacerated", "ripped", "diced", "cut")

--- a/code/game/objects/items/mantis.dm
+++ b/code/game/objects/items/mantis.dm
@@ -8,6 +8,9 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	flags_1 = CONDUCT_1
 	force = 20
+	armour_penetration = 30
+	wound_bonus = 35
+	bare_wound_bonus = 40
 	w_class = WEIGHT_CLASS_NORMAL
 	sharpness = SHARP_EDGED
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "lacerated", "ripped", "diced", "cut")


### PR DESCRIPTION
# Document the changes in your pull request
It has been brought to my attention that the mantis blade is weak and mostly just bloat at this point. This aim at making it viable with current balance:
 Gave the mantis blade the following:
	armour_penetration = 30
	wound_bonus = 20
	bare_wound_bonus = 20
 used to have none of these (0).
This should improve its performance against armored targets and give it a hell of a lot more chance to wound. 

# Wiki Documentation
see above

# Changelog
:cl:  
tweak: changed the stats of the mantis blade  
/:cl:
