### PR TITLE
Changes Phlogiston & Pyroxadone Recipes

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -205,7 +205,7 @@
 	name = "Pyroxadone"
 	id = /datum/reagent/medicine/pyroxadone
 	results = list(/datum/reagent/medicine/pyroxadone = 2)
-	required_reagents = list(/datum/reagent/medicine/cryoxadone = 1, /datum/reagent/medicine/omnizine = 1, /datum/reagent/phlogiston = 1)
+	required_reagents = list(/datum/reagent/medicine/cryoxadone = 1, /datum/reagent/medicine/omnizine = 1, /datum/reagent/napalm = 1)
 
 /datum/chemical_reaction/clonexadone
 	name = "Clonexadone"

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -355,7 +355,7 @@
 	name = /datum/reagent/phlogiston
 	id = /datum/reagent/phlogiston
 	results = list(/datum/reagent/phlogiston = 3)
-	required_reagents = list(/datum/reagent/phosphorus = 1, /datum/reagent/toxin/acid = 1, /datum/reagent/stable_plasma = 1)
+	required_reagents = list(/datum/reagent/phosphorus = 1, /datum/reagent/hellwater = 1, /datum/reagent/stable_plasma = 1)
 
 /datum/chemical_reaction/phlogiston/on_reaction(datum/reagents/holder, created_volume)
 	if(holder.has_reagent(/datum/reagent/stabilizing_agent))


### PR DESCRIPTION
# Document the changes in your pull request

Phlogiston now requires **Hell Water** instead of Acid (Still 1u)

Pyroxadone's non-xenobio recipe requires Napalm instead of Phlog (same u's)


felt it was silly that chemists can so easily create a nonsense chemical from the 1800s (not a realism argument*)
also it was VERY cheap for how effective it was

# Wiki Documentation

Will require an update to the chemistry guide

# Changelog

:cl:  
tweak: Phlogiston Now Costs Hell Water Instead Of Acid
tweak: Pyroxadone's Non-Xenobio Recipe Now Takes Napalm Instead Of Phlogiston
/:cl:
