### PR TITLE
re-adds reactive pyro armor

### DIFF
--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -10,6 +10,7 @@
 	var/static/list/anomaly_armor_types = list(
 		/obj/effect/anomaly/grav	                = /obj/item/clothing/suit/armor/reactive/repulse,
 		/obj/effect/anomaly/flux 	           		= /obj/item/clothing/suit/armor/reactive/tesla,
+		/obj/effect/anomaly/pyro	  			    = /obj/item/clothing/suit/armor/reactive/fire,
 		/obj/effect/anomaly/bluespace 	            = /obj/item/clothing/suit/armor/reactive/teleport
 		)
 


### PR DESCRIPTION
the reason this was removed in the first place, four years ago, is really shitty.

reactive pyro armor ignites people nearby when it reacts. this is quite powerful, but so are the other anomaly armors (most notably, gravitational anomaly armor fucking stunning people nearby with wallthrows) if you use an anomaly core to make reactive armor, which very few people do, you deserve a powerful item.

# Changelog

:cl:  
tweak: using a pyro core on a reactive armor shell once again results in reactive pyro armor
/:cl:
