### PR TITLE
Adjusts some ghost role spawner descriptions

### DIFF
--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -408,7 +408,7 @@
 /datum/map_template/ruin/lavaland/medical
 	name = "SIC Medical Outpost"
 	id = "medical"
-	description = "One of the SIC Medical Outposts was teleported after a bluespace anomaly"
+	description = "A Sol Interplanetary Coalition Medical Outpost was spontaneously transported to Lavaland due to bluespace instabilities."
 	suffix = "lavaland_surface_medical.dmm"
 	allow_duplicates = FALSE
 	cost = 15

--- a/yogstation/code/modules/ruins/lavaland_ruin_code.dm
+++ b/yogstation/code/modules/ruins/lavaland_ruin_code.dm
@@ -69,7 +69,7 @@
 /obj/effect/mob_spawn/human/gasstation_clerk
 	name = "Gas Station Clerk"
 	short_desc = "You are a gas station clerk."
-	flavour_text = "While working a standard shift on some backwater colony, you felt a sudden splurge of nausea as the alarm for a bluespace translocation cut off abruptly. Calling corporate, they instruct you to continue business with any locals or passerbys. While they permit you to explore the planet, you are not to leave the planet unless the gas station is destroyed. If a hostile individual attempts to destroy the store or steal its goods, you have been given clearance to stop them any means necessary."
+	flavour_text = "While working a standard shift on some backwater colony, you felt a sudden splurge of nausea as the alarm for a bluespace translocation cut off abruptly. Calling corporate, they instruct you to continue business with any locals or passerbys. While they permit you to explore the planet, you are not to leave the planet unless the gas station is destroyed. If a hostile individual attempts to destroy the store or steal its goods, you have been given clearance to stop them by any means necessary."
 	roundstart = FALSE
 	death = FALSE
 	icon = 'icons/obj/machines/sleeper.dmi'

--- a/yogstation/code/modules/ruins/lavaland_ruin_code.dm
+++ b/yogstation/code/modules/ruins/lavaland_ruin_code.dm
@@ -12,9 +12,9 @@
 	mask = /obj/item/clothing/mask/bandana/green
 	r_pocket = /obj/item/tank/internals/emergency_oxygen/double
 	r_hand = /obj/item/instrument/guitar
-	flavour_text = "You are a travelling Bard! Your only purpose in life is to travel the galaxy, playing songs and telling epic tales of adventure, you have seen many things and you only wish to share your knowledge with all those who you pass. You are a very passive person and dislike the idea of killing another sentient person, if you cannot stop conflict through peace then you would rather remain neutral."
-	important_info = "Despite your peaceful demeanor, you are not immune to brainwashing or conversion techniques, if converted or brainwashed you are to follow the will of your masters."
-	short_desc = "You are a travelling Bard!"
+	flavour_text = "You are a travelling bard! Your only purpose in life is to travel the galaxy, playing songs and telling epic tales of adventure. You have seen many things and you only wish to share your knowledge with all those who you pass. You are a very passive person and dislike the idea of killing another sentient person. If you cannot stop conflict through peace then you would rather remain neutral."
+	important_info = "Despite your peaceful demeanor, you are not immune to brainwashing or conversion techniques. If converted or brainwashed, you are to follow the will of your masters."
+	short_desc = "You are a travelling bard!"
 	id_job = "Travelling Bard"
 	id = /obj/item/card/id
 	roundstart = FALSE
@@ -32,8 +32,8 @@
 	back = /obj/item/storage/backpack/medic
 	belt = /obj/item/storage/belt/medical
 	glasses = /obj/item/clothing/glasses/hud/health
-	short_desc = "You are an SIC medical doctor."
-	flavour_text = "You were working on a medical outpost on a SIC space station when a bluespace translocation was reported in the vicinity, it seems to have moved the outpost to some strange ashen wasteland, regardless of the situation the medical supplies are low and medical scanners report you aren't the first here."
+	short_desc = "You are a SIC medical doctor."
+	flavour_text = "You were working on a Sol Interplantery Coalition medical outpost when a bluespace translocation was reported. After a bout of nausea from reality shifting, a glance outside told you that it seems to have moved the station to some strange ashen wasteland. Regardless of the situation, supplies are low and scanners report a variety of unknown lifeforms outside."
 	important_info = "Time to put your expertise to use and see if there's anyone out there who needs help."
 	id_job = "Medical Doctor"
 	id = /obj/item/card/id
@@ -53,8 +53,8 @@
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	head = /obj/item/clothing/head/helmet/swat
 	mask = /obj/item/clothing/mask/gas
-	flavour_text = "You are an SIC Spaceport officer, the outpost you were assigned to was moved due to a bluespace anomaly, you are to ensure that no harm comes to the outpost or its staff. You do not follow Space Law. You are the Law."
-	short_desc = "You are an SIC security officer."
+	flavour_text = "You are a Sol Interplanetary Coalition officer. The medical outpost you were assigned to experienced a bluespace anomaly. After the nausea passed from the translocation, the doctors told you there were unknown lifeforms out in the ashen wasteland you now find yourself in. Regardless of the situation, you are to ensure that no harm comes to the outpost or its staff. You do not follow Space Law. You are the Law."
+	short_desc = "You are a SIC security officer."
 	id_job = "Security Officer"
 	id_access = "Security Officer"
 	r_pocket = /obj/item/tank/internals/emergency_oxygen/double
@@ -69,7 +69,7 @@
 /obj/effect/mob_spawn/human/gasstation_clerk
 	name = "Gas Station Clerk"
 	short_desc = "You are a gas station clerk."
-	flavour_text = "The gas station you worked most of your life in was moved to some hellhole in the middle of nowhere for some reason, you are to try to make the best of the situation and make as much money as possible from any locals or passerbys you may encounter. Feel free to explore around the planet and find things to sell to potential customers but do not leave the planet unless the gas station is somehow completely destroyed, If someone is trying to break in or is trying to steal your products you have the right to use any means necessary to stop them including murder."
+	flavour_text = "While working a standard shift on some backwater colony, you felt a sudden splurge of nausea as the alarm for a bluespace translocation cut off abruptly. Calling corporate, they instruct you to continue business with any locals or passerbys. While they permit you to explore the planet, you are not to leave the planet unless the gas station is destroyed. If a hostile individual attempts to destroy the store or steal its goods, you have been given clearance to stop them any means necessary. Murder is permitted."
 	roundstart = FALSE
 	death = FALSE
 	icon = 'icons/obj/machines/sleeper.dmi'
@@ -109,4 +109,4 @@
 				/obj/item/organ/heart/gland/plasma = 8)
 
 /obj/effect/mob_spawn/human/lavaland_syndicate/comms/space // Weird typo fix override
-	flavour_text = "Monitor enemy activity as best you can, and try to keep a low profile. Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen off your trail. Do not let the base fall into enemy hands!"
+	flavour_text = "Monitor enemy activity as best you can. Try to keep a low profile. Use the communication equipment to provide support to any field agents. Sow disinformation to throw Nanotrasen off your trail. Do not let the base fall into enemy hands."

--- a/yogstation/code/modules/ruins/lavaland_ruin_code.dm
+++ b/yogstation/code/modules/ruins/lavaland_ruin_code.dm
@@ -69,7 +69,7 @@
 /obj/effect/mob_spawn/human/gasstation_clerk
 	name = "Gas Station Clerk"
 	short_desc = "You are a gas station clerk."
-	flavour_text = "While working a standard shift on some backwater colony, you felt a sudden splurge of nausea as the alarm for a bluespace translocation cut off abruptly. Calling corporate, they instruct you to continue business with any locals or passerbys. While they permit you to explore the planet, you are not to leave the planet unless the gas station is destroyed. If a hostile individual attempts to destroy the store or steal its goods, you have been given clearance to stop them any means necessary. Murder is permitted."
+	flavour_text = "While working a standard shift on some backwater colony, you felt a sudden splurge of nausea as the alarm for a bluespace translocation cut off abruptly. Calling corporate, they instruct you to continue business with any locals or passerbys. While they permit you to explore the planet, you are not to leave the planet unless the gas station is destroyed. If a hostile individual attempts to destroy the store or steal its goods, you have been given clearance to stop them any means necessary."
 	roundstart = FALSE
 	death = FALSE
 	icon = 'icons/obj/machines/sleeper.dmi'


### PR DESCRIPTION
# Document the changes in your pull request

Just changes a few of the lavaland spawner flavor texts, some just grammar changes or fixes, others actually full rewrites. They still convey the same information and whatnot, especially when it comes to special rules. I'll do the rest of the spawners sometime, maybe, when lore for them is more finalized, especially since some of them include Free Golems, the Wishgranter, and the Tiger Cooperative (from a glance).

# Changelog

:cl:  
tweak: Some flavor text tweaks for some ghost roles, more to come Soon™
/:cl:
