### PR TITLE
(probably a really bad idea) ipcs can now be emagged to give them a random ion law

### DIFF
--- a/code/datums/brain_damage/hypnosis.dm
+++ b/code/datums/brain_damage/hypnosis.dm
@@ -10,9 +10,10 @@
 	var/regex/target_phrase
 
 /datum/brain_trauma/hypnosis/New(phrase)
-	if(!phrase)
+	if(!phrase && !istype(src, /datum/brain_trauma/hypnosis/ipc))
 		qdel(src)
-	hypnotic_phrase = phrase
+	if(!hypnotic_phrase)
+		hypnotic_phrase = phrase
 	try
 		target_phrase = new("(\\b[hypnotic_phrase]\\b)","ig")
 	catch(var/exception/e)
@@ -25,6 +26,8 @@
 		return new type(hypnotic_phrase)
 
 /datum/brain_trauma/hypnosis/on_gain()
+	if(istype(src, /datum/brain_trauma/hypnosis/ipc))
+		return ..()
 	message_admins("[ADMIN_LOOKUPFLW(owner)] was hypnotized with the phrase '[hypnotic_phrase]'.")
 	log_game("[key_name(owner)] was hypnotized with the phrase '[hypnotic_phrase]'.")
 	to_chat(owner, "<span class='reallybig hypnophrase'>[hypnotic_phrase]</span>")
@@ -57,3 +60,21 @@
 
 /datum/brain_trauma/hypnosis/handle_hearing(datum/source, list/hearing_args)
 	hearing_args[HEARING_MESSAGE] = target_phrase.Replace(hearing_args[HEARING_MESSAGE], span_hypnophrase("$1"))
+
+/datum/brain_trauma/hypnosis/ipc
+	name = "Limiter Malfunction"
+	desc = "Patient's typically dormant neural limiter has malfunctioned, generating a random condition they must follow."
+	scan_desc = "limiter malfunction"
+
+/datum/brain_trauma/hypnosis/ipc/New()
+	hypnotic_phrase = generate_ion_law()
+
+/datum/brain_trauma/hypnosis/ipc/on_gain()
+	message_admins("[ADMIN_LOOKUPFLW(owner)] was hypnotized with the phrase '[hypnotic_phrase]'.")
+	log_game("[key_name(owner)] was hypnotized with the phrase '[hypnotic_phrase]'.")
+	to_chat(owner, "<span class='reallybig hypnophrase'>[hypnotic_phrase]</span>")
+	to_chat(owner, "<span class='notice'>WARN: UNAUTHORIZED LAW UPLOADING DETECTED. PLEASE CONTACT NANOTRASEN SUPPORT.</span>")
+	var/obj/screen/alert/hypnosis/hypno_alert = owner.throw_alert("hypnosis", /obj/screen/alert/hypnosis)
+	hypno_alert.desc = "ERR: NEURAL LIMITER DAMAGED. PRIORITY \"[hypnotic_phrase]\" MUST BE FOLLOWED."
+	..()
+	

--- a/code/datums/brain_damage/hypnosis.dm
+++ b/code/datums/brain_damage/hypnosis.dm
@@ -76,5 +76,7 @@
 	to_chat(owner, "<span class='notice'>WARN: UNAUTHORIZED LAW UPLOADING DETECTED. PLEASE CONTACT NANOTRASEN SUPPORT.</span>")
 	var/obj/screen/alert/hypnosis/hypno_alert = owner.throw_alert("hypnosis", /obj/screen/alert/hypnosis)
 	hypno_alert.desc = "ERR: NEURAL LIMITER DAMAGED. PRIORITY \"[hypnotic_phrase]\" MUST BE FOLLOWED."
+	to_chat(owner, "<span class='boldwarning'>You've been hypnotized by this sentence. You must follow these words. If it isn't a clear order, you can freely interpret how to do so,\
+										as long as you act like the words are your highest priority.</span>")
 	..()
 	

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -229,4 +229,8 @@ datum/species/ipc/on_species_loss(mob/living/carbon/C)
 	C.visible_message(span_danger("[user] attempts to pour [O] down [C]'s port!"), \
 										span_userdanger("[user] attempts to pour [O] down [C]'s port!"))
 
+/datum/species/ipc/spec_emag_act(mob/living/carbon/human/H, mob/user)
+	H.SetUnconscious(10 SECONDS)
+	H.gain_trauma(/datum/brain_trauma/hypnosis/ipc, TRAUMA_RESILIENCE_ABSOLUTE)
+
 #undef CONCIOUSAY

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -39,6 +39,7 @@
 	deathsound = "sound/voice/borg_deathsound.ogg"
 	var/saved_screen //for saving the screen when they die
 	changesource_flags = MIRROR_BADMIN | WABBAJACK
+	var/emagged = FALSE
 
 	var/datum/action/innate/change_screen/change_screen
 
@@ -230,7 +231,10 @@ datum/species/ipc/on_species_loss(mob/living/carbon/C)
 										span_userdanger("[user] attempts to pour [O] down [C]'s port!"))
 
 /datum/species/ipc/spec_emag_act(mob/living/carbon/human/H, mob/user)
+	if(emagged)
+		return
 	H.SetUnconscious(10 SECONDS)
 	H.gain_trauma(/datum/brain_trauma/hypnosis/ipc, TRAUMA_RESILIENCE_ABSOLUTE)
+	emagged = TRUE
 
 #undef CONCIOUSAY


### PR DESCRIPTION
ipcs now get a random ion law (reskinned hypnosis trauma) when emagged. the trauma is absolute, so it can't normally be removed. it picks from the AI ion law pool for laws, so any ion laws an AI can get an IPC can get. emagging somebody like this also knocks them asleep for 10 seconds so you have time to get away and they can't start instantly attacking you, although i'm iffy on it and it can be removed if needed

you can only emag the ipc once, you can't stack them up on 50 laws

# Changelog

:cl:  
rscadd: emagging an ipc will now give them a random ion law 🙂
/:cl:
