### PR TITLE
Buffs (most) hardlight bow projectiles

### DIFF
--- a/code/modules/projectiles/guns/ballistic/bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bow.dm
@@ -261,7 +261,7 @@
 
 /obj/item/gun/ballistic/bow/energy/syndicate
 	name = "Syndicate Hardlight Bow"
-	desc = "A modern bow that can fabricate hardlight arrows using an internal energy. This one is designed for silent takedowns of targets by the syndicate."
+	desc = "A modern bow that can fabricate hardlight arrows using an internal energy. This one is designed by the Syndicate for silent takedowns of targets."
 	icon_state = "bow_syndicate"
 	item_state = "bow_syndicate"
 	mag_type = /obj/item/ammo_box/magazine/internal/bow/energy/syndicate
@@ -274,6 +274,10 @@
 	draw_sound = null
 	var/folded = FALSE
 	var/stored_ammo ///what was stored in the magazine before being folded?
+
+/obj/item/gun/ballistic/bow/energy/syndicate/examine(mob/user)
+	. = ..()
+	. += "It can be folded into a compact form by using CTRL + CLICK."
 
 /obj/item/gun/ballistic/bow/energy/syndicate/shoot_live_shot(mob/living/user, pointblank, atom/pbtarget, message)
 	if(!folded)
@@ -319,7 +323,7 @@
 
 /obj/item/gun/ballistic/bow/energy/clockwork
 	name = "Brass Bow"
-	desc = "A bow made from brass and other components that you can't quite understand. It glows with a deep energy and frabricates arrows by itself."
+	desc = "A bow made from brass and other components that you can't quite understand. It glows with a deep energy and fabricates arrows by itself."
 	icon_state = "bow_clockwork"
 	item_state = "bow_clockwork"
 	mag_type = /obj/item/ammo_box/magazine/internal/bow/energy/clockcult

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -171,8 +171,8 @@
 	name = "X-ray bolt"
 	icon_state = "arrow_xray"
 	light_color = LIGHT_COLOR_GREEN
-	damage = 25
-	irradiate = 500
+	damage = 21
+	irradiate = 400
 	range = 20
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF
 	embed_type = /obj/item/ammo_casing/caseless/arrow/energy/xray

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -143,10 +143,10 @@
 		M.adjust_fire_stacks(1)
 		M.IgniteMob()
 
-/obj/item/projectile/energy/arrow //Hardlight projectile. Slightly more robust than a standard laser. Capable of hardening in target's flesh
+/obj/item/projectile/energy/arrow //Hardlight projectile. Significantly more robust than a standard laser. Capable of hardening in target's flesh
 	name = "energy bolt"
 	icon_state = "arrow_energy"
-	damage = 25
+	damage = 32
 	damage_type = BURN
 	var/embed_chance = 0.4
 	var/obj/item/embed_type = /obj/item/ammo_casing/caseless/arrow/energy
@@ -159,20 +159,20 @@
 		if(prob(embed_chance * clamp((100 - (embede.getarmor(part, flag) - armour_penetration)), 0, 100)))
 			embede.embed_object(new embed_type(), part, FALSE)
 
-/obj/item/projectile/energy/arrow/disabler //Hardlight projectile. Forceful impact makes the impact more draining than a standard disabler. Needs to be competitive in DPS
+/obj/item/projectile/energy/arrow/disabler //Hardlight projectile. Much more draining than a standard disabler. Needs to be competitive in DPS
 	name = "disabler bolt"
 	icon_state = "arrow_disable"
 	light_color = LIGHT_COLOR_BLUE
-	damage = 40
+	damage = 48
 	damage_type = STAMINA
 	embed_type = /obj/item/ammo_casing/caseless/arrow/energy/disabler
 
-/obj/item/projectile/energy/arrow/xray //Slightly weakened arrow capable of passing through material; also irradiates targets moderately
+/obj/item/projectile/energy/arrow/xray //Hardlight projectile. Weakened arrow capable of passing through material. Massive irradiation on hit.
 	name = "X-ray bolt"
 	icon_state = "arrow_xray"
 	light_color = LIGHT_COLOR_GREEN
-	damage = 15
-	irradiate = 300
+	damage = 25
+	irradiate = 500
 	range = 20
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF
 	embed_type = /obj/item/ammo_casing/caseless/arrow/energy/xray


### PR DESCRIPTION
# Document the changes in your pull request

Makes hardlight burn arrow do 32 damage up from 25 (12 more damage than a laser, 14 less damage than a slug)
Makes hardlight disabler arrow do 48 damage up from 40 (23 more than a disabler, 7 less than a beanbag)
Makes hardlight x-ray arrow do 21 damage and 400 irradiate up from 15 and 300 (previous values were equal to an x-ray beam)

Redlight bolts remain unaffected because Rat'var didn't buy a warranty

# Wiki Documentation

Values should 🅱️ changed on Guide to Combat under Energy section

# Changelog

:cl:  
tweak: All hardlight arrows have been made tremendously more scary (Rat'var forgot to invest in that good arrow juice, so his servants' arrows remain unchanged)
tweak: Syndicate hardlight bow now has an addendum that it can be CTRL+CLICK'd to fold.
/:cl:
