### PR TITLE
Energy Cutlass should now look like an Energy Cutlass

### DIFF
--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -203,6 +203,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	icon_state_on = "cutlass1"
+	saber_color = null
 	light_color = "#ff0000"
 
 /obj/item/melee/transforming/energy/blade


### PR DESCRIPTION
@nmajask fix for the e-saw didn't get applied to the cutlass.

# Document the changes in your pull request

Sets the default saber color of an energy cutlass to null. This change has been tested and yes it has fixed the sprite no I did not get a screenshot.

# Spriting
![image](https://user-images.githubusercontent.com/107460718/190853075-3321cd62-5416-4949-b687-d842a6645031.png)
Sprite being fixed, the reason why there are 2 of them is that this is a rotating animation.

# Changelog

:cl:  
bugfix: The energy cutlass is no longer a green lightsaber
/:cl:
