### PR TITLE
Makes Ice Wing Watcher Crusher Trophy Work Like Iceblock Talisman & Buffs Magma Wing Trophy

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -247,7 +247,7 @@
 	desc = "A still-searing wing from a magmawing watcher. Suitable as a trophy for a kinetic crusher."
 	icon_state = "magma_wing"
 	gender = NEUTER
-	bonus_value = 5
+	bonus_value = 8
 
 /obj/item/crusher_trophy/blaster_tubes/magma_wing/effect_desc()
 	return "mark detonation to make the next destabilizer shot deal <b>[bonus_value]</b> damage"
@@ -265,7 +265,44 @@
 	name = "icewing watcher wing"
 	desc = "A carefully preserved frozen wing from an icewing watcher. Suitable as a trophy for a kinetic crusher."
 	icon_state = "ice_wing"
-	bonus_value = 8
+	bonus_value = 0
+
+/obj/item/crusher_trophy/watcher_wing/ice_wing/effect_desc()
+	return "mark detonation to freeze a creature in a block of ice for a period, preventing them from moving"
+
+/obj/item/crusher_trophy/watcher_wing/ice_wing/on_mark_detonation(mob/living/target, mob/living/user)
+	target.apply_status_effect(/datum/status_effect/ice_block_talisman)
+
+/datum/status_effect/ice_wing_talisman
+	id = "ice_wing_talisman"
+	duration = 25
+	status_type = STATUS_EFFECT_REFRESH
+	alert_type = /obj/screen/alert/status_effect/ice_block_talisman
+	var/icon/cube
+
+/obj/screen/alert/status_effect/ice_wing_talisman
+	name = "Frozen Solid"
+	desc = "You're frozen inside an ice cube, and cannot move!"
+	icon_state = "frozen"
+
+/datum/status_effect/ice_wing_talisman/on_apply()
+	RegisterSignal(owner, COMSIG_MOVABLE_PRE_MOVE, .proc/owner_moved)
+	if(!owner.stat)
+		to_chat(owner, span_userdanger("You become frozen in a cube!"))
+	cube = icon('icons/effects/freeze.dmi', "ice_cube")
+	var/icon/size_check = icon(owner.icon, owner.icon_state)
+	cube.Scale(size_check.Width(), size_check.Height())
+	owner.add_overlay(cube)
+	return ..()
+
+/datum/status_effect/ice_wing_talisman/proc/owner_moved()
+	return COMPONENT_MOVABLE_BLOCK_PRE_MOVE
+
+/datum/status_effect/ice_wing_talisman/on_remove()
+	if(!owner.stat)
+		to_chat(owner, span_notice("The cube melts!"))
+	owner.cut_overlay(cube)
+	UnregisterSignal(owner, COMSIG_MOVABLE_PRE_MOVE)
 
 //legion
 /obj/item/crusher_trophy/legion_skull


### PR DESCRIPTION
# Document the changes in your pull request

lets be fair, a whole 4% more effect was boring as fuck. And if I can't give people Demonic-Frost Miner on Lavaland, this should be more doable.

also buffs Magma wing's by 4%, because they're a little more rare anyway.

# Wiki Documentation

If the wiki for fauna includes crusher trophies, this may need a mention.

# Changelog

:cl:  
tweak: Ice Wing Watcher Crusher Trophy reworked into a copy of the Iceblock Talisman
tweak: Magma Wing Watcher Crusher Trophy 
/:cl:
