### PR TITLE
REVERT #12677; Emergency Spare ID Can Be Used For ID Modification Again

### DIFF
--- a/code/modules/modular_computers/file_system/programs/command/card.dm
+++ b/code/modules/modular_computers/file_system/programs/command/card.dm
@@ -63,9 +63,6 @@
 	if(!id_card)
 		return
 
-	if(istype(id_card, /obj/item/card/id/captains_spare/temporary))
-		to_chat(user, span_warning("ERROR: [id_card] is not compatable with this program"))
-		return
 	region_access = list()
 	if(!target_dept && (ACCESS_CHANGE_IDS in id_card.access))
 		minor = FALSE


### PR DESCRIPTION
# Document the changes in your pull request

Reverts https://github.com/yogstation13/Yogstation/pull/12677

The amount of times I or another Head has been locked out of ID modification when there are NO OTHER HEADS, and is NO CAPTAIN, not a dead captain, **NO** captain, but it's just high enough pop to prevent skeleton crew access, and/or the true spare is already stolen, is infuriating.

The comms console already requires you to have a head's ID authorized at minimum to print it, and not be a silicon. This step was one too far and cripples acting captain function.

# Changelog

:cl:  
tweak: You may once again use the emergency spare to give yourself AA
/:cl:
