### PR TITLE
Removes mindswap from the spellbook (only)

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -159,11 +159,6 @@
 	spell_type = /obj/effect/proc_holder/spell/pointed/trigger/blind
 	cost = 1
 
-/datum/spellbook_entry/mindswap
-	name = "Mindswap"
-	spell_type = /obj/effect/proc_holder/spell/targeted/mind_transfer
-	category = "Mobility"
-
 /datum/spellbook_entry/forcewall
 	name = "Force Wall"
 	spell_type = /obj/effect/proc_holder/spell/targeted/forcewall


### PR DESCRIPTION
# Document the changes in your pull request

For admin reasons. Its theoretical existence causes friendly fire that is rough to deal with in tickets (or so I'm told)

This removes mindswap from the spellbook but leaves it for robeless apprentices.

# Wiki Documentation

It's not in the spellbook!

# Changelog

:cl: 
rscdel: The Wizard Federation has somehow managed to make their recordings of the spell Mindswap mindswap itself with a spirit of forgetfulness. Robeless apprentices have been able to remember it!
/:cl: