### PR TITLE
makes tele armor use do_teleport

### DIFF
--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -79,22 +79,7 @@
 			owner.visible_message(span_danger("The reactive teleport system is still recharging! It fails to teleport [H]!"))
 			return
 		owner.visible_message(span_danger("The reactive teleport system flings [H] clear of [attack_text], shutting itself off in the process!"))
-		playsound(get_turf(owner),'sound/magic/blink.ogg', 100, 1)
-		var/list/turfs = new/list()
-		for(var/turf/T in orange(tele_range, H))
-			if(T.density)
-				continue
-			if(T.x>world.maxx-tele_range || T.x<tele_range)
-				continue
-			if(T.y>world.maxy-tele_range || T.y<tele_range)
-				continue
-			turfs += T
-		if(!turfs.len)
-			turfs += pick(/turf in orange(tele_range, H))
-		var/turf/picked = pick(turfs)
-		if(!isturf(picked))
-			return
-		H.forceMove(picked)
+		do_teleport(H, get_turf(H), tele_range, asoundin = 'sound/magic/blink.ogg', channel = TELEPORT_CHANNEL_BLUESPACE)
 		H.rad_act(rad_amount)
 		reactivearmor_cooldown = world.time + reactivearmor_cooldown_duration
 		return 1


### PR DESCRIPTION
it will now respect no teleport flags

:cl:
bugfix: Reactive tele armor now respects teleport flags
tweak: Reactive tele armor now teleports further if you are wearing a BoH
/:cl: