### PR TITLE
Reduces Reagent Capacity of Pills to 10u

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -260,7 +260,7 @@
 		var/vol_each_text = params["volume"]
 		var/vol_each_max = reagents.total_volume / amount
 		if (item_type == "pill")
-			vol_each_max = min(50, vol_each_max)
+			vol_each_max = min(10, vol_each_max)
 		else if (item_type == "patch")
 			vol_each_max = min(40, vol_each_max)
 		else if (item_type == "bottle")

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -246,6 +246,7 @@
 	var/static/list/names = list("maintenance pill","floorpill","mystery pill","suspicious pill","strange pill")
 	var/static/list/descs = list("Your feeling is telling you no, but...","Drugs are expensive, you can't afford not to eat any pills that you find."\
 	, "Surely, there's no way this could go bad.")
+	volume = 50
 
 /obj/item/reagent_containers/pill/floorpill/Initialize()
 	list_reagents = list(get_random_reagent_id() = rand(10,50))

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -7,7 +7,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	possible_transfer_amounts = list()
-	volume = 50
+	volume = 10
 	grind_results = list()
 	var/apply_type = INGEST
 	var/apply_method = "swallow"

--- a/tgui/packages/tgui/interfaces/ChemMaster.js
+++ b/tgui/packages/tgui/interfaces/ChemMaster.js
@@ -263,7 +263,7 @@ const PackagingControls = (props, context) => {
           label="Pills"
           amount={pillAmount}
           amountUnit="pills"
-          sideNote="max 50u"
+          sideNote="max 10u"
           onChangeAmount={(e, value) => setPillAmount(value)}
           onCreate={() => act('create', {
             type: 'pill',


### PR DESCRIPTION
# Document the changes in your pull request

Pills currently are instant use items with 50u capacity
a normal size beaker...is 50u.
In theory you can cram 25HP into a pill and keep a BAG of bottles of 10 each.

This reduces the cap on pill volume to 10u, still much higher than it should be imo, but still within what everyone else sees as acceptable.

# Wiki Documentation

Requires an update to the Guide to Chemistry, to reflect this change in the chem master info

# Changelog

:cl:  
tweak: Reduced pill max capacity to 10u (Does not affect floorpills)
/:cl:
