### PR TITLE
There are now two random slaughter demons in the bag

### DIFF
--- a/code/modules/antagonists/slaughter/slaughterevent.dm
+++ b/code/modules/antagonists/slaughter/slaughterevent.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/slaughter
 	name = "Spawn Slaughter Demon"
 	typepath = /datum/round_event/ghost_role/slaughter
-	weight = 1 //Very rare
+	weight = 2 //Very rare
 	max_occurrences = 1
 	earliest_start = 1 HOURS
 	min_players = 20


### PR DESCRIPTION
# Document the changes in your pull request

Weight 1 changed to weight 2, you may now see it randomly trigger in your lifetime

It's neither unbalanced nor interesting enough to be worth being the rarest event in the game by a factor of 2
(it is now equal to syndicate portal storms, immovable ducks, and bureaucratic errors, but it still isn't considered until 1 hour in which makes it still the rarest event)

# Wiki Documentation

weight: 2

# Changelog

:cl:  
tweak: Random spawn slaughter demon event weight incremented to 2 from 1
/:cl: