### PR TITLE
should maybe make toolset implant tools count for crafting

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -153,6 +153,13 @@
 	var/list/present_qualities = list()
 	present_qualities |= contents["tool_behaviour"]
 	for(var/obj/item/I in user.contents)
+		if(istype(I, /obj/item/organ/cyberimp/arm/toolset))
+			var/obj/item/organ/cyberimp/arm/toolset/T = I
+			if(I.owner == user)
+				for(var/obj/item/implant_item in I.contents)
+				possible_tools += implant_item.type
+				if(implant_item.tool_behaviour)
+					present_qualities.Add(implant_item.tool_behaviour)
 		if(istype(I, /obj/item/storage))
 			for(var/obj/item/SI in I.contents)
 				possible_tools += SI.type

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -157,9 +157,9 @@
 			var/obj/item/organ/cyberimp/arm/toolset/T = I
 			if(T.owner == user)
 				for(var/obj/item/implant_item in I.contents)
-				possible_tools += implant_item.type
-				if(implant_item.tool_behaviour)
-					present_qualities.Add(implant_item.tool_behaviour)
+					possible_tools += implant_item.type
+					if(implant_item.tool_behaviour)
+						present_qualities.Add(implant_item.tool_behaviour)
 		if(istype(I, /obj/item/storage))
 			for(var/obj/item/SI in I.contents)
 				possible_tools += SI.type

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -155,7 +155,7 @@
 	for(var/obj/item/I in user.contents)
 		if(istype(I, /obj/item/organ/cyberimp/arm/toolset))
 			var/obj/item/organ/cyberimp/arm/toolset/T = I
-			if(I.owner == user)
+			if(T.owner == user)
 				for(var/obj/item/implant_item in I.contents)
 				possible_tools += implant_item.type
 				if(implant_item.tool_behaviour)


### PR DESCRIPTION
# Document the changes in your pull request

makes toolsets like 10%  better by allowing their tools to be used in crafting recipes as if they were a belt or held toolbox

# Wiki Documentation

toolset implants can now be used in crafting recipes, which they used to counterintuitively not be able to

# Changelog

:cl:  
tweak: toolset implants can now be used in crafting recipes, which they used to counterintuitively not be able to
/:cl:
