### PR TITLE
tones down hulk to be less ridiculous and returns it to genetics

### DIFF
--- a/code/datums/mutations/_combined.dm
+++ b/code/datums/mutations/_combined.dm
@@ -13,6 +13,10 @@
 
 /* RECIPES */
 
+/datum/generecipe/hulk
+	required = "/datum/mutation/human/strong; /datum/mutation/human/radioactive"
+	result = GENETICS_HULK
+
 /datum/generecipe/mindread
 	required = "/datum/mutation/human/antenna; /datum/mutation/human/paranoia"
 	result = MINDREAD

--- a/code/datums/mutations/hulk.dm
+++ b/code/datums/mutations/hulk.dm
@@ -74,7 +74,6 @@
 	text_gain_indication = span_notice("Your muscles hurt!")
 	health_req = 1
 	var/health_based = 0
-	power = /obj/effect/proc_holder/spell/aoe_turf/repulse/hulk
 
 /datum/mutation/human/active_hulk/on_acquiring(mob/living/carbon/human/owner)
 	if(..())
@@ -98,6 +97,8 @@
 	owner.say("PUNY HUMANS!!")
 	owner.physiology.stamina_mod = 0.3
 	owner.update_body()
+	if(iswizard(owner))
+		owner.mind.AddSpell(/obj/effect/proc_holder/spell/aoe_turf/repulse/hulk) //Restricted to Wizards. Mistakes were made.
 
 /datum/mutation/human/active_hulk/on_attack_hand(atom/target, proximity)
 	if(proximity) //no telekinetic hulk attack
@@ -123,6 +124,7 @@
 	owner.physiology.stamina_mod = initial(owner.physiology.stamina_mod)
 	owner.update_body_parts()
 	owner.dna.species.handle_mutant_bodyparts(owner)
+	owner.mind.spell_list.Remove(/obj/effect/proc_holder/spell/aoe_turf/repulse/hulk)
 
 /datum/mutation/human/active_hulk/proc/handle_speech(original_message, wrapped_message)
 	var/message = wrapped_message[1]

--- a/code/datums/mutations/hulk.dm
+++ b/code/datums/mutations/hulk.dm
@@ -50,7 +50,7 @@
 	name = "Hulk"
 	desc = "A seemingly dormant genome, but reacts violently to aggitation."
 	difficulty = 16
-	instability = 90
+	instability = 50
 	class = MUT_OTHER
 	locked = TRUE
 	quality = POSITIVE

--- a/code/datums/mutations/hulk.dm
+++ b/code/datums/mutations/hulk.dm
@@ -50,7 +50,7 @@
 	name = "Hulk"
 	desc = "A seemingly dormant genome, but reacts violently to aggitation."
 	difficulty = 16
-	instability = 50
+	instability = 70
 	class = MUT_OTHER
 	locked = TRUE
 	quality = POSITIVE

--- a/code/datums/mutations/hulk.dm
+++ b/code/datums/mutations/hulk.dm
@@ -104,7 +104,7 @@
 	if(proximity) //no telekinetic hulk attack
 		if(prob(3))
 			owner.Jitter(10)
-		owner.adjustStaminaLoss(-0.5)
+		owner.adjustStaminaLoss(-0.3)
 		return target.attack_hulk(owner)
 
 /datum/mutation/human/active_hulk/on_life()

--- a/code/datums/mutations/hulk.dm
+++ b/code/datums/mutations/hulk.dm
@@ -50,7 +50,7 @@
 	name = "Hulk"
 	desc = "A seemingly dormant genome, but reacts violently to aggitation."
 	difficulty = 16
-	instability = 70
+	instability = 90
 	class = MUT_OTHER
 	locked = TRUE
 	quality = POSITIVE

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -218,7 +218,7 @@
 		var/message = "[user] has [hulk_verb]ed [src]!"
 		visible_message(span_danger("[message]"), \
 								span_userdanger("[message]"))
-		apply_damage(15, BRUTE, wound_bonus=10)
+		apply_damage(15, BRUTE, BODY_ZONE_CHEST, run_armor_check(BODY_ZONE_CHEST, MELEE), wound_bonus=10)
 		return 1
 
 /mob/living/carbon/human/attack_hand(mob/user)


### PR DESCRIPTION
basically, hulk now respects melee armor instead of completely ignoring it. Hulk attacks also calculate armor and damage to just the chest, so riot suit + sec jumpsuit does 6 damage instead of 15. Hulks also do not get the very funny AoE stun spell, unless the hulkee is a wizard. Hulk smashes also restore less stamina so you can't infinitely extend your hulk timer.

Alternative to  #15705


# Changelog

:cl:  
tweak: Hulk's recipe has returned.
tweak: non-wizard hulks don't get the AoE stun spell, and hulk smashes respect melee armor. Hulks smashes now remove less stamina damage per smash
/:cl:
