### PR TITLE
Replace the beanbag in the ammunition locker with rubbershot

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -176,4 +176,4 @@
 /obj/structure/closet/ammunitionlocker/PopulateContents()
 	..()
 	for(var/i in 1 to 3)
-		new /obj/item/storage/box/beanbag(src)
+		new /obj/item/storage/box/rubbershot(src)

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -176,4 +176,4 @@
 /obj/structure/closet/ammunitionlocker/PopulateContents()
 	..()
 	for(var/i in 1 to 3)
-		new /obj/item/storage/box/rubbershot(src)
+		new /obj/item/storage/box/beanbag(src)


### PR DESCRIPTION
# Document the changes in your pull request

Replace the 3 boxes of beanbag shells with 3 boxes of rubbershot.
The combat shotguns of cargo and the compact shotgun of the warden are loaded with buckshot, the lethal locker has boxes of buckshot. Since the riot shotguns are loaded with rubbershot the ammunition locker should have rubbershot instead of beanbag. That way you can quickly grab a box of the same ammunitions to reload the riot shotgun.

# Wiki Documentation

There's no beanbag in the armory now, instead there's 3 boxes of rubbershot.

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
tweak: replaced the beanbags in the armory with rubbershot.
/:cl:
