### PR TITLE
Changes IAA flavor text + technical changes

### DIFF
--- a/code/game/gamemodes/traitor/internal_affairs.dm
+++ b/code/game/gamemodes/traitor/internal_affairs.dm
@@ -11,7 +11,7 @@
 	required_enemies = 5
 	recommended_enemies = 8
 	reroll_friendly = 0
-	traitor_name = "Nanotrasen Internal Affairs Agent"
+	traitor_name = "Syndicate Internal Affairs Agent"
 	antag_flag = ROLE_INTERNAL_AFFAIRS
 	title_icon = "traitor"
 
@@ -20,7 +20,7 @@
 	antag_datum = /datum/antagonist/traitor/internal_affairs
 	restricted_jobs = list("AI", "Cyborg")//Yogs -- Silicons can no longer be IAA
 
-	announce_text = "There are Nanotrasen Internal Affairs Agents trying to kill each other!\n\
+	announce_text = "There are Syndicate Internal Affairs Agents trying to kill each other!\n\
 	<span class='danger'>IAA</span>: Eliminate your targets and protect yourself!\n\
 	<span class='notice'>Crew</span>: Stop the IAA agents before they can cause too much mayhem."
 
@@ -81,8 +81,8 @@
 
 
 /datum/game_mode/traitor/internal_affairs/generate_report()
-	return "Nanotrasen denies any accusations of placing internal affairs agents onboard your station to eliminate inconvenient employees.  Any further accusations against CentCom for such \
-			actions will be met with a conversation with an official internal affairs agent."
+	return "Nanotrasen believes that a Syndicate cell operating in the region has successfully been tricked by a false intelligence leak. If this leak was successful, \
+			be wary of Syndicate agents turning on their own on your station; we are unsure the lengths they will go to excise treason."
 
 /datum/game_mode/traitor/double_agents/generate_credit_text()
 	var/list/round_credits = list()

--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -116,15 +116,20 @@
 			continue
 		remove_objective(objective_)
 
-	var/datum/objective/martyr/martyr_objective = new
-	martyr_objective.owner = owner
-	add_objective(martyr_objective)
+	if(!marauder)
+		var/datum/objective/martyr/martyr_objective = new
+		martyr_objective.owner = owner
+		add_objective(martyr_objective)
+	else
+		var/datum/objective/hijack/hijack_objective = new
+		hijack_objective.owner = owner
+		add_objective(hijack_objective)
 
 /datum/antagonist/traitor/proc/reinstate_escape_objective()
 	if(!owner||!objectives.len)
 		return
 	for (var/objective_ in objectives)
-		if(!istype(objective_, /datum/objective/martyr))
+		if(!istype(objective_, /datum/objective/martyr) || !istype(objective_, /datum/objective/hijack))
 			continue
 		remove_objective(objective_)
 

--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -3,7 +3,7 @@
 #define PINPOINTER_PING_TIME 40
 #define PROB_ACTUAL_TRAITOR 20
 #define TRAITOR_AGENT_ROLE "Gorlex Marauders Exile"
-#define TRAITOR_AGENT_SROLE "gorlex marauder exile"
+#define TRAITOR_AGENT_SROLE "gorlex marauders exile"
 
 /datum/antagonist/traitor/internal_affairs
 	name = "Syndicate Internal Affairs Agent"

--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -108,22 +108,29 @@
 /proc/is_internal_objective(datum/objective/O)
 	return (istype(O, /datum/objective/assassinate/internal)||istype(O, /datum/objective/destroy/internal))
 
-/datum/antagonist/traitor/proc/replace_escape_objective()
+/datum/antagonist/traitor/proc/replace_escape_objective_martyr()
 	if(!owner || !objectives.len)
 		return
 	for (var/objective_ in objectives)
-		if(!(istype(objective_, /datum/objective/escape)||istype(objective_, /datum/objective/survive)))
+		if(!(istype(objective_, /datum/objective/escape)||istype(objective_, /datum/objective/survive)||istype(objective_, /datum/objective/hijack)))
 			continue
 		remove_objective(objective_)
 
-	if(!marauder)
-		var/datum/objective/martyr/martyr_objective = new
-		martyr_objective.owner = owner
-		add_objective(martyr_objective)
-	else
-		var/datum/objective/hijack/hijack_objective = new
-		hijack_objective.owner = owner
-		add_objective(hijack_objective)
+	var/datum/objective/martyr/martyr_objective = new
+	martyr_objective.owner = owner
+	add_objective(martyr_objective)
+
+/datum/antagonist/traitor/proc/replace_escape_objective_hijack() //Should work?
+	if(!owner || !objectives.len)
+		return
+	for (var/objective_ in objectives)
+		if(!(istype(objective_, /datum/objective/escape)||istype(objective_, /datum/objective/survive)||istype(objective_, /datum/objective/martyr)))
+			continue
+		remove_objective(objective_)
+	
+	var/datum/objective/hijack/hijack_objective = new
+	hijack_objective.owner = owner
+	add_objective(hijack_objective)
 
 /datum/antagonist/traitor/proc/reinstate_escape_objective()
 	if(!owner||!objectives.len)
@@ -182,9 +189,10 @@
 	if(last_man_standing)
 		if(!marauder)
 			to_chat(owner.current,span_userdanger("Every agent confirmed turncoat has been eliminated. However, given that the entire cell was compromised, your loyalty is being called into question. Die a glorious death, and prove your unending allegiance to the Syndicate."))
+			replace_escape_objective_martyr(owner)
 		else
 			to_chat(owner.current,span_userdanger("Each of the others lies dead at your feet. Your final obstacle of this trial is to hijack the shuttle. Leave none standing and no survivors in your wake. Your brothers await you with open arms, Marauder."))
-		replace_escape_objective(owner)
+			replace_escape_objective_hijack(owner)
 
 /datum/antagonist/traitor/internal_affairs/proc/iaa_process()
 	if(owner&&owner.current&&owner.current.stat!=DEAD)

--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -2,14 +2,14 @@
 #define PINPOINTER_EXTRA_RANDOM_RANGE 10
 #define PINPOINTER_PING_TIME 40
 #define PROB_ACTUAL_TRAITOR 20
-#define TRAITOR_AGENT_ROLE "Syndicate External Affairs Agent"
+#define TRAITOR_AGENT_ROLE "Gorlex Marauders Exile"
+#define TRAITOR_AGENT_SROLE "gorlex marauder exile"
 
 /datum/antagonist/traitor/internal_affairs
-	name = "Internal Affairs Agent"
-	employer = "Nanotrasen"
-	special_role = "internal affairs agent"
+	name = "Syndicate Internal Affairs Agent"
+	special_role = "internal affairs agent" //Doesn't have it listed but employer should still be syndicate
 	antagpanel_category = "IAA"
-	var/syndicate = FALSE
+	var/marauder = FALSE
 	var/last_man_standing = FALSE
 	var/list/datum/mind/targets_stolen
 	greentext_achieve = /datum/achievement/greentext/internal
@@ -36,7 +36,7 @@
 		var/obj/item/implant/dusting/E = new/obj/item/implant/dusting(H)
 		E.implant(H)
 
-	company = /datum/corporation/mi13
+	company = pick(subtypesof(/datum/corporation/traitor))
 
 	.=..()
 /datum/antagonist/traitor/internal_affairs/on_removal()
@@ -138,7 +138,7 @@
 /datum/antagonist/traitor/internal_affairs/proc/steal_targets(datum/mind/victim)
 	if(!owner.current||owner.current.stat==DEAD)
 		return
-	to_chat(owner.current, span_userdanger(" Target eliminated: [victim.name]"))
+	to_chat(owner.current, span_userdanger("Target eliminated: [victim.name]"))
 	for(var/objective_ in victim.get_all_objectives())
 		if(istype(objective_, /datum/objective/assassinate/internal))
 			var/datum/objective/assassinate/internal/objective = objective_
@@ -152,7 +152,7 @@
 				add_objective(new_objective)
 				targets_stolen += objective.target
 				var/status_text = objective.check_completion() ? "neutralised" : "active"
-				to_chat(owner.current, span_userdanger(" New target added to database: [objective.target.name] ([status_text]) "))
+				to_chat(owner.current, span_userdanger("New target added to database: [objective.target.name] ([status_text])"))
 		else if(istype(objective_, /datum/objective/destroy/internal))
 			var/datum/objective/destroy/internal/objective = objective_
 			var/datum/objective/destroy/internal/new_objective = new
@@ -165,7 +165,7 @@
 				add_objective(new_objective)
 				targets_stolen += objective.target
 				var/status_text = objective.check_completion() ? "neutralised" : "active"
-				to_chat(owner.current, span_userdanger(" New target added to database: [objective.target.name] ([status_text]) "))
+				to_chat(owner.current, span_userdanger("New target added to database: [objective.target.name] ([status_text])"))
 	last_man_standing = TRUE
 	for(var/objective_ in objectives)
 		if(!is_internal_objective(objective_))
@@ -175,10 +175,10 @@
 			last_man_standing = FALSE
 			return
 	if(last_man_standing)
-		if(syndicate)
-			to_chat(owner.current,span_userdanger(" All the loyalist agents are dead, and no more is required of you. Die a glorious death, agent. "))
+		if(!marauder)
+			to_chat(owner.current,span_userdanger("Every agent confirmed turncoat has been eliminated. However, given that the entire cell was compromised, your loyalty is being called into question. Die a glorious death, and prove your unending allegiance to the Syndicate."))
 		else
-			to_chat(owner.current,span_userdanger(" All the other agents are dead, and you're the last loose end. Stage a Syndicate terrorist attack to cover up for today's events. You no longer have any limits on collateral damage."))
+			to_chat(owner.current,span_userdanger("Each of the others lies dead at your feet. Your final obstacle of this trial is to hijack the shuttle. Leave none standing and no survivors in your wake. Your brothers await you with open arms, Marauder."))
 		replace_escape_objective(owner)
 
 /datum/antagonist/traitor/internal_affairs/proc/iaa_process()
@@ -197,12 +197,12 @@
 					objective.stolen = TRUE
 			else
 				if(objective.stolen)
-					var/fail_msg = span_userdanger("Your sensors tell you that [objective.target.current.real_name], one of the targets you were meant to have killed, pulled one over on you, and is still alive - do the job properly this time! ")
+					var/fail_msg = span_userdanger("Your sensors tell you that [objective.target.current.real_name], one of the targets you were meant to have killed, lives once again.")
 					if(last_man_standing)
-						if(syndicate)
-							fail_msg += span_userdanger(" You no longer have permission to die. ")
+						if(!marauder)
+							fail_msg += span_userdanger("You no longer have permission to die. Track the treacherous vermin down, and kill them. No loose ends are permitted.")
 						else
-							fail_msg += span_userdanger(" The truth could still slip out!</font><B><font size=5 color=red> Cease any terrorist actions as soon as possible, unneeded property damage or loss of employee life will lead to your contract being terminated.")
+							fail_msg += span_userdanger("They will not judge us weak.</font><B><font size=5 color=red> Cease your terror on Nanotrasen and eliminate the tenacious target once more. Fail to do this, and a bullet awaits you at the base.")
 						reinstate_escape_objective(owner)
 						last_man_standing = FALSE
 					to_chat(owner.current, fail_msg)
@@ -227,11 +227,11 @@
 
 		//Optional traitor objective
 		if(prob(PROB_ACTUAL_TRAITOR))
-			employer = "The Syndicate"
+			company = /datum/corporation/gorlex //Should not double wammy the corporate introduction, I hope
 			owner.special_role = TRAITOR_AGENT_ROLE
-			special_role = TRAITOR_AGENT_ROLE
-			syndicate = TRUE
-			forge_single_objective()
+			special_role = TRAITOR_AGENT_SROLE
+			marauder = TRUE
+			forge_single_objective() //Weird flex but okay
 			greentext_achieve = /datum/achievement/greentext/external
 
 /datum/antagonist/traitor/internal_affairs/forge_traitor_objectives()
@@ -243,19 +243,17 @@
 	add_objective(escape_objective)
 
 /datum/antagonist/traitor/internal_affairs/proc/greet_iaa()
-	var/crime = pick("distribution of contraband" , "unauthorized erotic action on duty", "embezzlement", "piloting under the influence", "dereliction of duty", "syndicate collaboration", "mutiny", "multiple homicides", "corporate espionage", "receiving bribes", "malpractice", "worship of prohibited life forms", "possession of profane texts", "murder", "arson", "insulting their manager", "grand theft", "conspiracy", "attempting to unionize", "vandalism", "gross incompetence")
-
 	to_chat(owner.current, span_userdanger("You are the [special_role]."))
-	if(syndicate)
-		to_chat(owner.current, span_userdanger("Your target has been framed for [crime], and you have been tasked with eliminating them to prevent them defending themselves in court."))
-		to_chat(owner.current, "<B><font size=5 color=red>Any damage you cause will further increase tensions between The Syndicate and Nanotrasen, so you should limit collateral damage.</font></B>") //yogs - murderbone rule exists, apparently
-		to_chat(owner.current, span_userdanger(" You have been provided with a standard uplink to accomplish your task. "))
+	if(!marauder)
+		to_chat(owner.current, span_userdanger("An intel leak suggests that operatives on this station have been turned by Nanotrasen. For now, your target is the only confirmed turncoat."))
+		to_chat(owner.current, "<B><font size=5 color=red>Any apparent damage you cause may draw early suspicion to an intelligence leak. Limit collateral damage to avoid this.</font></B>") //yogs - murderbone rule exists, apparently
+		to_chat(owner.current, span_userdanger("You have been provided with a standard uplink to accomplish your task."))
 	else
-		to_chat(owner.current, span_userdanger("Your target is suspected of [crime], and you have been tasked with eliminating them by any means necessary to avoid a costly and embarrassing public trial."))
-		to_chat(owner.current, "<B><font size=5 color=red>While you have a license to kill, unneeded property damage or loss of employee life will lead to your contract being terminated.</font></B>")
-		to_chat(owner.current, span_userdanger("For the sake of plausible deniability, you have been equipped with an array of captured Syndicate weaponry available via uplink."))
+		to_chat(owner.current, span_userdanger("You have been granted a chance to rejoin the Gorlex ranks, despite your dishonorable behavior. Complete this small task and eliminate every other Syndicate agent on the station to prove yourself. Your listed target is the first of many."))
+		to_chat(owner.current, "<B><font size=5 color=red>Unnecessary collateral damage will condemn yourself. Keep your destructive force focused on your targets, or you will fail this trial.</font></B>")
+		to_chat(owner.current, span_userdanger("We have given you a standard uplink for tools in your glorious hunt. Use them well, use them cunningly."))
 
-	to_chat(owner.current, span_userdanger("Finally, watch your back. Your target has friends in high places, and intel suggests someone may have taken out a contract of their own to protect them."))
+	to_chat(owner.current, span_userdanger("Your target still likely has an uplink of their own, and other agents may be moving to eliminate you, if your identity has been compromised. Be careful, and watch your back."))
 	owner.announce_objectives()
 
 /datum/antagonist/traitor/internal_affairs/greet()

--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -225,13 +225,13 @@
 			kill_objective.update_explanation_text()
 			add_objective(kill_objective)
 
-		//Optional traitor objective
-		if(prob(PROB_ACTUAL_TRAITOR))
+		//Lower chance of someone needing to do an additional objective, but getting hijack instead of DaGD
+		if(prob(PROB_ACTUAL_TRAITOR)) //20%
 			company = /datum/corporation/gorlex //Should not double wammy the corporate introduction, I hope
 			owner.special_role = TRAITOR_AGENT_ROLE
 			special_role = TRAITOR_AGENT_SROLE
 			marauder = TRUE
-			forge_single_objective() //Weird flex but okay
+			forge_single_objective()
 			greentext_achieve = /datum/achievement/greentext/external
 
 /datum/antagonist/traitor/internal_affairs/forge_traitor_objectives()

--- a/code/modules/corporations/corporation.dm
+++ b/code/modules/corporations/corporation.dm
@@ -53,6 +53,7 @@ GLOBAL_LIST_EMPTY(corporations)
 	name = "Sentience-Enabled Life Forms"
 	paymodifier = 1
 
-/datum/corporation/mi13
-	name = "MI13"
-	paymodifier = 3
+// Syndicate, but not a standard traitor- too high-risk to make a normal agent
+/datum/corporation/gorlex
+	name = "Gorlex Marauders"
+	paymodifier = 1.5


### PR DESCRIPTION
# Document the changes in your pull request

Changes the flavor text of IAA to essentially reflect a handful of Syndicate agents turning on one another after a false intelligence leak spurred by Nanotrasen makes the Syndicate believe some in the cell have turncoated.

The 20% chance to be an actual traitor which gives you an objective has been rebranded as a Gorlex Marauders Exile who is undergoing a trial to rejoin the ranks of the Marauders (violence). Having this additional objective also means you are guaranteed the hijack rather than die a glorious death.

I don't actually *see* anywhere how IAA gets hijack because looking at this code it seems like it should just be getting die a glorious death all the time, so something might've been overseen or missed. I tried to scour and looking at the gamemode's code the adjustments I've made *should* account for it and work properly, but, y'know, BYOND.

# Wiki Documentation

IAA section in traitor may need to be revised?

# Changelog

:cl:  
tweak: IAA is now a little bit diffy and not NT just doing some crazed ass PR stunt because they don't really need to
tweak: Changes how IAA handles distribution of martyr versus hijack objective
/:cl:
