### PR TITLE
makes bullets easier to land hits with

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -9,6 +9,7 @@
 	sharpness = SHARP_POINTY
 	impact_effect_type = /obj/effect/temp_visual/impact_effect
 	wound_falloff_tile = -5
+	speed = 0.4
 
 /obj/item/projectile/bullet/smite
 	name = "divine retribution"

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -2,7 +2,7 @@
 
 /obj/item/projectile/bullet/p50
 	name =".50 bullet"
-	speed = 0.4
+	speed = 0.3
 	damage = 70
 	paralyze = 100
 	dismemberment = 50


### PR DESCRIPTION
# Document the changes in your pull request

All bullets have been doubled in speed (0.8 deciseconds per tile -> 0.4)

Sniper rounds have been buffed to accomodate (0.4 -> 0.3)

Energy/non-bullet projectiles untouched

## Rationale

i think this will incorporate an interesting new dynamic to bullet vs energy combat

bullets should not be outran or dodged

bullet gameplay will be improved when you click on someone and the shot connects unless they dodge it by a hair which can still happen

energy weapons can go through glass and are usually much more spammable than bullet weapons and are not bullets

# Changelog

:cl:  
tweak: bullets are now twice as fast
/:cl:
