### PR TITLE
Adds New 10x10 Maint Ruin: The Wizard Supply Closet

### DIFF
--- a/_maps/RandomRuins/StationRuins/maint/10x10/10x10_wizard.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/10x10/10x10_wizard.dmm
@@ -1,0 +1,267 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"b" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/template_noop)
+"d" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/template_noop)
+"e" = (
+/turf/closed/wall,
+/area/template_noop)
+"g" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#c1caff"
+	},
+/obj/structure/table/wood/fancy/exoticpurple,
+/obj/item/greentext/quiet,
+/turf/open/floor/carpet/exoticgreen,
+/area/template_noop)
+"h" = (
+/obj/structure/table/wood/fancy/exoticpurple,
+/obj/item/chair/wood/wings,
+/obj/item/bedsheet/wiz{
+	pixel_x = 7;
+	pixel_y = 9
+	},
+/obj/item/chair/wood/wings{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/turf/open/floor/carpet/exoticgreen,
+/area/template_noop)
+"i" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/structure/table/wood/fancy/exoticpurple,
+/obj/item/storage/pill_bottle/dice{
+	icon_state = "magicdicebag"
+	},
+/turf/open/floor/carpet/exoticgreen,
+/area/template_noop)
+"k" = (
+/obj/structure/table/wood/fancy/exoticpurple,
+/obj/item/toy/figure/wizard,
+/obj/item/clothing/gloves/rapid/hug,
+/turf/open/floor/carpet/exoticgreen,
+/area/template_noop)
+"n" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/turf/open/floor/plating,
+/area/template_noop)
+"q" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/template_noop)
+"r" = (
+/turf/open/floor/carpet/exoticgreen,
+/area/template_noop)
+"v" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/template_noop)
+"A" = (
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/template_noop)
+"E" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/structure/table/wood/fancy/exoticpurple,
+/obj/item/clothing/suit/wizrobe/red,
+/obj/item/clothing/head/wizard/red,
+/obj/item/clothing/shoes/sandal/magic,
+/obj/item/staff,
+/obj/item/clothing/mask/gas/tiki_mask/yalp_elor,
+/turf/open/floor/carpet/exoticgreen,
+/area/template_noop)
+"G" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#c1caff"
+	},
+/obj/structure/table/wood/fancy/exoticpurple,
+/obj/machinery/microwave{
+	name = "box of cooking";
+	pixel_x = -1;
+	pixel_y = 6
+	},
+/turf/open/floor/carpet/exoticgreen,
+/area/template_noop)
+"K" = (
+/obj/structure/table/wood/fancy/exoticpurple,
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_x = -1;
+	pixel_y = -3
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_x = -6;
+	pixel_y = 7
+	},
+/turf/open/floor/carpet/exoticgreen,
+/area/template_noop)
+"N" = (
+/turf/open/floor/plating,
+/area/template_noop)
+"R" = (
+/obj/machinery/door/airlock/uranium,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/carpet/exoticpurple,
+/area/template_noop)
+"U" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile{
+	color = "#008000"
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"V" = (
+/obj/machinery/door/airlock/uranium,
+/obj/structure/barricade/wooden,
+/turf/open/floor/carpet/exoticpurple,
+/area/template_noop)
+"W" = (
+/obj/structure/table/wood/fancy/exoticpurple,
+/obj/item/book/random/triple,
+/turf/open/floor/carpet/exoticgreen,
+/area/template_noop)
+"Y" = (
+/turf/closed/wall/mineral/uranium,
+/area/template_noop)
+
+(1,1,1) = {"
+N
+d
+e
+N
+N
+N
+N
+N
+N
+v
+"}
+(2,1,1) = {"
+N
+N
+n
+q
+N
+N
+A
+N
+N
+N
+"}
+(3,1,1) = {"
+e
+n
+Y
+Y
+V
+V
+Y
+Y
+b
+e
+"}
+(4,1,1) = {"
+N
+A
+Y
+G
+r
+r
+g
+Y
+N
+N
+"}
+(5,1,1) = {"
+N
+d
+U
+k
+r
+r
+K
+U
+N
+v
+"}
+(6,1,1) = {"
+N
+N
+U
+W
+r
+r
+h
+U
+N
+N
+"}
+(7,1,1) = {"
+N
+N
+Y
+i
+r
+r
+E
+Y
+N
+A
+"}
+(8,1,1) = {"
+e
+n
+Y
+Y
+R
+V
+Y
+Y
+n
+e
+"}
+(9,1,1) = {"
+N
+A
+q
+N
+N
+d
+N
+n
+A
+d
+"}
+(10,1,1) = {"
+N
+N
+N
+N
+v
+N
+N
+e
+N
+N
+"}

--- a/yogstation/code/datums/ruins/station.dm
+++ b/yogstation/code/datums/ruins/station.dm
@@ -1303,6 +1303,6 @@
 	name = "Maint fakewalls"
 
 /datum/map_template/ruin/station/maint/tenxten/wizard
-	id= "wizard"
+	id = "wizard"
 	suffix = "10x10_wizard.dmm"
 	name = "Maint wizard"

--- a/yogstation/code/datums/ruins/station.dm
+++ b/yogstation/code/datums/ruins/station.dm
@@ -1301,3 +1301,8 @@
 	id= "fakewalls"
 	suffix = "10x10_fakewalls.dmm"
 	name = "Maint fakewalls"
+
+/datum/map_template/ruin/station/maint/tenxten/wizard
+	id= "wizard"
+	suffix = "10x10_wizard.dmm"
+	name = "Maint wizard"

--- a/yogstation/code/game/objects/effects/landmarks.dm
+++ b/yogstation/code/game/objects/effects/landmarks.dm
@@ -166,7 +166,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 
 /obj/effect/landmark/stationroom/maint/tenxten
 	template_names = list("Maint aquarium", "Maint bigconstruction", "Maint bigtheatre", "Maint deltalibrary", "Maint graffitiroom", "Maint junction", "Maint podrepairbay", "Maint pubbybar", "Maint roosterdome", "Maint sanitarium", "Maint snakefighter", "Maint vault", "Maint ward", "Maint assaultpod", "Maint maze", "Maint maze2", "Maint boxfactory",
-	"Maint sixsectorsdown", "Maint advbotany", "Maint beach", "Maint botany_apiary", "Maint gamercave", "Maint ladytesla_altar", "Maint olddiner", "Maint smallmagician", "Maint fourshops", "Maint fishinghole", "Maint fakewalls")
+	"Maint sixsectorsdown", "Maint advbotany", "Maint beach", "Maint botany_apiary", "Maint gamercave", "Maint ladytesla_altar", "Maint olddiner", "Maint smallmagician", "Maint fourshops", "Maint fishinghole", "Maint fakewalls", "Maint wizard")
 
 /// Type of landmark that find all others of the same type, and only spawns count number of ruins at them
 /obj/effect/landmark/stationroom/limited_spawn


### PR DESCRIPTION
# Document the changes in your pull request

![ss (2022-09-24 at 09 53 04)](https://user-images.githubusercontent.com/1534478/192126152-dbda9204-9437-493a-b8dc-0653b57abdc1.png)

Adds a new 10x10 ruin themed around wizards, providing:
1. Wizard Action Figure
2. Gloves of Hugging
3. 3x Donk Pocket Box Spawners
4. Microwave
5. Red Wizard Clothes + Staff + Yalp Enor Mask
6. Greentext Book (Quiet)
7. Wizard Bedsheet
8. Dice Bag
9. Triple-Random-Book spawner

# Wiki Documentation

There is currently no mention of maint-ruins on the wiki, however, mayhap we should add a tab on the Ruins page?

# Changelog

:cl:  
rscadd: Added new 10x10 Wizard-Themed Maint Ruin
/:cl:
