### PR TITLE
Improves Sheet Snatcher + Makes It Available To Craft/Buy

### DIFF
--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -167,8 +167,8 @@ GLOBAL_LIST_INIT(leather_recipes, list ( \
 	new/datum/stack_recipe("leather satchel", /obj/item/storage/backpack/satchel/leather, 5), \
 	new/datum/stack_recipe("leather shoes", /obj/item/clothing/shoes/laceup, 2), \
 	new/datum/stack_recipe("muzzle", /obj/item/clothing/mask/muzzle, 2), \
-	new/datum/stack_recipe("toolbelt", /obj/item/storage/belt/utility, 4), \
 	new/datum/stack_recipe("medical webbing", /obj/item/storage/belt/medical/mining, 4), \
+	new/datum/stack_recipe("toolbelt", /obj/item/storage/belt/utility, 4), \
 	new/datum/stack_recipe("wallet", /obj/item/storage/wallet, 1), \
 ))
 

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -348,6 +348,7 @@ GLOBAL_LIST_INIT(cloth_recipes, list ( \
 	new/datum/stack_recipe("construction bag", /obj/item/storage/bag/construction, 4), \
 	new/datum/stack_recipe("mining satchel", /obj/item/storage/bag/ore, 4), \
 	new/datum/stack_recipe("plant bag", /obj/item/storage/bag/plants, 4), \
+	new/datum/stack_recipe("sheet snatcher", /obj/item/storage/bag/sheetsnatcher, 4), \
 	null, \
 	new/datum/stack_recipe("bedsheet", /obj/item/bedsheet, 3), \
 	new/datum/stack_recipe("empty sandbag", /obj/item/emptysandbag, 4), \

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -284,7 +284,7 @@
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "sheetsnatcher"
 
-	var/capacity = 300; //the number of sheets it can carry.
+	var/capacity = 2000; //the number of sheets it can carry.
 	w_class = WEIGHT_CLASS_NORMAL
 	component_type = /datum/component/storage/concrete/stack
 
@@ -293,7 +293,7 @@
 	var/datum/component/storage/concrete/stack/STR = GetComponent(/datum/component/storage/concrete/stack)
 	STR.allow_quick_empty = TRUE
 	STR.set_holdable(list(/obj/item/stack/sheet), list(/obj/item/stack/sheet/mineral/sandstone, /obj/item/stack/sheet/mineral/wood))
-	STR.max_combined_stack_amount = 300
+	STR.max_combined_stack_amount = 2000
 
 // -----------------------------
 //    Sheet Snatcher (Cyborg)
@@ -302,12 +302,12 @@
 /obj/item/storage/bag/sheetsnatcher/borg
 	name = "sheet snatcher 9000"
 	desc = ""
-	capacity = 500//Borgs get more because >specialization
+	capacity = 10000//Borgs get more because >specialization
 
 /obj/item/storage/bag/sheetsnatcher/borg/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/concrete/stack/STR = GetComponent(/datum/component/storage/concrete/stack)
-	STR.max_combined_stack_amount = 500
+	STR.max_combined_stack_amount = 10000
 
 // -----------------------------
 //           Book bag

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -284,7 +284,7 @@
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "sheetsnatcher"
 
-	var/capacity = 2000; //the number of sheets it can carry.
+	var/capacity = 500; //the number of sheets it can carry.
 	w_class = WEIGHT_CLASS_NORMAL
 	component_type = /datum/component/storage/concrete/stack
 
@@ -293,7 +293,7 @@
 	var/datum/component/storage/concrete/stack/STR = GetComponent(/datum/component/storage/concrete/stack)
 	STR.allow_quick_empty = TRUE
 	STR.set_holdable(list(/obj/item/stack/sheet), list(/obj/item/stack/sheet/mineral/sandstone, /obj/item/stack/sheet/mineral/wood))
-	STR.max_combined_stack_amount = 2000
+	STR.max_combined_stack_amount = 500
 
 // -----------------------------
 //    Sheet Snatcher (Cyborg)
@@ -302,12 +302,12 @@
 /obj/item/storage/bag/sheetsnatcher/borg
 	name = "sheet snatcher 9000"
 	desc = ""
-	capacity = 10000//Borgs get more because >specialization
+	capacity = 1000//Borgs get more because >specialization
 
 /obj/item/storage/bag/sheetsnatcher/borg/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/concrete/stack/STR = GetComponent(/datum/component/storage/concrete/stack)
-	STR.max_combined_stack_amount = 10000
+	STR.max_combined_stack_amount = 1000
 
 // -----------------------------
 //           Book bag

--- a/code/modules/vending/engivend.dm
+++ b/code/modules/vending/engivend.dm
@@ -22,7 +22,8 @@
 					/obj/item/laserlevel = 3)
 	contraband = list(/obj/item/stock_parts/cell/potato = 3)
 	premium = list(/obj/item/storage/belt/utility = 3,
-				   /obj/item/storage/box/smart_metal_foam = 1)
+				   /obj/item/storage/box/smart_metal_foam = 1,
+				   /obj/item/storage/bag/sheetsnatcher = 2)
 	refill_canister = /obj/item/vending_refill/engivend
 	default_price = 20
 	extra_price = 50


### PR DESCRIPTION
# Document the changes in your pull request

Buffs sheet snatchers to have a usable capacity of 500 sheets; instead of 300
1000 instead of 500 for borgs

makes them craftable with 4 cloth
puts two in the premium stock of engi-vends

# Wiki Documentation

Will need to be added to the Engi-Vend stock and possibly the crafting page

# Changelog

:cl:  
tweak: Sheet Snatchers can now be crafted for 4 cloth
tweak: 2 Sheet Snatchers may be bought at Engi-Vends from their premium stock
tweak: Sheet Snatchers can hold 500 sheets total
tweak: Borg Sheet Snatchers may hold 1,000 sheets total
spellcheck: Re-alphabetized Leather crafting, Again
/:cl:
