### PR TITLE
Makes Changes To Venomous Mobs*

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2289,12 +2289,22 @@
 
 /datum/supply_pack/critter/snake
 	name = "Snake Crate"
-	desc = "Tired of these MOTHER FUCKING snakes on this MOTHER FUCKING space station? Then this isn't the crate for you. Contains three poisonous snakes."
+	desc = "Tired of these MOTHER FUCKING snakes on this MOTHER FUCKING space station? Then this isn't the crate for you. Contains three non-venomous snakes."
 	cost = 3000
+	contains = list(/mob/living/simple_animal/hostile/retaliate/poison/snake/novenom,
+					/mob/living/simple_animal/hostile/retaliate/poison/snake/novenom,
+					/mob/living/simple_animal/hostile/retaliate/poison/snake/novenom)
+	crate_name = "snake crate"
+
+/datum/supply_pack/critter/snake/venomous
+	name = "Viper Crate"
+	desc = "A crate of three Vipers. Handle carefully."
+	cost = 5000
 	contains = list(/mob/living/simple_animal/hostile/retaliate/poison/snake,
 					/mob/living/simple_animal/hostile/retaliate/poison/snake,
 					/mob/living/simple_animal/hostile/retaliate/poison/snake)
-	crate_name = "snake crate"
+	crate_name = "viper crate"
+	contraband = TRUE
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Costumes & Toys /////////////////////////////////

--- a/code/modules/mob/living/simple_animal/friendly/snake.dm
+++ b/code/modules/mob/living/simple_animal/friendly/snake.dm
@@ -37,7 +37,7 @@
 	can_be_held = TRUE
 	worn_slot_flags = ITEM_SLOT_NECK
 	obj_damage = 0
-	poison_per_bite = 1
+	poison_per_bite = 10
 	environment_smash = ENVIRONMENT_SMASH_NONE
 
 /mob/living/simple_animal/hostile/retaliate/poison/snake/ListTargets(atom/the_target)

--- a/code/modules/mob/living/simple_animal/friendly/snake.dm
+++ b/code/modules/mob/living/simple_animal/friendly/snake.dm
@@ -1,6 +1,6 @@
 /mob/living/simple_animal/hostile/retaliate/poison
 	var/poison_per_bite = 0
-	var/poison_type = /datum/reagent/toxin
+	var/poison_type = /datum/reagent/toxin/venom
 
 /mob/living/simple_animal/hostile/retaliate/poison/AttackingTarget()
 	. = ..()
@@ -11,8 +11,8 @@
 	return .
 
 /mob/living/simple_animal/hostile/retaliate/poison/snake
-	name = "snake"
-	desc = "A slithery snake. These legless reptiles are the bane of mice and adventurers alike."
+	name = "viper"
+	desc = "A type of snake, infamous for their venomous bites."
 	icon_state = "snake"
 	icon_living = "snake"
 	icon_dead = "snake_dead"
@@ -33,12 +33,12 @@
 	pass_flags = PASSTABLE | PASSMOB
 	mob_size = MOB_SIZE_SMALL
 	mob_biotypes = list(MOB_ORGANIC, MOB_BEAST, MOB_REPTILE)
-	gold_core_spawnable = FRIENDLY_SPAWN
+	gold_core_spawnable = HOSTILE_SPAWN
 	can_be_held = TRUE
 	worn_slot_flags = ITEM_SLOT_NECK
 	obj_damage = 0
+	poison_per_bite = 1
 	environment_smash = ENVIRONMENT_SMASH_NONE
-
 
 /mob/living/simple_animal/hostile/retaliate/poison/snake/ListTargets(atom/the_target)
 	. = oview(vision_range, targets_from) //get list of things in vision range
@@ -64,3 +64,9 @@
 		adjustBruteLoss(-2)
 	else
 		return ..()
+
+/mob/living/simple_animal/hostile/retaliate/poison/snake/novenom
+	name = "snake"
+	desc = "A slithery snake. These legless reptiles are the bane of mice and unattended toes."
+	poison_per_bite = 0
+	gold_core_spawnable = FRIENDLY_SPAWN

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -6,7 +6,7 @@
 
 /mob/living/simple_animal/hostile/poison
 	var/poison_per_bite = 5
-	var/poison_type = /datum/reagent/toxin
+	var/poison_type = /datum/reagent/toxin/heparin
 
 /mob/living/simple_animal/hostile/poison/AttackingTarget()
 	. = ..()
@@ -109,6 +109,7 @@
 	melee_damage_lower = 5
 	melee_damage_upper = 10
 	poison_per_bite = 3
+	poison_type = /datum/reagent/toxin/sodium_thiopental
 	var/atom/movable/cocoon_target
 	var/fed = 0
 	var/obj/effect/proc_holder/wrap/wrap
@@ -166,9 +167,9 @@
 	poison_per_bite = 5
 	move_to_delay = 5
 
-//vipers are the rare variant of the hunter, no IMMEDIATE damage but so much poison medical care will be needed fast.
+//recluses are the rare variant of the hunter, no IMMEDIATE damage but so much poison medical care will be needed fast.
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper
-	name = "viper"
+	name = "void recluse"
 	desc = "Furry and black, it makes you shudder to look at it. This one has effervescent purple eyes."
 	icon_state = "viper"
 	icon_living = "viper"

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -108,8 +108,8 @@
 	health = 40
 	melee_damage_lower = 5
 	melee_damage_upper = 10
-	poison_per_bite = 3
-	poison_type = /datum/reagent/toxin/sodium_thiopental
+	poison_per_bite = 4
+	poison_type = /datum/reagent/toxin/staminatoxin
 	var/atom/movable/cocoon_target
 	var/fed = 0
 	var/obj/effect/proc_holder/wrap/wrap
@@ -164,7 +164,7 @@
 	health = 120
 	melee_damage_lower = 10
 	melee_damage_upper = 20
-	poison_per_bite = 5
+	poison_per_bite = 10
 	move_to_delay = 5
 
 //recluses are the rare variant of the hunter, no IMMEDIATE damage but so much poison medical care will be needed fast.

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -6,7 +6,7 @@
 
 /mob/living/simple_animal/hostile/poison
 	var/poison_per_bite = 5
-	var/poison_type = /datum/reagent/toxin/heparin
+	var/poison_type = /datum/reagent/toxin/acid
 
 /mob/living/simple_animal/hostile/poison/AttackingTarget()
 	. = ..()

--- a/yogstation/code/modules/mob/living/simple_animal/hostile/mining_mobs/marrow_weaver.dm
+++ b/yogstation/code/modules/mob/living/simple_animal/hostile/mining_mobs/marrow_weaver.dm
@@ -25,7 +25,7 @@
 	pass_flags = PASSTABLE
 	attack_sound = 'sound/weapons/bite.ogg'
 	deathmessage = "rolls over, frothing at the mouth before stilling."
-	var/poison_type = /datum/reagent/toxin
+	var/poison_type = /datum/reagent/toxin/spore
 	var/poison_per_bite = 5
 	var/buttmad = 0
 	var/melee_damage_lower_angery0 = 13
@@ -42,8 +42,8 @@
 			melee_damage_upper = melee_damage_upper_angery1
 			move_to_delay = 8
 			speed = 3
-			poison_type = /datum/reagent/toxin/spore
-			poison_per_bite = 5
+			poison_type = /datum/reagent/toxin/venom
+			poison_per_bite = 1
 	else if(buttmad == 1)
 		if(health > maxHealth/2)
 			buttmad = 0
@@ -122,7 +122,7 @@
 	health = 450
 	maxHealth = 450
 	poison_type = /datum/reagent/cluwnification
-
+	
 /mob/living/simple_animal/hostile/asteroid/marrowweaver/ice
 	name = "Frostbite Spider"
 	desc = "A big, angry, venomous ice spider. It likes to snack on bone marrow. Its preferred food source is you."
@@ -133,3 +133,4 @@
 	melee_damage_lower = 10 //stronger venom, but weaker attack.
 	melee_damage_upper = 13
 	poison_type = /datum/reagent/consumable/frostoil
+	poison_per_bite = 5

--- a/yogstation/code/modules/mob/living/simple_animal/hostile/mining_mobs/marrow_weaver.dm
+++ b/yogstation/code/modules/mob/living/simple_animal/hostile/mining_mobs/marrow_weaver.dm
@@ -43,7 +43,7 @@
 			move_to_delay = 8
 			speed = 3
 			poison_type = /datum/reagent/toxin/venom
-			poison_per_bite = 1
+			poison_per_bite = 6
 	else if(buttmad == 1)
 		if(health > maxHealth/2)
 			buttmad = 0


### PR DESCRIPTION
# Document the changes in your pull request

Makes Snakes into Vipers that actually inject 10u of Venom into you per bite. Replaces the snakes from the original cargo pack with a variant that injects 0u like before, so mostly harmless. Adds a Contraband cargo pack that contains 3 vipers

renames Viper spiders into Void Recluses to avoid confusion, and also because it's cooler

Makes Giant Spiders inject Acid
Makes Nurse Spiders and Brood Mothers inject Tirizine

Makes Weavers use 5u Spore Toxin by default, and inject 8u Venom when angry (at or below 33% hp)

# Sprites

Maybe could use a new sprite for venomous snakes, but it's not critical.

# Wiki Documentation

Will need to be documented on the hostile mobs pages

# Changelog

:cl:  
rscadd: Added Viper Crate Contraband Cargo Pack 
rscadd: Added Vipers, snakes that inject Venom into you on bite
tweak: Weavers now inject Spore Toxin by default, and Venom when enraged
tweak: Giant Spiders now inject Acid on bite
tweak: Nurse Spiders/Broodmothers inject Tirizine on bite
spellcheck: Viper Spiders have been Renamed Void Recluses
/:cl:
