### PR TITLE
Makes all protolathes/fabs not ever need a console

### DIFF
--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -2,18 +2,25 @@
 	name = "technology fabricator"
 	desc = "Makes researched and prototype items with materials and energy."
 	layer = BELOW_OBJ_LAYER
-	var/consoleless_interface = FALSE			//Whether it can be used without a console.
-	var/efficiency_coeff = 1				//Materials needed / coeff = actual.
+	/// Divisor for material usage eg (2 coeff = 500 / 2 = 500)
+	var/efficiency_coeff = 1
+	/// Categories this lathe has
 	var/list/categories = list()
-	var/datum/component/remote_materials/materials
+	/// What designs it can print from a department
 	var/allowed_department_flags = ALL
-	var/production_animation				//What's flick()'d on print.
+	/// Animation when an item is printed
+	var/production_animation
+	/// What designs it can print from a "machine" eg PROTOLATHE | AUTOLATHE | MECHFAB
 	var/allowed_buildtypes = NONE
+	/// Name of the lathe in the UI
+	var/department_tag = "Unidentified"
+
 	var/list/datum/design/cached_designs
 	var/list/datum/design/matching_designs
-	var/department_tag = "Unidentified"			//used for material distribution among other things.
 	var/datum/techweb/stored_research
 	var/datum/techweb/host_research
+
+	var/datum/component/remote_materials/materials
 
 	var/screen = RESEARCH_FABRICATOR_SCREEN_MAIN
 	var/selected_category
@@ -44,8 +51,6 @@
 	calculate_efficiency()
 
 /obj/machinery/rnd/production/ui_interact(mob/user)
-	if(!consoleless_interface)
-		return ..()
 	user.set_machine(src)
 	var/datum/browser/popup = new(user, "rndconsole", name, 460, 550)
 	popup.set_content(generate_ui())

--- a/code/modules/research/machinery/departmental_circuit_imprinter.dm
+++ b/code/modules/research/machinery/departmental_circuit_imprinter.dm
@@ -4,7 +4,6 @@
 	icon_state = "circuit_imprinter"
 	circuit = /obj/item/circuitboard/machine/circuit_imprinter/department
 	requires_console = FALSE
-	consoleless_interface = TRUE
 
 /obj/machinery/rnd/production/circuit_imprinter/department/science
 	name = "department circuit imprinter (Science)"

--- a/code/modules/research/machinery/departmental_protolathe.dm
+++ b/code/modules/research/machinery/departmental_protolathe.dm
@@ -4,7 +4,6 @@
 	icon_state = "protolathe"
 	circuit = /obj/item/circuitboard/machine/protolathe/department
 	requires_console = FALSE
-	consoleless_interface = TRUE
 
 /obj/machinery/rnd/production/protolathe/department/engineering
 	name = "department protolathe (Engineering)"

--- a/code/modules/research/machinery/techfab.dm
+++ b/code/modules/research/machinery/techfab.dm
@@ -33,5 +33,4 @@
 	console_link = FALSE
 	production_animation = "protolathe_n"
 	requires_console = FALSE
-	consoleless_interface = TRUE
 	allowed_buildtypes = PROTOLATHE | IMPRINTER


### PR DESCRIPTION
# Document the changes in your pull request

Basically we never use this since its disabled for departmental fabs and circuit printers
Also its incredibly dumb to need the RND computer

# Changelog

:cl:  
tweak: Some RnD machines no longer need the science console
/:cl:
