### PR TITLE
Gives Sentient Diseases 2 more stealth on their initial symptom

### DIFF
--- a/code/modules/antagonists/disease/disease_abilities.dm
+++ b/code/modules/antagonists/disease/disease_abilities.dm
@@ -311,7 +311,7 @@ new /datum/disease_ability/symptom/powerful/heal/youth
 /datum/symptom/sentient
 	name = "Sentient Resistance"
 	desc = "Due to its sentience, the virus is able to passively increase its resistance to detection and cures"
-	stealth = 2
+	stealth = 4
 	resistance = 2
 	stage_speed = 0
 	transmittable = 0


### PR DESCRIPTION
# Document the changes in your pull request

Poor guys get metagamed in no time because they pick names like "Ligma" and have no goddamn stealth

# Changelog

:cl:  
tweak: Sentient Diseases are slightly stealthier by default
/:cl:
