### PR TITLE
NTOS Download based on distance

### DIFF
--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -58,7 +58,7 @@
 //NTNet transfer speeds, used when downloading/uploading a file/program.
 #define NTNETSPEED_LOWSIGNAL 0.5	// GQ/s transfer speed when the device is wirelessly connected and on Low signal
 #define NTNETSPEED_HIGHSIGNAL 1	// GQ/s transfer speed when the device is wirelessly connected and on High signal
-#define NTNETSPEED_ETHERNET 2		// GQ/s transfer speed when the device is using wired connection
+#define NTNETSPEED_ETHERNET 3		// GQ/s transfer speed when the device is using wired connection
 
 //Caps for NTNet logging. Less than 10 would make logging useless anyway, more than 500 may make the log browser too laggy. Defaults to 100 unless user changes it.
 #define MAX_NTNET_LOGS 300

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -119,15 +119,15 @@
 		if(3)
 			download_netspeed = NTNETSPEED_ETHERNET
 	
-	var/dist = 100
-	// Loop through every ntnet relay, find the closest one and use that
-	for(var/obj/machinery/ntnet_relay/n in SSnetworks.station_network.relays)
-		var/cur_dist = get_dist_euclidian(n, computer)
-		if(n.is_operational() && cur_dist <= dist)
-			dist = cur_dist
-	
-	// At 0 tiles distance, 3x download speed. At 100 tiles distance, 1x download speed.
-	download_netspeed *= max((-dist/50) + 3, 1)
+	if(ntnet_status != 3) // Ethernet unaffected by distance
+		var/dist = 100
+		// Loop through every ntnet relay, find the closest one and use that
+		for(var/obj/machinery/ntnet_relay/n in SSnetworks.station_network.relays)
+			var/cur_dist = get_dist_euclidian(n, computer)
+			if(n.is_operational() && cur_dist <= dist)
+				dist = cur_dist
+		// At 0 tiles distance, 3x download speed. At 100 tiles distance, 1x download speed.
+		download_netspeed *= max((-dist/50) + 3, 1)
 
 	download_completion = min(downloaded_file.size, download_completion + download_netspeed) // Add the progress
 

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -127,7 +127,7 @@
 			dist = cur_dist
 	
 	// At 0 tiles distance, 3x download speed. At 100 tiles distance, 1x download speed.
-	download_completion *= max((-dist/50) + 3, 1)
+	download_netspeed *= max((-dist/50) + 3, 1)
 	download_completion += download_netspeed
 
 /datum/computer_file/program/ntnetdownload/ui_act(action, params)

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -110,7 +110,7 @@
 		complete_file_download()
 	// Download speed according to connectivity state. NTNet server is assumed to be on unlimited speed so we're limited by our local connectivity
 	download_netspeed = 0
-	// Speed defines are found in misc.dm
+	// Speed defines are found in code/__DEFINES/machines.dm
 	switch(ntnet_status)
 		if(1)
 			download_netspeed = NTNETSPEED_LOWSIGNAL
@@ -118,6 +118,16 @@
 			download_netspeed = NTNETSPEED_HIGHSIGNAL
 		if(3)
 			download_netspeed = NTNETSPEED_ETHERNET
+	
+	var/dist = 100
+	// Loop through every ntnet relay, find the closest one and use that
+	for(var/obj/machinery/ntnet_relay/n in SSnetworks.station_network.relays)
+		var/cur_dist = get_dist_euclidian(n, computer)
+		if(n.is_operational() && cur_dist <= dist)
+			dist = cur_dist
+	
+	// At 0 tiles distance, 3x download speed. At 100 tiles distance, 1x download speed.
+	download_completion *= max((-dist/50) + 3, 1)
 	download_completion += download_netspeed
 
 /datum/computer_file/program/ntnetdownload/ui_act(action, params)

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -128,7 +128,8 @@
 	
 	// At 0 tiles distance, 3x download speed. At 100 tiles distance, 1x download speed.
 	download_netspeed *= max((-dist/50) + 3, 1)
-	download_completion += download_netspeed
+
+	download_completion = min(downloaded_file.size, download_completion + download_netspeed) // Add the progress
 
 /datum/computer_file/program/ntnetdownload/ui_act(action, params)
 	if(..())


### PR DESCRIPTION
# Document the changes in your pull request

Download speed now increases the closer you are to a NTNet Relay (Usually in tcomms)

Uses euclidean distance, so think of it as a circle instead of a square

![](https://i.imgur.com/9YoL2ke.png)

At 0 tiles distance, you will download 3x faster

At 100 tiles distance, you will download the same speed as before (1x)

Default network card will now download at 0.5-1.5 GQ/s
Advanced network card will now download at 1-3 GQ/s
Ethernet (computers) are unaffected by distance but have been bumped up in speed 2->3 GQ/s

## BoxStation distances:

Center Evac is ~90 tiles away (1.2x)

R&D desk is ~80 tiles away (1.4x)

Engineering Foyer is ~50 tiles away (2x)

Brig Central is ~40 tiles away (2.2x)

Medical Treatment is ~40 tiles away (2.2x)

Cargo Office is ~30 tiles away (2.4x)

Center of Bridge is ~4 tiles away (2.92x)

Net Admin chair is ~12 tiles away (2.76x)

##

Also fixed downloading more than what you are supposed to (completion % going over 100%)

# Changelog

:cl:   
tweak: NTOS Download speed now increases the closer you are to a NTNet Relay
bugfix: fixed downloading more GQ than the file had
/:cl:
