### PR TITLE
fixes upgrading wooden bucklers into strobe shields

### DIFF
--- a/code/datums/components/crafting/weapons.dm
+++ b/code/datums/components/crafting/weapons.dm
@@ -28,6 +28,7 @@
 	reqs = list(/obj/item/wallframe/flasher = 1,
 				/obj/item/assembly/flash/handheld = 1,
 				/obj/item/shield/riot = 1)
+	blacklist = list(/obj/item/shield/riot/buckler, /obj/item/shield/riot/tele)
 	time = 4 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON


### PR DESCRIPTION
buckler is subtype of normal riot shield so you can craft a strobe shield using a wooden buckler

# Changelog

:cl:  
bugfix: wooden and teleshields are now blacklisted from making strobe shields
/:cl:
