### PR TITLE
Mutate spell will no longer put entire lizardpeople on your head

### DIFF
--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -75,15 +75,7 @@
 	locked = TRUE
 	difficulty = 16
 	text_gain_indication = span_notice("You feel pressure building up behind your eyes.")
-	layer_used = FRONT_MUTATIONS_LAYER
 	limb_req = BODY_ZONE_HEAD
-
-/datum/mutation/human/laser_eyes/New(class_ = MUT_OTHER, timer, datum/mutation/human/copymut)
-	..()
-	visual_indicators |= mutable_appearance('icons/effects/genetics.dmi', "lasereyes", -FRONT_MUTATIONS_LAYER)
-
-/datum/mutation/human/laser_eyes/get_visual_indicator()
-	return visual_indicators[1]
 
 /datum/mutation/human/laser_eyes/on_ranged_attack(atom/target, mouseparams)
 	if(owner.a_intent == INTENT_HARM)

--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -80,3 +80,13 @@
 /datum/mutation/human/laser_eyes/on_ranged_attack(atom/target, mouseparams)
 	if(owner.a_intent == INTENT_HARM)
 		owner.LaserEyes(target, mouseparams)
+
+/datum/mutation/human/thermal/on_acquiring(mob/living/carbon/human/owner)
+	if(..())
+		return
+	ADD_TRAIT(owner, CULT_EYES, GENETIC_MUTATION)
+
+/datum/mutation/human/thermal/on_losing(mob/living/carbon/human/owner)
+	if(..())
+		return
+	REMOVE_TRAIT(owner, CULT_EYES, GENETIC_MUTATION)

--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -80,13 +80,3 @@
 /datum/mutation/human/laser_eyes/on_ranged_attack(atom/target, mouseparams)
 	if(owner.a_intent == INTENT_HARM)
 		owner.LaserEyes(target, mouseparams)
-
-/datum/mutation/human/thermal/on_acquiring(mob/living/carbon/human/owner)
-	if(..())
-		return
-	ADD_TRAIT(owner, CULT_EYES, GENETIC_MUTATION)
-
-/datum/mutation/human/thermal/on_losing(mob/living/carbon/human/owner)
-	if(..())
-		return
-	REMOVE_TRAIT(owner, CULT_EYES, GENETIC_MUTATION)


### PR DESCRIPTION
# Document the changes in your pull request

Apparently lasereyes doesn't know how to find the icon it's supposed to use, so how about we just not make it try until someone figures it out?

# Changelog

:cl:  
bugfix: Mutate spell no longer steadily buries you in random icons with every cast
/:cl: