### PR TITLE
Makes AI immune to radiation

### DIFF
--- a/code/__HELPERS/radiation.dm
+++ b/code/__HELPERS/radiation.dm
@@ -5,6 +5,7 @@
 	var/static/list/ignored_things = typecacheof(list(
 		/mob/dead,
 		/mob/camera,
+		/mob/living/silicon/ai,
 		/obj/effect,
 		/obj/docking_port,
 		/atom/movable/lighting_object,


### PR DESCRIPTION
AI is in a database network and shouldn't be affected by radiation
~~GUYS WHY THE AI SAT IS NEAR INCINERATOR ON BOX, MOST RADIOACTIVE AREA EVER~~
# Document the changes in your pull request
makes ai rad immune



# Wiki Documentation
AI is rad immune

# Changelog


:cl:  

tweak: AI is now rad immune
/:cl:
