### PR TITLE
Fixes description discrepancies from #15706 and renames some drinks for Lore™ purposes

### DIFF
--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -338,7 +338,7 @@
 	harvest_time = 25
 	harvest_message_low = "You pluck a few choice tasty mushrooms."
 	harvest_message_med = "You grab a good haul of mushrooms."
-	harvest_message_high = "You hit the mushroom motherlode and harvest several from the batch."
+	harvest_message_high = "You hit the mushroom motherlode, your harvest containing several sizeable mushrooms."
 	regrowth_time_low = 3000
 	regrowth_time_high = 5400
 

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -338,19 +338,19 @@
 	harvest_time = 25
 	harvest_message_low = "You pluck a few choice tasty mushrooms."
 	harvest_message_med = "You grab a good haul of mushrooms."
-	harvest_message_high = "You hit the mushroom motherlode and make off with a bunch of tasty mushrooms."
+	harvest_message_high = "You hit the mushroom motherlode and harvest several from the batch."
 	regrowth_time_low = 3000
 	regrowth_time_high = 5400
 
 /obj/item/reagent_containers/food/snacks/grown/ash_flora/seraka
 	name = "seraka cap"
-	desc = "Small, deeply flavourful mushrooms originally native to Tizira."
+	desc = desc = "Small, deeply flavourful mushrooms originally native to Sangris. These ones are flaked in ash and soot."
 	icon_state = "seraka_cap"
 	seed = /obj/item/seeds/lavaland/seraka
 
 /obj/item/seeds/lavaland/seraka
 	name = "pack of seraka mycelium"
-	desc = "This mycelium grows into seraka mushrooms, a species of savoury mushrooms originally native to Tizira used in food and traditional medicine."
+	desc = "This mycelium grows into seraka mushrooms, a species of savoury mushrooms originally native to Sangris. They are most commonly used in food and traditional medicine."
 	icon_state = "mycelium-seraka"
 	species = "seraka"
 	plantname = "Seraka Mushrooms"

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -344,7 +344,7 @@
 
 /obj/item/reagent_containers/food/snacks/grown/ash_flora/seraka
 	name = "seraka cap"
-	desc = desc = "Small, deeply flavourful mushrooms originally native to Sangris. These ones are flaked in ash and soot."
+	desc = "Small, deeply flavourful mushrooms originally native to Sangris. These ones are flaked in ash and soot."
 	icon_state = "seraka_cap"
 	seed = /obj/item/seeds/lavaland/seraka
 

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2423,25 +2423,25 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	..()
 
 /datum/reagent/consumable/ethanol/white_tiziran
-	name = "White Tiziran"
+	name = "Kriiya"
 	description = "A mix of vodka and kortara, often utilized during vuulek celebrations."
 	boozepwr = 65
 	color = "#A68340"
 	quality = DRINK_GOOD
 	taste_description = "strikes and gutters"
 	glass_icon_state = "white_tiziran"
-	glass_name = "White Tiziran"
+	glass_name = "Kriiya"
 	glass_desc = "A sweet mint vodka with a hint of cocoa."
 
 /datum/reagent/consumable/ethanol/drunken_espatier
-	name = "Drunken Espatier"
+	name = "M'thalu"
 	description = "A drink concocted by vuulek warriors for traditional duels. Strong and numbing."
 	boozepwr = 65
 	color = "#A68340"
 	quality = DRINK_GOOD
 	taste_description = "sorrow"
 	glass_icon_state = "drunken_espatier"
-	glass_name = "Drunken Espatier"
+	glass_name = "M'thalu"
 	glass_desc = "A drink that numbs the body, making it difficult to be aware of injury."
 	
 /datum/reagent/consumable/ethanol/drunken_espatier/on_mob_life(mob/living/carbon/C, delta_time, times_fired)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2397,7 +2397,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/bilk/kortara
 	name = "Kortara"
-	description = "A sweet, milky nut-based drink enjoyed on Tizira. Frequently mixed with fruit juices and cocoa for extra refreshment."
+	description = "A sweet, milky nut-based drink traditional in vuulek cuisine. Frequently mixed with fruit juices and cocoa for extra refreshment."
 	boozepwr = 25
 	color = "#EEC39A"
 	quality = DRINK_GOOD
@@ -2409,14 +2409,14 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	
 /datum/reagent/consumable/ethanol/sea_breeze
 	name = "Sea Breeze"
-	description = "Light and refreshing with a mint and cocoa hit- like mint choc chip ice cream you can drink!"
+	description = "Light and refreshing with a hint of mint and cocoa. Sweet, like a smoothie."
 	boozepwr = 15
 	color = "#CFFFE5"
 	quality = DRINK_VERYGOOD
 	taste_description = "mint choc chip"
 	glass_icon_state = "sea_breeze"
 	glass_name = "Sea Breeze"
-	glass_desc = "Minty, chocolatey, and creamy. It's like drinkable mint chocolate chip!"
+	glass_desc = "A mint-chocolate, creamy shake."
 
 /datum/reagent/consumable/ethanol/sea_breeze/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	M.apply_status_effect(/datum/status_effect/throat_soothed)
@@ -2424,25 +2424,25 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/white_tiziran
 	name = "White Tiziran"
-	description = "A mix of vodka and kortara. The Lizard imbibes."
+	description = "A mix of vodka and kortara, often utilized during vuulek celebrations."
 	boozepwr = 65
 	color = "#A68340"
 	quality = DRINK_GOOD
 	taste_description = "strikes and gutters"
 	glass_icon_state = "white_tiziran"
 	glass_name = "White Tiziran"
-	glass_desc = "I had a rough night and I hate the fucking humans, man."
+	glass_desc = "A sweet mint vodka with a hint of cocoa."
 
 /datum/reagent/consumable/ethanol/drunken_espatier
 	name = "Drunken Espatier"
-	description = "Look, if you had to get into a shootout in the cold vacuum of space, you'd want to be drunk too."
+	description = "A drink concocted by vuulek warriors for traditional duels. Strong and numbing."
 	boozepwr = 65
 	color = "#A68340"
 	quality = DRINK_GOOD
 	taste_description = "sorrow"
 	glass_icon_state = "drunken_espatier"
 	glass_name = "Drunken Espatier"
-	glass_desc = "A drink to make facing death easier."
+	glass_desc = "A drink that numbs the body, making it difficult to be aware of injury."
 	
 /datum/reagent/consumable/ethanol/drunken_espatier/on_mob_life(mob/living/carbon/C, delta_time, times_fired)
 	C.hal_screwyhud = SCREWYHUD_HEALTHY //almost makes you forget how much it hurts
@@ -2458,7 +2458,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	taste_description = "regret"
 	glass_icon_state = "protein_blend"
 	glass_name = "Protein Blend"
-	glass_desc = "Vile, even by lizard standards."
+	glass_desc = "A vile-looking drink that's hard to stomach, even if nutritious."
 	nutriment_factor = 3 * REAGENTS_METABOLISM
 
 /datum/reagent/consumable/ethanol/protein_blend/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
@@ -2471,7 +2471,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/mushi_kombucha
 	name = "Mushi Kombucha"
-	description = "A popular summer beverage on Tizira, made from sweetened mushroom tea."
+	description = "A popular mushroom tea among vuulen, traditionally enjoyed during blistering days of heat."
 	boozepwr = 10
 	color = "#C46400"
 	quality = DRINK_VERYGOOD

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2416,7 +2416,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	taste_description = "mint choc chip"
 	glass_icon_state = "sea_breeze"
 	glass_name = "Sea Breeze"
-	glass_desc = "A mint-chocolate, creamy shake."
+	glass_desc = "A creamy mint-chocolate shake."
 
 /datum/reagent/consumable/ethanol/sea_breeze/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	M.apply_status_effect(/datum/status_effect/throat_soothed)
@@ -2458,7 +2458,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	taste_description = "regret"
 	glass_icon_state = "protein_blend"
 	glass_name = "Protein Blend"
-	glass_desc = "A vile-looking drink that's hard to stomach, even if nutritious."
+	glass_desc = "A vile yet nutritious drink that's hard to stomach."
 	nutriment_factor = 3 * REAGENTS_METABOLISM
 
 /datum/reagent/consumable/ethanol/protein_blend/on_mob_life(mob/living/carbon/M, delta_time, times_fired)


### PR DESCRIPTION
# Document the changes in your pull request

Author of #15706 decided to merge only some of the suggestions made to make descriptions fit within the setting of our server, not TG's, so there are currently conflicting descriptions in the code. Because our lore is TG's now, I guess.

Don't know how you can make this shit up.

Also renames things now for some differentiation in some capacity I might go change the nut names but for now these are the most egregious offenders

# Wiki Documentation

Will need to update and shift around drinks on Guide to Drinks

# Changelog

:cl:  
spellcheck: Fixes lizard foods having discrepancies in description
spellcheck: Renames White Tiziran to Kriiya
spellcheck: Renames Drunken Espatier to M'thalu
/:cl:
