### PR TITLE
Ports 'Fix mecha directional armor' from Paradise

### DIFF
--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -1,10 +1,10 @@
 /obj/mecha/proc/get_armour_facing(relative_dir)
 	switch(abs(relative_dir))
 		if(180) // BACKSTAB!
-			return facing_modifiers[MECHA_BACK_ARMOUR]
+			return facing_modifiers[BACK_ARMOUR]
 		if(0, 45)
-			return facing_modifiers[MECHA_FRONT_ARMOUR]
-	return facing_modifiers[MECHA_SIDE_ARMOUR] //always return non-0
+			return facing_modifiers[FRONT_ARMOUR]
+	return facing_modifiers[SIDE_ARMOUR] //always return non-0
 
 /obj/mecha/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
 	. = ..()

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -1,12 +1,10 @@
 /obj/mecha/proc/get_armour_facing(relative_dir)
-	switch(relative_dir)
-		if(0) // BACKSTAB!
-			return facing_modifiers[BACK_ARMOUR]
-		if(45, 90, 270, 315)
-			return facing_modifiers[SIDE_ARMOUR]
-		if(225, 180, 135)
-			return facing_modifiers[FRONT_ARMOUR]
-	return 1 //always return non-0
+	switch(abs(relative_dir))
+		if(180) // BACKSTAB!
+			return facing_modifiers[MECHA_BACK_ARMOUR]
+		if(0, 45)
+			return facing_modifiers[MECHA_FRONT_ARMOUR]
+	return facing_modifiers[MECHA_SIDE_ARMOUR] //always return non-0
 
 /obj/mecha/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
 	. = ..()
@@ -43,7 +41,7 @@
 				break
 
 	if(attack_dir)
-		var/facing_modifier = get_armour_facing(dir2angle(attack_dir) - dir2angle(src))
+		var/facing_modifier = get_armour_facing(dir2angle(attack_dir) - dir2angle(dir))
 		booster_damage_modifier /= facing_modifier
 		booster_deflection_modifier *= facing_modifier
 	if(prob(deflect_chance * booster_deflection_modifier))


### PR DESCRIPTION
# Document the changes in your pull request
Ports [this PR](https://github.com/ParadiseSS13/Paradise/pull/16206/files)!
Should fix mechas not correctly taking damage from north/south/sides.
NOTE. This doesn't add features, the bot made a mistake.

:cl:  
bugfix: Fixes mechas not caring what direction they received damage from.  

/:cl:
