### PR TITLE
makes the improvised shotgun shell not harder to get than actual shotgun shells

### DIFF
--- a/code/datums/components/crafting/weapons.dm
+++ b/code/datums/components/crafting/weapons.dm
@@ -386,10 +386,9 @@
 /datum/crafting_recipe/improvisedslug
 	name = "Improvised Shotgun Shell"
 	result = /obj/item/ammo_casing/shotgun/improvised
-	reqs = list(/obj/item/grenade/chem_grenade = 1,
-				/obj/item/stack/sheet/metal = 1,
+	reqs = list(/obj/item/stack/sheet/metal = 1,
 				/obj/item/stack/cable_coil = 1,
-				/datum/reagent/fuel = 10)
+				/datum/reagent/fuel = 5)
 	tools = list(TOOL_SCREWDRIVER)
 	time = 0.5 SECONDS
 	category = CAT_WEAPONRY


### PR DESCRIPTION
improvised shotgun shells offer a nice alternative to buckshot for unarmored opponents as they can do heavy wounding, although against people who are armored they do pretty much nothing. the only issue is these are orders of magnitude harder to get than actual shotgun shells because they require a completed chemical grenade for some fucking reason whereas you can walk up to an autolathe and hit the x25 button for actual shotgun ammo

# Changelog

:cl:  
tweak: improvised shotgun ammo is cheaper to craft
/:cl:
