### PR TITLE
Adds in a new 10x5 Medical themed maint ruin: Medical Celebration & Adds Donut ruin to landmarks.dm

### DIFF
--- a/_maps/RandomRuins/StationRuins/maint/10x5/10x5_medicalmaint.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/10x5/10x5_medicalmaint.dmm
@@ -1,0 +1,503 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/structure/frame/machine,
+/obj/item/vending_refill/snack,
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"b" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/item/toy/plush/foxplushie{
+	color = "#333F45"
+	},
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"c" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/rock/pile{
+	pixel_x = 1;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/structure/flora/stump,
+/turf/open/floor/grass,
+/area/template_noop)
+"d" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/template_noop)
+"e" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/med_data/laptop,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"f" = (
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating,
+/area/template_noop)
+"g" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 8
+	},
+/obj/item/book/manual/wiki/medicine{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/wrench/medical{
+	pixel_x = -2;
+	pixel_y = -14
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"h" = (
+/obj/effect/turf_decal/trimline/blue/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"i" = (
+/obj/item/stack/cable_coil/cut/red{
+	amount = 2;
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/item/trash/can{
+	pixel_x = 9;
+	pixel_y = 12
+	},
+/obj/item/trash/sosjerky,
+/turf/open/floor/plating,
+/area/template_noop)
+"j" = (
+/obj/structure/table/glass,
+/obj/structure/sign/poster/ripped{
+	pixel_x = -32
+	},
+/obj/machinery/light/broken,
+/obj/item/organ/ears/cat{
+	pixel_x = 1;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/regular{
+	empty = 1;
+	name = "First-Aid (empty)";
+	pixel_y = 1
+	},
+/obj/item/storage/firstaid/emergency,
+/turf/open/floor/plating,
+/area/template_noop)
+"k" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"l" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"m" = (
+/obj/item/trash/waffles,
+/turf/open/floor/plating,
+/area/template_noop)
+"n" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/template_noop)
+"o" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"p" = (
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/obj/item/clothing/neck/stethoscope{
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"q" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"r" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-27"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 10
+	},
+/obj/item/toy/plush/lizardplushie{
+	color = "#490092";
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"s" = (
+/obj/structure/table,
+/obj/item/plate,
+/obj/item/reagent_containers/food/snacks/cakeslice/birthday{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/machinery/modular_computer/telescreen/preset/medical{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"u" = (
+/obj/machinery/light/built{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"v" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"w" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"x" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/glowstick{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/obj/item/trash/plate,
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"y" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"z" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_x = -2;
+	pixel_y = 15
+	},
+/obj/item/shard{
+	pixel_y = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/template_noop)
+"A" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/item/healthanalyzer{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/britcup{
+	desc = "Kingston's personal cup.";
+	pixel_x = -4;
+	pixel_y = -2
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"B" = (
+/obj/machinery/medical_kiosk,
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"D" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"F" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/structure/noticeboard{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"G" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/obj/item/organ/tail/lizard/fake{
+	pixel_y = -12
+	},
+/turf/open/floor/grass,
+/area/template_noop)
+"H" = (
+/obj/effect/turf_decal/trimline/blue/filled/shrink_cw/lower,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"I" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"J" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/plating,
+/area/template_noop)
+"K" = (
+/obj/effect/turf_decal/trimline/blue/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/item/broken_bottle{
+	pixel_x = 10;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"L" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"N" = (
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
+/obj/item/reagent_containers/glass/bottle,
+/obj/item/reagent_containers/glass/bottle/formaldehyde{
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -28
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/template_noop)
+"O" = (
+/obj/item/chair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/shreds{
+	pixel_y = -5
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/template_noop)
+"P" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"R" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/item/toy/figure/md,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"S" = (
+/obj/effect/turf_decal/trimline/blue/corner/lower,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"T" = (
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/template_noop)
+"U" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"V" = (
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 30
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"W" = (
+/obj/effect/decal/cleanable/robot_debris/gib,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/template_noop)
+"X" = (
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"Y" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/template_noop)
+"Z" = (
+/obj/item/clothing/neck/yogs/stripedscarf/pink{
+	pixel_x = 3
+	},
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+
+(1,1,1) = {"
+I
+q
+d
+o
+j
+"}
+(2,1,1) = {"
+Y
+U
+p
+w
+N
+"}
+(3,1,1) = {"
+u
+e
+Z
+n
+r
+"}
+(4,1,1) = {"
+l
+A
+J
+m
+H
+"}
+(5,1,1) = {"
+S
+W
+v
+P
+h
+"}
+(6,1,1) = {"
+L
+G
+c
+z
+f
+"}
+(7,1,1) = {"
+Y
+g
+y
+y
+K
+"}
+(8,1,1) = {"
+B
+k
+X
+O
+F
+"}
+(9,1,1) = {"
+V
+i
+X
+x
+s
+"}
+(10,1,1) = {"
+T
+a
+D
+b
+R
+"}

--- a/_maps/RandomRuins/StationRuins/maint/10x5/10x5_medicalmaint.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/10x5/10x5_medicalmaint.dmm
@@ -23,24 +23,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/template_noop)
-"c" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/flora/rock/pile{
-	pixel_x = 1;
-	pixel_y = -2
-	},
-/obj/effect/decal/cleanable/blood/footprints{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/structure/flora/stump,
-/turf/open/floor/grass,
-/area/template_noop)
 "d" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
@@ -90,28 +72,6 @@
 	pixel_y = 12
 	},
 /obj/item/trash/sosjerky,
-/turf/open/floor/plating,
-/area/template_noop)
-"j" = (
-/obj/structure/table/glass,
-/obj/structure/sign/poster/ripped{
-	pixel_x = -32
-	},
-/obj/machinery/light/broken,
-/obj/item/organ/ears/cat{
-	pixel_x = 1;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 8;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/regular{
-	empty = 1;
-	name = "First-Aid (empty)";
-	pixel_y = 1
-	},
-/obj/item/storage/firstaid/emergency,
 /turf/open/floor/plating,
 /area/template_noop)
 "k" = (
@@ -183,11 +143,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/template_noop)
-"u" = (
-/obj/machinery/light/built{
-	dir = 1
+"t" = (
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/stump,
+/turf/open/floor/grass,
 /area/template_noop)
 "v" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
@@ -267,6 +236,32 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/template_noop)
+"E" = (
+/obj/structure/table/glass,
+/obj/structure/sign/poster/ripped{
+	pixel_x = -32
+	},
+/obj/machinery/light/broken,
+/obj/item/organ/ears/cat{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 12;
+	pixel_y = 4
+	},
+/obj/item/storage/firstaid/regular{
+	empty = 1;
+	name = "First-Aid (empty)";
+	pixel_x = 1;
+	pixel_y = 2
+	},
+/obj/item/storage/firstaid/emergency{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/turf/open/floor/plating,
+/area/template_noop)
 "F" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -328,23 +323,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/white,
 /area/template_noop)
-"N" = (
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder,
-/obj/item/reagent_containers/glass/bottle,
-/obj/item/reagent_containers/glass/bottle/formaldehyde{
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -28
+"M" = (
+/obj/machinery/light/built{
+	dir = 1
 	},
 /turf/open/floor/plating{
-	icon_state = "platingdmg1"
+	icon_state = "panelscorched"
 	},
 /area/template_noop)
 "O" = (
@@ -365,6 +349,31 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/white,
+/area/template_noop)
+"Q" = (
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder{
+	pixel_x = -1;
+	pixel_y = 13
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -28
+	},
+/obj/item/reagent_containers/glass/bottle/formaldehyde{
+	pixel_x = -12;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/glass/bottle{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
 /area/template_noop)
 "R" = (
 /obj/structure/chair/office{
@@ -436,17 +445,17 @@ I
 q
 d
 o
-j
+E
 "}
 (2,1,1) = {"
 Y
 U
 p
 w
-N
+Q
 "}
 (3,1,1) = {"
-u
+M
 e
 Z
 n
@@ -469,7 +478,7 @@ h
 (6,1,1) = {"
 L
 G
-c
+t
 z
 f
 "}

--- a/yogstation/code/datums/ruins/station.dm
+++ b/yogstation/code/datums/ruins/station.dm
@@ -1136,6 +1136,12 @@
 	suffix = "10x5_bamboo.dmm"
 	name = "Maint bamboo"
 
+///Author: Gravehat
+/datum/map_template/ruin/station/maint/tenxfive/medicalmaint
+	id = "medicalmaint"
+	suffix = "10x5_medicalmaint.dmm"
+	name = "Maint medicalmaint"
+
 ///The base for the 10x10 rooms.
 /datum/map_template/ruin/station/maint/tenxten
 	prefix = "_maps/RandomRuins/StationRuins/maint/10x10/"

--- a/yogstation/code/game/objects/effects/landmarks.dm
+++ b/yogstation/code/game/objects/effects/landmarks.dm
@@ -146,7 +146,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 	template_names = list("Maint 2storage", "Maint 9storage", "Maint airstation", "Maint biohazard", "Maint boxbedroom", "Maint boxchemcloset", "Maint boxclutter2", "Maint boxclutter3", "Maint boxclutter4", "Maint boxclutter5", "Maint boxclutter6", "Maint boxclutter8",
 	"Maint boxwindow", "Maint bubblegumaltar", "Maint deltajanniecloset", "Maint deltaorgantrade", "Maint donutcapgun", "Maint dronehole", "Maint gibs", "Maint hazmat", "Maint hobohut", "Maint hullbreach", "Maint kilolustymaid", "Maint kilomechcharger", "Maint kilotheatre",
 	"Maint medicloset", "Maint memorial", "Maint metaclutter2", "Maint metaclutter4", "Maint metagamergear", "Maint owloffice", "Maint plasma", "Maint pubbyartism", "Maint pubbyclutter1", "Maint pubbyclutter2", "Maint pubbyclutter3", "Maint radspill", "Maint shrine", "Maint singularity",
-	"Maint tanning", "Maint tranquility", "Maint wash", "Maint command", "Maint dummy", "Maint spaceart", "Maint containmentcell", "Maint naughtyroom", "Maint vendoraccident")
+	"Maint tanning", "Maint tranquility", "Maint wash", "Maint command", "Maint dummy", "Maint spaceart", "Maint containmentcell", "Maint naughtyroom", "Maint vendoraccident", "Maint donut")
 
 /obj/effect/landmark/stationroom/maint/threexfive
 	template_names = list("Maint airlockstorage", "Maint boxclutter7", "Maint boxkitchen", "Maint boxmaintfreezers", "Maint canisterroom", "Maint checkpoint", "Maint hank", "Maint junkcloset", "Maint kilomobden", "Maint laststand", "Maint monky", "Maint onioncult", "Maint pubbyclutter5",
@@ -162,7 +162,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 
 /obj/effect/landmark/stationroom/maint/tenxfive
 	template_names = list("Maint barbershop", "Maint deltaarcade", "Maint deltabotnis", "Maint deltacafeteria", "Maint deltaclutter1", "Maint deltarobotics", "Maint factory", "Maint maintmedical", "Maint meetingroom", "Maint phage", "Maint skidrow", "Maint transit", "Maint ballpit", "Maint commie", "Maint firingrange", "Maint clothingstore",
-	"Maint butchersden", "Maint courtroom", "Maint gaschamber", "Maint oldaichamber", "Maint radiationtherapy", "Maint ratburger", "Maint tank_heaven", "Maint bamboo")
+	"Maint butchersden", "Maint courtroom", "Maint gaschamber", "Maint oldaichamber", "Maint radiationtherapy", "Maint ratburger", "Maint tank_heaven", "Maint bamboo", "Maint medicalmaint")
 
 /obj/effect/landmark/stationroom/maint/tenxten
 	template_names = list("Maint aquarium", "Maint bigconstruction", "Maint bigtheatre", "Maint deltalibrary", "Maint graffitiroom", "Maint junction", "Maint podrepairbay", "Maint pubbybar", "Maint roosterdome", "Maint sanitarium", "Maint snakefighter", "Maint vault", "Maint ward", "Maint assaultpod", "Maint maze", "Maint maze2", "Maint boxfactory",


### PR DESCRIPTION
Medical Maint Maint Medical

# Document the changes in your pull request

Adds in a new maint ruin and adds it and a previously not spawning ruin to landmarks.dm
![image](https://user-images.githubusercontent.com/107460718/189118272-1d81f4b4-f686-4443-9f57-613c0c51d7a5.png)
Notable things it contains include, the holy medical wrench, an entire medical kiosk, a fully functioning medical record laptop, an All-In-One Grinder, an IV drip, a fully functioning accessible crew monitor telescreen, a lizard tail, a pair of cat ears, a beaker, a bottle of formaldehyde a lizard plushie, a fox plushie, a stethoscope, a random donk pocket spawner, and a random glowstick spawner.

![image](https://user-images.githubusercontent.com/107460718/189122772-333c2391-74ef-4f61-aa94-6ebe43780679.png)
Medical Maint on Asteroid Station.

Why? I looked at maint medical and it looked ugly as hell so I made a ruin intending to replace it but decided against it as it would make for a great ghetto meth lab; so I opted for coexistence. There are some player references here but it is incredibly unspecific and I will not be naming them.

# Changelog

:cl:  
rscadd: Added a new medical-themed 10x5 maint ruin
bugfix: Adds Maint donut to landmarks.dm
/:cl:
