### PR TITLE
Green Grapes Contain Aiuri Instead of Kelotane

### DIFF
--- a/code/modules/hydroponics/grown/berries.dm
+++ b/code/modules/hydroponics/grown/berries.dm
@@ -229,7 +229,7 @@
 	species = "greengrape"
 	plantname = "Green-Grape Vine"
 	product = /obj/item/reagent_containers/food/snacks/grown/grapes/green
-	reagents_add = list(/datum/reagent/medicine/kelotane = 0.2, /datum/reagent/consumable/nutriment = 0.1, /datum/reagent/consumable/sugar = 0.1)
+	reagents_add = list(/datum/reagent/medicine/c2/aiuri = 0.2, /datum/reagent/consumable/nutriment = 0.1, /datum/reagent/consumable/sugar = 0.1)
 	// No rarity: technically it's a beneficial mutant, but it's not exactly "new"...
 	mutatelist = list()
 


### PR DESCRIPTION
# Document the changes in your pull request

Botany balance so far seems to have been "do not hand out free trek chems"
this brings them back in line with Poppys which have Libital in them

# Wiki Documentation

Requires an update to the Guide To Plants to mention the change from Kelotane to Aiuri

# Changelog
:cl:  
tweak: Green Grapes contain Airui instead of Kelotane now
/:cl:
