### PR TITLE
Makes surgerys not cancel if wrong step

### DIFF
--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -21,7 +21,7 @@
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 30)
 
 /obj/item/crowbar/attack(mob/living/M, mob/user)
-	if(user.a_intent == INTENT_HARM || !attempt_initiate_surgery(src, M, user))
+	if(!attempt_initiate_surgery(src, M, user))
 		..()
 
 /obj/item/crowbar/suicide_act(mob/user)

--- a/code/game/objects/items/tools/wrench.dm
+++ b/code/game/objects/items/tools/wrench.dm
@@ -21,7 +21,7 @@
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 30)
 
 /obj/item/wrench/attack(mob/living/M, mob/user)
-	if(user.a_intent == INTENT_HARM || !attempt_initiate_surgery(src, M, user))
+	if(!attempt_initiate_surgery(src, M, user))
 		..()
 
 /obj/item/wrench/suicide_act(mob/user)

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -86,9 +86,6 @@
 			else
 				to_chat(user, span_warning("You need to expose [M]'s [parse_zone(selected_zone)] first!"))
 
-	else if(!current_surgery.step_in_progress)
-		attempt_cancel_surgery(current_surgery, I, M, user)
-
 	return TRUE
 
 /proc/attempt_cancel_surgery(datum/surgery/S, obj/item/I, mob/living/M, mob/user)

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -5,6 +5,8 @@
 	var/mob/living/carbon/C
 	var/obj/item/bodypart/affecting
 	var/selected_zone = user.zone_selected
+	if(user.a_intent == INTENT_HARM)
+		return FALSE
 
 	if(iscarbon(M))
 		C = M
@@ -48,7 +50,7 @@
 
 		if(!available_surgeries.len)
 			to_chat(user, span_warning("You can't preform any surgeries on [M]'s [parse_zone(selected_zone)]!"))
-			return
+			return TRUE
 		
 		var/P = show_radial_menu(user, M, radial_list, radius = 40, require_near = TRUE, tooltips = TRUE)
 		if(P && user && user.Adjacent(M) && (I in user))
@@ -56,22 +58,22 @@
 
 			for(var/datum/surgery/other in M.surgeries)
 				if(other.location == selected_zone)
-					return //during the input() another surgery was started at the same location.
+					return TRUE //during the input() another surgery was started at the same location.
 
 			//we check that the surgery is still doable after the input() wait.
 			if(C)
 				affecting = C.get_bodypart(check_zone(selected_zone))
 			if(affecting)
 				if(!S.requires_bodypart)
-					return
+					return TRUE
 				if(S.requires_bodypart_type && affecting.status != S.requires_bodypart_type)
-					return
+					return TRUE
 			else if(C && S.requires_bodypart)
-				return
+				return TRUE
 			if(S.lying_required && (M.mobility_flags & MOBILITY_STAND))
-				return
+				return TRUE
 			if(!S.can_start(user, M))
-				return
+				return TRUE
 
 			if(S.ignore_clothes || get_location_accessible(M, selected_zone))
 				var/datum/surgery/procedure = new S.type(M, selected_zone, affecting)

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -13,7 +13,7 @@
 	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/retractor/attack(mob/living/M, mob/user)
-	if(user.a_intent == INTENT_HARM || !attempt_initiate_surgery(src, M, user))
+	if(!attempt_initiate_surgery(src, M, user))
 		..()
 
 /obj/item/retractor/augment
@@ -49,7 +49,7 @@
 	attack_verb = list("attacked", "pinched")
 
 /obj/item/hemostat/attack(mob/living/M, mob/user)
-	if(user.a_intent == INTENT_HARM || !attempt_initiate_surgery(src, M, user))
+	if(!attempt_initiate_surgery(src, M, user))
 		..()
 
 /obj/item/hemostat/augment
@@ -86,7 +86,7 @@
 	attack_verb = list("burnt")
 
 /obj/item/cautery/attack(mob/living/M, mob/user)
-	if(user.a_intent == INTENT_HARM || !attempt_initiate_surgery(src, M, user))
+	if(!attempt_initiate_surgery(src, M, user))
 		..()
 
 /obj/item/cautery/augment
@@ -135,7 +135,7 @@
 	return (MANUAL_SUICIDE)
 
 /obj/item/surgicaldrill/attack(mob/living/M, mob/user)
-	if(user.a_intent == INTENT_HARM || !attempt_initiate_surgery(src, M, user))
+	if(!attempt_initiate_surgery(src, M, user))
 		..()
 
 /obj/item/surgicaldrill/augment
@@ -180,7 +180,7 @@
 	AddComponent(/datum/component/butchering, 80 * toolspeed, 100, 0)
 
 /obj/item/scalpel/attack(mob/living/M, mob/user)
-	if(user.a_intent == INTENT_HARM || !attempt_initiate_surgery(src, M, user))
+	if(!attempt_initiate_surgery(src, M, user))
 		..()
 
 /obj/item/scalpel/augment
@@ -239,7 +239,7 @@
 	AddComponent(/datum/component/butchering, 40 * toolspeed, 100, 5, 'sound/weapons/circsawhit.ogg') //saws are very accurate and fast at butchering
 
 /obj/item/circular_saw/attack(mob/living/M, mob/user)
-	if(user.a_intent == INTENT_HARM || !attempt_initiate_surgery(src, M, user))
+	if(!attempt_initiate_surgery(src, M, user))
 		..()
 
 /obj/item/circular_saw/augment
@@ -279,7 +279,7 @@
 	attack_verb = list("corrected", "properly set")
 
 /obj/item/bonesetter/attack(mob/living/M, mob/user)
-	if(user.a_intent == INTENT_HARM || !attempt_initiate_surgery(src, M, user))
+	if(!attempt_initiate_surgery(src, M, user))
 		..()
 
 /obj/item/bonesetter/bone
@@ -301,7 +301,7 @@
 	attack_verb = list("slapped")
 
 /obj/item/surgical_drapes/attack(mob/living/M, mob/user)
-	if(user.a_intent == INTENT_HARM || !attempt_initiate_surgery(src, M, user))
+	if(!attempt_initiate_surgery(src, M, user))
 		..()
 
 /obj/item/surgical_drapes/goliath


### PR DESCRIPTION
# Document the changes in your pull request

Fixes: #15580 

return TRUE = No Attack
return FALSE = Attack

literately adds returns lol
and removes the cancel code

# Changelog

:cl:  
tweak: Surgerys no longer cancel if wrong tool
/:cl:
