### PR TITLE
Makes Many Emotes VISIBLE instead of AUDIBLE

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -44,7 +44,6 @@
 	key = "collapse"
 	key_third_person = "collapses"
 	message = "collapses!"
-	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/collapse/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
@@ -180,7 +179,6 @@
 	key_third_person = "glares"
 	message = "glares."
 	message_param = "glares at %t."
-	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/grin
 	key = "grin"
@@ -209,7 +207,6 @@
 	key_third_person = "kisses"
 	message = "blows a kiss."
 	message_param = "blows a kiss to %t."
-	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/laugh
 	key = "laugh"
@@ -272,7 +269,7 @@
 	key = "pout"
 	key_third_person = "pouts"
 	message = "pouts."
-	emote_type = EMOTE_AUDIBLE
+	emote_type = EMOTE_VISIBLE
 
 /datum/emote/living/scream
 	key = "scream"
@@ -291,19 +288,16 @@
 	key = "scowl"
 	key_third_person = "scowls"
 	message = "scowls."
-	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/shake
 	key = "shake"
 	key_third_person = "shakes"
 	message = "shakes their head."
-	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/shiver
 	key = "shiver"
 	key_third_person = "shiver"
 	message = "shivers."
-	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/sigh
 	key = "sigh"
@@ -366,7 +360,6 @@
 	key = "surrender"
 	key_third_person = "surrenders"
 	message = span_surrender("puts their hands on their head and falls to the ground, they surrender!")
-	emote_type = EMOTE_AUDIBLE
 	mob_type_blacklist_typecache = list(/mob/living/simple_animal)
 
 /datum/emote/living/surrender/run_emote(mob/user, params, type_override, intentional)


### PR DESCRIPTION
# Document the changes in your pull request

Makes Collapsing, Glaring, Blowing a Kiss, Pouting, Scowling, Shaking Your Head, Shivering, and Surrendering **Visible** emotes instead of AUDIBLE emotes

because none of these things require you to be able to hear to **SEE** it happening.

# Changelog

:cl:  
tweak: You can now see Collapse, Glare, Kiss, Pout, Scowl, Shaking-Head, Shivering, and Surrendering emotes, instead of only Hear them.
/:cl:
