### PR TITLE
Limits Abductors to 25 Pop

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -669,6 +669,7 @@
 	requirements = list(101,101,101,80,60,50,30,20,10,10)
 	repeatable = TRUE
 	var/datum/team/abductor_team/new_team
+	minimum_players = 25
 
 /datum/dynamic_ruleset/midround/from_ghosts/abductors/ready(forced = FALSE)
 	if (required_candidates > (dead_players.len + list_observers.len))

--- a/code/modules/events/abductor.dm
+++ b/code/modules/events/abductor.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/ghost_role/abductor
 	weight = 12
 	max_occurrences = 1
-	min_players = 20
+	min_players = 25
 	gamemode_blacklist = list("nuclear","wizard","revolution")
 
 /datum/round_event/ghost_role/abductor


### PR DESCRIPTION
# Document the changes in your pull request

mmm I love the antag that can cause absolute nightmare chaos on *60 pop* doing it at 15 pop, where there's noone to stop or fix it :)

# Changelog

:cl:  
tweak: Midround Abductors are now pop limited
/:cl:
