### PR TITLE
Makes Medical Webbing craftable

### DIFF
--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -168,7 +168,7 @@ GLOBAL_LIST_INIT(leather_recipes, list ( \
 	new/datum/stack_recipe("leather shoes", /obj/item/clothing/shoes/laceup, 2), \
 	new/datum/stack_recipe("muzzle", /obj/item/clothing/mask/muzzle, 2), \
 	new/datum/stack_recipe("toolbelt", /obj/item/storage/belt/utility, 4), \
-	new/datum/stack_recipe("medical webbing", /obj/item/storage/belt/medical/mining, 4) \
+	new/datum/stack_recipe("medical webbing", /obj/item/storage/belt/medical/mining, 4), \
 	new/datum/stack_recipe("wallet", /obj/item/storage/wallet, 1), \
 ))
 

--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -168,6 +168,7 @@ GLOBAL_LIST_INIT(leather_recipes, list ( \
 	new/datum/stack_recipe("leather shoes", /obj/item/clothing/shoes/laceup, 2), \
 	new/datum/stack_recipe("muzzle", /obj/item/clothing/mask/muzzle, 2), \
 	new/datum/stack_recipe("toolbelt", /obj/item/storage/belt/utility, 4), \
+	new/datum/stack_recipe("medical webbing", /obj/item/storage/belt/medical/mining, 4) \
 	new/datum/stack_recipe("wallet", /obj/item/storage/wallet, 1), \
 ))
 


### PR DESCRIPTION
# Document the changes in your pull request

You can now use 4 leather to craft a medical webbing much like you can use 4 leather to make a toolbelt

Considering this item is literal clone of the medical belt is only obtainable by spawning as a mining medic this should offer another way to obtain the precious drip

Looks a lot cooler and it'd be neat to be able to get it if you want

# Wiki Documentation

Crafting recipes with leather (probably Guide to Construction) now include Medical Webbing for four leather

# Changelog

:cl:  
rscadd: Medical webbing is now craftable with four leather in hand
/:cl:
