### PR TITLE
should prevent admin spqned xeno queens from causing shuttle shenanigans

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -25,8 +25,9 @@
 	var/datum/action/small_sprite/smallsprite = new/datum/action/small_sprite/queen()
 
 /mob/living/carbon/alien/humanoid/royal/queen/Initialize()
-	SSshuttle.registerHostileEnvironment(src) //yogs: aliens delay shuttle
-	addtimer(CALLBACK(src, .proc/game_end), 30 MINUTES) //yogs: time until shuttle is freed/called
+	if(!is_centcom_level(get_turf(src)))
+		SSshuttle.registerHostileEnvironment(src) //yogs: aliens delay shuttle
+		addtimer(CALLBACK(src, .proc/game_end), 30 MINUTES) //yogs: time until shuttle is freed/called
 	//there should only be one queen
 	for(var/mob/living/carbon/alien/humanoid/royal/queen/Q in GLOB.carbon_list)
 		if(Q == src)
@@ -53,11 +54,14 @@
 	..()
 
 /mob/living/carbon/alien/humanoid/royal/queen/proc/game_end()
-	if(stat != DEAD)
-		SSshuttle.clearHostileEnvironment(src)
-		if(EMERGENCY_IDLE_OR_RECALLED)
-			priority_announce("Xenomorph infestation detected: Emergency shuttle will be sent to recover any survivors, if this is in error feel free to recall.")
-			SSshuttle.emergency.request(null, set_coefficient=0.5)
+	if(is_centcom_level(get_turf(src)))
+		return
+	if(stat == DEAD)
+		return
+	SSshuttle.clearHostileEnvironment(src)
+	if(EMERGENCY_IDLE_OR_RECALLED)
+		priority_announce("Xenomorph infestation detected: Emergency shuttle will be sent to recover any survivors, if this is in error feel free to recall.")
+		SSshuttle.emergency.request(null, set_coefficient=0.5)
 
 /mob/living/carbon/alien/humanoid/royal/queen/death()//yogs start: dead queen doesnt stop shuttle
 	SSshuttle.clearHostileEnvironment(src)


### PR DESCRIPTION
admin spawned xeno queens should no longer cause massive uhoh stinky bullshit to the shuttle

:cl:  
bugfix: admin spawned xeno queens should no longer cause massive uhoh stinky bullshit to the shuttle
/:cl:
