### PR TITLE
Reduces Phytosian Ammonia/Saltpetre/RobHarv Healing

### DIFF
--- a/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
@@ -159,19 +159,19 @@
 		return 1
 
 	if(chem.type == /datum/reagent/saltpetre)
-		H.adjustFireLoss(-2.5*REAGENTS_EFFECT_MULTIPLIER)
-		H.adjustToxLoss(-1*REAGENTS_EFFECT_MULTIPLIER)
+		H.adjustFireLoss(-1.5*REAGENTS_EFFECT_MULTIPLIER)
+		H.adjustToxLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER)
 		H.reagents.remove_reagent(chem.type, chem.metabolization_rate * REAGENTS_METABOLISM)
 		return 1
 
 	if(chem.type == /datum/reagent/ammonia)
-		H.adjustBruteLoss(-1*REAGENTS_EFFECT_MULTIPLIER)
-		H.adjustFireLoss(-1*REAGENTS_EFFECT_MULTIPLIER)
+		H.adjustBruteLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER)
+		H.adjustFireLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER)
 		H.reagents.remove_reagent(chem.type, chem.metabolization_rate * REAGENTS_METABOLISM)
 		return 1
 
 	if(chem.type == /datum/reagent/plantnutriment/robustharvestnutriment)
-		H.adjustToxLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
+		H.adjustToxLoss(-1*REAGENTS_EFFECT_MULTIPLIER)
 		for(var/V in H.reagents.reagent_list)//slow down the processing of harmful reagents.
 			var/datum/reagent/R = V
 			if(istype(R, /datum/reagent/toxin) || istype(R, /datum/reagent/drug))


### PR DESCRIPTION
# Document the changes in your pull request

As a phytosian player, these particular chems are a bit...much, currently. This still lets you use them to heal, BUT, half as effectively as before, because as a quick example, you can chug 500-1000u of Ammonia, and dive unarmored into combat against a traitor with armor and an esword, and have close to a 50/50 of winning that fight, instead of it being heavily traitor-sided like it probably should be.

Saltpetre's burn heal isn't quite halved, but is still significantly lower

# Wiki Documentation

If any mention is made of phytosians healing from ammonia, saltpetre, and robust harvest, it needs to mention it's half as effective as it currently mentions...if it does?

# Changelog

:cl:  
tweak: Phytosians heal half as much from non-addictive botany chems
/:cl:
