### PR TITLE
[s] Fixes several bugs & typos picked up by OpenDream

### DIFF
--- a/code/modules/antagonists/clockcult/clock_mobs/_eminence.dm
+++ b/code/modules/antagonists/clockcult/clock_mobs/_eminence.dm
@@ -4,8 +4,8 @@
 
 //The Eminence is a unique mob that functions like the leader of the cult. It's incorporeal but can interact with the world in several ways.
 /mob/camera/eminence
-	name = "\the Emininence"
-	real_name = "\the Eminence"
+	name = "Eminence" // Yogs -- fixes dangling \the
+	real_name = "Eminence" // Yogs -- ditto
 	desc = "The leader-elect of the servants of Ratvar."
 	icon = 'icons/effects/clockwork_effects.dmi'
 	icon_state = "eminence"

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -147,7 +147,7 @@
 	resistance_flags = FLAMMABLE
 
 /obj/item/clothing/suit/wizrobe/paper
-	name = "papier-mache robe" // no non-latin characters!
+	name = "papier-mâché robe" // yogs -- we live in the future
 	desc = "A robe held together by various bits of clear-tape and paste."
 	icon_state = "wizard-paper"
 	item_state = "wizard-paper"
@@ -166,7 +166,7 @@
 	if(!isliving(usr))
 		return
 	if(!robe_charge)
-		to_chat(usr, span_warning("\The robe's internal magic supply is still recharging!"))
+		to_chat(usr, span_warning("\The [src]'s internal magic supply is still recharging!")) // Yogs -- text macro fix
 		return
 
 	usr.say("Rise, my creation! Off your page into this realm!", forced = "stickman summoning")
@@ -177,7 +177,7 @@
 	src.robe_charge = FALSE
 	sleep(3 SECONDS)
 	src.robe_charge = TRUE
-	to_chat(usr, span_notice("\The robe hums, its internal magic supply restored."))
+	to_chat(usr, span_notice("\The [src] hums, \his internal magic supply restored.")) // Yogs -- text macro fix
 
 
 //Shielded Armour

--- a/code/modules/events/swarmer.dm
+++ b/code/modules/events/swarmer.dm
@@ -25,4 +25,4 @@
 		return MAP_ERROR
 	var/obj/structure/swarmer_beacon/new_beacon = new /obj/structure/swarmer_beacon(pick(spawn_locs))
 	log_game("A Swarmer Beacon was spawned via an event.")
-	notify_ghosts("\A Swarmer Beacon has spawned!", source = new_beacon, action = NOTIFY_ORBIT, flashwindow = FALSE, header = "Swarmer Beacon Spawned")
+	notify_ghosts("A Swarmer Beacon has spawned!", source = new_beacon, action = NOTIFY_ORBIT, flashwindow = FALSE, header = "Swarmer Beacon Spawned") // yogs -- text macro fix

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -355,13 +355,13 @@
 			plantname = input
 
 		if(penchoice == "Plant Description")
-			var/input = stripped_input(user,"What do you want to change the description of \the plant to?", ,"", MAX_NAME_LEN)
+			var/input = stripped_input(user,"What do you want to change the description of the [plantname] to?", ,"", MAX_NAME_LEN) // yogs -- text macro fix
 			if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
 				return
 			plantdesc = input
 
 		if(penchoice == "Seed Description")
-			var/input = stripped_input(user,"What do you want to change the description of \the seeds to?", ,"", MAX_NAME_LEN)
+			var/input = stripped_input(user,"What do you want to change the description of \the [src] to?", ,"", MAX_NAME_LEN) // yogs -- text macro fix
 			if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
 				return
 			desc = input

--- a/code/modules/mob/living/simple_animal/hostile/rat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/rat.dm
@@ -180,7 +180,7 @@
 			src.visible_message(span_warning("[src] starts biting into [C]!"),span_notice("You start eating [C]..."))
 			if(!do_after(src, 3 SECONDS, FALSE, target))
 				return
-			to_chat(src, span_notice ("You finish eating [C]."))
+			to_chat(src, span_notice("You finish eating [C]."))
 			heal_bodypart_damage(5)
 			C.adjustBruteLoss(15)
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -707,7 +707,7 @@
 			var/species_type = pick(subtypesof(/datum/species/jelly))
 			H.set_species(species_type)
 			H.reagents.del_reagent(type)
-			to_chat(H, span_warning("You've become \a jellyperson!"))
+			to_chat(H, span_warning("You have become a jellyperson!")) // Yogs -- text macro fix
 
 /datum/reagent/mulligan
 	name = "Mulligan Toxin"

--- a/code/modules/vehicles/speedbike.dm
+++ b/code/modules/vehicles/speedbike.dm
@@ -44,7 +44,7 @@
 	icon = 'icons/obj/car.dmi'
 	icon_state = "speedwagon"
 	layer = LYING_MOB_LAYER
-	var/static/mutable_appearance/overlay = mutable_appearance(icon, "speedwagon_cover", ABOVE_MOB_LAYER)
+	var/static/mutable_appearance/overlay // Yogs -- fixes potential game crash or something
 	max_buckled_mobs = 4
 	var/crash_all = FALSE //CHAOS
 	pixel_y = -48
@@ -52,6 +52,8 @@
 
 /obj/vehicle/ridden/space/speedwagon/Initialize()
 	. = ..()
+	if(isnull(overlay)) // yogs
+		overlay = mutable_appearance(icon, "speedwagon_cover", ABOVE_MOB_LAYER) // yogs
 	add_overlay(overlay)
 	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
 	D.vehicle_move_delay = 0

--- a/yogstation/code/modules/cargo/cargo_packs.dm
+++ b/yogstation/code/modules/cargo/cargo_packs.dm
@@ -175,7 +175,7 @@
 	hidden = TRUE
 	cost = 2000
 	contains = list(/mob/living/simple_animal/hostile/carp)
-	crate name = "fish crate"
+	crate_name = "fish crate"
 
 /datum/supply_pack/critter/carp/generate()
 	. = ..()


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/29939414/188333861-095fca0a-e06c-4386-8764-acdb206735fb.png)

## Summary

Today I had a go at trying to make Yogs compile on the open-source DM compiler, OpenDream.

It currently cannot. However, while trying that, I found several examples of incorrect/bizarre syntax within the codebase that OD compiletime'd on, and for good reason!

We had several examples of `\the` and other text macros being used without an associated interpolated value (which made them do nothing, or, worse, emit a tab character followed by "he"). Also, I found a goofy bug with the carp fish crate where the syntax accidentally created a brand new type that was equivalent to a normal fish crate, except named differently.

Expect me to come back with more as OD matures and gets smarter about roasting our shitcode :)

## Changelog

:cl:  Altoids
bugfix: Speedbikes should now display their overlay icon thing correctly.
bugfix: There is no longer a secret evil twin of the carp fish crate lurking within the cargo supply packs.
spellcheck: Fixed missing "the"s and "a"s in several places.
spellcheck: The Eminence is no longer called the Emininence in some contexts.
spellcheck: The paper mache robe is now spelt as Frenchily as it wanted to be.
/:cl:
