### PR TITLE
Preternis no longer have 0.1 slowdown

### DIFF
--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -18,11 +18,10 @@ adjust_charge - take a positive or negative value to adjust the charge level
 	toxic_food = NONE
 	liked_food = FRIED | SUGAR | JUNKFOOD | FRUIT
 	disliked_food = GROSS | VEGETABLES
-	brutemod = 1.25 //Have you ever punched a metal plate?
+	brutemod = 1.25
 	burnmod = 1.5 //Computers don't like heat
 	coldmod = 0.8 //Computers like cold, but their lungs may not
 	heatmod = 1.75 //Again, computers don't like heat
-	speedmod = 0.1 //Metal legs are heavy and slow
 	punchstunthreshold = 9 //Stun range 9-10 on punch, you are being slugged in the brain by a metal robot fist.
 	siemens_coeff = 1.75 //Computers REALLY don't like being shorted out
 	payday_modifier = 0.8 //Useful to NT for engineering + very close to Human


### PR DESCRIPTION
# Document the changes in your pull request

Based on their damage mods they’re clearly made of something lighter than plasteel - tinfoil, possibly. So no, these metal legs should not be heavy and slow.

Possibly less controversial mutually exclusive course of action to #15657 

# Wiki Documentation

Is behind on their damage mods

# Changelog

:cl: 
tweak: preternis no longer have a move speed penalty
/:cl: