### PR TITLE
Fixes stool buckling feedback

### DIFF
--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -17,7 +17,7 @@
 /obj/structure/chair/examine(mob/user)
 	. = ..()
 	. += span_notice("It's held together by a couple of <b>bolts</b>.")
-	if(!has_buckled_mobs())
+	if(can_buckle && !has_buckled_mobs())
 		. += span_notice("Drag your sprite to sit in it.")
 
 /obj/structure/chair/Initialize()


### PR DESCRIPTION
# Document the changes in your pull request

makes chair check if it can even buckle in the first place
Fixes: #15653


# Changelog

:cl:  
bugfix: Stools no longer say you can buckle by dragging yourself on to them
/:cl:
