### PR TITLE
more nerfs to make choomists cry

### DIFF
--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -17,10 +17,20 @@
 	return
 
 /datum/wires/explosive/chem_grenade
-	duds_number = 1
+	duds_number = 2
 	holder_type = /obj/item/grenade/chem_grenade
 	randomize = TRUE
 	var/fingerprint
+
+/datum/wires/explosive/chem_grenade/New(atom/holder)
+	wires = list(
+		WIRE_BOOM //two duds and the explosion wire.
+	)
+	..()
+
+/datum/wires/explosive/chem_grenade/on_pulse(wire)
+	if(wire == WIRE_BOOM)
+		explode()
 
 /datum/wires/explosive/chem_grenade/interactable(mob/user)
 	var/obj/item/grenade/chem_grenade/G = holder

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -16,10 +16,6 @@
 	var/casedesc = "This basic model accepts both beakers and bottles. It heats contents by 10°K upon ignition." // Appears when examining empty casings.
 	var/obj/item/assembly/prox_sensor/landminemode = null
 
-/obj/item/grenade/chem_grenade/ComponentInitialize()
-	. = ..()
-	AddComponent(/datum/component/empprotection, EMP_PROTECT_WIRES)
-
 /obj/item/grenade/chem_grenade/Initialize()
 	. = ..()
 	create_reagents(1000)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1334,9 +1334,10 @@
 	// Heart attack code will not do damage if corazone is present
 	// because it's SPACE MAGIC ASPIRIN
 	name = "Corazone"
-	description = "A medication used to treat pain, fever, and inflammation, along with heart attacks."
+	description = "A medication used to treat pain, fever, and inflammation, along with heart attacks. Causes rapid organ failure when overdosed."
 	color = "#F5F5F5"
 	self_consuming = TRUE
+	overdose_threshold = 30
 
 /datum/reagent/medicine/corazone/on_mob_metabolize(mob/living/M)
 	..()
@@ -1346,6 +1347,12 @@
 /datum/reagent/medicine/corazone/on_mob_end_metabolize(mob/living/M)
 	REMOVE_TRAIT(M, TRAIT_STABLEHEART, type)
 	REMOVE_TRAIT(M, TRAIT_STABLELIVER, type)
+	..()
+
+/datum/reagent/medicine/corazone/overdose_process(mob/living/M)
+	M.adjustOrganLoss(ORGAN_SLOT_HEART, 1.5 * REM)
+	M.adjustOrganLoss(ORGAN_SLOT_LIVER, 1 * REM)
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.8 * REM)
 	..()
 
 /datum/reagent/medicine/muscle_stimulant


### PR DESCRIPTION
grenades have been changed. instead of 1 wire to stick stuff onto, the grenade now has three. this is paired with removing the EMP protection from grenade wires, so a stray EMP can cause them to blow up. also makes corazone cause a bunch of organ damage to you if you overdose (overdose is currently 30u) which isnt problematic until you get total liver failure from it which prevents you from metabolizing the corazone anymore which will most likely cause your heart attacks to become real, killing you. for people who are already experiencing heart attacks (from heart damage) your heart is already probably fucked up and the heart damage wont matter so much, go to medbay and get surgery instead of guzzling 900u of chems lol


# Changelog

:cl:  
tweak: corazone now overdoses at 30u, the overdose causes some heart, liver and brain damage
tweak: chem grenades can now blow up from EMPs
/:cl:
