### PR TITLE
Reduces mine spark effect

### DIFF
--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -124,7 +124,7 @@
 		return
 	visible_message(span_danger("[victim] sets off [icon2html(src, viewers(src))] [src]!"))
 	var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
-	s.set_up(3, 1, src)
+	s.set_up(1, 0, src)
 	s.start()
 	mineEffect(victim)
 	triggered = 1


### PR DESCRIPTION
# Document the changes in your pull request

setting off a landmine no-longer sends sparks flying several tiles away.
Doing this to stop landmines chain-reactioning on sparks

# Changelog

:cl:  
tweak: landmines a little less sparky
/:cl:
