### PR TITLE
Adds "The round has ended" to logs when the round ends

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -163,6 +163,8 @@
 	set waitfor = FALSE
 
 	to_chat(world, "<BR><BR><BR><span class='big bold'>The round has ended.</span>")
+	log_admin("The round has ended.")
+	
 	if(LAZYLEN(GLOB.round_end_notifiees))
 		send2irc("Notice", "[GLOB.round_end_notifiees.Join(", ")] the round has ended.")
 


### PR DESCRIPTION
# Document the changes in your pull request

Erm actualyl mr admin i blew it after it said the round ended on my screen (did not)

# Changelog

:cl:  
rscadd: tells admins when round ends in logs
/:cl:
