### PR TITLE
Gives the ability for  Xenomorphs to cool down, Embryos' die with the host, Beds bucklecuff victims, and bed escape time reduced to 55 seconds

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -158,6 +158,18 @@
 /obj/item/restraints/handcuffs/alien
 	icon_state = "handcuffAlien"
 
+/obj/item/restraints/handcuffs/alien/beno
+	name = "resin handcuffs"
+	desc = "Extremely weak cuffs made to restrict movement."
+	icon_state = "cuff" // Needs sprite
+	breakouttime = 10 //Deciseconds = 1s
+	break_strength = 1
+	item_flags = DROPDEL
+
+/obj/item/restraints/handcuffs/alien/beno/dropped(mob/user)	
+	user.visible_message(span_danger("[user]'s [name] falls apart"))
+	. = ..()
+
 /obj/item/restraints/handcuffs/fake
 	name = "fake handcuffs"
 	desc = "Fake handcuffs meant for gag purposes."

--- a/code/game/objects/structures/beds_chairs/alien_nest.dm
+++ b/code/game/objects/structures/beds_chairs/alien_nest.dm
@@ -60,7 +60,10 @@
 	if(has_buckled_mobs())
 		unbuckle_all_mobs()
 
+	var/mob/living/carbon/human/alienprisoner = M
 	if(buckle_mob(M))
+		alienprisoner.handcuffed = new /obj/item/restraints/handcuffs/alien/beno(alienprisoner)
+		alienprisoner.update_handcuffed()
 		M.visible_message(\
 			"[user.name] secretes a thick vile goo, securing [M.name] into [src]!",\
 			span_danger("[user.name] drenches you in a foul-smelling resin, trapping you in [src]!"),\

--- a/code/game/objects/structures/beds_chairs/alien_nest.dm
+++ b/code/game/objects/structures/beds_chairs/alien_nest.dm
@@ -32,7 +32,7 @@
 			else
 				M.visible_message(\
 					span_warning("[M.name] struggles to break free from the gelatinous resin!"),\
-					span_notice("You struggle to break free from the gelatinous resin... (Stay still for two minutes.)"),\
+					span_notice("You struggle to break free from the gelatinous resin... (Stay still for fifty-five seconds.)"),\
 					span_italics("You hear squelching..."))
 				if(!do_after(M, 55 SECONDS, src))
 					if(M && M.buckled)

--- a/code/game/objects/structures/beds_chairs/alien_nest.dm
+++ b/code/game/objects/structures/beds_chairs/alien_nest.dm
@@ -34,7 +34,7 @@
 					span_warning("[M.name] struggles to break free from the gelatinous resin!"),\
 					span_notice("You struggle to break free from the gelatinous resin... (Stay still for two minutes.)"),\
 					span_italics("You hear squelching..."))
-				if(!do_after(M, 2 MINUTES, src))
+				if(!do_after(M, 55 SECONDS, src))
 					if(M && M.buckled)
 						to_chat(M, span_warning("You fail to unbuckle yourself!"))
 					return

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -59,6 +59,14 @@
 
 	//After then, it reacts to the surrounding atmosphere based on your thermal protection
 	if(!on_fire) // If you're on fire, ignore local air temperature
+		if(loc_temp < bodytemperature)
+			//Place is colder than we are
+			var/thermal_protection = heat_protection //This returns a 0 - 1 value, which corresponds to the percentage of heat protection.			
+			if(thermal_protection > 1)
+				adjust_bodytemperature((1+thermal_protection) / ((loc_temp + bodytemperature) * BODYTEMP_HEAT_DIVISOR) / heat_capacity_factor)
+		else
+			adjust_bodytemperature(heat_capacity_factor / ((loc_temp + bodytemperature) * BODYTEMP_HEAT_DIVISOR))
+
 		if(loc_temp > bodytemperature)
 			//Place is hotter than we are
 			var/thermal_protection = heat_protection //This returns a 0 - 1 value, which corresponds to the percentage of heat protection.

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -59,6 +59,11 @@
 
 /// Controls Xenomorph Embryo growth. If embryo is fully grown (or overgrown), stop the proc. If not, increase the stage by one and if it's not fully grown (stage 6), add a timer to do this proc again after however long the growth time variable is.
 /obj/item/organ/body_egg/alien_embryo/proc/advance_embryo_stage()
+	if(owner.stat == DEAD) // Shitcode that gets rid of aliens from dead hosts.
+		new /obj/item/organ/body_egg/alien_embryo(owner.loc)
+		owner.visible_message(span_danger("[src] weakly wriggles out of [owner]!"))
+		owner.adjustBruteLoss(40)
+		qdel(src)
 	if(stage >= 6)
 		return
 	if(++stage < 6)


### PR DESCRIPTION
When has there ever been a xenomorph chest burst from a dead body in any of the source material?

# Document the changes in your pull request

Adds a check if the host is dead that qdels the embryo, spawns a dead one in its place alongside adding in some flavor text and brute damage. Adds new cuffs under the alien subtype that are as weak as fake cuffs but are there to stop buckled individuals from using their hands that destroy themselves upon removal that uses the sprites of the unused abductor alien handcuffs. Gives the ability for xenomorphs to cooldown in space and other cold areas. The escape time has also been reduced to encourage the xenomorphs to be more attentive as you are no longer a threat because of the cuffs.

Why? Current Xeno gameplay is unfun for anyone captured being executed or dying in crit shortly after being impregnated. This pr was made to address that and other issues that may arise from simply forcing xenomorphs from spacing the room and getting free spawns from corpses to, actual xenomorph behavior of taking in live captures to convert.

# Wiki Documentation

Xenomorph embryos die alongside the host. Resin nest buckle cuff people and lets Xenomorphs can cooldown in cold areas.

# Changelog

:cl:  
rscadd: Adds resin cuffs and makes the alien nest auto bucklecuff hosts
tweak: Xenomorph embryos now die shortly after the host
tweak: Xenomorphs can cooldown now
/:cl:
