### PR TITLE
Adds Broken Bottles to Trash Spawners

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -70,7 +70,8 @@
 			/obj/item/trash/raisins = 1,
 			/obj/item/trash/sosjerky = 1,
 			/obj/item/reagent_containers/food/snacks/grown/poppy = 1,
-			/obj/item/trash/syndi_cakes = 1)
+			/obj/item/trash/syndi_cakes = 1,
+			/obj/item/broken_bottle = 1)
 
 /obj/effect/spawner/lootdrop/trashbin
 	name = "trash spawner"
@@ -85,7 +86,8 @@
 			/obj/item/trash/raisins = 1,
 			/obj/item/trash/sosjerky = 1,
 			/obj/item/reagent_containers/food/snacks/grown/poppy = 1,
-			/obj/item/trash/syndi_cakes = 1)
+			/obj/item/trash/syndi_cakes = 1,
+			/obj/item/broken_bottle = 1)
 
 /obj/effect/spawner/lootdrop/donkpockets
 	name = "donk pocket box spawner"


### PR DESCRIPTION
# Document the changes in your pull request

See: Title

About the only reason I can think to not do this, is they do 9 damage and are sharp
However I counter with

Glass Shards found all over maint on nearly every map

# Changelog

:cl:  
tweak: Added Broken Bottles to the Trash spawner.
/:cl:
