### PR TITLE
Makes Vampires cost much less to spawn on dynamic

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -599,7 +599,7 @@
 	restricted_roles = list("Cyborg", "AI")
 	required_candidates = 1
 	weight = 5
-	cost = 25
+	cost = 15
 	requirements = list(80,70,60,50,50,45,30,30,25,25)
 	minimum_players = 25
 


### PR DESCRIPTION
# Document the changes in your pull request

Vamps are...well I'll say it again as I did when I relegated them to midrounds

toothless.

25 pop minimum AND being higher threat than *an actual megafauna* was basically resigning them to the abyss.
Now they cost 10 less threat.

# Changelog

:cl:  
tweak: Vampires midround costs 10 less threat on dynamic
/:cl:
