### PR TITLE
Adds Nagant Revolver to the Russian Surplus Crate

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -616,10 +616,11 @@
 /datum/supply_pack/security/armory/russian
 	name = "Russian Surplus Crate"
 	desc = "Hello Comrade, we have the most modern russian military equipment the black market can offer, for the right price of course. Sadly we couldnt remove the lock so it requires Armory access to open."
-	cost = 5000
+	cost = 7000
 	contraband = TRUE
 	contains = list(/obj/item/reagent_containers/food/snacks/rationpack,
 					/obj/item/ammo_box/a762,
+					/obj/item/ammo_box/n762,
 					/obj/item/storage/toolbox/ammo,
 					/obj/item/clothing/suit/armor/vest/russian,
 					/obj/item/clothing/head/helmet/rus_helmet,
@@ -630,12 +631,13 @@
 					/obj/item/clothing/mask/russian_balaclava,
 					/obj/item/clothing/head/helmet/rus_ushanka,
 					/obj/item/clothing/suit/armor/vest/russian_coat,
+					/obj/item/gun/ballistic/revolver/nagant,
 					/obj/item/gun/ballistic/rifle/boltaction,
 					/obj/item/gun/ballistic/rifle/boltaction)
 	crate_name = "surplus military crate"
 
 /datum/supply_pack/security/armory/russian/fill(obj/structure/closet/crate/C)
-	for(var/i in 1 to 10)
+	for(var/i in 1 to 12)
 		var/item = pick(contains)
 		new item(C)
 
@@ -692,7 +694,7 @@
 
 /datum/supply_pack/security/armory/wt550ammo
 	name = "Surplus Security Autorifle Ammo Crate"
-	desc = "Contains four 20-round magazines for the surplus security autorifle. Each magazine is designed to facilitate rapid tactical reloads. Requires Armory access to open."
+	desc = "Contains four 22-round magazines for the surplus security autorifle. Each magazine is designed to facilitate rapid tactical reloads. Requires Armory access to open."
 	cost = 3000
 	contains = list(/obj/item/ammo_box/magazine/wt550m9,
 					/obj/item/ammo_box/magazine/wt550m9,
@@ -701,7 +703,7 @@
 
 /datum/supply_pack/security/armory/wt550ammo_rubber
 	name = "Surplus Security Autorifle Ammo Crate"
-	desc = "Contains four 20-round less than lethal magazines for the surplus security autorifle. Each magazine is designed to facilitate rapid tactical reloads. Requires Armory access to open."
+	desc = "Contains four 22-round less-than-lethal magazines for the surplus security autorifle. Each magazine is designed to facilitate rapid tactical reloads. Requires Armory access to open."
 	cost = 2500
 	contains = list(/obj/item/ammo_box/magazine/wt550m9/wtr,
 					/obj/item/ammo_box/magazine/wt550m9/wtr,
@@ -710,7 +712,7 @@
 
 /datum/supply_pack/security/armory/wt550ammo_single
 	name = "Surplus Security Autorifle Ammo Crate Single-Pack"
-	desc = "Contains a 20-round magazine for the surplus security autorifle. Each magazine is designed to facilitate rapid tactical reloads. Requires Armory access to open."
+	desc = "Contains a 22-round magazine for the surplus security autorifle. Each magazine is designed to facilitate rapid tactical reloads. Requires Armory access to open."
 	cost = 750 //one of the few single-pack items that who's price per unit is the exact same as the bulk
 	contains = list(/obj/item/ammo_box/magazine/wt550m9)
 	small_item = TRUE


### PR DESCRIPTION
# Document the changes in your pull request

Makes it so you can now get the Nagant revolver through the Russian Surplus crate. It can only give a max of one and the crate can also spawn an ammo box which should contain 14 rounds for the revolver.

In addition, the crate now spawns with 12 items out of 16 instead of 10 out of 14. To offset this plus the fact you can get another weapon, the price has been increased to 7000 from 5000.

Yes, this could mean you get a lot of mosin ammo but no mosin or nagant ammo for mosins however this is most certainly the vibe that the Russian Surplus crate is going for in its uncertainty. Also, as a 20 damage gun that needs each bullet individually loaded and stored, the Nagant is a lot less frightening now. It's certainly still good, but keep in mind it comes in the crate which also has 60 damage rifles.

# Wiki Documentation

Adds Nagant Revolver and a 7.62x38mR ammo box to potential stuff from the Russian Surplus crate, said crate gives 12 random things now, it also costs 7000
Guide to Combat needs to rectify that Nagant can be ordered through cargo now

# Changelog

:cl:  
rscadd: Adds Nagant revolver and ammo for it as potential things to get from the Russian Surplus Crate
tweak: Russian Surplus now gives more stuff but is more expensive
tweak: Fixes a typo in the descriptions for the WT magazine crates
/:cl:
