### PR TITLE
Slings can no longer pull and drag through walls while Shadow Walking

### DIFF
--- a/yogstation/code/datums/components/walks.dm
+++ b/yogstation/code/datums/components/walks.dm
@@ -51,11 +51,14 @@
 	var/atom/movable/pulled
 
 /datum/component/walk/shadow/can_walk(mob/living/user, turf/destination)
+	if(user.pulling && isclosedturf(destination))
+		to_chat(user, span_warning("You can't pass through while pulling!"))
+		return MOVE_NOT_ALLOWED
 	return (destination.get_lumcount() <= SHADOWWALK_THRESHOLD ? MOVE_ALLOWED : DEFER_MOVE)
 
 /datum/component/walk/shadow/preprocess_move(mob/living/user, turf/destination)
 	if(user.pulling)
-		if(user.pulling.anchored || (user.pulling == user.loc && user.pulling.density))
+		if(user.pulling.anchored || (user.pulling == user.loc && user.pulling.density) || (user.pulling && isclosedturf(user.loc)))
 			user.stop_pulling()
 			return
 		if(isliving(user.pulling))


### PR DESCRIPTION
Walls do matter.

# Document the changes in your pull request

Makes it so that slings that are pulling an object cannot phase through walls and other closed objects while pulling and also stops them from pulling if they phased through the wall first and then pulled the object. This is so that slings cannot just kidnap people and drag them to inaccessible areas for no risk whatsoever, making them care about who and where they will decide to convert.

# Wiki Documentation

Slings can no longer pull through walls

# Changelog

:cl:  
tweak: Slings will not pull objects through walls
/:cl:
