### PR TITLE
Makes armblade not suck against security

### DIFF
--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -159,6 +159,7 @@
 	w_class = WEIGHT_CLASS_HUGE
 	tool_behaviour = TOOL_MINING
 	force = 25
+	armour_penetration = 20
 	throwforce = 0 //Just to be on the safe side
 	throw_range = 0
 	throw_speed = 0


### PR DESCRIPTION
# Document the changes in your pull request

Gives base ling armblade 20 AP so it can suck less against security

The standard 40 melee armor (jumpsuit + vest) will still make secoffs tankier than your average dumbo especially considering the -20/+20 wound/bare_wound bonuses of the armblade

For something that immediately spells you as a ling the armblade itself is actually quite mediocre against Nanotrasen's finest, this should make it feel like less of a noodle against sec (15 damage against them rn, will be 20 assuming no other modifiers after this pr)

This does give xenobio armblade the 20 AP because it's the only one that inherits which makes it only mildly better than your average circular saw or welder because its force is 15

# Wiki Documentation

Armblade (or slime) isn't detailed on Guide to Combat but could be added, may also want to add its stats if they don't exist to Changeling page

# Changelog

:cl:  
tweak: Armblade has minor AP now
/:cl:
