### PR TITLE
New ash drake fire buff doesn't stack 5 morbillion fire stacks directly in front of its snout

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -278,23 +278,22 @@ Difficulty: Medium
 		if(istype(T, /turf/closed))
 			break
 		var/obj/effect/hotspot/hot_hot_there_is_already_fire_here_why_would_you_make_more = locate() in T
-		if(hot_hot_there_is_already_fire_here_why_would_you_make_more)
-			continue
-		new /obj/effect/hotspot(T)
-		T.hotspot_expose(700,50,1)
-		for(var/mob/living/L in T.contents)
-			if(L in hit_list || L == source)
-				continue
-			hit_list += L
-			L.adjustFireLoss(30)
-			to_chat(L, span_userdanger("You're hit by [source]'s fire breath!"))
+		if(!hot_hot_there_is_already_fire_here_why_would_you_make_more)
+			new /obj/effect/hotspot(T)
+			T.hotspot_expose(700,50,1)
+			for(var/mob/living/L in T.contents)
+				if(L in hit_list || L == source)
+					continue
+				hit_list += L
+				L.adjustFireLoss(30)
+				to_chat(L, span_userdanger("You're hit by [source]'s fire breath!"))
 
-		// deals damage to mechs
-		for(var/obj/mecha/M in T.contents)
-			if(M in hit_list)
-				continue
-			hit_list += M
-			M.take_damage(45, BRUTE, MELEE, 1)
+			// deals damage to mechs
+			for(var/obj/mecha/M in T.contents)
+				if(M in hit_list)
+					continue
+				hit_list += M
+				M.take_damage(45, BRUTE, MELEE, 1)
 		sleep(0.15 SECONDS)
 
 /mob/living/simple_animal/hostile/megafauna/dragon/proc/swoop_attack(lava_arena = FALSE, atom/movable/manual_target, var/swoop_cooldown = 30)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -277,6 +277,9 @@ Difficulty: Medium
 	for(var/turf/T in turfs)
 		if(istype(T, /turf/closed))
 			break
+		var/obj/effect/hotspot/hot_hot_there_is_already_fire_here_why_would_you_make_more = locate() in T
+		if(hot_hot_there_is_already_fire_here_why_would_you_make_more)
+			continue
 		new /obj/effect/hotspot(T)
 		T.hotspot_expose(700,50,1)
 		for(var/mob/living/L in T.contents)


### PR DESCRIPTION
# Document the changes in your pull request

whgat if you were hit 500 times what if though that would be funny

line already has anti-frustration behavior in that you can only be hit once a line anyway

keeps bossfight cool and challenging without instantly killing you 

# Changelog

:cl: ToasterBiome, Lazenn, VaelophisNyx, SomeguyManperson, ynot01, Mqiib, Jesus Christ himself
tweak: ash drake fire line no longer stacks multiple in front of itself
/:cl:
