### PR TITLE
Adjusts damage slowdown algorithm to be less harsh starting out

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1441,7 +1441,7 @@ GLOBAL_LIST_EMPTY(mentor_races)
 					health_deficiency *= 0.5
 				if(flight)
 					health_deficiency *= 0.333
-				if(health_deficiency < 100) // https://i.imgur.com/W4nusN8.png
+				if(health_deficiency < 100) // https://i.imgur.com/W4nusN8.png https://www.desmos.com/calculator/qsf6iakqgp
 					. += (health_deficiency / 50) ** 2.58
 				else
 					. += (health_deficiency / 100) + 5

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1440,9 +1440,11 @@ GLOBAL_LIST_EMPTY(mentor_races)
 				if(HAS_TRAIT(H, TRAIT_RESISTDAMAGESLOWDOWN))
 					health_deficiency *= 0.5
 				if(flight)
-					. += (health_deficiency / 75)
+					health_deficiency *= 0.333
+				if(health_deficiency < 100) // https://i.imgur.com/W4nusN8.png
+					. += (health_deficiency / 50) ** 2.58
 				else
-					. += (health_deficiency / 25)
+					. += (health_deficiency / 100) + 5
 		if(CONFIG_GET(flag/disable_human_mood) && !H.mood_enabled) // Yogs -- Mood as preference
 			if(!HAS_TRAIT(H, TRAIT_NOHUNGER))
 				var/hungry = (500 - H.nutrition) / 5 //So overeat would be 100 and default level would be 80


### PR DESCRIPTION
# Document the changes in your pull request

Currently, hitting that 40 damage threshold spells death.

This will make it so damage slowdown is less impactful when it first crosses the threshold, but once you start teetering towards death it will become harder hitting.

Graph comparing the formulas

40 being the usual damage slowdown threshold

Red being current calculation

Blue being the proposed change

![](https://i.imgur.com/jk7sAJV.png)

# Changelog

:cl:  
tweak: adjusted damage slowdown to be exponential instead of linear  
/:cl:
