### PR TITLE
Reverts #15573 and stops meatpockets from giving you clinical obesity if you dare eat something else soon after

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_pastry.dm
+++ b/code/modules/food_and_drinks/food/snacks_pastry.dm
@@ -311,9 +311,8 @@
 	name = "meatpocket"
 	desc = "Can this really be called a donkpocket? You should...probably cook this."
 	icon_state = "donkpocketmeaty"
-	bitesize = 4
 	bonus_reagents = list(/datum/reagent/consumable/nutriment/protein = 2)
-	list_reagents = list(/datum/reagent/consumable/nutriment/protein = 2, /datum/reagent/consumable/nutriment/vitamin = 3)
+	list_reagents = list(/datum/reagent/consumable/nutriment/protein = 2)
 	cooked_type = /obj/item/reagent_containers/food/snacks/donkpocket/warm/meaty
 	filling_color = "#CD853F"
 	tastes = list("raw meat" = 4)
@@ -323,9 +322,8 @@
 	name = "warm meatpocket"
 	desc = "Can this really be called a donkpocket?"
 	icon_state = "donkpocketcookedmeaty"
-	bitesize = 5
-	bonus_reagents = list(/datum/reagent/consumable/nutriment/protein = 4, /datum/reagent/consumable/nutriment/vitamin = 4, /datum/reagent/consumable/drippings = 2)
-	list_reagents = list(/datum/reagent/consumable/nutriment/protein = 4, /datum/reagent/consumable/nutriment/vitamin = 4, /datum/reagent/consumable/drippings = 2)
+	bonus_reagents = list(/datum/reagent/consumable/nutriment/protein = 4, /datum/reagent/consumable/nutriment/vitamin = 2)
+	list_reagents = list(/datum/reagent/consumable/nutriment/protein = 4, /datum/reagent/consumable/nutriment/vitamin = 2)
 	tastes = list("meat" = 4)
 	foodtype = MEAT
 


### PR DESCRIPTION
Heard people were having problems with obesity when they've eaten a meatpocket beforehand or soon after. 

# Document the changes in your pull request

Reverts #15573 as these should only go for a bite size of 3-4 this time as this pr gets rid of vitamins from the raw version and halves it in its cooked, also removes the meat drippings from the meat pocket entirely.

# Wiki Documentation

Reagent changes to meatpockets

# Changelog
:cl:  
tweak: Raw meatpocket no longer has vitamins
tweak: Warmed meatpocket halved vitamins and removed meat drippings
/:cl:
