### PR TITLE
Makes NIRN accessible for PDA

### DIFF
--- a/code/modules/modular_computers/file_system/programs/supply/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/supply/budgetordering.dm
@@ -5,7 +5,7 @@
 	program_icon_state = "bountyboard"
 	extended_desc = "Nanotrasen Internal Requisition Network interface for supply purchasing using a department budget account."
 	requires_ntnet = TRUE
-	usage_flags = PROGRAM_CONSOLE | PROGRAM_LAPTOP | PROGRAM_TABLET | PROGRAM_PHONE | PROGRAM_TELESCREEN
+	usage_flags = PROGRAM_CONSOLE | PROGRAM_LAPTOP | PROGRAM_TABLET | PROGRAM_PHONE | PROGRAM_TELESCREEN | PROGRAM_PDA
 	size = 20
 	tgui_id = "NtosCargo"
 	program_icon = "store"


### PR DESCRIPTION
Why? Because why not

# Document the changes in your pull request
PDA can download NRIN


# Wiki Documentation
NIRN available for PDA

# Changelog


:cl:  

tweak: NIRN is available for PDA
/:cl:
