### PR TITLE
Nitrous Oxide Explosion Reaction Removal

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1250,7 +1250,7 @@
 
 /datum/reagent/nitrous_oxide
 	name = "Nitrous Oxide"
-	description = "A potent oxidizer used as fuel in rockets and as an anaesthetic during surgery."
+	description = "A potent anaesthetic used during surgery."
 	reagent_state = LIQUID
 	metabolization_rate = 1.5 * REAGENTS_METABOLISM
 	color = "#808080"

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -463,14 +463,6 @@
 	required_temp = 474
 	required_reagents = list(/datum/reagent/teslium = 1)
 
-/datum/chemical_reaction/reagent_explosion/nitrous_oxide
-	name = "N2O explosion"
-	id = "n2o_explosion"
-	required_reagents = list(/datum/reagent/nitrous_oxide = 1)
-	strengthdiv = 7
-	required_temp = 575
-	modifier = 1
-
 /datum/chemical_reaction/firefighting_foam
 	name = "Firefighting Foam"
 	id = /datum/reagent/firefighting_foam


### PR DESCRIPTION
# Document the changes in your pull request

Removes N2O's 575K explosion reaction, because its just far too strong, and easy to make.
retains all other qualities.

# Wiki Documentation
Will require a tweak to the Guide to Chemistry to not mention the explosion temp.

# Changelog

:cl:  
rscdel: N2O cannot explode anymore
spellcheck: N2O does not mention oxidizer nor rocket fuel anymore
/:cl:
