### PR TITLE
Gem storage & satchel accessibility QoL

### DIFF
--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -170,6 +170,7 @@ GLOBAL_LIST_INIT(leather_recipes, list ( \
 	new/datum/stack_recipe("medical webbing", /obj/item/storage/belt/medical/mining, 4), \
 	new/datum/stack_recipe("toolbelt", /obj/item/storage/belt/utility, 4), \
 	new/datum/stack_recipe("wallet", /obj/item/storage/wallet, 1), \
+	new/datum/stack_recipe("gem satchel", /obj/item/storage/bag/gem, 1) \
 ))
 
 /obj/item/stack/sheet/leather/Initialize(mapload, new_amount, merge = TRUE)

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -198,8 +198,8 @@
 	STR.allow_quick_empty = TRUE
 	STR.set_holdable(list(/obj/item/gem))
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
-	STR.max_combined_w_class = 16
-	STR.max_items = 16 
+	STR.max_combined_w_class = 48
+	STR.max_items = 48 
 
 /obj/item/storage/bag/gem/equipped(mob/user)
 	. = ..()

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -379,7 +379,8 @@
 		/obj/item/jawsoflife,
 		/obj/item/restraints/legcuffs/bola/watcher,
 		/obj/item/stack/sheet/mineral,
-		/obj/item/grenade/plastic/miningcharge
+		/obj/item/grenade/plastic/miningcharge,
+		/obj/item/gem
 		))
 
 

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -56,6 +56,7 @@
 		new /datum/data/mining_equipment("Minebot AI Upgrade",			/obj/item/slimepotion/slime/sentience/mining,						1000, VENDING_MINEBOT),
 		new /datum/data/mining_equipment("Pocket Fire Extinguisher",		/obj/item/extinguisher/mini,									50, VENDING_EQUIPMENT),
 		new /datum/data/mining_equipment("Lesser Mining Charge",		/obj/item/grenade/plastic/miningcharge/lesser,						300, VENDING_EQUIPMENT),
+		new /datum/data/mining_equipment("Gem Satchel",					/obj/item/storage/bag/gem,											150, VENDING_EQUIPMENT),
 		new /datum/data/mining_equipment("Explorer's Webbing",			/obj/item/storage/belt/mining,										500, VENDING_EQUIPMENT),
 		new /datum/data/mining_equipment("Mining Conscription Kit",		/obj/item/storage/backpack/duffelbag/mining_conscript,				1000, VENDING_EQUIPMENT),
 		new /datum/data/mining_equipment("GAR Meson Scanners",			/obj/item/clothing/glasses/meson/gar,								500, VENDING_EQUIPMENT),
@@ -315,6 +316,7 @@
 		new /datum/data/mining_equipment("Mecha Plasma Cutter",			/obj/item/mecha_parts/mecha_equipment/weapon/energy/plasma,		3000, VENDING_MECHA),
 		new /datum/data/mining_equipment("Pocket Fire Extinguisher",		/obj/item/extinguisher/mini,									50, VENDING_EQUIPMENT),
 		new /datum/data/mining_equipment("Lesser Mining Charge",		/obj/item/grenade/plastic/miningcharge/lesser,					300, VENDING_EQUIPMENT),
+		new /datum/data/mining_equipment("Gem Satchel",					/obj/item/storage/bag/gem,										150, VENDING_EQUIPMENT),
 		new /datum/data/mining_equipment("GAR Meson Scanners",			/obj/item/clothing/glasses/meson/gar,							500, VENDING_EQUIPMENT),
 		new /datum/data/mining_equipment("Mining Hardsuit",				/obj/item/clothing/suit/space/hardsuit/mining,					2000, VENDING_EQUIPMENT),
 		new /datum/data/mining_equipment("Jetpack Upgrade",				/obj/item/tank/jetpack/suit,									2000, VENDING_EQUIPMENT),
@@ -449,6 +451,7 @@
 	new /obj/item/clothing/glasses/meson(src)
 	new /obj/item/t_scanner/adv_mining_scanner/lesser(src)
 	new /obj/item/storage/bag/ore(src)
+	new /obj/item/storage/bag/gem(src)
 	new /obj/item/clothing/suit/hooded/explorer(src)
 	new /obj/item/encryptionkey/headset_mining(src)
 	new /obj/item/clothing/mask/gas/explorer(src)


### PR DESCRIPTION
They are now not a pain in the ass to store.

# Document the changes in your pull request

- Gem Satchels can be crafted with 1 leather
- Gem Satchels can be bought in the mining vendors for 150 points
- Gem satchels start inside the voucher conscript kit
- Tripled the gem satchel storage capacity
- Explorer webbing accepts gems

This has been tested apart from the tripled storage capacity and appears to function as intended.

# Wiki Documentation

Above bulletin points.

# Changelog

:cl:  
rscadd: Gem Satchels can be bought from the mining vendors for 150 points  
tweak: Gem Satchels can be crafted with 1 leather
tweak: Gem satchels start inside the voucher conscript kit
tweak: Tripled the gem satchel storage capacity
tweak: Explorer webbing accepts gems
/:cl:
