### PR TITLE
makes the cargo shuttle ignore crates with unstamped manifests because 1 person got griefed by a clown

### DIFF
--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -44,6 +44,12 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 		var/sold = FALSE
 		if(QDELETED(thing))
 			continue
+		if(istype(thing, /obj/structure/closet/crate))
+			var/obj/structure/closet/crate/C = thing
+			if(C.manifest)
+				var/obj/item/paper/manifest = C.manifest
+				if(!manifest.stamped) // Unstamped papers on crates // Futureproofing
+					continue
 		for(var/datum/export/E in GLOB.exports_list)
 			if(!E)
 				continue

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -44,12 +44,6 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 		var/sold = FALSE
 		if(QDELETED(thing))
 			continue
-		if(istype(thing, /obj/structure/closet/crate))
-			var/obj/structure/closet/crate/C = thing
-			if(C.manifest)
-				var/obj/item/paper/manifest = C.manifest
-				if(!manifest.stamped) // Unstamped papers on crates // Futureproofing
-					continue
 		for(var/datum/export/E in GLOB.exports_list)
 			if(!E)
 				continue

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -176,6 +176,12 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		for(var/atom/movable/AM in shuttle_area)
 			if(iscameramob(AM))
 				continue
+			if(istype(AM, /obj/structure/closet/crate))
+				var/obj/structure/closet/crate/C = AM
+				if(C.manifest)
+					var/obj/item/paper/manifest = C.manifest
+					if(!manifest.stamped) // Unstamped papers on crates // Futureproofing
+						continue
 			if(bounty_ship_item_and_contents(AM, dry_run = FALSE))
 				matched_bounty = TRUE
 			if(!AM.anchored || istype(AM, /obj/mecha))


### PR DESCRIPTION
# Document the changes in your pull request
Literally makes them ignored instead of blocking them

Closes: #15972 (for being bad)

# Wiki Documentation

Cargo shuttle wont sell unopened crates

# Changelog

:cl:  
tweak: Cargo shuttle wont sell unopened crates now
/:cl:
