### PR TITLE
Adds gen_turf_only to all map_generators and turns it on

### DIFF
--- a/code/datums/mapgen/CaveGenerator.dm
+++ b/code/datums/mapgen/CaveGenerator.dm
@@ -4,7 +4,8 @@
 	var/open_turf_types = list(/turf/open/floor/plating/asteroid/airless = 1)
 	///Weighted list of the types that spawns if the turf is closed
 	var/closed_turf_types = list(/turf/closed/mineral/random = 1)
-
+	///If this is set to TRUE then it will only change turfs that are /turf/open/genturf, for more flexability in design
+	var/gen_gurf_only = TRUE
 
 	///Weighted list of mobs that can spawn in the area.
 	var/list/mob_spawn_list
@@ -53,7 +54,7 @@
 	for(var/i in turfs) //Go through all the turfs and generate them
 		var/turf/gen_turf = i
 
-		if(!istype(gen_turf,/turf/open/genturf))
+		if(gen_gurf_only && !istype(gen_turf,/turf/open/genturf))
 			continue
 
 		if(istype(gen_turf,/turf/closed/mineral))

--- a/code/datums/mapgen/CaveGenerator.dm
+++ b/code/datums/mapgen/CaveGenerator.dm
@@ -53,11 +53,14 @@
 	for(var/i in turfs) //Go through all the turfs and generate them
 		var/turf/gen_turf = i
 
-		var/area/A = gen_turf.loc
-		if(!(A.area_flags & CAVES_ALLOWED))
+		if(!istype(gen_turf,/turf/open/genturf))
 			continue
 
 		if(istype(gen_turf,/turf/closed/mineral))
+			continue
+
+		var/area/A = gen_turf.loc
+		if(!(A.area_flags & CAVES_ALLOWED))
 			continue
 
 		var/closed = text2num(string_gen[world.maxx * (gen_turf.y - 1) + gen_turf.x])


### PR DESCRIPTION
# Document the changes in your pull request

Map generators will only generate new turfs on /turf/open/genturf so you can have things in the same area while also not overriding it (icemoon stuff)

map_generator options let you turn these off per map_generator datum

# Changelog

:cl:  
rscadd: Adds gen_turf_only to map_generators and turns it on
/:cl:
