### PR TITLE
Food and Drink color fixes and tweaks

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_other.dm
+++ b/code/modules/food_and_drinks/food/snacks_other.dm
@@ -93,7 +93,7 @@
 	desc = "A large fried potato nugget that may or may not try to valid you."
 	icon_state = "tatortot"
 	list_reagents = list(/datum/reagent/consumable/nutriment = 4)
-	filling_color = "FFD700"
+	filling_color = "#FFD700"
 	tastes = list("potato" = 3, "valids" = 1)
 	foodtype = FRIED | VEGETABLES
 
@@ -195,7 +195,7 @@
 	desc = "It's slightly twitching in your hand. Ew..."
 	icon_state = "spiderling"
 	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/toxin = 4)
-	filling_color = "#00800"
+	filling_color = "#008000"
 	tastes = list("cobwebs" = 1, "guts" = 2)
 	foodtype = MEAT | TOXIC
 
@@ -204,7 +204,7 @@
 	desc = "Still gross, but at least it has a mountain of sugar on it."
 	icon_state = "spiderlollipop"
 	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/toxin = 1, /datum/reagent/iron = 10, /datum/reagent/consumable/sugar = 5, /datum/reagent/medicine/omnizine = 2) //lollipop, but vitamins = toxins
-	filling_color = "#00800"
+	filling_color = "#008000"
 	tastes = list("cobwebs" = 1, "sugar" = 2)
 	foodtype = JUNKFOOD | SUGAR
 
@@ -491,7 +491,7 @@
 	icon_state = "taco"
 	bonus_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 2)
 	list_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/consumable/nutriment/vitamin = 2)
-	filling_color = "F0D830"
+	filling_color = "#F0D830"
 	tastes = list("taco" = 4, "meat" = 2, "cheese" = 2, "lettuce" = 1)
 	foodtype = MEAT | DAIRY | GRAIN | VEGETABLES
 

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -73,7 +73,7 @@
 /datum/reagent/consumable/berryjuice
 	name = "Berry Juice"
 	description = "A delicious blend of several different kinds of berries."
-	color = "#863333" // rgb: 134, 51, 51
+	color = "#770b0b" // rgb: 119, 11, 11
 	taste_description = "berries"
 	glass_icon_state = "berryjuice"
 	glass_name = "glass of berry juice"
@@ -82,7 +82,7 @@
 /datum/reagent/consumable/applejuice
 	name = "Apple Juice"
 	description = "The sweet juice of an apple, fit for all ages."
-	color = "#ECFF56" // rgb: 236, 255, 86
+	color = "#e99e12" // rgb: 233, 158, 18
 	taste_description = "apples"
 
 /datum/reagent/consumable/poisonberryjuice
@@ -102,7 +102,7 @@
 /datum/reagent/consumable/watermelonjuice
 	name = "Watermelon Juice"
 	description = "Delicious juice made from watermelon."
-	color = "#863333" // rgb: 134, 51, 51
+	color = "#ff3561" // rgb: 255, 53, 97
 	taste_description = "juicy watermelon"
 	glass_icon_state = "glass_red"
 	glass_name = "glass of watermelon juice"
@@ -111,7 +111,7 @@
 /datum/reagent/consumable/lemonjuice
 	name = "Lemon Juice"
 	description = "This juice is VERY sour."
-	color = "#863333" // rgb: 175, 175, 0
+	color = "#ECFF56" // rgb: 236, 255, 86
 	taste_description = "sourness"
 	glass_icon_state  = "lemonglass"
 	glass_name = "glass of lemon juice"
@@ -120,7 +120,7 @@
 /datum/reagent/consumable/banana
 	name = "Banana Juice"
 	description = "The raw essence of a banana. HONK"
-	color = "#863333" // rgb: 175, 175, 0
+	color = "#fdff98" // rgb: 253, 255, 152
 	taste_description = "banana"
 	glass_icon_state = "banana"
 	glass_name = "glass of banana juice"
@@ -187,7 +187,7 @@
 /datum/reagent/consumable/grapejuice
 	name = "Grape Juice"
 	description = "The juice of a bunch of grapes. Guaranteed non-alcoholic."
-	color = "#290029" // dark purple
+	color = "#290029" // rgn: 41, 0, 41 dark purple
 	taste_description = "grape soda"
 
 /datum/reagent/consumable/milk
@@ -404,6 +404,7 @@
 /datum/reagent/consumable/lemonade
 	name = "Lemonade"
 	description = "Sweet, tangy lemonade. Good for the soul."
+	color = "#ECFF56" // rgb: 236, 255, 86 Same as the lemon juice if this ever matters
 	quality = DRINK_NICE
 	taste_description = "sunshine and summertime"
 	glass_icon_state = "lemonpitcher"


### PR DESCRIPTION
Muh Color.

# Document the changes in your pull request

- Fixes a few filling colors missing #'s
- Adds a missing 0 to spider-based food
- Adds a color value for lemonade the same as the tweaked lemon juice color
- Tweaks juice colors
Berry Juice: 
![image](https://user-images.githubusercontent.com/107460718/193429127-80bfca82-a8b4-4675-9a12-e9316be4423e.png)
Apple Juice:
![image](https://user-images.githubusercontent.com/107460718/193429168-a66997bf-ee69-4d43-910b-e3101f492649.png)
Watermelon Juice:
![image](https://user-images.githubusercontent.com/107460718/193429180-68fb6cda-0890-4661-93fa-c673a974e9b9.png)
Lemon Juice:
![image](https://user-images.githubusercontent.com/107460718/193429288-6a3c7e77-6932-4f92-8e96-13f50aa2ecfe.png)
Banana Juice:
![image](https://user-images.githubusercontent.com/107460718/193429310-d7040fba-a6b9-46c5-a969-21db1007e3ef.png)

These changes are untested.

# Wiki Documentation

The colors have changed

# Changelog

:cl:  
rscadd: Adds a color value to lemonade 
bugfix: Fixes some missing food item color fillings
tweak: Tweaks some juice colors
/:cl:
