### PR TITLE
Plasaman

### DIFF
--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -52,7 +52,7 @@ const speciesmap = {
     "icon": "seedling",
     "color": "#05fa46",
   },
-  "Plasaman": {
+  "Plasmaman": {
     "icon": "skull",
     "color": "#d60b66",
   },


### PR DESCRIPTION
fix typo resulting in icon wouldn't appear on crew monitor

# Changelog



:cl:  

spellcheck: plasaman

/:cl:
