### PR TITLE
cleanbots no longer vainly struggle to clean up bones for eternity

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -187,7 +187,6 @@
 		/obj/effect/decal/cleanable/greenglow,
 		/obj/effect/decal/cleanable/dirt,
 		/obj/effect/decal/cleanable/insectguts,
-		/obj/effect/decal/remains
 		)
 
 	if(blood)


### PR DESCRIPTION
OOC: Namjay1170: better pr title "Cleanbots get off mr bones wild ride"
# Document the changes in your pull request

I think they're supposed to spray acid on them, but they don't, they just mop the same tile over and over and over and over forever because human remains cannot be destroyed or moved by any means apart from bombing.
Now they don't mop the same tile over and over because they don't notice the remains.

# Changelog

:cl:  
bugfix: cleanbots no longer get permanently stuck on remains
tweak: relatedly, cleanbots no longer see remains
/:cl: