### PR TITLE
Fixes Regal Rats & Reenables them

### DIFF
--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -1,4 +1,4 @@
-#define REGAL_RAT_CHANCE 0
+#define REGAL_RAT_CHANCE 2
 #define PLAGUE_RAT_CHANCE 0
 SUBSYSTEM_DEF(minor_mapping)
 	name = "Minor Mapping"

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -97,9 +97,9 @@ GLOBAL_VAR_INIT(mouse_killed, 0)
 		if(!stat)
 			var/mob/M = AM
 			to_chat(M, span_notice("[icon2html(src, M)] Squeak!"))
-	//if(istype(AM, /obj/item/reagent_containers/food/snacks/royalcheese))
-	//	evolve()
-	//	qdel(AM)
+	if(istype(AM, /obj/item/reagent_containers/food/snacks/royalcheese))
+		evolve()
+		qdel(AM)
 	..()
 
 /mob/living/simple_animal/mouse/handle_automated_action()
@@ -121,10 +121,10 @@ GLOBAL_VAR_INIT(mouse_killed, 0)
 			be_fruitful()
 			qdel(cheese)
 			return
-	//for(var/obj/item/reagent_containers/food/snacks/royalcheese/bigcheese in range(1, src))
-	//	qdel(bigcheese)
-	//	evolve()
-	//	return
+	for(var/obj/item/reagent_containers/food/snacks/royalcheese/bigcheese in range(1, src))
+		qdel(bigcheese)
+		evolve()
+		return
 
 
 /**
@@ -267,9 +267,9 @@ GLOBAL_VAR_INIT(mouse_killed, 0)
 	var/list/cheeses = list(/obj/item/reagent_containers/food/snacks/cheesewedge, /obj/item/reagent_containers/food/snacks/cheesewheel,
 							/obj/item/reagent_containers/food/snacks/store/cheesewheel, /obj/item/reagent_containers/food/snacks/customizable/cheesewheel,
 							/obj/item/reagent_containers/food/snacks/cheesiehonkers) //all cheeses - royal
-	//if(istype(F, /obj/item/reagent_containers/food/snacks/royalcheese))
-	//	evolve()
-	//	return
+	if(istype(F, /obj/item/reagent_containers/food/snacks/royalcheese))
+		evolve()
+		return
 	if(istype(F, /obj/item/grown/bananapeel/bluespace))
 		var/obj/item/grown/bananapeel/bluespace/B
 		var/teleport_radius = max(round(B.seed.potency / 10), 1)

--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -192,10 +192,10 @@
 	background_icon_state = "bg_clock"
 	button_icon_state = "smoke"
 
-/datum/action/cooldown/domain/proc/domain()
+/datum/action/cooldown/domain/Trigger()
 	var/turf/T = owner.loc
 	if(!istype(T))
-		return
+		return FALSE
 	T.atmos_spawn_air("miasma=4;TEMP=[T20C]")
 	switch (rand(1,10))
 		if (8)
@@ -206,10 +206,6 @@
 			new /obj/effect/decal/cleanable/oil/slippery(T)
 		else
 			new /obj/effect/decal/cleanable/dirt(T)
-	StartCooldown()
-
-/datum/action/cooldown/domain/Trigger()
-	domain()
 	StartCooldown()
 
 #define REGALRAT_INTERACTION "regalrat"

--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -103,8 +103,8 @@
 	. = ..()
 	if(!.)
 		return
-	var/turf/T = get_turf(owner)
-	if(!T)
+	var/turf/T = owner.loc
+	if(!istype(T))
 		return
 	var/loot = rand(1,100)
 	switch(loot)

--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -104,6 +104,7 @@
 		return
 	var/turf/T = owner.loc
 	if(!istype(T))
+		to_chat(owner, "There is no cheese in here!")
 		return
 	var/loot = rand(1,100)
 	switch(loot)
@@ -195,6 +196,7 @@
 /datum/action/cooldown/domain/Trigger()
 	var/turf/T = owner.loc
 	if(!istype(T))
+		to_chat(owner, "Building our domain here is for cowards!")
 		return FALSE
 	T.atmos_spawn_air("miasma=4;TEMP=[T20C]")
 	switch (rand(1,10))

--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -47,7 +47,6 @@
 	var/title = pick("King","Lord","Prince","Emperor","Supreme","Overlord","Master","Shogun","Bojar","Tsar","Hetman")
 	name = "[kingdom] [title]"
 	language_holder += new /datum/language_holder/mouse(src)
-	qdel(src)
 
 /mob/living/simple_animal/hostile/regalrat/handle_automated_action()
 	if(prob(20))
@@ -77,7 +76,7 @@
 			. += "<span class='notice'>This is your king. Long live his majesty!</span>"
 		else
 			. += "<span class='warning'>This is a false king! Strike him down!</span>"
-	else if(istype(user,/mob/living/simple_animal/hostile/regalrat))
+	else if(istype(user,/mob/living/simple_animal/hostile/regalrat) && (user != src))
 		. += "<span class='warning'>Who is this foolish false king? This will not stand!</span>"
 
 /mob/living/simple_animal/hostile/regalrat/handle_environment(datum/gas_mixture/environment)
@@ -188,14 +187,14 @@
 	name = "Rat King's Domain"
 	desc = "Corrupts this area to be more suitable for your rat army."
 	check_flags = AB_CHECK_CONSCIOUS
-	cooldown_time = 6 SECONDS
+	cooldown_time = 10 SECONDS
 	icon_icon = 'icons/mob/actions/actions_spells.dmi'
 	background_icon_state = "bg_clock"
 	button_icon_state = "smoke"
 
 /datum/action/cooldown/domain/proc/domain()
-	var/turf/T = get_turf(owner)
-	if(!T)
+	var/turf/T = owner.loc
+	if(!istype(T))
 		return
 	T.atmos_spawn_air("miasma=4;TEMP=[T20C]")
 	switch (rand(1,10))
@@ -210,7 +209,6 @@
 	StartCooldown()
 
 /datum/action/cooldown/domain/Trigger()
-	StartCooldown(10 SECONDS)
 	domain()
 	StartCooldown()
 
@@ -230,7 +228,7 @@
 			target.reagents.add_reagent(/datum/reagent/rat_spit, rand(1,3), no_react = TRUE)
 			to_chat(src, span_notice("You finish licking [target]."))
 	else if(istype(target, /obj/item/reagent_containers/food/snacks/cheesewedge))
-		to_chat(src, span_green("You eat [src], restoring some health."))
+		to_chat(src, span_green("You eat [target], restoring some health."))
 		heal_bodypart_damage(30)
 		qdel(target)
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -664,6 +664,9 @@ DISABLE_HUMAN_MOOD
 ## A cap on how many monkeys may be created via monkey cubes
 #MONKEYCAP 64
 
+## Cap on how many regal rat minions there can be
+RATCAP 64
+
 ## Enable the capitalist agenda on your server.
 ECONOMY
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -665,7 +665,7 @@ DISABLE_HUMAN_MOOD
 #MONKEYCAP 64
 
 ## Cap on how many regal rat minions there can be
-RATCAP 64
+#RATCAP 64
 
 ## Enable the capitalist agenda on your server.
 ECONOMY


### PR DESCRIPTION
# Document the changes in your pull request

The biggest problem was the use of `get_turf()` because it will always get the turf. We use `loc` instead as if your inside of a pipe the loc is well `.../pipe` and we can `istype(T)` it

The config option for ratcap was missing

Fixes examining yourself calling you a foolish king

Eating no longer tell you that your eating yourself

And finally turns them back on

### Todo
- [x] Add Nonturf text warning

# Wiki Documentation

Reenabled

# Changelog

:cl:  
bugfix: Eating as a regal rat no longer tells you that your eating yourself
bugfix: Examinning yourself as a regal rat no longer calls you a foolish king
bugfix: You now cant use ability in nonturfs as a regal rat
rscadd: Regal rats reenabled
/:cl:
