### PR TITLE
Makes quiet mode not turn itself off for admins/mentors

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -306,15 +306,15 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	// yogs start - Donor stuff
 	if(ckey in GLOB.donators)
 		prefs.unlock_content |= 2
-		//add_donor_verbs()
 	else
-		prefs.unlock_content &= ~2
+		prefs.unlock_content &= ~2 // is_donator relies on prefs.unlock_content
+
+	if(is_donator(src))
+		src.add_donator_verbs()
+	else
 		if(prefs.yogtoggles & QUIET_ROUND)
 			prefs.yogtoggles &= ~QUIET_ROUND
 			prefs.save_preferences()
-	
-	if(is_donator(src))
-		src.add_donator_verbs()
 
 	// yogs end
 	. = ..()	//calls mob.Login()


### PR DESCRIPTION
# Document the changes in your pull request
Removes mild inconvenience 

# Changelog

:cl:  
tweak: Mentors & Admins wont loose their quiet mode preference now
/:cl:
