### PR TITLE
Limits Changelings Gamemode & Dynamic Roundstart

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -13,8 +13,8 @@ GLOBAL_VAR(changeling_team_objective_type) //If this is not null, we hand our th
 	false_report_weight = 10
 	restricted_jobs = list("AI", "Cyborg")
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Brig Physician") //YOGS - added hop and brig physician
-	required_players = 15
-	required_enemies = 1
+	required_players = 25
+	required_enemies = 2
 	recommended_enemies = 4
 	reroll_friendly = 1
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -108,6 +108,7 @@
 	cost = 16
 	scaling_cost = 10
 	requirements = list(75,70,60,50,40,20,20,10,10,10)
+	minimum_players = 25
 	antag_cap = list("denominator" = 29)
 
 /datum/dynamic_ruleset/roundstart/changeling/pre_execute(population)


### PR DESCRIPTION
# Document the changes in your pull request

Does what it says on the tin
slaps a minimum of 25 onto dynamic lings which had none
and ups the non-dynamic lings to 25 from 15, which is ABYSMALLY low for this type of antag. Their gimmick barely works below 20 people anyway
non-dynamic lings also requires at least 2 lings now, because they have lots of ways to interact with other changelings, and solo ling is bad.

# Changelog

:cl:  
tweak: Changelings now requires a population of 25 or higher.
tweak: changelings now requires a minimum antag count of 2
/:cl:
