### PR TITLE
fixes every type of syringe (not just AP) ignoring the armor that is supposed to protect against them

### DIFF
--- a/code/modules/projectiles/projectile/bullets/dart_syringe.dm
+++ b/code/modules/projectiles/projectile/bullets/dart_syringe.dm
@@ -12,7 +12,7 @@
 	if(iscarbon(target))
 		var/mob/living/carbon/C = target
 		if(blocked != 100) // not completely blocked
-			if(C.embed_object(container, def_zone, FALSE))
+			if(C.can_inject(null, FALSE, def_zone, piercing) && C.embed_object(container, def_zone, FALSE))
 				dropped = TRUE
 				..()
 				return BULLET_ACT_HIT


### PR DESCRIPTION
No

# Changelog

:cl:  
bugfix: syringes respect armor like they're supposed to
/:cl:
