### PR TITLE
Restricts CE, RD, and CMO for changlings

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -12,7 +12,7 @@ GLOBAL_VAR(changeling_team_objective_type) //If this is not null, we hand our th
 	antag_flag = ROLE_CHANGELING
 	false_report_weight = 10
 	restricted_jobs = list("AI", "Cyborg")
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Brig Physician") //YOGS - added hop and brig physician
+	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Brig Physician") //YOGS - added hop and brig physician
 	required_players = 15
 	required_enemies = 1
 	recommended_enemies = 4


### PR DESCRIPTION
# Document the changes in your pull request

Syncs it to excluded roles for dynamic clings

# Wiki Documentation

You can no longer spawn in a CE, RD, or CMO

# Changelog

:cl:  
tweak: You can no longer spawn in as a CE, RD, or CMO as a changling
/:cl:
