### PR TITLE
Gives topaz 50 more mining points on scan

### DIFF
--- a/code/game/objects/items/gems.dm
+++ b/code/game/objects/items/gems.dm
@@ -198,7 +198,7 @@
 /obj/item/gem/topaz
 	name = "\improper Topaz"
 	icon_state = "topaz"
-	point_value = 150
+	point_value = 200
 
 /obj/item/ai_cpu/stalwart //very jank code-theft because it's not directly a gem
 	name = "\improper Bluespace Data Crystal"


### PR DESCRIPTION
# Document the changes in your pull request

i made topaz to have a tier of just shittier gems but then i didn't make any more so for right now they can be good

# Wikeez nuts
Topaz 150 points -> 200 points

# Changelog

:cl:  
tweak: topaz gets 200 points on scanning instead of 150
/:cl:
