### PR TITLE
Grammar changes all over bloodsucker code

### DIFF
--- a/code/datums/martial/hunterfu.dm
+++ b/code/datums/martial/hunterfu.dm
@@ -34,7 +34,7 @@
 /datum/martial_art/hunterfu/proc/body_slam(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(D.mobility_flags & MOBILITY_STAND)
 		D.visible_message(
-			span_danger("[A] slams both themself and [D] into the ground!"),
+			span_danger("[A] slams both [A.p_them()]self and [D] into the ground!"),
 			span_userdanger("You're slammed into the ground by [A]!"),
 			span_hear("You hear a sickening sound of flesh hitting flesh!"),
 		)

--- a/code/datums/martial/hunterfu.dm
+++ b/code/datums/martial/hunterfu.dm
@@ -34,7 +34,7 @@
 /datum/martial_art/hunterfu/proc/body_slam(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(D.mobility_flags & MOBILITY_STAND)
 		D.visible_message(
-			span_danger("[A] slams both them and [D] into the ground!"),
+			span_danger("[A] slams both themself and [D] into the ground!"),
 			span_userdanger("You're slammed into the ground by [A]!"),
 			span_hear("You hear a sickening sound of flesh hitting flesh!"),
 		)
@@ -76,11 +76,11 @@
 		D.apply_damage(stake_damagehigh, BRUTE, BODY_ZONE_CHEST)
 		return TRUE
 	if(D.mind.has_antag_datum(/datum/antagonist/sinfuldemon))
-		to_chat(D, span_danger("Their arm tears through our demonic form!"))
+		to_chat(D, span_danger("Their arm tears through your demonic form!"))
 		D.apply_damage(stake_damagehigh, BRUTE, BODY_ZONE_CHEST)
 		return TRUE
 	if(D.mind.has_antag_datum(/datum/antagonist/bloodsucker))
-		to_chat(D, span_cultlarge("Their arm stakes straight into our undead flesh!"))
+		to_chat(D, span_cultlarge("Their arm stakes straight into your undead flesh!"))
 		D.apply_damage(A.get_punchdamagehigh() + 10, BURN)				//20 damage
 		D.apply_damage(A.get_punchdamagehigh(), BRUTE, BODY_ZONE_CHEST)	//10 damage
 		return TRUE
@@ -112,10 +112,10 @@
 			D.SetSleeping(40)
 			return TRUE
 		if(D.mind.has_antag_datum(/datum/antagonist/bloodsucker))
-			to_chat(D, span_warning("Our undead form protects us from being put to sleep!"))
+			to_chat(D, span_warning("Your undead form protects you from being put to sleep!"))
 			return TRUE
 		if(D.mind.has_antag_datum(/datum/antagonist/sinfuldemon))
-			to_chat(D, span_warning("Our demonic form protects us from being put to sleep!"))
+			to_chat(D, span_warning("Your demonic form protects you from being put to sleep!"))
 			return TRUE
 		else
 			D.SetSleeping(30)
@@ -137,7 +137,7 @@
 		D.Paralyze(20)
 		return TRUE
 	if(D.mind.has_antag_datum(/datum/antagonist/heretic))
-		to_chat(D, span_cultlarge("The holy water burns our flesh!"))
+		to_chat(D, span_cultlarge("The holy water burns your flesh!"))
 		D.apply_damage(holykick_hereticburn, BURN)
 		D.apply_damage(holykick_staminadamage, STAMINA)
 		D.Paralyze(20)
@@ -147,20 +147,20 @@
 		return TRUE
 	if(D.mind.has_antag_datum(/datum/antagonist/cult))
 		for(var/datum/action/innate/cult/blood_magic/BD in D.actions)
-			to_chat(D, span_cultlarge("Our blood rites falter as the holy water drips onto our body!"))
+			to_chat(D, span_cultlarge("Your blood rites falter as the holy water drips onto your body!"))
 			for(var/datum/action/innate/cult/blood_spell/BS in BD.spells)
 				qdel(BS)
 		D.apply_damage(holykick_staminadamage, STAMINA)
 		D.Paralyze(20)
 		return TRUE
 	if(D.mind.has_antag_datum(/datum/antagonist/sinfuldemon))
-		to_chat(D, span_cultlarge("The holy water burns deep inside us!"))
+		to_chat(D, span_cultlarge("The holy water burns deep inside you!"))
 		D.apply_damage(holykick_hereticburn, BURN)
 		D.apply_damage(holykick_staminadamage, STAMINA)
 		D.Paralyze(40)
 		return TRUE
 	if(D.mind.has_antag_datum(/datum/antagonist/wizard) || (/datum/antagonist/wizard/apprentice))
-		to_chat(D, span_danger("The holy water seems to be muting us somehow!"))
+		to_chat(D, span_danger("The holy water seems to be muting you somehow!"))
 		if(D.silent <= 10)
 			D.silent = clamp(D.silent + 10, 0, 10)
 		D.apply_damage(holykick_staminadamage, STAMINA)

--- a/code/game/gamemodes/bloodsuckers/bloodsucker.dm
+++ b/code/game/gamemodes/bloodsuckers/bloodsucker.dm
@@ -60,7 +60,7 @@
 	..()
 
 /datum/game_mode/bloodsucker/generate_report()
-	return "There's been a report of the undead roaming around the sector, especially those that display Vampiric abilities.\
+	return "There's been a report of the undead roaming around the sector, especially those that display vampiric abilities.\
 			 They've displayed the ability to disguise themselves as anyone and brainwash the minds of people they capture alive.\
 			 Please take care of the crew and their health, as it is impossible to tell if one is lurking in the darkness behind."
 

--- a/code/modules/antagonists/bloodsuckers/bloodsucker_flaws.dm
+++ b/code/modules/antagonists/bloodsuckers/bloodsucker_flaws.dm
@@ -7,7 +7,7 @@
 		my_clan = CLAN_TZIMISCE
 		to_chat(owner, span_announce("As you arrive near the station, you recall all you know and why you are here.\n\
 			* As a part of the Tzimisce Clan, you are able to <i>Dice</i> corpses into muscle pieces.\n\
-			* With muscles pieces you are able to mutilate dead husked vassals into greater beings,\n\
+			* With muscle pieces you are able to mutilate dead husked vassals into greater beings,\n\
 			* The more you climb up the Ranks the more research you gather about fleshcrafting and beings you can make.\n\
 			* Remember to fuel a vassalrack with the muscles to be able to toy with those dead vassals, you are also able to ressurect people this way.\n\
 			* Finally, your Favorite Vassal will turn into a battle monster to help you in combat."))
@@ -30,11 +30,11 @@
 	to_chat(owner, span_announce("List of all Clans:\n\
 		Gangrel - Prone to Frenzy, strange outcomes from being on frenzy, special power.\n\
 		Lasombra - Life in the shadows, very weak to fire but no brute damage, upgradable abilities through tasks.\n\
-		Toreador - More human then other bloodsucker, easily disguise among crew, but bound with moral."))
+		Toreador - More human then other bloodsucker, easily disguise among crew, but bound with morals."))
 
-	var/answer = input("You have Ranked up far enough to remember your clan. Which clan are you part of?", "Our mind feels luxurious...") in options
+	var/answer = input("You have Ranked up far enough to remember your clan. Which clan are you part of?", "Your mind feels luxurious...") in options
 	if(!answer) 
-		to_chat(owner, span_warning("You have wilingfully decided to stay ignorant."))
+		to_chat(owner, span_warning("You have willfully decided to stay ignorant."))
 		return
 	switch(answer)
 		if(CLAN_GANGREL)
@@ -55,11 +55,11 @@
 		if(CLAN_LASOMBRA)
 			my_clan = CLAN_LASOMBRA
 			to_chat(owner, span_announce("You have Ranked up enough to learn: You are part of the Lasombra Clan!\n\
-				* As part of the Lasombra Clan, your past teachings have shown you how to become in touch with the Abyss and practice it's prophecies.\n\
+				* As part of the Lasombra Clan, your past teachings have shown you how to become in touch with the Abyss and practice its prophecies.\n\
 				* It'll take long before the Abyss can break through this plane's veil, but you'll try to salvage any of the energy that comes through,\n\
 				* To harness it's energy you must first find an influence and make a Resting Place altar to feed the harvested essence to.\n\
 				* On the Resting Place you can give ranks or blood in exchange for shadowpoints, that can be spent on the table to ascend your abilities.\n\
-				* The Abyss has blackened your veins and made you immune to brute damage but highly receptive to burn, so you might need to be extra careful when on Torpor.\n\
+				* The Abyss has blackened your veins and made you immune to brute damage but highly receptive to burn, so you might need to be extra careful when in Torpor.\n\
 				* Finally, your Favorite Vassal will gain the Lesser Glare and Shadow Walk abilities to help you in combat."))
 			bloodsucker.physiology.burn_mod *= 2
 			bloodsucker.physiology.brute_mod *= 0
@@ -81,12 +81,12 @@
 		if(CLAN_TOREADOR)
 			my_clan = CLAN_TOREADOR
 			to_chat(owner, span_announce("You have Ranked up enough to learn: You are part of the Toreador Clan!\n\
-				* As part of the Toreador, you can't ignore your own emotions and disrespect inhuman actions.\n\
-				* Being in Masquarade doesn't spend your blood, as well as having any negative effects on your immortal powers.\n\
-				* You passively rise morale of your living vassals around you.\n\
-				* Also you get really sad when comitting inhumane actions, but your humanity loss can't go above a certain treashold.\n\
-				* Remember, that those bloodsuckers who dare to act inhuman or break the Masquarade shouldn't be forgiven, and deserve only <span class='red'>death</span>.\n\
-				* Finally, your Favorite Vassal will gain the Mesmerise ability to help you in non-lethaly dealing with enemies or vassalising people."))
+				* As part of the Toreador, you can't ignore your own emotions and you disrespect inhuman actions.\n\
+				* Being in Masquerade doesn't spend your blood, or have any negative effects on your immortal powers.\n\
+				* You passively raise morale of your living vassals around you.\n\
+				* Also you get really sad when comitting inhumane actions, but your humanity loss can't go above a certain threshold.\n\
+				* Remember that those bloodsuckers who dare to act inhuman or break the Masquerade shouldn't be forgiven, and deserve only <span class='red'>death</span>.\n\
+				* Finally, your Favorite Vassal will gain the Mesmerise ability to help you in non-lethally dealing with enemies or vassalising people."))
 			if(owner.current && ishuman(owner.current) && !owner.current.GetComponent(/datum/component/mood))
 				owner.current.AddComponent(/datum/component/mood) //You are not a emotionless beast!
 

--- a/code/modules/antagonists/bloodsuckers/bloodsucker_frenzy.dm
+++ b/code/modules/antagonists/bloodsuckers/bloodsucker_frenzy.dm
@@ -28,7 +28,7 @@
 	status_type = STATUS_EFFECT_UNIQUE
 	duration = -1
 	tick_interval = 10
-	examine_text = span_notice("They seem... inhumane, and feral!")
+	examine_text = span_notice("They look feral and inhuman!")
 	alert_type = /obj/screen/alert/status_effect/frenzy
 	/// Store whether they were an advancedtooluser, to give the trait back upon exiting.
 	var/was_tooluser = FALSE
@@ -52,7 +52,7 @@
 	// Disable ALL Powers and notify their entry
 	bloodsuckerdatum.DisableAllPowers()
 	to_chat(owner, span_userdanger("<FONT size = 3>Blood! You need Blood, now! You enter a total Frenzy! Your skin starts sizzling...."))
-	to_chat(owner, span_announce("* Bloodsucker Tip: While in Frenzy, you instantly Aggresively grab, have stun resistance, cannot speak, hear, or use any powers outside of Feed and Trespass (If you have it)."))
+	to_chat(owner, span_announce("* Bloodsucker Tip: While in Frenzy, you instantly Aggresively grab, have stun resistance, and cannot speak, hear, or use any powers outside of Feed and Trespass (If you have it)."))
 	// Stamina resistances
 	user.physiology.stamina_mod *= 0.4
 

--- a/code/modules/antagonists/bloodsuckers/bloodsucker_integration.dm
+++ b/code/modules/antagonists/bloodsuckers/bloodsucker_integration.dm
@@ -21,7 +21,7 @@
 	. = ..()
 	SEND_SIGNAL(src, COMSIG_LIVING_BIOLOGICAL_LIFE, delta_time, times_fired)
 
-// Used when analyzing a Bloodsucker, Masquerade will hide brain traumas (Unless you're a Beefman)
+// Used when analyzing a Bloodsucker, Masquerade will hide brain traumas
 /mob/living/carbon/get_traumas()
 	if(!mind)
 		return ..()

--- a/code/modules/antagonists/bloodsuckers/bloodsucker_mobs.dm
+++ b/code/modules/antagonists/bloodsuckers/bloodsucker_mobs.dm
@@ -87,7 +87,7 @@
 /mob/living/simple_animal/hostile/bloodsucker/tzimisce
 
 /mob/living/simple_animal/hostile/bloodsucker/tzimisce/triplechest
-	name = "gigantous monstrosity"
+	name = "gigantic monstrosity"
 	desc = "You wouldn't think a being so messed up like this would be able to even breathe."
 	icon_state = "triplechest"
 	icon_living = "triplechest"

--- a/code/modules/antagonists/bloodsuckers/bloodsucker_objectives.dm
+++ b/code/modules/antagonists/bloodsuckers/bloodsucker_objectives.dm
@@ -42,7 +42,7 @@
 
 // EXPLANATION
 /datum/objective/bloodsucker/lair/update_explanation_text()
-	explanation_text = "Claim a coffin by entering it to create your lair, and protect it until the end of the shift."//  Make sure to keep it safe!"
+	explanation_text = "Claim a coffin by entering it to create your lair, and protect it until the end of the shift."//  Make sure to keep it safe!
 
 // WIN CONDITIONS?
 /datum/objective/bloodsucker/lair/check_completion()

--- a/code/modules/antagonists/bloodsuckers/bloodsuckers.dm
+++ b/code/modules/antagonists/bloodsuckers/bloodsuckers.dm
@@ -726,7 +726,7 @@
 
 	return fullname
 
-///When a Bloodsucker breaks the Masquerade, they get their HUD icon changed, and Malkavian Bloodsuckers get alerted.
+///When a Bloodsucker breaks the Masquerade, they get their HUD icon changed.
 /datum/antagonist/bloodsucker/proc/break_masquerade()
 	if(broke_masquerade)
 		return
@@ -745,11 +745,11 @@
 		if(bloodsuckerdatum.my_clan == CLAN_TOREADOR)
 			var/datum/objective/assassinate/masquerade_objective = new /datum/objective/assassinate
 			masquerade_objective.target = owner.current
-			masquerade_objective.explanation_text = "Ensure [owner.current], who has broken the Masquerade, is Final Death'ed."
+			masquerade_objective.explanation_text = "Ensure [owner.current], who has broken the Masquerade, suffers Final Death."
 			bloodsuckerdatum.objectives += masquerade_objective
 			clan_minds.announce_objectives()
 
-///This is admin-only of reverting a broken masquerade, sadly it doesn't remove the Malkavian objectives yet.
+///This is admin-only of reverting a broken masquerade.
 /datum/antagonist/bloodsucker/proc/fix_masquerade()
 	if(!broke_masquerade)
 		return

--- a/code/modules/antagonists/bloodsuckers/bloodsuckers_objects.dm
+++ b/code/modules/antagonists/bloodsuckers/bloodsuckers_objects.dm
@@ -163,7 +163,7 @@
 		if(target.StakeCanKillMe())
 			bloodsuckerdatum.FinalDeath()
 		else
-			to_chat(target, span_userdanger("You have been staked! Your powers are useless, your death forever, while it remains in place."))
+			to_chat(target, span_userdanger("You have been staked! Your powers are useless while it remains in place, and death would be permanent!"))
 			to_chat(target, span_userdanger("You have been staked!"))
 
 /// Created by welding and acid-treating a simple stake.
@@ -388,6 +388,6 @@
 			<b>Strength</b>: They are able to slowly advance their abilities.<br> \
 			<b>Weakness</b>: Immensely weak to burn damage."
 		if(CLAN_TZIMISCE)
-			dat += "The page is covered in blood. It seems like it will need time to vanish..."
+			dat += "The page is covered in blood..."
 
 	reader << browse("<meta charset=UTF-8><TT><I>Penned by [author].</I></TT> <BR>" + "[dat]", "window=book[window_size != null ? ";size=[window_size]" : ""]")

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -720,7 +720,7 @@
 	description = "The blood of Ethereals, and the stuff that keeps them going. Great for them, horrid for anyone else."
 	nutriment_factor = 5 * REAGENTS_METABOLISM
 	color = "#97ee63"
-	taste_description = "pure electrictiy"
+	taste_description = "pure electricity"
 
 /datum/reagent/consumable/liquidelectricity/reaction_mob(mob/living/M, method=TOUCH, reac_volume) //can't be on life because of the way blood works.
 	if((method == INGEST || method == INJECT || method == PATCH) && iscarbon(M))

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/szlachta.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/szlachta.dm
@@ -19,7 +19,7 @@
 
 /datum/species/szlachta/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()
-	C.real_name = "towering monstrocity"
+	C.real_name = "towering monstrosity"
 	C.name = C.real_name
 	if(C.mind)
 		C.mind.name = C.real_name


### PR DESCRIPTION
# Document the changes in your pull request

Grammar, usage, spelling, rewordings and reorderings to make things read smoother, and I killed some comment references to Malkavians and Beefmen.
There's definitely more that I haven't looked at, but it's been a day. I'm done thinking.

(bloodsuckers aren't _supposed_ to refer to themselves as plural, are they? like "me and my Beast?")

# Changelog

:cl: 
spellcheck: Updated some grammar and such in and around Bloodsucker
/:cl: