### PR TITLE
Removes two hijack items from the surplus crate

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -686,6 +686,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			along with slurred speech, aggression, and the ability to infect others with this agent."
 	item = /obj/item/storage/box/syndie_kit/romerol
 	cost = 25
+	surplus = 0 //Hijack-only, don't let this exist in surplus
 	cant_discount = TRUE
 	exclude_modes = list(/datum/game_mode/infiltration) // yogs: infiltration
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2190,7 +2190,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/his_grace
 	cost = 20
 	restricted_roles = list("Chaplain")
-	surplus = 5 //Very low chance to get it in a surplus crate even without being the chaplain
+	surplus = 0 //This is a hijack item. Do not add this into surplus.
 
 /datum/uplink_item/role_restricted/horror
 	name = "Horror-in-a-box"


### PR DESCRIPTION
# Document the changes in your pull request

His Grace now has zero chance to spawn in a null crate instead of 5%, considering it is a hijack-only item for chaplain that costs a whole 20 TC. It does not matter how rare it is. Martial arts aren't permitted in the null crate nor should there be the chance for this murderbone exclusive item.

Also threw in romerol because it's 25 TC and hijack-only too, and it being in null crate means you can just bypass the whole deal of "you need to coordinate with another traitor to buy it".

# Wiki Documentation

Don't think actual chances and the potential contents of the null crate is documented anywhere but I could maybe make a list myself.

# Changelog

:cl:  
rscdel: His Grace can no longer occur in null crates.
rscdel: Romerol bottle can no longer occur in null crates.
/:cl:
