### PR TITLE
Disabled Ragin Mages/Bullshit Mages & REMOVES DYNAMIC RAGIN MAGES

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -870,7 +870,9 @@
 //////////////////////////////////////////////
 
 // Dynamic is a wonderful thing that adds wizards to every round and then adds even more wizards during the round.
-/datum/dynamic_ruleset/roundstart/wizard/ragin
+//
+/*
+datum/dynamic_ruleset/roundstart/wizard/ragin
 	name = "Ragin' Mages"
 	antag_flag = ROLE_RAGINMAGES
 	antag_datum = /datum/antagonist/wizard/
@@ -925,6 +927,7 @@
 		log_admin("Shit is about to get wild. -Bullshit Wizards")
 
 		return TRUE
+*/ //NO. TO BOTH.
 
 //////////////////////////////////////////////
 //                                          //

--- a/code/game/gamemodes/wizard/raginmages.dm
+++ b/code/game/gamemodes/wizard/raginmages.dm
@@ -3,7 +3,7 @@
 	config_tag = "raginmages"
 	var/antag_datum = /datum/antagonist/wizard/
 	antag_flag = ROLE_RAGINMAGES
-	required_players = 40
+	required_players = 150
 	announce_span = "userdanger"
 	announce_text = "There are many, many wizards attacking the station!\n\
 	<span class='danger'>Wizards</span>: Accomplish your objectives and cause utter catastrophe!\n\
@@ -115,7 +115,7 @@
 	config_tag = "veryraginbullshitmages"
 	antag_datum = /datum/antagonist/wizard/
 	antag_flag = ROLE_BULLSHITMAGES
-	required_players = 40
+	required_players = 200
 	bullshit_mode = TRUE
 	time_check = 250
 	spawn_delay_min = 50


### PR DESCRIPTION
# Document the changes in your pull request

1. WHY THE FUCK WERE EITHER OF THESE VALID DYNAMIC RULESETS
2. Both of these are incredibly unfun gamemodes for everyone but a handful of players in the round, that should be reserved for admin bus ONLY, and as such now feature pop requirements high enough that they will only happen if admin fired, or if somehow yogstation gains a lot of popularity overnight.

# Wiki Documentation

Will need mention that Ragin Mages and Bullshit Mages basically should never happen naturally

# Changelog

:cl:  
rscdel: Removes Dynamic Ragin Mages/Bullshit Mages
tweak: Pop Limits Ragin Mages/Bullshit Mages to 150/200 pop each
/:cl:
