### PR TITLE
Pills & Chemmaster Nerf

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -260,7 +260,7 @@
 		var/vol_each_text = params["volume"]
 		var/vol_each_max = reagents.total_volume / amount
 		if (item_type == "pill")
-			vol_each_max = min(50, vol_each_max)
+			vol_each_max = min(10, vol_each_max)
 		else if (item_type == "patch")
 			vol_each_max = min(40, vol_each_max)
 		else if (item_type == "bottle")
@@ -306,6 +306,9 @@
 				if(STRB)
 					drop_threshold = STRB.max_items - bottle.contents.len
 			for(var/i = 0; i < amount; i++)
+				if(vol_each < 1)
+					playsound(src, 'sound/machines/buzz-sigh.ogg', 100, 0)
+					return FALSE
 				if(i < drop_threshold)
 					P = new/obj/item/reagent_containers/pill(target_loc)
 				else
@@ -321,6 +324,9 @@
 				reagents.trans_to(P, vol_each, transfered_by = usr)
 			return TRUE
 		if(item_type == "patch")
+			if(vol_each < 1)
+				playsound(src, 'sound/machines/buzz-sigh.ogg', 100, 0)
+				return FALSE
 			var/obj/item/reagent_containers/pill/patch/P
 			for(var/i = 0; i < amount; i++)
 				P = new/obj/item/reagent_containers/pill/patch(drop_location())
@@ -329,6 +335,9 @@
 				reagents.trans_to(P, vol_each, transfered_by = usr)
 			return TRUE
 		if(item_type == "bottle")
+			if(vol_each < 1)
+				playsound(src, 'sound/machines/buzz-sigh.ogg', 100, 0)
+				return FALSE
 			var/obj/item/reagent_containers/glass/bottle/P
 			for(var/i = 0; i < amount; i++)
 				P = new/obj/item/reagent_containers/glass/bottle(drop_location())
@@ -337,6 +346,9 @@
 				reagents.trans_to(P, vol_each, transfered_by = usr)
 			return TRUE
 		if(item_type == "condimentPack")
+			if(vol_each < 1)
+				playsound(src, 'sound/machines/buzz-sigh.ogg', 100, 0)
+				return FALSE
 			var/obj/item/reagent_containers/food/condiment/pack/P
 			for(var/i = 0; i < amount; i++)
 				P = new/obj/item/reagent_containers/food/condiment/pack(drop_location())
@@ -346,6 +358,9 @@
 				reagents.trans_to(P, vol_each, transfered_by = usr)
 			return TRUE
 		if(item_type == "condimentBottle")
+			if(vol_each < 1)
+				playsound(src, 'sound/machines/buzz-sigh.ogg', 100, 0)
+				return FALSE
 			var/obj/item/reagent_containers/food/condiment/P
 			for(var/i = 0; i < amount; i++)
 				P = new/obj/item/reagent_containers/food/condiment(drop_location())

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -7,7 +7,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	possible_transfer_amounts = list()
-	volume = 50
+	volume = 10 //50u was too much sorry folks
 	grind_results = list()
 	var/apply_type = INGEST
 	var/apply_method = "swallow"
@@ -243,6 +243,7 @@
 	name = "floorpill"
 	desc = "A strange pill found in the depths of maintenance."
 	icon_state = "pill21"
+	volume = 50 //maint pills are fine tho
 	var/static/list/names = list("maintenance pill","floorpill","mystery pill","suspicious pill","strange pill")
 	var/static/list/descs = list("Your feeling is telling you no, but...","Drugs are expensive, you can't afford not to eat any pills that you find."\
 	, "Surely, there's no way this could go bad.")

--- a/tgui/packages/tgui/interfaces/ChemMaster.js
+++ b/tgui/packages/tgui/interfaces/ChemMaster.js
@@ -263,7 +263,7 @@ const PackagingControls = (props, context) => {
           label="Pills"
           amount={pillAmount}
           amountUnit="pills"
-          sideNote="max 50u"
+          sideNote="max 10u"
           onChangeAmount={(e, value) => setPillAmount(value)}
           onCreate={() => act('create', {
             type: 'pill',


### PR DESCRIPTION
# Document the changes in your pull request

Chemmasters cannot produce items with **TOTAL VOLUMES** under 1u

pills excluding floorpills now contain at max 10u instead of 50u

# Wiki Documentation

needs a tweak to the chem master part of the Guide To Chemistry to adjust the pill volume to match, and maybe mention the limiter.

# Changelog

:cl:  
tweak: Chem Masters & Condimasters cannot produce packets, pills, bottles, or patches with less than 1u total volume
tweak: Pills now cannot contain more than 10u except Floor Pills.
/:cl:
