### PR TITLE
Removes Disco Balls Access Requirements

### DIFF
--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_disco.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_disco.dmm
@@ -571,10 +571,6 @@
 /obj/item/wrench,
 /turf/open/floor/light/colour_cycle/dancefloor_a,
 /area/crew_quarters/bar)
-"bP" = (
-/obj/machinery/jukebox/disco,
-/turf/open/floor/light/colour_cycle/dancefloor_a,
-/area/crew_quarters/bar)
 "bT" = (
 /obj/machinery/processor,
 /obj/machinery/firealarm{
@@ -768,6 +764,10 @@
 	tag = ""
 	},
 /turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
+"fY" = (
+/obj/machinery/jukebox/disco/bar,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
 /area/crew_quarters/bar)
 "hg" = (
 /obj/structure/disposalpipe/segment,
@@ -1187,7 +1187,7 @@ aE
 bc
 bc
 by
-bP
+fY
 bc
 ct
 bc

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -18,7 +18,7 @@
 	name = "radiant dance machine mark IV"
 	desc = "The first three prototypes were discontinued after mass casualty incidents."
 	icon_state = "disco"
-	req_access = list(ACCESS_BAR)
+	req_access = list(null)
 	anchored = FALSE
 	var/list/spotlights = list()
 	var/list/sparkles = list()
@@ -29,6 +29,15 @@
 	anchored = TRUE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	flags_1 = NODECONSTRUCT_1
+
+/obj/machinery/jukebox/disco/bar
+	name = "radiant dance machine mark IV"
+	desc = "The first three prototypes were discontinued after mass casualty incidents."
+	icon_state = "disco"
+	anchored = FALSE
+	req_access = list(ACCESS_BAR)
+	var/list/spotlights = list()
+	var/list/sparkles = list()
 
 /datum/track
 	var/song_name = "generic"

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -31,13 +31,7 @@
 	flags_1 = NODECONSTRUCT_1
 
 /obj/machinery/jukebox/disco/bar
-	name = "radiant dance machine mark IV"
-	desc = "The first three prototypes were discontinued after mass casualty incidents."
-	icon_state = "disco"
-	anchored = FALSE
 	req_access = list(ACCESS_BAR)
-	var/list/spotlights = list()
-	var/list/sparkles = list()
 
 /datum/track
 	var/song_name = "generic"

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -18,7 +18,7 @@
 	name = "radiant dance machine mark IV"
 	desc = "The first three prototypes were discontinued after mass casualty incidents."
 	icon_state = "disco"
-	req_access = list(null)
+	req_access = null
 	anchored = FALSE
 	var/list/spotlights = list()
 	var/list/sparkles = list()


### PR DESCRIPTION
# Document the changes in your pull request

Adds a subtype of disco ball that has bar access requirements and uses that in the box bar variant

Cargo-ordered and admin spawned disco balls now have no access requirement

# Changelog

:cl:  
tweak: Cargo-ordered/admin spawned disco balls now have no access requirements
/:cl:
