### PR TITLE
Dankpockets now subtype of donkpockets & dank pizza now costs cannabis not ambrosia vulgaris

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_pastry.dm
+++ b/code/modules/food_and_drinks/food/snacks_pastry.dm
@@ -270,13 +270,22 @@
 /obj/item/reagent_containers/food/snacks/donkpocket/warm/MakeBakeable()
 	AddComponent(/datum/component/bakeable, /obj/item/reagent_containers/food/snacks/badrecipe, rand(10 SECONDS, 15 SECONDS), FALSE)
 
-/obj/item/reagent_containers/food/snacks/dankpocket
+/obj/item/reagent_containers/food/snacks/donkpocket/dank
 	name = "dankpocket"
 	desc = "The food of choice for the seasoned botanist."
 	icon_state = "dankpocket"
-	list_reagents = list(/datum/reagent/toxin/lipolicide = 3, /datum/reagent/drug/space_drugs = 3, /datum/reagent/consumable/nutriment = 4)
+	list_reagents = list(/datum/reagent/drug/space_drugs = 1, /datum/reagent/consumable/nutriment = 1)
+	cooked_type = /obj/item/reagent_containers/food/snacks/donkpocket/warm/dank
 	filling_color = "#00FF00"
-	tastes = list("meat" = 2, "dough" = 2)
+	tastes = list("grass" = 2, "dough" = 2)
+	foodtype = GRAIN | VEGETABLES
+
+/obj/item/reagent_containers/food/snacks/dankpocket/warm
+	name = "warm dankpocket"
+	desc = "The food of choice for the seasoned botanist. Smells danker now."
+	icon_state = "dankpocket"
+	list_reagents = list(/datum/reagent/toxin/lipolicide = 3, /datum/reagent/drug/space_drugs = 3, /datum/reagent/consumable/nutriment = 4)
+	tastes = list("grass" = 2, "dough" = 2, "drugs" = 2)
 	foodtype = GRAIN | VEGETABLES
 
 /obj/item/reagent_containers/food/snacks/donkpocket/spicy

--- a/code/modules/food_and_drinks/food/snacks_pastry.dm
+++ b/code/modules/food_and_drinks/food/snacks_pastry.dm
@@ -280,7 +280,7 @@
 	tastes = list("grass" = 2, "dough" = 2)
 	foodtype = GRAIN | VEGETABLES
 
-/obj/item/reagent_containers/food/snacks/dankpocket/warm
+/obj/item/reagent_containers/food/snacks/donkpocket/warm/dank
 	name = "warm dankpocket"
 	desc = "The food of choice for the seasoned botanist. Smells danker now."
 	icon_state = "dankpocket"

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
@@ -199,7 +199,7 @@ datum/crafting_recipe/food/donut/meat
 		/obj/item/reagent_containers/food/snacks/pastrybase = 1,
 		/obj/item/reagent_containers/food/snacks/grown/cannabis = 1
 	)
-	result = /obj/item/reagent_containers/food/snacks/dankpocket
+	result = /obj/item/reagent_containers/food/snacks/donkpocket/dank
 	subcategory = CAT_PASTRY
 
 /datum/crafting_recipe/food/donkpocket/spicy

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pizza.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pizza.dm
@@ -19,7 +19,7 @@
 	name = "Dank Pizza"
 	reqs = list(
 		/obj/item/reagent_containers/food/snacks/flatdough = 1,
-		/obj/item/reagent_containers/food/snacks/grown/ambrosia/vulgaris = 3,
+		/obj/item/reagent_containers/food/snacks/grown/cannabis = 3,
 		/obj/item/reagent_containers/food/snacks/cheesewedge = 1,
 		/obj/item/reagent_containers/food/snacks/grown/tomato = 1
 	)


### PR DESCRIPTION
# Document the changes in your pull request

fixes [15554](https://github.com/yogstation13/Yogstation/issues/15554)

you can cook the dank pockets now (and gotta to get much use out of them)
also makes dank pockets not taste of meat, since they dont contain any?
and makes dank pizza cost cannabis leaves instead of vulgaris leaves, for consistency

# Wiki Documentation

Guide to Food will need both of these updated.

# Changelog

:cl:  
tweak: Dankpockets can now be cooked
tweak: Dank Pizza now costs cannabis leaves not ambrosia vulgaris leaves
/:cl:
