### PR TITLE
Add Sorting to NTos PDAs

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -370,6 +370,8 @@
 /proc/sortNames(list/L, order=1)
 	return sortTim(L, order >= 0 ? /proc/cmp_name_asc : /proc/cmp_name_dsc)
 
+/proc/sortUsernames(list/L, order=1)
+	return sortTim(L, order >= 0 ? /proc/cmp_username_asc : /proc/cmp_username_dsc)
 
 /// Converts a bitfield to a list of numbers (or words if a wordlist is provided)
 /proc/bitfield2list(bitfield = 0, list/wordlist)

--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -16,6 +16,12 @@
 /proc/cmp_name_dsc(atom/a, atom/b)
 	return sorttext(a.name, b.name)
 
+/proc/cmp_username_asc(datum/computer_file/program/pdamessager/a, datum/computer_file/program/pdamessager/b)
+	return sorttext(b.username, a.username)
+
+/proc/cmp_username_dsc(datum/computer_file/program/pdamessager/a, datum/computer_file/program/pdamessager/b)
+	return sorttext(a.username, b.username)
+
 GLOBAL_VAR_INIT(cmp_field, "name")
 /proc/cmp_records_asc(datum/data/record/a, datum/data/record/b)
 	return sorttext(b.fields[GLOB.cmp_field], a.fields[GLOB.cmp_field])

--- a/code/modules/modular_computers/file_system/programs/ntpda_msg.dm
+++ b/code/modules/modular_computers/file_system/programs/ntpda_msg.dm
@@ -34,6 +34,7 @@ GLOBAL_LIST_EMPTY(NTPDAMessages)
 	. = ..()
 	username = "NewUser[rand(100, 999)]"
 	GLOB.NTPDAs += src
+	GLOB.NTPDAs = sortNames(GLOB.NTPDAs)
 	for (var/obj/machinery/telecomms/message_server/preset/server in GLOB.telecomms_list)
 		if (server.decryptkey)
 			authkey = server.decryptkey

--- a/code/modules/modular_computers/file_system/programs/ntpda_msg.dm
+++ b/code/modules/modular_computers/file_system/programs/ntpda_msg.dm
@@ -34,7 +34,7 @@ GLOBAL_LIST_EMPTY(NTPDAMessages)
 	. = ..()
 	username = "NewUser[rand(100, 999)]"
 	GLOB.NTPDAs += src
-	GLOB.NTPDAs = sortNames(GLOB.NTPDAs)
+	GLOB.NTPDAs = sortUsernames(GLOB.NTPDAs)
 	for (var/obj/machinery/telecomms/message_server/preset/server in GLOB.telecomms_list)
 		if (server.decryptkey)
 			authkey = server.decryptkey
@@ -242,6 +242,7 @@ GLOBAL_LIST_EMPTY(NTPDAMessages)
 					return
 
 			username = newname
+			GLOB.NTPDAs = sortUsernames(GLOB.NTPDAs)
 			computer.visible_message(span_notice("Username set to [newname]."), null, null, 1)
 			return TRUE
 


### PR DESCRIPTION
# Document the changes in your pull request

Does what the tins says
sorts usernames like the PDA

# Changelog

:cl:  
tweak: [NTos Messenger] Name list is now sorted
/:cl:
