### PR TITLE
Kills off Orion references mostly

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_medical.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_medical.dmm
@@ -1067,21 +1067,6 @@
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall/mineral/titanium,
 /area/ruin/powered)
-"cl" = (
-/obj/machinery/door/airlock/glass_large{
-	name = "Orion Medical Outpost V"
-	},
-/obj/structure/fans/tiny/invisible,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8;
-	icon_state = "tile_corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4;
-	icon_state = "tile_corner"
-	},
-/turf/open/floor/plasteel/white,
-/area/ruin/powered)
 "cm" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
@@ -1127,6 +1112,21 @@
 	icon_state = "tile_corner"
 	},
 /turf/open/floor/plasteel,
+/area/ruin/powered)
+"uk" = (
+/obj/machinery/door/airlock/glass_large{
+	name = "SIC Medical Outpost V"
+	},
+/obj/structure/fans/tiny/invisible,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4;
+	icon_state = "tile_corner"
+	},
+/turf/open/floor/plasteel/white,
 /area/ruin/powered)
 "wO" = (
 /obj/effect/turf_decal/tile/blue,
@@ -1715,7 +1715,7 @@ by
 bT
 by
 by
-cl
+uk
 ZO
 Yg
 cn

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -406,9 +406,9 @@
 	unpickable = TRUE //council-vote
 
 /datum/map_template/ruin/lavaland/medical
-	name = "Orion Medical Outpost"
+	name = "SIC Medical Outpost"
 	id = "medical"
-	description = "One of the Orion Medical Outposts was teleported after a bluespace anomaly"
+	description = "One of the SIC Medical Outposts was teleported after a bluespace anomaly"
 	suffix = "lavaland_surface_medical.dmm"
 	allow_duplicates = FALSE
 	cost = 15

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -374,7 +374,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 
 /obj/machinery/computer/arcade/orion_trail
 	name = "The Orion Trail"
-	desc = "Learn how our ancestors got to Orion, and have fun in the process!"
+	desc = "Learn how our ancestors planned to colonize Orion, and have fun in the process!"
 	icon_state = "arcade"
 	circuit = /obj/item/circuitboard/computer/arcade/orion_trail
 	var/busy = FALSE //prevent clickspam that allowed people to ~speedrun~ the game.
@@ -461,7 +461,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	var/dat = ""
 	if(gameStatus == ORION_STATUS_GAMEOVER)
 		dat = "<center><h1>Game Over</h1></center>"
-		dat += "Like many before you, your crew never made it to Orion, lost to space... <br><b>Forever</b>."
+		dat += "Like all before you, your crew never made it to Orion, lost to space... <br><b>Forever</b>."
 		if(!settlers.len)
 			dat += "<br>Your entire crew died, and your ship joins the fleet of ghost-ships littering the galaxy."
 		else
@@ -484,7 +484,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 			obj_flags &= ~EMAGGED //removes the emagged status after you lose
 			gameStatus = ORION_STATUS_START
 			name = "The Orion Trail"
-			desc = "Learn how our ancestors got to Orion, and have fun in the process!"
+			desc = "Learn how our ancestors planned to colonize Orion, and have fun in the process!"
 
 		dat += "<P ALIGN=Right><a href='byond://?src=[REF(src)];menu=1'>May They Rest In Peace</a></P>"
 	else if(event)
@@ -506,7 +506,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 		dat += "<P ALIGN=Right><a href='byond://?src=[REF(src)];close=1'>Close</a></P>"
 	else
 		dat = "<center><h2>The Orion Trail</h2></center>"
-		dat += "<br><center><h3>Experience the journey of your ancestors!</h3></center><br><br>"
+		dat += "<br><center><h3>Experience the planned journey of your ancestors!</h3></center><br><br>"
 		dat += "<center><b><a href='byond://?src=[REF(src)];newgame=1'>New Game</a></b></center>"
 		dat += "<P ALIGN=Right><a href='byond://?src=[REF(src)];close=1'>Close</a></P>"
 	var/datum/browser/popup = new(user, "arcade", "The Orion Trail",400,700)
@@ -1083,14 +1083,14 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 		prizevend(user)
 	obj_flags &= ~EMAGGED
 	name = "The Orion Trail"
-	desc = "Learn how our ancestors got to Orion, and have fun in the process!"
+	desc = "Learn how our ancestors planned to colonize Orion, and have fun in the process!"
 
 /obj/machinery/computer/arcade/orion_trail/emag_act(mob/user)
 	if(obj_flags & EMAGGED)
 		return
 	to_chat(user, span_notice("You override the cheat code menu and skip to Cheat #[rand(1, 50)]: Realism Mode."))
 	name = "The Orion Trail: Realism Edition"
-	desc = "Learn how our ancestors got to Orion, and try not to die in the process!"
+	desc = "Learn how our ancestors planned to colonize Orion, and try not to die in the process!"
 	newgame()
 	obj_flags |= EMAGGED
 
@@ -1103,7 +1103,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 
 /obj/item/orion_ship
 	name = "model settler ship"
-	desc = "A model spaceship, it looks like those used back in the day when travelling to Orion! It even has a miniature FX-293 reactor, which was renowned for its instability and tendency to explode..."
+	desc = "A model spaceship, it looks like old concepts for a ship built to travel to Orion! It even has a miniature FX-293 reactor, which was renowned for its instability and tendency to explode..."
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "ship"
 	w_class = WEIGHT_CLASS_SMALL

--- a/yogstation/code/modules/ruins/lavaland_ruin_code.dm
+++ b/yogstation/code/modules/ruins/lavaland_ruin_code.dm
@@ -25,15 +25,15 @@
 ///Orion Medical Outpost Staff
 
 /obj/effect/mob_spawn/human/orion_doctor
-	name = "Orion Outpost Doctor"
+	name = "SIC Outpost Doctor"
 	uniform = /obj/item/clothing/under/rank/medical
 	shoes = /obj/item/clothing/shoes/sneakers/white
 	gloves = /obj/item/clothing/gloves/color/white
 	back = /obj/item/storage/backpack/medic
 	belt = /obj/item/storage/belt/medical
 	glasses = /obj/item/clothing/glasses/hud/health
-	short_desc = "You are an Orion medical doctor."
-	flavour_text = "You were working on a medical outpost on Orion when a bluespace translocation was reported in the vicinity, it seems to have moved the outpost to some strange ashen wasteland, regardless of the situation the medical supplies are low and medical scanners report you aren't the first here."
+	short_desc = "You are an SIC medical doctor."
+	flavour_text = "You were working on a medical outpost on a SIC space station when a bluespace translocation was reported in the vicinity, it seems to have moved the outpost to some strange ashen wasteland, regardless of the situation the medical supplies are low and medical scanners report you aren't the first here."
 	important_info = "Time to put your expertise to use and see if there's anyone out there who needs help."
 	id_job = "Medical Doctor"
 	id = /obj/item/card/id
@@ -43,7 +43,7 @@
 	icon_state = "sleeper"
 
 /obj/effect/mob_spawn/human/orion_security
-	name = "Orion Outpost Security Officer"
+	name = "SIC Outpost Security Officer"
 	uniform = /obj/item/clothing/under/syndicate
 	shoes = /obj/item/clothing/shoes/combat
 	suit = /obj/item/clothing/suit/armor/vest
@@ -53,8 +53,8 @@
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	head = /obj/item/clothing/head/helmet/swat
 	mask = /obj/item/clothing/mask/gas
-	flavour_text = "You are an Orion Spaceport officer, the outpost you were assigned to was moved due to a bluespace anomaly, you are to ensure that no harm comes to the outpost or its staff. You do not follow Space Law. You are the Law."
-	short_desc = "You are an Orion security officer."
+	flavour_text = "You are an SIC Spaceport officer, the outpost you were assigned to was moved due to a bluespace anomaly, you are to ensure that no harm comes to the outpost or its staff. You do not follow Space Law. You are the Law."
+	short_desc = "You are an SIC security officer."
 	id_job = "Security Officer"
 	id_access = "Security Officer"
 	r_pocket = /obj/item/tank/internals/emergency_oxygen/double


### PR DESCRIPTION
There is no orion in yogstation lore
![joo-dee-1](https://user-images.githubusercontent.com/1534478/188157053-b9937401-111d-4ad1-aeff-e7fa3cdeefbe.jpg)

# Document the changes in your pull request

Reflavors most references to Orion so they are now SIC (Sol Interplanetary-Coalition), and makes Orion Trail not imply humanity moved to Orion actually, only planned to but never did.

# Wiki Documentation

needs updates to the ghost roles page probably? if there is one?
arcade machine entry for orion trail also needs to be updated

# Changelog

:cl:  
spellcheck: Orion is mostly now corrected into not existing, outside of references with Orion Trail
/:cl:
