### PR TITLE
Removes space comms agent sleeper RNG

### DIFF
--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -149,11 +149,6 @@
 	flavour_text = "Monitor enemy activity as best you can, and try to keep a low profile. Monitor enemy activity as best you can, and try to keep a low profile. Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen off your trail. Do not let the base fall into enemy hands!"
 	important_info = "DO NOT abandon the base."
 
-/obj/effect/mob_spawn/human/lavaland_syndicate/comms/space/Initialize()
-	. = ..()
-	if(prob(90)) //only has a 10% chance of existing, otherwise it'll just be a NPC syndie.
-		new /mob/living/simple_animal/hostile/syndicate/ranged(get_turf(src))
-		return INITIALIZE_HINT_QDEL
 
 /datum/outfit/lavaland_syndicate/comms
 	name = "Lavaland Syndicate Comms Agent"


### PR DESCRIPTION
# Document the changes in your pull request

From what I can tell, space comms agents NEVER spawn, as:
-only 10% chance
-ruin doesn't have 100% chance to spawn (which is what made comms agent spawning possible in servers like /tg/)
These two factors colliding mean that a space comms agent will essentially NEVER spawn.
This PR removes the first factor, restoring reasonable RNG to the space comms agent.

# Spriting
nada

# Wiki Documentation

nada because what i'm removing wasn't covered on ruin wiki
# Changelog


:cl:  
tweak: Space Comms Agents can now spawn outside of extraordinary luck (massively increases chance by removing an element of RNG)
/:cl:
