### PR TITLE
Halves default cargo shuttle transit time

### DIFF
--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -33,7 +33,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 /obj/docking_port/mobile/supply
 	name = "supply shuttle"
 	id = "supply"
-	callTime = 600
+	callTime = 30 SECONDS
 
 	dir = WEST
 	port_direction = EAST


### PR DESCRIPTION
# Document the changes in your pull request

Cargo shuttle taking 2 minutes for a round trip plus loading/unloading/ordering time is a pain in the ass for anyone who wants to get stuff on it. Whether or nit its worth the dramatic tension of not having proper gear for a minute is debatable and im here to bring that debate


# Wiki Documentation

Cargo shuttle transit time default 30 seconds from 1 minute

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
tweak: Cargo shuttle transit time default 30 seconds from 1 minute
/:cl:
