### PR TITLE
Id bomb armor increased to 25

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -152,7 +152,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
 	slot_flags = ITEM_SLOT_ID
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 25, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	var/mining_points = 0 //For redeeming at mining equipment vendors
 	var/list/access = list()


### PR DESCRIPTION
What do you mean the hop doesn't exist?

# Document the changes in your pull request

Increases the bomb armor of Id's to 25, the same as the security helmet. This is in order to prevent explosives like the PDA bomber which is weak enough to not kill you but strong enough to shred, from completely getting rid of access.

This will decrease the effectiveness of the PDA bomber to just bombing PDAs instead of your Id, which was already inconsistent in its performance in doing so. While also making explosives less punishing, stronger explosives will still destroy them and so will gibbing.

# Wiki Documentation

Bomb armor increased to 25

# Changelog

:cl:  
tweak: Increased Id bomb armor to 25
/:cl:
