### PR TITLE
Updates and "modernizes" tactical syndikits

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -723,6 +723,7 @@
 
 /obj/item/storage/belt/holster/syndicate/ComponentInitialize()
 	. = ..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 4
 
 /obj/item/storage/belt/quiver

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -717,6 +717,14 @@
 		/obj/item/ammo_box/c38 = 2)
 	generate_items_inside(items_inside, src)
 
+/obj/item/storage/belt/holster/syndicate
+	name = "syndicate shoulder holster"
+	desc = "A modified holster that can carry more than enough firepower."
+
+/obj/item/storage/belt/holster/syndicate/ComponentInitialize()
+	. = ..()
+	STR.max_items = 4
+
 /obj/item/storage/belt/quiver
 	name = "leather quiver"
 	desc = "A quiver made from the hide of some animal. Used to hold arrows."

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -113,8 +113,8 @@
 		if("sabotage") //Maybe 29 TC?
 			new /obj/item/grenade/plastic/c4 (src) //1 TC
 			new /obj/item/grenade/plastic/c4 (src) //1 TC
-			new /obj/item/doorCharge(src) //These were removed from the uplink but... 2 TC? Explosion doesn't seem good
-			new /obj/item/doorCharge(src) //See above
+			new /obj/item/doorCharge(src) //2 TC
+			new /obj/item/doorCharge(src) //2 TC
 			new /obj/item/camera_bug(src) //1 TC
 			new /obj/item/sbeacondrop/powersink(src) //8 TC
 			new /obj/item/computer_hardware/hard_drive/portable/syndicate/bomberman(src) //6 TC

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -100,15 +100,19 @@
 			new /obj/item/implanter/explosive(src) //2 TC, nukies only
 			new /obj/item/implanter/storage(src) //8 TC
 
-		if("hacker") //31 TC cost
+		if("hacker") //28 TC cost
 			new /obj/item/aiModule/syndicate(src) //4 TC
-			new /obj/item/card/emag/bluespace(src) //We're going to lowball this at 20 TC
+			new /obj/item/card/emag(src) //6 TC
 			new /obj/item/encryptionkey/binary(src) //2 TC
 			new /obj/item/aiModule/toyAI(src) //Um, free...?
 			new /obj/item/multitool/ai_detect(src) //1 TC
 			new /obj/item/storage/toolbox/syndicate(src) //1 TC
 			new /obj/item/camera_bug(src) //1 TC
 			new /obj/item/card/id/syndicate(src) //2 TC
+			new /obj/item/flashlight/emp(src) //2 TC
+			new /obj/item/computer_hardware/hard_drive/portable/syndicate/bomberman(src) //6 TC
+			new /obj/item/clothing/glasses/hud/diagnostic/sunglasses(src) //RD glasses. 1 TC, if that
+			new /obj/item/pen/edagger(src) //2 TC
 
 		if("sabotage") //Maybe 29 TC?
 			new /obj/item/grenade/plastic/c4 (src) //1 TC

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -24,122 +24,123 @@
 	name = initial(name)
 
 /obj/item/storage/box/syndicate/bundle_A/PopulateContents()
-	switch (pickweight(list("recon" = 2, "bloodyspai" = 3, "stealth" = 2, "screwed" = 2, "sabotage" = 3, "guns" = 2, "murder" = 2, "implant" = 1, "hacker" = 3, "sniper" = 1, "metaops" = 1)))
-		if("recon")
-			new /obj/item/clothing/glasses/thermal/xray(src) // ~8 tc?
-			new /obj/item/storage/briefcase/launchpad(src) //6 tc
-			new	/obj/item/twohanded/binoculars(src) // 2 tc?
-			new /obj/item/encryptionkey/syndicate(src) // 2 tc
-			new /obj/item/storage/box/syndie_kit/space(src) //4 tc
-			new /obj/item/grenade/syndieminibomb/concussion/frag(src) // ~2 tc each?
-			new /obj/item/grenade/syndieminibomb/concussion/frag(src)
-			new /obj/item/flashlight/emp(src)
+	switch (pickweight(list("recon" = 2, "bloodyspai" = 3, "stealth" = 2, "guns" = 2, "screwed" = 2, "murder" = 2, "implant" = 1, "hacker" = 3, "sabotage" = 3, "sniper" = 1, "metaops" = 1)))
+		if("recon") //28ish TC
+			new /obj/item/clothing/glasses/thermal/xray(src) //Would argue 6 TC. Thermals are 4 TC but work on organic targets in darkness
+			new /obj/item/storage/briefcase/launchpad(src) //6 TC
+			new	/obj/item/twohanded/binoculars(src) //1 TC, maybe. Very good but mining medic/detective get them for free
+			new /obj/item/encryptionkey/syndicate(src) //2 TC
+			new /obj/item/storage/box/syndie_kit/space(src) //4 TC
+			new /obj/item/grenade/syndieminibomb/concussion/frag(src) //Minibomb with one less range on each part except for fire. 3-4 TC.
+			new /obj/item/grenade/syndieminibomb/concussion/frag(src) //See above
+			new /obj/item/flashlight/emp(src) //2 TC
 
-		if("bloodyspai")
-			new /obj/item/clothing/under/chameleon/syndicate(src) // 2 tc since it's not the full set
-			new /obj/item/clothing/mask/chameleon/syndicate(src) // Goes with above
-			new /obj/item/card/id/syndicate(src) // 2 tc
-			new /obj/item/clothing/shoes/chameleon/noslip/syndicate(src) // 2 tc
-			new /obj/item/camera_bug(src) // 1 tc
-			new /obj/item/multitool/ai_detect(src) // 1 tc
-			new /obj/item/encryptionkey/syndicate(src) // 2 tc
-			new /obj/item/reagent_containers/syringe/mulligan(src) // 4 tc
-			new /obj/item/switchblade(src) //I'll count this as 2 tc
-			new /obj/item/storage/box/fancy/cigarettes/cigpack_syndicate (src) // 2 tc this shit heals
-			new /obj/item/flashlight/emp(src) // 2 tc
-			new /obj/item/chameleon(src) // 7 tc
+		if("bloodyspai") //31 TCish
+			new /obj/item/clothing/under/chameleon/syndicate(src) //1 TC, has only two parts of the massive kit
+			new /obj/item/clothing/mask/chameleon/syndicate(src) //See above
+			new /obj/item/card/id/syndicate(src) //2 TC
+			new /obj/item/clothing/shoes/chameleon/noslip/syndicate(src) //2 TC
+			new /obj/item/camera_bug(src) //1 TC
+			new /obj/item/multitool/ai_detect(src) //1 TC
+			new /obj/item/encryptionkey/syndicate(src) //2 TC
+			new /obj/item/reagent_containers/syringe/mulligan(src) //4 TC
+			new /obj/item/switchblade(src) //1 TC, if even. 20 force melee is good but it's no edagger
+			new /obj/item/storage/box/fancy/cigarettes/cigpack_syndicate (src) //2 TC (for now)
+			new /obj/item/flashlight/emp(src) //2 TC
+			new /obj/item/chameleon(src) //7 TC
+			new /obj/item/card/emag(src) //6 TC
 
-		if("stealth")
-			new /obj/item/gun/energy/kinetic_accelerator/crossbow(src)
-			new /obj/item/pen/sleepy(src)
-			new /obj/item/healthanalyzer/rad_laser(src)
-			new /obj/item/chameleon(src)
-			new /obj/item/soap/syndie(src)
-			new /obj/item/clothing/glasses/thermal/syndi(src)
-			new /obj/item/flashlight/emp(src)
-			new /obj/item/jammer(src)
+		if("stealth") //32 TC
+			new /obj/item/gun/energy/kinetic_accelerator/crossbow(src) //10 TC
+			new /obj/item/pen/sleepy(src) //4 TC
+			new /obj/item/chameleon(src) //7 TC
+			new /obj/item/clothing/glasses/thermal/syndi(src) //4 TC
+			new /obj/item/flashlight/emp(src) //2 TC
+			new /obj/item/jammer(src) //5 TC
 
-		if("guns")
-			new /obj/item/gun/ballistic/revolver(src)
-			new /obj/item/ammo_box/a357(src)
-			new /obj/item/ammo_box/a357(src)
-			new /obj/item/card/emag(src)
-			new /obj/item/grenade/plastic/c4(src)
-			new /obj/item/clothing/gloves/color/latex/nitrile(src)
-			new /obj/item/clothing/mask/gas/clown_hat(src)
-			new /obj/item/clothing/under/suit_jacket/really_black(src)
+		if("guns") //Total cost of 31 TC
+			new /obj/item/gun/ballistic/revolver(src) //6 TC
+			new /obj/item/gun/ballistic/revolver(src) //6 TC
+			new /obj/item/gun/ballistic/automatic/pistol(src) //6 TC
+			new /obj/item/gun/ballistic/automatic/pistol(src) //6 TC
+			new /obj/item/ammo_box/a357(src) //1 TC
+			new /obj/item/ammo_box/a357(src) //1 TC
+			new /obj/item/ammo_box/a357(src) //1 TC
+			new /obj/item/ammo_box/a357(src) //1 TC
+			new /obj/item/ammo_box/magazine/m10mm(src) //1 TC for two
+			new /obj/item/ammo_box/magazine/m10mm(src) //See above
+			new /obj/item/ammo_box/magazine/m10mm(src) //1 TC for two
+			new /obj/item/ammo_box/magazine/m10mm(src) //See above
+			new /obj/item/storage/belt/holster/syndicate(src) //A holster for your four guns. It could be 1 TC I guess, since the tactical webbing can't hold normal items?
+			new /obj/item/clothing/gloves/color/latex/nitrile(src) //Free?
+			new /obj/item/clothing/mask/gas/clown_hat(src) //Free?
+			new /obj/item/clothing/under/suit_jacket/really_black(src) //Free?
 
-		if("screwed")
-			new /obj/item/sbeacondrop/bomb(src)
-			new /obj/item/grenade/syndieminibomb(src)
-			new /obj/item/sbeacondrop/powersink(src)
-			new /obj/item/clothing/suit/space/syndicate/black/red(src)
-			new /obj/item/clothing/head/helmet/space/syndicate/black/red(src)
-			new /obj/item/encryptionkey/syndicate(src)
+		if("screwed") //Total of 31 TC
+			new /obj/item/sbeacondrop/bomb(src) //11 TC
+			new /obj/item/grenade/syndieminibomb(src) //6 TC
+			new /obj/item/sbeacondrop/powersink(src) //8 TC
+			new /obj/item/clothing/suit/space/syndicate/black/red(src) //Total of 4 TC
+			new /obj/item/clothing/head/helmet/space/syndicate/black/red(src) //See above
+			new /obj/item/encryptionkey/syndicate(src) //2 TC
 
-		if("murder")
-			new /obj/item/melee/transforming/energy/sword/saber(src)
-			new /obj/item/clothing/glasses/thermal/syndi(src)
-			new /obj/item/card/emag(src)
-			new /obj/item/clothing/shoes/chameleon/noslip/syndicate(src)
-			new /obj/item/encryptionkey/syndicate(src)
-			new /obj/item/grenade/syndieminibomb(src)
+		if("murder") //Total cost of 28 TC
+			new /obj/item/melee/transforming/energy/sword/saber(src) //8 TC
+			new /obj/item/clothing/glasses/thermal/syndi(src) //4 TC
+			new /obj/item/card/emag(src) //6 TC
+			new /obj/item/clothing/shoes/chameleon/noslip/syndicate(src) //2 TC
+			new /obj/item/encryptionkey/syndicate(src) //2 TC
+			new /obj/item/grenade/syndieminibomb(src) //6 TC
 
-		if("implant")
-			new /obj/item/implanter/freedom(src)
-			new /obj/item/implanter/uplink/precharged(src)
-			new /obj/item/implanter/emp(src)
-			new /obj/item/implanter/adrenalin(src)
-			new /obj/item/implanter/explosive(src)
-			new /obj/item/implanter/storage(src)
+		if("implant") //28 TC cost, then you get a spare 10 for a total of 38 TC (fair and balanced™)
+			new /obj/item/implanter/freedom(src) //5 TC
+			new /obj/item/implanter/uplink/precharged(src) //4 TC + 10 to use
+			new /obj/item/implanter/emp(src) //1 TC, kit with 5 grenades costs 2
+			new /obj/item/implanter/adrenalin(src) //8 TC
+			new /obj/item/implanter/explosive(src) //2 TC, nukies only
+			new /obj/item/implanter/storage(src) //8 TC
 
-		if("hacker")
-			new /obj/item/aiModule/syndicate(src)
-			new /obj/item/card/emag(src)
-			new /obj/item/encryptionkey/binary(src)
-			new /obj/item/aiModule/toyAI(src)
-			new /obj/item/multitool/ai_detect(src)
-			new /obj/item/storage/toolbox/syndicate(src)
-			new /obj/item/camera_bug(src)
-			new /obj/item/clothing/glasses/thermal/syndi(src)
-			new /obj/item/card/id/syndicate(src)
+		if("hacker") //31 TC cost
+			new /obj/item/aiModule/syndicate(src) //4 TC
+			new /obj/item/card/emag/bluespace(src) //We're going to lowball this at 20 TC
+			new /obj/item/encryptionkey/binary(src) //2 TC
+			new /obj/item/aiModule/toyAI(src) //Um, free...?
+			new /obj/item/multitool/ai_detect(src) //1 TC
+			new /obj/item/storage/toolbox/syndicate(src) //1 TC
+			new /obj/item/camera_bug(src) //1 TC
+			new /obj/item/card/id/syndicate(src) //2 TC
 
-		if("lordsingulo")
-			new /obj/item/sbeacondrop(src)
-			new /obj/item/clothing/suit/space/syndicate/black/red(src)
-			new /obj/item/clothing/head/helmet/space/syndicate/black/red(src)
-			new /obj/item/card/emag(src)
-			new /obj/item/storage/toolbox/syndicate(src)
+		if("sabotage") //Maybe 29 TC?
+			new /obj/item/grenade/plastic/c4 (src) //1 TC
+			new /obj/item/grenade/plastic/c4 (src) //1 TC
+			new /obj/item/doorCharge(src) //These were removed from the uplink but... 2 TC? Explosion doesn't seem good
+			new /obj/item/doorCharge(src) //See above
+			new /obj/item/camera_bug(src) //1 TC
+			new /obj/item/sbeacondrop/powersink(src) //8 TC
+			new /obj/item/computer_hardware/hard_drive/portable/syndicate/bomberman(src) //6 TC
+			new /obj/item/storage/toolbox/syndicate(src) //1 TC
+			new /obj/item/pizzabox/bomb(src) //6 TC
+			new /obj/item/storage/box/syndie_kit/emp(src) //2 TC
 
-		if("sabotage")
-			new /obj/item/grenade/plastic/c4 (src)
-			new /obj/item/grenade/plastic/c4 (src)
-			new /obj/item/doorCharge(src)
-			new /obj/item/doorCharge(src)
-			new /obj/item/camera_bug(src)
-			new /obj/item/sbeacondrop/powersink(src)
-			new /obj/item/computer_hardware/hard_drive/portable/syndicate/bomberman(src)
-			new /obj/item/storage/toolbox/syndicate(src) //To actually get to those places
-			new /obj/item/pizzabox/bomb(src)
-			new /obj/item/storage/box/syndie_kit/emp(src)
+		if("sniper") //30 TC, you only get 11 shots total with the sniper and 14 with the revolver. A mini-ebow would probably be better than the sniper in a normal traitor game
+			new /obj/item/gun/ballistic/automatic/sniper_rifle(src) //12 TC, nukies only
+			new /obj/item/ammo_box/magazine/sniper_rounds/penetrator(src) //5 TC, nukies only
+			new /obj/item/gun/ballistic/revolver(src) //6 TC
+			new /obj/item/ammo_box/a357/heartpiercer(src) //3 TC
+			new /obj/item/clothing/glasses/thermal/syndi(src) //4 TC
+			new /obj/item/clothing/gloves/color/latex/nitrile(src) //Free?
+			new /obj/item/clothing/mask/gas/clown_hat(src) //Free?
+			new /obj/item/clothing/under/suit_jacket/really_black(src) //Free?
 
-		if("sniper") //This shit is unique so can't really balance it around tc, also no silencer because getting killed without ANY indicator on what killed you sucks
-			new /obj/item/gun/ballistic/automatic/sniper_rifle(src) // 12 tc
-			new /obj/item/ammo_box/magazine/sniper_rounds/penetrator(src)
-			new /obj/item/clothing/glasses/thermal/syndi(src)
-			new /obj/item/clothing/gloves/color/latex/nitrile(src)
-			new /obj/item/clothing/mask/gas/clown_hat(src)
-			new /obj/item/clothing/under/suit_jacket/really_black(src)
-
-		if("metaops")
-			new /obj/item/clothing/suit/space/hardsuit/syndi(src) // 8 tc
-			new /obj/item/gun/ballistic/shotgun/bulldog/unrestricted(src) // 8 tc
-			new /obj/item/implanter/explosive(src) // 2 tc
-			new /obj/item/ammo_box/magazine/m12g(src) // 2 tc
-			new /obj/item/ammo_box/magazine/m12g(src) // 2 tc
-			new /obj/item/grenade/plastic/c4 (src) // 1 tc
-			new /obj/item/grenade/plastic/c4 (src) // 1 tc
-			new /obj/item/card/emag(src) // 6 tc
+		if("metaops") //30 TC
+			new /obj/item/clothing/suit/space/hardsuit/syndi(src) //8 TC
+			new /obj/item/gun/ballistic/shotgun/bulldog/unrestricted(src) //8 TC, nukies only
+			new /obj/item/implanter/explosive(src) //2 TC, nukies only
+			new /obj/item/ammo_box/magazine/m12g(src) //2 TC, nukies only
+			new /obj/item/ammo_box/magazine/m12g(src) //2 TC, nukies only
+			new /obj/item/grenade/plastic/c4 (src) //1 TC
+			new /obj/item/grenade/plastic/c4 (src) //1 TC
+			new /obj/item/card/emag(src) //6 TC
 
 /obj/item/storage/box/syndicate/bundle_B/PopulateContents()
 	switch (pickweight(list( "bond" = 2, "neo"=1, "ninja" = 1, "darklord" = 1, "white_whale_holy_grail" = 2, "mad_scientist" = 2, "bee" = 2, "mr_freeze" = 2, "gang_boss" = 1)))

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1868,7 +1868,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "An implant injected into the body, and later activated at the user's will. Has no telecrystals and must be charged by the use of physical telecrystals. \
 			Undetectable (except via surgery), and excellent for escaping confinement."
 	item = /obj/item/storage/box/syndie_kit/imp_uplink
-	cost = UPLINK_IMPLANT_TELECRYSTAL_COST
+	cost = UPLINK_IMPLANT_TELECRYSTAL_COST //4 TC
 	// An empty uplink is kinda useless.
 	surplus = 0
 	restricted = TRUE


### PR DESCRIPTION
# Document the changes in your pull request

Passes over the existing Tactical Syndikits to actually comment in their total TC value and maybe adjust those that were too crazy or too worthless.

Comprehensive List of Changes:
- Recon: Unchanged (Cost of ~28 TC)
- Bloodyspai: Has received an EMAG (Cost of ~31 TC)
- Stealth: Has lost syndicate soap and radioactive microlaser (Cost of 32 TC)
- Guns: Has received another .357, two stechkin pistols, two more .357 speedloaders, four 10mm magazines, a syndicate shoulder holster (empty shoulder holster that can hold 4 instead of 3), but has lost EMAG and C4 (Cost of 31 TC)
- Screwed: Unchanged (Cost of 31 TC)
- Murder: Unchanged (Cost of 28 TC)
- Implant: Unchanged (Cost of 28 TC, and you get 10 TC to spend)
- Hacker: Lost thermal goggles, but gains Diagnostic Sunglasses, Bomberman program, and edagger (28ish TC)
- Lord Singulo: **Gone.** Didn't have weight anyway, but it remained for whatever reason.
- Sabotage: Unchanged (Cost of ~29 TC)
- Sniper: Has received a .357 revolver and a .357 Heartpiercer speedloader (Cost of 30 TC)
- Metaops: Unchanged (Cost of 30 TC)

Also throws the TC cost onto the Radio Implant in code as a comment because it's not obvious to those who do not seek, not even worth putting on the changelog

# Wiki Documentation

All of the above will have to be updated under the tactical syndikit lists in Syndicate Items page

# Changelog

:cl:  
rscadd: Adds the syndicate shoulder holster, which can hold one additional thing (four guns, FOUR GUNS)
rscdel: Removes leftovers of the Lord Singulo bundle
tweak: Passes over and modernizes most of the Tactical Syndikits
/:cl:
