### PR TITLE
Makes the Software Download Tool UI Nicer

### DIFF
--- a/tgui/packages/tgui/interfaces/NtosNetDownloader.js
+++ b/tgui/packages/tgui/interfaces/NtosNetDownloader.js
@@ -105,9 +105,8 @@ export const NtosNetDownloader = (props, context) => {
           <Flex.Item grow={1} basis={0} height="100%">
             <Section fill scrollable>
               {items?.map(program => (
-                <Box>
+                <Box key={program.filename}>
                   <Program
-                    key={program.filename}
                     program={program} />
                   <Divider />
                 </Box>

--- a/tgui/packages/tgui/interfaces/NtosNetDownloader.js
+++ b/tgui/packages/tgui/interfaces/NtosNetDownloader.js
@@ -1,6 +1,6 @@
 import { scale, toFixed } from 'common/math';
 import { useBackend, useLocalState } from '../backend';
-import { Box, Button, Flex, Icon, LabeledList, NoticeBox, ProgressBar, Section, Tabs } from '../components';
+import { Box, Button, Divider, Flex, Icon, LabeledList, NoticeBox, ProgressBar, Section, Tabs } from '../components';
 import { flow } from 'common/fp';
 import { filter, sortBy } from 'common/collections';
 import { NtosWindow } from '../layouts';
@@ -48,7 +48,7 @@ export const NtosNetDownloader = (props, context) => {
       theme={PC_device_theme}
       width={600}
       height={600}>
-      <NtosWindow.Content scrollable>
+      <NtosWindow.Content>
         {!!error && (
           <NoticeBox>
             <Box mb={1}>
@@ -89,7 +89,7 @@ export const NtosNetDownloader = (props, context) => {
             </LabeledList.Item>
           </LabeledList>
         </Section>
-        <Flex>
+        <Flex height="92%">
           <Flex.Item minWidth="105px" shrink={0} basis={0}>
             <Tabs vertical>
               {all_categories.map(category => (
@@ -102,12 +102,17 @@ export const NtosNetDownloader = (props, context) => {
               ))}
             </Tabs>
           </Flex.Item>
-          <Flex.Item grow={1} basis={0}>
-            {items?.map(program => (
-              <Program
-                key={program.filename}
-                program={program} />
-            ))}
+          <Flex.Item grow={1} basis={0} height="100%">
+            <Section fill scrollable>
+              {items?.map(program => (
+                <Box>
+                  <Program
+                    key={program.filename}
+                    program={program} />
+                  <Divider />
+                </Box>
+              ))}
+            </Section>
           </Flex.Item>
         </Flex>
       </NtosWindow.Content>
@@ -128,7 +133,7 @@ const Program = (props, context) => {
   } = data;
   const disk_free = disk_size - disk_used;
   return (
-    <Section>
+    <Box>
       <Flex align="baseline">
         <Flex.Item grow={1} blod>
           <Icon name={program.icon} mr={1} />
@@ -137,7 +142,7 @@ const Program = (props, context) => {
         <Flex.Item shrink={0} width="48px" textAlign="right" color="label" nowrap>
           {program.size} GQ
         </Flex.Item>
-        <Flex.Item shrink={0} width="134px" textAlign="right">
+        <Flex.Item shrink={0} width="134px" textAlign="right" pr={"1rem"}>
           {(downloading && program.filename === downloadname) && (
             <ProgressBar
               width="101px"
@@ -187,6 +192,6 @@ const Program = (props, context) => {
           download and usage of software from non-official servers.
         </NoticeBox>
       )}
-    </Section>
+    </Box>
   );
 };


### PR DESCRIPTION
# Document the changes in your pull request
- Moved the scrollable to the software part instead of the whole window
- Added dividers inplace of having to remove the section

![image](https://user-images.githubusercontent.com/20369082/192786044-e057177d-49d9-448c-876b-b0d4a1dddc6b.png)
![image](https://user-images.githubusercontent.com/20369082/192786058-a726eba9-1791-45c0-9703-a564dfb85de4.png)

# Changelog

:cl:  
tweak: Software Download Tool UI Improvements
/:cl:
