### PR TITLE
Makes Shoes & Gloves Cover Legs & Arms Respectively

### DIFF
--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -4,7 +4,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/clothing/gloves.dmi'
 	siemens_coefficient = 0.5
-	body_parts_covered = HANDS
+	body_parts_covered = HANDS | ARMS
 	slot_flags = ITEM_SLOT_GLOVES
 	attack_verb = list("challenged")
 	var/transfer_prints = FALSE

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -5,7 +5,7 @@
 	gender = PLURAL //Carn: for grammarically correct text-parsing
 	var/chained = 0
 
-	body_parts_covered = FEET
+	body_parts_covered = FEET | LEGS
 	slot_flags = ITEM_SLOT_FEET
 
 	permeability_coefficient = 0.5


### PR DESCRIPTION
# Document the changes in your pull request

for the time being we dont have anything to handle hands/feet so a lot of things that people assumed were good are literally useless because their armor is protecting something that cant be targeted.

simply makes shoes cover legs and gloves cover feet globally.

# Changelog

:cl:  
tweak: Shoes & Gloves cover their entire respective limb not just hands or feet.
/:cl:
