### PR TITLE
Removes Narsie Hardsuit from Necro Chest and places it inside the Cult Altar ruin

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_cultaltar.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_cultaltar.dmm
@@ -55,29 +55,6 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered)
-"o" = (
-/obj/effect/rune/narsie{
-	color = "#ff0000";
-	used = 1
-	},
-/obj/item/cult_shift,
-/obj/effect/decal/remains/human,
-/obj/item/melee/cultblade/dagger,
-/obj/effect/step_trigger/sound_effect{
-	happens_once = 1;
-	name = "a grave mistake";
-	sound = 'sound/hallucinations/i_see_you1.ogg';
-	triggerer_only = 1
-	},
-/obj/effect/step_trigger/message{
-	message = "<span class='cult italic'><b><span class='big'>You've made a grave mistake, haven't you?</span></b></span>";
-	name = "ohfuck"
-	},
-/obj/item/reagent_containers/food/drinks/bottle/holywater/hell,
-/turf/open/floor/engine/cult{
-	initial_gas_mix = "o2=14;n2=23;TEMP=300"
-	},
-/area/ruin/unpowered)
 "q" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/shoes/cult,
@@ -89,6 +66,30 @@
 /area/ruin/unpowered)
 "s" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered)
+"u" = (
+/obj/effect/rune/narsie{
+	color = "#ff0000";
+	used = 1
+	},
+/obj/effect/decal/remains/human,
+/obj/item/clothing/suit/space/hardsuit/cult,
+/obj/item/melee/cultblade/dagger,
+/obj/item/cult_shift,
+/obj/item/reagent_containers/food/drinks/bottle/holywater/hell,
+/obj/effect/step_trigger/sound_effect{
+	happens_once = 1;
+	name = "a grave mistake";
+	sound = 'sound/hallucinations/i_see_you1.ogg';
+	triggerer_only = 1
+	},
+/obj/effect/step_trigger/message{
+	message = "<span class='cult italic'><b><span class='big'>You've made a grave mistake, haven't you?</span></b></span>";
+	name = "ohfuck"
+	},
+/turf/open/floor/engine/cult{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
 /area/ruin/unpowered)
 
 (1,1,1) = {"
@@ -218,7 +219,7 @@ b
 b
 d
 b
-o
+u
 b
 d
 b

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -13,12 +13,13 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 	desc = "It's watching you suspiciously."
 
 /obj/structure/closet/crate/necropolis/tendril/PopulateContents()
-	var/loot = rand(1,26)
+	var/loot = rand(1,25)
 	switch(loot)
 		if(1)
 			new /obj/item/shared_storage/red(src)
 		if(2)
-			new /obj/item/clothing/suit/space/hardsuit/cult(src)
+			new /obj/item/clothing/under/drip(src)
+			new /obj/item/clothing/shoes/drip(src)
 		if(3)
 			new /obj/item/soulstone/anybody(src)
 		if(4)
@@ -75,9 +76,6 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 			new /obj/item/grenade/plastic/miningcharge/mega(src)
 		if(25)
 			new /obj/item/clothing/gloves/gauntlets(src)
-		if(26)
-			new /obj/item/clothing/under/drip(src)
-			new /obj/item/clothing/shoes/drip(src)
 
 //KA modkit design discs
 /obj/item/disk/design_disk/modkit_disc


### PR DESCRIPTION
Debloating

# Document the changes in your pull request

Removes the Cult Hardsuit from the Necropolis Chest Lootpool and moves it to the Cult Altar Lavaland ruin. This should make seeing that ruin less of a disappointment on both ends of the necropolis chest and ruin pulls. Also reordered the loot inside the Cult Altar ruin so that some of its contents are more visible.

I have yet to make the replacement armor for this but I might as well get this over with now.

# Wiki Documentation

Adds the Cult Hardsuit to the Cult Altar loot pool, and removes the Cult Hardsuit from the Necropolis chest loot pool.

# Changelog

:cl:  
tweak: Moves Cult Hardsuit to Cult Altar ruin and removes it from the Necropolis Chest
/:cl:
