### PR TITLE
Raises Minimum Pop for Blob, Xenos, Spiders; Removes Blob-Infection (Unused) Dynamic; Adjusts Related Dynamic Enemy Role Requirements & More

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -400,51 +400,17 @@
 	antag_datum = /datum/antagonist/blob
 	antag_flag = ROLE_BLOB
 	enemy_roles = list("Security Officer", "Detective", "Head of Security", "Captain")
-	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
+	required_enemies = list(4,3,2,2,1,0,0,0,0,0)
 	required_candidates = 1
 	weight = 2
-	cost = 10
+	cost = 30
 	requirements = list(100,100,100,80,60,50,45,30,20,20)
-	repeatable = TRUE
+	repeatable = FALSE
+	minimum_players = 30
 
 /datum/dynamic_ruleset/midround/from_ghosts/blob/generate_ruleset_body(mob/applicant)
 	var/body = applicant.become_overmind()
 	return body
-
-// Infects a random player, making them explode into a blob.
-/datum/dynamic_ruleset/midround/blob_infection
-	name = "Blob Infection"
-	antag_datum = /datum/antagonist/blob
-	antag_flag = ROLE_BLOB
-	protected_roles = list("Prisoner", "Security Officer", "Warden", "Detective", "Head of Security", "Captain")
-	restricted_roles = list("Cyborg", "AI", "Positronic Brain")
-	enemy_roles = list("Security Officer", "Detective", "Head of Security", "Captain")
-	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
-	required_candidates = 1
-	weight = 2
-	cost = 10
-	requirements = list(101,101,101,80,60,50,30,20,10,10)
-	repeatable = TRUE
-
-/datum/dynamic_ruleset/midround/blob_infection/trim_candidates()
-	..()
-	candidates = living_players
-	for(var/mob/living/player as anything in candidates)
-		var/turf/player_turf = get_turf(player)
-		if(!player_turf || !is_station_level(player_turf.z))
-			candidates -= player
-			continue
-
-		if(player.mind && (player.mind.special_role || length(player.mind.antag_datums) > 0))
-			candidates -= player
-
-/datum/dynamic_ruleset/midround/blob_infection/execute()
-	if(!candidates || !candidates.len)
-		return FALSE
-	var/mob/living/carbon/human/blob_antag = pick_n_take(candidates)
-	assigned += blob_antag.mind
-	blob_antag.mind.special_role = antag_flag
-	return ..()
 
 //////////////////////////////////////////////
 //                                          //
@@ -457,18 +423,16 @@
 	antag_datum = /datum/antagonist/xeno
 	antag_flag = ROLE_ALIEN
 	enemy_roles = list("Security Officer", "Detective", "Head of Security", "Captain")
-	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
+	required_enemies = list(4,3,2,2,1,0,0,0,0,0)
 	required_candidates = 1
 	weight = 3
-	cost = 20
+	cost = 30 //these things impact a round probably more than most game-defining antags, ffs.
 	requirements = list(100,100,100,70,50,40,30,25,20,10)
-	repeatable = TRUE
+	repeatable = FALSE
 	var/list/vents = list()
-	minimum_players = 30
+	minimum_players = 40
 
 /datum/dynamic_ruleset/midround/from_ghosts/xenomorph/execute()
-	// 50% chance of being incremented by one
-	required_candidates += prob(50)
 	for(var/obj/machinery/atmospherics/components/unary/vent_pump/temp_vent in GLOB.machines)
 		if(QDELETED(temp_vent))
 			continue

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -430,7 +430,7 @@
 	requirements = list(100,100,100,70,50,40,30,25,20,10)
 	repeatable = FALSE
 	var/list/vents = list()
-	minimum_players = 40
+	minimum_players = 35
 
 /datum/dynamic_ruleset/midround/from_ghosts/xenomorph/execute()
 	for(var/obj/machinery/atmospherics/components/unary/vent_pump/temp_vent in GLOB.machines)

--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/ghost_role/alien_infestation
 	weight = 5
 
-	min_players = 10
+	min_players = 40
 
 	dynamic_should_hijack = TRUE
 

--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/ghost_role/alien_infestation
 	weight = 5
 
-	min_players = 40
+	min_players = 30
 
 	dynamic_should_hijack = TRUE
 

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/ghost_role/blob
 	weight = 8
 	max_occurrences = 1
-	min_players = 25
+	min_players = 40
 	dynamic_should_hijack = TRUE
 	gamemode_blacklist = list("blob") //Just in case a blob survives that long
 	

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/ghost_role/blob
 	weight = 8
 	max_occurrences = 1
-	min_players = 40
+	min_players = 30
 	dynamic_should_hijack = TRUE
 	gamemode_blacklist = list("blob") //Just in case a blob survives that long
 	

--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/spider_infestation
 	weight = 5
 	max_occurrences = 1
-	min_players = 15
+	min_players = 30
 	dynamic_should_hijack = TRUE
 
 /datum/round_event/spider_infestation

--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/spider_infestation
 	weight = 5
 	max_occurrences = 1
-	min_players = 30
+	min_players = 25
 	dynamic_should_hijack = TRUE
 
 /datum/round_event/spider_infestation


### PR DESCRIPTION
# Document the changes in your pull request

1. Raises minimum pop for Xenos, Spiders, and Blob for dynamic and non-dynamic (Spiders only non-dynamic as I cant locate their dynamic ruleset) to 30 (25 for spiders)
   Xenos, Blob, and Spiders spawning as low as they were on non-dynamic, and dynamic, is a bit....Much? What exactly are...10 players meant to do against Xenos? You just lose. Blob is pretty much the same. Spiders are less of an issue but can still be a problem when you don't have the manpower to take it on.

2. Removes Unused Dynamic Blob Infection
   Removes an unused Blob Infection event spawn from dynamic, because we haven't had blob-infection enabled for years and it should stay dead.

3. Dynamic Xenos and Blob have had their required "enemy players" adjusted so that they need more sec and such at higher pop, and shouldn't spawn at *lower* pops if there is no sec or such. I probably have these numbers backwards so if you know better, say something.

4. Adjusts threat cost of blob and xenos
   Dynamic blob and Xenos cost a lot more to spawn because of how hard they impact a round. These are game enders, they should not be spawning extremely frequently.
   
5. Makes blob and Xenos in dynamic NOT repeat
   Always fun winning against xenos for once....only for A SECOND XENO INFESTATION EVENT TO HAPPEN.
these, again, are ROUND ENDING EVENTS. They should not happen more than once per round without admin intervention

# Changelog

:cl:  
tweak: Xenos, Blob, and Spiders should happen less frequently and cant happen below 30 pop (25 for spiders)
tweak: Dynamic Blob and Xenos no longer can repeat in a round
tweak: Removed unused Blob Infection dynamic ruleset
/:cl:
