### PR TITLE
Makes robo control program free-access and limits bot control to access

### DIFF
--- a/code/modules/modular_computers/file_system/programs/science/robocontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/science/robocontrol.dm
@@ -5,7 +5,6 @@
 	category = PROGRAM_CATEGORY_SCI
 	program_icon_state = "robot"
 	extended_desc = "A remote controller used for giving basic commands to non-sentient robots."
-	transfer_access = ACCESS_ROBOTICS
 	requires_ntnet = TRUE
 	network_destination = "robotics control network"
 	size = 12
@@ -39,8 +38,8 @@
 
 	for(var/B in GLOB.bots_list)
 		var/mob/living/simple_animal/bot/Bot = B
-		if(!Bot.on || Bot.z != zlevel || Bot.remote_disabled) //Only non-emagged bots on the same Z-level are detected!
-			continue //Also, the PDA must have access to the bot type.
+		if(!Bot.on || Bot.z != zlevel || Bot.remote_disabled || !Bot.bot_core.check_access(computer.GetAccess()))
+			continue //Only non-emagged bots on the same Z-level are detected! Also, the PDA must have access to the bot type.
 		var/list/newbot = list("name" = Bot.name, "mode" = Bot.get_mode_ui(), "model" = Bot.model, "locat" = get_area(Bot), "bot_ref" = REF(Bot), "mule_check" = FALSE)
 		if(Bot.bot_type == MULE_BOT)
 			var/mob/living/simple_animal/bot/mulebot/MULE = Bot

--- a/code/modules/modular_computers/file_system/programs/science/robocontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/science/robocontrol.dm
@@ -38,7 +38,7 @@
 
 	for(var/B in GLOB.bots_list)
 		var/mob/living/simple_animal/bot/Bot = B
-		if(!Bot.on || Bot.z != zlevel || Bot.remote_disabled || !Bot.bot_core.check_access(computer.GetAccess()))
+		if(!Bot.on || Bot.z != zlevel || Bot.remote_disabled || !Bot.bot_core.check_access(computer))
 			continue //Only non-emagged bots on the same Z-level are detected! Also, the PDA must have access to the bot type.
 		var/list/newbot = list("name" = Bot.name, "mode" = Bot.get_mode_ui(), "model" = Bot.model, "locat" = get_area(Bot), "bot_ref" = REF(Bot), "mule_check" = FALSE)
 		if(Bot.bot_type == MULE_BOT)


### PR DESCRIPTION
# Document the changes in your pull request

Comments and surrounding code suggest this was supposed to exist but it was incomplete.

# Changelog

:cl:  
tweak: Made NTOS Robo Control free access
tweak: Made NTOS Robo Control only allow control to bots you have access to
/:cl:
