### PR TITLE
Felinids now have a family history of heart disease

### DIFF
--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -14,6 +14,8 @@
 			heart_attack_contestants[H] = 3
 		else
 			heart_attack_contestants[H] = 1
+		if(is_species(H, /datum/species/human/felinid))
+			heart_attack_contestants[H] = heart_attack_contestants[H] * 5 //Did you know those with a family history of heart disease are 5 times more likely to suffer a heart attack than their peers?
 
 	if(LAZYLEN(heart_attack_contestants))
 		var/mob/living/carbon/human/winner = pickweight(heart_attack_contestants)

--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -14,7 +14,7 @@
 			heart_attack_contestants[H] = 3
 		else
 			heart_attack_contestants[H] = 1
-		if(is_species(H, /datum/species/human/felinid))
+		if(iscatperson(H))
 			heart_attack_contestants[H] = heart_attack_contestants[H] * 5 //Did you know those with a family history of heart disease are 5 times more likely to suffer a heart attack than their peers?
 
 	if(LAZYLEN(heart_attack_contestants))


### PR DESCRIPTION
**LORE**
Unfortunately the same genes that give Felinids their distinctive features also put them at a higher risk of heart disease. 

Those with a history of heart disease are 5x more likely to suffer a heart attack than their peers. If you or a loved one has a history of heart disease take the proper health steps to minimize your risks.

:cl:  
rscadd: Felinids now have a family history of heart disease 
/:cl:
