### PR TITLE
vendors can no longer instantly fucking gib you

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -460,8 +460,6 @@ GLOBAL_LIST_EMPTY(vending_products)
 					freebie(user, 1)
 				if(76 to 90)
 					tilt(user)
-				if(91 to 100)
-					tilt(user, crit=TRUE)
 				else
 					return
 


### PR DESCRIPTION
who the fuck thought a 10% chance everytime you hit a vendor to gib you was a good idea
:cl:  
rscdel: Removed vendors instant crushing you


/:cl:
