### PR TITLE
Bags of holding can't hold things their size or bigger

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -57,8 +57,8 @@
 /obj/item/storage/backpack/holding/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.allow_big_nesting = TRUE
-	STR.max_w_class = WEIGHT_CLASS_GIGANTIC
+	STR.allow_big_nesting = FALSE
+	STR.max_w_class = WEIGHT_CLASS_NORMAL
 	STR.max_combined_w_class = 35
 
 /obj/item/storage/backpack/holding/suicide_act(mob/living/user)

--- a/yogstation/code/game/objects/items/storage/backpack.dm
+++ b/yogstation/code/game/objects/items/storage/backpack.dm
@@ -48,8 +48,8 @@
 					old_other_storage.RemoveComponent()
 					var/datum/component/storage/this_storage = GetComponent(/datum/component/storage)
 					var/datum/component/storage/twin_storage = twin.AddComponent(/datum/component/storage/bluespace/bag_of_holding, this_storage.master()) // add a slave storage component
-					twin_storage.allow_big_nesting = TRUE
-					twin_storage.max_w_class = WEIGHT_CLASS_GIGANTIC
+					twin_storage.allow_big_nesting = FALSE
+					twin_storage.max_w_class = WEIGHT_CLASS_NORMAL
 					twin_storage.max_combined_w_class = 35
 					twin_storage.max_items = 21
 					twin.cut = FALSE
@@ -88,8 +88,8 @@
 			if(m_storage)
 				m_storage.RemoveComponent()
 			m_storage = m_obj.AddComponent(m_obj.component_type)
-			m_storage.allow_big_nesting = TRUE
-			m_storage.max_w_class = WEIGHT_CLASS_GIGANTIC
+			m_storage.allow_big_nesting = FALSE
+			m_storage.max_w_class = WEIGHT_CLASS_NORMAL
 			m_storage.max_combined_w_class = 35
 			m_storage.max_items = 21
 			for(var/datum/component/storage/slave in new_slaves)


### PR DESCRIPTION
# Document the changes in your pull request

Discussed recently in #15957 (also do not merge this if you merge that)

They're just really big duffelbags with no slowdown now, instead of the final resting place of the armory in any round that features a powergamer

Might prevent boh bombing, so I'm gonna have this as a draft until I can test that (even though boh bombing has no purpose anymore other than grief and die glorious) and if it does break it I'm gonna uhhhh cry I think

# Wiki Documentation

Does the wiki even talk about what bohs do

# Changelog

:cl:  
tweak: Bags of holding can't hold things their size or bigger
/:cl: