### PR TITLE
Makes Helmets with HIDEMASK properly hide mask sprites

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -428,16 +428,17 @@ There are several things that need to be remembered:
 
 	if(wear_mask)
 		update_hud_wear_mask(wear_mask)
-		overlays_standing[FACEMASK_LAYER] = wear_mask.build_worn_icon(default_layer = FACEMASK_LAYER, default_icon_file = 'icons/mob/clothing/mask/mask.dmi')
-		var/mutable_appearance/mask_overlay = overlays_standing[FACEMASK_LAYER]
-		if(mask_overlay)
-			remove_overlay(FACEMASK_LAYER)
-			if(OFFSET_FACEMASK in dna.species.offset_features)
-				mask_overlay.pixel_x += dna.species.offset_features[OFFSET_FACEMASK][1]
-				mask_overlay.pixel_y += dna.species.offset_features[OFFSET_FACEMASK][2]
-				overlays_standing[FACEMASK_LAYER] = mask_overlay
-		apply_overlay(FACEMASK_LAYER)
-	update_mutant_bodyparts() //e.g. upgate needed because mask now hides lizard snout
+		if(!(head && (head.flags_inv & HIDEMASK)))
+			overlays_standing[FACEMASK_LAYER] = wear_mask.build_worn_icon(default_layer = FACEMASK_LAYER, default_icon_file = 'icons/mob/clothing/mask/mask.dmi')
+			var/mutable_appearance/mask_overlay = overlays_standing[FACEMASK_LAYER]
+			if(mask_overlay)
+				remove_overlay(FACEMASK_LAYER)
+				if(OFFSET_FACEMASK in dna.species.offset_features)
+					mask_overlay.pixel_x += dna.species.offset_features[OFFSET_FACEMASK][1]
+					mask_overlay.pixel_y += dna.species.offset_features[OFFSET_FACEMASK][2]
+					overlays_standing[FACEMASK_LAYER] = mask_overlay
+			apply_overlay(FACEMASK_LAYER)
+		update_mutant_bodyparts() //e.g. upgate needed because mask now hides lizard snout
 
 /mob/living/carbon/human/update_inv_back()
 	remove_overlay(BACK_LAYER)


### PR DESCRIPTION
# Document the changes in your pull request

![ss (2022-09-12 at 03 22 42)](https://user-images.githubusercontent.com/1534478/189752466-2ba1e4f0-5ea4-483b-8bba-03b704298099.png)
![ss (2022-09-12 at 03 22 46)](https://user-images.githubusercontent.com/1534478/189752469-830660ee-8fce-43d0-81f6-41677c5e476a.png)
![ss (2022-09-12 at 03 25 06)](https://user-images.githubusercontent.com/1534478/189752471-712314f7-b426-4d17-9738-aa9719bb5cb5.png)

blue nosed plasmemes be gone

makes the update icon proc for masks properly check if the mask should be hidden

# Changelog

:cl:  
bugfix: Helmets that should have been hiding masks, now do hide masks.
/:cl:
