### PR TITLE
Make NTOS Crew Manifest program public access

### DIFF
--- a/code/modules/modular_computers/file_system/programs/command/crewmanifest.dm
+++ b/code/modules/modular_computers/file_system/programs/command/crewmanifest.dm
@@ -4,7 +4,6 @@
 	category = PROGRAM_CATEGORY_CMD
 	program_icon_state = "id"
 	extended_desc = "Program for viewing and printing the current crew manifest"
-	transfer_access = ACCESS_HEADS
 	requires_ntnet = FALSE
 	size = 4
 	tgui_id = "NtosCrewManifest"


### PR DESCRIPTION
# Document the changes in your pull request

title

due to PDA change you can no longer rely on the PDA messenger to see jobs

# Changelog

:cl:  
tweak: NTOS Crew Manifest program is now public access
/:cl:
