### PR TITLE
disables metastation

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -28,7 +28,7 @@ endmap
 
 map yogsmeta
 	minplayers 25
-	votable
+	disabled
 endmap
 
 map yogsdelta


### PR DESCRIPTION
Widely disliked, unmaintained map that's due to be replaced by asteroidstation very shortly.


# Changelog

:cl:  
rscdel: Metastation is now disabled
/:cl:
