### PR TITLE
removes the mini extinguishers from survival box because lmao hugbox

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -128,7 +128,6 @@
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/tank/internals/emergency_oxygen(src)
 	new /obj/item/reagent_containers/autoinjector/medipen(src)
-	new /obj/item/extinguisher/mini(src)
 	
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_PREMIUM_INTERNALS))
 		new /obj/item/flashlight/flare(src)
@@ -143,7 +142,6 @@
 	new /obj/item/tank/internals/emergency_oxygen(src)
 	new /obj/item/crowbar/red(src)
 	new /obj/item/gps/mining(src)
-	new /obj/item/extinguisher/mini(src)
 	new /obj/item/reagent_containers/autoinjector/medipen(src)
 
 // Engineer survival box
@@ -151,7 +149,6 @@
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/tank/internals/emergency_oxygen/engi(src)
 	new /obj/item/reagent_containers/autoinjector/medipen(src)
-	new /obj/item/extinguisher/mini(src)
 
 /obj/item/storage/box/engineer/radio/PopulateContents()
 	..() // we want the regular items too.
@@ -168,7 +165,6 @@
 	new /obj/item/clothing/mask/gas/sechailer(src)
 	new /obj/item/tank/internals/emergency_oxygen(src)
 	new /obj/item/reagent_containers/autoinjector/medipen(src)
-	new /obj/item/extinguisher/mini(src)
 
 /obj/item/storage/box/security/radio/PopulateContents()
 	..() // we want the regular stuff too
@@ -179,7 +175,6 @@
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/tank/internals/plasmaman/belt/full(src)
 	new /obj/item/reagent_containers/autoinjector/medipen(src)
-	new /obj/item/extinguisher/mini(src)
 
 /obj/item/storage/box/plasmaman/miner/PopulateContents() //mining box for plasmemes
 	new /obj/item/clothing/mask/gas/explorer(src)
@@ -187,7 +182,6 @@
 	new /obj/item/crowbar/red(src)
 	new /obj/item/gps/mining(src)
 	new /obj/item/reagent_containers/autoinjector/medipen(src)
-	new /obj/item/extinguisher/mini(src)
 
 /obj/item/storage/box/gloves
 	name = "box of latex gloves"


### PR DESCRIPTION
> We'll make fire extinguishers bulky to make it harder to carry one around

ok

> We'll also increase their water capacity to compensate

sounds good to me

> But we'll now completely nullify the most common DoT by giving everyone a fire extinguisher in their backpack roundstart

what

removes fire extinguishers from survival boxes except syndicate (nukeop) survival boxes because they're nukeops, the backpack fire extinguisher ruins being on fire because you can instantly put yourself out to cancel the damage from being on fire with no prepwork or anything, you just take out the fire extinguisher you spawned with and then extinguish yourself. This makes incendiary weapons worthless because it eliminates unprepared players having to stop drop and roll to extinguish themselves. This also turns blazing oil blob from a situational strain that can be extremely powerful, to complete noob bait if literally anyone is fighting you because they all spawn with fire extinguishers and can just kill you. If you want to carry around a fire extinguisher 24/7 like the powergamer I know you are, just bug cargo or break into the service hall to use the autolathe


# Changelog

:cl:  
rscdel: Survival box fire extinguishers have been removed
/:cl:
