### PR TITLE
Reduces the maximum alert level of Aurora Caelus event to Red Alert

### DIFF
--- a/code/modules/events/aurora_caelus.dm
+++ b/code/modules/events/aurora_caelus.dm
@@ -4,7 +4,7 @@
 	max_occurrences = 1
 	weight = 1
 	earliest_start = 5 MINUTES
-	max_alert = SEC_LEVEL_DELTA
+	max_alert = SEC_LEVEL_RED
 
 /datum/round_event_control/aurora_caelus/canSpawnEvent(players, gamemode)
 	if(!CONFIG_GET(flag/starlight))


### PR DESCRIPTION
# Document the changes in your pull request

This small change prevents the Aurora Caelus event from occurring during alert levels higher than Red.

### Rationale
The Aurora Caelus event causes peaceful music to play, and is a fun and generally RP focused event based around harmless ions. Though I think it is fun to have it occur during crazy moments in the station, partly due to the contrast it provides against the backdrop of chaos on the station, and partly because it is sort of a break from the madness - I think it is a bit much to have it occur during the Delta and Omega alert levels. You got this loud alert siren, Nar'Sie is ravaging the station or what have you, and the Aurora event starts playing it's music and making announcements. A bit out of place, is all.

### Testing
Tested by compiling on Master branch and then confirming the event still functions. Did not test the max-level functionality as I did not know how to trigger the event without Admin commands overriding the event condition check, and I made no changes to it, regardless.

# Wiki Documentation
No significant change - wiki docs do not seem to currently mention max alert levels.

# Changelog

:cl:  
rscadd: The station now activates anti-ion magneto-fields during Delta Alerts!
/:cl:
