### PR TITLE
Makes paper sharp

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -65,7 +65,7 @@
 			to_chat(user, span_notice("The paper slides uncomfortably across your gloved palm."))
 		else
 			to_chat(user, span_warning("You cut yourself on the paper!"))
-			var/obj/item/bodypart/affecting = butterfingers.get_bodypart("[(user.active_hand_index % 2 == 0) ? "r" : "l" ]_arm")
+			var/obj/item/bodypart/affecting = butterfingers.get_active_hand()
 			if(affecting && affecting.receive_damage(1)) //One brute damage
 				butterfingers.update_damage_overlays()
 

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -23,6 +23,7 @@
 	throw_range = 1
 	throw_speed = 1
 	pressure_resistance = 0
+	sharpness = SHARP_EDGED //Paper cuts
 	slot_flags = ITEM_SLOT_HEAD
 	body_parts_covered = HEAD
 	resistance_flags = FLAMMABLE

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -57,6 +57,19 @@
 	..()
 
 
+/obj/item/paper/attack_hand(mob/living/carbon/human/user) //Basically repurposed light tube code
+	..()
+	if(prob(1))
+		var/mob/living/carbon/human/butterfingers = user
+		if(butterfingers.gloves)
+			to_chat(user, span_notice("The paper slides uncomfortably across your gloved palm."))
+		else
+			to_chat(user, span_warning("You cut yourself on the paper!"))
+			var/obj/item/bodypart/affecting = butterfingers.get_bodypart("[(user.active_hand_index % 2 == 0) ? "r" : "l" ]_arm")
+			if(affecting && affecting.receive_damage(1)) //One brute damage
+				butterfingers.update_damage_overlays()
+
+
 /obj/item/paper/Initialize()
 	. = ..()
 	pixel_y = rand(-8, 8)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -66,7 +66,7 @@
 		else
 			to_chat(user, span_warning("You cut yourself on the paper!"))
 			var/obj/item/bodypart/affecting = butterfingers.get_active_hand()
-			if(affecting && affecting.receive_damage(1)) //One brute damage
+			affecting?.receive_damage(1)
 
 
 /obj/item/paper/Initialize()

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -67,7 +67,6 @@
 			to_chat(user, span_warning("You cut yourself on the paper!"))
 			var/obj/item/bodypart/affecting = butterfingers.get_active_hand()
 			if(affecting && affecting.receive_damage(1)) //One brute damage
-				butterfingers.update_damage_overlays()
 
 
 /obj/item/paper/Initialize()


### PR DESCRIPTION
# Document the changes in your pull request

As title.

Considering paper can give the owie hurtie cuts in the IRL server, it's now sharp. Should still do zero damage when you hit someone with it.

There is a 1% chance if you don't have gloves when you pick up paper to cut yourself for 1 brute damage.

# Wiki Documentation

No.

# Changelog

:cl:  
experimental: Paper is now sharp
experimental: Paper cuts can very rarely happen if you don't wear gloves when picking up paper
/:cl:
