### PR TITLE
Removes the 2 Extra Turrets from the Syndicate Lavaland Base

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -5628,12 +5628,6 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel,
 /area/ruin/powered/syndicate_lava_base/main)
-"DC" = (
-/obj/machinery/porta_turret/syndicate,
-/obj/machinery/porta_turret/syndicate,
-/obj/machinery/porta_turret/syndicate,
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/main)
 "Ec" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -7100,7 +7094,7 @@ ab
 ab
 ab
 ab
-DC
+LH
 eh
 eh
 eh


### PR DESCRIPTION
Which sadistic fucker thought this was a good idea

# Document the changes in your pull request

Gets rid of 2 Turrets that quite literally makes that 1 spot in the base in particular just 1 shot you into crit even with strong armor.

# Changelog

:cl:  
bugfix: Syndicate Base should no longer obliterate your insides with bullet inside a bullet inside a bullet bulletshit
/:cl:
