### PR TITLE
Preternis chem purge also purges the effects of the chems

### DIFF
--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -135,6 +135,7 @@ adjust_charge - take a positive or negative value to adjust the charge level
 				to_chat(H,span_info("NOTICE: Digestive subroutines are inefficient. Seek sustenance via power-cell C.O.N.S.U.M.E. technology induction."))
 
 	if(chem.current_cycle >= 20)
+		chem.on_mob_end_metabolize()
 		H.reagents.del_reagent(chem.type)
 
 

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -135,7 +135,7 @@ adjust_charge - take a positive or negative value to adjust the charge level
 				to_chat(H,span_info("NOTICE: Digestive subroutines are inefficient. Seek sustenance via power-cell C.O.N.S.U.M.E. technology induction."))
 
 	if(chem.current_cycle >= 20)
-		chem.on_mob_end_metabolize()
+		chem.on_mob_end_metabolize(H)
 		H.reagents.del_reagent(chem.type)
 
 


### PR DESCRIPTION
Didn't call on_mob_end_metabolize() before deleting the chemical from the system
Some chems that would revert the player to normal as the chem ran out would instead leave the player in whatever fucked up state they were in

:cl:  
bugfix: no more permanent rotatium angle
/:cl:
