### PR TITLE
Revert "Sterilizes the codebase - Pt.6 Dwarfism now permanently gives you dwarf beard"

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -96,18 +96,7 @@
 	new_transform.Scale(1, 0.8)
 	owner.transform = new_transform.Multiply(owner.transform)
 	passtable_on(owner, GENETIC_MUTATION)
-	owner.visible_message(span_danger("[owner] suddenly shrinks and grows a beard!"), span_notice("Everything around you seems to grow.."))
-	grow_beard(owner)
-
-/datum/mutation/human/dwarfism/proc/grow_beard(mob/living/carbon/human/owner)
-	var/mob/living/carbon/human/H = owner
-	to_chat(H, span_warning("Your chin itches."))
-	H.facial_hair_style = "Beard (Dwarf)"
-	H.update_hair()
-
-/datum/mutation/human/dwarfism/on_life()
-	if(owner.facial_hair_style != "Beard (Dwarf)")
-		grow_beard(owner)
+	owner.visible_message(span_danger("[owner] suddenly shrinks!"), span_notice("Everything around you seems to grow.."))
 
 /datum/mutation/human/dwarfism/on_losing(mob/living/carbon/human/owner)
 	if(..())


### PR DESCRIPTION
Reverts yogstation13/Yogstation#14719
There wll be a reckoning for all rockandstoneposters and it gets closer every time some stupid pr such as the targer revert for this is merged

🆑 
rscdel: you no longer are forced to have a permanent beard whenever you get the dwarfism mutation, its the dwarfism mutation not the facial hypertosis mutation
/:cl: