### PR TITLE
Re-modularizes Yogs Detective Coats

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -718,9 +718,9 @@
 	new /obj/item/clothing/under/yogs/golddetective(src)
 	new /obj/item/clothing/under/yogs/greydetective(src)
 	new /obj/item/clothing/under/yogs/blackdetective(src)
-	new /obj/item/clothing/suit/det_suit/golddetective(src)
-	new /obj/item/clothing/suit/det_suit/detectivecoat(src)
-	new /obj/item/clothing/suit/det_suit/bluedetective(src)
+	new /obj/item/clothing/suit/yogs/golddetective(src)
+	new /obj/item/clothing/suit/yogs/detectivecoat(src)
+	new /obj/item/clothing/suit/yogs/bluedetective(src)
 
 /obj/item/storage/backpack/duffelbag/clothing/sec/warden
 	name = "Warden's clothing duffelbag"

--- a/yogstation/code/modules/clothing/suits/miscellaneous.dm
+++ b/yogstation/code/modules/clothing/suits/miscellaneous.dm
@@ -243,12 +243,16 @@
     icon_state = "caretakerhood"
     flags_inv = HIDEEARS|HIDEEYES|HIDEFACE|HIDEFACIALHAIR|HIDEHAIR
 
-/obj/item/clothing/suit/det_suit/golddetective
+/obj/item/clothing/suit/yogs/golddetective
 	name = "gold detective jacket"
 	desc = "A detective jacket, in gold!"
 	icon_state = "gold_detective"
 	item_state = "gold_item"
-	mutantrace_variation = NO_MUTANTRACE_VARIATION //Check inherits from det_suit
+	armor = list(MELEE = 25, BULLET = 10, LASER = 25, ENERGY = 10, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 45)
+
+/obj/item/clothing/suit/yogs/golddetective/Initialize()
+	. = ..()
+	allowed = GLOB.detective_vest_allowed
 
 /obj/item/clothing/suit/yogs/leathercoat
 	name = "black leather coat"
@@ -268,12 +272,16 @@
 	icon_state = "janitor_coat"
 	item_state = "janitor_item"
 
-/obj/item/clothing/suit/det_suit/detectivecoat
+/obj/item/clothing/suit/yogs/detectivecoat
 	name = "detective long coat"
 	desc = "For those detectives that value fashion over function."
 	icon_state = "detective_coat"
 	item_state = "detective_item"
-	mutantrace_variation = NO_MUTANTRACE_VARIATION //Check inherits from det_suit
+	armor = list(MELEE = 25, BULLET = 10, LASER = 25, ENERGY = 10, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 45)
+
+/obj/item/clothing/suit/yogs/detectivecoat/Initialize()
+	. = ..()
+	allowed = GLOB.detective_vest_allowed
 
 /obj/item/clothing/suit/yogs/blacktrenchcoat
 	name = "black trenchcoat"
@@ -294,12 +302,16 @@
 	icon_state = "monkrobes"
 	item_state = "monkrobes"
 
-/obj/item/clothing/suit/det_suit/bluedetective
+/obj/item/clothing/suit/yogs/bluedetective
 	name = "blue detective jacket"
 	desc = "A detective jacket that is blue!"
 	icon_state = "blue_detective"
 	item_state = "blue_item"
-	mutantrace_variation = NO_MUTANTRACE_VARIATION //Check inherits from det_suit
+	armor = list(MELEE = 25, BULLET = 10, LASER = 25, ENERGY = 10, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 45)
+
+/obj/item/clothing/suit/yogs/bluedetective/Initialize()
+	. = ..()
+	allowed = GLOB.detective_vest_allowed
 
 /obj/item/clothing/suit/hooded/spesshoodie
     mob_overlay_icon = 'yogstation/icons/mob/clothing/suit/suit.dmi'


### PR DESCRIPTION
# Document the changes in your pull request

Fixes the yogs detective coats not having proper sprites because when re-branded they try to call upon a different icons folder.

They have been re-modularized to squash this bug.

# Changelog

:cl:  
bugfix: Non-grungy trenchcoats should be properly visible now
/:cl:
