### PR TITLE
IPC Lungs require much less pressure to function

### DIFF
--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -507,7 +507,7 @@
 	var/temperature = breath.return_temperature()
 	for(var/id in breath.get_gases())
 		var/moles = breath.get_moles(id)
-		total_heat_capacity += GLOB.meta_gas_info[id][META_GAS_SPECIFIC_HEAT] * moles
+		total_heat_capacity += GLOB.meta_gas_info[id][META_GAS_SPECIFIC_HEAT] * moles * 3.5
 	// Normal atmos is 0.416
 	// 20C -> 293K
 	// At about 50C overheating will begin


### PR DESCRIPTION
# Document the changes in your pull request

Takes IPC lungs from requiring nearly 10x the pressure of everyone else on internals, down to about 10-15% more
~24kPa minimum on oxygen internals

Why? Because that pressure determines how fast your tank drains, and at 95 kPa emergency internals only last about a minute or two for IPCs. And IPCs aren't even breathing, it's cooling. This is however simply easier than making IPCs not actually consume their internals gases.

# Wiki Documentation

Requires an update to the Notes section on the IPC wiki page

# Changelog

:cl:  
tweak: IPCs can run on sensible amounts of pressure instead of requiring an entire emergency internals tank per 2 minutes
/:cl:
