### PR TITLE
completely ruins flashbangs because AoE stuns were a mistake

### DIFF
--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -24,7 +24,7 @@
 	M.show_message(span_userdanger("BANG"), MSG_AUDIBLE)
 	var/distance = max(0,get_dist(get_turf(src),T))
 	if(!distance || loc == M || loc == M.loc)	//Stop allahu akbarring rooms with this.
-		M.Knockdown(200)
+		M.Knockdown(20 SECONDS)
 		M.soundbang_act(1, 20, 10, 15)
 		return
 	if(iscyborg(M))

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -43,8 +43,8 @@
 
 	// If flashed and banged
 	if(flashed && banged)
-		M.Knockdown(max(150/max(1,distance), 60))
+		M.Knockdown(max(15 / max(1, distance), 6) SECONDS)
 	// If banged only
 	else if (banged)
-		M.Knockdown(max(50/max(1, distance), 30))
+		M.Knockdown(max(5 / max(1, distance), 3) SECONDS)
 	//flashed only is handled by flash_act

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -24,7 +24,7 @@
 	M.show_message(span_userdanger("BANG"), MSG_AUDIBLE)
 	var/distance = max(0,get_dist(get_turf(src),T))
 	if(!distance || loc == M || loc == M.loc)	//Stop allahu akbarring rooms with this.
-		M.Paralyze(200)
+		M.Knockdown(200)
 		M.soundbang_act(1, 20, 10, 15)
 		return
 	if(iscyborg(M))
@@ -41,9 +41,10 @@
 	var/flashed = M.flash_act(affect_silicon = 1)
 	var/banged = M.soundbang_act(1, 20/max(1,distance), rand(0, 5))
 
-	// If missing two resists
+	// If flashed and banged
 	if(flashed && banged)
-		M.Paralyze(max(150/max(1,distance), 60))
-	// If missing one resist
-	else if (flashed || banged)
-		M.Paralyze(max(50/max(1, distance), 30))
+		M.Knockdown(max(150/max(1,distance), 60))
+	// If banged only
+	else if (banged)
+		M.Knockdown(max(50/max(1, distance), 30))
+	//flashed only is handled by flash_act


### PR DESCRIPTION
replaces flashbang stun with a knockdown. you shouldnt need to be a powergamer to avoid these especially since security is really fond of shoving 7 up their ass. aoe stuns were a mistake.

other than the stun being replaced by a knockdown, they're the same. if you are about to complain about these being shitty, they're still:

AoE disarm
AoE blind
AoE deafen
AoE confusion (makes it really hard to run away)

i also replaced the paralyze if it blew up in your hand with a knockdown because im not that malicious

if you have eye protection, the knockdown is shorter and you dont get flashed

if you have ear protection, you don't get knocked down, but you still get flashed and blinded

# Changelog

:cl:  
tweak: all of the fucking hardstuns from flashbangs have been replaced with knockdowns
/:cl:
