### PR TITLE
AIs now have BIG TEXT in binary chat (tg port)

### DIFF
--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -1,27 +1,59 @@
 /mob/living/proc/robot_talk(message)
 	log_talk(message, LOG_SAY)
-	var/desig = "Default Cyborg" //ezmode for taters
+
+	var/designation = "Default Cyborg"
+	var/spans = list(SPAN_ROBOT)
+
 	if(issilicon(src))
-		var/mob/living/silicon/S = src
-		desig = trim_left(S.designation + " " + S.job)
-	var/message_a = say_quote(message)
-	var/rendered = "Robotic Talk, [span_name("[name]")] [span_message("[message_a]")]"
+		var/mob/living/silicon/player = src
+		designation = trim_left(player.designation + " " + player.job)
+
+	if(isAI(src))
+		// AIs are loud and ugly
+		spans |= SPAN_COMMAND
+
+	var/quoted_message = say_quote(
+		message,
+		spans
+	)
+
 	for(var/mob/M in GLOB.player_list)
 		if(M.binarycheck())
 			if(isAI(M))
-				var/renderedAI = span_binarysay("Robotic Talk, <a href='?src=[REF(M)];track=[html_encode(name)]'>[span_name("[name] ([desig])")]</a> [span_message("[message_a]")]")
-				to_chat(M, renderedAI)
+				to_chat(
+					M,
+					span_binarysay("\
+						Robotic Talk, \
+						<a href='?src=[REF(M)];track=[html_encode(name)]'>[span_name("[name] ([designation])")]</a> \
+						<span class='message'>[quoted_message]</span>\
+					")
+				)
 			else
-				to_chat(M, span_binarysay("[rendered]"))
+				to_chat(
+					M,
+					span_binarysay("\
+						Robotic Talk, \
+						[span_name("[name]")] <span class='message'>[quoted_message]</span>\
+					")
+				)
+
 		if(isobserver(M))
 			var/following = src
+
 			// If the AI talks on binary chat, we still want to follow
-			// it's camera eye, like if it talked on the radio
+			// its camera eye, like if it talked on the radio
+
 			if(isAI(src))
 				var/mob/living/silicon/ai/ai = src
 				following = ai.eyeobj
-			var/link = FOLLOW_LINK(M, following)
-			to_chat(M, span_binarysay("[link] [rendered]"))
+
+			to_chat(
+				M,
+				FOLLOW_LINK(M, following) + span_binarysay(" \
+					Robotic Talk, \
+					[span_name("[name]")] <span class='message'>[quoted_message]</span>\
+				")
+			)
 
 /mob/living/silicon/binarycheck()
 	return 1

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -25,7 +25,7 @@
 					span_binarysay("\
 						Robotic Talk, \
 						<a href='?src=[REF(M)];track=[html_encode(name)]'>[span_name("[name] ([designation])")]</a> \
-						<span class='message'>[quoted_message]</span>\
+						[span_message("[quoted_message]")]\
 					")
 				)
 			else
@@ -33,7 +33,7 @@
 					M,
 					span_binarysay("\
 						Robotic Talk, \
-						[span_name("[name]")] <span class='message'>[quoted_message]</span>\
+						[span_name("[name]")] [span_message("[quoted_message]")]\
 					")
 				)
 
@@ -54,7 +54,7 @@
 				span_binarysay("\
 					[follow_link] \
 					Robotic Talk, \
-					[span_name("[name]")] <span class='message'>[quoted_message]</span>\
+					[span_name("[name]")] [span_message("[quoted_message]")]\
 				")
 			)
 

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -47,9 +47,12 @@
 				var/mob/living/silicon/ai/ai = src
 				following = ai.eyeobj
 
+			var/follow_link = FOLLOW_LINK(M, following)
+
 			to_chat(
 				M,
-				FOLLOW_LINK(M, following) + span_binarysay(" \
+				span_binarysay("\
+					[follow_link] \
 					Robotic Talk, \
 					[span_name("[name]")] <span class='message'>[quoted_message]</span>\
 				")


### PR DESCRIPTION
# Document the changes in your pull request

AIs now have big text (loud) when speaking in binary. Should make it easy to see who is the big cheese in binary chat and make it hard to ignore when the AI is yelling at you.

![image](https://user-images.githubusercontent.com/49619518/193504908-066af9e8-bd4d-47a7-be3e-caa0905b616f.png)
![image](https://user-images.githubusercontent.com/49619518/193504940-b7414f24-74fc-4a7a-a54a-9956cde7a969.png)

Original tg PR: https://github.com/tgstation/tgstation/pull/69871
All credit to **scriptis**.

(Note: I have avoided porting the three instances of "avoid_highlighting = src == M" in the code because it caused a runtime and broke binary chat. Hopefully this won't be a problem)

# Changelog

:cl:  scriptis, ported by Jumps0
tweak: AIs now have BIG TEXT in binary chat
/:cl:
