### PR TITLE
Syndicate Disguised Baseball Bat Baton Is Now Stealthy & Not Nukie Locked

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -550,15 +550,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 6
 	surplus = 50
 
-/datum/uplink_item/dangerous/donkbat
-	name = "Toy Baseball Bat"
-	desc = "A weighted solid plastic baseball bat, perfect for knocking the wind out of people."
-	item = /obj/item/melee/classic_baton/donkbat
-	cost = 6
-	manufacturer = /datum/corporation/traitor/donkco
-	surplus = 0
-	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
-
 /datum/uplink_item/dangerous/foamsmg
 	name = "Toy Submachine Gun"
 	desc = "A fully-loaded Donksoft bullpup submachine gun that fires riot grade darts with a 20-round magazine."
@@ -638,6 +629,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/pen/edagger
 	cost = 2
 	manufacturer = /datum/corporation/traitor/donkco
+
+/datum/uplink_item/stealthy_weapons/donkbat
+	name = "Toy Baseball Bat"
+	desc = "A weighted solid plastic baseball bat, perfect for knocking the wind out of people."
+	item = /obj/item/melee/classic_baton/donkbat
+	cost = 6
+	manufacturer = /datum/corporation/traitor/donkco
+	surplus = 0
 
 /datum/uplink_item/stealthy_weapons/martialarts
 	name = "Martial Arts Scroll"


### PR DESCRIPTION
# Document the changes in your pull request

oops

# Changelog

:cl:
bugfix: categorizes the uplink baseball bat correctly
bugfix: you can buy the uplink bat as non-nukies as intended
/:cl:
