### PR TITLE
captain's antique laser gun now shoots hellfire lasers

### DIFF
--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -7,6 +7,9 @@
 	e_cost = 130
 	select_name = "maim"
 
+/obj/item/ammo_casing/energy/laser/hellfire/antique
+	e_cost = 83
+
 /obj/item/ammo_casing/energy/lasergun
 	projectile_type = /obj/item/projectile/beam/laser
 	e_cost = 83

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -41,6 +41,7 @@
 	item_state = "caplaser"
 	desc = "This is an antique laser gun. All craftsmanship is of the highest quality. It is decorated with assistant leather and chrome. The object menaces with spikes of energy. On the item is an image of Space Station 13. The station is exploding."
 	force = 10
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/hellfire/antique)
 	ammo_x_offset = 3
 	selfcharge = 1
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF


### PR DESCRIPTION
you know for a gun that only 1 exists of, and that's a grand theft objective, and one that the owner of the gun cannot take outside of extreme emergencies, this gun really is worse than the ones you can print for no cost from the armory protolathe huh

the antique fires a special version of hellfire that has the same energy cost as normal lasers so you're not losing ammo capacity

# Changelog

:cl:  
tweak: antique lasergun now shoots hellfire
/:cl:
