### PR TITLE
Ballistic guns now won't say they can be unsuppressed if they can't

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -478,7 +478,11 @@
 	if (bolt_locked)
 		. += "The [bolt_wording] is locked back and needs to be released before firing."
 	if (suppressed)
-		. += "It has a [suppressed] attached that can be removed with <b>alt+click</b>."
+		if(can_unsuppress)
+			. += "It has a [suppressed] attached that can be removed with <b>alt+click</b>."
+		else
+			. += "It has a <b>suppressor</b> built into the barrel."
+			
 
 /obj/item/gun/ballistic/verb/set_reload()
 	set name = "Set Reload Speech"

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -135,12 +135,6 @@
 	can_unsuppress = FALSE
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/tra32
 
-/obj/item/gun/ballistic/revolver/tracking/examine(mob/user) //So the suppressor doesn't have a weird detach text
-	. = ..()
-	if (suppressed)
-		. -= "It has a [suppressed] attached that can be removed with <b>alt+click</b>."
-		. += "It has a <b>suppressor</b> built into the barrel."
-
 /obj/item/gun/ballistic/revolver/mateba
 	name = "\improper Unica 6 auto-revolver"
 	desc = "A retro high-powered autorevolver typically used by officers of the New Russia military. Uses .357 ammo."


### PR DESCRIPTION
# Document the changes in your pull request

saw this turns out we have a thing for it

:cl:  
bugfix: the syndicate pocket syringe gun thingy no longer says it can be unsuppressed when it can't
/:cl:
