### PR TITLE
Disables Drifting Space Pod ""Ruin""

### DIFF
--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -329,12 +329,13 @@
 	always_place = TRUE // This is just the space part, king_goat_boss in /code/datums/ruins/lavaland.dm needs to have this set to true aswell for goat king to actually be reachable
 	allow_duplicates = FALSE
 
+/*
 /datum/map_template/ruin/space/drifting_spacepod
 	id = "drifting_spacepod"
 	suffix = "drifting_spacepod.dmm"
 	name = "Drifting Spacepod"
 	description = "An abandoned spacepod, just drifting through space."
-
+*/
 /datum/map_template/ruin/space/gaming
 	id = "gaming"
 	suffix = "gameroom.dmm"


### PR DESCRIPTION
# Document the changes in your pull request

So these pods spawn a lot, and have enough initial speed to explode on contact with anything
space is also full of walls. So the most common occurance for one of these drifting pods is to spawn, then drift at high speed into any static space ruin, and space it. They also eat up the space ruin spawn budget/time.

just commented them out for now.

# Changelog

:cl:  
rscdel: Removes Drifting Space Pods from space, so they will stop exploding on ruin walls
/:cl:
