### PR TITLE
Fixes Revenants still being able to damage unintended windows

### DIFF
--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -266,9 +266,9 @@
 	for(var/obj/machinery/dna_scannernew/dna in T)
 		dna.open_machine()
 	for(var/obj/structure/window/window in T)
-		window.take_damage(rand(30,80))
 		if(window && window.fulltile)
 			if(!istype(window, /obj/structure/window/reinforced) || !istype(window, /obj/structure/window/plasma) || !istype(window, /obj/structure/window/plastitanium) || !istype(window, /obj/structure/window/plasma/reinforced))
+				window.take_damage(rand(30,80))
 				new /obj/effect/temp_visual/revenant/cracks(window.loc)
 	for(var/obj/machinery/light/light in T)
 		light.flicker(20) //spooky

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -266,10 +266,11 @@
 	for(var/obj/machinery/dna_scannernew/dna in T)
 		dna.open_machine()
 	for(var/obj/structure/window/window in T)
-		if(window && window.fulltile)
+		if(window)
 			if(!istype(window, /obj/structure/window/reinforced) || !istype(window, /obj/structure/window/plasma) || !istype(window, /obj/structure/window/plastitanium) || !istype(window, /obj/structure/window/plasma/reinforced))
 				window.take_damage(rand(30,80))
-				new /obj/effect/temp_visual/revenant/cracks(window.loc)
+				if(window.fulltile)
+					new /obj/effect/temp_visual/revenant/cracks(window.loc)
 	for(var/obj/machinery/light/light in T)
 		light.flicker(20) //spooky
 


### PR DESCRIPTION
# Document the changes in your pull request

order of operations issue; damage happens before check for window type

# Changelog

:cl:  
bugfix: fixed revenants still being able to damage reinforced/plasma/etc windows
/:cl:
