### PR TITLE
Allows any species to be CE, CMO, and RD

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -20,9 +20,9 @@ REVIVAL_BRAIN_LIFE -1
 JOB_SPECIES_WHITELIST /datum/job/captain human
 JOB_SPECIES_WHITELIST /datum/job/hop human
 JOB_SPECIES_WHITELIST /datum/job/hos human,lizard
-JOB_SPECIES_WHITELIST /datum/job/chief_engineer human,plasmaman,moth,ethereal,preternis,polysmorph
-JOB_SPECIES_WHITELIST /datum/job/rd human,pod,plasmaman,ethereal,preternis,polysmorph
-JOB_SPECIES_WHITELIST /datum/job/cmo human,lizard,pod,moth
+##JOB_SPECIES_WHITELIST /datum/job/chief_engineer human,plasmaman,moth,ethereal,preternis,polysmorph
+##JOB_SPECIES_WHITELIST /datum/job/rd human,pod,plasmaman,ethereal,preternis,polysmorph
+##JOB_SPECIES_WHITELIST /datum/job/cmo human,lizard,pod,moth
 
 
 ## OOC DURING ROUND ###


### PR DESCRIPTION
# Document the changes in your pull request

Revives https://github.com/yogstation13/Yogstation/pull/15935 because our head-dev closed it without listing a real reason at all. Give me a reason why this shouldn't be? These three heads slots are fairly harmless to let any species play as and realistically you could study for and become any of them as any in game species, even the lore doesn't explicitly blacklist any one species from these particular jobs. They still get paid less, they still aren't protected by asimov. I don't see a reasoning to prevent it.
Tell me.

# Changelog

:cl:  
tweak: removes the species whitelist for CE, CMO, and RD, allowing them to be any species
/:cl:
