### PR TITLE
Fixes IPC trying to speak while dead & removes brain loss on revival

### DIFF
--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -194,6 +194,7 @@
 	if(H.mind)
 		H.mind.grab_ghost()
 	to_chat(user, span_notice("You reset the IPC's internal circuitry - reviving them!"))
+	H.setOrganLoss(ORGAN_SLOT_BRAIN, 0)
 	H.revive()
 	qdel(src)
 	return TRUE

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -1,3 +1,5 @@
+#define CONCIOUSAY(text) if(H.stat == CONSCIOUS) { ##text }
+
 /datum/species/ipc // im fucking lazy mk2 and cant get sprites to normally work
 	name = "IPC" //inherited from the real species, for health scanners and things
 	id = "ipc"
@@ -181,14 +183,16 @@ datum/species/ipc/on_species_loss(mob/living/carbon/C)
 	addtimer(CALLBACK(src, .proc/afterrevive, H), 0)
 	return
 
-/datum/species/ipc/proc/afterrevive(mob/living/carbon/human/H)
-	H.say("Reactivating [pick("core systems", "central subroutines", "key functions")]...")
+/datum/species/ipc/proc/afterrevive(mob/living/carbon/human/H)	
+	CONCIOUSAY(H.say("Reactivating [pick("core systems", "central subroutines", "key functions")]..."))
 	sleep(3 SECONDS)
-	H.say("Reinitializing [pick("personality matrix", "behavior logic", "morality subsystems")]...")
+	CONCIOUSAY(H.say("Reinitializing [pick("personality matrix", "behavior logic", "morality subsystems")]..."))
 	sleep(3 SECONDS)
-	H.say("Finalizing setup...")
+	CONCIOUSAY(H.say("Finalizing setup..."))
 	sleep(3 SECONDS)
-	H.say("Unit [H.real_name] is fully functional. Have a nice day.")
+	CONCIOUSAY(H.say("Unit [H.real_name] is fully functional. Have a nice day."))
+	if(H.stat == DEAD)
+		return
 	H.dna.features["ipc_screen"] = saved_screen
 	H.update_body()
 
@@ -220,4 +224,5 @@ datum/species/ipc/on_species_loss(mob/living/carbon/C)
 /datum/species/ipc/force_drink_text(obj/O, mob/living/carbon/C, mob/user)
 	C.visible_message(span_danger("[user] attempts to pour [O] down [C]'s port!"), \
 										span_userdanger("[user] attempts to pour [O] down [C]'s port!"))
-	
+
+#undef CONCIOUSAY


### PR DESCRIPTION
# Document the changes in your pull request

why does say send to deadchat if your dead
also sets brain damage to 0 so you dont instantly die

# Changelog

:cl:  
bugfix: Fixed some funnyness with IPC revival
/:cl:
