### PR TITLE
potentially fixes fake plasmafloods obstructing things

### DIFF
--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -171,6 +171,7 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 	var/image/plasma_image = image(image_icon,center,image_state,FLY_LAYER)
 	plasma_image.alpha = 50
 	plasma_image.plane = GAME_PLANE
+	plasma_image.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	flood_images += plasma_image
 	flood_turfs += center
 	if(target.client)


### PR DESCRIPTION
# Document the changes in your pull request

I have no reason to believe removing the mouse opacity from the image wouldn't work but wierder things haven't worked

# Changelog
:cl:  
bugfix: fake plasmafloods no longer prevent clicking anything on their tile. Probably. I think.
/:cl:
