### PR TITLE
Removes Alligators from Fishing Loot Pool

### DIFF
--- a/yogstation/code/datums/components/fishable.dm
+++ b/yogstation/code/datums/components/fishable.dm
@@ -64,6 +64,5 @@
 	rare_loot = list(
 		/obj/item/reagent_containers/food/snacks/fish/squid,
 		/obj/item/stack/sheet/bluespace_crystal,
-		/obj/item/clothing/head/soft/fishfear/legendary,
-		/mob/living/simple_animal/hostile/retaliate/gator
+		/obj/item/clothing/head/soft/fishfear/legendary
 	)


### PR DESCRIPTION
# Document the changes in your pull request

Accidentally left in after its removal was requested in the original PR

# Changelog

:cl:  
bugfix: Removed alligators from the fishing loot pool, pending proper fishing rework
/:cl:
