### PR TITLE
Creates an unlocked subtype of the RnD console

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -1168,3 +1168,10 @@ Nothing else in the console has ID requirements.
 
 /obj/machinery/computer/rdconsole/experiment
 	name = "E.X.P.E.R.I-MENTOR R&D Console"
+
+/obj/machinery/computer/rdconsole/nolock
+	name = "R&D Console"
+	desc = "A console used to interface with R&D tools. This one seems to not have an access requirement."
+
+	req_access = list()	//lA AND SETTING MANIPULATION REQUIRES SCIENTIST ACCESS.
+


### PR DESCRIPTION
why no ghostrole sci


# Document the changes in your pull request

Ghostroles which rely on research for upgrades (Old Station and Free Miners) are unable to do research. Hopefully, this PR will provide a means for them to do research.

# Spriting
nada

# Wiki Documentation

no

# Changelog



:cl:  
rscadd: There's a new subtype of the RnD console, it will soon reach old stations. This subtype doesn't have a lock.
/:cl:
