### PR TITLE
Embedded Syringes Inject Full Transfer Amt. Per Tick

### DIFF
--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -200,7 +200,7 @@
 	return TRUE
 	
 /obj/item/reagent_containers/syringe/embed_tick(embedde, part)
-	reagents.trans_to(embedde, amount_per_transfer_from_this * 0.2)
+	reagents.trans_to(embedde, amount_per_transfer_from_this)
 
 /obj/item/reagent_containers/syringe/epinephrine
 	name = "syringe (epinephrine)"


### PR DESCRIPTION
# Document the changes in your pull request

Should make syringe guns loaded with things that aren't bluespace syringes not wet-noodles without explosive mixes. The main problem with them right now is they inject 5u on contact...then...1u. Per tick. Painfully weak for what they're supposed to be.

"its too OP!" then fucking remove syringe guns
what do you want them to be, because useless means that the answer is Bloat.

# Changelog

:cl:  
tweak: Embedded syringes now inject their full normal transfer amount per tick instead of 20% of that.
/:cl:
