### PR TITLE
Fixes Drifting Space Pods

### DIFF
--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -329,13 +329,12 @@
 	always_place = TRUE // This is just the space part, king_goat_boss in /code/datums/ruins/lavaland.dm needs to have this set to true aswell for goat king to actually be reachable
 	allow_duplicates = FALSE
 
-/*
 /datum/map_template/ruin/space/drifting_spacepod
 	id = "drifting_spacepod"
 	suffix = "drifting_spacepod.dmm"
 	name = "Drifting Spacepod"
 	description = "An abandoned spacepod, just drifting through space."
-*/
+
 /datum/map_template/ruin/space/gaming
 	id = "gaming"
 	suffix = "gameroom.dmm"

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -329,12 +329,13 @@
 	always_place = TRUE // This is just the space part, king_goat_boss in /code/datums/ruins/lavaland.dm needs to have this set to true aswell for goat king to actually be reachable
 	allow_duplicates = FALSE
 
+/*
 /datum/map_template/ruin/space/drifting_spacepod
 	id = "drifting_spacepod"
 	suffix = "drifting_spacepod.dmm"
 	name = "Drifting Spacepod"
 	description = "An abandoned spacepod, just drifting through space."
-
+*/
 /datum/map_template/ruin/space/gaming
 	id = "gaming"
 	suffix = "gameroom.dmm"

--- a/config/spaceruinblacklist.txt
+++ b/config/spaceruinblacklist.txt
@@ -25,7 +25,7 @@
 #_maps/RandomRuins/SpaceRuins/derelict5.dmm
 #_maps/RandomRuins/SpaceRuins/derelict6.dmm
 #_maps/RandomRuins/SpaceRuins/djstation.dmm
-_maps/RandomRuins/SpaceRuins/drifting_spacepod.dmm
+#_maps/RandomRuins/SpaceRuins/drifting_spacepod.dmm
 #_maps/RandomRuins/SpaceRuins/emptyshell.dmm
 #_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
 #_maps/RandomRuins/SpaceRuins/gondolaasteroid.dmm

--- a/config/spaceruinblacklist.txt
+++ b/config/spaceruinblacklist.txt
@@ -25,6 +25,7 @@
 #_maps/RandomRuins/SpaceRuins/derelict5.dmm
 #_maps/RandomRuins/SpaceRuins/derelict6.dmm
 #_maps/RandomRuins/SpaceRuins/djstation.dmm
+_maps/RandomRuins/SpaceRuins/drifting_spacepod.dmm
 #_maps/RandomRuins/SpaceRuins/emptyshell.dmm
 #_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
 #_maps/RandomRuins/SpaceRuins/gondolaasteroid.dmm

--- a/yogstation/code/modules/spacepods/prebuilt.dm
+++ b/yogstation/code/modules/spacepods/prebuilt.dm
@@ -58,7 +58,7 @@
 	add_armor(new armor_type(src))
 	cell = new /obj/item/stock_parts/cell/high/empty(src)
 	internal_tank = new /obj/machinery/portable_atmospherics/canister/air(src)
-	velocity_x = rand(-15, 15)
-	velocity_y = rand(-15, 15)
+	velocity_x = rand(-3, 3)
+	velocity_y = rand(-3, 3)
 	obj_integrity = rand(100, max_integrity)
 	brakes = FALSE


### PR DESCRIPTION
# Document the changes in your pull request

Modifies the randomized velocities of drifting spacepods so they pick between +/-3 instead of **15**

# Changelog

:cl:  
tweak: Makes drifting spacepod space ruins not ghetto torpedoes
/:cl:
