### PR TITLE
KA low pressure damage is halved when on the station z level

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -202,7 +202,10 @@
 			damage = damage * pressure_decrease
 			pressure_decrease_active = TRUE
 		else if(is_station_level(z))
-			damage *= min(pressure_decrease * 2, 1) //if you have a pressure mod you get to ignore this because uhmmmmmm tc tax
+			pressure_decrease = min(pressure_decrease * 2, 1) //if you have a pressure mod you get to ignore this because uhmmmmmm tc tax
+			name = "destabilized [name]"
+			damage = damage * pressure_decrease
+			pressure_decrease_active = TRUE 
 
 /obj/item/projectile/kinetic/on_range()
 	strike_thing()

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -201,6 +201,8 @@
 			name = "weakened [name]"
 			damage = damage * pressure_decrease
 			pressure_decrease_active = TRUE
+		else if(is_station_level(z))
+			damage *= min(pressure_decrease * 2, 1) //if you have a pressure mod you get to ignore this because uhmmmmmm tc tax
 
 /obj/item/projectile/kinetic/on_range()
 	strike_thing()


### PR DESCRIPTION
# Document the changes in your pull request

KA damage is halved if it's being used out of pressure on the station, this is negated if it has a pressure reduction mod to keep those in the semi-viable state they are in until it inevitably somehow becomes a meta pick

puts it more in line with other conventional ranged weaponry as dealing 40-70 damage at mid range with the long-ish but still short cooldown they get is a bit much compared to other similar weapons
no this does not decrease in-pressure damage at all it's a separate modifier 

# Wiki Documentation

KA low pressure damage is halved when on station, 1 pressure penalty reduction mod will negate this entirely

# Changelog

:cl:  
tweak: KAs now deal half their normal damage when fired in an optimal environment on the station z-level
/:cl:
