### PR TITLE
Revenant Balance Check

### DIFF
--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -70,7 +70,6 @@
 /mob/living/simple_animal/revenant/Initialize(mapload)
 	. = ..()
 	flags_1 |= RAD_NO_CONTAMINATE_1
-	ADD_TRAIT(src, TRAIT_SIXTHSENSE, INNATE_TRAIT)
 	AddSpell(new /obj/effect/proc_holder/spell/targeted/night_vision/revenant(null))
 	AddSpell(new /obj/effect/proc_holder/spell/targeted/telepathy/revenant(null))
 	AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/revenant/defile(null))
@@ -299,6 +298,9 @@
 	var/turf/T = get_turf(src)
 	if(isclosedturf(T))
 		to_chat(src, span_revenwarning("You cannot use abilities from inside of a wall."))
+		return FALSE
+	if(isspaceturf(T))
+		to_chat(src, span_revenwarning("You cannot use abilities in space!"))
 		return FALSE
 	for(var/obj/O in T)
 		if(O.density && !O.CanPass(src, T))

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -268,7 +268,8 @@
 	for(var/obj/structure/window/window in T)
 		window.take_damage(rand(30,80))
 		if(window && window.fulltile)
-			new /obj/effect/temp_visual/revenant/cracks(window.loc)
+			if(!istype(window, /obj/structure/window/reinforced) || !istype(window, /obj/structure/window/plasma) || !istype(window, /obj/structure/window/plastitanium) || !istype(window, /obj/structure/window/plasma/reinforced))
+				new /obj/effect/temp_visual/revenant/cracks(window.loc)
 	for(var/obj/machinery/light/light in T)
 		light.flicker(20) //spooky
 


### PR DESCRIPTION
# Document the changes in your pull request

Reverts the deadchat part of https://github.com/yogstation13/Yogstation/pull/10735 because you are IN the round, you SHOULD NOT be able to see or hear deadchat. Wizard scrying orb was removed for a similar reason (yes different but very similar). this was the ORIGNAL INTENT FIVE FUCKING YEARS AGO.
revenants being spoon fed OOC info as an IN-CHARACTER ANTAG, is fucking abysmal. Being told right where a body is with no need to go like...scout for it, is unbalanced to the core.

Makes Revenants unable to fire abilities on space turfs, because camping outside the evac area in space spamming abilities is cringe as hell

makes Defile unable to damage Reinforced, Plasma, Reinforced Plasma, and Plastitanium windows, because also spacing an area or loosing a plasma or fusion flood with one or two ability casts is NOT ok. Firelocks dont even help because it will still break THOSE too leaving you with a revenant capable of spacing important areas.

# Changelog

:cl:  
rscdel: Revenants cannot hear dead chat anymore, as participants IN a round
tweak: Defile cannot damage non-standard windows (reinforced/plasma/etc)
tweak: Revenants cannot use abilities in space
/:cl:
