### PR TITLE
Makes Nightmares cost less Threat to spawn on Dynamic

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -508,7 +508,7 @@
 	required_enemies = list(2,2,1,1,1,1,0,0,0,0)
 	required_candidates = 1
 	weight = 4
-	cost = 5
+	cost = 3
 	requirements = list(90,85,80,70,50,40,30,25,20,10)
 	repeatable = TRUE
 	var/list/spawn_locs = list()


### PR DESCRIPTION
# Document the changes in your pull request

Nightmares are an oddball midround
they're even less threatening to crew than a vampire, and basically are barely an antagonist past breaking lights

so 2 points cheaper to spawn doesn't seem too bad for them in my eyes.

# Changelog

:cl:  
tweak: Nightmares are now cheaper to spawn for Dynamic mode
/:cl:
