### PR TITLE
Makes chemical grenades explode on emp but not in a way that makes them horrible to use just nerf the fucking chems if they're that much of a problem you inbreds

### DIFF
--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -17,20 +17,10 @@
 	return
 
 /datum/wires/explosive/chem_grenade
-	duds_number = 2
+	duds_number = 1
 	holder_type = /obj/item/grenade/chem_grenade
 	randomize = TRUE
 	var/fingerprint
-
-/datum/wires/explosive/chem_grenade/New(atom/holder)
-	wires = list(
-		WIRE_BOOM //two duds and the explosion wire.
-	)
-	..()
-
-/datum/wires/explosive/chem_grenade/on_pulse(wire)
-	if(wire == WIRE_BOOM)
-		explode()
 
 /datum/wires/explosive/chem_grenade/interactable(mob/user)
 	var/obj/item/grenade/chem_grenade/G = holder

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -141,7 +141,7 @@
 
 /obj/item/grenade/chem_grenade/emp_act(severity)
 	..()
-	if(prob(40/severity)
+	if(prob(40/severity))
 		prime()
 
 /obj/item/grenade/chem_grenade/on_found(mob/finder)

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -16,6 +16,10 @@
 	var/casedesc = "This basic model accepts both beakers and bottles. It heats contents by 10°K upon ignition." // Appears when examining empty casings.
 	var/obj/item/assembly/prox_sensor/landminemode = null
 
+/obj/item/grenade/chem_grenade/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/empprotection, EMP_PROTECT_WIRES)
+
 /obj/item/grenade/chem_grenade/Initialize()
 	. = ..()
 	create_reagents(1000)
@@ -134,6 +138,11 @@
 		name = initial(name)
 		desc = initial(desc)
 		icon_state = "[initial(icon_state)]_locked"
+
+/obj/item/grenade/chem_grenade/emp_act(severity)
+	..()
+	if(prob(40/severity)
+		prime()
 
 /obj/item/grenade/chem_grenade/on_found(mob/finder)
 	var/obj/item/assembly/A = wires.get_attached(wires.get_wire(1))


### PR DESCRIPTION
# Document the changes in your pull request

chemical grenades get a 40/20% chance to explode on being emped
kills the stupid fucking wire bullshit that was used to handle that but also had the convenient side effect of making grenade wiring horrible since you'd have to waste time throwing more signallers or whatever the fuck into the grenade and NOT knowing they have dud wires means you have a 2/3 chance to have a bunch of dud grenades because apparently making everything unfriendly to new players is a good way to stop experienced players from using it (even though they will already know how to bypass the bullshit)

# Wiki Documentation

Chemical grenades explode when emped 40% of the time or 20% on low severity emp

# Changelog

:cl:  
tweak: chemical grenades no longer have 2 fucking dud wires that don't do anything
tweak: chemical grenades now have a 40% chance to explode on being emped rather than not having wire protection for emps  
/:cl:
