### PR TITLE
Buffs Syndicate Fedora and adds new Syndikit Special around it

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -153,14 +153,15 @@
 			new /obj/item/reagent_containers/syringe/stimulants(src)
 			new /obj/item/reagent_containers/glass/rag(src)
 
-		if("oddjob") //Total TC value of 29-32 TC
-			new /obj/item/clothing/head/det_hat/evil(src) //6 TC
+		if("oddjob") //Total TC value of 27ish TC
+			new /obj/item/clothing/head/det_hat/evil(src) //6 TC. Absolutely necessary
 			new /obj/item/clothing/under/syndicate/sniper(src) //Variant of tactical turtleneck that looks like a suit, provides 10 melee armor, has no sensors. Would say it's free
 			new /obj/item/clothing/suit/det_suit/grey/evil(src) //Grey det trenchcoat with hos coat values, 2ish TC
-			new /obj/item/clothing/shoes/chameleon/noslip/syndicate(src) //2 TC
-			new /obj/item/clothing/gloves/krav_maga/combatglovesplus(src) //5 TC, nukies only, dress to kill
-			new /obj/item/dnainjector/dwarf(src) //Gives you dwarfism (smaller hitbox, instantly climb tables), would argue 2-3 TC
-			new /obj/item/autosurgeon/anti_stun(src) //12 TC
+			new /obj/item/clothing/shoes/laceup(src) //Fancy shoes. Free
+			new /obj/item/gun/ballistic/automatic/pistol/deagle/gold(src) //Gold deagle (golden gun); you only get 7 shots. Realistically only like 7 TC just because you can't reload it; still highballing it
+			new /obj/item/grenade/syndieminibomb(src) //Hand grenade. 6 TC
+			new /obj/item/deployablemine(src) //I don't know if anyone remembers remote mines in Goldeneye because I certainly do. Hilariously less lethal than the 4 TC rubber ducky for clown ops, so I say 3
+			new /obj/item/dnainjector/dwarf(src) //Gives you dwarfism (smaller hitbox, instantly climb tables), would argue 2-3 TC. The only other core item to this kit
 
 		if("ninja")
 			new /obj/item/katana(src) // Unique , hard to tell how much tc this is worth. 8 tc?

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -142,7 +142,7 @@
 			new /obj/item/card/emag(src) // 6 tc
 
 /obj/item/storage/box/syndicate/bundle_B/PopulateContents()
-	switch (pickweight(list( "bond" = 2, "neo"=1, "ninja" = 1, "darklord" = 1, "white_whale_holy_grail" = 2, "mad_scientist" = 2, "bee" = 2, "mr_freeze" = 2, "gang_boss" = 1)))
+	switch (pickweight(list( "bond" = 2, "oddjob" = 2, "neo" = 1, "ninja" = 1, "darklord" = 1, "white_whale_holy_grail" = 2, "mad_scientist" = 2, "bee" = 2, "mr_freeze" = 2, "gang_boss" = 1)))
 		if("bond")
 			new /obj/item/gun/ballistic/automatic/pistol(src)
 			new /obj/item/suppressor(src)
@@ -152,6 +152,15 @@
 			new /obj/item/card/id/syndicate(src)
 			new /obj/item/reagent_containers/syringe/stimulants(src)
 			new /obj/item/reagent_containers/glass/rag(src)
+
+		if("oddjob") //Total TC value of 29-32 TC
+			new /obj/item/clothing/head/det_hat/evil(src) //6 TC
+			new /obj/item/clothing/under/syndicate/sniper(src) //Variant of tactical turtleneck that looks like a suit, provides 10 melee armor, has no sensors. Would say it's free
+			new /obj/item/clothing/suit/det_suit/grey/evil(src) //Grey det trenchcoat with hos coat values, 2ish TC
+			new /obj/item/clothing/shoes/chameleon/noslip/syndicate(src) //2 TC
+			new /obj/item/clothing/gloves/krav_maga/combatglovesplus(src) //5 TC, nukies only, dress to kill
+			new /obj/item/dnainjector/dwarf(src) //Gives you dwarfism (smaller hitbox, instantly climb tables), would argue 2-3 TC
+			new /obj/item/autosurgeon/anti_stun(src) //12 TC
 
 		if("ninja")
 			new /obj/item/katana(src) // Unique , hard to tell how much tc this is worth. 8 tc?

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -104,7 +104,7 @@
 	sharpness = SHARP_NONE
 	hitsound = 'sound/weapons/genhit.ogg'
 	attack_verb = list("poked", "tipped")
-	embedding = embedding.setRating(0) //Zero percent chance to embed
+	embedding = list("embed_chance" = 0) //Zero percent chance to embed
 	var/extended = 0
 
 /obj/item/clothing/head/det_hat/evil/attack_self(mob/user)

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -104,6 +104,7 @@
 	sharpness = SHARP_NONE
 	hitsound = 'sound/weapons/genhit.ogg'
 	attack_verb = list("poked", "tipped")
+	embedding = embedding.setRating(0) //Zero percent chance to embed
 	var/extended = 0
 
 /obj/item/clothing/head/det_hat/evil/attack_self(mob/user)
@@ -111,7 +112,10 @@
 	playsound(src.loc, 'sound/weapons/batonextend.ogg', 50, 1)
 	if(extended)
 		force = 15
+		armour_penetration = 15
 		throwforce = 40
+		wound_bonus = -10
+		bare_wound_bonus = 10
 		sharpness = SHARP_EDGED
 		w_class = WEIGHT_CLASS_BULKY //Kinda hard to put a razorblade hat in your bag innit
 		icon_state = "syndicate_fedora_sharp"

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -99,7 +99,7 @@
 	name = "suspicious fedora"
 	icon_state = "syndicate_fedora"
 	desc = "A suspicious black fedora with a red band."
-	w_class = 4
+	armor = list(MELEE = 40, BULLET = 30, LASER = 30, ENERGY = 10, BOMB = 25, BIO = 0, RAD = 0, FIRE = 70, ACID = 90, WOUND = 20)
 	throw_speed = 4
 	sharpness = SHARP_NONE
 	hitsound = 'sound/weapons/genhit.ogg'
@@ -113,14 +113,16 @@
 		force = 15
 		throwforce = 40
 		sharpness = SHARP_EDGED
+		w_class = WEIGHT_CLASS_BULKY //Kinda hard to put a razorblade hat in your bag innit
 		icon_state = "syndicate_fedora_sharp"
 		attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut", "tipped")
 		hitsound = 'sound/weapons/bladeslice.ogg'
-		hattable = FALSE
+		hattable = FALSE //So you don't accidentally throw it onto somebody's head instead of decapitating them
 	else
 		force = 0
 		throwforce = 0
 		sharpness = SHARP_NONE
+		w_class = WEIGHT_CLASS_NORMAL
 		icon_state = "syndicate_fedora"
 		attack_verb = list("poked", "tipped")
 		hitsound = 'sound/weapons/genhit.ogg'

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -67,6 +67,11 @@
 	icon_state = "greydet"
 	item_state = "greydet"
 
+/obj/item/clothing/suit/det_suit/grey/evil
+	name = "padded trenchcoat"
+	desc = "A grey trenchcoat that offers significantly more protection than your average duster."
+	armor = list(MELEE = 30, BULLET = 30, LASER = 30, ENERGY = 10, BOMB = 25, BIO = 0, RAD = 0, FIRE = 70, ACID = 90, WOUND = 20)
+
 /obj/item/clothing/suit/det_suit/tan
 	name = "tan trenchcoat"
 	desc = "For those warmer days in the city. Or nights, if you're a grizzled P.I."


### PR DESCRIPTION
# Document the changes in your pull request

Buffs up the syndicate fedora to have some qol and also tweak its numbers a bit to be more interesting™

It can no longer embed and suffers an overall wound bonus of -10 now, but gains 15 AP, a bare wound bonus of 10, and it's only bulky when the blade is extended. In addition, it provides security beret comparable armor levels when worn, due to its robust fibers.

Adds a new syndikit special themed around Oddjob, the clear inspiration for the syndicate fedora. The bundle (rough value of 27 TC) contains:
- The Syndicate Fedora
- A syndicate sniper suit (just a reskinned tactical turtleneck)
- A new overcoat that looks like the black detective trenchcoat but has HoS coat armor values
- Laceup shoes (for style)
- A golden deagle (only the magazine in it; seven shots is all you get)
- A minibomb
- A landmine (just yer ordinary landmine)
- A Dwarfism mutation injector

# Wiki Documentation

Update numbers and create a listing of syndicate fedora on Guide to Combat
Also give it a spot not only in melee weapons but also under armor
Add the Oddjob SyndiKit Special to Syndicate/Uplink items page

# Changelog

:cl:  
rscadd: Adds the Oddjob Syndikit Special bundle, which turns a Syndicate agent into a small, scampering, well-dressed fedora-thrower that possesses a vague Goldeneye loadout
tweak: Syndicate fedora now has 15 AP, -10 wound bonus, 10 bare wound bonus. Only bulky when extended now, and can no longer embed
/:cl:
