### PR TITLE
Fixes Teslium Destabilization Not Working In Grenades & Fixes Explosions Runtime

### DIFF
--- a/code/game/objects/effects/effect_system/effects_other.dm
+++ b/code/game/objects/effects/effect_system/effects_other.dm
@@ -90,7 +90,7 @@
 	var/explosion_message = 1				//whether we show a message to mobs.
 
 /datum/effect_system/reagents_explosion/set_up(amt, loca, flash = 0, flash_fact = 0, message = 1)
-	amount = amt
+	amount = max(amt,0)
 	explosion_message = message
 	if(isturf(loca))
 		location = loca

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -443,18 +443,14 @@
 	var/T3 = created_volume * 120
 	var/added_delay = 0.5 SECONDS
 	var/turf/T = get_turf(holder.my_atom)
-	message_admins("created volume: [created_volume]")
 	if(created_volume >= 75)
 		addtimer(CALLBACK(src, .proc/zappy_zappy, T, T1), added_delay)
-		message_admins("created volume T1: [created_volume] [T1]")
 		added_delay += 1.5 SECONDS
 	if(created_volume >= 40)
 		addtimer(CALLBACK(src, .proc/zappy_zappy, T, T2), added_delay)
-		message_admins("created volume T2: [created_volume] [T2]")
 		added_delay += 1.5 SECONDS
 	if(created_volume >= 10)			//10 units minimum for lightning, 40 units for secondary blast, 75 units for tertiary blast.
 		addtimer(CALLBACK(src, .proc/zappy_zappy, T, T3), added_delay)
-		message_admins("created volume T3: [created_volume] [T3]")
 	addtimer(CALLBACK(src, .proc/explode, holder, created_volume), added_delay)
 
 /datum/chemical_reaction/reagent_explosion/teslium_lightning/proc/zappy_zappy(turf/T, power)

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -442,21 +442,26 @@
 	var/T2 = created_volume * 50
 	var/T3 = created_volume * 120
 	var/added_delay = 0.5 SECONDS
+	var/turf/T = get_turf(holder.my_atom)
+	message_admins("created volume: [created_volume]")
 	if(created_volume >= 75)
-		addtimer(CALLBACK(src, .proc/zappy_zappy, holder, T1), added_delay)
+		addtimer(CALLBACK(src, .proc/zappy_zappy, T, T1), added_delay)
+		message_admins("created volume T1: [created_volume] [T1]")
 		added_delay += 1.5 SECONDS
 	if(created_volume >= 40)
-		addtimer(CALLBACK(src, .proc/zappy_zappy, holder, T2), added_delay)
+		addtimer(CALLBACK(src, .proc/zappy_zappy, T, T2), added_delay)
+		message_admins("created volume T2: [created_volume] [T2]")
 		added_delay += 1.5 SECONDS
 	if(created_volume >= 10)			//10 units minimum for lightning, 40 units for secondary blast, 75 units for tertiary blast.
-		addtimer(CALLBACK(src, .proc/zappy_zappy, holder, T3), added_delay)
+		addtimer(CALLBACK(src, .proc/zappy_zappy, T, T3), added_delay)
+		message_admins("created volume T3: [created_volume] [T3]")
 	addtimer(CALLBACK(src, .proc/explode, holder, created_volume), added_delay)
 
-/datum/chemical_reaction/reagent_explosion/teslium_lightning/proc/zappy_zappy(datum/reagents/holder, power)
-	if(QDELETED(holder.my_atom))
+/datum/chemical_reaction/reagent_explosion/teslium_lightning/proc/zappy_zappy(turf/T, power)
+	if(QDELETED(T))
 		return
-	tesla_zap(holder.my_atom, 7, power, tesla_flags)
-	playsound(holder.my_atom, 'sound/machines/defib_zap.ogg', 50, TRUE)
+	tesla_zap(T, 7, power, tesla_flags)
+	playsound(T, 'sound/machines/defib_zap.ogg', 50, TRUE)
 
 /datum/chemical_reaction/reagent_explosion/teslium_lightning/heat
 	id = "teslium_lightning2"


### PR DESCRIPTION
# Document the changes in your pull request

turns out returning if the container was qdel'd when you have a reaction that wants to run for longer than 1 frame is not great

also turns out passing a -100 to something that wants a positive number causes problems :)

fixes both these things

# Changelog

:cl:  @Chubbygummibear, VaelophisNyx
bugfix: Explosions cannot be passed a negative number anymore to prevent runtimes
bugfix: Teslium Destabilization Reaction Now Works In Chem Grenades
/:cl:
