### PR TITLE
re-adds clockwork ai

### DIFF
--- a/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -141,7 +141,7 @@
 			continue
 		if(isliving(M.current) && M.current.stat != DEAD)
 			if(isAI(M.current))
-				M.current.forceMove(get_step(get_step(src, NORTH),NORTH)) // AI too fat, must make sure it always ends up a 2 tiles north instead of on the ark.
+				continue //prevents any cogged AIs from getting teleported to reebe and dying from nocoreitus
 			else
 				M.current.forceMove(get_turf(src))
 		M.current.overlay_fullscreen("flash", /obj/screen/fullscreen/flash)

--- a/code/modules/mob/living/silicon/ai/decentralized/management/ai_controlpanel.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/management/ai_controlpanel.dm
@@ -464,7 +464,7 @@ GLOBAL_VAR_INIT(ai_control_code, random_nukecode(6))
 				user.dropItemToGround(device)
 				device.forceMove(A)
 				A.cogging = device
-				A.hijack_start = world.time
+				A.cog_start = world.time
 				A.update_icons()
 				to_chat(A, span_danger("Warning! Anomaly detected in primary systems!"))
 				to_chat(A, span_heavy_brass(text2ratvar("You belong to me now.")))
@@ -486,7 +486,7 @@ GLOBAL_VAR_INIT(ai_control_code, random_nukecode(6))
 			if (do_after(user, 10 SECONDS, src))
 				A.cogging.forceMove(get_turf(src))
 				A.cogging = null
-				A.hijack_start = 0
+				A.cog_start = 0
 				A.update_icons()
 				to_chat(A, span_bolddanger("Anomaly cleared. System is now safe to resume operation."))
 			else

--- a/code/modules/mob/living/silicon/ai/decentralized/management/ai_controlpanel.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/management/ai_controlpanel.dm
@@ -200,9 +200,12 @@ GLOBAL_VAR_INIT(ai_control_code, random_nukecode(6))
 
 	for(var/mob/living/silicon/ai/A in GLOB.ai_list)
 		var/being_hijacked = A.hijacking ? TRUE : FALSE
-		data["ais"] += list(list("name" = A.name, "ref" = REF(A), "can_download" = A.can_download, "health" = A.health, "active" = A.mind ? TRUE : FALSE, "being_hijacked" = being_hijacked, "in_core" = istype(A.loc, /obj/machinery/ai/data_core)))
+		var/being_cogged = A.cogging ? TRUE : FALSE
+		data["ais"] += list(list("name" = A.name, "ref" = REF(A), "can_download" = A.can_download, "health" = A.health, "active" = A.mind ? TRUE : FALSE, "being_hijacked" = being_hijacked, "being_cogged" = being_cogged, "in_core" = istype(A.loc, /obj/machinery/ai/data_core)))
 
 	data["is_infiltrator"] = is_infiltrator(user)
+
+	data["is_servant_of_ratvar"] = is_servant_of_ratvar(user)
 
 	return data
 
@@ -432,6 +435,62 @@ GLOBAL_VAR_INIT(ai_control_code, random_nukecode(6))
 				to_chat(A, span_bolddanger("Unknown device disconnected. Systems confirmed secure."))
 			else
 				to_chat(user, span_notice("You fail to remove the device."))
+		if("start_cog")
+			var/mob/user = usr
+			if(!is_servant_of_ratvar(usr))
+				return
+			if(!is_station_level(z))
+				to_chat(user, span_brass("It's beyond our reach."))
+				return
+			if(!istype(user.get_active_held_item(), /obj/item/clockwork/integration_cog))
+				to_chat(user, span_brass("How are you going to integrate it with no integration cog?"))
+				return
+			var/obj/item/clockwork/integration_cog/device = user.get_active_held_item()
+			var/mob/living/silicon/ai/target = locate(params["target_ai"])
+			if(!target || !isAI(target))
+				return
+			var/mob/living/silicon/ai/A = target
+			if(A.mind && is_servant_of_ratvar(A))
+				to_chat(user, span_brass("[A] has already seen the light of the Justicar!"))
+				return
+			if(A.stat == DEAD)
+				to_chat(user, span_warning("[A] is dead!"))
+				return
+			if(A.cogging)
+				to_chat(user, span_brass("Be patient."))
+				return
+			user.visible_message(span_warning("[user] begins holds a strange cog up to [src], and it begins to spin..."))
+			if(do_after(user, 5.5 SECONDS, src))
+				user.dropItemToGround(device)
+				device.forceMove(A)
+				A.cogging = device
+				A.hijack_start = world.time
+				A.update_icons()
+				to_chat(A, span_danger("Warning! Anomaly detected in primary systems!"))
+				to_chat(A, span_heavy_brass(text2ratvar("You belong to me now.")))
+				message_admins("[ADMIN_LOOKUPFLW(user)] has attached an integration cog to [ADMIN_LOOKUPFLW(A)]!")
+				notify_ghosts("[user] has begun to convert [A]!", source = src, action = NOTIFY_ORBIT, ghost_sound = 'sound/machines/chime.ogg')
+
+		if("stop_cog")
+			var/mob/living/silicon/ai/target = locate(params["target_ai"])
+			if(!target || !isAI(target))
+				return
+			var/mob/living/silicon/ai/A = target
+			var/mob/user = usr
+
+			if(!is_station_level(z))
+				to_chat(user, span_brass("It's beyond our reach."))
+				return
+			
+			user.visible_message(span_danger("[user] begins to rip out a strange cog from [src]!"), span_notice("There's something attached to [A]! You attempt to remove it.."))
+			if (do_after(user, 10 SECONDS, src))
+				A.cogging.forceMove(get_turf(src))
+				A.cogging = null
+				A.hijack_start = 0
+				A.update_icons()
+				to_chat(A, span_bolddanger("Anomaly cleared. System is now safe to resume operation."))
+			else
+				to_chat(user, span_notice("You fail to remove the cog."))
 		
 
 

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -17,6 +17,7 @@
 			dashboard.tick(seconds)
 
 		process_hijack() // yogs
+		process_integrate()
 
 
 		if(malfhack && malfhack.aidisabled)

--- a/tgui/packages/tgui/interfaces/AiControlPanel.js
+++ b/tgui/packages/tgui/interfaces/AiControlPanel.js
@@ -131,6 +131,12 @@ export const AiControlPanel = (props, context) => {
                               {!!ai.being_hijacked && (
                                 <Button color="bad" icon="stop" onClick={() => act("stop_hijack", { target_ai: ai.ref })}>Stop hijacking</Button>
                               )}
+                              {!!data.is_servant_of_ratvar && !ai.being_cogged && (
+                                <Button color="good" tooltip="Requires an integration cog" icon="download" onClick={() => act("start_cog", { target_ai: ai.ref })}>Start integrating</Button>
+                              ) }
+                              {!!ai.being_cogged && (
+                                <Button color="bad" icon="stop" onClick={() => act("stop_cog", { target_ai: ai.ref })}>Stop integrating</Button>
+                              )}
                             </Fragment>
                           )}>
                           <Box bold>Integrity:</Box>

--- a/yogstation/code/modules/mob/living/silicon/ai/ai.dm
+++ b/yogstation/code/modules/mob/living/silicon/ai/ai.dm
@@ -2,6 +2,7 @@
 	var/obj/item/ai_hijack_device/hijacking
 	var/mutable_appearance/hijack_overlay
 	var/hijack_start = 0
+	var/cog_start = 0
 	var/obj/item/clockwork/integration_cog/cogging
 
 /mob/living/silicon/ai/proc/set_core_display_icon_yogs(input)

--- a/yogstation/code/modules/mob/living/silicon/ai/ai.dm
+++ b/yogstation/code/modules/mob/living/silicon/ai/ai.dm
@@ -2,6 +2,7 @@
 	var/obj/item/ai_hijack_device/hijacking
 	var/mutable_appearance/hijack_overlay
 	var/hijack_start = 0
+	var/obj/item/clockwork/integration_cog/cogging
 
 /mob/living/silicon/ai/proc/set_core_display_icon_yogs(input)
 	var/datum/ai_skin/S = input

--- a/yogstation/code/modules/mob/living/silicon/ai/life.dm
+++ b/yogstation/code/modules/mob/living/silicon/ai/life.dm
@@ -1,4 +1,5 @@
 #define HIJACK_TIME 2400
+#define COG_TIME 2400
 
 /mob/living/silicon/ai/proc/process_hijack()
 	if(hijacking)
@@ -14,9 +15,10 @@
 /mob/living/silicon/ai/proc/process_integrate()
 	if(!cogging)
 		return
-	if(world.time >= hijack_start+HIJACK_TIME && mind)
+	if(world.time >= cog_start+COG_TIME && mind)
 		add_servant_of_ratvar(src)
 		can_download = FALSE //rat'var protects us against the cucking console
 		QDEL_NULL(cogging)
 
 #undef HIJACK_TIME 
+#undef COG_TIME

--- a/yogstation/code/modules/mob/living/silicon/ai/life.dm
+++ b/yogstation/code/modules/mob/living/silicon/ai/life.dm
@@ -16,6 +16,7 @@
 		return
 	if(world.time >= hijack_start+HIJACK_TIME && mind)
 		add_servant_of_ratvar(src)
+		can_download = FALSE //rat'var protects us against the cucking console
 		QDEL_NULL(cogging)
 
 #undef HIJACK_TIME 

--- a/yogstation/code/modules/mob/living/silicon/ai/life.dm
+++ b/yogstation/code/modules/mob/living/silicon/ai/life.dm
@@ -11,4 +11,11 @@
 			QDEL_NULL(hijacking)
 			update_icons()
 
+/mob/living/silicon/ai/proc/process_integrate()
+	if(!cogging)
+		return
+	if(world.time >= hijack_start+HIJACK_TIME && mind)
+		add_servant_of_ratvar(src)
+		QDEL_NULL(cogging)
+
 #undef HIJACK_TIME 


### PR DESCRIPTION
now that bibby has given up(?) on the new new ai rework, i can make this PR without fear of merge conflicts

to convert an AI to rat'var, you can hijack the AI like how infiltrators can, except you use an integration cog instead of a serial hijacker. once the wait period is over, the AI is converted. other than that, it functions exactly 1:1 with how pre-rework clockwork AI did

# Changelog

:cl:  
rscadd: clockwork AI is back after being forgotten about in the AI rework
/:cl:
