### PR TITLE
Maybe fixes not being to jump to/orbit bombs

### DIFF
--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -126,7 +126,7 @@
 		log_game("[key_name(user)] planted [name] on [target.name] at [AREACOORD(user)] with a [det_time] second fuse")
 
 		if(notify_ghosts)
-			notify_ghosts("[user] has planted \a [src] on [target] with a [det_time] second fuse!", source = src, action = NOTIFY_ORBIT, header = "Bomb Planted" )
+			notify_ghosts("[user] has planted \a [src] on [target] with a [det_time] second fuse!", source = target, action = NOTIFY_JUMP, header = "Bomb Planted" )
 
 		moveToNullspace()	//Yep
 


### PR DESCRIPTION
# Document the changes in your pull request

turns out for explosives it just deletes itself or does something weird in a way that you cant orbit it

# Changelog

:cl:  
tweak: Should be able to jump to bombs as a ghost
/:cl:
