### PR TITLE
[Hugbox] Comms Consoles AutoLogout After 3 Minutes

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -51,8 +51,13 @@
 	. = ..()
 	GLOB.shuttle_caller_list += src
 
-/obj/machinery/computer/communications/proc/autologout
-		action = "toggleAuthentication" // We actually want to log out
+/obj/machinery/computer/communications/proc/autologout(action)
+	if(authenticated)
+		authenticated = FALSE
+		authorize_access = null
+		authorize_name = null
+		playsound(src, 'sound/machines/terminal_off.ogg', 50, FALSE)
+		return
 
 /// Are we NOT a silicon, AND we're logged in as the captain?
 /obj/machinery/computer/communications/proc/authenticated_as_non_silicon_captain(mob/user)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -51,6 +51,9 @@
 	. = ..()
 	GLOB.shuttle_caller_list += src
 
+/obj/machinery/computer/communications/proc/autologout
+		action = "toggleAuthentication" // We actually want to log out
+
 /// Are we NOT a silicon, AND we're logged in as the captain?
 /obj/machinery/computer/communications/proc/authenticated_as_non_silicon_captain(mob/user)
 	if (issilicon(user))
@@ -71,6 +74,7 @@
 
 /// Are we a silicon, OR logged in?
 /obj/machinery/computer/communications/proc/authenticated(mob/user)
+	addtimer(CALLBACK(src, .proc/autologout), 3 MINUTES)
 	if (issilicon(user))
 		return TRUE
 	return authenticated


### PR DESCRIPTION
# Document the changes in your pull request

Comms consoles automatically log out 3 minutes after logging in. This does not care if you're using the console, but who's going to be using the console for that long??
and just like....
log back in.

# Changelog

:cl:  
tweak: Comms Consoles automatically log out after 3 minutes pass.
/:cl:
