### PR TITLE
Updates All* Mech Armor Values (Excludes Ripley 1) & Adds Conveyors To The ExoFab MISC Tab

### DIFF
--- a/code/game/gamemodes/clown_ops/clown_weapons.dm
+++ b/code/game/gamemodes/clown_ops/clown_weapons.dm
@@ -267,7 +267,7 @@
 	icon_state = "darkhonker"
 	max_integrity = 300
 	deflect_chance = 15
-	armor = list(MELEE = 40, BULLET = 40, LASER = 50, ENERGY = 35, BOMB = 20, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 40, BULLET = 40, LASER = 50, ENERGY = 35, BOMB = 20, BIO = 100, RAD = 100, FIRE = 100, ACID = 100)
 	max_temperature = 35000
 	operation_req_access = list(ACCESS_SYNDICATE)
 	internals_req_access = list(ACCESS_SYNDICATE)

--- a/code/game/mecha/combat/combat.dm
+++ b/code/game/mecha/combat/combat.dm
@@ -2,7 +2,7 @@
 	force = 30
 	internals_req_access = list(ACCESS_MECH_SCIENCE, ACCESS_MECH_SECURITY)
 	internal_damage_threshold = 50
-	armor = list(MELEE = 30, BULLET = 30, LASER = 15, ENERGY = 20, BOMB = 20, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 100)
+	armor = list(MELEE = 30, BULLET = 30, LASER = 15, ENERGY = 20, BOMB = 20, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
 	mouse_pointer = 'icons/mecha/mecha_mouse.dmi'
 	destruction_sleep_duration = 40
 	exit_delay = 40

--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -6,7 +6,7 @@
 	dir_in = 1 //Facing North.
 	max_integrity = 400
 	deflect_chance = 20
-	armor = list(MELEE = 40, BULLET = 35, LASER = 15, ENERGY = 10, BOMB = 20, BIO = 0, RAD = 50, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 40, BULLET = 35, LASER = 15, ENERGY = 10, BOMB = 20, BIO = 100, RAD = 50, FIRE = 100, ACID = 100)
 	max_temperature = 30000
 	infra_luminosity = 8
 	force = 40

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -20,7 +20,7 @@
 	icon_state = "darkgygax"
 	max_integrity = 300
 	deflect_chance = 15
-	armor = list(MELEE = 40, BULLET = 40, LASER = 50, ENERGY = 35, BOMB = 20, BIO = 100, RAD = 40, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 40, BULLET = 40, LASER = 50, ENERGY = 35, BOMB = 20, BIO = 100, RAD = 100, FIRE = 100, ACID = 100)
 	max_temperature = 35000
 	leg_overload_coeff = 100
 	operation_req_access = list(ACCESS_SYNDICATE)

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -6,7 +6,7 @@
 	dir_in = 1 //Facing North.
 	max_integrity = 250
 	deflect_chance = 5
-	armor = list(MELEE = 25, BULLET = 20, LASER = 30, ENERGY = 15, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 25, BULLET = 20, LASER = 30, ENERGY = 15, BOMB = 0, BIO = 100, RAD = 40, FIRE = 100, ACID = 100)
 	max_temperature = 25000
 	infra_luminosity = 6
 	wreckage = /obj/structure/mecha_wreckage/gygax
@@ -20,7 +20,7 @@
 	icon_state = "darkgygax"
 	max_integrity = 300
 	deflect_chance = 15
-	armor = list(MELEE = 40, BULLET = 40, LASER = 50, ENERGY = 35, BOMB = 20, BIO = 0, RAD =20, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 40, BULLET = 40, LASER = 50, ENERGY = 35, BOMB = 20, BIO = 100, RAD = 40, FIRE = 100, ACID = 100)
 	max_temperature = 35000
 	leg_overload_coeff = 100
 	operation_req_access = list(ACCESS_SYNDICATE)

--- a/code/game/mecha/combat/honker.dm
+++ b/code/game/mecha/combat/honker.dm
@@ -6,7 +6,7 @@
 	max_integrity = 140
 	deflect_chance = 60
 	internal_damage_threshold = 60
-	armor = list(MELEE = -20, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
+	armor = list(MELEE = -20, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 20, FIRE = 100, ACID = 100)
 	max_temperature = 25000
 	infra_luminosity = 5
 	operation_req_access = list(ACCESS_THEATRE)

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -5,7 +5,7 @@
 	step_in = 5
 	max_integrity = 500
 	deflect_chance = 25
-	armor = list(MELEE = 50, BULLET = 55, LASER = 40, ENERGY = 30, BOMB = 30, BIO = 0, RAD = 60, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 50, BULLET = 55, LASER = 40, ENERGY = 30, BOMB = 30, BIO = 100, RAD = 60, FIRE = 100, ACID = 100)
 	max_temperature = 60000
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	infra_luminosity = 3

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -5,7 +5,7 @@
 	step_in = 5
 	max_integrity = 500
 	deflect_chance = 25
-	armor = list(MELEE = 50, BULLET = 55, LASER = 40, ENERGY = 30, BOMB = 30, BIO = 100, RAD = 60, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 50, BULLET = 55, LASER = 40, ENERGY = 30, BOMB = 30, BIO = 100, RAD = 100, FIRE = 100, ACID = 100)
 	max_temperature = 60000
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	infra_luminosity = 3

--- a/code/game/mecha/combat/phazon.dm
+++ b/code/game/mecha/combat/phazon.dm
@@ -7,7 +7,7 @@
 	step_energy_drain = 3
 	max_integrity = 200
 	deflect_chance = 30
-	armor = list(MELEE = 30, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 30, BIO = 0, RAD = 50, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 30, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 30, BIO = 100, RAD = 50, FIRE = 100, ACID = 100)
 	max_temperature = 25000
 	infra_luminosity = 3
 	wreckage = /obj/structure/mecha_wreckage/phazon

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -67,7 +67,7 @@
 	fast_pressure_step_in = 2 //step_in while in low pressure conditions
 	slow_pressure_step_in = 4 //step_in while in normal pressure conditions
 	step_in = 4
-	armor = list(MELEE = 40, BULLET = 20, LASER = 10, ENERGY = 20, BOMB = 40, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 40, BULLET = 20, LASER = 10, ENERGY = 20, BOMB = 40, BIO = 100, RAD = 55, FIRE = 100, ACID = 100)
 	wreckage = /obj/structure/mecha_wreckage/ripley/mkii
 	enclosed = TRUE
 	enter_delay = 40
@@ -85,7 +85,7 @@
 	step_in = 4
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	lights_power = 7
-	armor = list(MELEE = 40, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 60, BIO = 0, RAD = 70, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 40, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 60, BIO = 100, RAD = 70, FIRE = 100, ACID = 100)
 	max_equip = 5 // More armor, less tools
 	wreckage = /obj/structure/mecha_wreckage/ripley/firefighter
 	enclosed = TRUE
@@ -118,6 +118,7 @@
 
 /obj/mecha/working/ripley/deathripley/real
 	desc = "OH SHIT IT'S THE DEATHSQUAD WE'RE ALL GONNA DIE. FOR REAL"
+	armor = list(MELEE = 50, BULLET = 50, LASER = 50, ENERGY = 80, BOMB = 90, BIO = 100, RAD = 100, FIRE = 100, ACID = 100)
 
 /obj/mecha/working/ripley/deathripley/real/Initialize()
 	. = ..()

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -970,7 +970,7 @@
 /datum/design/conveyor_belt
 	name = "Conveyor Belt"
 	id = "conveyor_belt"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | MECHFAB
 	materials = list(/datum/material/iron = 3000)
 	build_path = /obj/item/stack/conveyor
 	category = list("initial", "Construction")

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -973,7 +973,7 @@
 	build_type = AUTOLATHE | MECHFAB
 	materials = list(/datum/material/iron = 3000)
 	build_path = /obj/item/stack/conveyor
-	category = list("initial", "Construction")
+	category = list("initial", "Construction", "Misc")
 	maxstack = 30
 
 
@@ -983,7 +983,7 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 450, /datum/material/glass = 190)
 	build_path = /obj/item/conveyor_switch_construct
-	category = list("initial", "Construction")
+	category = list("initial", "Construction", "Misc")
 
 /datum/design/laptop
 	name = "Laptop Frame"

--- a/yogstation/code/game/mecha/makeshift/lockermech.dm
+++ b/yogstation/code/game/mecha/makeshift/lockermech.dm
@@ -1,4 +1,4 @@
-/obj/mecha/makeshift
+/obj/mecha/working/makeshift
 	desc = "A locker with stolen wires, struts, electronics and airlock servos crudely assembled into something that resembles the functions of a mech."
 	name = "Locker Mech"
 	icon = 'yogstation/icons/mecha/lockermech.dmi'
@@ -6,14 +6,14 @@
 	max_integrity = 100 //its made of scraps
 	lights_power = 5
 	step_in = 4 //Same speed as a ripley, for now.
-	armor = list(melee = 20, bullet = 10, laser = 10, energy = 0, bomb = 10, bio = 0, rad = 0, fire = 70, acid = 60) //Same armour as a locker
+	armor = list(MELEE = 20, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 10, BIO = 0, RAD = 0, FIRE = 70, ACID = 60) //Same armour as a locker
 	internal_damage_threshold = 30 //Its got shitty durability
 	max_equip = 2 //You only have two arms and the control system is shitty
 	wreckage = null
 	var/list/cargo = list()
 	var/cargo_capacity = 5 // you can fit a few things in this locker but not much.
 
-/obj/mecha/makeshift/Topic(href, href_list)
+/obj/mecha/working/makeshiftTopic(href, href_list)
 	..()
 	if(href_list["drop_from_cargo"])
 		var/obj/O = locate(sanitize(href_list["drop_from_cargo"]))
@@ -24,21 +24,21 @@
 			log_message("Unloaded [O]. Cargo compartment capacity: [cargo_capacity - src.cargo.len]", LOG_MECHA)
 	return
 
-/obj/mecha/makeshift/go_out()
+/obj/mecha/working/makeshiftgo_out()
 	..()
 	update_icon()
 
-/obj/mecha/makeshift/moved_inside(mob/living/carbon/human/H)
+/obj/mecha/working/makeshiftmoved_inside(mob/living/carbon/human/H)
 	..()
 	update_icon()
 
 
-/obj/mecha/makeshift/Exit(atom/movable/O)
+/obj/mecha/working/makeshiftExit(atom/movable/O)
 	if(O in cargo)
 		return 0
 	return ..()
 
-/obj/mecha/makeshift/contents_explosion(severity, target)
+/obj/mecha/working/makeshiftcontents_explosion(severity, target)
 	for(var/X in cargo)
 		var/obj/O = X
 		if(prob(30/severity))
@@ -46,7 +46,7 @@
 			O.forceMove(loc)
 	. = ..()
 
-/obj/mecha/makeshift/get_stats_part()
+/obj/mecha/working/makeshiftget_stats_part()
 	var/output = ..()
 	output += "<b>Cargo Compartment Contents:</b><div style=\"margin-left: 15px;\">"
 	if(cargo.len)
@@ -57,7 +57,7 @@
 	output += "</div>"
 	return output
 
-/obj/mecha/makeshift/relay_container_resist(mob/living/user, obj/O)
+/obj/mecha/working/makeshiftrelay_container_resist(mob/living/user, obj/O)
 	to_chat(user, span_notice("You lean on the back of [O] and start pushing so it falls out of [src]."))
 	if(do_after(user, 1 SECONDS, O))//Its a fukken locker
 		if(!user || user.stat != CONSCIOUS || user.loc != src || O.loc != src )
@@ -69,6 +69,6 @@
 		if(user.loc == src) //so we don't get the message if we resisted multiple times and succeeded.
 			to_chat(user, span_warning("You fail to push [O] out of [src]!"))
 
-/obj/mecha/makeshift/Destroy()
+/obj/mecha/working/makeshiftDestroy()
 	new /obj/structure/closet(loc)
 	..()

--- a/yogstation/code/game/mecha/makeshift/lockermech.dm
+++ b/yogstation/code/game/mecha/makeshift/lockermech.dm
@@ -13,7 +13,7 @@
 	var/list/cargo = list()
 	var/cargo_capacity = 5 // you can fit a few things in this locker but not much.
 
-/obj/mecha/working/makeshiftTopic(href, href_list)
+/obj/mecha/working/makeshift/Topic(href, href_list)
 	..()
 	if(href_list["drop_from_cargo"])
 		var/obj/O = locate(sanitize(href_list["drop_from_cargo"]))
@@ -24,21 +24,21 @@
 			log_message("Unloaded [O]. Cargo compartment capacity: [cargo_capacity - src.cargo.len]", LOG_MECHA)
 	return
 
-/obj/mecha/working/makeshiftgo_out()
+/obj/mecha/working/makeshift/go_out()
 	..()
 	update_icon()
 
-/obj/mecha/working/makeshiftmoved_inside(mob/living/carbon/human/H)
+/obj/mecha/working/makeshift/moved_inside(mob/living/carbon/human/H)
 	..()
 	update_icon()
 
 
-/obj/mecha/working/makeshiftExit(atom/movable/O)
+/obj/mecha/working/makeshift/Exit(atom/movable/O)
 	if(O in cargo)
 		return 0
 	return ..()
 
-/obj/mecha/working/makeshiftcontents_explosion(severity, target)
+/obj/mecha/working/makeshift/contents_explosion(severity, target)
 	for(var/X in cargo)
 		var/obj/O = X
 		if(prob(30/severity))
@@ -46,7 +46,7 @@
 			O.forceMove(loc)
 	. = ..()
 
-/obj/mecha/working/makeshiftget_stats_part()
+/obj/mecha/working/makeshift/get_stats_part()
 	var/output = ..()
 	output += "<b>Cargo Compartment Contents:</b><div style=\"margin-left: 15px;\">"
 	if(cargo.len)
@@ -57,7 +57,7 @@
 	output += "</div>"
 	return output
 
-/obj/mecha/working/makeshiftrelay_container_resist(mob/living/user, obj/O)
+/obj/mecha/working/makeshift/relay_container_resist(mob/living/user, obj/O)
 	to_chat(user, span_notice("You lean on the back of [O] and start pushing so it falls out of [src]."))
 	if(do_after(user, 1 SECONDS, O))//Its a fukken locker
 		if(!user || user.stat != CONSCIOUS || user.loc != src || O.loc != src )
@@ -69,6 +69,6 @@
 		if(user.loc == src) //so we don't get the message if we resisted multiple times and succeeded.
 			to_chat(user, span_warning("You fail to push [O] out of [src]!"))
 
-/obj/mecha/working/makeshiftDestroy()
+/obj/mecha/working/makeshift/Destroy()
 	new /obj/structure/closet(loc)
 	..()

--- a/yogstation/code/game/mecha/makeshift/makeshift_tools.dm
+++ b/yogstation/code/game/mecha/makeshift/makeshift_tools.dm
@@ -6,7 +6,7 @@
 	drill_delay = 15
 
 /obj/item/mecha_parts/mecha_equipment/drill/makeshift/can_attach(obj/mecha/M as obj)
-	if(istype(M, /obj/mecha/makeshift))
+	if(istype(M, /obj/mecha/working/makeshift))
 		return TRUE
 	return FALSE
 
@@ -17,6 +17,6 @@
 	dam_force = 10
 
 /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/makeshift/can_attach(obj/mecha/M as obj)
-	if(istype(M, /obj/mecha/makeshift))
+	if(istype(M, /obj/mecha/working/makeshift))
 		return TRUE
 	return FALSE

--- a/yogstation/code/modules/crafting/recipes.dm
+++ b/yogstation/code/modules/crafting/recipes.dm
@@ -21,7 +21,7 @@
 
 /datum/crafting_recipe/lockermech
 	name = "Locker Mech"
-	result = /obj/mecha/makeshift
+	result = /obj/mecha/working/makeshift
 	reqs = list(/obj/item/stack/cable_coil = 20,
 				/obj/item/stack/sheet/metal = 10,
 				/obj/item/storage/toolbox = 2, // For feet


### PR DESCRIPTION
# Document the changes in your pull request

consistency's sake, every mech now has *some* rad armor, though none that had any added exceed 55 except syndicate mechs, which now feature rad immunity.
also gives all mechs but the open-cockpit Ripley 1 bio *immunity*...not that there's even much that targets bio armor?

Updates Deathsquad Ripleys to have better innate armor, because deathsquad

cleans up some ancient code in combat.dm and the locker mech file that still featured non-define armor names

adds conveyors to the exosuit fabricator's MISC tab, since they're needed for Clarkes and it confuses the shit out of roboticists

# Wiki Documentation

Ripley 2 -   Bio Armor: 100 Rad Armor: 55
Ripley 3 -  Bio Armor: 100 Rad Armor: UNCHANGED (70)
Durand -  Bio Armor: 100 Rad Armor: UNCHANGED (50)
Gygax -  Bio Armor: 100 Rad Armor: 40
H.O.N.K -  Bio Armor: 100 Rad Armor: 20
Dark H.O.N.K - Bio Armor: 100 Rad Armor: 100
Dark Gygax -  Bio Armor: 100 Rad Armor: 100
Seraph, Mauler, Marauder -  Bio Armor: 100 Rad Armor: 100
Phazon -  Bio Armor: 100 Rad Armor: UNCHANGED (50)

# Changelog

:cl:  
tweak: The Syndicate has began plating their mechs in Lead! They are now Immune to Radiation!
tweak: ALL Mechs except the Ripley I have Bio Immunity, as they are sealed environments
tweak: Ripley IIs now have 55 rad armor instead of 0
tweak: Gygaxes now have 40 rad armor instead of 0
tweak: H.O.N.Ks now have 20 rad armor instead of 0
tweak: Conveyor Belts and Switches can now be found in the Exosuit Fab Misc Tab
tweak: Locker Mech is now a type of Working Mech (Like Ripleys), instead of a snowflake unique category
/:cl:
