### PR TITLE
Fixes some watcher gem shit

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
@@ -162,9 +162,11 @@
 		new /obj/item/gem/fdiamond(loc)
 		deathmessage = "spits out a diamond as it dies!"
 	. = ..()
+	deathmessage = initial(deathmessage)
 
 /mob/living/simple_animal/hostile/asteroid/basilisk/watcher/magmawing/death(gibbed)
 	if(prob(10))
-		new /obj/item/gem/fdiamond(loc)
+		new /obj/item/gem/magma(loc)
 		deathmessage = "spits out a golden gem as it dies!"
 	. = ..()
+	deathmessage = initial(deathmessage)


### PR DESCRIPTION
# Document the changes in your pull request
Watcher death messages are reset after dying if they shart out a gem

Magmawing watchers now shart out the correct gem


# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
bugfix: watchersnnow have their death message reset after they drop gems becausw that changes it to account for the gem
bugfix: magmawing watchers dont drop frost diamonds because they arent icewing watchers
/:cl:
