### PR TITLE
hyper active bone marrow now refers to your spine and not your bone as your bone marrow is in the spine area

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -439,8 +439,8 @@
 	name = "Hyperactive Bone Marrow"
 	desc = "A mutation that stimulates the subject's bone marrow causes it to work three times faster than usual."
 	quality = POSITIVE
-	text_gain_indication = span_notice("You feel your bones ache for a moment.")
-	text_lose_indication = span_notice("You feel something in your bones calm down.")
+	text_gain_indication = span_notice("You feel your spine ache for a moment.")
+	text_lose_indication = span_notice("The aching in your spine seems to have calmed down.")
 	difficulty = 12
 	instability = 20
 	power_coeff = 1


### PR DESCRIPTION
hyper active bone marrow now refers to your spine and not your bone as your bone marrow is in the spine area
please tell me if the description is ba
:cl:  
tweak: hyper active bone marrow now refers to your spine and not your bone as your bone marrow is in the spine area
/:cl:
