### PR TITLE
Allows you to swap the cells in a chem dispenser by clicking on it

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -349,7 +349,7 @@
 	if(default_deconstruction_crowbar(I))
 		return
 	if(panel_open && user.a_intent != INTENT_HARM)
-		if(HAS_TRAIT(I, TRAIT_NODROP)
+		if(HAS_TRAIT(I, TRAIT_NODROP))
 			to_chat(user, span_notice("[I] is stuck to your hand!"))
 			return
 		I.forceMove(src) // Force it out of our hands so we can put the old cell in it

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -358,6 +358,7 @@
 				cell.forceMove(get_turf(src))
 			component_parts -= cell // Remove the old cell so the new one spawns when deconstructed
 			I.moveToNullspace() // Now get out of contents
+			to_chat(user, span_notice("You replace [cell] with [I]."))
 			cell = I // Set the cell
 			component_parts += I // Add new cell
 		return

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -348,7 +348,9 @@
 		return
 	if(default_deconstruction_crowbar(I))
 		return
-	if(panel_open && user.a_intent != INTENT_HARM && user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
+	if(panel_open && user.a_intent != INTENT_HARM)
+		if(user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
+			return // Feedback in proc
 		if(HAS_TRAIT(I, TRAIT_NODROP))
 			to_chat(user, span_notice("[I] is stuck to your hand!"))
 			return

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -349,7 +349,7 @@
 	if(default_deconstruction_crowbar(I))
 		return
 	if(panel_open && user.a_intent != INTENT_HARM)
-		if(user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
+		if(!user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
 			return // Feedback in proc
 		if(HAS_TRAIT(I, TRAIT_NODROP))
 			to_chat(user, span_notice("[I] is stuck to your hand!"))

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -348,6 +348,19 @@
 		return
 	if(default_deconstruction_crowbar(I))
 		return
+	if(panel_open && user.a_intent != INTENT_HARM)
+		if(HAS_TRAIT(I, TRAIT_NODROP)
+			to_chat(user, span_notice("[I] is stuck to your hand!"))
+			return
+		I.forceMove(src) // Force it out of our hands so we can put the old cell in it
+		if(istype(I, /obj/item/stock_parts/cell))
+			if(!user.put_in_hands(cell))
+				cell.forceMove(get_turf(src))
+			component_parts -= cell // Remove the old cell so the new one spawns when deconstructed
+			I.moveToNullspace() // Now get out of contents
+			cell = I // Set the cell
+			component_parts += I // Add new cell
+		return
 	if(istype(I, /obj/item/reagent_containers) && !(I.item_flags & ABSTRACT) && I.is_open_container())
 		var/obj/item/reagent_containers/B = I
 		. = TRUE //no afterattack

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -348,7 +348,7 @@
 		return
 	if(default_deconstruction_crowbar(I))
 		return
-	if(panel_open && user.a_intent != INTENT_HARM)
+	if(panel_open && user.a_intent != INTENT_HARM && user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
 		if(HAS_TRAIT(I, TRAIT_NODROP))
 			to_chat(user, span_notice("[I] is stuck to your hand!"))
 			return


### PR DESCRIPTION
# Document the changes in your pull request
QoL change

Allows you to swap cells

# Wiki Documentation

Dont need an inducer no more or crowbar to reassemble the machine

# Changelog

:cl:  
tweak: You can now swap the cell in a chemistry dispenser by clicking on it with a new cell with the panel open
/:cl:
