### PR TITLE
Adds the Half-Dragon Syndikit Special bundle

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -142,7 +142,7 @@
 			new /obj/item/card/emag(src) // 6 tc
 
 /obj/item/storage/box/syndicate/bundle_B/PopulateContents()
-	switch (pickweight(list( "bond" = 2, "neo"=1, "ninja" = 1, "darklord" = 1, "white_whale_holy_grail" = 2, "mad_scientist" = 2, "bee" = 2, "mr_freeze" = 2, "gang_boss" = 1)))
+	switch (pickweight(list( "bond" = 2, "neo"=1, "ninja" = 1, "darklord" = 1, "white_whale_holy_grail" = 2, "mad_scientist" = 2, "bee" = 2, "mr_freeze" = 2, "gang_boss" = 1, "half_dragon" = 1)))
 		if("bond")
 			new /obj/item/gun/ballistic/automatic/pistol(src)
 			new /obj/item/suppressor(src)
@@ -247,6 +247,10 @@
 			new /obj/item/storage/box/fancy/donut_box(src) //d o n u t s
 			new /obj/item/reagent_containers/glass/bottle/drugs(src)
 			new /obj/item/slimecross/stabilized/green(src) //secret identity
+
+		if("half_dragon") //I am fire, I am Death. Combined cost of 32 TC
+			new /obj/item/dragons_blood/syndicate/true(src) //Combines draconid, angel potion, and fire breath injector, works for any species. Total of 18 TC worth
+			new /obj/item/book/granter/martial/flyingfang(src) //Flying fang. 14 TC
 
 /obj/item/stand_arrow/boss
 	desc = "An arrow that can unleash <span class='holoparasite'>massive potential</span> from those stabbed by it. It has been laced with syndicate mindslave nanites that will be linked to whoever first uses it in their hand."

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1097,16 +1097,19 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 
 	var/mob/living/carbon/human/ascendant = user 
 	to_chat(user, span_userdanger("Warmth surges, bubbles in your body. Your exterior form sloughs off as your new power becomes apparent, old skin disintegrating. You feel divine."))
+	playsound(user.loc,'sound/items/drink.ogg', rand(10,50), 1)
 
-	ascendant.dna.features = list("mcolor" = "A02720", "tail_lizard" = "Dark Tiger", "tail_human" = "None", "snout" = "Sharp", "horns" = "Drake", "ears" = "None", "wings" = "None", "frills" = "None", "spines" = "Long", "body_markings" = "Dark Tiger Body", "legs" = "Digitigrade Legs")
-	ascendant.set_species(/datum/species/lizard/draconid)
-	ascendant.eye_color = "fee5a3"
+	if(islizard(ascendant)) //So they can keep their special snowflake horns and everything otherwise
+		ascendant.set_species(/datum/species/lizard/draconid)
+	else //Otherwise made the generic red lizard
+		ascendant.dna.features = list("mcolor" = "A02720", "tail_lizard" = "Dark Tiger", "tail_human" = "None", "snout" = "Sharp", "horns" = "Drake", "ears" = "None", "wings" = "None", "frills" = "None", "spines" = "Long", "body_markings" = "Dark Tiger Body", "legs" = "Digitigrade Legs")
+		ascendant.set_species(/datum/species/lizard/draconid)
+	ascendant.eye_color = "fee5a3" //Needs to be separate since the species auto-changes color and digitgrade on lizards but not eye color
 	ascendant.dna.update_ui_block(DNA_EYE_COLOR_BLOCK)
-	ascendant.updateappearance() //Makes them the red lizard
+	ascendant.updateappearance()
 
 	ascendant.dna.species.GiveSpeciesFlight(ascendant) //Yes it gives wings too
 	ADD_TRAIT(ascendant, TRAIT_HOLY, SPECIES_TRAIT) //A sprinkle of holiness too because why not
-	playsound(ascendant.loc, 'sound/items/poster_ripped.ogg', 50, TRUE, -1)
 
 	ascendant.dna.add_mutation(FIREBREATH) //And fire breath
 

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1068,7 +1068,7 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 	qdel(src)
 
 /obj/item/dragons_blood/syndicate
-	name = "bottle of refined dragons blood"
+	name = "bottle of refined dragon's blood"
 	desc = "You're totally going to drink this, aren't you?"
 
 /obj/item/dragons_blood/syndicate/attack_self(mob/living/carbon/human/user)
@@ -1087,6 +1087,30 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 		playsound(user.loc,'sound/items/drink.ogg', rand(10,50), 1)
 	qdel(src)
 
+/obj/item/dragons_blood/syndicate/true
+	name = "bottle of pure dragon's blood"
+	desc = "An alchemical wonder; we are blessed by the blood."
+
+/obj/item/dragons_blood/syndicate/true/attack_self(mob/living/carbon/human/user)
+	if(!istype(user))
+		return
+
+	var/mob/living/carbon/human/ascendant = user 
+	to_chat(user, span_userdanger("Warmth surges, bubbles in your body. Your exterior form sloughs off as your new power becomes apparent, old skin disintegrating. You feel divine."))
+
+	ascendant.dna.features = list("mcolor" = "A02720", "tail_lizard" = "Dark Tiger", "tail_human" = "None", "snout" = "Sharp", "horns" = "Drake", "ears" = "None", "wings" = "None", "frills" = "None", "spines" = "Long", "body_markings" = "Dark Tiger Body", "legs" = "Digitigrade Legs")
+	ascendant.set_species(/datum/species/lizard/draconid)
+	ascendant.eye_color = "fee5a3"
+	ascendant.dna.update_ui_block(DNA_EYE_COLOR_BLOCK)
+	ascendant.updateappearance() //Makes them the red lizard
+
+	ascendant.dna.species.GiveSpeciesFlight(ascendant) //Yes it gives wings too
+	ADD_TRAIT(ascendant, TRAIT_HOLY, SPECIES_TRAIT) //A sprinkle of holiness too because why not
+	playsound(ascendant.loc, 'sound/items/poster_ripped.ogg', 50, TRUE, -1)
+
+	ascendant.dna.add_mutation(FIREBREATH) //And fire breath
+
+	qdel(src)
 
 /datum/disease/transformation/dragon
 	name = "dragon transformation"


### PR DESCRIPTION
# Document the changes in your pull request

Adds a Half-Dragon Syndikit Special bundle that has two items: Pure Dragon's Blood and a Flying Fang Tablet. The total value is 32 TC.

Pure Dragon's Blood makes a user a draconid, gives them wings, and grants them the fire breath mutator. Because it's technically giving them the mutator and not inherently granting the ability, it functions just like the mutator that can be purchased by lizard traitors. This means you can technically lose the ability with mutadone.

![image](https://user-images.githubusercontent.com/98909416/193103740-6d7fc177-f1a5-4070-a89f-034f1b7b74b7.png)
Nice awkward line at the end because of this but it's okay

# Wiki Documentation

To be detailed in Syndikit Special bundles at the very end; Pure Dragon's Blood should be explained as well

# Changelog

:cl:  
rscadd: Adds the Half-Dragon Syndikit Special bundle, which is entirely themed around (go figure) being a representation of a dragon
rscadd: Adds Pure Dragon's Blood found in the bundle, which gives a user the draconid species, fire breath, and wings.
/:cl:
