### PR TITLE
Revert "gives minimum player age to virologist cause new players end up taking it then doing nothing wasting it because its a one slot job"

### DIFF
--- a/code/modules/jobs/job_types/virologist.dm
+++ b/code/modules/jobs/job_types/virologist.dm
@@ -10,7 +10,6 @@
 	selection_color = "#d4ebf2"
 	exp_type = EXP_TYPE_CREW
 	exp_requirements = 120
-	minimal_player_age = 7
 	exp_type_department = EXP_TYPE_MEDICAL
 
 	outfit = /datum/outfit/job/virologist


### PR DESCRIPTION
Might as well add minimum player age to anything with unique mechanics if we're going down this route

:cl:
Rscdel: viro doesnt get a minimum player age
/:cl: