### PR TITLE
IAA shouldn't be in dynamic, I'm not fixing the bugs for it.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -1003,37 +1003,3 @@
 		if(!bloodsuckermind.make_bloodsucker(assigned_bloodsuckers))
 			assigned -= assigned_bloodsuckers
 	return TRUE
-
-//////////////////////////////////////////////
-//                                          //
-//         Internal Affairs Agents          //
-//                                          //
-//////////////////////////////////////////////
-
-/datum/dynamic_ruleset/roundstart/iaa
-	name = "Internal Affairs Agents"
-	persistent = TRUE
-	antag_flag = ROLE_INTERNAL_AFFAIRS
-	antag_datum = /datum/antagonist/traitor/internal_affairs
-	minimum_required_age = 0
-	protected_roles = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Brig Physician")
-	restricted_roles = list("Cyborg", "AI")
-	required_candidates = 1
-	weight = 5
-	cost = 10
-	scaling_cost = 9
-	requirements = list(25,25,25,25,25,25,25,25,25,25)
-	antag_cap = list("denominator" = 24)
-
-/datum/dynamic_ruleset/roundstart/iaa/pre_execute(population)
-	. = ..()
-	var/num_traitors = get_antag_cap(population) * (scaled_times + 1)
-	for (var/i = 1 to num_traitors)
-		if(candidates.len <= 0)
-			break
-		var/mob/M = pick_n_take(candidates)
-		assigned += M.mind
-		M.mind.special_role = ROLE_INTERNAL_AFFAIRS
-		M.mind.restricted_roles = restricted_roles
-		log_game("[key_name(M)] has been selected as a Internal Affairs Agent")
-	return TRUE


### PR DESCRIPTION
# Document the changes in your pull request

IAA agents kept on spawning solo, or with very few members. I don't want players to be given a singular goal either to kill themselves, or hijack.

# Changelog

:cl:  Xoxeyos
rscdel: Removes IAA from dynamic.
/:cl:
