### PR TITLE
Changes the Chemical Dispenser's Tier-Locked-Chems & Adds New Reactions

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -53,36 +53,39 @@
 		/datum/reagent/oxygen,
 		/datum/reagent/phosphorus,
 		/datum/reagent/potassium,
-		/datum/reagent/uranium/radium,
 		/datum/reagent/silicon,
 		/datum/reagent/silver,
 		/datum/reagent/sodium,
-		/datum/reagent/stable_plasma,
-		/datum/reagent/consumable/sugar,
-		/datum/reagent/sulfur,
-		/datum/reagent/toxin/acid
-	)
-	var/list/t2_upgrade_reagents = list(
 		/datum/reagent/iron,
 		/datum/reagent/water,
-		/datum/reagent/fuel
+		/datum/reagent/oil,
+		/datum/reagent/sulfur
+	)
+	var/list/t2_upgrade_reagents = list(
+		/datum/reagent/consumable/sugar,
+		/datum/reagent/ash,
+		/datum/reagent/fuel,
+		/datum/reagent/toxin/acid
 	)
 	var/list/t3_upgrade_reagents = list(
-		/datum/reagent/ammonia,
-		/datum/reagent/ash,
-		/datum/reagent/oil
-	)
-	var/list/t4_upgrade_reagents = list(
 		/datum/reagent/acetone,
+		/datum/reagent/ammonia,
 		/datum/reagent/diethylamine,
 		/datum/reagent/saltpetre
+	)
+	var/list/t4_upgrade_reagents = list(
+		/datum/reagent/uranium/radium,
+		/datum/reagent/stable_plasma,
+		/datum/reagent/toxin,
+		/datum/reagent/medicine/charcoal
 	)
 	var/list/emagged_reagents = list(
 		/datum/reagent/toxin/carpotoxin,
 		/datum/reagent/medicine/mine_salve,
 		/datum/reagent/medicine/morphine,
 		/datum/reagent/drug/space_drugs,
-		/datum/reagent/toxin
+		/datum/reagent/toxin/venom,
+		/datum/reagent/uranium
 	)
 
 	var/list/saved_recipes = list()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2132,3 +2132,11 @@
 /datum/reagent/adrenaline/on_mob_delete(mob/living/L)
 	. = ..()
 	REMOVE_TRAIT(L, TRAIT_IGNOREDAMAGESLOWDOWN, type)
+
+
+/datum/reagent/sulfur_trioxide
+	name = "Sulfur Trioxide"
+	description = "A super-oxygenated sulfur compound."
+	color = "#ebf0ff"
+	taste_description = "metallic rotten eggs"
+	reagent_state = SOLID

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -783,3 +783,59 @@
 	var/location = get_turf(holder.my_atom)
 	for(var/i in 1 to created_volume)
 		new /obj/item/stack/sheet/ashresin(location)
+
+// formerly un-creatable chems:
+
+/datum/chemical_reaction/surfur_trioxide
+	name = "sulfur trioxide"
+	id = "sulfur trioxide"
+	results = list(/datum/reagent/sulfur_trioxide = 2)
+	required_reagents = list(/datum/reagent/sulfur = 1, /datum/reagent/oxygen = 3)
+
+/datum/chemical_reaction/surfuric_acid
+	name = "sulfuric acid"
+	id = "sulfuric acid"
+	results = list(/datum/reagent/toxin/acid = 1)
+	required_reagents = list(/datum/reagent/sulfur_trioxide = 1, /datum/reagent/water = 1)
+
+/datum/chemical_reaction/sugar
+	name = "sugar"
+	id = "sugar"
+	results = list(/datum/reagent/consumable/sugar = 1)
+	required_reagents = list(/datum/reagent/carbon = 1, /datum/reagent/oxygen = 1, /datum/reagent/hydrogen = 1)
+
+/datum/chemical_reaction/welding_fuel
+	name = "welding fuel"
+	id = "welding fuel"
+	results = list(/datum/reagent/fuel = 1)
+	required_reagents = list(/datum/reagent/oil = 1, /datum/reagent/toxin/acid = 3)
+	required_temp = 400
+
+/datum/chemical_reaction/stableplasma
+	name = "stable plasma"
+	id = "stable plasma"
+	results = list(/datum/reagent/stable_plasma = 5)
+	required_reagents = list(/datum/reagent/toxin/plasma = 3, /datum/reagent/hydrogen = 3)
+	required_catalysts =  list(/datum/reagent/consumable/ethanol = 5)
+	required_temp = 100
+
+/datum/chemical_reaction/waterformation
+	name = "water formation"
+	id = "water formation"
+	results = list(/datum/reagent/water = 1)
+	required_reagents = list(/datum/reagent/oxygen = 1, /datum/reagent/hydrogen = 2)
+	required_temp = 380
+
+/datum/chemical_reaction/ice
+	name = "freezing water"
+	id = "freezing water"
+	results = list(/datum/reagent/consumable/ice = 1)
+	required_reagents = list(/datum/reagent/water = 1)
+	required_temp = 273
+
+/datum/chemical_reaction/water2
+	name = "melting ice"
+	id = "meling ice"
+	results = list(/datum/reagent/water = 1)
+	required_reagents = list(/datum/reagent/consumable/ice = 1)
+	required_temp = 300


### PR DESCRIPTION
# Document the changes in your pull request

Shuffles some chems around the tiers and what not. I'll document this better later, I'm just trying this to see if the linter here can pinpoint what's causing this to break so hard right now?

# Wiki Documentation

Will require mentions on the guide to chemistry I think, if tiers are mentioned?

# Changelog

:cl:  
experimental: Opening as a bug-test before documentation
/:cl:
