### PR TITLE
Sling Noclip Removal + Tweaks

### DIFF
--- a/yogstation/code/datums/components/walks.dm
+++ b/yogstation/code/datums/components/walks.dm
@@ -47,32 +47,6 @@
 /datum/component/walk/proc/finalize_move(mob/living/user, turf/destination)
 	return
 
-/datum/component/walk/shadow
-	var/atom/movable/pulled
-
-/datum/component/walk/shadow/can_walk(mob/living/user, turf/destination)
-	return (destination.get_lumcount() <= SHADOWWALK_THRESHOLD ? MOVE_ALLOWED : DEFER_MOVE)
-
-/datum/component/walk/shadow/preprocess_move(mob/living/user, turf/destination)
-	if(user.pulling)
-		if(user.pulling.anchored || (user.pulling == user.loc && user.pulling.density))
-			user.stop_pulling()
-			return
-		if(isliving(user.pulling))
-			var/mob/living/L = user.pulling
-			L.stop_pulling()
-			if(L.buckled && L.buckled.buckle_prevents_pull)
-				user.stop_pulling()
-				return
-			L.face_atom(user)
-		pulled = user.pulling
-		user.pulling.forceMove(get_turf(user))
-
-/datum/component/walk/shadow/finalize_move(mob/living/user, turf/destination)
-	if(pulled)
-		user.start_pulling(pulled, TRUE)
-		pulled = null
-
 /datum/component/walk/jaunt
 
 /datum/component/walk/jaunt/can_walk(mob/living/user, turf/destination)

--- a/yogstation/code/game/gamemodes/shadowling/shadowling.dm
+++ b/yogstation/code/game/gamemodes/shadowling/shadowling.dm
@@ -144,7 +144,7 @@ Made by Xhuis
 	say_mod = "chitters"
 	species_traits = list(NOBLOOD,NO_UNDERWEAR,NO_DNA_COPY,NOTRANSSTING,NOEYESPRITES,NOFLASH)
 	inherent_traits = list(TRAIT_NOGUNS, TRAIT_RESISTCOLD, TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE, TRAIT_NOBREATH, TRAIT_RADIMMUNE, TRAIT_VIRUSIMMUNE, TRAIT_PIERCEIMMUNE)
-	no_equip = list(SLOT_WEAR_MASK, SLOT_GLASSES, SLOT_GLOVES, SLOT_SHOES, SLOT_W_UNIFORM, SLOT_S_STORE)
+	no_equip = list(SLOT_WEAR_MASK, SLOT_GLOVES, SLOT_SHOES, SLOT_W_UNIFORM, SLOT_S_STORE)
 	nojumpsuit = TRUE
 	mutanteyes = /obj/item/organ/eyes/night_vision/alien/sling
 	burnmod = 1.5 //1.5x burn damage, 2x is excessive

--- a/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
@@ -180,17 +180,17 @@
 		if(istype(LO, /obj/structure/light_prism))
 			qdel(LO)
 
-	for(var/obj/structure/glowshroom/G in orange(7, user)) //High radius because glowshroom spam wrecks shadowlings
+	for(var/obj/structure/glowshroom/G in orange(5, user))
 		if(G.light_power > 0)
 			var/obj/structure/glowshroom/shadowshroom/S = new /obj/structure/glowshroom/shadowshroom(G.loc) //I CAN FEEL THE WARP OVERTAKING ME! IT IS A GOOD PAIN!
 			S.generation = G.generation
 			G.visible_message(span_warning("[G] suddenly turns dark!"))
 			qdel(G)
-	for(var/turf/open/floor/grass/fairy/F in view(7, user))
+	for(var/turf/open/floor/grass/fairy/F in view(5, user))
 		if(F.light_power > 0)
 			F.visible_message(span_warning("[F] suddenly turns dark!"))
 			F.ChangeTurf(/turf/open/floor/grass/fairy/dark, flags = CHANGETURF_INHERIT_AIR)
-	for(var/obj/structure/marker_beacon/M in view(7, user))
+	for(var/obj/structure/marker_beacon/M in view(5, user))
 		M.deconstruct()
 
 /obj/effect/proc_holder/spell/aoe_turf/flashfreeze //Stuns and freezes nearby people - a bit more effective than a changeling's cryosting
@@ -743,7 +743,7 @@
 	name = "Void Jaunt"
 	desc = "Move through the void for a time, avoiding mortal eyes and lights."
 	panel = "Shadowling Abilities"
-	charge_max = 800
+	charge_max = 700
 	clothes_req = FALSE
 	antimagic_allowed = TRUE
 	phase_allowed = TRUE

--- a/yogstation/code/modules/antagonists/shadowling/special_shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/special_shadowling_abilities.dm
@@ -92,7 +92,6 @@
 			H.faction |= "faithless"
 			for(var/datum/antagonist/shadowling/antag_datum in H.mind.antag_datums)
 				antag_datum.show_to_ghosts = TRUE
-			H.LoadComponent(/datum/component/walk/shadow)
 
 			H.equip_to_slot_or_del(new /obj/item/clothing/suit/space/shadowling(H), SLOT_WEAR_SUIT)
 			H.equip_to_slot_or_del(new /obj/item/clothing/head/shadowling(H), SLOT_HEAD)


### PR DESCRIPTION
# Document the changes in your pull request

Removes Shadowling ability to noclip through solid objects in the dark, because I could not figure out how to make it not let them drag other people through solid walls, their single most overpowered ability. I will HAPPILY let them keep the noclip if someone helps me with that.

Lets slings wear glasses. There's....please give me a reason to not let them wear them?

Decreases the cooldown on Void Jaunt, so slings can have a tiny bit more mobility to make up for this

reduced bonus range vs shrooms/grass/markers because it really does not need the bonus range. These rarely get used anyway.

# Changelog

:cl:  
rscdel: Slings cannot no-clip now
tweak: Slings can wear glasses now
tweak: Sling Void Jaunt cooldown is 1s faster
tweak: Veil does not get bonus range against marker beacons, glowing mushrooms, or fairy grass
/:cl:
