### PR TITLE
Ling transformation sting is now temporary

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -339,6 +339,7 @@
 #define HORROR_TRAIT "horror"
 #define HOLDER_TRAIT "holder_trait"
 #define SINFULDEMON_TRAIT "sinfuldemon"
+#define CHANGESTING_TRAIT "changesting"
 
 ///Traits given by station traits
 #define STATION_TRAIT_BANANIUM_SHIPMENTS "station_trait_bananium_shipments"

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -67,12 +67,12 @@
 
 /datum/action/changeling/sting/transformation
 	name = "Transformation Sting"
-	desc = "We silently sting a human, injecting a retrovirus that forces them to transform. Costs 50 chemicals."
+	desc = "We silently sting a human, injecting a retrovirus that forces them to transform for a short time. Costs 20 chemicals."
 	helptext = "The victim will transform much like a changeling would. Does not provide a warning to others. Mutations will not be transferred, and monkeys will become human."
 	button_icon_state = "sting_transform"
 	sting_icon = "sting_transform"
-	chemical_cost = 50
-	dna_cost = 3
+	chemical_cost = 20
+	dna_cost = 2
 	var/datum/changelingprofile/selected_dna = null
 
 /datum/action/changeling/sting/transformation/Trigger()
@@ -104,14 +104,26 @@
 		to_chat(user, span_notice("Our genes cry out as we sting [target.name]!"))
 
 	var/mob/living/carbon/C = target
+
 	. = TRUE
 	if(istype(C))
+
+		//block that stores the old identity for use in reverting
+		var/mob/living/carbon/human/OldDNA = new /mob/living/carbon/human()
+		OldDNA.real_name = C.real_name
+		C.dna.transfer_identity(OldDNA)
+		addtimer(CALLBACK(src, .proc/revert, C, OldDNA), 5 MINUTES, TIMER_UNIQUE|TIMER_OVERRIDE)
+
 		C.real_name = NewDNA.real_name
 		NewDNA.transfer_identity(C)
 		if(ismonkey(C))
 			C.humanize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPORGANS | TR_KEEPDAMAGE | TR_KEEPVIRUS | TR_KEEPSTUNS | TR_KEEPREAGENTS | TR_DEFAULTMSG)
 		C.updateappearance(mutcolor_update=1)
 
+/datum/action/changeling/sting/transformation/proc/revert(mob/living/carbon/target, mob/living/carbon/original)
+	target.real_name = original.real_name
+	original.dna.transfer_identity(target)
+	qdel(original)
 
 /datum/action/changeling/sting/false_armblade
 	name = "False Armblade Sting"

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -72,7 +72,7 @@
 	button_icon_state = "sting_transform"
 	sting_icon = "sting_transform"
 	chemical_cost = 20
-	dna_cost = 2
+	dna_cost = 1
 	var/datum/changelingprofile/selected_dna = null
 
 /datum/action/changeling/sting/transformation/Trigger()
@@ -112,7 +112,7 @@
 		var/mob/living/carbon/human/OldDNA = new /mob/living/carbon/human()
 		OldDNA.real_name = C.real_name
 		C.dna.transfer_identity(OldDNA)
-		addtimer(CALLBACK(src, .proc/revert, C, OldDNA), 5 MINUTES, TIMER_UNIQUE|TIMER_OVERRIDE)
+		addtimer(CALLBACK(src, .proc/revert, C, OldDNA), 10 MINUTES, TIMER_UNIQUE|TIMER_OVERRIDE)
 
 		C.real_name = NewDNA.real_name
 		NewDNA.transfer_identity(C)


### PR DESCRIPTION
This just isn't fun, but the idea of it being a good distraction is
Now it's temporary, lasting only 10 minutes, long enough to create chaos, but short enough that you'll still go back eventually
To help with fueling chaos it only costs 20 Chems now because you'll be expected to use it rapidly within a shorter time span
To balance out it being "weaker" it now only takes 1 dna to evolve
Might also create interesting events if someone is caught "swapping back" and is confused for a changeling

Probably also helps with admin headaches by keeping people distinct from each other more often than not

:cl:  
tweak: Changeling sting is now temporary
/:cl:
