### PR TITLE
Command and security jumpsuits start with max suit sensors

### DIFF
--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -189,6 +189,8 @@
 	icon_state = "hop"
 	item_state = "b_suit"
 	can_adjust = FALSE
+	sensor_mode = SENSOR_COORDS
+	random_sensor = FALSE
 	mutantrace_variation = MUTANTRACE_VARIATION
 
 /obj/item/clothing/under/rank/head_of_personnel/skirt

--- a/code/modules/clothing/under/jobs/engineering.dm
+++ b/code/modules/clothing/under/jobs/engineering.dm
@@ -6,6 +6,8 @@
 	item_state = "gy_suit"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 10, FIRE = 80, ACID = 40)
 	resistance_flags = NONE
+	sensor_mode = SENSOR_COORDS
+	random_sensor = FALSE
 	mutantrace_variation = MUTANTRACE_VARIATION
 
 /obj/item/clothing/under/rank/chief_engineer/skirt

--- a/code/modules/clothing/under/jobs/medsci.dm
+++ b/code/modules/clothing/under/jobs/medsci.dm
@@ -8,6 +8,8 @@
 	item_state = "lb_suit"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 10, BIO = 10, RAD = 0, FIRE = 0, ACID = 35)
 	can_adjust = FALSE
+	sensor_mode = SENSOR_COORDS
+	random_sensor = FALSE
 	mutantrace_variation = MUTANTRACE_VARIATION
 
 /obj/item/clothing/under/rank/research_director/skirt
@@ -106,6 +108,8 @@
 	item_state = "w_suit"
 	permeability_coefficient = 0.5
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 10, RAD = 0, FIRE = 0, ACID = 0)
+	sensor_mode = SENSOR_COORDS
+	random_sensor = FALSE
 	mutantrace_variation = MUTANTRACE_VARIATION
 
 /obj/item/clothing/under/rank/chief_medical_officer/skirt

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -47,6 +47,7 @@
 	strip_delay = 50
 	alt_covers_chest = TRUE
 	sensor_mode = 3
+	sensor_mode = SENSOR_COORDS
 	random_sensor = FALSE
 	mutantrace_variation = MUTANTRACE_VARIATION
 
@@ -120,6 +121,7 @@
 	strip_delay = 60
 	alt_covers_chest = TRUE
 	sensor_mode = 3
+	sensor_mode = SENSOR_COORDS
 	random_sensor = FALSE
 	mutantrace_variation = MUTANTRACE_VARIATION
 

--- a/yogstation/code/modules/clothing/under/jobs/security.dm
+++ b/yogstation/code/modules/clothing/under/jobs/security.dm
@@ -18,6 +18,7 @@
 	item_state = "recovery"
 	alt_covers_chest = TRUE
 	sensor_mode = 3
+	sensor_mode = SENSOR_COORDS
 	random_sensor = FALSE
 	mutantrace_variation = MUTANTRACE_VARIATION
 
@@ -27,7 +28,8 @@
 	icon_state = "secwhite"
 	item_state = "secwhite"
 	alt_covers_chest = FALSE
-	random_sensor = TRUE
+	sensor_mode = SENSOR_COORDS
+	random_sensor = FALSE
 
 /obj/item/clothing/under/yogs/rank/physician/white/skirt
 	name = "white brig physician's jumpskirt"
@@ -37,4 +39,6 @@
 	can_adjust = FALSE
 	body_parts_covered = CHEST|GROIN|ARMS
 	fitted = FEMALE_UNIFORM_TOP
+	sensor_mode = SENSOR_COORDS
+	random_sensor = FALSE
 	mutantrace_variation = NO_MUTANTRACE_VARIATION

--- a/yogstation/code/modules/jobs/job_types/brig_physician.dm
+++ b/yogstation/code/modules/jobs/job_types/brig_physician.dm
@@ -42,6 +42,7 @@
 	shoes = /obj/item/clothing/shoes/jackboots
 	digitigrade_shoes = /obj/item/clothing/shoes/xeno_wraps/jackboots
 	uniform = /obj/item/clothing/under/yogs/rank/miner/medic
+	uniform_skirt = /obj/item/clothing/under/yogs/rank/physician/white/skirt
 	suit = /obj/item/clothing/suit/toggle/labcoat/emt/physician
 	l_hand = /obj/item/storage/firstaid/regular
 	r_hand = /obj/item/modular_computer/laptop/preset/brig_physician


### PR DESCRIPTION
# Document the changes in your pull request

Command and all security jumpsuits now start with maximum suit sensors, instead of just security officers. Also brig physicians can start with a skirt if they so choose.

# Changelog

:cl:  
tweak: command and sec jumpsuits start at max suit sensors
tweak: brig physician can start with a skirt now
/:cl:
