### PR TITLE
Landmines are no longer completely invisible when armed

### DIFF
--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -82,7 +82,9 @@
 	desc = "Better stay away from that thing."
 	density = FALSE
 	anchored = TRUE
+	icon = 'icons/obj/misc.dmi'
 	icon_state = "uglymine"
+	alpha = 40
 	var/triggered = 0
 	var/smartmine = FALSE
 	var/disarm_time = 12 SECONDS

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -84,11 +84,15 @@
 	anchored = TRUE
 	icon = 'icons/obj/misc.dmi'
 	icon_state = "uglymine"
-	alpha = 40
+	alpha = 20
 	var/triggered = 0
 	var/smartmine = FALSE
 	var/disarm_time = 12 SECONDS
 	var/disarm_product = /obj/item/deployablemine // ie what drops when the mine is disarmed
+
+/obj/effect/mine/Initialize()
+	. = ..()
+	layer = ABOVE_MOB_LAYER
 
 /obj/effect/mine/attackby(obj/I, mob/user, params)
 	if(istype(I, /obj/item/multitool))

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -84,7 +84,7 @@
 	anchored = TRUE
 	icon = 'icons/obj/misc.dmi'
 	icon_state = "uglymine"
-	alpha = 20
+	alpha = 30
 	var/triggered = 0
 	var/smartmine = FALSE
 	var/disarm_time = 12 SECONDS


### PR DESCRIPTION
They had no idea where the icon states were in the first place

# Document the changes in your pull request

Points the landmines to the correct dmi file. It makes landmines mostly invisible.
30 Alpha
![image](https://user-images.githubusercontent.com/107460718/187098760-617ef60c-feec-4395-b386-db986fdbf041.png)
![image](https://user-images.githubusercontent.com/107460718/187098837-a32c4880-3750-4840-bd81-1158c783c729.png)

20 Alpha
![image](https://user-images.githubusercontent.com/107460718/187098875-f263513a-3532-418f-aea1-22fd8a7d9f18.png)
![image](https://user-images.githubusercontent.com/107460718/187098878-b0c7dfde-1c20-4463-bdb7-f7fe51a036c3.png)

Also thanks to @VaelophisNyx for finding the correct alpha level so they aren't too noticeable.

Edit: Changed the alpha to 20 and made it start on top of the mob layer on initializing.
Edit 2: Changed to alpha 30.

# Wiki Documentation

Landmines are now slightly invisible.

# Changelog

:cl:   
bugfix: Landmines now look for a dmi folder  
tweak: Landmines are now slightly invisible
/:cl:
