### PR TITLE
Restores DoS app to syndinet

### DIFF
--- a/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
@@ -7,6 +7,7 @@
 	size = 20
 	requires_ntnet = TRUE
 	available_on_ntnet = FALSE
+	available_on_syndinet = TRUE
 	tgui_id = "NtosNetDos"
 	program_icon = "satellite-dish"
 


### PR DESCRIPTION
Looked like a fuckup, will close if removal was intended or rebalance it.



# Document the changes in your pull request

Restores syndinet access to the DoS app, as it seemed that the non-inclusion was unintentional.

# Spriting
bro im changing ONE VARIABLE


# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
bugfix: The Syndicate have identified an error with their software distribution network, and restored access to the Denial of Service program.
/:cl:
