### PR TITLE
Removes the 10% chance of getting a bluespace emag when emagging an emag with another emag

### DIFF
--- a/yogstation/code/game/objects/items/cards_ids.dm
+++ b/yogstation/code/game/objects/items/cards_ids.dm
@@ -74,13 +74,6 @@
 		return
 	if(istype(otherEmag, /obj/item/card/emag/improvised))
 		return
-	if(prob(10))
-		to_chat(user, span_notice("By some ungodly miracle, the emag gains new functionality instead of being destroyed."))
-		playsound(src.loc, "sparks", 50, 1)
-		qdel(otherEmag)
-		color = rgb(40, 130, 255)
-		prox_check = FALSE
-		return
 	to_chat(user, span_notice("The cyptographic sequencers attempt to override each other before destroying themselves."))
 	playsound(src.loc, "sparks", 50, 1)
 	qdel(otherEmag)


### PR DESCRIPTION
# Document the changes in your pull request

This used to be 16 TC thrown out the window versues 12 now.
Bluespace emags are just plain annoying too


# Wiki Documentation

# Changelog

:cl:  
rscdel: You can no longer gamble with your two emags, sadge.
/:cl:
