### PR TITLE
Removes ability to throw ghosts

### DIFF
--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -54,7 +54,7 @@
 
 /datum/chemical_reaction/proc/goonchem_vortex(turf/T, setting_type, range)
 	for(var/atom/movable/X in orange(range, T))
-		if(iseffect(X))
+		if(iseffect(X) || isobserver(X))
 			continue
 		if(!X.anchored)
 			var/distance = get_dist(X, T)


### PR DESCRIPTION
# Document the changes in your pull request

You are no longer able to throw ghosts (with sorium)

# Changelog

:cl:  
bugfix: fixed chemists being able to throw ghosts
/:cl:
