### PR TITLE
ports chat highlight fix from tg & removes self highlights

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -534,9 +534,9 @@ GLOBAL_LIST_EMPTY(species_list)
 				var/turf_link = TURF_LINK(M, turf_target)
 				rendered_message = "[turf_link] [message]"
 
-			to_chat(M, rendered_message)
+			to_chat(M, rendered_message, avoid_highlighting = speaker_key == M.key)
 		else
-			to_chat(M, message)
+			to_chat(M, message, avoid_highlighting = speaker_key == M.key)
 
 //Used in chemical_mob_spawn. Generates a random mob based on a given gold_core_spawnable value.
 /proc/create_random_mob(spawn_location, mob_class = HOSTILE_SPAWN)

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -47,4 +47,6 @@
 		create_chat_message(speaker, message_language, raw_message, spans)
 	// Recompose the message, because it's scrambled by default
 	message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mods)
-	to_chat(src, "[link] [message]")
+	to_chat(src,
+		html = "[link] [message]",
+		avoid_highlighting = speaker == src)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -252,6 +252,12 @@ GLOBAL_LIST_INIT(special_radio_keys, list(
 		return
 	var/deaf_message
 	var/deaf_type
+	var/avoid_highlight
+	if(istype(speaker, /atom/movable/virtualspeaker))
+		var/atom/movable/virtualspeaker/virt = speaker
+		avoid_highlight = src == virt.source
+	else
+		avoid_highlight = src == speaker
 	if(speaker != src)
 		if(!radio_freq) //These checks have to be seperate, else people talking on the radio will make "You can't hear yourself!" appear when hearing people over the radio while deaf.
 			deaf_message = "[span_name("[speaker]")] [speaker.verb_say] something but you cannot hear [speaker.p_them()]."
@@ -268,7 +274,7 @@ GLOBAL_LIST_INIT(special_radio_keys, list(
 	message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mods)
 	SEND_SIGNAL(src, COMSIG_MOVABLE_HEAR, args)
 
-	show_message(message, 2, deaf_message, deaf_type, avoid_highlighting = speaker == src)
+	show_message(message, 2, deaf_message, deaf_type, avoid_highlight)
 	return message
 
 /mob/living/send_speech(message, message_range = 6, obj/source = src, bubble_type = bubble_icon, list/spans, datum/language/message_language=null, list/message_mods = list())

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -268,7 +268,7 @@ GLOBAL_LIST_INIT(special_radio_keys, list(
 	message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mods)
 	SEND_SIGNAL(src, COMSIG_MOVABLE_HEAR, args)
 
-	show_message(message, 2, deaf_message, deaf_type)
+	show_message(message, 2, deaf_message, deaf_type, avoid_highlighting = speaker == src)
 	return message
 
 /mob/living/send_speech(message, message_range = 6, obj/source = src, bubble_type = bubble_icon, list/spans, datum/language/message_language=null, list/message_mods = list())

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -133,7 +133,7 @@
 /**
   * Show a message to this mob (visual)
   */
-/mob/proc/show_message(msg, type, alt_msg, alt_type)//Message, type of message (1 or 2), alternative message, alt message type (1 or 2)
+/mob/proc/show_message(msg, type, alt_msg, alt_type, avoid_highlighting = FALSE)//Message, type of message (1 or 2), alternative message, alt message type (1 or 2)
 
 	if(!client)
 		return
@@ -161,7 +161,7 @@
 		if(type & 2) //audio
 			to_chat(src, "<I>... You can almost hear something ...</I>")
 	else
-		to_chat(src, msg)
+		to_chat(src, msg, avoid_highlighting = avoid_highlighting)
 
 /**
   * Generate a visible message from this atom

--- a/code/modules/tgchat/to_chat.dm
+++ b/code/modules/tgchat/to_chat.dm
@@ -10,6 +10,7 @@
 /proc/to_chat_immediate(target, html,
 		type = null,
 		text = null,
+		avoid_highlighting = FALSE,
 		// FIXME: These flags are now pointless and have no effect
 		handle_whitespace = TRUE,
 		trailing_newline = TRUE,
@@ -23,6 +24,7 @@
 	if(type) message["type"] = type
 	if(text) message["text"] = text
 	if(html) message["html"] = html
+	if(avoid_highlighting) message["avoidHighlighting"] = avoid_highlighting
 	var/message_blob = TGUI_CREATE_MESSAGE("chat/message", message)
 	var/message_html = message_to_html(message)
 
@@ -56,6 +58,7 @@
 /proc/to_chat(target, html,
 		type = null,
 		text = null,
+		avoid_highlighting = FALSE,
 		// FIXME: These flags are now pointless and have no effect
 		handle_whitespace = TRUE,
 		trailing_newline = TRUE,
@@ -72,4 +75,5 @@
 	if(type) message["type"] = type
 	if(text) message["text"] = text
 	if(html) message["html"] = html
+	if(avoid_highlighting) message["avoidHighlighting"] = avoid_highlighting
 	SSchat.queue(target, message, confidential)

--- a/tgui/packages/tgui-panel/chat/renderer.js
+++ b/tgui/packages/tgui-panel/chat/renderer.js
@@ -170,7 +170,7 @@ class ChatRenderer {
     }
   }
 
-  setHighlight(text, color) {
+  setHighlight(text, color, matchWord, matchCase) {
     if (!text || !color) {
       this.highlightRegex = null;
       this.highlightColor = null;
@@ -179,12 +179,11 @@ class ChatRenderer {
     const allowedRegex = /^[a-z0-9_-\s]+$/ig;
     const lines = String(text)
       .split(',')
-      .map(str => str.trim())
+      // eslint-disable-next-line no-useless-escape
+      .map(str => str.trim().replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'))
       .filter(str => (
         // Must be longer than one character
         str && str.length > 1
-        // Must be alphanumeric (with some punctuation)
-        && allowedRegex.test(str)
       ));
     // Nothing to match, reset highlighting
     if (lines.length === 0) {
@@ -192,7 +191,9 @@ class ChatRenderer {
       this.highlightColor = null;
       return;
     }
-    this.highlightRegex = new RegExp('(' + lines.join('|') + ')', 'gi');
+    const pattern = `${(matchWord ? '\\b' : '')}(${lines.join('|')})${(matchWord ? '\\b' : '')}`;
+    const flags = 'g' + (matchCase ? '' : 'i');
+    this.highlightRegex = new RegExp(pattern, flags);
     this.highlightColor = color;
   }
 

--- a/tgui/packages/tgui-panel/chat/renderer.js
+++ b/tgui/packages/tgui-panel/chat/renderer.js
@@ -176,7 +176,7 @@ class ChatRenderer {
       this.highlightColor = null;
       return;
     }
-    const allowedRegex = /^[a-z0-9_-\s]+$/ig;
+    //const allowedRegex = /^[a-z0-9_-\s]+$/ig;
     const lines = String(text)
       .split(',')
       // eslint-disable-next-line no-useless-escape

--- a/tgui/packages/tgui-panel/chat/renderer.js
+++ b/tgui/packages/tgui-panel/chat/renderer.js
@@ -176,7 +176,7 @@ class ChatRenderer {
       this.highlightColor = null;
       return;
     }
-    //const allowedRegex = /^[a-z0-9_-\s]+$/ig;
+    // const allowedRegex = /^[a-z0-9_-\s]+$/ig;
     const lines = String(text)
       .split(',')
       // eslint-disable-next-line no-useless-escape

--- a/tgui/packages/tgui-panel/chat/renderer.js
+++ b/tgui/packages/tgui-panel/chat/renderer.js
@@ -303,7 +303,7 @@ class ChatRenderer {
           logger.error('Error: message is missing text payload', message);
         }
         // Highlight text
-        if (this.highlightRegex) {
+        if (!message.avoidHighlighting && this.highlightRegex) {
           const highlighted = highlightNode(node,
             this.highlightRegex,
             text => (

--- a/tgui/packages/tgui-panel/settings/SettingsPanel.js
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.js
@@ -54,6 +54,8 @@ export const SettingsGeneral = (props, context) => {
     lineHeight,
     highlightText,
     highlightColor,
+    matchWord,
+    matchCase,
   } = useSelector(context, selectSettings);
   const dispatch = useDispatch(context);
   return (
@@ -119,6 +121,22 @@ export const SettingsGeneral = (props, context) => {
           onChange={(e, value) => dispatch(updateSettings({
             highlightText: value,
           }))} />
+        <Button.Checkbox
+          checked={matchWord}
+          tooltipPosition="bottom-start"
+          tooltip="Not compatible with punctuation."
+          onClick={() => dispatch(updateSettings({
+            matchWord: !matchWord,
+          }))}>
+          Match word
+        </Button.Checkbox>
+        <Button.Checkbox
+          checked={matchCase}
+          onClick={() => dispatch(updateSettings({
+            matchCase: !matchCase,
+          }))}>
+          Match case
+        </Button.Checkbox>
       </Box>
       <Divider />
       <Box>

--- a/tgui/packages/tgui-panel/settings/reducer.js
+++ b/tgui/packages/tgui-panel/settings/reducer.js
@@ -15,6 +15,8 @@ const initialState = {
   adminMusicVolume: 0.15,
   highlightText: '',
   highlightColor: '#ffdd44',
+  matchWord: false,
+  matchCase: false,
   view: {
     visible: false,
     activeTab: SETTINGS_TABS[0].id,


### PR DESCRIPTION
# Document the changes in your pull request
Ports: https://github.com/tgstation/tgstation/pull/60146
Ports: https://github.com/tgstation/tgstation/pull/52991

Fixes highlighting and adds two new settings to match case and the whole word

# Changelog

:cl:  
bugfix: Chat highlight wont skip every other word now
tweak: Chat highlight no longer highlights your own messages
/:cl:
