### PR TITLE
nerfs syndicate buckshot and flechette

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -79,7 +79,7 @@
 	
 /obj/item/projectile/bullet/pellet/shotgun_buckshot/syndie
 	name = "syndicate buckshot pellet"
-	damage = 18
+	damage = 15.5 //7 damage more and crit instantly assuming PBS
 	wound_bonus = 2
 	bare_wound_bonus = 2
 	wound_falloff_tile = -2.5
@@ -87,7 +87,7 @@
 /obj/item/projectile/bullet/pellet/shotgun_flechette
 	name = "flechette pellet"
 	speed = 0.4 //You're special
-	damage = 15
+	damage = 13
 	wound_bonus = 4
 	bare_wound_bonus = 4
 	armour_penetration = 40


### PR DESCRIPTION
# Document the changes in your pull request

As it turns out being one-hit isn't exceptionally fun

Also after going into a test server and firing the flechettes exactly twice I'm nerfing its damage because it's absurdly accurate with good AP which means it's very good to fire down a hallway to just tag anyone that's clumped in there. Yes it's 3 TC instead of 2 but whewie is it good

# Wiki Documentation

Update on guide to combat under shotgun shell values

# Changelog

:cl:  
tweak: Syndicate buckshot 15.5 per pellet down from 18
tweak: Flechette 13 per pellet down from 15
/:cl:
