### PR TITLE
Prevents golaiths from rolling a nat36

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -183,9 +183,9 @@
 
 /obj/effect/temp_visual/goliath_tentacle/original/Initialize(mapload, new_spawner)
 	. = ..()
-	for(var/turf/T in orange(2, src)) // 24 tiles
-		if(prob(85)) // Remove about 20 tiles
-			continue
+	var/list/turf/turfs = circlerangeturfs(get_turf(src), 2)
+	for(var/i in 1 to rand(4, 10))
+		var/turf/T = pick_n_take(turfs)
 		new /obj/effect/temp_visual/goliath_tentacle(T, spawner)
 
 /obj/effect/temp_visual/goliath_tentacle/proc/tripanim()


### PR DESCRIPTION
# Document the changes in your pull request

Limits them to 4 to 10 turfs

Lol 2.1841644090746E-30 chance of that roll

# Changelog

:cl:  
tweak: Golaiths shouldn't be able to roll a 2.1841E-30 chance to fuck you over now
/:cl:
