### PR TITLE
You hungrily gobble \the [O], gobbling it down!

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2281,7 +2281,7 @@ GLOBAL_LIST_EMPTY(mentor_races)
 	. = TRUE
 	if(C == user)
 		if(fullness <= 50)
-			user.visible_message(span_notice("[user] hungrily [eatverb]s \the [O], gobbling it down!"), span_notice("You hungrily [eatverb] \the [O], gobbling it down!"))
+			user.visible_message(span_notice("[user] frantically [eatverb]s \the [O], like a disgusting animal!"), span_notice("You frantically [eatverb] \the [O], forgoing table manners!"))
 		else if(fullness > 50 && fullness < 150)
 			user.visible_message(span_notice("[user] hungrily [eatverb]s \the [O]."), span_notice("You hungrily [eatverb] \the [O]."))
 		else if(fullness > 150 && fullness < 500)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2281,7 +2281,7 @@ GLOBAL_LIST_EMPTY(mentor_races)
 	. = TRUE
 	if(C == user)
 		if(fullness <= 50)
-			user.visible_message(span_notice("[user] frantically [eatverb]s \the [O], like a disgusting animal!"), span_notice("You frantically [eatverb] \the [O], forgoing table manners!"))
+			user.visible_message(span_notice("[user] frantically [eatverb]s \the [O], scarfing it down!"), span_notice("You frantically [eatverb] \the [O], scarfing it down!"))
 		else if(fullness > 50 && fullness < 150)
 			user.visible_message(span_notice("[user] hungrily [eatverb]s \the [O]."), span_notice("You hungrily [eatverb] \the [O]."))
 		else if(fullness > 150 && fullness < 500)


### PR DESCRIPTION
# Document the changes in your pull request

Gently despaghettifies eating flavor by taking "gobble" out of the fullness < 50 template, removing the about 20% chance of redundancy when you're very hungy
Also replaces hungrily with frantically for variety and to sell the fact that you are as close to starving as you'll ever be on Nanotrasen property

# Changelog

:cl:  
tweak: Changes the flavor text for eating while starving to prevent redundant wording
/:cl: