### PR TITLE
Makes Space Dragons Cost 5 more Threat on Dynamic

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -556,7 +556,7 @@
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 1
 	weight = 4
-	cost = 10
+	cost = 15
 	requirements = list(101,101,101,80,60,50,30,20,10,10)
 	repeatable = TRUE
 	var/list/spawn_locs = list()


### PR DESCRIPTION
# Document the changes in your pull request

Space dragons have gone back to being fairly extremely deadly station-zlevel megafauna...so...they should reasonably be fairly high threat for a mid-round, y'know?

# Changelog

:cl:  
tweak: Space Dragons are now 5 threat More Expensive for dynamic to spawn
/:cl:
