### PR TITLE
gives minimum player age to virologist cause new players end up taking it then doing nothing wasting it because its a one slot job

### DIFF
--- a/code/modules/jobs/job_types/virologist.dm
+++ b/code/modules/jobs/job_types/virologist.dm
@@ -10,6 +10,7 @@
 	selection_color = "#d4ebf2"
 	exp_type = EXP_TYPE_CREW
 	exp_requirements = 120
+	minimal_player_age = 7
 	exp_type_department = EXP_TYPE_MEDICAL
 
 	outfit = /datum/outfit/job/virologist


### PR DESCRIPTION
gives minimum player age to virologist cause new players end up taking it then doing nothing wasting it because its a one slot job
:cl:  
rscadd: gives minimum player age to virologist cause new players end up taking it then doing nothing wasting it because its a one slot job
/:cl:
