### PR TITLE
Removes threshold from Regen Coma

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -238,7 +238,6 @@
 	var/active_coma = FALSE //to prevent multiple coma procs
 	threshold_descs = list(
 		"Stealth 2" = "Host appears to die when falling into a coma.",
-		"Resistance 4" = "The virus also stabilizes the host while they are in critical condition.",
 		"Stage Speed 7" = "Increases healing speed.",
 	)
 


### PR DESCRIPTION
Removes unused resistance 4 stabilization threshold on the regen coma symptom. I'm not fixing it because regen coma is already S tier, and self respiration covers this niche.

:cl:  
rscdel: Removes Threshold from regen coma  
/:cl:
