### PR TITLE
adds a phytosian evolver which removes there natural slowness for 3 tc to the uplink

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -571,6 +571,12 @@
 	race = /datum/species/lizard
 	mutationtext = span_danger("The pain subsides. You feel... scaly.")
 
+/datum/reagent/mutationtoxin/pod/syndicate
+	name = "Advanced Phytosian Mutation Toxin"
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/pod/syndicate
+	mutationtext = span_danger("The pain subsides. You feel Faster.")
+
 /datum/reagent/mutationtoxin/fly
 	name = "Fly Mutation Toxin"
 	description = "An insectifying toxin."

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -675,6 +675,14 @@
 	if(hypo.penetrates)
 		to_chat(user, span_notice("[hypo] already has a piercing mechanism!"))
 		return FALSE
+
+/obj/item/reagent_containers/autoinjector/magillitis
+	name = "experimental phytosian autoinjector"
+	desc = "A modified air-needle autoinjector with a small single-use reservoir. It contains an experimental serum that combats phytosians natural slowness."
+	icon_state = "hypo_syndie"
+	volume = 5
+	reagent_flags = NONE
+	list_reagents = list(/datum/reagent/mutationtoxin/pod/syndicate = 5)
 	else
 		hypo.penetrates = TRUE
 		return TRUE

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -676,7 +676,7 @@
 		to_chat(user, span_notice("[hypo] already has a piercing mechanism!"))
 		return FALSE
 
-/obj/item/reagent_containers/autoinjector/magillitis
+/obj/item/reagent_containers/autoinjector/phytosiansyndicateshit
 	name = "experimental phytosian autoinjector"
 	desc = "A modified air-needle autoinjector with a small single-use reservoir. It contains an experimental serum that combats phytosians natural slowness."
 	icon_state = "hypo_syndie"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -678,7 +678,7 @@
 
 /obj/item/reagent_containers/autoinjector/phytosiansyndicateshit
 	name = "experimental phytosian autoinjector"
-	desc = "A modified air-needle autoinjector with a small single-use reservoir. It contains an experimental serum that combats phytosians natural slowness."
+	desc = "A modified air-needle autoinjector with a small single-use reservoir. It contains an experimental serum that acts on phytosians genetics to make them faster."
 	icon_state = "hypo_syndie"
 	volume = 5
 	reagent_flags = NONE

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2011,6 +2011,15 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/seeds/tomato/killer
 	restricted_species = list("pod")
 
+/datum/uplink_item/race_restricted/podevolver
+	name = "Phytosian Evolver"
+	desc = "The Syndicates Geneticist have cooked up a mutation toxin that eliminates phytosians natural slowness."
+	cost = 3
+	manufacturer = /datum/corporation/traitor/donkco
+	item = /obj/item/reagent_containers/autoinjector/phytosiansyndicateshit
+	restricted_species = list("pod")
+
+
 /datum/uplink_item/race_restricted/radiationbomb
 	name = "Radiation grenade"
 	desc = "A radiation bomb guaranteed to irradiate the fuck out of non-gaseous lifeforms."

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
@@ -282,4 +282,5 @@
 #undef STATUS_MESSAGE_COOLDOWN
 
 /datum/species/pod/syndicate
-changesource_flags = MIRROR_BADMIN
+	changesource_flags = MIRROR_BADMIN
+	speedmod = 0

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
@@ -280,3 +280,6 @@
 			H.nutrition = min(H.nutrition+30, NUTRITION_LEVEL_FULL)
 
 #undef STATUS_MESSAGE_COOLDOWN
+
+/datum/species/pod/syndicate
+changesource_flags = MIRROR_BADMIN


### PR DESCRIPTION
adds a phytosian evolver which removes there natural slowness for 3 tc to the uplink this is obviouslly race exclusive

frankly phytosians race exclusive is shit  i would know i originally coded it


# Wiki Documentation

adds a phytosian evolver which removes there natural slowness for 3 tc to the uplink
adds a new race only acieveable from badmin mirror or syndicate evo.ver hypospray
# Changelog

adds a phytosian evolver which removes there natural slowness for 3 tc to the uplink

:cl:  
rscadd: Added new syndicate hypospray that inject you with a mutation toxin
/:cl:
