### PR TITLE
gives autolathes the ability to print 7.62mmR ammo

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -1111,6 +1111,14 @@
 	build_path = /obj/item/ammo_box/a762
 	category = list("hacked", "Security")
 
+/datum/design/n762box
+	name = "Ammo Box (7.62mmR)"
+	id = "n762"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 15000)
+	build_path = /obj/item/ammo_box/n762
+	category = list("hacked", "Security")
+
 /datum/design/decal_painter
 	name = "Decal Painter"
 	id = "decal_painter"


### PR DESCRIPTION
the mosin, also from russian surplus can have ammo printed for it from the autolathe, and unlike the mosin you can't get big boxes of ammo from russian surplus, only the weird faux-speedloaders, which makes using the revolver actually difficult since it does only 20 damage with no AP, and unlike the mosin rifle which does 60 damage, you can't print ammo for it, making it a better choice to just take the rifle if you want to do damage and not run out of ammo, since the surplus crates contain tons of ammo for the rifles.


# Changelog

:cl:  
tweak: you can now print nagant revolver ammo from a hacked autolathe
/:cl:
