### PR TITLE
Makes Voice of God not kill AI

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1034,7 +1034,7 @@
 
 /obj/mecha/Exited(atom/movable/M, atom/newloc)
 	if(occupant && occupant == M) // The occupant exited the mech without calling go_out()
-		go_out(TRUE, newloc)
+		go_out(FALSE, newloc) // Voice of god breaks things (such as gibbing AI)
 
 	if(cell && cell == M)
 		cell = null


### PR DESCRIPTION
# Document the changes in your pull request

I just decided to change go_out(forced) to false since its only used for AI and malf ctakeover calls it true
Not too many ways to made the code better due to convoluted movement code

# Changelog

:cl:  
bugfix: Voice of god no longer kills AI
/:cl:
