### PR TITLE
nerfs gamer chem #1 to remind powergaming chemists that their actions have consequences

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -176,7 +176,7 @@
 	taste_description = "spicy jelly"
 
 /datum/reagent/medicine/pyroxadone/on_mob_life(mob/living/carbon/M)
-	if(M.bodytemperature > BODYTEMP_HEAT_DAMAGE_LIMIT)
+	if(M.bodytemperature > BODYTEMP_HEAT_DAMAGE_LIMIT && M.IsUnconscious())
 		var/power = 0
 		switch(M.bodytemperature)
 			if(BODYTEMP_HEAT_DAMAGE_LIMIT to 400)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -130,13 +130,13 @@
 
 /datum/reagent/medicine/cryoxadone
 	name = "Cryoxadone"
-	description = "A chemical mixture with almost magical healing powers. Its main limitation is that the patient's body temperature must be under 270K for it to metabolise correctly."
+	description = "A chemical mixture with almost magical healing powers. Its main limitations are that the patient's body temperature must be under 270K for it to metabolise correctly, and the patient must be unconscious."
 	color = "#0000C8"
 	taste_description = "sludge"
 
 /datum/reagent/medicine/cryoxadone/on_mob_life(mob/living/carbon/M)
 	var/power = -0.00006 * (M.bodytemperature ** 2) + 6
-	if(M.bodytemperature < T0C)
+	if(M.bodytemperature < T0C && (M.IsUnconscious() || istype(src, /datum/reagent/medicine/cryoxadone/hugbox)))
 		M.adjustOxyLoss(-3 * power, 0)
 		M.adjustBruteLoss(-power, 0)
 		M.adjustFireLoss(-power, 0)
@@ -149,6 +149,10 @@
 		. = 1
 	metabolization_rate = REAGENTS_METABOLISM * (0.00001 * (M.bodytemperature ** 2) + 0.5)
 	..()
+
+/datum/reagent/medicine/cryoxadone/hugbox //hugbox is to keep parity with stuff thats main purpose is to give you cryodoxone eg xenobio bullshit
+	name = "Advanced Cryoxadone"
+	description = "A strange form of Cryoxadone that induces micro-sleep in the patient, allowing them to heal even while awake."
 
 /datum/reagent/medicine/clonexadone
 	name = "Clonexadone"

--- a/code/modules/research/xenobiology/crossbreeding/burning.dm
+++ b/code/modules/research/xenobiology/crossbreeding/burning.dm
@@ -122,7 +122,7 @@ Burning extracts:
 	user.visible_message(span_danger("[src] releases a burst of chilling smoke!"))
 	var/datum/reagents/R = new/datum/reagents(100)
 	R.add_reagent(/datum/reagent/consumable/frostoil, 40)
-	user.reagents.add_reagent(/datum/reagent/medicine/cryoxadone,10)
+	user.reagents.add_reagent(/datum/reagent/medicine/cryoxadone/hugbox,10)
 	var/datum/effect_system/smoke_spread/chem/smoke = new
 	smoke.set_up(R, 7, get_turf(user))
 	smoke.start()

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -331,7 +331,7 @@
 			user.ExtinguishMob()
 			user.adjust_fire_stacks(-20)
 			user.reagents.add_reagent(/datum/reagent/consumable/frostoil,4)
-			user.reagents.add_reagent(/datum/reagent/medicine/cryoxadone,5)
+			user.reagents.add_reagent(/datum/reagent/medicine/cryoxadone/hugbox,5)
 			return 100
 
 		if(SLIME_ACTIVATE_MAJOR)


### PR DESCRIPTION
basically, cryoxadone now only heals you while you are asleep. that's it. for cryo tubes, there is no change in functionality because cryo tubes put you to sleep when you're inside them. a special hugbox form of cryoxadone has been created to prevent xenobiologists from having their healing abilities actually just kill them because slime people getting injected with frost oil and the cryoxadone that's supposed to heal them not doing that is a bad thing.

Tested, seems to work fine

# Changelog

:cl:  
tweak: cryoxadone (&  pyroxadone) excluding xenobio cryoxadone now only heals you if you're not conscious
/:cl:
