### PR TITLE
fix a harmless NTOS runtime

### DIFF
--- a/code/modules/modular_computers/computers/item/laptop/laptop_presets.dm
+++ b/code/modules/modular_computers/computers/item/laptop/laptop_presets.dm
@@ -7,7 +7,6 @@
 
 /obj/item/modular_computer/laptop/preset/civillian
 	desc = "A low-end laptop often used for personal recreation."
-	starting_files = list(new /datum/computer_file/program/chatclient)
 
 /obj/item/modular_computer/laptop/preset/brig_physician
 	desc = "A low-end laptop often used by brig physicians."

--- a/code/modules/modular_computers/computers/item/phone/phone_presets.dm
+++ b/code/modules/modular_computers/computers/item/phone/phone_presets.dm
@@ -32,8 +32,7 @@
 								/obj/item/computer_hardware/sensorpackage)
 
 /obj/item/modular_computer/tablet/phone/preset/advanced/command
-	starting_files = list(	new /datum/computer_file/program/chatclient,
-							new /datum/computer_file/program/budgetorders,
+	starting_files = list(	new /datum/computer_file/program/budgetorders,
 							new /datum/computer_file/program/card_mod)
 	starting_components = list( /obj/item/computer_hardware/processor_unit/small,
 								/obj/item/stock_parts/cell/computer,
@@ -51,8 +50,7 @@
 	RegisterSignal(src, COMSIG_PDA_CHECK_DETONATE, .proc/pda_no_detonate)
 
 /obj/item/modular_computer/tablet/phone/preset/advanced/command/hop
-	starting_files = list(	new /datum/computer_file/program/chatclient,
-							new /datum/computer_file/program/budgetorders,
+	starting_files = list(	new /datum/computer_file/program/budgetorders,
 							new /datum/computer_file/program/card_mod,
 							new /datum/computer_file/program/cargobounty)
 	finish_color = "brown"
@@ -69,23 +67,20 @@
 								/obj/item/computer_hardware/card_slot/secondary,
 								/obj/item/computer_hardware/sensorpackage)
 
-	starting_files = list(	new /datum/computer_file/program/chatclient,
-							new /datum/computer_file/program/budgetorders,
+	starting_files = list(	new /datum/computer_file/program/budgetorders,
 							new /datum/computer_file/program/card_mod,
 							new /datum/computer_file/program/alarm_monitor)
 	finish_color = "orange"
 
 /obj/item/modular_computer/tablet/phone/preset/advanced/command/rd
-	starting_files = list(	new /datum/computer_file/program/chatclient,
-							new /datum/computer_file/program/budgetorders,
+	starting_files = list(	new /datum/computer_file/program/budgetorders,
 							new /datum/computer_file/program/card_mod,
 							new /datum/computer_file/program/robocontrol)
 	finish_color = "purple"
 	pen_type = /obj/item/pen/fountain
 
 /obj/item/modular_computer/tablet/phone/preset/advanced/command/cmo
-	starting_files = list(	new /datum/computer_file/program/chatclient,
-							new /datum/computer_file/program/budgetorders,
+	starting_files = list(	new /datum/computer_file/program/budgetorders,
 							new /datum/computer_file/program/card_mod,
 							new /datum/computer_file/program/crew_monitor)
 	finish_color = "white"


### PR DESCRIPTION
# Document the changes in your pull request

NTOS would runtime trying to install the chat_client as a starting_file because it already exists on the hard drive, and would continue to install the others after reporting the runtime

no changelog because there are no user-facing changes