### PR TITLE
Reverts #15807: "makes the syndicate tactical and special kit 16 tc to encourage people to actually use them"

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -219,15 +219,15 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			These items are collectively worth more than 20 telecrystals, but you do not know which specialization \
 			you will receive. May contain discontinued and/or exotic items."
 	item = /obj/item/storage/box/syndicate/bundle_A
-	cost = 16
+	cost = 20 //These are 20 TC for a reason; sacrifice modularity for a pre-determined kit that will define your strategy
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/infiltration) // yogs: infiltration
 
 /datum/uplink_item/bundles_TC/bundle_B
 	name = "Syndi-kit Special"
 	desc = "Syndicate Bundles, also known as Syndi-Kits, are specialized groups of items that arrive in a plain box. \
-			In Syndi-kit Special, you will receive items used by famous syndicate agents of the past. Collectively worth more than 20 telecrystals, the syndicate loves a good throwback."
+			In Syndi-kit Special, you will receive items used by famous Syndicate agents of the past. Collectively worth more than 20 telecrystals, the Syndicate loves a good throwback."
 	item = /obj/item/storage/box/syndicate/bundle_B
-	cost = 16
+	cost = 20 //See above
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/infiltration) // yogs: infiltration
 
 /datum/uplink_item/bundles_TC/surplus


### PR DESCRIPTION
# Document the changes in your pull request

Reverts #15807 because I'm literally in the process of adjusting the kits to be less garbage overall

Also entirely misses the point that you are buying a pre-defined loadout that will force your strategy and also give you a collection of items over 20 TC. Getting 4 spare TC to spend massively misses the point of the bundles.

# Wiki Documentation

Roll the cost back

# Changelog

:cl:  
tweak: Syndikits are 20 TC again
/:cl:
