### PR TITLE
Makes mortar and pestles not made of solid lead leading to tired arms in as little as one cycle

### DIFF
--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -376,7 +376,7 @@
 				return
 			to_chat(user, "You start grinding...")
 			if((do_after(user, 2.5 SECONDS, src)) && grinded)
-				user.adjustStaminaLoss(5)
+				user.adjustStaminaLoss(14)
 				if(grinded.reagents) //food and pills
 					grinded.reagents.trans_to(src, grinded.reagents.total_volume, transfered_by = user)
 				if(grinded.juice_results) //prioritize juicing

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -376,7 +376,7 @@
 				return
 			to_chat(user, "You start grinding...")
 			if((do_after(user, 2.5 SECONDS, src)) && grinded)
-				user.adjustStaminaLoss(40)
+				user.adjustStaminaLoss(5)
 				if(grinded.reagents) //food and pills
 					grinded.reagents.trans_to(src, grinded.reagents.total_volume, transfered_by = user)
 				if(grinded.juice_results) //prioritize juicing


### PR DESCRIPTION
# Document the changes in your pull request

You can in fact, use this thing a few times now and not get too tired. Instead of...once.

# Changelog

:cl:  
tweak: Mortar and Pestle grinding costs about 1/3rd the stamina now
/:cl:
