### PR TITLE
Massively Reduces Granite Spawn Rate And Ore Chance

### DIFF
--- a/code/datums/mapgen/Cavegens/LavalandGenerator.dm
+++ b/code/datums/mapgen/Cavegens/LavalandGenerator.dm
@@ -24,7 +24,7 @@
 	var/basalt_death_limit = 3
 	var/basalt_turf = /turf/closed/mineral/random/volcanic/hard
 
-	var/initial_granite_chance = 35
+	var/initial_granite_chance = 20
 	var/granite_smoothing_interations = 100
 	var/granite_birth_limit = 4
 	var/granite_death_limit = 3

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -272,8 +272,8 @@
 	hardness = 3
 
 	mineralSpawnChanceList = list(
-		/turf/closed/mineral/uranium/volcanic/hard/harder = 10, /turf/closed/mineral/diamond/volcanic/hard/harder = 5, /turf/closed/mineral/gold/volcanic/hard/harder = 15, /turf/closed/mineral/titanium/volcanic/hard/harder = 15, /turf/closed/mineral/magmite/volcanic/hard/harder = 2, /turf/closed/mineral/gem/volcanic/hard/harder = 3,
-		/turf/closed/mineral/silver/volcanic/hard/harder = 20, /turf/closed/mineral/plasma/volcanic/hard/harder = 25, /turf/closed/mineral/iron/volcanic/hard/harder = 10, /turf/closed/mineral/dilithium/volcanic/hard/harder = 6, /turf/closed/mineral/gibtonite/volcanic/hard/harder = 7, /turf/closed/mineral/bscrystal/volcanic/hard/harder = 8)
+		/turf/closed/mineral/uranium/volcanic/hard/harder = 6, /turf/closed/mineral/diamond/volcanic/hard/harder = 2, /turf/closed/mineral/gold/volcanic/hard/harder = 11, /turf/closed/mineral/titanium/volcanic/hard/harder = 12, /turf/closed/mineral/magmite/volcanic/hard/harder = 2, /turf/closed/mineral/gem/volcanic/hard/harder = 2,
+		/turf/closed/mineral/silver/volcanic/hard/harder = 13, /turf/closed/mineral/plasma/volcanic/hard/harder = 21, /turf/closed/mineral/iron/volcanic/hard/harder = 10, /turf/closed/mineral/dilithium/volcanic/hard/harder = 4, /turf/closed/mineral/gibtonite/volcanic/hard/harder = 7, /turf/closed/mineral/bscrystal/volcanic/hard/harder = 3)
 
 /turf/closed/mineral/random/snow
 	name = "snowy mountainside"


### PR DESCRIPTION

![ss (2022-09-17 at 11 44 55)](https://user-images.githubusercontent.com/1534478/190890160-82402516-5c90-47d1-8c12-7fd4e8f2c18c.png)


# Document the changes in your pull request

Reduces granite spawn chance by half, but this in turn comes out to a lot less than just half because of how cellular automa works.

also reduces the ore chances a bit

# Changelog

:cl:  
tweak: Granite now CONSIDERABLY less common
tweak: Granite now has a lower chance to yield ores
/:cl:
