### PR TITLE
Allows Cyborgs/AIs to change their accent on the fly

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -196,7 +196,7 @@
 		add_verb(src, list(/mob/living/silicon/ai/proc/ai_network_change, \
 		/mob/living/silicon/ai/proc/ai_statuschange, /mob/living/silicon/ai/proc/ai_hologram_change, \
 		/mob/living/silicon/ai/proc/botcall, /mob/living/silicon/ai/proc/control_integrated_radio, \
-		/mob/living/silicon/ai/proc/set_automatic_say_channel))
+		/mob/living/silicon/ai/proc/set_automatic_say_channel, /mob/living/silicon/ai/proc/changeaccent))
 
 	GLOB.ai_list += src
 	GLOB.shuttle_caller_list += src

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -754,6 +754,14 @@
 		return //won't work if dead
 	checklaws()
 
+/mob/living/silicon/robot/verb/changeaccent()
+	set category = "Robot Commands"
+	set name = "Change Accent"
+
+	if(usr.stat == DEAD)
+		return //won't work if dead
+	accentchange()
+
 /mob/living/silicon/robot/verb/set_automatic_say_channel() //Borg version of setting the radio for autosay messages.
 	set name = "Set Auto Announce Mode"
 	set desc = "Modify the default radio setting for stating your laws."

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -460,3 +460,19 @@
 			.+= "<b>[number]:</b> [law]"
 			number++
 	.+= ""
+
+/mob/living/silicon/proc/accentchange()
+	var/mob/living/L = usr
+	if(!istype(L))
+		return
+	var/datum/mind/mega = usr.mind
+	if(!istype(mega))
+		return
+	var/aksent = input(usr, "Choose your accent:","Available Accents") as null|anything in (assoc_list_strip_value(strings("accents.json", "accent_file_names", directory = "strings/accents")) + "None")
+	if(aksent) // Accents were an accidents why the fuck do I have to do mind.RegisterSignal(mob, COMSIG_MOB_SAY)
+		if(aksent == "None")
+			mega.accent_name = null
+			mega.UnregisterSignal(L, COMSIG_MOB_SAY)
+		else
+			mega.accent_name = aksent
+			mega.RegisterSignal(L, COMSIG_MOB_SAY, /datum/mind/.proc/handle_speech, TRUE)

--- a/yogstation/code/modules/mob/living/silicon/ai/ai.dm
+++ b/yogstation/code/modules/mob/living/silicon/ai/ai.dm
@@ -48,3 +48,8 @@
 		hijacking = null
 		hijack_start = 0
 		to_chat(src, span_bolddanger("Unknown device disconnected. Systems confirmed secure."))
+
+/mob/living/silicon/ai/proc/changeaccent()
+	set category = "AI Commands"
+	set name = "Change Accent"
+	return accentchange()


### PR DESCRIPTION
# Document the changes in your pull request

## Why this is good for the game
AI law 2 become french
Also it just makes sense for a robotic being to just change their accent (maybe add this for IPCs?)

# Wiki Documentation

AI/Cyborg can change accents now

# Changelog

:cl:  
rscadd: AIs and Cyborgs can now change their accent on the fly
/:cl:
