### PR TITLE
Revert #15909: "gives minimum player age to virologist cause new players end up taking it then doing nothing wasting it because its a one slot job"

### DIFF
--- a/code/modules/jobs/job_types/virologist.dm
+++ b/code/modules/jobs/job_types/virologist.dm
@@ -10,7 +10,6 @@
 	selection_color = "#d4ebf2"
 	exp_type = EXP_TYPE_CREW
 	exp_requirements = 120
-	minimal_player_age = 7
 	exp_type_department = EXP_TYPE_MEDICAL
 
 	outfit = /datum/outfit/job/virologist


### PR DESCRIPTION
# Document the changes in your pull request

Revert #15909

Other one-slot jobs that have no minimum age requirement:
Chaplain (can be massively important)
Clerk
Clown
Mime
Brig Physician (important)
Mining Medic (vaguely important)
Network Admin (vaguely important)
Quartermaster (can be massively important)
Curator
Bartender
Artist

# Changelog

:cl:  
tweak: Virology has no player age requirement again
/:cl:
