### PR TITLE
Replace detomatix with bomberman in sabo syndie kit

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -118,7 +118,7 @@
 			new /obj/item/doorCharge(src)
 			new /obj/item/camera_bug(src)
 			new /obj/item/sbeacondrop/powersink(src)
-			new /obj/item/cartridge/virus/syndicate(src)
+			new /obj/item/computer_hardware/hard_drive/portable/syndicate/bomberman(src)
 			new /obj/item/storage/toolbox/syndicate(src) //To actually get to those places
 			new /obj/item/pizzabox/bomb(src)
 			new /obj/item/storage/box/syndie_kit/emp(src)


### PR DESCRIPTION
# Document the changes in your pull request

# Changelog

:cl:  
tweak: Sabotage syndie kit now has BomberMan disk instead of Detomatix cartridge
/:cl:
