### PR TITLE
Syndie Fedora Cost Increase

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2311,7 +2311,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Syndicate Fedora"
 	desc = "This Syndicate Fedora of micro-woven adamantium silk is sure to prove your style!"
 	item = /obj/item/clothing/head/det_hat/evil
-	cost = 3
+	cost = 6
 
 /datum/uplink_item/badass/balloon
 	name = "Syndicate Balloon"


### PR DESCRIPTION
# Document the changes in your pull request

Cost of Syndie fedora is 6 TC now because it is an incredibly effective weapon for its cost and a 40 force throw that can repeat and quickly destroy anything.

Woe upon ye, Fedora Man.

# Wiki Documentation

Syndie Items, Pointless Badassery

# Changelog

:cl:  
tweak: Inflation in the premium hat market has doubled the price of the Syndicate fedora
/:cl:
