### PR TITLE
Changes the Darklord bundle to be more Sith-like

### DIFF
--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -299,6 +299,30 @@
 	to_chat(user,span_warning("[src] suddenly vanishes!"))
 	qdel(src)
 
+/obj/item/book/granter/spell/teslablast
+	spell = /obj/effect/proc_holder/spell/targeted/tesla
+	spellname = "tesla blast"
+	desc = "A book that crackles with power."
+	remarks = list("ZAP!", "I feel some tingling in my fingers...", "Swirl your hands to charge...?", "Let loose a bolt of pure electricity? Shocking...", "FEEL THE THUNDER!")
+
+/obj/item/book/granter/spell/teslablast/recoil(mob/user)
+	..()
+	to_chat(user, span_warning("The book twists into lightning and leaps at you!"))
+	tesla_zap(user, 8, 20000, TESLA_MOB_DAMAGE) //Will chain at a range of 8, but shouldn't straight up crit
+	qdel(src)
+
+/obj/item/book/granter/spell/repulse
+	spell = /obj/effect/proc_holder/spell/aoe_turf/repulse
+	spellname = "repulse"
+	desc = "A book that pushes against your touch."
+	remarks = list("The words seem to push away from me...", "Flick a hand and flick everything around me? Awesome", "My mind feels a little percussive.", "Just a little shove...", "Book almost flew out of my hands...")
+
+/obj/item/book/granter/spell/repulse/recoil(mob/user)
+	..()
+	to_chat(user, span_warning("The book bursts into a gale of force!"))
+	user.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)), 8, 10) //Random 8 tile throw with 10 force; will break bones
+	qdel(src)
+
 /obj/item/book/granter/spell/random
 	icon_state = "random_book"
 

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -162,13 +162,15 @@
 			new /obj/item/card/id/syndicate(src) // 2 tc
 			new /obj/item/chameleon(src) // 7 tc
 
-		if("darklord")
-			new /obj/item/twohanded/dualsaber(src)
-			new /obj/item/dnainjector/telemut/darkbundle(src)
-			new /obj/item/clothing/suit/hooded/chaplain_hoodie(src)
-			new /obj/item/card/id/syndicate(src)
-			new /obj/item/clothing/shoes/chameleon/noslip/syndicate(src) //because slipping while being a dark lord sucks
-			new /obj/item/book/granter/spell/summonitem(src)
+		if("darklord") //This is now basically just a wizard instead of just desword: the kit. Hard to quantify the TC cost of spells, but taking SP * 4 would yield a theoretical TC of 31-ish
+			new /obj/item/melee/transforming/energy/sword/saber/red(src) //8 TC. A red lightsaber. Enough said
+			new /obj/item/clothing/mask/chameleon/syndicate(src) //Not even 1 TC, the real value of the chameleon kit is the jumpsuit. However this is absolutely necessary for your Sithsona
+			new /obj/item/card/id/syndicate(src) //2 TC, so you can give yourself a proper name
+			new /obj/item/clothing/suit/wizrobe/black(src) //Dark robes for the dark lord. Free
+			new /obj/item/clothing/gloves/combat(src) //Maybe 1 TC, so you don't shock yourself
+			new /obj/item/book/granter/spell/teslablast(src) //Lightning bolt, LIGHTNING BOLT. A 2 SP cost spell that requires robes
+			new /obj/item/book/granter/spell/repulse(src) //"Force Push". 2 SP cost spell that requires robes
+			new /obj/item/book/granter/spell/summonitem(src) //So you can throw your lightsaber and call it back. A 1 SP cost spell that doesn't require robes
 
 		if("white_whale_holy_grail") //Unique items that don't appear anywhere else
 			new /obj/item/pneumatic_cannon/speargun(src)


### PR DESCRIPTION
# Document the changes in your pull request

Makes the Darklord bundle not just glorified desword murderbone and instead makes it glorified Sith murderbone I guess because it's thematically much more in line and cooler.

The TK injector, robes, desword, and no slips were all removed. Instead, the bundle now offers:

- A guaranteed red energy sword
- A chameleon mask and agent ID (so you can adopt your Sithsona)
- A black wizard robe and combat gloves (latter so you don't shock yourself, Tesla Blast spell should still work)
- Tesla Blast spellbook
- Repulse spellbook
- Instant Summons spellbook

# Spriting
New books could maybe use sprites but this PR doesn't include them

# Wiki Documentation

Darklord bundle will have to be updated on the Syndicate Items page

# Changelog

:cl:  
rscadd: Adds a spellbook for Tesla Blast
rscadd: Adds a spellbook for Repulse
tweak: Darklord bundle has been tweaked to not include a desword but it now has a few spells to live out your Sith desires
/:cl:
