### PR TITLE
Shadowling Damage From Light Is Now Clone Damage

### DIFF
--- a/yogstation/code/game/gamemodes/shadowling/shadowling.dm
+++ b/yogstation/code/game/gamemodes/shadowling/shadowling.dm
@@ -186,7 +186,7 @@ Made by Xhuis
 			H.heal_overall_damage(5,5)
 			H.adjustToxLoss(-5)
 			H.adjustOrganLoss(ORGAN_SLOT_BRAIN, -25) //Shad O. Ling gibbers, "CAN U BE MY THRALL?!!"
-			H.adjustCloneLoss(-1)
+			H.adjustCloneLoss(-5)
 			H.SetKnockdown(0)
 			H.SetStun(0)
 			H.SetParalyzed(0)
@@ -236,7 +236,7 @@ Made by Xhuis
 			H.heal_overall_damage(4,4)
 			H.adjustToxLoss(-5)
 			H.adjustOrganLoss(ORGAN_SLOT_BRAIN, -25)
-			H.adjustCloneLoss(-1)
+			H.adjustCloneLoss(-5)
 
 /datum/game_mode/proc/update_shadow_icons_added(datum/mind/shadow_mind)
 	var/datum/atom_hud/antag/shadow_hud = GLOB.huds[ANTAG_HUD_SHADOW]

--- a/yogstation/code/game/gamemodes/shadowling/shadowling.dm
+++ b/yogstation/code/game/gamemodes/shadowling/shadowling.dm
@@ -178,7 +178,7 @@ Made by Xhuis
 		var/turf/T = H.loc
 		var/light_amount = T.get_lumcount()
 		if(light_amount > LIGHT_DAM_THRESHOLD) //Can survive in very small light levels. Also doesn't take damage while incorporeal, for shadow walk purposes
-			H.take_overall_damage(0, LIGHT_DAMAGE_TAKEN)
+			H.adjustCloneLoss(LIGHT_DAMAGE_TAKEN)
 			if(H.stat != DEAD)
 				to_chat(H, span_userdanger("The light burns you!")) //Message spam to say "GET THE FUCK OUT"
 				H.playsound_local(get_turf(H), 'sound/weapons/sear.ogg', 150, 1, pressure_affected = FALSE)
@@ -231,7 +231,7 @@ Made by Xhuis
 		var/turf/T = H.loc
 		var/light_amount = T.get_lumcount()
 		if(light_amount > LIGHT_DAM_THRESHOLD && !H.incorporeal_move)
-			H.take_overall_damage(0, LIGHT_DAMAGE_TAKEN/2)
+			H.adjustCloneLoss(LIGHT_DAMAGE_TAKEN/2)
 		else if (light_amount < LIGHT_HEAL_THRESHOLD)
 			H.heal_overall_damage(4,4)
 			H.adjustToxLoss(-5)

--- a/yogstation/code/game/gamemodes/shadowling/shadowling.dm
+++ b/yogstation/code/game/gamemodes/shadowling/shadowling.dm
@@ -178,7 +178,7 @@ Made by Xhuis
 		var/turf/T = H.loc
 		var/light_amount = T.get_lumcount()
 		if(light_amount > LIGHT_DAM_THRESHOLD) //Can survive in very small light levels. Also doesn't take damage while incorporeal, for shadow walk purposes
-			H.adjustCloneLoss(LIGHT_DAMAGE_TAKEN)
+			H.adjustCloneLoss(LIGHT_DAMAGE_TAKEN) 
 			if(H.stat != DEAD)
 				to_chat(H, span_userdanger("The light burns you!")) //Message spam to say "GET THE FUCK OUT"
 				H.playsound_local(get_turf(H), 'sound/weapons/sear.ogg', 150, 1, pressure_affected = FALSE)


### PR DESCRIPTION
# Document the changes in your pull request

Doing this after observing a chemist chug three burn healing chems to automatically heal the damage from lights, so he could walk around in the light for extreme durations for a sling. Not ok.

Also they have free clone healing in darkness so, this isn't a huge nerf. You can still chug chems to heal burns just, not ignore lights so easily. Sling DNA was removed for this very reason with antiglow, letting you 100% ignore lights.

"muh winrate!!!" get out. Irrelevant.

buffs their clone healing in darkness to 5 per tick instead of 1 so it matches their burn healing

# Changelog

:cl:  
tweak: Shadowlings and their empowered thralls take Clone damage instead of Burn damage from light
tweak: Shadowlings heal 5x faster from clone damage, making the prior change not effect their ability to recover from walking in lights
/:cl:
