### PR TITLE
Fixes a no cooldown exploit with sling spells

### DIFF
--- a/code/modules/spells/spell_types/shadow_walk.dm
+++ b/code/modules/spells/spell_types/shadow_walk.dm
@@ -16,6 +16,9 @@
 
 /obj/effect/proc_holder/spell/targeted/shadowwalk/cast(list/targets,mob/living/user = usr)
 	var/L = user.loc
+	if(istype(user.loc, /obj/effect/dummy/phased_mob/shadowling))
+		to_chat(user, span_boldwarning("You can't shadow walk while void jaunting!"))
+		return
 	if(istype(user.loc, /obj/effect/dummy/phased_mob/shadow))
 		var/obj/effect/dummy/phased_mob/shadow/S = L
 		S.end_jaunt(FALSE)


### PR DESCRIPTION
Why

# Document the changes in your pull request

Fixes #15850 by disallowing the use of shadow walk if you are void jaunting. This does not affect the ability of Void jaunt and Shadow walk to be used to cancel itself. You can still however use Void jaunt to cancel out of Shadow walk as I didn't write a check for this and it shouldn't really matter as it already had no cooldown in the first place.


# Changelog

:cl:  
bugfix: Fixes an exploit with sling abilities
/:cl:
