### PR TITLE
Allows any species to be CE, CMO, and RD

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -20,10 +20,6 @@ REVIVAL_BRAIN_LIFE -1
 JOB_SPECIES_WHITELIST /datum/job/captain human
 JOB_SPECIES_WHITELIST /datum/job/hop human
 JOB_SPECIES_WHITELIST /datum/job/hos human,lizard
-JOB_SPECIES_WHITELIST /datum/job/chief_engineer human,plasmaman,moth,ethereal,preternis,polysmorph
-JOB_SPECIES_WHITELIST /datum/job/rd human,pod,plasmaman,ethereal,preternis,polysmorph
-JOB_SPECIES_WHITELIST /datum/job/cmo human,lizard,pod,moth
-
 
 ## OOC DURING ROUND ###
 ## Comment this out if you want OOC to be automatically disabled during the round, it will be enabled during the lobby and after the round end results.


### PR DESCRIPTION
# Document the changes in your pull request

The species restrictions for CE/CMO/RD have always felt arbitrary to me, so I decided to make them available to any non-humans instead of each one having a list of which species are allowed. Other command roles are unaffected.

# Changelog

:cl:  
tweak: removes the species whitelist for CE, CMO, and RD, allowing them to be any species
/:cl:
