### PR TITLE
Robotic Limbs that are easy to dismember are 400% less likely to dismember

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -557,7 +557,7 @@
 					Paralyze(100)
 
 			if((TRAIT_EASYDISMEMBER in L.owner.dna.species.species_traits) && L.body_zone != "chest")
-				if(prob(20))
+				if(prob(5))
 					L.dismember(BRUTE)
 
 /mob/living/carbon/human/acid_act(acidpwr, acid_volume, bodyzone_hit) //todo: update this to utilize check_obscured_slots() //and make sure it's check_obscured_slots(TRUE) to stop aciding through visors etc


### PR DESCRIPTION
# Document the changes in your pull request
IPC buff
Loosing limbs is brutal

# Wiki Documentation

20% -> 5%

# Changelog

:cl:  
tweak: Easy Dismemberable Robotic limbs now have a 5% chance to dismember on emp
/:cl:
