### PR TITLE
re-add frag 12

### DIFF
--- a/code/datums/components/crafting/weapons.dm
+++ b/code/datums/components/crafting/weapons.dm
@@ -394,6 +394,17 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 
+/datum/crafting_recipe/frag12
+	name = "FRAG-12 Shell"
+	result = /obj/item/ammo_casing/shotgun/frag12
+	reqs = list(/obj/item/ammo_casing/shotgun/techshell = 1,
+				/datum/reagent/glycerol = 5,
+				/datum/reagent/toxin/acid/fluacid = 5)
+	tools = list(TOOL_SCREWDRIVER)
+	time = 5
+	category = CAT_WEAPONRY
+	subcategory = CAT_AMMO
+
 /datum/crafting_recipe/laserbuckshot
 	name = "Laser Buckshot Shell"
 	result = /obj/item/ammo_casing/shotgun/laserbuckshot


### PR DESCRIPTION
since frag 12 is no longer fucking taser shells that stun you for 5 seconds this is fine i think. also explosions dont double explode people anymore so shooting someone doesnt instantly kill and nugget them anymore.

from testing: unarmored assistant takes around 50 damage
HoS takes around 40 damage

the advantage of these over normal slugs is the short knockdown they inflict on victims because they explode

these require 5u glycerol (so corn oil which requires botany) 5u fluacid, and an unloaded tech shell
# Changelog

:cl:  
rscadd: frag 12 can be crafted again
/:cl:
