### PR TITLE
adds a minimal player age to psychiatrist

### DIFF
--- a/yogstation/code/modules/jobs/job_types/psychiatrist.dm
+++ b/yogstation/code/modules/jobs/job_types/psychiatrist.dm
@@ -9,6 +9,7 @@
 	supervisors = "the chief medical officer"
 	selection_color = "#d4ebf2"
 	alt_titles = list("Counsellor", "Therapist", "Mentalist")
+	minimal_player_age = 5 //stop griefing
 
 	outfit = /datum/outfit/job/psych
 


### PR DESCRIPTION
stop griefing

merge this or #15816 but not both or you will make me upset

# Changelog

:cl:  
tweak: psychiatrist now has a minimal player age because ban evaders prevent us from having nice things
/:cl:
